### PR TITLE
adds option to set plunger speed in uL/sec

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -81,7 +81,9 @@ class Pipette(Instrument):
             trash_container=None,
             tip_racks=[],
             aspirate_speed=300,
-            dispense_speed=500):
+            dispense_speed=500,
+            aspirate_flowrate=None,
+            dispense_flowrate=None):
 
         self.robot = robot
         self.axis = axis
@@ -153,6 +155,12 @@ class Pipette(Instrument):
         for key, val in self.positions.items():
             if val is None:
                 self.positions[key] = default_positions[key]
+
+        # converting flowrate to speed relies on calibrated plunger positions
+        if helpers.is_number(aspirate_flowrate):
+            self.set_flowrate(aspirate=aspirate_flowrate)
+        if helpers.is_number(dispense_flowrate):
+            self.set_flowrate(dispense=dispense_flowrate)
 
         self.calibrator = Calibrator(self.robot._deck, self.calibration_data)
 
@@ -1448,20 +1456,29 @@ class Pipette(Instrument):
             tips -= 1
         return tips
 
-    def set_speed(self, **kwargs):
+    def set_speed(self, aspirate=None, dispense=None):
         """
         Set the speed (mm/minute) the :any:`Pipette` plunger will move
         during :meth:`aspirate` and :meth:`dispense`
-
         Parameters
         ----------
         kwargs: Dict
             A dictionary who's keys are either "aspirate" or "dispense",
             and who's values are int or float (Example: `{"aspirate": 300}`)
         """
-        keys = {'aspirate', 'dispense'} & kwargs.keys()
-        for key in keys:
-            self.speeds[key] = kwargs.get(key)
+        if helpers.is_number(aspirate):
+            self.speeds['aspirate'] = aspirate
+        if helpers.is_number(dispense):
+            self.speeds['dispense'] = dispense
+        return self
+
+    def set_flowrate(self, aspirate=None, dispense=None):
+        ul_per_mm = self.max_volume / self._plunge_distance(self.max_volume)
+        if helpers.is_number(aspirate):
+            aspirate = (aspirate / ul_per_mm) * 60
+        if helpers.is_number(dispense):
+            dispense = (dispense / ul_per_mm) * 60
+        self.set_speed(aspirate=aspirate, dispense=dispense)
         return self
 
     @property

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -411,6 +411,24 @@ class PipetteTest(unittest.TestCase):
         self.p200.set_speed(dispense=100)
         self.assertEqual(self.p200.speeds['dispense'], 100)
 
+    def test_set_flowrate(self):
+
+        p = pipette.Pipette(
+            self.robot,
+            axis="b",
+            name='other-other-pipette-for-flowrate-tests',
+            max_volume=200,
+            aspirate_flowrate=50,
+            dispense_flowrate=75
+        )
+        p.set_max_volume(200)
+        # speed = (flowrate / (max_volume / plunger_distance)) * 60
+        self.assertEquals(p.speeds['aspirate'], 150)
+        self.assertEquals(p.speeds['dispense'], 225)
+        p.set_flowrate(aspirate=75, dispense=50)
+        self.assertEquals(p.speeds['aspirate'], 225)
+        self.assertEquals(p.speeds['dispense'], 150)
+
     def test_distribute(self):
         self.p200.reset()
         self.p200.distribute(


### PR DESCRIPTION
## Description:

Option to set a `Pipette`'s plunger speed in micro-liters-per-second (`uL/sec`)

Examples:
```
# set value on instantiation
p200 = Pipette(axis='b', max_volume=200, aspirate_flowrate=60, dispense_flowrate=120)
```
```
# update the value at any moment during protocol
p200.set_flowrate(aspirate=75, dispense=50)
```

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
