### PR TITLE
Serialization: filter private attributes of objects serialized

### DIFF
--- a/api/opentrons/server/serialize.py
+++ b/api/opentrons/server/serialize.py
@@ -48,7 +48,11 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa C901
         except TypeError:
             pass
         tail = {i: v for i, v in enumerate(items)}
-        return object_container({**iterate(obj.__dict__), **tail})
+
+        # Filter out private attributes
+        attributes = {
+            k: v for k, v in obj.__dict__.items() if not k.startswith('_')}
+        return object_container({**iterate(attributes), **tail})
     else:
         return object_container({})
 

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -116,16 +116,12 @@ async def test_get_object_by_id(session, root):
                     'i': type_id(session.server.root),
                     't': id(type),
                     'v': set([
-                        '__dict__',
-                        '__module__',
                         'value',
-                        '__init__',
-                        '__doc__',
                         'throw',
                         'next',
                         'combine',
-                        'add',
-                        '__weakref__'])
+                        'add'
+                       ])
                     }
                 }
     # We care only about dictionary keys, since we don't want


### PR DESCRIPTION
A small PR to:

* skip object attributes starting with `_` during serialization to reduce chatter and not pull private and internal attributes.
* add `_` to private attributes of `Session` and `SessionManager` to make the API cleaner.

## Description:


Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
