### PR TITLE
rounds plunger positions to avoid 2.5.x calibration bug

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1109,7 +1109,7 @@ class Pipette(Instrument):
         current_position = self.robot._driver.get_plunger_positions()
         current_position = current_position['target'][self.axis]
         kwargs = {}
-        kwargs[position] = current_position
+        kwargs[position] = round(current_position, 1)
         self.calibrate_plunger(**kwargs)
 
         return self


### PR DESCRIPTION
## Description:

Rounds calibrated plunger coordinates to 1 decimal place to address reported UI bug in https://github.com/OpenTrons/opentrons/issues/337

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
