### PR TITLE
(Chore) - Flesh out PR template and add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+## overview
+
+This issue is for:
+
+- [ ] Bug, feature request, or other (if other, please describe below)?
+- [ ] API, App, both?
+- [ ] Version?
+- [ ] OS and OS version?
+
+## expected or desired behavior
+
+Describe how you expect the software to act or how you think the software should act.
+
+## actual behavior
+
+Describe how the software actually behaves.
+
+## steps to reproduce problem
+
+1. Steal underpants 
+2. ???
+3. Profit!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,31 @@
-## Description:
+## overview
 
+Write a high level description of the pull request.
 
-Check List:
+This PR includes:
 
-- [ ] Are there breaking changes in the API and how are they being communicated?
-- [ ] Who is reviewing your code?
+- [ ] Chore work
+- [ ] Bug fixes
+- [ ] Backwards-compatible feature additions
+- [ ] Breaking changes
+- [ ] Documentation updates
+- [ ] Test updates
+
+**Note**: If you did not check "Documentation updates" and/or "Test updates" then your PR may not be ready!
+
+## changelog
+
+Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.
+
+- (Chore) Change description
+- (Fix) Change description
+- (Feature) Change description
+- (Refactor) Change description
+- (Docs) Change description
+- (Tests) Change description
+
+**Note**: If your PR incorporates many changes, or many different types of changes, please consider splitting it up into smaller PRs.
+
+## review requests
+
+Describe any specific requests for your reviewers here. Tag any people or groups as necessary.


### PR DESCRIPTION
## overview

So, I fell down a pull-request/issue template rabbit hole the other day (mostly thanks to [this repository](https://github.com/stevemao/github-issue-templates)), and I thought there was some opportunity to improve ours! The following PR description is written using this new PR template.

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

- (Chore) Flesh out PR template to ensure change type and review needs info is present
- (Chore) Add an issue template to help capture relevant info

## review requests

This PR is basically a proposal, so @OpenTrons/py and @OpenTrons/js please sound off if you think anything is missing, if you think this whole effort is unnecessary, if you have a brilliant idea, etc.