### PR TITLE
set plunger to 'bottom' during pick-up-tip to avoid firmware bug

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -996,6 +996,8 @@ class Pipette(Instrument):
         def _do():
             nonlocal location, presses
 
+            self.motor.move(self._get_plunger_position('bottom'))
+
             if location:
                 self.move_to(location, strategy='arc', enqueue=False)
 


### PR DESCRIPTION
A user discovered a new bug, where given a special combination of coordinates, the AB motors squeal again during `pipette._position_for_aspirate()` where the plunger is set to `bottom` position.

This patch sets the plunger to `bottom` position during `pipette.pick_up_tip()` to avoid this moment all together. However, the long-term solution will be to switch to a newer build of smoothieware EDGE that fixes this bug.

This issue has not been reported by any other user.