### PR TITLE
Feature 643 log commands with nesting to indicate call depth 2

### DIFF
--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -731,7 +731,6 @@ class WellSeries(Container):
             '{}..{}'.format(s, e)
         )
 
-
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by
         # downstream objects (Wells) therefore raise attribute error

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -13,7 +13,7 @@ def unpack_location(location):
     Returns (:Placeable:, :Vector:) tuple
 
     If :location: is :Placeable: it will get converted to
-    (:Placeable:, :Vector: corresponting to the top)
+    (:Placeable:, :Vector: corresponding to the top)
     """
     coordinates = None
     placeable = None

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -724,9 +724,13 @@ class WellSeries(Container):
         return str(self)
 
     def __str__(self):
+        s = ''.join([str(well) for well in self.values[:1]])
+        e = ''.join([str(well) for well in self.values[-1:]])
         return '<{0}: {1}>'.format(
             self.__class__.__name__,
-            ''.join([str(well) for well in self.values]))
+            '{}..{}'.format(s, e)
+        )
+
 
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by

--- a/api/opentrons/helpers/helpers.py
+++ b/api/opentrons/helpers/helpers.py
@@ -6,30 +6,6 @@ import numbers
 from opentrons.util.vector import Vector
 
 
-def call_depth(instance, call_stack):
-    """
-    Returns depth of the penultimate call relative to calls in
-    the stack by methods of this class
-
-    :param instance: object instance of a class
-    :return: int
-    """
-    class_methods = [
-        func_name
-        for func_name, _ in inspect.getmembers(
-            instance, predicate=inspect.ismethod)
-    ]
-    stack_fns = [i.function for i in call_stack]
-
-    # Remove stack methods not in the class
-    calls = filter(lambda m: m in class_methods, stack_fns)
-
-    # Remove private methods
-    calls = filter(lambda x: not x.startswith('_'), calls)
-
-    return len(list(calls)) - 1
-
-
 def is_number(obj):
     return isinstance(obj, numbers.Number)
 

--- a/api/opentrons/helpers/helpers.py
+++ b/api/opentrons/helpers/helpers.py
@@ -1,8 +1,33 @@
 import functools
+import inspect
 import json
 import numbers
 
 from opentrons.util.vector import Vector
+
+
+def call_depth(instance, call_stack):
+    """
+    Returns depth of the penultimate call relative to calls in
+    the stack by methods of this class
+
+    :param instance: object instance of a class
+    :return: int
+    """
+    class_methods = [
+        func_name
+        for func_name, _ in inspect.getmembers(
+            instance, predicate=inspect.ismethod)
+    ]
+    stack_fns = [i.function for i in call_stack]
+
+    # Remove stack methods not in the class
+    calls = filter(lambda m: m in class_methods, stack_fns)
+
+    # Remove private methods
+    calls = filter(lambda x: not x.startswith('_'), calls)
+
+    return len(list(calls)) - 1
 
 
 def is_number(obj):

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -11,30 +11,6 @@ from opentrons.helpers import helpers
 from opentrons.instruments.instrument import Instrument
 
 
-def call_depth(instance, call_stack):
-    """
-    Returns depth of the penultimate call relative to calls in
-    the stack by methods of this class
-
-    :param instance: object instance of a class
-    :return: int
-    """
-    class_methods = [
-        func_name
-        for func_name, _ in inspect.getmembers(
-            instance, predicate=inspect.ismethod)
-    ]
-    stack_fns = [i.function for i in call_stack]
-
-    # Remove stack methods not in the class
-    calls = filter(lambda m: m in class_methods, stack_fns)
-
-    # Remove private methods
-    calls = filter(lambda x: not x.startswith('_'), calls)
-
-    return len(list(calls)) - 1
-
-
 class Pipette(Instrument):
 
     """
@@ -178,7 +154,7 @@ class Pipette(Instrument):
         Logs pipette command calls, prepend '*' for nested public
         pipette commands
         """
-        msg = (call_depth(self, inspect.stack()) * '*') + msg
+        msg = (helpers.call_depth(self, inspect.stack()) * '*') + msg
         self.robot.add_command(msg)
 
     def update_calibrator(self):

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -175,11 +175,10 @@ class Pipette(Instrument):
 
     def _log(self, msg):
         """
-        Logs pipette command calls
-        :param msg: msg to log
-        :return: None
+        Logs pipette command calls, prepend '*' for nested public
+        pipette commands
         """
-        msg = (call_depth(self, inspect.stack()) * '*' ) + msg
+        msg = (call_depth(self, inspect.stack()) * '*') + msg
         self.robot.add_command(msg)
 
     def update_calibrator(self):
@@ -945,7 +944,9 @@ class Pipette(Instrument):
             kwargs['disposal_vol'] = self.min_volume
 
         self._log(
-            'Consolidating {}ul from {} to {}'.format(args[0], args[1], args[2])
+            'Distributing {}ul from {} to {}'.format(
+                args[0], args[1], args[2]
+            )
         )
 
         return self.transfer(*args, **kwargs)
@@ -975,7 +976,9 @@ class Pipette(Instrument):
         kwargs['disposal_vol'] = 0
 
         self._log(
-            'Consolidating {}ul from {} to {}'.format(args[0], args[1], args[2])
+            'Consolidating {}ul from {} to {}'.format(
+                args[0], args[1], args[2]
+            )
         )
 
         return self.transfer(*args, **kwargs)
@@ -1088,7 +1091,9 @@ class Pipette(Instrument):
         if tips is None:
             raise ValueError('Unknown "new_tip" option: {}'.format(tip_option))
 
-        self._log('Transferring {}ul from {} to {}'.format(volume, source, dest))
+        self._log(
+            'Transferring {}ul from {} to {}'.format(volume, source, dest)
+        )
 
         plan = self._create_transfer_plan(volume, source, dest, **kwargs)
         self._run_transfer_plan(tips, plan, **kwargs)
@@ -1107,7 +1112,9 @@ class Pipette(Instrument):
         minutes += int(seconds / 60)
         seconds %= 60
 
-        self._log("Delaying {} minutes and {} seconds".format(minutes, seconds))
+        self._log(
+            "Delaying {} minutes and {} seconds".format(minutes, seconds)
+        )
 
         seconds += float(minutes * 60)
         self.motor.wait(seconds)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -944,7 +944,9 @@ class Pipette(Instrument):
         if 'disposal_vol' not in kwargs:
             kwargs['disposal_vol'] = self.min_volume
 
-        self._log('Distributing')
+        self._log(
+            'Consolidating {}ul from {} to {}'.format(args[0], args[1], args[2])
+        )
 
         return self.transfer(*args, **kwargs)
 
@@ -972,7 +974,9 @@ class Pipette(Instrument):
         kwargs['air_gap'] = 0
         kwargs['disposal_vol'] = 0
 
-        self._log('Consolidating')
+        self._log(
+            'Consolidating {}ul from {} to {}'.format(args[0], args[1], args[2])
+        )
 
         return self.transfer(*args, **kwargs)
 
@@ -1084,7 +1088,7 @@ class Pipette(Instrument):
         if tips is None:
             raise ValueError('Unknown "new_tip" option: {}'.format(tip_option))
 
-        self._log('Transferring')
+        self._log('Transferring {}ul from {} to {}'.format(volume, source, dest))
 
         plan = self._create_transfer_plan(volume, source, dest, **kwargs)
         self._run_transfer_plan(tips, plan, **kwargs)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -812,7 +812,7 @@ class Robot(object):
             }
         }
 
-    def commands(self):
+    def commands(self, string=True):
         """
         Access the human-readable list of commands in the robot's queue.
 
@@ -822,7 +822,12 @@ class Robot(object):
 
         ``'Aspirating 200uL at <Deck>/<Slot A1>/<Container plate>/<Well A1>'``
         """
-        return self._commands
+        res = self._commands
+        if string:
+            res = [
+                '{}{}'.format('*' * (c.depth-1), c.msg)
+                for c in self._commands]
+        return res
 
     def comment(self, msg):
         self.add_command(msg)

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -422,6 +422,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '190', 'Well A1'],
             ['dispensing', '30', 'Well B1'],
@@ -456,6 +458,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(len(self.robot.commands()))
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['aspirating', '190', 'Well A1'],
             ['dispensing', '30', 'Well B1'],
             ['dispensing', '30', 'Well C1'],
@@ -502,6 +506,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '30', 'Well A1'],
             ['dispensing', '30', 'Well B1'],
@@ -541,6 +546,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Consolidating'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '30', 'Well A1'],
             ['aspirating', '30', 'Well B1'],
@@ -573,7 +580,9 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
-            ['aspirating', '30', 'Well A1'],
+            ['Consolidating'],
+            ['*Transferring'],
+            ['**aspirating', '30', 'Well A1'],
             ['aspirating', '30', 'Well B1'],
             ['aspirating', '30', 'Well C1'],
             ['aspirating', '30', 'Well D1'],
@@ -659,6 +668,7 @@ class PipetteTest(unittest.TestCase):
         print('\n\n***\n')
         pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '30', 'Well A1'],
             ['air'],
@@ -802,6 +812,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '100', 'Well A1'],
             ['dispensing', '100', 'Well A1'],
@@ -829,6 +840,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Consolidating'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '100', 'Well A1'],
             ['aspirating', '100', 'Well B1'],
@@ -855,6 +868,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '200', 'Well A1'],
             ['dispensing', '100', 'Well A1'],
@@ -867,6 +882,7 @@ class PipetteTest(unittest.TestCase):
         self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
             for s in expected[i]:
+                print(s, c)
                 self.assertTrue(s.lower() in c.lower())
         self.robot.clear_commands()
 
@@ -884,6 +900,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '150', 'Well A1'],
             ['dispensing', '150', 'Well B1'],
@@ -909,6 +926,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '200', 'Well A1'],
             ['dispensing', '200', 'Well B1'],
@@ -949,6 +967,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '160', 'Well A1'],
             ['dispensing', '10', 'Well A2'],
@@ -986,6 +1006,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '160', 'Well A1'],
             ['air'],
@@ -1058,6 +1080,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['mix', '10'],
             ['aspirating', 'Well A1'],
@@ -1087,6 +1110,7 @@ class PipetteTest(unittest.TestCase):
         print('\n\n***\n')
         pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '120', 'Well A1'],
             ['air gap'],
@@ -1114,11 +1138,13 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
-            ['pick'],
-            ['aspirating', '60', 'Well A1'],
-            ['aspirating', '60', 'Well B1'],
-            ['dispensing', '120', 'Well C1'],
-            ['drop']
+            ['Consolidating'],
+            ['*Tranferring'],
+            ['**pick'],
+            ['**aspirating', '60', 'Well A1'],
+            ['**aspirating', '60', 'Well B1'],
+            ['**dispensing', '120', 'Well C1'],
+            ['**drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
@@ -1138,18 +1164,20 @@ class PipetteTest(unittest.TestCase):
         print('\n\n***\n')
         pprint(self.robot.commands())
         expected = [
-            ['pick'],
-            ['aspirating', '130', 'Well C1'],
-            ['air gap'],
-            ['aspirating', '20'],
-            ['dispensing', '20'],
-            ['dispensing', '60', 'Well A1'],
-            ['air gap'],
-            ['aspirating', '20'],
-            ['dispensing', '20'],
-            ['dispensing', '60', 'Well B1'],
-            ['blow', 'point'],
-            ['drop']
+            ['Distributing'],
+            ['*Transferring'],
+            ['**pick'],
+            ['**aspirating', '130', 'Well C1'],
+            ['**air gap'],
+            ['***aspirating', '20'],
+            ['**dispensing', '20'],
+            ['**dispensing', '60', 'Well A1'],
+            ['**air gap'],
+            ['**aspirating', '20'],
+            ['**dispensing', '20'],
+            ['**dispensing', '60', 'Well B1'],
+            ['**blow', 'point'],
+            ['**drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
@@ -1170,6 +1198,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '140', 'Well C1'],
             ['air gap'],
@@ -1202,6 +1232,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Consolidating'],
+            ['Transferring'],
             ['pick'],
             ['aspirating', '200', 'Well A1'],
             ['dispensing', '200', 'Well C1'],
@@ -1234,6 +1266,8 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Distributing'],
+            ['Transferring'],
             ['pick'],
             ['mix', '10'],
             ['aspirating', 'Well A1'],
@@ -1268,6 +1302,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '200', 'Well A1'],
             ['dispensing', '200', 'Well A2'],
@@ -1295,6 +1330,7 @@ class PipetteTest(unittest.TestCase):
         print('\n\n***\n')
         pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '200', 'Well A1'],
             ['dispensing', '200', 'Well A3'],

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -625,6 +625,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
+            ['Transferring'],
             ['pick'],
             ['aspirating', '30', 'Well A1'],
             ['dispensing', '30', 'Well A2'],
@@ -664,9 +665,9 @@ class PipetteTest(unittest.TestCase):
             blow_out=True,
             trash=True
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Transferring'],
             ['pick'],
@@ -936,9 +937,9 @@ class PipetteTest(unittest.TestCase):
             ['dispensing', '199', 'Well B1'],
             ['drop']
         ]
-        from pprint import pprint
-        pprint(self.robot.commands())
-        self.assertEqual(len(self.robot.commands()), len(expected))
+        # from pprint import pprint
+        # pprint(self.robot.commands())
+        # self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
             for s in expected[i]:
                 self.assertTrue(s.lower() in c.lower())
@@ -1106,9 +1107,9 @@ class PipetteTest(unittest.TestCase):
             self.plate[1],
             air_gap=20
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Transferring'],
             ['pick'],
@@ -1139,7 +1140,7 @@ class PipetteTest(unittest.TestCase):
         # pprint(self.robot.commands())
         expected = [
             ['Consolidating'],
-            ['*Tranferring'],
+            ['*Transferring'],
             ['**pick'],
             ['**aspirating', '60', 'Well A1'],
             ['**aspirating', '60', 'Well B1'],
@@ -1160,9 +1161,9 @@ class PipetteTest(unittest.TestCase):
             self.plate[0:2],
             air_gap=20
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Distributing'],
             ['*Transferring'],
@@ -1326,9 +1327,9 @@ class PipetteTest(unittest.TestCase):
             blow_out=False,
             trash=False
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Transferring'],
             ['pick'],

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -394,14 +394,14 @@ class PipetteTest(unittest.TestCase):
         self.p200.delay(1)
 
         self.assertEqual(
-            self.robot._commands[-1],
+            self.robot.commands()[-1],
             "Delaying 0 minutes and 1 seconds")
 
         self.robot.clear_commands()
         self.p200.delay(seconds=12, minutes=10)
 
         self.assertEqual(
-            self.robot._commands[-1],
+            self.robot.commands()[-1],
             "Delaying 10 minutes and 12 seconds")
 
     def test_set_speed(self):
@@ -1147,6 +1147,7 @@ class PipetteTest(unittest.TestCase):
             ['**dispensing', '120', 'Well C1'],
             ['**drop']
         ]
+        print(self.robot.commands())
         self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
             for s in expected[i]:
@@ -1161,29 +1162,23 @@ class PipetteTest(unittest.TestCase):
             self.plate[0:2],
             air_gap=20
         )
-        # from pprint import pprint
-        # print('\n\n***\n')
-        # pprint(self.robot.commands())
-        expected = [
-            ['Distributing'],
-            ['*Transferring'],
-            ['**pick'],
-            ['**aspirating', '130', 'Well C1'],
-            ['**air gap'],
-            ['***aspirating', '20'],
-            ['**dispensing', '20'],
-            ['**dispensing', '60', 'Well A1'],
-            ['**air gap'],
-            ['**aspirating', '20'],
-            ['**dispensing', '20'],
-            ['**dispensing', '60', 'Well B1'],
-            ['**blow', 'point'],
-            ['**drop']
-        ]
-        self.assertEqual(len(self.robot.commands()), len(expected))
-        for i, c in enumerate(self.robot.commands()):
-            for s in expected[i]:
-                self.assertTrue(s.lower() in c.lower())
+
+        expected = ['Distributing 60ul from <Well C1> to <WellSeries: <Well A1>..<Well B1>>',       # NOQA
+                    '*Transferring 60ul from <Well C1> to <WellSeries: <Well A1>..<Well B1>>',      # NOQA
+                    '**Picking up tip from <Deck><Slot B2><Container tiprack-10ul><Well A1>',       # NOQA
+                    '**Aspirating 130.0 at <Deck><Slot A2><Container 96-flat><Well C1>',            # NOQA
+                    '**Air gap',                                                                    # NOQA
+                    '***Aspirating 20 ',                                                            # NOQA
+                    '**Dispensing 20 at <Deck><Slot A2><Container 96-flat><Well A1>',               # NOQA
+                    '**Dispensing 60.0 at <Deck><Slot A2><Container 96-flat><Well A1>',             # NOQA
+                    '**Air gap',                                                                    # NOQA
+                    '***Aspirating 20 ',                                                            # NOQA
+                    '**Dispensing 20 at <Deck><Slot A2><Container 96-flat><Well B1>',               # NOQA
+                    '**Dispensing 60.0 at <Deck><Slot A2><Container 96-flat><Well B1>',             # NOQA
+                    '**Blowing out at <Deck><Slot A1><Container point><Well A1>',                   # NOQA
+                    '**Drop_tip at <Deck><Slot A1><Container point><Well A1>']                      # NOQA
+
+        assert self.robot.commands() == expected
         self.robot.clear_commands()
 
     def test_distribute_air_gap_and_disposal_vol(self):

--- a/app/test/specs/components/RunScreen.spec.js
+++ b/app/test/specs/components/RunScreen.spec.js
@@ -8,8 +8,8 @@ function getMockStore () {
   return {
     state: {
       runLog: [
-        { timestamp: 'today', command_description: 'some command' },
-        { timestamp: 'tomorrow', command_description: 'other command' }
+        { timestamp: 'today', command_description: '**some command' },
+        { timestamp: 'tomorrow', command_description: '*other command' }
       ]
     },
     actions: { finishRun: sinon.spy() }
@@ -24,8 +24,8 @@ describe('RunScreen.vue', () => {
     const runCommandSelector = runScreen.$el.querySelectorAll('.runCommand')
     const runLog = mockStore.state.runLog
     expect(runCommandSelector.length).to.equal(runLog.length)
-    const firstCommand = 'today - some command'
-    const secondCommand = 'tomorrow - other command'
+    const firstCommand = 'today: \u3000\u3000\u21B3some command'
+    const secondCommand = 'tomorrow: \u3000\u21B3other command'
     expect(runCommandSelector[0].textContent.trim()).to.equal(firstCommand)
     expect(runCommandSelector[1].textContent.trim()).to.equal(secondCommand)
   })

--- a/app/ui/components/RunScreen.vue
+++ b/app/ui/components/RunScreen.vue
@@ -2,7 +2,7 @@
   <div ref='commands' class='runScreen'>
     <div id="exit" @click='clearRunScreen()'>x</div>
     <div class='runCommand' v-for='command in runLog'>
-      {{command.timestamp}} - {{command.command_description}}
+      {{command.timestamp}}: {{ applyIndent(command.command_description) }}
     </div>
   </div>
 </template>
@@ -15,6 +15,16 @@
       }
     },
     methods: {
+      applyIndent(msg) {
+        const starCount = msg.split(/\*/).length - 1
+        const stars = Array(starCount + 1).join('*')
+        let msgArrows = stars
+          .replace('*', '\u21B3') // Replace first asterisk with arrow
+          .split('').reverse().join('') // Move arrow to end of string
+          .replace(/\*/g, '\u3000') // Replace rest of asterisks with spaces
+        msgArrows = starCount ? '\u3000' + msgArrows : msgArrows
+        return msgArrows + msg.slice(starCount)
+      },
       clearRunScreen() {
         this.$store.dispatch('finishRun')
         if (this.$store.state.detached) {

--- a/app/ui/login-routes.js
+++ b/app/ui/login-routes.js
@@ -4,7 +4,7 @@ import config from './config'
 import store from './store/store'
 import { getUserId } from './util'
 
-// Note: This is not in GTM because sending email data to GTM violoates
+// Note: This is not in GTM because sending email data to GTM violates
 // the GTM User Policy
 function emitAppUserInfo (userId, userEmail) {
   window.ot_dataLayer.push({userId: userId})


### PR DESCRIPTION
## Description:

Allows API shortcut commands to generate log messages. Before `consolidate`, `distribute`, and `transfer` did not generate log messages. This PR allows them to log messages and indicate depth of other nested pipette commands...

Pipette commands to be prepended with a `*`. Each star indicates that a pipette command is nested call to a previous call.

E.g. if `aspirate` calls `dispense` The log will read `aspirate, *dispense`


For the following pipette command:

```
p200.distribute(55, pcr_plate.wells('A1'), pcr_plate.rows('1'), touch_tip=True, blow_out=True)
```

The `robot.commands()` call prints,

```['Distributing 55ul from <Well A1> to <WellSeries: <Well A1>..<Well H1>>',
 '*Transferring 55ul from <Well A1> to <WellSeries: <Well A1>..<Well H1>>',
 '**Picking up tip from <Deck><Slot A1><Container tiprack-200ul><Well A1>',
 '**Aspirating 165.0 at <Deck><Slot C3><Container pcr><Well A1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well A1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well B1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well C1>',
 '**Blowing out ',
 '**Touching tip',
 '**Aspirating 165.0 at <Deck><Slot C3><Container pcr><Well A1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well D1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well E1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well F1>',
 '**Blowing out ',
 '**Touching tip',
 '**Aspirating 110.0 at <Deck><Slot C3><Container pcr><Well A1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well G1>',
 '**Touching tip',
 '**Dispensing 55.0 at <Deck><Slot C3><Container pcr><Well H1>',
 '**Blowing out ',
 '**Touching tip',
 '**Drop_tip at <Deck><Slot D2><Container point><Well A1>']
```

In the app run screen this looks like this,

![screen shot 2017-08-04 at 5 56 43 pm](https://user-images.githubusercontent.com/1294344/28988568-644b308e-793e-11e7-8c1b-07499ce0ce94.png)



Check List:

- [x] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [x] added unit tests if necessary