### PR TITLE
(v3) 🚀 Fix CSS HMR in dev

### DIFF
--- a/app/webpack/rules.js
+++ b/app/webpack/rules.js
@@ -3,7 +3,17 @@
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
+const DEV = process.env.NODE_ENV !== 'production'
 const DATA_URL_BYTE_LIMIT = 8192
+
+const CSS_MODULE_LOADER = {
+  loader: 'css-loader',
+  options: {
+    modules: true,
+    sourceMap: true,
+    localIdentName: '[name]__[local]__[hash:base64:5]'
+  }
+}
 
 module.exports = {
   // babel loader for JSX
@@ -34,25 +44,17 @@ module.exports = {
   // global CSS files
   globalCss: {
     test: /\.global\.css$/,
-    use: ExtractTextPlugin.extract({
-      use: 'css-loader',
-      fallback: 'style-loader'
-    })
+    use: DEV
+      ? ['style-loader', 'css-loader']
+      : ExtractTextPlugin.extract({use: 'css-loader', fallback: 'style-loader'})
   },
 
   // local CSS (CSS module) files
   localCss: {
     test: /^((?!\.global).)*\.css$/,
-    use: ExtractTextPlugin.extract({
-      use: {
-        loader: 'css-loader',
-        options: {
-          modules: true,
-          sourceMap: true,
-          localIdentName: '[name]__[local]__[hash:base64:5]'
-        }
-      }
-    })
+    use: DEV
+      ? ['style-loader', CSS_MODULE_LOADER]
+      : ExtractTextPlugin.extract({use: CSS_MODULE_LOADER})
   },
 
   // handlebars HTML templates


### PR DESCRIPTION
## overview

I broke hot module reloading with CSS back in #338 because I set the [Extract Text Plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) to be always active, even in dev. A closer reading of the plugin's README revealed that it doesn't actually work with HMR... my bad. This PR fixes HMR with CSS by turning off that plugin in dev mode.

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.

- (Chore) Stopped using the Extract Text webpack plugin when NODE_ENV isn't `production`
