### PR TITLE
Adding proper sequencing and back-pressure + cleanup

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -43,11 +43,11 @@ def parse_address(address):
     match = re.fullmatch(
         '^(\d+)\.(\d+)\.(\d+)\.(\d+)(:(?P<port>\d+))?$', address)
     if not match:
-        raise ValueError('address')
+        raise ValueError('Expected format ip[:port]. Example: 127.0.0.1:31950')
 
     octets = [o for o in match.groups()[0:4] if 0 <= int(o) <= 255]
     if len(octets) != 4:
-        raise ValueError('address')
+        raise ValueError('Expected octets to be between 0 and 255')
 
     port = match.groupdict().get('port', None)
     if port:
@@ -71,6 +71,9 @@ if __name__ == "__main__":
         print(str(e))
         exit(1)
 
+    # TODO(artyom, 20170828): consider moving class name definition into
+    # command line arguments, so one could us as a shell starting various
+    # RPC servers with different root objects from a command line
     server = Server(RobotContainer())
     print(
         'Started Opentrons API Server listening at ws://{host}:{port}/'

--- a/api/opentrons/server/robot_container.py
+++ b/api/opentrons/server/robot_container.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from asyncio import Queue
+from concurrent import futures
 from opentrons.robot.robot import Robot
 from opentrons.util.trace import EventBroker
 
@@ -19,19 +20,23 @@ class RobotContainer(object):
         self.notifications = Queue(loop=self.loop)
         EventBroker.get_instance().add(self.notify)
 
+    def same_thread(self):
+        try:
+            return asyncio.get_event_loop() == self.loop
+        except RuntimeError:
+            return True
+
     def update_filters(self, filters):
         def update():
             self.filters = set(filters)
 
-        try:
-            if asyncio.get_event_loop() != self.loop:
-                self.loop.call_soon_threadsafe(update)
-            else:
-                update()
-        except RuntimeError:
-            # If running tests and event loop is not set
-            # get_event_loop will throw a RuntimeError
+        # If same thread, just call the function,
+        # without wrapping it into threadsafe call
+        # to prevent freezing during test run
+        if self.same_thread():
             update()
+        else:
+            self.loop.call_soon_threadsafe(update)
 
     def notify(self, info):
         if info.get('name', None) not in self.filters:
@@ -44,8 +49,12 @@ class RobotContainer(object):
         if 'self' in arguments:
             arguments['self_id'] = arguments.pop('self')
 
-        asyncio.run_coroutine_threadsafe(
+        future = asyncio.run_coroutine_threadsafe(
                 self.notifications.put(info), self.loop)
+
+        # If same thread, don't wait, will freeze otherwise
+        if not self.same_thread():
+            futures.wait([future])
 
     def reset_robot(self, robot):
         # robot is essentially a singleton

--- a/api/opentrons/server/robot_container.py
+++ b/api/opentrons/server/robot_container.py
@@ -32,7 +32,6 @@ class RobotContainer(object):
 
         # If same thread, just call the function,
         # without wrapping it into threadsafe call
-        # to prevent freezing during test run
         if self.same_thread():
             update()
         else:

--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -7,7 +7,6 @@ import traceback
 
 from aiohttp import web
 from asyncio import Queue
-from concurrent import futures
 from opentrons.server import serialize
 from threading import Thread
 from threading import current_thread
@@ -297,6 +296,8 @@ class Server(object):
                     id(current_thread())))
                 self.send(response)
 
+        log.info('Scheduling a call from thread id {0}'
+                 .format(id(current_thread())))
         asyncio.run_coroutine_threadsafe(
             call(func),
             self.exec_loop)

--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -6,6 +6,7 @@ import logging
 import traceback
 
 from aiohttp import web
+from aiohttp import WSCloseCode
 from asyncio import Queue
 from opentrons.server import serialize
 from threading import Thread

--- a/api/opentrons/server/tests/conftest.py
+++ b/api/opentrons/server/tests/conftest.py
@@ -1,38 +1,41 @@
-import logging
+# Uncomment to enable logging during tests
+# import logging
+# from logging.config import dictConfig
+
 import pytest
 import os
 
 from collections import namedtuple
-from logging.config import dictConfig
 from opentrons.server import rpc
 from uuid import uuid4 as uuid
 
-logging_config = dict(
-    version=1,
-    formatters={
-        'basic': {
-            'format':
-            '[Line %(lineno)s] %(message)s'
-        }
-    },
-    handlers={
-        'debug': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'basic',
-        }
-    },
-    loggers={
-        '__main__': {
-            'handlers': ['debug'],
-            'level': logging.DEBUG
-        },
-        'opentrons.server': {
-            'handlers': ['debug'],
-            'level': logging.DEBUG
-        },
-    }
-)
-dictConfig(logging_config)
+# Uncomment to enable logging during tests
+# logging_config = dict(
+#     version=1,
+#     formatters={
+#         'basic': {
+#             'format':
+#             '[Line %(lineno)s] %(message)s'
+#         }
+#     },
+#     handlers={
+#         'debug': {
+#             'class': 'logging.StreamHandler',
+#             'formatter': 'basic',
+#         }
+#     },
+#     loggers={
+#         '__main__': {
+#             'handlers': ['debug'],
+#             'level': logging.DEBUG
+#         },
+#         'opentrons.server': {
+#             'handlers': ['debug'],
+#             'level': logging.DEBUG
+#         },
+#     }
+# )
+# dictConfig(logging_config)
 
 Session = namedtuple(
     'Session',
@@ -57,7 +60,9 @@ def protocol(request):
 @pytest.fixture
 def robot_container(loop, request):
     from opentrons.server import robot_container
-    container = robot_container.RobotContainer(loop=loop)
+    container = robot_container.RobotContainer(
+        loop=loop,
+        filters=['add-command', 'move-to'])
     yield container
     container.finalize()
 

--- a/api/opentrons/server/tests/conftest.py
+++ b/api/opentrons/server/tests/conftest.py
@@ -89,7 +89,7 @@ def session(loop, test_client, request):
         return await socket.send_json(request)
 
     def finalizer():
-        server.stop()
+        server.shutdown()
 
     request.addfinalizer(finalizer)
     return Session(server, socket, token, call)

--- a/api/opentrons/server/tests/test_integration.py
+++ b/api/opentrons/server/tests/test_integration.py
@@ -27,12 +27,6 @@ async def test_notifications(session, robot_container, protocol):
 
     responses = []
 
-    # NOTE: Streaming absolutely every response in the loop
-    # causes aiohttp flow control to fail and start
-    # composing partial frames. For now, we'll just sample
-    # 50 responses we've got, and confirm that all are notifications
-    # which means that async calls are working and the actual
-    # call hasn't returned yet, but notifications are coming in
     while True:
         res = await session.socket.receive_json()
         if (res['$']['type'] == rpc.CALL_RESULT_MESSAGE):


### PR DESCRIPTION
This PR:
* Fixes sequencing errors and dropped frames.
* Cleans up IP address parse errors in main.py.
* Makes main.py handle `SIGINT` (`^C`) gracefully again.

# Sequencing errors and dropped frames

When making calls that produce notifications, the following could happen:
* A client could receive `CALL_RESULT_MESSAGE` *before* receiving all notifications produced during the call;
* Notifications are arriving too fast can result in server dropping frames, making responses invalid.

In order to fix this the following changes have been made:

* Added a send queue to separate producer and consumer
* In `rpc.py` adding call result to the queue from `exec_loop` after function call returns
* In `rpc.py` call `await client.drain()` to wait for socket buffer to be transmitted, before sending more data (http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.StreamResponse.drain)
* In `robot_container.py` wait for notification to be added to the queue before exiting `notify()`