### PR TITLE
(v3, bugfix) Use first available 1-channel instrument for move to and jog

### DIFF
--- a/app/ui/containers/ConnectedJogModal.js
+++ b/app/ui/containers/ConnectedJogModal.js
@@ -9,18 +9,38 @@ import JogModal from '../components/JogModal'
 
 const mapStateToProps = (state) => ({
   isJogging: robotSelectors.getJogInProgress(state),
-  isUpdating: robotSelectors.getOffsetUpdateInProgress(state)
+  isUpdating: robotSelectors.getOffsetUpdateInProgress(state),
+  singleChannel: robotSelectors.getSingleChannel(state)
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   const {slot} = ownProps
   return {
-    jog: (axis, direction) => () => {
-      // TODO(mc, 2017-10-06): don't hardcode the pipette
-      dispatch(robotActions.jog('right', axis, direction))
+    // TODO(mc, 2017-10-06): make jog buttons containers so we can get rid
+    // of this supercurried function
+    jog: (instrument) => (axis, direction) => () => {
+      dispatch(robotActions.jog(instrument, axis, direction))
     },
-    updateOffset: () => dispatch(robotActions.updateOffset('right', slot))
+    updateOffset: (instrument) => () => {
+      dispatch(robotActions.updateOffset(instrument, slot))
+    }
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(JogModal)
+// TODO(mc, 2017-11-03): investigate whether or not we can just get access to
+// dispatch and/or state in here. I think we're overcomplicating things
+const mergeProps = (stateProps, dispatchProps) => {
+  const props = {...stateProps, ...dispatchProps}
+  const {singleChannel, jog, updateOffset} = props
+
+  props.jog = jog(singleChannel.axis)
+  props.updateOffset = updateOffset(singleChannel.axis)
+
+  return props
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(JogModal)

--- a/app/ui/containers/ConnectedSetupPanel.js
+++ b/app/ui/containers/ConnectedSetupPanel.js
@@ -13,27 +13,28 @@ const mapStateToProps = (state) => ({
   labwareReviewed: robotSelectors.getLabwareReviewed(state),
   instrumentsCalibrated: robotSelectors.getInstrumentsCalibrated(state),
   tipracksConfirmed: robotSelectors.getTipracksConfirmed(state),
-  labwareConfirmed: robotSelectors.getLabwareConfirmed(state)
+  labwareConfirmed: robotSelectors.getLabwareConfirmed(state),
+  singleChannel: robotSelectors.getSingleChannel(state)
 })
 
 const mapDispatchToProps = (dispatch) => ({
   clearLabwareReviewed: () => dispatch(robotActions.setLabwareReviewed(false)),
   setLabware: (slot) => () => dispatch(push(`/setup-deck/${slot}`)),
-  // TODO(mc, 2017-10-06): don't hardcode the pipette
-  moveToLabware: (slot) => () => dispatch(robotActions.moveTo('right', slot))
+  moveToLabware: (axis, slot) => () => dispatch(robotActions.moveTo(axis, slot))
 })
 
 const mergeProps = (stateProps, dispatchProps) => {
   const props = {...stateProps, ...dispatchProps}
 
+  // TODO(mc, 2017-11-03): this assumes a single channel pipette will be
+  // available, so revisit so we don't have to make that assumption
   if (props.labwareReviewed) {
-    const setLabware = props.setLabware
-    const moveToLabware = props.moveToLabware
+    const {singleChannel, setLabware, moveToLabware} = props
 
     props.setLabware = (slot) => () => {
       // TODO(mc, 2017-10-06): batch or rethink this double dispatch
       setLabware(slot)()
-      moveToLabware(slot)()
+      moveToLabware(singleChannel.axis, slot)()
     }
   }
 

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -185,6 +185,11 @@ export function getInstruments (state) {
   })
 }
 
+export function getSingleChannel (state) {
+  return getInstruments(state)
+    .find((instrument) => instrument.channels === SINGLE_CHANNEL)
+}
+
 export function getInstrumentsCalibrated (state) {
   const instruments = getInstruments(state)
 

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -20,6 +20,7 @@ const {
   getIsDone,
   getRunTime,
   getInstruments,
+  getSingleChannel,
   getInstrumentsCalibrated,
   getLabware,
   getUnconfirmedTipracks,
@@ -344,6 +345,30 @@ describe('robot selectors', () => {
         calibration: constants.UNPROBED
       }
     ])
+  })
+
+  test('get single channel', () => {
+    const state = makeState({
+      session: {
+        protocolInstrumentsByAxis: {
+          left: {axis: 'left', name: 'p200m', channels: 8, volume: 200},
+          right: {axis: 'right', name: 'p50s', channels: 1, volume: 50}
+        }
+      },
+      calibration: {
+        instrumentsByAxis: {
+          left: constants.PROBING
+        }
+      }
+    })
+
+    expect(getSingleChannel(state)).toEqual({
+      axis: 'right',
+      name: 'p50s',
+      channels: 'single',
+      volume: 50,
+      calibration: constants.UNPROBED
+    })
   })
 
   test('get instruments are calibrated', () => {


### PR DESCRIPTION
## overview

The pipette used for move to container and jog had been hard-coded. If a given protocol didn't have the pipette that had been hard-coded, things would break pretty drastically. This is a quick and dirty PR to use whichever single-channel pipette is attached for these operations. This PR operates under the assumption that a single-channel pipette will be available.

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Fix) Use attached single-channel for labware calibration movements instead of hard-coding it

## review requests

Some of our React/redux containers need some love, because things are getting a little unwieldy. Feel free to point out any confusion, but I would appreciate it if we could punt on it for a future PR in for the sake of getting this bugfix in quickly.

