### PR TITLE
(v3 alpha, fix) Update client remote to use MainRouter

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 .PHONY: test docs publish clean install exe dev
 
 install:
-	python setup.py install && pip install -r requirements.txt
+	pip install -r requirements.txt && pip install -e .
 
 test:
 	python -m pylama opentrons tests && python -m pytest \

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -63,7 +63,7 @@ export default function client (dispatch) {
           .on('notification', handleRobotNotification)
           .on('error', handleClientError)
 
-        sessionManager = rpcClient.remote
+        sessionManager = rpcClient.remote.session_manager
         session = sessionManager.session
         robot = sessionManager.robot
 

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -47,7 +47,9 @@ describe('api client', () => {
     rpcClient = {
       on: jest.fn(() => rpcClient),
       close: jest.fn(),
-      remote: sessionManager
+      remote: {
+        session_manager: sessionManager
+      }
     }
 
     dispatch = jest.fn()


### PR DESCRIPTION
## overview

#352 changed the shape of the RPC remote object. This PR fixes the client breakage due to that change. While I was here, I also fixed the API `make install` task, because it wasn't quite right.

This PR includes:

- [X] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Chore) Update API `make install` to use `pip install -e .`
- (Fix) Update API client to expect `opentrons.api.MainRouter` as the remote object
- (Tests) Update API client tests to for the above fix

## review requests

I would love to merge this ASAP, so please review in the next 30 minutes. If you're on your phone, this PR is small enough that you should be able to review it from the mobile site without issue.
