### PR TITLE
(v3 alpha, feature) Calibration API client state

### DIFF
--- a/app/rpc/remote-object.js
+++ b/app/rpc/remote-object.js
@@ -73,5 +73,6 @@ export default function RemoteObject (context, source, seen) {
       return result
     }, {}))
 
-  return Promise.all([props, methods]).then(([p, m]) => Object.assign(remote, p, m))
+  return Promise.all([props, methods])
+    .then(([p, m]) => Object.assign(remote, p, m, {_id: id}))
 }

--- a/app/rpc/test/remote-object.test.js
+++ b/app/rpc/test/remote-object.test.js
@@ -116,4 +116,18 @@ describe('rpc remote object factory', () => {
         })
       })
   })
+
+  test('remote method object arg with _id,', () => {
+    const source = {i: 1, t: 2, v: {}}
+    const typeValues = {method: {}}
+
+    context.resolveTypeValues.mockReturnValueOnce(Promise.resolve(typeValues))
+    context.callRemote.mockReturnValueOnce(Promise.resolve('call result!'))
+
+    return RemoteObject(context, source)
+      .then((remote) => remote.method({_id: 'foo'}))
+      .then((result) => expect(context.callRemote)
+        .toHaveBeenCalledWith(1, 'method', [{i: 'foo'}])
+      )
+  })
 })

--- a/app/rpc/test/remote-object.test.js
+++ b/app/rpc/test/remote-object.test.js
@@ -40,7 +40,7 @@ describe('rpc remote object factory', () => {
     context.resolveTypeValues.mockReturnValueOnce(Promise.resolve({}))
 
     return RemoteObject(context, source)
-      .then((remote) => expect(remote).toEqual({foo: 'bar'}))
+      .then((remote) => expect(remote).toEqual({_id: 1, foo: 'bar'}))
   })
 
   test('deserializes an object with remote methods from type', () => {
@@ -53,7 +53,7 @@ describe('rpc remote object factory', () => {
     return RemoteObject(context, source)
       .then((remote) => {
         expect(context.resolveTypeValues).toHaveBeenCalledWith(source)
-        expect(remote).toEqual({foo: 'bar', baz: expect.any(Function)})
+        expect(remote).toEqual({_id: 1, foo: 'bar', baz: expect.any(Function)})
         return remote.baz(1, 2, 3)
       })
       .then((result) => {
@@ -72,7 +72,7 @@ describe('rpc remote object factory', () => {
       .then((remote) => {
         expect(context.resolveTypeValues).toHaveBeenCalledWith(source)
         expect(context.resolveTypeValues).toHaveBeenCalledWith(child)
-        expect(remote).toEqual({foo: 'bar', bar: {baz: 'qux'}})
+        expect(remote).toEqual({_id: 1, foo: 'bar', bar: {_id: 2, baz: 'qux'}})
       })
   })
 
@@ -89,8 +89,9 @@ describe('rpc remote object factory', () => {
         expect(context.resolveTypeValues).toHaveBeenCalledWith(child1)
         expect(context.resolveTypeValues).toHaveBeenCalledWith(child2)
         expect(remote).toEqual({
+          _id: 1,
           foo: 'bar',
-          children: [{baz: 'qux'}, {fizz: 'buzz'}]
+          children: [{_id: 3, baz: 'qux'}, {_id: 2, fizz: 'buzz'}]
         })
       })
   })
@@ -109,8 +110,9 @@ describe('rpc remote object factory', () => {
         // only need 4 type resolutions because of childDup
         expect(context.resolveTypeValues).toHaveBeenCalledTimes(4)
         expect(remote).toEqual({
-          parent1: {c: {foo: 'foo'}},
-          parent2: {c: {foo: 'foo'}}
+          _id: 34,
+          parent1: {_id: 32, c: {_id: 31, foo: 'foo'}},
+          parent2: {_id: 33, c: {_id: 31, foo: 'foo'}}
         })
       })
   })

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -20,8 +20,8 @@ export const actionTypes = {
   // calibration
   HOME: makeRobotActionName('HOME'),
   HOME_RESPONSE: makeRobotActionName('HOME_RESPONSE'),
-  MOVE_TIP_TO_FRONT: makeRobotActionName('MOVE_TO_FRONT'),
-  MOVE_TIP_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
+  MOVE_TO_FRONT: makeRobotActionName('MOVE_TO_FRONT'),
+  MOVE_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
   PROBE_TIP: makeRobotActionName('PROBE_TIP'),
   PROBE_TIP_RESPONSE: makeRobotActionName('PROBE_TIP_RESPONSE'),
   MOVE_TO: makeRobotActionName('MOVE_TO'),
@@ -50,15 +50,17 @@ export const actions = {
     return makeRobotAction({type: actionTypes.CONNECT})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   connectResponse (error = null) {
     return {type: actionTypes.CONNECT_RESPONSE, error}
   },
 
-  // TODO(mc, 2017-09-07): connect should take a URL or robot identifier
+  // TODO(mc, 2017-09-07): disconnect should take a URL or robot identifier
   disconnect () {
     return makeRobotAction({type: actionTypes.DISCONNECT})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   disconnectResponse (error = null) {
     return {type: actionTypes.DISCONNECT_RESPONSE, error}
   },
@@ -68,6 +70,7 @@ export const actions = {
     return makeRobotAction({type: actionTypes.SESSION, payload: {file}})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   sessionResponse (error = null, session) {
     return {type: actionTypes.SESSION_RESPONSE, payload: {session}, error}
   },
@@ -79,20 +82,21 @@ export const actions = {
     return action
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   homeResponse (error = null) {
     return {type: actionTypes.HOME_RESPONSE, error}
   },
 
-  moveTipToFront (instrument) {
+  moveToFront (instrument) {
     return makeRobotAction({
-      type: actionTypes.MOVE_TIP_TO_FRONT,
+      type: actionTypes.MOVE_TO_FRONT,
       payload: {instrument}
     })
   },
 
-  moveTipToFrontResponse (error = null) {
+  moveToFrontResponse (error = null) {
     const action = {
-      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      type: actionTypes.MOVE_TO_FRONT_RESPONSE,
       error: error != null
     }
     if (error) action.payload = error
@@ -160,6 +164,7 @@ export const actions = {
     return makeRobotAction({type: actionTypes.RUN})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   runResponse (error = null) {
     return {type: actionTypes.RUN_RESPONSE, error}
   },
@@ -168,6 +173,7 @@ export const actions = {
     return makeRobotAction({type: actionTypes.PAUSE})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   pauseResponse (error) {
     return {type: actionTypes.PAUSE_RESPONSE, error}
   },
@@ -176,6 +182,7 @@ export const actions = {
     return makeRobotAction({type: actionTypes.RESUME})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   resumeResponse (error) {
     return {type: actionTypes.RESUME_RESPONSE, error}
   },
@@ -184,6 +191,7 @@ export const actions = {
     return makeRobotAction({type: actionTypes.CANCEL})
   },
 
+  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   cancelResponse (error) {
     return {type: actionTypes.CANCEL_RESPONSE, error}
   },

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -7,15 +7,31 @@ const makeRobotActionName = (action) => makeActionName(NAME, action)
 const makeRobotAction = (action) => ({...action, meta: {robotCommand: true}})
 
 export const actionTypes = {
-  // requests and responses
+  // connect and disconnect
   CONNECT: makeRobotActionName('CONNECT'),
   CONNECT_RESPONSE: makeRobotActionName('CONNECT_RESPONSE'),
   DISCONNECT: makeRobotActionName('DISCONNECT'),
   DISCONNECT_RESPONSE: makeRobotActionName('DISCONNECT_RESPONSE'),
+
+  // protocol loading
   SESSION: makeRobotActionName('SESSION'),
   SESSION_RESPONSE: makeRobotActionName('SESSION_RESPONSE'),
+
+  // calibration
   HOME: makeRobotActionName('HOME'),
   HOME_RESPONSE: makeRobotActionName('HOME_RESPONSE'),
+  MOVE_TIP_TO_FRONT: makeRobotActionName('MOVE_TO_FRONT'),
+  MOVE_TIP_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
+  PROBE_TIP: makeRobotActionName('PROBE_TIP'),
+  PROBE_TIP_RESPONSE: makeRobotActionName('PROBE_TIP_RESPONSE'),
+  MOVE_TO: makeRobotActionName('MOVE_TO'),
+  MOVE_TO_RESPONSE: makeRobotActionName('MOVE_TO_RESPONSE'),
+  JOG: makeRobotActionName('JOG'),
+  JOG_RESPONSE: makeRobotActionName('JOG_RESPONSE'),
+  UPDATE_OFFSET: makeRobotActionName('UPDATE_OFFSET'),
+  UPDATE_OFFSET_RESPONSE: makeRobotActionName('UPDATE_OFFSET_RESPONSE'),
+
+  // protocol run controls
   RUN: makeRobotActionName('RUN'),
   RUN_RESPONSE: makeRobotActionName('RUN_RESPONSE'),
   PAUSE: makeRobotActionName('PAUSE'),
@@ -24,6 +40,7 @@ export const actionTypes = {
   RESUME_RESPONSE: makeRobotActionName('RESUME_RESPONSE'),
   CANCEL: makeRobotActionName('CANCEL'),
   CANCEL_RESPONSE: makeRobotActionName('CANCEL_RESPONSE'),
+
   TICK_RUN_TIME: makeRobotActionName('TICK_RUN_TIME')
 }
 
@@ -64,6 +81,79 @@ export const actions = {
 
   homeResponse (error = null) {
     return {type: actionTypes.HOME_RESPONSE, error}
+  },
+
+  moveTipToFront (instrument) {
+    return makeRobotAction({
+      type: actionTypes.MOVE_TIP_TO_FRONT,
+      payload: {instrument}
+    })
+  },
+
+  moveTipToFrontResponse (error = null) {
+    const action = {
+      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      error: error != null
+    }
+    if (error) action.payload = error
+
+    return action
+  },
+
+  probeTip (instrument) {
+    return makeRobotAction({type: actionTypes.PROBE_TIP, payload: {instrument}})
+  },
+
+  probeTipResponse (error = null) {
+    const action = {type: actionTypes.PROBE_TIP_RESPONSE, error: error != null}
+    if (error) action.payload = error
+
+    return action
+  },
+
+  moveTo (instrument, labware) {
+    return makeRobotAction({
+      type: actionTypes.MOVE_TO,
+      payload: {instrument, labware}
+    })
+  },
+
+  moveToResponse (error = null) {
+    const action = {type: actionTypes.MOVE_TO_RESPONSE, error: error != null}
+    if (error) action.payload = error
+
+    return action
+  },
+
+  jog (instrument, coordinates) {
+    return makeRobotAction({
+      type: actionTypes.JOG,
+      payload: {instrument, coordinates}
+    })
+  },
+
+  jogResponse (error = null) {
+    const action = {type: actionTypes.JOG_RESPONSE, error: error != null}
+    if (error) action.payload = error
+
+    return action
+  },
+
+  updateOffset (instrument, labware) {
+    return makeRobotAction({
+      type: actionTypes.UPDATE_OFFSET,
+      payload: {instrument, labware}
+    })
+  },
+
+  updateOffsetResponse (error = null) {
+    const action = {
+      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      error: error != null
+    }
+    if (error) action.payload = error
+
+    return action
   },
 
   run () {

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -241,19 +241,19 @@ export default function client (dispatch) {
     }
 
     function apiInstrumentToInstrument (apiInstrument) {
-      const {axis: originalAxis, name, channels} = apiInstrument
+      const {_id, axis: originalAxis, name, channels} = apiInstrument
       const axis = INSTRUMENT_AXES[originalAxis]
       const volume = Number(name.match(RE_VOLUME)[1])
 
-      protocolInstrumentsByAxis[axis] = {axis, name, channels, volume}
+      protocolInstrumentsByAxis[axis] = {_id, axis, name, channels, volume}
     }
 
     function apiContainerToContainer (apiContainer) {
-      const {name, type, slot: id} = apiContainer
+      const {_id, name, type, slot: id} = apiContainer
       const isTiprack = RE_TIPRACK.test(type)
       const slot = letterSlotToNumberSlot(id)
 
-      protocolLabwareBySlot[slot] = {name, id, slot, type, isTiprack}
+      protocolLabwareBySlot[slot] = {_id, name, id, slot, type, isTiprack}
     }
   }
 

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -36,7 +36,7 @@ export default function client (dispatch) {
       case actionTypes.DISCONNECT: return disconnect(state, action)
       case actionTypes.SESSION: return createSession(state, action)
       case actionTypes.HOME: return home(state, action)
-      case actionTypes.MOVE_TIP_TO_FRONT: return moveTipToFront(state, action)
+      case actionTypes.MOVE_TO_FRONT: return moveToFront(state, action)
       case actionTypes.PROBE_TIP: return probeTip(state, action)
       case actionTypes.MOVE_TO: return moveTo(state, action)
       case actionTypes.JOG: return jog(state, action)
@@ -122,13 +122,13 @@ export default function client (dispatch) {
       .catch((error) => dispatch(actions.homeResponse(error)))
   }
 
-  function moveTipToFront (state, action) {
+  function moveToFront (state, action) {
     const {payload: {instrument: axis}} = action
     const instrument = selectors.getState(state).protocolInstrumentsByAxis[axis]
 
     remote.calibration_manager.move_to_front(instrument)
-      .then(() => dispatch(actions.moveTipToFrontResponse()))
-      .catch((error) => dispatch(actions.moveTipToFrontResponse(error)))
+      .then(() => dispatch(actions.moveToFrontResponse()))
+      .catch((error) => dispatch(actions.moveToFrontResponse(error)))
   }
 
   function probeTip (state, action) {

--- a/app/ui/robot/reducer.js
+++ b/app/ui/robot/reducer.js
@@ -27,9 +27,7 @@ export const constants = {
 }
 
 // state helpers
-const getModuleState = (state) => state[NAME]
 const makeRequestState = () => ({inProgress: false, error: null})
-// const makeInstrumentState = () => ({})
 
 const handleRequest = (state, request, payload, error, props = {}) => ({
   ...state,
@@ -74,23 +72,27 @@ const INITIAL_STATE = {
 }
 
 export const selectors = {
+  getState (allState) {
+    return allState[NAME]
+  },
+
   getSessionName (allState) {
-    return getModuleState(allState).sessionName
+    return selectors.getState(allState).sessionName
   },
 
   getConnectionStatus (allState) {
-    const state = getModuleState(allState)
+    const state = selectors.getState(allState)
     if (state.isConnected) return constants.CONNECTED
     if (state.connectRequest.inProgress) return constants.CONNECTING
     return constants.DISCONNECTED
   },
 
   getIsReadyToRun (allState) {
-    return getModuleState(allState).sessionState === constants.LOADED
+    return selectors.getState(allState).sessionState === constants.LOADED
   },
 
   getIsRunning (allState) {
-    const {sessionState} = getModuleState(allState)
+    const {sessionState} = selectors.getState(allState)
     return (
       sessionState === constants.RUNNING ||
       sessionState === constants.PAUSED
@@ -98,11 +100,11 @@ export const selectors = {
   },
 
   getIsPaused (allState) {
-    return getModuleState(allState).sessionState === constants.PAUSED
+    return selectors.getState(allState).sessionState === constants.PAUSED
   },
 
   getIsDone (allState) {
-    const {sessionState} = getModuleState(allState)
+    const {sessionState} = selectors.getState(allState)
     return (
       sessionState === constants.ERROR ||
       sessionState === constants.FINISHED ||
@@ -111,7 +113,10 @@ export const selectors = {
   },
 
   getCommands (allState) {
-    const {protocolCommands, protocolCommandsById} = getModuleState(allState)
+    const {
+      protocolCommands,
+      protocolCommandsById
+    } = selectors.getState(allState)
 
     return protocolCommands.map(idToCommandList(true))
 
@@ -149,7 +154,7 @@ export const selectors = {
   },
 
   getRunTime (allState) {
-    const {runTime} = getModuleState(allState)
+    const {runTime} = selectors.getState(allState)
     const startTime = selectors.getStartTime(allState)
     const runTimeSeconds = (runTime && startTime)
       ? Math.floor((runTime - Date.parse(startTime)) / 1000)
@@ -166,7 +171,7 @@ export const selectors = {
     const {
       protocolInstrumentsByAxis,
       instrumentCalibrationByAxis
-    } = getModuleState(allState)
+    } = selectors.getState(allState)
 
     return constants.INSTRUMENT_AXES.map((axis) => {
       const instrument = protocolInstrumentsByAxis[axis] || {axis}
@@ -186,7 +191,7 @@ export const selectors = {
     const {
       protocolLabwareBySlot,
       labwareConfirmationBySlot
-    } = getModuleState(allState)
+    } = selectors.getState(allState)
 
     return constants.DECK_SLOTS.map((slot) => {
       const labware = protocolLabwareBySlot[slot] || {slot}

--- a/app/ui/robot/test/__mocks__/calibration-manager.js
+++ b/app/ui/robot/test/__mocks__/calibration-manager.js
@@ -1,0 +1,11 @@
+// mock calibration manager
+// based on api/opentrons/api/calibration.py
+export default function MockCalibrationManager () {
+  return {
+    move_to_front: jest.fn(),
+    tip_probe: jest.fn(),
+    move_to: jest.fn(),
+    jog: jest.fn(),
+    update_offset: jest.fn()
+  }
+}

--- a/app/ui/robot/test/__mocks__/session.js
+++ b/app/ui/robot/test/__mocks__/session.js
@@ -7,6 +7,8 @@ export default function MockSession () {
     commands: [],
     command_log: {},
     state: 'loaded',
+    instruments: [],
+    containers: [],
 
     run: jest.fn(() => Promise.resolve())
   }

--- a/app/ui/robot/test/__mocks__/session.js
+++ b/app/ui/robot/test/__mocks__/session.js
@@ -1,5 +1,5 @@
 // mock rpc session
-// based on api/opentrons/session/session.py
+// based on api/opentrons/api/session.py
 export default function MockSession () {
   return {
     name: 'MOCK SESSION',

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -13,6 +13,7 @@ describe('robot actions', () => {
   })
 
   test('connect response action', () => {
+    // TODO(mc, 2017-10-02): In FSA, action.error is bool, payload is an Error
     const expected = {
       type: actionTypes.CONNECT_RESPONSE,
       error: new Error('AHHH')
@@ -31,6 +32,7 @@ describe('robot actions', () => {
   })
 
   test('disconnect response action', () => {
+    // TODO(mc, 2017-10-02): In FSA, action.error is bool, payload is an Error
     const expected = {
       type: actionTypes.DISCONNECT_RESPONSE,
       error: new Error('AHHH')
@@ -53,6 +55,7 @@ describe('robot actions', () => {
   test('session response', () => {
     const error = new Error('AH')
     const session = {name: 'session-name'}
+    // TODO(mc, 2017-10-02): In FSA, action.error is bool, payload is an Error
     const expected = {
       type: actionTypes.SESSION_RESPONSE,
       payload: {session},
@@ -82,12 +85,138 @@ describe('robot actions', () => {
   })
 
   test('home response action', () => {
+    // TODO(mc, 2017-10-02): In FSA, action.error is bool, payload is an Error
     const expected = {
       type: actionTypes.HOME_RESPONSE,
       error: new Error('AHHH')
     }
 
     expect(actions.homeResponse(new Error('AHHH'))).toEqual(expected)
+  })
+
+  test('move tip to front action', () => {
+    const expected = {
+      type: actionTypes.MOVE_TIP_TO_FRONT,
+      payload: {instrument: 'right'},
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.moveTipToFront('right')).toEqual(expected)
+  })
+
+  test('move tip to front response action', () => {
+    const success = {
+      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      error: false
+    }
+    const failure = {
+      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(actions.moveTipToFrontResponse()).toEqual(success)
+    expect(actions.moveTipToFrontResponse(new Error('AH'))).toEqual(failure)
+  })
+
+  test('probe tip action', () => {
+    const expected = {
+      type: actionTypes.PROBE_TIP,
+      payload: {instrument: 'left'},
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.probeTip('left')).toEqual(expected)
+  })
+
+  test('probe tip response action', () => {
+    const success = {
+      type: actionTypes.PROBE_TIP_RESPONSE,
+      error: false
+    }
+    const failure = {
+      type: actionTypes.PROBE_TIP_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(actions.probeTipResponse()).toEqual(success)
+    expect(actions.probeTipResponse(new Error('AH'))).toEqual(failure)
+  })
+
+  test('move to action', () => {
+    const expected = {
+      type: actionTypes.MOVE_TO,
+      payload: {instrument: 'left', labware: 3},
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.moveTo('left', 3)).toEqual(expected)
+  })
+
+  test('move to response action', () => {
+    const success = {
+      type: actionTypes.MOVE_TO_RESPONSE,
+      error: false
+    }
+    const failure = {
+      type: actionTypes.MOVE_TO_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(actions.moveToResponse()).toEqual(success)
+    expect(actions.moveToResponse(new Error('AH'))).toEqual(failure)
+  })
+
+  test('jog action', () => {
+    const expected = {
+      type: actionTypes.JOG,
+      payload: {instrument: 'left', coordinates: {x: 3}},
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.jog('left', {x: 3})).toEqual(expected)
+  })
+
+  test('jog response action', () => {
+    const success = {
+      type: actionTypes.JOG_RESPONSE,
+      error: false
+    }
+    const failure = {
+      type: actionTypes.JOG_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(actions.jogResponse()).toEqual(success)
+    expect(actions.jogResponse(new Error('AH'))).toEqual(failure)
+  })
+
+  test('update offset action', () => {
+    const expected = {
+      type: actionTypes.UPDATE_OFFSET,
+      payload: {instrument: 'left', labware: 2},
+      meta: {robotCommand: true}
+    }
+
+    expect(actions.updateOffset('left', 2)).toEqual(expected)
+  })
+
+  test('update offset response action', () => {
+    const success = {
+      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      error: false
+    }
+    const failure = {
+      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(actions.updateOffsetResponse()).toEqual(success)
+    expect(actions.updateOffsetResponse(new Error('AH'))).toEqual(failure)
   })
 
   test('run action', () => {

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -96,27 +96,27 @@ describe('robot actions', () => {
 
   test('move tip to front action', () => {
     const expected = {
-      type: actionTypes.MOVE_TIP_TO_FRONT,
+      type: actionTypes.MOVE_TO_FRONT,
       payload: {instrument: 'right'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.moveTipToFront('right')).toEqual(expected)
+    expect(actions.moveToFront('right')).toEqual(expected)
   })
 
   test('move tip to front response action', () => {
     const success = {
-      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      type: actionTypes.MOVE_TO_FRONT_RESPONSE,
       error: false
     }
     const failure = {
-      type: actionTypes.MOVE_TIP_TO_FRONT_RESPONSE,
+      type: actionTypes.MOVE_TO_FRONT_RESPONSE,
       error: true,
       payload: new Error('AH')
     }
 
-    expect(actions.moveTipToFrontResponse()).toEqual(success)
-    expect(actions.moveTipToFrontResponse(new Error('AH'))).toEqual(failure)
+    expect(actions.moveToFrontResponse()).toEqual(success)
+    expect(actions.moveToFrontResponse(new Error('AH'))).toEqual(failure)
   })
 
   test('probe tip action', () => {

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -227,14 +227,14 @@ describe('api client', () => {
     test('maps api instruments and intruments by axis', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
         protocolInstrumentsByAxis: {
-          left: {axis: 'left', name: 'p200', channels: 1, volume: 200},
-          right: {axis: 'right', name: 'p50', channels: 8, volume: 50}
+          left: {_id: 2, axis: 'left', name: 'p200', channels: 1, volume: 200},
+          right: {_id: 1, axis: 'right', name: 'p50', channels: 8, volume: 50}
         }
       }))
 
       session.instruments = [
-        {axis: 'a', name: 'p50', channels: 8},
-        {axis: 'b', name: 'p200', channels: 1}
+        {_id: 1, axis: 'a', name: 'p50', channels: 8},
+        {_id: 2, axis: 'b', name: 'p200', channels: 1}
       ]
 
       return sendConnect()
@@ -244,16 +244,16 @@ describe('api client', () => {
     test('maps api containers to labware by slot', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
         protocolLabwareBySlot: {
-          1: {id: 'A1', slot: 1, name: 'a1', type: 'tiprack', isTiprack: true},
-          5: {id: 'B2', slot: 5, name: 'b2', type: 'b', isTiprack: false},
-          9: {id: 'C3', slot: 9, name: 'c3', type: 'c', isTiprack: false}
+          1: {_id: 1, id: 'A1', slot: 1, name: 'a', type: 'tiprack', isTiprack: true},
+          5: {_id: 2, id: 'B2', slot: 5, name: 'b', type: 'B', isTiprack: false},
+          9: {_id: 3, id: 'C3', slot: 9, name: 'c', type: 'C', isTiprack: false}
         }
       }))
 
       session.containers = [
-        {slot: 'A1', name: 'a1', type: 'tiprack'},
-        {slot: 'B2', name: 'b2', type: 'b'},
-        {slot: 'C3', name: 'c3', type: 'c'}
+        {_id: 1, slot: 'A1', name: 'a', type: 'tiprack'},
+        {_id: 2, slot: 'B2', name: 'b', type: 'B'},
+        {_id: 3, slot: 'C3', name: 'c', type: 'C'}
       ]
 
       return sendConnect()

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -283,9 +283,9 @@ describe('api client', () => {
       }
     })
 
-    test('handles MOVE_TIP_TO_FRONT success', () => {
-      const action = actions.moveTipToFront('left')
-      const expectedResponse = actions.moveTipToFrontResponse()
+    test('handles MOVE_TO_FRONT success', () => {
+      const action = actions.moveToFront('left')
+      const expectedResponse = actions.moveToFrontResponse()
 
       calibrationManager.move_to_front.mockReturnValue(Promise.resolve())
 
@@ -298,9 +298,9 @@ describe('api client', () => {
         })
     })
 
-    test('handles MOVE_TIP_TO_FRONT failure', () => {
-      const action = actions.moveTipToFront('left')
-      const expectedResponse = actions.moveTipToFrontResponse(new Error('AH'))
+    test('handles MOVE_TO_FRONT failure', () => {
+      const action = actions.moveToFront('left')
+      const expectedResponse = actions.moveToFrontResponse(new Error('AH'))
 
       calibrationManager.move_to_front
         .mockReturnValue(Promise.reject(new Error('AH')))

--- a/app/ui/robot/test/reducer.test.js
+++ b/app/ui/robot/test/reducer.test.js
@@ -31,6 +31,11 @@ describe('robot reducer', () => {
       protocolLabwareBySlot: {},
 
       homeRequest: {inProgress: false, error: null},
+      moveToFrontRequest: {inProgress: false, error: null},
+      probeTipRequest: {inProgress: false, error: null},
+      moveToRequest: {inProgress: false, error: null},
+      jogRequest: {inProgress: false, error: null},
+      updateOffsetRequest: {inProgress: false, error: null},
 
       runRequest: {inProgress: false, error: null},
       pauseRequest: {inProgress: false, error: null},
@@ -216,6 +221,136 @@ describe('robot reducer', () => {
 
     expect(reducer(state, action)).toEqual({
       homeRequest: {inProgress: false, error: new Error('AH')}
+    })
+  })
+
+  test('handles moveToFront action', () => {
+    const state = {moveToFrontRequest: {inProgress: false, error: new Error()}}
+    const action = {type: actionTypes.MOVE_TO_FRONT}
+
+    expect(reducer(state, action)).toEqual({
+      moveToFrontRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles moveToFrontResponse action', () => {
+    const state = {moveToFrontRequest: {inProgress: true, error: null}}
+    const success = {type: actionTypes.MOVE_TO_FRONT_RESPONSE, error: false}
+    const failure = {
+      type: actionTypes.MOVE_TO_FRONT_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(reducer(state, success)).toEqual({
+      moveToFrontRequest: {inProgress: false, error: null}
+    })
+    expect(reducer(state, failure)).toEqual({
+      moveToFrontRequest: {inProgress: false, error: new Error('AH')}
+    })
+  })
+
+  test('handles probeTip action', () => {
+    const state = {probeTipRequest: {inProgress: false, error: new Error()}}
+    const action = {type: actionTypes.PROBE_TIP}
+
+    expect(reducer(state, action)).toEqual({
+      probeTipRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles probeTipResponse action', () => {
+    const state = {probeTipRequest: {inProgress: true, error: null}}
+    const success = {type: actionTypes.PROBE_TIP_RESPONSE, error: false}
+    const failure = {
+      type: actionTypes.PROBE_TIP_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(reducer(state, success)).toEqual({
+      probeTipRequest: {inProgress: false, error: null}
+    })
+    expect(reducer(state, failure)).toEqual({
+      probeTipRequest: {inProgress: false, error: new Error('AH')}
+    })
+  })
+
+  test('handles moveTo action', () => {
+    const state = {moveToRequest: {inProgress: false, error: new Error()}}
+    const action = {type: actionTypes.MOVE_TO}
+
+    expect(reducer(state, action)).toEqual({
+      moveToRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles moveToResponse action', () => {
+    const state = {moveToRequest: {inProgress: true, error: null}}
+    const success = {type: actionTypes.MOVE_TO_RESPONSE, error: false}
+    const failure = {
+      type: actionTypes.MOVE_TO_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(reducer(state, success)).toEqual({
+      moveToRequest: {inProgress: false, error: null}
+    })
+    expect(reducer(state, failure)).toEqual({
+      moveToRequest: {inProgress: false, error: new Error('AH')}
+    })
+  })
+
+  test('handles jog action', () => {
+    const state = {jogRequest: {inProgress: false, error: new Error()}}
+    const action = {type: actionTypes.JOG}
+
+    expect(reducer(state, action)).toEqual({
+      jogRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles jogResponse action', () => {
+    const state = {jogRequest: {inProgress: true, error: null}}
+    const success = {type: actionTypes.JOG_RESPONSE, error: false}
+    const failure = {
+      type: actionTypes.JOG_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(reducer(state, success)).toEqual({
+      jogRequest: {inProgress: false, error: null}
+    })
+    expect(reducer(state, failure)).toEqual({
+      jogRequest: {inProgress: false, error: new Error('AH')}
+    })
+  })
+
+  test('handles updateOffset action', () => {
+    const state = {updateOffsetRequest: {inProgress: false, error: new Error()}}
+    const action = {type: actionTypes.UPDATE_OFFSET}
+
+    expect(reducer(state, action)).toEqual({
+      updateOffsetRequest: {inProgress: true, error: null}
+    })
+  })
+
+  test('handles updateOffsetResponse action', () => {
+    const state = {updateOffsetRequest: {inProgress: true, error: null}}
+    const success = {type: actionTypes.UPDATE_OFFSET_RESPONSE, error: false}
+    const failure = {
+      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      error: true,
+      payload: new Error('AH')
+    }
+
+    expect(reducer(state, success)).toEqual({
+      updateOffsetRequest: {inProgress: false, error: null}
+    })
+    expect(reducer(state, failure)).toEqual({
+      updateOffsetRequest: {inProgress: false, error: new Error('AH')}
     })
   })
 

--- a/app/ui/robot/test/reducer.test.js
+++ b/app/ui/robot/test/reducer.test.js
@@ -21,11 +21,14 @@ describe('robot reducer', () => {
 
       sessionRequest: {inProgress: false, error: null},
       sessionName: '',
+      sessionErrors: [],
+      sessionState: '',
+
       protocolText: '',
       protocolCommands: [],
       protocolCommandsById: {},
-      sessionErrors: [],
-      sessionState: '',
+      protocolInstrumentsByAxis: {},
+      protocolLabwareBySlot: {},
 
       homeRequest: {inProgress: false, error: null},
 

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -13,7 +13,9 @@ const {
   getIsRunning,
   getIsPaused,
   getIsDone,
-  getRunTime
+  getRunTime,
+  getInstruments,
+  getDeck
 } = selectors
 
 describe('robot selectors', () => {
@@ -225,5 +227,71 @@ describe('robot selectors', () => {
         }
       ])
     })
+  })
+
+  test('get instruments', () => {
+    const state = makeState({
+      protocolInstrumentsByAxis: {
+        left: {axis: 'left', channels: 8, volume: 200}
+      },
+      instrumentCalibrationByAxis: {
+        left: {isProbed: true}
+      }
+    })
+
+    expect(getInstruments(state)).toEqual([
+      {axis: 'left', channels: 'multi', volume: 200, isProbed: true},
+      {axis: 'right'}
+    ])
+  })
+
+  test('get deck', () => {
+    const state = makeState({
+      protocolLabwareBySlot: {
+        1: {id: 'A1', slot: 1, name: 'a1', type: 'a', isTiprack: true},
+        5: {id: 'B2', slot: 5, name: 'b2', type: 'b', isTiprack: false},
+        9: {id: 'C3', slot: 9, name: 'c3', type: 'c', isTiprack: false}
+      },
+      labwareConfirmationBySlot: {
+        1: {isConfirmed: false},
+        5: {isConfirmed: true},
+        9: {isConfirmed: false}
+      }
+    })
+
+    expect(getDeck(state)).toEqual([
+      {
+        slot: 1,
+        id: 'A1',
+        name: 'a1',
+        type: 'a',
+        isTiprack: true,
+        isConfirmed: false
+      },
+      {slot: 2},
+      {slot: 3},
+      {slot: 4},
+      {
+        slot: 5,
+        id: 'B2',
+        name: 'b2',
+        type: 'b',
+        isTiprack: false,
+        isConfirmed: true
+      },
+      {slot: 6},
+      {slot: 7},
+      {slot: 8},
+      {
+        slot: 9,
+        id: 'C3',
+        name: 'c3',
+        type: 'c',
+        isTiprack: false,
+        isConfirmed: false
+      },
+      {slot: 10},
+      {slot: 11}
+    ])
   })
 })

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -232,7 +232,8 @@ describe('robot selectors', () => {
   test('get instruments', () => {
     const state = makeState({
       protocolInstrumentsByAxis: {
-        left: {axis: 'left', channels: 8, volume: 200}
+        left: {axis: 'left', channels: 8, volume: 200},
+        right: {axis: 'right', channels: 1, volume: 50}
       },
       instrumentCalibrationByAxis: {
         left: {isProbed: true}
@@ -241,7 +242,7 @@ describe('robot selectors', () => {
 
     expect(getInstruments(state)).toEqual([
       {axis: 'left', channels: 'multi', volume: 200, isProbed: true},
-      {axis: 'right'}
+      {axis: 'right', channels: 'single', volume: 50, isProbed: false}
     ])
   })
 


### PR DESCRIPTION
## overview

This PR adds calibration API state tracking to the client and starts work on the selectors that will need to be wired into components and containers. **Targets `app-3-0-alpha`**

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.

- (Feature, Tests) Add instrument and labware state translation to API client
- (Feature, Tests) Add private ID field to RemoteObjects
- (Feature, Tests) Add actions for CalibrationManager calls and responses
- (Feature, Tests) Wire calibration actions and responses to API client
- (Feature, Tests) Track calibration API request state in redux store

## review requests

@OpenTrons/js please review for correctness
