### PR TITLE
(Chore) Update stylelint and move tasks to Makefile

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -12,7 +12,7 @@ ENV := $(BIN)/cross-env NODE_ENV
 # tasks
 #####################################################################
 
-.PHONY: test test-ui clean install package
+.PHONY: install build package dev clean
 
 install:
 	npm install
@@ -34,30 +34,6 @@ package: build
 	export OT_COMMIT_SUFFIX=$(OT_COMMIT_SUFFIX) && \
 	npm run package
 
-# test tasks
-#####################################################################
-
-# watch argument for tests
-watch ?= false
-
-test: test-ui
-	make lint
-
-test-e2e: build
-	npm run test-e2e
-
-test-ui:
-	$(ENV)=test $(BIN)/jest './ui/.*\.test\.js' --watch=$(watch)
-
-lint:
-	$(BIN)/standard --verbose | $(BIN)/snazzy
-
-lint-fix:
-	$(BIN)/standard --fix
-
-# development tasks
-#####################################################################
-
 dev:
 	npm run build-dev
 	npm run dev
@@ -69,3 +45,35 @@ clean:
 		dll \
 		bin \
 		coverage
+
+# test tasks
+#####################################################################
+
+.PHONY: test test-e2e test-ui lint lint-js lint-js-fix lint-css lint-css-fix
+
+# watch argument for tests
+watch ?= false
+
+test: test-ui
+	$(MAKE) lint
+
+test-e2e: build
+	npm run test-e2e
+
+test-ui:
+	$(ENV)=test $(BIN)/jest './ui/.*\.test\.js' --watch=$(watch)
+
+lint:
+	$(BIN)/concurrently "$(MAKE) lint-js" "$(MAKE) lint-css"
+
+lint-js:
+	$(BIN)/standard --verbose | $(BIN)/snazzy
+
+lint-js-fix:
+	$(BIN)/standard --fix
+
+lint-css:
+	$(BIN)/stylelint '**/*.css' --verbose
+
+lint-css-fix:
+	$(BIN)/stylelint '**/*.css' --fix

--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,6 @@
     "test-all": "npm run lint && npm run test && npm run build && npm run test-e2e",
     "test-watch": "npm test -- --watch",
     "test-e2e": "cross-env ENABLE_VIRTUAL_SMOOTHIE=true INTEGRATION_TEST=true mocha --compilers js:babel-core/register --timeout 60000 test/e2e/integration_test.js",
-    "lint-styles": "stylelint app/*.css app/components/*.css --syntax scss",
-    "lint-styles-fix": "stylefmt -r app/*.css app/components/*.css",
     "hot-updates-server": "cross-env NODE_ENV=development node --trace-warnings -r babel-register ./node_modules/webpack-dev-server/bin/webpack-dev-server --config webpack.config.renderer.dev.js",
     "build": "concurrently \"npm run build-main\" \"npm run build-renderer\"",
     "build-dll": "cross-env NODE_ENV=development node --trace-warnings -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.renderer.dev.dll.js --profile --colors",
@@ -121,6 +119,13 @@
       "jest": true
     }
   },
+  "stylelint": {
+    "extends": "stylelint-config-standard",
+    "ignoreFiles": [
+      "**/dist/**",
+      "**/coverage/**"
+    ]
+  },
   "devDependencies": {
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
@@ -174,9 +179,8 @@
     "spectron": "^3.7.0",
     "standard": "^10.0.3",
     "style-loader": "^0.18.1",
-    "stylefmt": "^5.3.2",
-    "stylelint": "^7.10.1",
-    "stylelint-config-standard": "^16.0.0",
+    "stylelint": "~8.0.0",
+    "stylelint-config-standard": "^17.0.0",
     "url-loader": "^0.5.8",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.8.2",


### PR DESCRIPTION
This is a little PR to fix up CSS linting in `app`. This changes the Makefile linting tasks to look like:

* `make lint` - Lints JavaScript and CSS
* `make lint-js` and `make lint-js-fix` - Lints JS and fixes JS, respectively
* `make lint-css` and `make lint-css-fix` - Lints CSS and fixes CSS, respectively

Also, editor plugins! https://github.com/stylelint/stylelint/blob/master/docs/user-guide/complementary-tools.md#editor-plugins