### PR TITLE
Add interface state module and add hooks for nav panel

### DIFF
--- a/app/ui/containers/Root.js
+++ b/app/ui/containers/Root.js
@@ -3,7 +3,11 @@ import React from 'react'
 import {connect} from 'react-redux'
 
 import {
-  NAME as ROBOT_NAME,
+  actions as interfaceActions,
+  selectors as interfaceSelectors
+} from '../interface'
+
+import {
   actions as robotActions,
   selectors as robotSelectors
 } from '../robot'
@@ -12,9 +16,13 @@ import App from '../components/app'
 
 const mapStateToProps = (state) => {
   return {
+    // interface
+    isNavPanelOpen: interfaceSelectors.getIsNavPanelOpen(state),
+
+    // robot
     isRunning: state.robot.isRunning,
     isConnected: state.robot.isConnected,
-    connectionStatus: robotSelectors.getConnectionStatus(state[ROBOT_NAME]),
+    connectionStatus: robotSelectors.getConnectionStatus(state),
 
     // TODO(mc): remove development hardcoded values
     isPaused: false,
@@ -38,6 +46,10 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
+    // interface
+    onNavButtonClick: () => dispatch(interfaceActions.toggleNavPanel()),
+
+    // robot
     onRunButtonClick: () => dispatch(robotActions.run()),
     // TODO(mc): revisit when robot discovery / multiple robots is addressed
     onConnectButtonClick: () => dispatch(robotActions.connect())

--- a/app/ui/index.js
+++ b/app/ui/index.js
@@ -6,7 +6,13 @@ import {createStore, combineReducers, applyMiddleware} from 'redux'
 import {AppContainer} from 'react-hot-loader'
 import {createLogger} from 'redux-logger'
 
-// robot logic
+// interface state
+import {
+  NAME as INTERFACE_NAME,
+  reducer as interfaceReducer
+} from './interface'
+
+// robot state
 import {
   NAME as ROBOT_NAME,
   reducer as robotReducer,
@@ -17,6 +23,7 @@ import {
 import Root from './containers/Root'
 
 const reducer = combineReducers({
+  [INTERFACE_NAME]: interfaceReducer,
   [ROBOT_NAME]: robotReducer
 })
 

--- a/app/ui/interface/README.md
+++ b/app/ui/interface/README.md
@@ -1,0 +1,61 @@
+# user interface state module
+
+Redux state, selectors, reducer, actions, and middleware for dealing with interface state in the app
+
+``` js
+import {
+  NAME,
+  selectors,
+  actionTypes,
+  actions,
+  reducer
+} from './interface'
+```
+
+To use this module, add the interface reducer to the root reducer:
+
+``` js
+import {combineReducers} from 'redux'
+import {
+  NAME as INTERFACE_NAME,
+  reducer as interfaceReducer
+} from './interface'
+
+const rootReducer = combineReducers({
+  // ...
+  [INTERFACE_NAME]: interfaceReducer
+  // ...
+})
+```
+
+## selectors
+
+Selectors to get information from the state. Use them in `mapStateToProps`:
+
+``` js
+import {selectors} from './interface'
+
+const mapStateToProps = (state) => ({
+  isNavPanelOpen: selectors.getIsNavPanelOpen(state)
+})
+```
+
+name                          | value   | description
+------------------------------|---------|-------------------------------------
+`selectors.getIsNavPanelOpen` | Boolean | Whether or not the nav panel is open
+
+## action creators
+
+Action creators to modify the interface state. Use them in `mapDispatchToProps`:
+
+``` js
+import {actions} from './interface'
+
+const mapDispatchToProps = (dispatch) => ({
+  onNavButtonClick: () => dispatch(actions.toggleNavPanel())
+})
+```
+
+action                     | args | description
+---------------------------|------|-----------------------------------------
+`actions.toggleNavPanel()` | none | Toggles the open state of the nav panel

--- a/app/ui/interface/index.js
+++ b/app/ui/interface/index.js
@@ -1,0 +1,41 @@
+// user interface state module
+
+import {makeActionName} from '../util'
+
+export const NAME = 'interface'
+
+const makeInterfaceActionName = (action) => makeActionName(NAME, action)
+const getModuleState = (state) => state[NAME]
+
+const INITIAL_STATE = {
+  isNavPanelOpen: false
+}
+
+export const selectors = {
+  getIsNavPanelOpen (allState) {
+    return getModuleState(allState).isNavPanelOpen
+  }
+}
+
+export const actionTypes = {
+  TOGGLE_NAV_PANEL: makeInterfaceActionName('TOGGLE_NAV_PANEL')
+}
+
+export const actions = {
+  toggleNavPanel () {
+    return {
+      type: actionTypes.TOGGLE_NAV_PANEL
+    }
+  }
+}
+
+export function reducer (state = INITIAL_STATE, action) {
+  const {type} = action
+
+  switch (type) {
+    case actionTypes.TOGGLE_NAV_PANEL:
+      return {...state, isNavPanelOpen: !state.isNavPanelOpen}
+  }
+
+  return state
+}

--- a/app/ui/interface/test/actions.test.js
+++ b/app/ui/interface/test/actions.test.js
@@ -1,0 +1,11 @@
+// interface actions test
+
+import {actions, actionTypes} from '../'
+
+describe('interface actions', () => {
+  test('toggle nav panel', () => {
+    const expected = {type: actionTypes.TOGGLE_NAV_PANEL}
+
+    expect(actions.toggleNavPanel()).toEqual(expected)
+  })
+})

--- a/app/ui/interface/test/reducer.test.js
+++ b/app/ui/interface/test/reducer.test.js
@@ -1,0 +1,23 @@
+// interface reducer test
+
+import {reducer, actionTypes} from '../'
+
+describe('interface reducer', () => {
+  test('initial state', () => {
+    const state = reducer(undefined, {})
+
+    expect(state).toEqual({
+      isNavPanelOpen: false
+    })
+  })
+
+  test('handles toggleNavPanel', () => {
+    const action = {type: actionTypes.TOGGLE_NAV_PANEL}
+
+    let state = {isNavPanelOpen: false}
+    expect(reducer(state, action)).toEqual({isNavPanelOpen: true})
+
+    state = {isNavPanelOpen: true}
+    expect(reducer(state, action)).toEqual({isNavPanelOpen: false})
+  })
+})

--- a/app/ui/interface/test/selectors.test.js
+++ b/app/ui/interface/test/selectors.test.js
@@ -1,0 +1,11 @@
+// interface selectors test
+
+import {NAME, selectors} from '../'
+
+describe('user interface selectors', () => {
+  test('get is nav panel open', () => {
+    const state = {[NAME]: {isNavPanelOpen: true}}
+
+    expect(selectors.getIsNavPanelOpen(state)).toBe(true)
+  })
+})

--- a/app/ui/robot/README.md
+++ b/app/ui/robot/README.md
@@ -1,0 +1,24 @@
+# robot state module
+
+Redux state, selectors, reducer, actions, and middleware for dealing with robot state in the app
+
+``` js
+import {
+  NAME,
+  constants,
+  selectors,
+  actions,
+  reducer,
+  apiClientMiddleware
+} from './robot'
+```
+
+## name and constants
+
+## selectors
+
+## actions
+
+## reducer
+
+## apiClientMiddleware

--- a/app/ui/robot/index.js
+++ b/app/ui/robot/index.js
@@ -1,12 +1,14 @@
-// robot UI entry point
+// robot state module
 // split up into reducer.js, action.js, etc if / when necessary
+import {makeActionName} from '../util'
 import api from './api-client'
 
 export const NAME = 'robot'
 
 // reducer / action helpers
-const makeActionName = (action) => `${NAME}:${action}`
+const makeRobotActionName = (action) => makeActionName(NAME, action)
 const makeRequestState = () => ({inProgress: false, error: null})
+const getModuleState = (state) => state[NAME]
 
 const INITIAL_STATE = {
   // robot connection
@@ -30,7 +32,9 @@ export const constants = {
 }
 
 export const selectors = {
-  getConnectionStatus: (state) => {
+  getConnectionStatus (allState) {
+    const state = getModuleState(allState)
+
     if (state.isConnected) return constants.CONNECTED
     if (state.connectRequest.inProgress) return constants.CONNECTING
     return constants.DISCONNECTED
@@ -41,15 +45,15 @@ export const apiClientMiddleware = api
 
 export const actionTypes = {
   // requests and responses
-  CONNECT: makeActionName('CONNECT'),
-  CONNECT_RESPONSE: makeActionName('CONNECT_RESPONSE'),
-  HOME: makeActionName('HOME'),
-  HOME_RESPONSE: makeActionName('HOME_RESPONSE'),
-  RUN: makeActionName('RUN'),
-  RUN_RESPONSE: makeActionName('RUN_RESPONSE'),
+  CONNECT: makeRobotActionName('CONNECT'),
+  CONNECT_RESPONSE: makeRobotActionName('CONNECT_RESPONSE'),
+  HOME: makeRobotActionName('HOME'),
+  HOME_RESPONSE: makeRobotActionName('HOME_RESPONSE'),
+  RUN: makeRobotActionName('RUN'),
+  RUN_RESPONSE: makeRobotActionName('RUN_RESPONSE'),
 
   // instantaneous state
-  SET_IS_CONNECTED: makeActionName('SET_IS_CONNECTED')
+  SET_IS_CONNECTED: makeRobotActionName('SET_IS_CONNECTED')
 }
 
 export const actions = {

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -1,17 +1,19 @@
 // robot selectors test
-import {selectors, constants} from '../'
+import {NAME, selectors, constants} from '../'
+
+const makeState = (state) => ({[NAME]: state})
 
 describe('robot selectors', () => {
   it('should be able to get connection status', () => {
     const {getConnectionStatus} = selectors
 
     let state = {isConnected: false, connectRequest: {inProgress: false}}
-    expect(getConnectionStatus(state)).toBe(constants.DISCONNECTED)
+    expect(getConnectionStatus(makeState(state))).toBe(constants.DISCONNECTED)
 
     state = {...state, connectRequest: {inProgress: true}}
-    expect(getConnectionStatus(state)).toBe(constants.CONNECTING)
+    expect(getConnectionStatus(makeState(state))).toBe(constants.CONNECTING)
 
     state = {isConnected: true, connectRequest: {inProgress: false}}
-    expect(getConnectionStatus(state)).toBe(constants.CONNECTED)
+    expect(getConnectionStatus(makeState(state))).toBe(constants.CONNECTED)
   })
 })

--- a/app/ui/util.js
+++ b/app/ui/util.js
@@ -1,26 +1,25 @@
-module.exports = {
-  getUserEmail,
-  getUserId,
-  getUserProfile,
-  isAuthenticated,
-}
+// utility functions
 
-function getUserId () {
+export function getUserId () {
   return getUserProfile().user_id || null
 }
 
-function getUserEmail () {
+export function getUserEmail () {
   return getUserProfile().email || null
 }
 
-function getUserProfile () {
+export function getUserProfile () {
   return JSON.parse(localStorage.getItem('profile') || '{}')
 }
 
-function isAuthenticated () {
+export function isAuthenticated () {
   const profile = localStorage.getItem('profile')
   const idToken = localStorage.getItem('id_token')
   if (profile == null) return false
   if (idToken == null) return false
   return true
+}
+
+export function makeActionName (moduleName, actionName) {
+  return `${moduleName}:${actionName}`
 }


### PR DESCRIPTION
This PR adds an interface state module for tracking purely UI based state. The only piece of state in there right now is the nav panel expanded state, but will probably incorporate other dropdowns, modals, etc.