### PR TITLE
Deck pretty print

### DIFF
--- a/api/opentrons/util/pprint.py
+++ b/api/opentrons/util/pprint.py
@@ -1,0 +1,91 @@
+import functools
+from opentrons import containers
+
+def get_container(slot):
+    res = [None] + [
+        c for c in slot.get_all_children() 
+        if isinstance(c, containers.Container)]
+    return res.pop()
+
+def container_name(slot):
+    c = get_container(slot)    
+    return c.get_name() if c else ''
+
+def container_type(slot):
+    c = get_container(slot)    
+    return c.get_type() if c else ''
+
+def format_slot(slot, height, width, top_margin):
+    res = []
+    content_string = '|{:' + str(width-2) + 's}|'
+
+    divider = ['+{}+'.format('-'*(width-2))]
+    res += divider
+    
+    for _ in range(top_margin-1):
+        res += [content_string.format('')]
+
+    res += [content_string.format(slot.get_name())]
+    res += [content_string.format(container_name(slot))]
+    res += [content_string.format(container_type(slot))]
+
+    res += divider
+    
+    return res
+
+def join_cols(a, b):
+    return [
+        line_a[:-1] + line_b
+        for line_a, line_b in zip(a, b)
+    ]
+
+def join_rows(a, b):
+    return a[:-1] + b
+
+def stringify_deck(formatted_slots, n, m):
+    rows = [
+        [formatted_slots.pop() for _ in range(n)]
+        for _ in range(m)
+    ]
+        
+    output_rows = [
+        functools.reduce(join_cols, row)
+        for row in rows
+    ]
+    
+    return functools.reduce(join_rows, output_rows)
+
+def pprint(deck):
+    # Determine dimensions given the number of slots
+    size_map = {
+        10: (5, 2),
+        15: (5, 3)
+    }
+    
+    # Get all slots on a deck
+    deck = [c for c in deck.get_all_children() if isinstance(c, containers.Slot)]
+    
+    # Get all string labels of everything we'll be printing
+    # to calculate cell width
+    labels = sum([
+        [slot.get_name(), container_name(slot), container_type(slot)]
+        for slot in deck], [])
+    
+    slot_width = max([len(s) for s in labels]) + 10
+    slot_height = slot_width
+    
+    if not len(deck) in size_map:
+        raise ValueError('Unexpected deck size. Expected 10 slots for Hood or 15 slots for other')
+    
+    N, M = size_map[len(deck)]
+    
+    # Transpose the deck
+    # TODO: make sure order of slots on the deck doesn't affect us
+    deck = [
+        deck[row + col * M]
+        for row in range(M)
+        for col in reversed(range(N))
+    ]
+
+    pretty_slots = [format_slot(slot, slot_height, slot_width, 2) for slot in deck]
+    print('\n'.join(stringify_deck(pretty_slots, N, M)))

--- a/api/opentrons/util/pprint.py
+++ b/api/opentrons/util/pprint.py
@@ -1,19 +1,23 @@
 import functools
 from opentrons import containers
 
+
 def get_container(slot):
     res = [None] + [
-        c for c in slot.get_all_children() 
+        c for c in slot.get_all_children()
         if isinstance(c, containers.Container)]
     return res.pop()
 
+
 def container_name(slot):
-    c = get_container(slot)    
+    c = get_container(slot)
     return c.get_name() if c else ''
 
+
 def container_type(slot):
-    c = get_container(slot)    
+    c = get_container(slot)
     return c.get_type() if c else ''
+
 
 def format_slot(slot, height, width, top_margin):
     res = []
@@ -21,7 +25,7 @@ def format_slot(slot, height, width, top_margin):
 
     divider = ['+{}+'.format('-'*(width-2))]
     res += divider
-    
+
     for _ in range(top_margin-1):
         res += [content_string.format('')]
 
@@ -32,8 +36,9 @@ def format_slot(slot, height, width, top_margin):
     ]
 
     res += divider
-    
+
     return res
+
 
 def join_cols(a, b):
     return [
@@ -41,21 +46,24 @@ def join_cols(a, b):
         for line_a, line_b in zip(a, b)
     ]
 
+
 def join_rows(a, b):
     return a[:-1] + b
+
 
 def stringify_deck(formatted_slots, n, m):
     rows = [
         [formatted_slots.pop() for _ in range(n)]
         for _ in range(m)
     ]
-        
+
     output_rows = [
         functools.reduce(join_cols, row)
         for row in rows
     ]
-    
+
     return functools.reduce(join_rows, output_rows)
+
 
 def pprint(deck):
     # Determine dimensions given the number of slots
@@ -63,24 +71,29 @@ def pprint(deck):
         10: (5, 2),
         15: (5, 3)
     }
-    
+
     # Get all slots on a deck
-    deck = [c for c in deck.get_all_children() if isinstance(c, containers.Slot)]
-    
+    deck = [
+        c for c in deck.get_all_children()
+        if isinstance(c, containers.Slot)
+    ]
+
+    if not len(deck) in size_map:
+        raise ValueError(
+            ('Unexpected deck size. Expected 10 ',
+             'slots for Hood or 15 slots for other'))
+
     # Get all string labels of everything we'll be printing
     # to calculate cell width
     labels = sum([
         [slot.get_name(), container_name(slot), container_type(slot)]
         for slot in deck], [])
-    
+
     slot_width = max([len(s) for s in labels]) + 10
     slot_height = slot_width
-    
-    if not len(deck) in size_map:
-        raise ValueError('Unexpected deck size. Expected 10 slots for Hood or 15 slots for other')
-    
+
     N, M = size_map[len(deck)]
-    
+
     # Transpose the deck
     # TODO: make sure order of slots on the deck doesn't affect us
     deck = [
@@ -89,5 +102,8 @@ def pprint(deck):
         for col in reversed(range(N))
     ]
 
-    pretty_slots = [format_slot(slot, slot_height, slot_width, 2) for slot in deck]
+    pretty_slots = [
+        format_slot(slot, slot_height, slot_width, 2)
+        for slot in deck]
+
     print('\n'.join(stringify_deck(pretty_slots, N, M)))

--- a/api/opentrons/util/pprint.py
+++ b/api/opentrons/util/pprint.py
@@ -25,9 +25,11 @@ def format_slot(slot, height, width, top_margin):
     for _ in range(top_margin-1):
         res += [content_string.format('')]
 
-    res += [content_string.format(slot.get_name())]
-    res += [content_string.format(container_name(slot))]
-    res += [content_string.format(container_type(slot))]
+    res += [
+        content_string.format(slot.get_name()),
+        content_string.format(container_name(slot)),
+        content_string.format(container_type(slot))
+    ]
 
     res += divider
     


### PR DESCRIPTION
This PR adds pprint function allowing to print a string representation of a deck, for example:
```
```+--------+--------+--------+--------+--------+
|        |        |        |        |        |
|A3      |B3      |C3      |D3      |E3      |
|        |        |        |        |        |
|        |        |        |        |        |
+--------+--------+--------+--------+--------+
|        |        |        |        |        |
|A2      |B2      |C2      |D2      |E2      |
|96-flat |        |        |        |        |
|96-flat |        |        |        |        |
+--------+--------+--------+--------+--------+
|        |        |        |        |        |
|A1      |B1      |C1      |D1      |E1      |
|96-flat |        |        |        |        |
|96-flat |        |        |        |        |
+--------+--------+--------+--------+--------+
```

You can print it as follows 

```
from opentrons.util import pprint
pprint.pprint(robot.deck)
```

TODO:
- Tests