### PR TITLE
replaces localhost with 127.0.0.1

### DIFF
--- a/app-shell/app/main/main.js
+++ b/app-shell/app/main/main.js
@@ -16,14 +16,14 @@ const {ServerManager} = require('./servermanager.js')
 const {PythonEnvManager} = require('./envmanager.js')
 const {waitUntilServerResponds} = require('./util.js')
 
-let appWindowUrl = 'http://localhost:31950/'
+let appWindowUrl = 'http://127.0.0.1:31950/'
 let mainWindow
 let mainLogger
 let serverManager = new ServerManager()
 
 if (process.env.NODE_ENV === 'development'){
   require('electron-debug')({showDevTools: 'undocked'});
-  appWindowUrl = 'http://localhost:8090/'
+  appWindowUrl = 'http://127.0.0.1:8090/'
 }
 
 function createWindow (windowUrl) {
@@ -97,7 +97,7 @@ function startUp () {
   serverManager.start()
   waitUntilServerResponds(
     () => createWindow(appWindowUrl),
-    'http://localhost:31950/'
+    'http://127.0.0.1:31950/'
   )
   addMenu()
   initAutoUpdater()


### PR DESCRIPTION
Nodejs running on Windows 10 is not able to resolve `localhost` when not connected to network or in airplane mode.

This PR replaces all mentions of `localhost` inside app-shell with the explicit `127.0.0.1`, which after testing does in fact resolve when in airplane mode.