### PR TITLE
(v3, bugfix) Align tip probe sequence with screens

### DIFF
--- a/app/ui/components/App.global.css
+++ b/app/ui/components/App.global.css
@@ -70,7 +70,7 @@ body {
 @font-face {
   font-family: 'sans';
   src: url('../fonts/OpenSans-Regular-webfont.woff');
-  font-weight: 300;
+  font-weight: normal;
   font-style: normal;
 }
 

--- a/app/ui/components/SetupPanel.css
+++ b/app/ui/components/SetupPanel.css
@@ -63,11 +63,6 @@
   font-style: italic;
 }
 
-.unavailable {
-  opacity: 0.1;
-  pointer-events: none;
-}
-
 .step_list button,
 .step_list a {
   color: black;

--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -9,13 +9,13 @@ import styles from './SetupPanel.css'
 import {constants as robotConstants} from '../robot'
 
 function PipetteLinks (props) {
-  const {axis, name, volume, channels, calibration, onClick} = props
+  const {axis, name, volume, channels, probed, onClick} = props
   const isDisabled = name == null
   const url = `/setup-instruments/${axis}`
 
   const linkStyle = classnames({[styles.disabled]: isDisabled})
 
-  const statusStyle = isDisabled || calibration === robotConstants.PROBED
+  const statusStyle = isDisabled || probed
     ? styles.confirmed
     : styles.alert
 

--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -43,8 +43,16 @@ function PipetteLinks (props) {
 }
 
 function LabwareLinks (props) {
-  const {name, calibration, isTiprack, tipracksConfirmed, onClick} = props
-  const isDisabled = !isTiprack && !tipracksConfirmed
+  const {
+    name,
+    calibration,
+    isTiprack,
+    instrumentsCalibrated,
+    tipracksConfirmed,
+    onClick
+  } = props
+
+  const isDisabled = !instrumentsCalibrated || !(isTiprack || tipracksConfirmed)
   const isConfirmed = calibration === robotConstants.CONFIRMED
 
   const buttonStyle = classnames(styles.btn_labware, {
@@ -95,6 +103,7 @@ export default function SetupPanel (props) {
       <LabwareLinks
         {...lab}
         key={slot}
+        instrumentsCalibrated={instrumentsCalibrated}
         tipracksConfirmed={tipracksConfirmed}
         onClick={onClick}
       />
@@ -140,7 +149,7 @@ export default function SetupPanel (props) {
         </section>
         <section className={styles.labware_group}>
           <h3>Labware Setup</h3>
-          <ul className={classnames({[styles.unavailable]: !instrumentsCalibrated}, styles.step_list)}>
+          <ul className={styles.step_list}>
             {tiprackList}
             {labwareList}
           </ul>

--- a/app/ui/components/TipProbe.css
+++ b/app/ui/components/TipProbe.css
@@ -1,9 +1,10 @@
 .info {
+  position: relative;
   display: block;
   border: 2px solid silver;
   border-radius: 0.25rem;
   margin-top: 1rem;
-  padding: 0.5rem;
+  padding: 1rem 0.75rem 0.5rem;
   font-size: 0.75rem;
   min-height: 7.1rem;
 }
@@ -13,10 +14,7 @@
   color: white;
   height: 1rem;
   width: 1rem;
-  margin: 0.5rem;
-  text-align: center;
-  border-radius: 0.5rem;
-  display: block;
+  margin: 0.5rem 0.5rem 0.5rem 0;
   float: left;
 }
 
@@ -27,7 +25,7 @@
   padding: 0 3rem;
   display: block;
   margin: 0 auto;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
   line-height: 3rem;
   font-size: 1rem;
   font-family: 'trons';
@@ -37,13 +35,15 @@
 }
 
 .warning {
+  position: absolute;
+  top: 100%;
   visibility: hidden;
   padding: 0.5rem 1rem;
   font-size: 0.75rem;
   text-transform: capitalize;
 }
 
-.info:hover + .warning {
+.info:hover .warning {
   visibility: visible;
 }
 
@@ -51,8 +51,13 @@
   pointer-events: none;
 }
 
-h3.title {
-  text-align: center;
+.important {
+  font-weight: bold;
+  font-size: 1rem;
+}
+
+.submessage {
+  margin-bottom: 1rem;
 }
 
 .progress {
@@ -60,4 +65,15 @@ h3.title {
   height: 3rem;
   display: block;
   margin: 0 auto;
+  margin-top: 1.5rem;
+}
+
+.close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  padding: 0.5rem;
+  cursor: pointer;
+  line-height: 1;
+  font-size: 1rem;
 }

--- a/app/ui/components/TipProbe.css
+++ b/app/ui/components/TipProbe.css
@@ -24,8 +24,7 @@
   height: 3rem;
   padding: 0 3rem;
   display: block;
-  margin: 0 auto;
-  margin-top: 1.5rem;
+  margin: 1rem auto;
   line-height: 3rem;
   font-size: 1rem;
   font-family: 'trons';
@@ -64,8 +63,7 @@
   width: 4rem;
   height: 3rem;
   display: block;
-  margin: 0 auto;
-  margin-top: 1.5rem;
+  margin: 1rem auto;
 }
 
 .close {

--- a/app/ui/components/TipProbe.js
+++ b/app/ui/components/TipProbe.js
@@ -17,6 +17,7 @@ TipProbe.propTypes = {
   instrument: PropTypes.shape({
     name: PropTypes.string,
     volume: PropTypes.number,
+    probed: PropTypes.bool,
     calibration: PropTypes.oneOf([
       UNPROBED,
       PREPARING_TO_PROBE,
@@ -61,17 +62,19 @@ function InfoBox (props) {
 }
 
 function TipProbeMessage (props) {
-  const {instrument: {calibration, volume}} = props
+  const {instrument: {probed, calibration, volume}} = props
   let icon = null
   let message = ''
 
   if (calibration === UNPROBED || calibration === PREPARING_TO_PROBE) {
-    icon = (
-      <Warning className={styles.alert} />
-    )
-    message = (
-      'For accuracy, you must define tip dimensions using the Tip Probe tool'
-    )
+    if (!probed) {
+      icon = (
+        <Warning className={styles.alert} />
+      )
+      message = (
+        'For accuracy, you must define tip dimensions using the Tip Probe tool'
+      )
+    }
   } else if (calibration === READY_TO_PROBE) {
     message = (
       <span>
@@ -136,7 +139,7 @@ function TipProbeButtonOrSpinner (props) {
 function TipProbeWarning (props) {
   const {instrument: {calibration}} = props
 
-  if (calibration === UNPROBED || calibration === PROBED) {
+  if (calibration === UNPROBED) {
     return (
       <p className={styles.warning}>
         ATTENTION:  REMOVE ALL LABWARE AND TRASH BIN FROM DECK BEFORE STARTING TIP PROBE.

--- a/app/ui/components/TipProbe.js
+++ b/app/ui/components/TipProbe.js
@@ -3,116 +3,146 @@ import PropTypes from 'prop-types'
 
 import {constants as robotConstants} from '../robot'
 import styles from './TipProbe.css'
-import {Spinner} from './icons'
+import {Spinner, Warning} from './icons'
 
-function PrepareForProbe (props) {
-  const {volume, onProbeTipClick} = props
-  return (
-    <span className={styles.info}>
-      <p>Complete the following steps prior to clicking [CONTINUE]</p>
-      <ol>
-        <li>Remove all labware from deck.</li>
-        <li>Remove trash bin to reveal Tip Probe tool.</li>
-        <li>Place a previously used or otherwise discarded <strong>{volume} ul</strong> tip on the pipette.</li>
-      </ol>
-      <button className={styles.btn_probe} onClick={onProbeTipClick}>
-        Continue
-      </button>
-    </span>
-  )
-}
+const {
+  UNPROBED,
+  PREPARING_TO_PROBE,
+  READY_TO_PROBE,
+  PROBING,
+  PROBED
+} = robotConstants
 
-PrepareForProbe.propTypes = {
-  volume: PropTypes.number.isRequired
-}
-
-function RobotIsMoving (props) {
-  return (
-    <span className={styles.info}>
-      <h3 className={styles.title}>Robot is Moving</h3>
-      <Spinner className={styles.progress} />
-    </span>
-  )
-}
-
-function ProbeSuccess (props) {
-  const {volume} = props
-  return (
-    <span className={styles.info}>
-      <p>Tip dimensions for <strong>{volume} ul</strong> tips are now defined.</p>
-      <ol>
-        <li>Remove tip by hand and discard.</li>
-        <li>Replace trash bin on top of Tip Probe tool once all tips have been defined.</li>
-      </ol>
-    </span>
-  )
-}
-
-function DefaultMessage (props) {
-  const {onPrepareClick, calibration, name} = props
-  const isProbed = calibration === robotConstants.PROBED
-
-  const infoIcon = isProbed || name == null
-    ? '✓'
-    : '!'
-
-  const infoMessage = isProbed
-    ? (<p>Instrument has been calibrated successfully by Tip Probe</p>)
-    : (<p>Tip dimensions must be defined using the Tip Probe tool</p>)
-
-  return (
-    <span>
-      <span className={styles.info}>
-        <span className={styles.alert}>{infoIcon}</span>
-        {infoMessage}
-        <button className={styles.btn_probe} onClick={onPrepareClick}>
-          Start Tip Probe
-        </button>
-      </span>
-      <p className={styles.warning}>ATTENTION:  REMOVE ALL LABWARE AND TRASH BIN FROM DECK BEFORE STARTING TIP PROBE.</p>
-    </span>
-  )
-}
-
-ProbeSuccess.propTypes = {
-  volume: PropTypes.number.isRequired
+TipProbe.propTypes = {
+  instrument: PropTypes.shape({
+    name: PropTypes.string,
+    volume: PropTypes.number,
+    calibration: PropTypes.oneOf([
+      UNPROBED,
+      PREPARING_TO_PROBE,
+      READY_TO_PROBE,
+      PROBING,
+      PROBED
+    ])
+  }).isRequired,
+  onPrepareClick: PropTypes.func.isRequired,
+  onProbeTipClick: PropTypes.func.isRequired,
+  onCancelClick: PropTypes.func.isRequired
 }
 
 export default function TipProbe (props) {
-  const {onPrepareClick, onProbeTipClick, instrument} = props
-  const status = instrument.calibration
+  return (
+    <InfoBox {...props}>
+      <TipProbeMessage {...props} />
+      <TipProbeButtonOrSpinner {...props} />
+      <TipProbeWarning {...props} />
+    </InfoBox>
+  )
+}
 
-  let probeMessage = null
-  if (status === robotConstants.READY_TO_PROBE) {
-    probeMessage = (
-      <PrepareForProbe {...instrument} onProbeTipClick={onProbeTipClick} />
-    )
-  } else if (
-    status === robotConstants.PREPARING_TO_PROBE ||
-    status === robotConstants.PROBING
-  ) {
-    probeMessage = (
-      <RobotIsMoving />
-    )
-  } else {
-    probeMessage = (
-      <DefaultMessage {...instrument} onPrepareClick={onPrepareClick} />
+function InfoBox (props) {
+  const {instrument: {calibration}, onCancelClick} = props
+  let cancelButton = null
+
+  if (calibration === READY_TO_PROBE || calibration === PROBED) {
+    cancelButton = (
+      <span role='button' onClick={onCancelClick} className={styles.close}>
+        X
+      </span>
     )
   }
 
-  return probeMessage
+  return (
+    <div className={styles.info}>
+      {cancelButton}
+      {props.children}
+    </div>
+  )
 }
 
-TipProbe.propTypes = {
-  onProbeTipClick: PropTypes.func.isRequired,
-  instrument: PropTypes.shape({
-    volume: PropTypes.number,
-    calibration: PropTypes.oneOf([
-      robotConstants.UNPROBED,
-      robotConstants.PREPARING_TO_PROBE,
-      robotConstants.READY_TO_PROBE,
-      robotConstants.PROBING,
-      robotConstants.PROBED
-    ])
-  })
+function TipProbeMessage (props) {
+  const {instrument: {calibration, volume}} = props
+  let icon = null
+  let message = ''
+
+  if (calibration === UNPROBED || calibration === PREPARING_TO_PROBE) {
+    icon = (
+      <Warning className={styles.alert} />
+    )
+    message = (
+      'For accuracy, you must define tip dimensions using the Tip Probe tool'
+    )
+  } else if (calibration === READY_TO_PROBE) {
+    message = (
+      <span>
+        Place a previously used or otherwise discarded
+        <strong>{` ${volume} uL `}</strong>
+        tip on the pipette and click CONTINUE.
+      </span>
+    )
+  } else if (calibration === PROBING) {
+    message = (
+      <span className={styles.important}>
+        Tip Probe is finding tip...
+      </span>
+    )
+  } else if (calibration === PROBED) {
+    message = (
+      <span>
+        <p className={styles.submessage}>
+          Tip dimensions are now defined.
+        </p>
+        <p className={styles.submessage}>
+          <strong>Remove tip by hand and discard.</strong>
+        </p>
+        <p className={styles.submessage}>
+          <strong>
+            Replace trash bin on top of Tip Probe tool once all tips have been defined.
+          </strong>
+        </p>
+      </span>
+    )
+  }
+
+  return (
+    <p>{icon}{message}</p>
+  )
+}
+
+function TipProbeButtonOrSpinner (props) {
+  const {instrument: {calibration}, onPrepareClick, onProbeTipClick} = props
+
+  switch (calibration) {
+    case UNPROBED: return (
+      <button className={styles.btn_probe} onClick={onPrepareClick}>
+        Start Tip Probe
+      </button>
+    )
+
+    case READY_TO_PROBE: return (
+      <button className={styles.btn_probe} onClick={onProbeTipClick}>
+        Continue
+      </button>
+    )
+
+    case PREPARING_TO_PROBE:
+    case PROBING:
+      return (<Spinner className={styles.progress} />)
+  }
+
+  return null
+}
+
+function TipProbeWarning (props) {
+  const {instrument: {calibration}} = props
+
+  if (calibration === UNPROBED || calibration === PROBED) {
+    return (
+      <p className={styles.warning}>
+        ATTENTION:  REMOVE ALL LABWARE AND TRASH BIN FROM DECK BEFORE STARTING TIP PROBE.
+      </p>
+    )
+  }
+
+  return null
 }

--- a/app/ui/containers/ConnectedTipProbe.js
+++ b/app/ui/containers/ConnectedTipProbe.js
@@ -10,13 +10,14 @@ const mapStateToProps = (state, ownProps) => ({
   instrument: ownProps.instrument
 })
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  onPrepareClick: () => {
-    dispatch(robotActions.moveToFront(ownProps.instrument.axis))
-  },
-  onProbeTipClick: () => {
-    dispatch(robotActions.probeTip(ownProps.instrument.axis))
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const {instrument: {axis}} = ownProps
+
+  return {
+    onPrepareClick: () => dispatch(robotActions.moveToFront(axis)),
+    onProbeTipClick: () => dispatch(robotActions.probeTip(axis)),
+    onCancelClick: () => console.log(`Cancel tip probe for ${axis}`)
   }
-})
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(TipProbe)

--- a/app/ui/containers/ConnectedTipProbe.js
+++ b/app/ui/containers/ConnectedTipProbe.js
@@ -16,7 +16,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onPrepareClick: () => dispatch(robotActions.moveToFront(axis)),
     onProbeTipClick: () => dispatch(robotActions.probeTip(axis)),
-    onCancelClick: () => console.log(`Cancel tip probe for ${axis}`)
+    onCancelClick: () => dispatch(robotActions.resetTipProbe(axis))
   }
 }
 

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -31,6 +31,7 @@ export const actionTypes = {
   MOVE_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
   PROBE_TIP: makeRobotActionName('PROBE_TIP'),
   PROBE_TIP_RESPONSE: makeRobotActionName('PROBE_TIP_RESPONSE'),
+  RESET_TIP_PROBE: makeRobotActionName('RESET_TIP_PROBE'),
   MOVE_TO: makeRobotActionName('MOVE_TO'),
   MOVE_TO_RESPONSE: makeRobotActionName('MOVE_TO_RESPONSE'),
   JOG: makeRobotActionName('JOG'),
@@ -141,6 +142,10 @@ export const actions = {
     if (error) action.payload = error
 
     return action
+  },
+
+  resetTipProbe (instrument) {
+    return {type: actionTypes.RESET_TIP_PROBE, payload: {instrument}}
   },
 
   moveTo (instrument, labware) {

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -15,7 +15,6 @@ import {
   FINISHED,
   STOPPED,
   UNPROBED,
-  PROBED,
   CONFIRMED,
   UNCONFIRMED,
   INSTRUMENT_AXES,
@@ -163,7 +162,10 @@ export function getInstrumentsByAxis (state) {
 
 export function getInstruments (state) {
   const protocolInstrumentsByAxis = getInstrumentsByAxis(state)
-  const {instrumentsByAxis: calibrationByAxis} = getCalibrationState(state)
+  const {
+    instrumentsByAxis: calibrationByAxis,
+    probedByAxis
+  } = getCalibrationState(state)
 
   return INSTRUMENT_AXES.map((axis) => {
     let instrument = protocolInstrumentsByAxis[axis] || {axis}
@@ -177,7 +179,8 @@ export function getInstruments (state) {
     if (instrument.name) {
       instrument = {
         ...instrument,
-        calibration: calibrationByAxis[axis] || UNPROBED
+        calibration: calibrationByAxis[axis] || UNPROBED,
+        probed: probedByAxis[axis] || false
       }
     }
 
@@ -189,7 +192,7 @@ export function getInstrumentsCalibrated (state) {
   const instruments = getInstruments(state)
 
   return instruments
-    .every((i) => i.name == null || i.calibration === PROBED)
+    .every((i) => i.name == null || i.probed)
 }
 
 export function getLabwareBySlot (state) {

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -178,6 +178,15 @@ describe('robot actions', () => {
     expect(actions.probeTipResponse(new Error('AH'))).toEqual(failure)
   })
 
+  test('reset tip probe action', () => {
+    const expected = {
+      type: actionTypes.RESET_TIP_PROBE,
+      payload: {instrument: 'right'}
+    }
+
+    expect(actions.resetTipProbe('right')).toEqual(expected)
+  })
+
   test('move to action', () => {
     const expected = {
       type: actionTypes.MOVE_TO,

--- a/app/ui/robot/test/calibration-reducer.test.js
+++ b/app/ui/robot/test/calibration-reducer.test.js
@@ -7,7 +7,11 @@ describe('robot reducer - calibration', () => {
 
     expect(state).toEqual({
       labwareReviewed: false,
+      // TODO(mc, 2017-11-03): instrumentsByAxis holds calibration status by
+      // axis. probedByAxis holds a flag for whether the instrument has been
+      // probed at least once by axis. Rethink or combine these states
       instrumentsByAxis: {},
+      probedByAxis: {},
       labwareBySlot: {},
 
       // homeRequest: {inProgress: false, error: null},
@@ -72,7 +76,7 @@ describe('robot reducer - calibration', () => {
         moveToFrontRequest: {inProgress: false, error: new Error()},
         instrumentsByAxis: {
           left: constants.UNPROBED,
-          right: constants.UNPROBED
+          right: constants.READY_TO_PROBE
         }
       }
     }
@@ -160,7 +164,8 @@ describe('robot reducer - calibration', () => {
         instrumentsByAxis: {
           left: constants.UNPROBED,
           right: constants.PROBING
-        }
+        },
+        probedByAxis: {}
       }
     }
     const success = {type: actionTypes.PROBE_TIP_RESPONSE, error: false}
@@ -179,6 +184,9 @@ describe('robot reducer - calibration', () => {
       instrumentsByAxis: {
         left: constants.UNPROBED,
         right: constants.PROBED
+      },
+      probedByAxis: {
+        right: true
       }
     })
     expect(reducer(state, failure).calibration).toEqual({
@@ -187,6 +195,31 @@ describe('robot reducer - calibration', () => {
         error: new Error('AH'),
         axis: 'right'
       },
+      instrumentsByAxis: {
+        left: constants.UNPROBED,
+        right: constants.UNPROBED
+      },
+      probedByAxis: {
+        right: false
+      }
+    })
+  })
+
+  test('handles RESET_TIP_PROBE', () => {
+    const state = {
+      calibration: {
+        instrumentsByAxis: {
+          left: constants.UNPROBED,
+          right: constants.PROBED
+        }
+      }
+    }
+    const action = {
+      type: actionTypes.RESET_TIP_PROBE,
+      payload: {instrument: 'right'}
+    }
+
+    expect(reducer(state, action).calibration).toEqual({
       instrumentsByAxis: {
         left: constants.UNPROBED,
         right: constants.UNPROBED

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -324,6 +324,9 @@ describe('robot selectors', () => {
       calibration: {
         instrumentsByAxis: {
           left: constants.PROBING
+        },
+        probedByAxis: {
+          left: true
         }
       }
     })
@@ -334,14 +337,16 @@ describe('robot selectors', () => {
         name: 'p200m',
         channels: 'multi',
         volume: 200,
-        calibration: constants.PROBING
+        calibration: constants.PROBING,
+        probed: true
       },
       {
         axis: 'right',
         name: 'p50s',
         channels: 'single',
         volume: 50,
-        calibration: constants.UNPROBED
+        calibration: constants.UNPROBED,
+        probed: false
       }
     ])
   })
@@ -355,10 +360,8 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {
-          left: constants.PROBED,
-          right: constants.PROBED
-        }
+        instrumentsByAxis: {},
+        probedByAxis: {left: true, right: true}
       }
     })
 
@@ -370,10 +373,8 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {
-          left: constants.UNPROBED,
-          right: constants.UNPROBED
-        }
+        instrumentsByAxis: {},
+        probedByAxis: {left: false, right: false}
       }
     })
 
@@ -384,9 +385,8 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {
-          right: constants.PROBED
-        }
+        instrumentsByAxis: {},
+        probedByAxis: {right: true}
       }
     })
 


### PR DESCRIPTION
## overview

This PR brings the tip probe sequence and views in the app into alignment with the UI/UX screens (which I'm going to call a bug). Mostly, it involves:

* Making sure the correct copy is in place
* Allowing the user to bail out of a tip probe
* Ensuring the view updates properly as the user switches between pipettes
* Minor styling cleanup

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Fix) Ensure tip probe state is cleared one one instrument if the other instrument is moved
- (Fix) Add missing copy for tip probe instructions
- (Fix) Separate out "has this instrument been probed?" and "what is this instrument doing right now for probing?" in the state
- (Feature) Allow the user to bail out of a tip probe in progress
- (Tests) Update tests for probe state split and tip probe bailout

## review requests

General app review rules apply
