### PR TITLE
(Chore) App 3.0 - Collect both app and API coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,6 @@ before_install:
 
 install:
   - source scripts/install-${TRAVIS_OS_NAME} # OS-specific installs
-  # TODO(mc, 2017-08-28): these should be in requirements.txt, but also are
-  # either pyyaml or coveralls needed anymore?
-  - pip install pyyaml coveralls
   - make install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,23 +42,26 @@ before_install:
 
 install:
   - source scripts/install-${TRAVIS_OS_NAME} # OS-specific installs
+  # TODO(mc, 2017-08-28): these should be in requirements.txt, but also are
+  # either pyyaml or coveralls needed anymore?
   - pip install pyyaml coveralls
-  - make -C api install
-  - make -C app install
+  - make install
 
 script:
   - "export OT_TIME_SUFFIX=-$(date '+%Y-%m-%d_%H-%M')"
   - "export OT_BRANCH_SUFFIX=-${TRAVIS_BRANCH}"
   - "export OT_COMMIT_SUFFIX=-${TRAVIS_COMMIT:0:7}"
+  # TODO(mc, 2018-08-28): use top level `make test`
   - make -C api test exe
   - > # Make docs on linux only
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then (make -C api docs > /dev/null) fi;
+  # TODO(mc, 2018-08-28): use top level `make test`
   - make -C app -j 2 build test && make -C app package
   # Clean up. This will leave only single-file build artifacts
   - find ./app/dist/** ! -name 'opentrons-v*' -exec rm -rf {} +
 
 after_success:
-  - cd api && coveralls && cd ..
+  - make coverage
 
 # Deploy the build version in an S3 bucket
 deploy:
@@ -78,7 +81,7 @@ deploy:
   # Publish API to PyPI and Anaconda
   - provider: script
     skip_cleanup: true
-    script: cd api && make publish && cd ..
+    script: make -C api publish
     on:
       tags: true
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# opentrons platform makefile
+# https://github.com/OpenTrons/opentrons
+
+SHELL := /bin/bash
+
+API_DIR := api
+APP_DIR := app
+
+.PHONY: install test coverage
+
+# install project dependencies for both api and app
+install:
+	$(MAKE) -C $(API_DIR) install
+	$(MAKE) -C $(APP_DIR) install
+
+# run api and app tests
+test:
+	$(MAKE) -C $(API_DIR) test
+	$(MAKE) -C $(APP_DIR) test
+
+# upload coverage reports
+# uses codecov's bash upload script
+# TODO(mc, 2018-08-28): add test as a task dependency once travis is setup to
+# use this Makefile for tests
+coverage:
+	$(SHELL) <(curl -s https://codecov.io/bash) -X coveragepy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Opentrons Platform
 
+[![Travis CI][travis-badge]][travis]
+[![Codecov][codecov-badge]][codecov]
+
 * [Overview](#overview)
 * [Opentrons API](#api)
 * [OT-App](#app)
@@ -134,3 +137,8 @@ make dev
 ```
 
 Enjoy!
+
+[travis]: https://travis-ci.org/OpenTrons/opentrons/branches
+[travis-badge]: https://img.shields.io/travis/OpenTrons/opentrons/app-3-0.svg?style=flat-square&maxAge=3600
+[codecov]: https://codecov.io/gh/OpenTrons/opentrons/branches
+[codecov-badge]: https://img.shields.io/codecov/c/github/OpenTrons/opentrons/app-3-0.svg?style=flat-square&maxAge=3600

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -5,5 +5,5 @@ omit =
     */lib_pypy/_*.py
     */site-packages/ordereddict.py
     */site-packages/nose/*
-    */unittest2/*
+    */tests/*
     opentrons/_version.py

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,6 @@
-SHELL:=/bin/bash
+# opentrons api makefile
+
+SHELL := /bin/bash
 
 .PHONY: test docs publish clean install exe dev
 
@@ -6,7 +8,7 @@ install:
 	python setup.py install && pip install -r requirements.txt
 
 test:
-	pylama opentrons tests && py.test --cov
+	pylama opentrons tests && py.test --cov && coverage xml
 
 docs:
 	cd docs && make html && make doctest

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,4 @@
-# app makefile
+# opentrons app makefile
 
 # use bash
 SHELL := /bin/bash

--- a/app/package.json
+++ b/app/package.json
@@ -110,6 +110,9 @@
       "!webpack**",
       "!coverage/**",
       "!**/test/**"
+    ],
+    "coverageReporters": [
+      "lcov", "text"
     ]
   },
   "standard": {


### PR DESCRIPTION
Hey guys, another CI-focused chore PR here. This one lets us start collecting coverage information from both the API and the app (also, badges!).

I've switch our coverage provider from Coveralls to Codecov. I've used both in the past, with all my newer projects using Codecov. They're not that different, it's just the Codecov makes multi-language projects super easy, and Coveralls makes it less easy than that. Check out the report for this PR: https://codecov.io/gh/OpenTrons/opentrons/branch/v3-chore-coverage

I've also started a top-level Makefile to start coordinating stuff that until now has only lived in travis.yml. Basically, it has some tasks to call sub-tasks in the Makefiles of `app` and `api`. Right now it's got:

* `make install` - Install all pip and npm dependencies
* `make test` - Run all project tests
* `make coverage` - Upload all coverage reports to codecov

Reviewers: please give this a sanity check and let me know if you disagree with any decisions I've made here and/or know of better ways to do things