### PR TITLE
Plunger current high only during move/home

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -1,7 +1,8 @@
 from opentrons.drivers.smoothie_drivers.v3_0_0 import serial_communication
 from os import environ
-from opentrons.robot.robot_configs import \
+from opentrons.robot.robot_configs import (
     config, PLUNGER_CURRENT_LOW, PLUNGER_CURRENT_HIGH
+)
 
 
 '''
@@ -182,10 +183,10 @@ class SmoothieDriver_3_0_0:
 
     def _setup(self):
         self._reset_from_error()
-        self._send_command(DEFAULT_ACCELERATION)
-        self._send_command(DEFAULT_CURRENT_CONTROL)
-        self._send_command(DEFAULT_MAX_AXIS_SPEEDS)
-        self._send_command(DEFAULT_STEPS_PER_MM)
+        self._send_command(config.acceleration)
+        self._send_command(config.current)
+        self._send_command(config.max_speeds)
+        self._send_command(config.steps_per_mm)
         self._send_command(HOMING_OFFSETS)
         self._send_command(GCODES['ABSOLUTE_COORDS'])
     # ----------- END Private functions ----------- #

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
@@ -5,6 +5,7 @@ import contextlib
 DRIVER_ACK = b'ok\r\nok\r\n'
 RECOVERY_TIMEOUT = 10
 DEFAULT_SERIAL_TIMEOUT = 5
+DEFAULT_WRITE_TIMEOUT = 30
 SMOOTHIE_BOARD_NAME = 'FT232R'
 
 ERROR_KEYWORD = b'error'
@@ -83,10 +84,12 @@ def _attempt_command_recovery(command, serial_conn):
     return response
 
 
-def write_and_return(command, serial_connection, timeout=None):
+def write_and_return(
+        command, serial_connection, timeout=DEFAULT_WRITE_TIMEOUT):
     '''Write a command and return the response'''
     clear_buffer(serial_connection)
-    with serial_with_temp_timeout(serial_connection, 30) as device_connection:
+    with serial_with_temp_timeout(
+            serial_connection, timeout) as device_connection:
         response = _write_to_device_and_return(command, device_connection)
     return response
 

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -4,6 +4,9 @@
 
 from collections import namedtuple
 
+PLUNGER_CURRENT_LOW = '0.1'
+PLUNGER_CURRENT_HIGH = '0.5'
+
 CURRENT_ROBOT = 'B2-5'
 
 robot_config = namedtuple(
@@ -25,7 +28,8 @@ Ibn = robot_config(
     steps_per_mm='M92 X160 Y160 Z800 A800 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
+        PLUNGER_CURRENT_LOW),
     deck_offset=(-27, -14.5, 0),
     probe_center={'z': 68.0, 'x': 268.4, 'y': 291.8181},
     probe_dimensions={'length': 47.74, 'width': 38, 'height': 63}
@@ -36,7 +40,8 @@ Amadeo = robot_config(
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
+        PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
     probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}
@@ -47,7 +52,8 @@ Ada = robot_config(
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
+        PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
     probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}
@@ -58,7 +64,8 @@ Rosalind = robot_config(
     steps_per_mm='M92 X80.0254 Y80.16 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
+        PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
     probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 PLUNGER_CURRENT_LOW = '0.1'
 PLUNGER_CURRENT_HIGH = '0.5'
 
-CURRENT_ROBOT = 'B2-5'
+CURRENT_ROBOT = 'B2-4'
 
 robot_config = namedtuple(
     'robot_config',
@@ -27,7 +27,7 @@ Ibn = robot_config(
     name='Ibn al-Nafis',
     steps_per_mm='M92 X160 Y160 Z800 A800 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
+    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-27, -14.5, 0),
@@ -38,8 +38,8 @@ Ibn = robot_config(
 Amadeo = robot_config(
     name='Amedeo Avogadro',
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
-    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
+    max_speeds='M203.1 X600 Y400 Z120 A120 B50 C50',
+    acceleration='M204 S10000 X2000 Y2000 Z1500 A1500 B2000 C2000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
@@ -51,7 +51,7 @@ Ada = robot_config(
     name='Ada Lovelace',
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
+    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
@@ -63,7 +63,7 @@ Rosalind = robot_config(
     name='Rosalind Franklin',
     steps_per_mm='M92 X80.0254 Y80.16 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
+    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -18,6 +18,25 @@ def position(x, y, z, a, b, c):
     return {axis: value for axis, value in zip('XYZABC', [x, y, z, a, b, c])}
 
 
+def test_plunger_commands(smoothie, monkeypatch):
+    from opentrons.drivers.smoothie_drivers.v3_0_0 import serial_communication
+    command_log = []
+    smoothie.simulating = False
+
+    def write_with_log(command):
+        command_log.append(command)
+        return serial_communication.DRIVER_ACK
+
+    monkeypatch.setattr(serial_communication, 'write_and_return',
+                        write_with_log)
+
+    smoothie.home()
+    smoothie.move(x=0, y=1, z=2, a=3)
+    smoothie.move(x=0, y=1, z=2, a=3, b=4, c=5)
+
+    assert command_log == []
+
+
 def test_functional(smoothie):
     from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import HOMED_POSITION  # NOQA
 


### PR DESCRIPTION
## overview

Keep plunger motor current low when not in use, and ramp to high when in use. Dwell after setting power.

This PR includes:

- [ ] Chore work
- [x] Bug fixes
- [x] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

When sending commands, driver detects whether the command is a MOVE or HOME action (aspirate/dispense are move actions) on B or C axes (the plunger motors), and if so ramps current to high (500 mA) before sending the command, and then back to low (100 mA) afterward. Also, per @andySigler, after issuing any SET_POWER command, a DWELL command is issued before returning.
