### PR TITLE
(v3) Feature - disconnect client

### DIFF
--- a/app/rpc/test/client.test.js
+++ b/app/rpc/test/client.test.js
@@ -1,3 +1,4 @@
+// RPC client tests
 import EventEmitter from 'events'
 import portfinder from 'portfinder'
 import WS from 'ws'

--- a/app/rpc/test/client.test.js
+++ b/app/rpc/test/client.test.js
@@ -61,6 +61,10 @@ describe('rpc client', () => {
     send (message) {
       this._ws.send(JSON.stringify(message))
     }
+
+    get readyState () {
+      return this._ws.readyState
+    }
   }
 
   beforeAll((done) => portfinder.getPort((error, port) => {
@@ -482,9 +486,21 @@ describe('rpc client', () => {
       })
     })
 
-    test('closes the socket', (done) => {
-      addListener(ws, 'close', done)
-      client.close()
+    test('closes the socket', () => {
+      return client.close()
+        .then(() => expect(
+          ws.readyState === global.WebSocket.CLOSING ||
+          ws.readyState === global.WebSocket.CLOSED
+        ).toBe(true))
+    })
+
+    test('client.close resolves if the socket is already closed', () => {
+      return client.close()
+        .then(() => client.close())
+        .then(() => expect(
+          ws.readyState === global.WebSocket.CLOSING ||
+          ws.readyState === global.WebSocket.CLOSED
+        ).toBe(true))
     })
   })
 })

--- a/app/rpc/websocket-client.js
+++ b/app/rpc/websocket-client.js
@@ -26,6 +26,12 @@ export default class WebSocketClient extends EventEmitter {
     this._ws.onmessage = (e) => this.emit('message', parseMessage(e.data))
     this._ws.onclose = (e) => this.emit('close', e.code, e.reason, e.wasClean)
     this._ws.onerror = (error) => this.emit('error', error)
+
+    // also export websocket readyState constants
+    this.CONNECTING = WebSocket.CONNECTING
+    this.OPEN = WebSocket.OPEN
+    this.CLOSING = WebSocket.CLOSING
+    this.CLOSED = WebSocket.CLOSED
   }
 
   get readyState () {

--- a/app/ui/components/NavPanel.js
+++ b/app/ui/components/NavPanel.js
@@ -62,7 +62,7 @@ SetupPanel.propTypes = {
 }
 
 const ConnectPanel = props => {
-  const {isConnected, onConnectClick} = props
+  const {isConnected, onConnectClick, onDisconnectClick} = props
   let connectButton
   let connectionStatus
   if (!isConnected) {
@@ -78,7 +78,7 @@ const ConnectPanel = props => {
   } else {
     connectButton =
       <Button
-        onClick={() => console.log('disconnect')}
+        onClick={onDisconnectClick}
         disabled={!isConnected}
         style={styles.btn_connect}
       >
@@ -100,7 +100,8 @@ const ConnectPanel = props => {
 
 ConnectPanel.propTypes = {
   isConnected: PropTypes.bool.isRequired,
-  onConnectClick: PropTypes.func.isRequired
+  onConnectClick: PropTypes.func.isRequired,
+  onDisconnectClick: PropTypes.func.isRequired
 }
 
 const panel = (props) => ({

--- a/app/ui/containers/Nav.js
+++ b/app/ui/containers/Nav.js
@@ -37,6 +37,7 @@ const mapDispatchToProps = (dispatch) => {
     // robot
     // TODO(mc): revisit when robot discovery / multiple robots is addressed
     onConnectClick: () => dispatch(robotActions.connect()),
+    onDisconnectClick: () => dispatch(robotActions.disconnect()),
     onRunClick: () => dispatch(robotActions.run()),
 
     // session

--- a/app/ui/containers/Root.js
+++ b/app/ui/containers/Root.js
@@ -47,8 +47,6 @@ const mapDispatchToProps = (dispatch) => {
     onNavIconClick: (panel) => () => dispatch(interfaceActions.setCurrentNavPanel(panel)),
 
     // robot
-    // TODO(mc): revisit when robot discovery / multiple robots is addressed
-    onConnectClick: () => dispatch(robotActions.connect()),
     onRunClick: () => dispatch(robotActions.run()),
     onPauseClick: () => dispatch(robotActions.pause()),
     onResumeClick: () => dispatch(robotActions.resume()),

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -10,6 +10,8 @@ export const actionTypes = {
   // requests and responses
   CONNECT: makeRobotActionName('CONNECT'),
   CONNECT_RESPONSE: makeRobotActionName('CONNECT_RESPONSE'),
+  DISCONNECT: makeRobotActionName('DISCONNECT'),
+  DISCONNECT_RESPONSE: makeRobotActionName('DISCONNECT_RESPONSE'),
   SESSION: makeRobotActionName('SESSION'),
   SESSION_RESPONSE: makeRobotActionName('SESSION_RESPONSE'),
   HOME: makeRobotActionName('HOME'),
@@ -33,6 +35,15 @@ export const actions = {
 
   connectResponse (error = null) {
     return {type: actionTypes.CONNECT_RESPONSE, error}
+  },
+
+  // TODO(mc, 2017-09-07): connect should take a URL or robot identifier
+  disconnect () {
+    return makeRobotAction({type: actionTypes.DISCONNECT})
+  },
+
+  disconnectResponse (error = null) {
+    return {type: actionTypes.DISCONNECT_RESPONSE, error}
   },
 
   // get session or make new session with protocol file

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -81,17 +81,21 @@ export default function client (dispatch) {
   }
 
   function disconnect () {
-    if (rpcClient) rpcClient.close()
+    if (!rpcClient) return dispatch(actions.disconnectResponse())
 
-    // null out saved client and session
-    rpcClient = null
-    sessionManager = null
-    session = null
-    robot = null
-    // TODO(mc, 2017-09-07): remove when server handles serial port
-    serialPort = null
+    rpcClient.close()
+      .then(() => {
+        // null out saved client and session
+        rpcClient = null
+        sessionManager = null
+        session = null
+        robot = null
+        // TODO(mc, 2017-09-07): remove when server handles serial port
+        serialPort = null
 
-    dispatch(actions.disconnectResponse())
+        dispatch(actions.disconnectResponse())
+      })
+      .catch((error) => dispatch(actions.disconnectResponse(error)))
   }
 
   function createSession (state, action) {

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -23,6 +23,10 @@ export default function client (dispatch) {
         connect(state, action)
         break
 
+      case actionTypes.DISCONNECT:
+        disconnect(state, action)
+        break
+
       case actionTypes.SESSION:
         createSession(state, action)
         break
@@ -74,6 +78,20 @@ export default function client (dispatch) {
         dispatch(actions.connectResponse())
       })
       .catch((e) => dispatch(actions.connectResponse(e)))
+  }
+
+  function disconnect () {
+    if (rpcClient) rpcClient.close()
+
+    // null out saved client and session
+    rpcClient = null
+    sessionManager = null
+    session = null
+    robot = null
+    // TODO(mc, 2017-09-07): remove when server handles serial port
+    serialPort = null
+
+    dispatch(actions.disconnectResponse())
   }
 
   function createSession (state, action) {

--- a/app/ui/robot/reducer.js
+++ b/app/ui/robot/reducer.js
@@ -38,6 +38,7 @@ const handleResponse = (state, request, payload, error, props = {}) => ({
 const INITIAL_STATE = {
   // robot API connection
   connectRequest: makeRequestState(),
+  disconnectRequest: makeRequestState(),
   isConnected: false,
 
   // protocol/workflow session
@@ -161,6 +162,20 @@ export function reducer (state = INITIAL_STATE, action) {
     case actionTypes.CONNECT_RESPONSE:
       return handleResponse(state, 'connectRequest', payload, error, {
         isConnected: error == null
+      })
+
+    case actionTypes.DISCONNECT:
+      return handleRequest(state, 'disconnectRequest', payload, error)
+
+    case actionTypes.DISCONNECT_RESPONSE:
+      return handleResponse(state, 'disconnectRequest', payload, error, {
+        isConnected: error != null,
+        sessionName: error ? state.sessionName : '',
+        protocolText: error ? state.protocolText : '',
+        protocolCommands: error ? state.protocolCommands : [],
+        protocolCommandsById: error ? state.protocolCommandsById : {},
+        sessionErrors: error ? state.sessionErrors : [],
+        sessionState: error ? state.sessionState : ''
       })
 
     case actionTypes.SESSION:

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -21,6 +21,24 @@ describe('robot actions', () => {
     expect(actions.connectResponse(new Error('AHHH'))).toEqual(expected)
   })
 
+  test('disconnect action', () => {
+    const expected = {
+      type: actionTypes.DISCONNECT,
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.disconnect()).toEqual(expected)
+  })
+
+  test('disconnect response action', () => {
+    const expected = {
+      type: actionTypes.DISCONNECT_RESPONSE,
+      error: new Error('AHHH')
+    }
+
+    expect(actions.disconnectResponse(new Error('AHHH'))).toEqual(expected)
+  })
+
   test('session action', () => {
     const file = {name: '/foo/bar/baz.py'}
     const expected = {

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -42,6 +42,7 @@ describe('api client', () => {
     // mock rpc client
     rpcClient = {
       on: jest.fn(() => rpcClient),
+      close: jest.fn(),
       remote: sessionManager
     }
 
@@ -54,7 +55,7 @@ describe('api client', () => {
     RpcClient.mockReset()
   })
 
-  describe('connect', () => {
+  describe('connect and disconnect', () => {
     test('connect RpcClient on CONNECT message', () => {
       expect(RpcClient).toHaveBeenCalledTimes(0)
       receive({}, actions.connect())
@@ -102,6 +103,30 @@ describe('api client', () => {
 
       return delay(1)
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
+    })
+
+    test('disconnect RPC on DISCONNECT message', () => {
+      receive({}, actions.connect())
+
+      return delay(1)
+        .then(() => receive({}, actions.disconnect()))
+        .then(() => expect(rpcClient.close).toHaveBeenCalled())
+    })
+
+    test('dispatch DISCONNECT_RESPONSE if already disconnected', () => {
+      const expected = actions.disconnectResponse()
+      receive({}, actions.disconnect())
+      expect(dispatch).toHaveBeenCalledWith(expected)
+    })
+
+    test('dispatch DISCONNECT_RESPONSE if close is called', () => {
+      const expected = actions.disconnectResponse()
+
+      receive({}, actions.connect())
+
+      return delay(1)
+        .then(() => receive({}, actions.disconnect()))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
   })
 })

--- a/app/ui/robot/test/reducer.test.js
+++ b/app/ui/robot/test/reducer.test.js
@@ -16,6 +16,7 @@ describe('robot reducer', () => {
 
     expect(state).toEqual({
       connectRequest: {inProgress: false, error: null},
+      disconnectRequest: {inProgress: false, error: null},
       isConnected: false,
 
       sessionRequest: {inProgress: false, error: null},
@@ -68,6 +69,70 @@ describe('robot reducer', () => {
     expect(reducer(state, action)).toEqual({
       connectRequest: {inProgress: false, error: new Error('AH')},
       isConnected: false
+    })
+  })
+
+  test('handles disconnect action', () => {
+    const state = {
+      disconnectRequest: {inProgress: false, error: new Error('AH')}
+    }
+    const action = {type: actionTypes.DISCONNECT}
+
+    expect(reducer(state, action)).toEqual({
+      disconnectRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles disconnect response success', () => {
+    const state = {
+      disconnectRequest: {inProgress: true, error: null},
+      isConnected: true,
+      sessionName: 'session.py',
+      protocolText: 'from opentrons import robot',
+      protocolCommands: [{id: 'foo'}],
+      protocolCommandsById: {foo: {id: 'foo'}},
+      sessionErrors: [{message: 'AHH'}],
+      sessionState: 'running'
+    }
+    const action = {type: actionTypes.DISCONNECT_RESPONSE, error: null}
+
+    expect(reducer(state, action)).toEqual({
+      disconnectRequest: {inProgress: false, error: null},
+      isConnected: false,
+      sessionName: '',
+      protocolText: '',
+      protocolCommands: [],
+      protocolCommandsById: {},
+      sessionErrors: [],
+      sessionState: ''
+    })
+  })
+
+  test('handles disconnectResponse failure', () => {
+    const state = {
+      disconnectRequest: {inProgress: true, error: null},
+      isConnected: true,
+      sessionName: 'session.py',
+      protocolText: 'from opentrons import robot',
+      protocolCommands: [{id: 'foo'}],
+      protocolCommandsById: {foo: {id: 'foo'}},
+      sessionErrors: [{message: 'AHH'}],
+      sessionState: 'running'
+    }
+    const action = {
+      type: actionTypes.DISCONNECT_RESPONSE,
+      error: new Error('AH')
+    }
+
+    expect(reducer(state, action)).toEqual({
+      disconnectRequest: {inProgress: false, error: new Error('AH')},
+      isConnected: true,
+      sessionName: 'session.py',
+      protocolText: 'from opentrons import robot',
+      protocolCommands: [{id: 'foo'}],
+      protocolCommandsById: {foo: {id: 'foo'}},
+      sessionErrors: [{message: 'AHH'}],
+      sessionState: 'running'
     })
   })
 


### PR DESCRIPTION
## Description

- Adds disconnect state and actions to store
- Wires up those actions to the UI
- Promisifies existing close method of RcpClient (resolve if actual WebSocket state changes to closed)

## Review requests

- Standard review for correctness
- Make sure it works as expected on your machine
    - API doesn't handle reconnects super well at the moment
    - Some bugginess with the API is therefor expected

Check List:

- [x] Are there breaking changes in the API and how are they being communicated?
    - Nothing public
- [x] Who is reviewing your code?
    - @OpenTrons/js 
