### PR TITLE
Placeable.wells(x=, y=)

### DIFF
--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -622,6 +622,8 @@ class Container(Placeable):
             new_wells = WellSeries(self.get_children_list())
         elif len(args) > 1:
             new_wells = WellSeries([self.well(n) for n in args])
+        elif 'x' in kwargs or 'y' in kwargs:
+            new_wells = self._parse_wells_x_y(*args, **kwargs)
         else:
             new_wells = self._parse_wells_to_and_length(*args, **kwargs)
 
@@ -673,6 +675,11 @@ class Container(Placeable):
                 step = step * -1 if step > 0 else step
             return WellSeries(
                 wrapped_wells[start + total_kids::step][:length])
+
+    def _parse_wells_x_y(self, *args, **kwargs):
+        x = kwargs.get('x', None)
+        y = kwargs.get('y', None)
+
 
 
 class WellSeries(Container):

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -679,7 +679,15 @@ class Container(Placeable):
     def _parse_wells_x_y(self, *args, **kwargs):
         x = kwargs.get('x', None)
         y = kwargs.get('y', None)
-
+        if x is None and isinstance(y, int):
+            return self.rows(y)
+        elif y is None and isinstance(x, int):
+            return self.cols(x)
+        elif isinstance(x, int) and isinstance(y, int):
+            i = (y * len(self.cols)) + x
+            return self.wells(i)
+        else:
+            raise ValueError('Placeable.wells(x=, y=) expects ints')
 
 
 class WellSeries(Container):

--- a/api/tests/opentrons/containers/test_placeable.py
+++ b/api/tests/opentrons/containers/test_placeable.py
@@ -302,3 +302,8 @@ class PlaceableTestCase(unittest.TestCase):
 
         expected = c.wells('A1', 'B1', 'C1', 'D1')
         self.assertWellSeriesEqual(c.wells(length=4), expected)
+
+        self.assertWellSeriesEqual(c.wells(43), c.wells(x=3, y=5))
+        self.assertWellSeriesEqual(c.rows(3), c.wells(y=3))
+        self.assertWellSeriesEqual(c.cols(4), c.wells(x=4))
+        self.assertRaises(ValueError, c.wells, **{'x': '1', 'y': '2'})


### PR DESCRIPTION
Small PR adding `Placeable.wells(x=, y=)` based of feedback. X and Y kwargs are integers

Users were before using `Placeable.cols()[x][y]` to get around this method not existing. This does not read too well, and would also raise error on containers without multiple columns (like "trough-12row")

`Placeable.wells(x=1, y=2)` will return well `B3`
`Placeable.wells(x=1)` will return column `B`
`Placeable.wells(y=2)` will return row `3`