### PR TITLE
Scale, rotation and shift aware calibration and movement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - "export OT_BRANCH_SUFFIX=-${TRAVIS_BRANCH}"
   - "export OT_COMMIT_SUFFIX=-${TRAVIS_COMMIT:0:7}"
   # TODO(mc, 2017-08-28): use top level `make test`
-  - make -C api test exe
+  - make -C api test
   - make -C api lint
   # TODO (artyom 20171030): bring this back once the API is stable and documentation is fixed
   # - > # Make docs on linux only

--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: test docs publish clean install exe dev
+.PHONY: test docs publish clean install dev
 
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -25,11 +25,6 @@ publish:
 
 dev:
 	python opentrons/server/main.py
-
-exe: dist/opentrons-api-server
-
-dist/opentrons-api-server:
-	pyinstaller opentrons-api-server.spec
 
 clean:
 	rm -rf \

--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -27,8 +27,8 @@ class CalibrationManager:
 
     def tip_probe(self, instrument):
         self._set_state('probing')
-        # calibration_functions.probe_instrument(
-        #     instrument._instrument, self._robot)
+        calibration_functions.probe_instrument(
+            instrument._instrument, self._robot)
         self._set_state('ready')
 
     def move_to_front(self, instrument):

--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -27,8 +27,8 @@ class CalibrationManager:
 
     def tip_probe(self, instrument):
         self._set_state('probing')
-        calibration_functions.probe_instrument(
-            instrument._instrument, self._robot)
+        # calibration_functions.probe_instrument(
+        #     instrument._instrument, self._robot)
         self._set_state('ready')
 
     def move_to_front(self, instrument):

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -58,8 +58,9 @@ test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
 
 # World > Smoothie XY-plane transformation
 # Gets updated when you press SPACE after calibrating all points
-# Defaulted to values that would bring the robot close to test
-# point when 1, 2 or 3 is pressed
+# You can also default it to the last known good calibration
+# if you want to test points or to measure real-world objects
+# using the tool
 XY = \
     array([
         [ 1.00, 0.00, -35.23],   # NOQA

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -44,22 +44,17 @@ expected = [
 ]
 
 # Actuals get overridden when ENTER is pressed
-actual = [
-    (33.0, 5.25),
-    (298.0, 6.25),
-    (169.5, 276.0),
-]
+actual = [(0, 0)] * 3
+
 # Accessible through 1,2,3 ... keyboard keys to test
 # calibration by moving to known locations
-test_points = [
-    (64.0, 92.8, TIP_LENGTH),           # dimple 4
-    (329.0, 92.8, TIP_LENGTH),          # dimple 6
-    (196.50, 273.80, TIP_LENGTH),       # dimple 11
-    (132.50, 90.50, TIP_LENGTH),        # Slot 5
-    (332.13, 47.41, TIP_LENGTH),        # Corner of 3
-    (190.65, 227.57, TIP_LENGTH),       # Corner of 8
-    (330.14, 222.78, TIP_LENGTH),       # Corner of 9
-]
+test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
+    [
+        (132.50, 90.50, TIP_LENGTH),        # Slot 5
+        (332.13, 47.41, TIP_LENGTH),        # Corner of 3
+        (190.65, 227.57, TIP_LENGTH),       # Corner of 8
+        (330.14, 222.78, TIP_LENGTH),       # Corner of 9
+    ]
 
 # World > Smoothie XY-plane transformation
 # Gets updated when you press SPACE after calibrating all points
@@ -85,7 +80,7 @@ def add_z(XY):
 T = add_z(XY)
 
 
-def step():
+def current_step():
     """
     Given current step index return step value in mm
     """
@@ -125,7 +120,7 @@ def status(text):
         points,
         'Smoothie: {0}'.format(current_position),
         'World: {0}'.format(tuple(dot(inv(T), list(current_position) + [1])[:-1])),  # NOQA
-        'Step: {0}'.format(step()),
+        'Step: {0}'.format(current_step()),
         'Current stage: ' + current_pipette,
         'Message: ' + text
     ])
@@ -141,12 +136,12 @@ def jog(axis, direction, step):
 
 
 key_mappings = {
-    'q': lambda: jog(current_pipette, +1, step()),
-    'a': lambda: jog(current_pipette, -1, step()),
-    'up': lambda: jog('Y', +1, step()),
-    'down': lambda: jog('Y', -1, step()),
-    'left': lambda: jog('X', -1, step()),
-    'right': lambda: jog('X', +1, step()),
+    'q': lambda: jog(current_pipette, +1, current_step()),
+    'a': lambda: jog(current_pipette, -1, current_step()),
+    'up': lambda: jog('Y', +1, current_step()),
+    'down': lambda: jog('Y', -1, current_step()),
+    'left': lambda: jog('X', -1, current_step()),
+    'right': lambda: jog('X', +1, current_step()),
 }
 
 
@@ -165,12 +160,12 @@ def key_pressed(key):
     elif key == '-':
         if step_index > 0:
             step_index -= 1
-        status('step: ' + repr(step()))
+        status('step: ' + repr(current_step()))
     # more travel
     elif key == '=':
         if step_index < len(steps) - 1:
             step_index += 1
-        status('step: ' + repr(step()))
+        status('step: ' + repr(current_step()))
     # skip calibration point
     elif key == 's':
         if (point_number < len(actual) - 1):

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+
+import asyncio
+import urwid
+from numpy.linalg import inv
+from numpy import dot, array, insert
+from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import SmoothieDriver_3_0_0  # NOQA
+from translate import solve
+from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
+
+driver = SmoothieDriver_3_0_0()
+
+# Distance increments for jog
+steps = [0.25, 0.5, 1, 5, 10, 20, 40, 80]
+# Index of selected step
+step_index = 2
+
+
+left = 'z'
+right = 'a'
+current_pipette = right
+
+status_text = urwid.Text('')
+current_position = (0, 0, 0)
+
+# 200uL tip. Used during calibration process
+# The actual calibration represents end of a pipette
+# without tip on
+TIP_LENGTH = DEFAULT_TIP_LENGTH
+# Smoothie Z value when Deck's Z=0
+Z_OFFSET = 3.75
+
+# Reference point being calibrated
+point_number = 0
+
+# (0, 0) is in bottom-left corner
+# Expected reference points
+# v0
+# expected = [
+#     (64.0, -2.5 + 90.5),        # 4
+#     (329.16, -2.5 + 90.5),      # 6
+#     (196.58, 274.0)             # 11
+# ]
+expected = [
+    (64.0, 92.8),       # 1
+    (329.0, 92.8),      # 3
+    (196.50, 273.80)    # 11
+]
+# Expected
+# Updated during calibration process when you press ENTER
+# Default values don't matter and get overridden when ENTER is pressed
+actual = [
+    (33.0, 5.25),
+    (298.0, 6.25),
+    (169.5, 276.0),
+]
+# Accessible through 1,2,3 ... keyboard keys to test
+# calibration by moving to known locations
+test_points = [
+    (64.0, 92.8, TIP_LENGTH),            # 4
+    (329.0, 92.8, TIP_LENGTH),          # 6
+    (196.50, 183.30, TIP_LENGTH),                # 11
+    (196.50, 273.80, TIP_LENGTH+127.8)     # 5?
+]
+
+# World > Smoothie XY-plane transformation
+# Gets updated when you press SPACE after calibrating all points
+# You can also default it to the last known good calibration
+# if you want to test points or to measure real-world objects
+# using the tool
+XY = \
+    array([[  9.98113208e-01,  -5.52486188e-03,  -3.46165381e+01],
+           [ -3.77358491e-03,   1.00000000e+00,  -1.03084906e+01],
+           [ -5.03305613e-19,   2.60208521e-18,   1.00000000e+00]])
+
+# Add fixed Z offset which is known so we don't have to calibrate for height
+# during calibration process
+T = insert(
+        insert(XY, 2, [0, 0, 0], axis=1),
+        2,
+        [0, 0, 1, Z_OFFSET],
+        axis=0)
+
+
+def step():
+    """
+    Given current step index return step value in mm
+    """
+    return steps[step_index]
+
+
+def position():
+    """
+    Read position from driver into a tuple and map 3-rd value
+    to the axis of a pipette currently used
+    """
+    try:
+        p = driver.position
+        res = (p['X'], p['Y'], p[current_pipette.upper()])
+    except KeyError:
+        # for some reason we are sometimes getting
+        # key error in dict returned from driver
+        pass
+    else:
+        return res
+
+
+def status(text):
+    """
+    Refresh status in a text box
+    """
+
+    points = '\n'.join([
+        # Highlight point being calibrated
+        ('* ' if point_number == point else '') + "{0} {1}"
+        # Display actual and expected coordinates
+        .format(coord[0], coord[1])
+        for point, coord in enumerate(zip(actual, expected))
+    ])
+
+    text = '\n'.join([
+        points,
+        'Smoothie: {0}'.format(current_position),
+        'World: {0}'.format(tuple(dot(inv(T), list(current_position) + [1])[:-1])),  # NOQA
+        'Step: {0}'.format(step()),
+        'Current stage: ' + current_pipette,
+        'Message: ' + text
+    ])
+
+    status_text.set_text(text)
+
+
+def jog(axis, direction, step):
+    global current_position
+    driver.move(**{axis: driver.position[axis.upper()] + direction * step})
+    current_position = position()
+    status('Jog: ' + repr([axis, str(direction), str(step)]))
+
+key_mappings = {
+    'q': lambda: jog(current_pipette, +1, step()),
+    'a': lambda: jog(current_pipette, -1, step()),
+    'up': lambda: jog('y', +1, step()),
+    'down': lambda: jog('y', -1, step()),
+    'left': lambda: jog('x', -1, step()),
+    'right': lambda: jog('x', +1, step()),
+}
+
+
+def key_pressed(key):
+    global current_position, current_pipette, step_index, point_number, XY
+
+    if not isinstance(key, str):  # mouse clicked?
+        return
+
+    if key == 'z':
+        current_pipette = left if current_pipette == right else right
+        status('current pipette axis: ' + repr(current_pipette))
+    elif key.isnumeric():
+        validate(int(key) - 1)
+    # less travel
+    elif key == '-':
+        if step_index > 0:
+            step_index -= 1
+        status('step: ' + repr(step()))
+    # more travel
+    elif key == '=':
+        if step_index < len(steps) - 1:
+            step_index += 1
+        status('step: ' + repr(step()))
+    # skip calibration point
+    elif key == 's':
+        if (point_number < len(actual) - 1):
+            point_number += 1
+        status('skipped #{0}'.format(point_number))
+    # save calibration point and move to next
+    elif key == 'enter':
+        actual[point_number] = position()[:-1]
+        if (point_number < len(actual) - 1):
+            point_number += 1
+        status('saved #{0}: {1}'.format(point_number, actual[point_number]))
+    # move to previous calibration point
+    elif key == 'backspace':
+        if (point_number > 0):
+            point_number -= 1
+        status('')
+    # home
+    elif key == '\\':
+        driver.home('za')
+        driver.home('x')
+        driver.home()
+        current_position = position()
+        status('Homed')
+    # calculate transformation matrix
+    elif key == ' ':
+        try:
+            XY = solve(expected, actual)
+        except Exception as e:
+            status(repr(e))
+        else:
+            status(repr(XY))
+    else:
+        try:
+            key_mappings[key]()
+        except KeyError:
+            status('invalid key: ' + repr(key))
+
+
+# move to test points based on current matrix value
+def validate(index):
+    v = array(list(test_points[index]) + [1])
+    x, y, z, _ = dot(inv(T), list(position()) + [1])
+
+    safe_height = 130
+
+    if z < safe_height:
+        _, _, z, _ = dot(T, [x, y, safe_height, 1])
+        driver.move(**{current_pipette: z})
+
+    x, y, z, _ = dot(T, v)
+    driver.move(**{'x': x, 'y': y})
+    driver.move(**{current_pipette: z})
+
+
+def main():
+    driver.connect()
+    tip = urwid.Text(u"X/Y/Z: left,right/up,down/q,a; Pipette (swap): z; Steps: -/=; Test points: 1, 2, 3")   # NOQA
+    pile = urwid.Pile([tip, status_text])
+    root = urwid.Filler(pile, 'top')
+    event_loop = urwid.main_loop.AsyncioEventLoop(
+        loop=asyncio.get_event_loop()
+    )
+    ui_loop = urwid.MainLoop(
+        root,
+        unhandled_input=key_pressed,
+        event_loop=event_loop)
+    status('Hello!')
+    ui_loop.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -58,9 +58,8 @@ test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
 
 # World > Smoothie XY-plane transformation
 # Gets updated when you press SPACE after calibrating all points
-# You can also default it to the last known good calibration
-# if you want to test points or to measure real-world objects
-# using the tool
+# Defaulted to values that would bring the robot close to test
+# point when 1, 2 or 3 is pressed
 XY = \
     array([
         [ 1.00, 0.00, -35.23],   # NOQA

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -62,9 +62,10 @@ test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
 # if you want to test points or to measure real-world objects
 # using the tool
 XY = \
-    array([[  1.00283019e+00,  -4.83425414e-03, -3.52323132e+01],
-       [ -1.13207547e-02,   9.97237569e-01, -1.81761811e+00],
-       [ -5.03305613e-19,   2.60208521e-18, 1.00000000e+00]])   # NOQA
+    array([
+        [ 1.00, 0.00, -35.23],   # NOQA
+        [-0.01, 1.00,  -1.81],   # NOQA
+        [ 0.00, 0.00,   1.00]])  # NOQA
 
 
 # Add fixed Z offset which is known so we don't have to calibrate for height

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+# pylama:ignore=C901
+
 import asyncio
 import urwid
 from numpy.linalg import inv
 from numpy import dot, array, insert
 from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import SmoothieDriver_3_0_0  # NOQA
 from translate import solve
-from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 
 driver = SmoothieDriver_3_0_0()
 
@@ -27,7 +28,7 @@ current_position = (0, 0, 0)
 # 200uL tip. Used during calibration process
 # The actual calibration represents end of a pipette
 # without tip on
-TIP_LENGTH = DEFAULT_TIP_LENGTH - 3
+TIP_LENGTH = 47  # DEFAULT_TIP_LENGTH
 # Smoothie Z value when Deck's Z=0
 Z_OFFSET = 4.5
 
@@ -66,9 +67,9 @@ test_points = [
 # if you want to test points or to measure real-world objects
 # using the tool
 XY = \
-    array([[  1.00188679e+00,  -1.38121547e-03,  -4.02423779e+01],
-           [ -1.32075472e-02,   9.95856354e-01,  -5.06868659e+00],
-           [ -5.03305613e-19,   2.60208521e-18,   1.00000000e+00]])
+    array([[  1.00094340e+00,  -3.45303867e-03,  -1.94897355e+01],    # NOQA
+           [  1.88679245e-03,   9.97237569e-01,  -1.66290112e+00],    # NOQA
+           [ -5.03305613e-19,   2.60208521e-18,   1.00000000e+00]])   # NOQA
 
 
 # Add fixed Z offset which is known so we don't have to calibrate for height
@@ -137,6 +138,7 @@ def jog(axis, direction, step):
     driver.move({axis: driver.position[axis] + direction * step})
     current_position = position()
     status('Jog: ' + repr([axis, str(direction), str(step)]))
+
 
 key_mappings = {
     'q': lambda: jog(current_pipette, +1, step()),
@@ -241,6 +243,7 @@ def main():
     ui_loop.run()
 
     print('Calibration data: \n', T)
+
 
 if __name__ == "__main__":
     main()

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -7,7 +7,7 @@ import urwid
 from numpy.linalg import inv
 from numpy import dot, array, insert
 from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import SmoothieDriver_3_0_0  # NOQA
-from translate import solve
+from solve import solve
 
 driver = SmoothieDriver_3_0_0()
 
@@ -28,7 +28,7 @@ current_position = (0, 0, 0)
 # 200uL tip. Used during calibration process
 # The actual calibration represents end of a pipette
 # without tip on
-TIP_LENGTH = 47  # DEFAULT_TIP_LENGTH
+TIP_LENGTH = 47
 # Smoothie Z value when Deck's Z=0
 Z_OFFSET = 4.5
 
@@ -62,9 +62,9 @@ test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
 # if you want to test points or to measure real-world objects
 # using the tool
 XY = \
-    array([[  1.00094340e+00,  -3.45303867e-03,  -1.94897355e+01],    # NOQA
-           [  1.88679245e-03,   9.97237569e-01,  -1.66290112e+00],    # NOQA
-           [ -5.03305613e-19,   2.60208521e-18,   1.00000000e+00]])   # NOQA
+    array([[  1.00283019e+00,  -4.83425414e-03, -3.52323132e+01],
+       [ -1.13207547e-02,   9.97237569e-01, -1.81761811e+00],
+       [ -5.03305613e-19,   2.60208521e-18, 1.00000000e+00]])   # NOQA
 
 
 # Add fixed Z offset which is known so we don't have to calibrate for height
@@ -237,7 +237,7 @@ def main():
     status('Hello!')
     ui_loop.run()
 
-    print('Calibration data: \n', T)
+    print('Calibration data: \n', repr(T))
 
 
 if __name__ == "__main__":

--- a/api/opentrons/cli/solve.py
+++ b/api/opentrons/cli/solve.py
@@ -1,0 +1,16 @@
+import numpy as np
+from numpy.linalg import inv
+
+
+def solve(expected, actual):
+    A = np.array([
+            list(point) + [1]
+            for point in expected
+        ]).transpose()
+
+    B = np.array([
+            list(point) + [1]
+            for point in actual
+        ]).transpose()
+
+    return np.dot(B, inv(A))

--- a/api/opentrons/cli/translate.py
+++ b/api/opentrons/cli/translate.py
@@ -1,0 +1,58 @@
+import numpy as np
+from numpy.linalg import inv
+from math import sqrt, pi, sin, cos
+
+
+def solve(expected, actual):
+    A = np.array([
+            list(point) + [1]
+            for point in expected
+        ]).transpose()
+
+    B = np.array([
+            list(point) + [1]
+            for point in actual
+        ]).transpose()
+
+    return np.dot(B, inv(A))
+
+
+def test():
+    theta = pi / 3.0  # 60 deg
+    scale = 2.0
+
+    expected = [
+        [cos(0)           , sin(0)],
+        [cos(pi / 2)      , sin(pi / 2)],
+        [cos(pi)          , sin(pi)]]
+
+    actual = [
+        [cos(theta) * scale + 0.5          , sin(theta) * scale + 0.25],
+        [cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25],
+        [cos(theta + pi) * scale + 0.5     , sin(theta + pi) * scale + 0.25]]
+
+    X = solve(expected, actual)
+
+    expected = np.array([cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25, 1])
+    result = np.dot(X, np.array([[0], [1], [1]])).transpose()
+
+    return np.isclose(expected, result).all()
+
+
+def calc():
+    expected = [
+        (64,    354.70),  # 1
+        (329,   354.70),  # 3
+        (196.50, 83.70),  # 11
+    ]
+
+    actual = [
+        (33.0, 5.0),
+        (298.0, 6.0),
+        (169.0, 276.0),
+    ]
+    return solve(expected, actual)
+
+
+if __name__ == '__main__':
+    print('TEST: ' + repr(calc()))

--- a/api/opentrons/cli/translate.py
+++ b/api/opentrons/cli/translate.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.linalg import inv
-from math import sqrt, pi, sin, cos
+from math import pi, sin, cos
 
 
 def solve(expected, actual):
@@ -22,18 +22,18 @@ def test():
     scale = 2.0
 
     expected = [
-        [cos(0)           , sin(0)],
-        [cos(pi / 2)      , sin(pi / 2)],
-        [cos(pi)          , sin(pi)]]
+        [cos(0)           , sin(0)],          # NOQA
+        [cos(pi / 2)      , sin(pi / 2)],     # NOQA
+        [cos(pi)          , sin(pi)]]         # NOQA
 
     actual = [
-        [cos(theta) * scale + 0.5          , sin(theta) * scale + 0.25],
-        [cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25],
-        [cos(theta + pi) * scale + 0.5     , sin(theta + pi) * scale + 0.25]]
+        [cos(theta) * scale + 0.5          , sin(theta) * scale + 0.25],            # NOQA
+        [cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25],   # NOQA
+        [cos(theta + pi) * scale + 0.5     , sin(theta + pi) * scale + 0.25]]       # NOQA
 
     X = solve(expected, actual)
 
-    expected = np.array([cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25, 1])
+    expected = np.array([cos(theta + pi / 2) * scale + 0.5 , sin(theta + pi / 2) * scale + 0.25, 1])   # NOQA
     result = np.dot(X, np.array([[0], [1], [1]])).transpose()
 
     return np.isclose(expected, result).all()

--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -71,12 +71,12 @@ def make_command(name, payload):
     return {'name': name, 'payload': payload}
 
 
-def home(axis):
-    text = 'Homing pipette plunger on axis {axis}'.format(axis=axis)
+def home(mount):
+    text = 'Homing pipette plunger on mount {mount}'.format(mount=mount)
     return make_command(
         name=types.HOME,
         payload={
-            'axis': axis,
+            'axis': mount,
             'text': text
         }
     )

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -16,7 +16,7 @@ from opentrons.robot.robot_configs import (
 
 # TODO (ben 2017112): figure out why fw setting wasn't working on Avogadro
 # and remove this
-HOMING_OFFSETS = 'M206 X5'
+HOMING_OFFSETS = 'M206 X5 Y5'
 
 # TODO (artyom, ben 20171026): move to config
 HOMED_POSITION = {
@@ -179,6 +179,7 @@ class SmoothieDriver_3_0_0:
             if moving_plunger:
                 self.set_current('BC', PLUNGER_CURRENT_HIGH)
 
+            print(command)
             command_line = command + ' M400'
             ret_code = serial_communication.write_and_return(
                 command_line, self._connection, timeout)
@@ -209,7 +210,7 @@ class SmoothieDriver_3_0_0:
                 isclose(coords, self._position[axis])
             )
 
-        coords = [axis + str(coords)
+        coords = [axis + str(round(coords, 3))
                   for axis, coords in target.items()
                   if valid_movement(coords, axis)]
 
@@ -249,11 +250,6 @@ class SmoothieDriver_3_0_0:
         self._send_command(command, timeout=30)
 
         position = HOMED_POSITION
-
-        if not self.simulating:
-            position = _parse_axis_values(
-                self._send_command(GCODES['CURRENT_POSITION'])
-            )
 
         # Only update axes that have been selected for homing
         homed = {

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -14,10 +14,6 @@ from opentrons.robot.robot_configs import (
   or knowing anything about what the axes are used for
 '''
 
-# TODO (ben 2017112): figure out why fw setting wasn't working on Avogadro
-# and remove this
-HOMING_OFFSETS = 'M206 X5 Y5'
-
 # TODO (artyom, ben 20171026): move to config
 HOMED_POSITION = {
     'X': 394,
@@ -191,7 +187,6 @@ class SmoothieDriver_3_0_0:
         self._send_command(config.current)
         self._send_command(config.max_speeds)
         self._send_command(config.steps_per_mm)
-        self._send_command(HOMING_OFFSETS)
         self._send_command(GCODES['ABSOLUTE_COORDS'])
     # ----------- END Private functions ----------- #
 

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -270,6 +270,7 @@ class SmoothieDriver_3_0_0:
         if axis.upper() in AXES:
             command = GCODES['PROBE'] + axis.upper() + str(probing_distance)
             self._send_command(command=command, timeout=30)
+            self.update_position(self._position)
             return self._position[axis.upper()]
         else:
             raise RuntimeError("Cant probe axis {}".format(axis))

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -176,7 +176,6 @@ class SmoothieDriver_3_0_0:
             if moving_plunger:
                 self.set_current('BC', PLUNGER_CURRENT_HIGH)
 
-            print(command)
             command_line = command + ' M400'
             ret_code = serial_communication.write_and_return(
                 command_line, self._connection, timeout)

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -164,11 +164,16 @@ class SmoothieDriver_3_0_0:
 
     # Potential place for command optimization (buffering, flushing, etc)
     def _send_command(self, command, timeout=None):
+<<<<<<< HEAD
         if self.simulating:
             pass
         else:
             moving_plunger = ('B' in command or 'C' in command) \
                 and (GCODES['MOVE'] in command or GCODES['HOME'] in command)
+=======
+        print('sending: ', command)
+        command_line = command + ' M400'
+>>>>>>> move calibration data under robot_config, test on Avogadro
 
             if moving_plunger:
                 self.set_current('BC', PLUNGER_CURRENT_HIGH)
@@ -196,6 +201,8 @@ class SmoothieDriver_3_0_0:
     def move(self, target):
         from numpy import isclose
 
+        print('Driver target: ', target)
+
         def valid_movement(coords, axis):
             return not (
                 (axis in DISABLE_AXES) or
@@ -214,6 +221,8 @@ class SmoothieDriver_3_0_0:
 
     def home(self, axis=AXES, disabled=DISABLE_AXES):
         axis = axis.upper()
+
+        print('Homing: ', axis)
 
         # If Y is requested make sure we home X first
         if 'Y' in axis:

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -136,10 +136,11 @@ class SmoothieDriver_3_0_0:
     def speed(self):
         pass
 
-    def set_speed(self, value):
-        ''' set total movement speed in mm/second'''
-        speed = value * SEC_PER_MIN
-        command = GCODES['SET_SPEED'] + str(speed)
+    def set_speed(self, values):
+        command = GCODES['SET_SPEED'] + ' ' + ' '.join([
+            '{axis}{value}'.format(axis=axis.upper(), value=value)
+            for axis, value in values.items()
+        ])
         self._send_command(command)
 
     def set_current(self, axes, value):
@@ -192,9 +193,8 @@ class SmoothieDriver_3_0_0:
     # ----------- END Private functions ----------- #
 
     # ----------- Public interface ---------------- #
-    def move(self, x=None, y=None, z=None, a=None, b=None, c=None):
+    def move(self, target):
         from numpy import isclose
-        target_position = {'X': x, 'Y': y, 'Z': z, 'A': a, 'B': b, 'C': c}
 
         def valid_movement(coords, axis):
             return not (
@@ -204,13 +204,13 @@ class SmoothieDriver_3_0_0:
             )
 
         coords = [axis + str(coords)
-                  for axis, coords in target_position.items()
+                  for axis, coords in target.items()
                   if valid_movement(coords, axis)]
 
         if coords:
             command = GCODES['MOVE'] + ''.join(coords)
             self._send_command(command)
-            self._update_position(target_position)
+            self._update_position(target)
 
     def home(self, axis=AXES, disabled=DISABLE_AXES):
         axis = axis.upper()

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1412,17 +1412,18 @@ class Pipette:
         return self
 
     def _move(self, pose_tree, x=None, y=None, z=None):
-        current_x, current_y, current_z = pose_tracker.absolute(
+        current_x, current_y, current_z = pose_tracker.transform(
             pose_tree,
-            self)
+            src=self)
 
         x = current_x if x is None else x
         y = current_y if y is None else y
         z = current_z if z is None else z
 
-        dx, dy, dz = \
-            pose_tracker.absolute(pose_tree, self) - \
-            pose_tracker.absolute(pose_tree, self.mount)
+        dx, dy, dz = pose_tracker.transform(
+            pose_tree,
+            src=self,
+            dst=self.mount)
 
         x, y, z = x and x - dx, y and y - dy, z and z - dz
 
@@ -1441,18 +1442,25 @@ class Pipette:
 
     def _probe(self, axis, movement):
         if axis in 'xy':
-            self.robot.gantry.probe(axis, movement)
+            value = self.robot.gantry.probe(axis, movement)
         elif axis == 'z':
-            pose_tree = self.instrument_mover.probe(axis, movement)
+            value = self.instrument_mover.probe(axis, movement)
+        return value
 
     def _add_tip(self, length):
-        x, y, z = pose_tracker.get(self.robot.poses, self)
+        x, y, z = pose_tracker.transform(
+            self.robot.poses,
+            src=self.mount,
+            dst=self)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z - length))
 
     def _remove_tip(self, length):
-        x, y, z = pose_tracker.get(self.robot.poses, self)
+        x, y, z = pose_tracker.transform(
+            self.robot.poses,
+            src=self.mount,
+            dst=self)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z + length))

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1426,12 +1426,20 @@ class Pipette:
 
         x, y, z = x and x - dx, y and y - dy, z and z - dz
 
-        res = self.instrument_mover.move(pose_tree, x, y, z)
+        pose_tree = self.robot.gantry.move(pose_tree, x=x, y=y)
+        pose_tree = self.instrument_mover.move(pose_tree, z=z)
 
-        return res
+        return pose_tree
 
     def _jog(self, pose_tree, axis, distance):
-        return self.instrument_mover.jog(pose_tree, axis, distance)
+        if axis == 'x':
+            pose_tree = self.robot.gantry.jog(pose_tree, axis, distance)
+        elif axis == 'y':
+            pose_tree = self.robot.gantry.jog(pose_tree, axis, distance)
+        elif axis == 'z':
+            pose_tree = self.instrument_mover.jog(pose_tree, axis, distance)
+
+        return pose_tree
 
     def _probe(self, axis, movement):
         return self.instrument_mover.probe(axis, movement)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -889,14 +889,14 @@ class Pipette:
         <opentrons.instruments.pipette.Pipette object at ...>
         """
         @commands.publish.both(command=commands.home)
-        def home(mount):
+        def _home(mount):
             self.current_volume = 0
             self.robot.poses = self.instrument_actuator.home(self.robot.poses)
             # TODO(artyom, 20171103): confirm expected behavior on pipette.home
             # Are we homing stage and plunger or plunger only?
             # self.robot.poses = self.instrument_mover.home(self.robot.poses)
 
-        home(self.mount)
+        _home(self.mount)
         return self
 
     @commands.publish.both(command=commands.distribute)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1412,15 +1412,15 @@ class Pipette:
         return self
 
     def _move(self, pose_tree, x=None, y=None, z=None):
-        current_x, current_y, current_z = pose_tracker.transform(
+        current_x, current_y, current_z = pose_tracker.absolute(
             pose_tree,
-            src=self)
+            self)
 
         x = current_x if x is None else x
         y = current_y if y is None else y
         z = current_z if z is None else z
 
-        dx, dy, dz = pose_tracker.transform(
+        dx, dy, dz = pose_tracker.change_base(
             pose_tree,
             src=self,
             dst=self.mount)
@@ -1441,6 +1441,7 @@ class Pipette:
         return pose_tree
 
     def _probe(self, axis, movement):
+        assert axis in 'xyz', "Axis must be 'x', 'y', or 'z'"
         if axis in 'xy':
             value = self.robot.gantry.probe(axis, movement)
         elif axis == 'z':
@@ -1448,7 +1449,7 @@ class Pipette:
         return value
 
     def _add_tip(self, length):
-        x, y, z = pose_tracker.transform(
+        x, y, z = pose_tracker.change_base(
             self.robot.poses,
             src=self,
             dst=self.mount)
@@ -1457,7 +1458,7 @@ class Pipette:
                 x, y, z - length))
 
     def _remove_tip(self, length):
-        x, y, z = pose_tracker.transform(
+        x, y, z = pose_tracker.change_base(
             self.robot.poses,
             src=self,
             dst=self.mount)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1427,13 +1427,13 @@ class Pipette:
         return self.instrument_mover.probe(axis, movement)
 
     def _add_tip(self, length):
+        x, y, z = pose_tracker.get(self.robot.poses, self)
         self.robot.poses = pose_tracker.update(
-            self.robot.poses,
-            self,
-            pose_tracker.Point(0, 0, -length))
+            self.robot.poses, self, pose_tracker.Point(
+                x, y, z - length))
 
     def _remove_tip(self, length):
+        x, y, z = pose_tracker.get(self.robot.poses, self)
         self.robot.poses = pose_tracker.update(
-            self.robot.poses,
-            self,
-            pose_tracker.Point(0, 0, length))
+            self.robot.poses, self, pose_tracker.Point(
+                x, y, z + length))

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1412,18 +1412,17 @@ class Pipette:
         return self
 
     def _move(self, pose_tree, x=None, y=None, z=None):
-        current_x, current_y, current_z = pose_tracker.transform(
+        current_x, current_y, current_z = pose_tracker.absolute(
             pose_tree,
-            src=self)
+            self)
 
         x = current_x if x is None else x
         y = current_y if y is None else y
         z = current_z if z is None else z
 
-        dx, dy, dz = pose_tracker.transform(
-            pose_tree,
-            src=self,
-            dst=self.mount)
+        dx, dy, dz = \
+            pose_tracker.absolute(pose_tree, self) - \
+            pose_tracker.absolute(pose_tree, self.mount)
 
         x, y, z = x and x - dx, y and y - dy, z and z - dz
 
@@ -1443,29 +1442,16 @@ class Pipette:
         return pose_tree
 
     def _probe(self, axis, movement):
-        if axis == 'x':
-            value = self.robot.gantry.probe(axis, movement)
-        elif axis == 'y':
-            value = self.robot.gantry.probe(axis, movement)
-        elif axis == 'z':
-            value = self.instrument_mover.probe(axis, movement)
-
-        return value
+        return self.instrument_mover.probe(axis, movement)
 
     def _add_tip(self, length):
-        x, y, z = pose_tracker.transform(
-            self.robot.poses,
-            src=self.mount,
-            dst=self)
+        x, y, z = pose_tracker.get(self.robot.poses, self)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z - length))
 
     def _remove_tip(self, length):
-        x, y, z = pose_tracker.transform(
-            self.robot.poses,
-            src=self.mount,
-            dst=self)
+        x, y, z = pose_tracker.get(self.robot.poses, self)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z + length))

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1432,9 +1432,7 @@ class Pipette:
         return pose_tree
 
     def _jog(self, pose_tree, axis, distance):
-        if axis == 'x':
-            pose_tree = self.robot.gantry.jog(pose_tree, axis, distance)
-        elif axis == 'y':
+        if axis in 'xy':
             pose_tree = self.robot.gantry.jog(pose_tree, axis, distance)
         elif axis == 'z':
             pose_tree = self.instrument_mover.jog(pose_tree, axis, distance)
@@ -1442,7 +1440,10 @@ class Pipette:
         return pose_tree
 
     def _probe(self, axis, movement):
-        return self.instrument_mover.probe(axis, movement)
+        if axis in 'xy':
+            self.robot.gantry.probe(axis, movement)
+        elif axis == 'z':
+            pose_tree = self.instrument_mover.probe(axis, movement)
 
     def _add_tip(self, length):
         x, y, z = pose_tracker.get(self.robot.poses, self)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1412,13 +1412,23 @@ class Pipette:
         return self
 
     def _move(self, pose_tree, x=None, y=None, z=None):
+        current_x, current_y, current_z = pose_tracker.absolute(
+            pose_tree,
+            self)
+
+        x = current_x if x is None else x
+        y = current_y if y is None else y
+        z = current_z if z is None else z
+
         dx, dy, dz = \
             pose_tracker.absolute(pose_tree, self) - \
-            pose_tracker.absolute(pose_tree, self.instrument_mover)
+            pose_tracker.absolute(pose_tree, self.mount)
 
         x, y, z = x and x - dx, y and y - dy, z and z - dz
 
-        return self.instrument_mover.move(pose_tree, x, y, z)
+        res = self.instrument_mover.move(pose_tree, x, y, z)
+
+        return res
 
     def _jog(self, pose_tree, axis, distance):
         return self.instrument_mover.jog(pose_tree, axis, distance)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1450,8 +1450,8 @@ class Pipette:
     def _add_tip(self, length):
         x, y, z = pose_tracker.transform(
             self.robot.poses,
-            src=self.mount,
-            dst=self)
+            src=self,
+            dst=self.mount)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z - length))
@@ -1459,8 +1459,8 @@ class Pipette:
     def _remove_tip(self, length):
         x, y, z = pose_tracker.transform(
             self.robot.poses,
-            src=self.mount,
-            dst=self)
+            src=self,
+            dst=self.mount)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
                 x, y, z + length))

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -1,73 +1,67 @@
-from ..trackers.pose_tracker import (
-    Point, absolute, update, relative, ROOT
-)
+from ..trackers.pose_tracker import Point, transform, update, ROOT
 
 
 class Mover:
-    def __init__(
-        self,
-        driver,
-        axis_mapping,
-        reference,
-        origin=ROOT,
-    ):
+    def __init__(self, driver, axis_mapping, dst, src=ROOT):
         self._driver = driver
-        self._origin = origin
-        self._reference = driver if reference is None else reference
-        self._parent = None
         self._axis_mapping = axis_mapping
+        self._dst = dst
+        self._src = src
 
     def jog(self, pose, axis, distance):
-        axis = axis.lower()
-
         assert axis in 'xyz', "axis value should be x, y or z"
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
 
-        x, y, z = absolute(pose, self)
+        x, y, z = transform(pose, src=self)
 
-        return self.move(
-            pose,
-            *Point(
-                x=x + distance if axis == 'x' else x,
-                y=y + distance if axis == 'y' else y,
-                z=z + distance if axis == 'z' else z
-            )
-        )
+        target = {
+            'x': x if 'x' in self._axis_mapping else None,
+            'y': y if 'y' in self._axis_mapping else None,
+            'z': z if 'z' in self._axis_mapping else None,
+        }
+
+        target[axis] += distance
+
+        return self.move(pose, **target)
 
     def move(self, pose, x=None, y=None, z=None):
-        # Potential users of this method might need less than 3 axis
+        """
+        Dispatch move command to the driver transforming
+        x, y and z from source coordinate system to destination.
 
-        x = x if 'x' in self._axis_mapping else 0
-        y = y if 'y' in self._axis_mapping else 0
-        z = z if 'z' in self._axis_mapping else 0
+        Value must be set for each axis that is mapped.
+        """
+        def defaults(_x, _y, _z):
+            _x = _x if x is not None else 0
+            _y = _y if y is not None else 0
+            _z = _z if z is not None else 0
+            return _x, _y, _z
 
-        x, y, z = relative(
+        dst_x, dst_y, dst_z = transform(
             pose,
-            src=self._origin,
-            dst=self._reference,
-            src_point=Point(x, y, z))
+            src=self._src,
+            dst=self._dst,
+            point=Point(*defaults(x, y, z)))
 
         driver_target = {}
 
         if 'x' in self._axis_mapping:
-            driver_target[self._axis_mapping['x']] = x
-        else:
-            x = 0
+            assert x is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['x']] = dst_x
 
         if 'y' in self._axis_mapping:
-            driver_target[self._axis_mapping['y']] = y
-        else:
-            y = 0
+            assert y is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['y']] = dst_y
 
         if 'z' in self._axis_mapping:
-            driver_target[self._axis_mapping['z']] = z
-        else:
-            z = 0
+            assert z is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['z']] = dst_z
 
         self._driver.move(target=driver_target)
 
         # Update pose with the new value. Since stepper motors are open loop
         # there is no need to to query diver for position
-        return update(pose, self, Point(x, y, z))
+        return update(pose, self, Point(*defaults(dst_x, dst_y, dst_z)))
 
     def home(self, pose):
         position = self._driver.home(axis=''.join(self._axis_mapping.values()))
@@ -91,14 +85,12 @@ class Mover:
         # })
 
     def probe(self, axis, movement):
-        axis = axis.lower()
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
 
         if axis in self._axis_mapping:
-            result = self._driver.probe_axis(
+            return self._driver.probe_axis(
                         self._axis_mapping[axis],
                         movement)
-
-        return result
 
     def delay(self, seconds):
         self._driver.delay(seconds)

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -92,10 +92,6 @@ class Mover:
 
     def probe(self, axis, movement):
         axis = axis.lower()
-        result = {}
-
-        if self._parent:
-            result = self._parent.probe(axis, movement)
 
         if axis in self._axis_mapping:
             result = self._driver.probe_axis(

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -105,12 +105,17 @@ class Mover:
 
     def probe(self, axis, movement):
         axis = axis.lower()
+        result = {}
 
         if self._parent:
-            self._parent.probe(axis, movement)
+            result = self._parent.probe(axis, movement)
 
         if axis in self._axis_mapping:
-            self._driver.probe_axis(self._axis_mapping[axis], movement)
+            result = self._driver.probe_axis(
+                        self._axis_mapping[axis],
+                        movement)
+
+        return result
 
     def delay(self, seconds):
         self._driver.delay(seconds)

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -40,17 +40,9 @@ class Mover:
             )
         )
 
-    def move(self, pose, x=None, y=None, z=None):
+    def move(self, pose, x, y=0, z=0):
         # Default coordinates that are None to current so we can
         # pass them around safely
-        current_x, current_y, current_z = relative(
-            pose,
-            src=self,
-            dst=self._origin)
-        x = current_x if x is None else x
-        y = current_y if y is None else y
-        z = current_z if z is None else z
-
         if self._parent:
             pose = self._parent.move(pose, x, y, z)
 
@@ -99,10 +91,13 @@ class Mover:
         return update(pose, self, point)
 
     def set_speed(self, value):
-        self._driver.set_speed({
-            axis: value
-            for axis in self._axis_mapping.values()
-        })
+        pass
+        # TODO (artyom 20171105): uncomment once proper plunger speeds are
+        # defined
+        # self._driver.set_speed({
+        #     axis: value
+        #     for axis in self._axis_mapping.values()
+        # })
 
     def probe(self, axis, movement):
         axis = axis.lower()

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -1,67 +1,73 @@
-from ..trackers.pose_tracker import Point, transform, update, ROOT
+from ..trackers.pose_tracker import (
+    Point, absolute, update, relative, ROOT
+)
 
 
 class Mover:
-    def __init__(self, driver, axis_mapping, dst, src=ROOT):
+    def __init__(
+        self,
+        driver,
+        axis_mapping,
+        reference,
+        origin=ROOT,
+    ):
         self._driver = driver
+        self._origin = origin
+        self._reference = driver if reference is None else reference
+        self._parent = None
         self._axis_mapping = axis_mapping
-        self._dst = dst
-        self._src = src
 
     def jog(self, pose, axis, distance):
+        axis = axis.lower()
+
         assert axis in 'xyz', "axis value should be x, y or z"
-        assert axis in self._axis_mapping, "mapping is not set for " + axis
 
-        x, y, z = transform(pose, src=self)
+        x, y, z = absolute(pose, self)
 
-        target = {
-            'x': x if 'x' in self._axis_mapping else None,
-            'y': y if 'y' in self._axis_mapping else None,
-            'z': z if 'z' in self._axis_mapping else None,
-        }
-
-        target[axis] += distance
-
-        return self.move(pose, **target)
+        return self.move(
+            pose,
+            *Point(
+                x=x + distance if axis == 'x' else x,
+                y=y + distance if axis == 'y' else y,
+                z=z + distance if axis == 'z' else z
+            )
+        )
 
     def move(self, pose, x=None, y=None, z=None):
-        """
-        Dispatch move command to the driver transforming
-        x, y and z from source coordinate system to destination.
+        # Potential users of this method might need less than 3 axis
 
-        Value must be set for each axis that is mapped.
-        """
-        def defaults(_x, _y, _z):
-            _x = _x if x is not None else 0
-            _y = _y if y is not None else 0
-            _z = _z if z is not None else 0
-            return _x, _y, _z
+        x = x if 'x' in self._axis_mapping else 0
+        y = y if 'y' in self._axis_mapping else 0
+        z = z if 'z' in self._axis_mapping else 0
 
-        dst_x, dst_y, dst_z = transform(
+        x, y, z = relative(
             pose,
-            src=self._src,
-            dst=self._dst,
-            point=Point(*defaults(x, y, z)))
+            src=self._origin,
+            dst=self._reference,
+            src_point=Point(x, y, z))
 
         driver_target = {}
 
         if 'x' in self._axis_mapping:
-            assert x is not None, "Value must be set for each axis mapped"
-            driver_target[self._axis_mapping['x']] = dst_x
+            driver_target[self._axis_mapping['x']] = x
+        else:
+            x = 0
 
         if 'y' in self._axis_mapping:
-            assert y is not None, "Value must be set for each axis mapped"
-            driver_target[self._axis_mapping['y']] = dst_y
+            driver_target[self._axis_mapping['y']] = y
+        else:
+            y = 0
 
         if 'z' in self._axis_mapping:
-            assert z is not None, "Value must be set for each axis mapped"
-            driver_target[self._axis_mapping['z']] = dst_z
+            driver_target[self._axis_mapping['z']] = z
+        else:
+            z = 0
 
         self._driver.move(target=driver_target)
 
         # Update pose with the new value. Since stepper motors are open loop
         # there is no need to to query diver for position
-        return update(pose, self, Point(*defaults(dst_x, dst_y, dst_z)))
+        return update(pose, self, Point(x, y, z))
 
     def home(self, pose):
         position = self._driver.home(axis=''.join(self._axis_mapping.values()))
@@ -85,12 +91,18 @@ class Mover:
         # })
 
     def probe(self, axis, movement):
-        assert axis in self._axis_mapping, "mapping is not set for " + axis
+        axis = axis.lower()
+        result = {}
+
+        if self._parent:
+            result = self._parent.probe(axis, movement)
 
         if axis in self._axis_mapping:
-            return self._driver.probe_axis(
+            result = self._driver.probe_axis(
                         self._axis_mapping[axis],
                         movement)
+
+        return result
 
     def delay(self, seconds):
         self._driver.delay(seconds)

--- a/api/opentrons/robot/gantry.py
+++ b/api/opentrons/robot/gantry.py
@@ -1,73 +1,67 @@
-from ..trackers.pose_tracker import (
-    Point, absolute, update, relative, ROOT
-)
+from ..trackers.pose_tracker import Point, transform, update, ROOT
 
 
 class Mover:
-    def __init__(
-        self,
-        driver,
-        axis_mapping,
-        reference,
-        origin=ROOT,
-    ):
+    def __init__(self, driver, axis_mapping, dst, src=ROOT):
         self._driver = driver
-        self._origin = origin
-        self._reference = driver if reference is None else reference
-        self._parent = None
         self._axis_mapping = axis_mapping
+        self._dst = dst
+        self._src = src
 
     def jog(self, pose, axis, distance):
-        axis = axis.lower()
-
         assert axis in 'xyz', "axis value should be x, y or z"
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
 
-        x, y, z = absolute(pose, self)
+        x, y, z = transform(pose, src=self)
 
-        return self.move(
-            pose,
-            *Point(
-                x=x + distance if axis == 'x' else x,
-                y=y + distance if axis == 'y' else y,
-                z=z + distance if axis == 'z' else z
-            )
-        )
+        target = {
+            'x': x if 'x' in self._axis_mapping else None,
+            'y': y if 'y' in self._axis_mapping else None,
+            'z': z if 'z' in self._axis_mapping else None,
+        }
+
+        target[axis] += distance
+
+        return self.move(pose, **target)
 
     def move(self, pose, x=None, y=None, z=None):
-        # Potential users of this method might need less than 3 axis
+        """
+        Dispatch move command to the driver transforming
+        x, y and z from source coordinate system to destination.
 
-        x = x if 'x' in self._axis_mapping else 0
-        y = y if 'y' in self._axis_mapping else 0
-        z = z if 'z' in self._axis_mapping else 0
+        Value must be set for each axis that is mapped.
+        """
+        def defaults(_x, _y, _z):
+            _x = _x if x is not None else 0
+            _y = _y if y is not None else 0
+            _z = _z if z is not None else 0
+            return _x, _y, _z
 
-        x, y, z = relative(
+        dst_x, dst_y, dst_z = transform(
             pose,
-            src=self._origin,
-            dst=self._reference,
-            src_point=Point(x, y, z))
+            src=self._src,
+            dst=self._dst,
+            point=Point(*defaults(x, y, z)))
 
         driver_target = {}
 
         if 'x' in self._axis_mapping:
-            driver_target[self._axis_mapping['x']] = x
-        else:
-            x = 0
+            assert x is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['x']] = dst_x
 
         if 'y' in self._axis_mapping:
-            driver_target[self._axis_mapping['y']] = y
-        else:
-            y = 0
+            assert y is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['y']] = dst_y
 
         if 'z' in self._axis_mapping:
-            driver_target[self._axis_mapping['z']] = z
-        else:
-            z = 0
+            assert z is not None, "Value must be set for each axis mapped"
+            driver_target[self._axis_mapping['z']] = dst_z
 
         self._driver.move(target=driver_target)
 
         # Update pose with the new value. Since stepper motors are open loop
         # there is no need to to query diver for position
-        return update(pose, self, Point(x, y, z))
+        return update(pose, self, Point(*defaults(dst_x, dst_y, dst_z)))
 
     def home(self, pose):
         position = self._driver.home(axis=''.join(self._axis_mapping.values()))
@@ -91,18 +85,12 @@ class Mover:
         # })
 
     def probe(self, axis, movement):
-        axis = axis.lower()
-        result = {}
-
-        if self._parent:
-            result = self._parent.probe(axis, movement)
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
 
         if axis in self._axis_mapping:
-            result = self._driver.probe_axis(
+            return self._driver.probe_axis(
                         self._axis_mapping[axis],
                         movement)
-
-        return result
 
     def delay(self, seconds):
         self._driver.delay(seconds)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -176,21 +176,25 @@ class Robot(object):
             'left': {
                 'carriage': Mover(
                     driver=self._driver,
-                    reference=id(CALIBRATION),
+                    src=pose_tracker.ROOT,
+                    dst=id(CALIBRATION),
                     axis_mapping={'z': 'Z'}),
                 'plunger': Mover(
                     driver=self._driver,
-                    reference='volume-calibration-left',
+                    src=pose_tracker.ROOT,
+                    dst='volume-calibration-left',
                     axis_mapping={'x': 'B'})
             },
             'right': {
                 'carriage': Mover(
                     driver=self._driver,
-                    reference=id(CALIBRATION),
+                    src=pose_tracker.ROOT,
+                    dst=id(CALIBRATION),
                     axis_mapping={'z': 'A'}),
                 'plunger': Mover(
                     driver=self._driver,
-                    reference='volume-calibration-right',
+                    src=pose_tracker.ROOT,
+                    dst='volume-calibration-right',
                     axis_mapping={'x': 'C'})
             }
         }
@@ -275,7 +279,8 @@ class Robot(object):
         self.gantry = Mover(
             driver=driver,
             axis_mapping={'x': 'X', 'y': 'Y'},
-            reference=id(CALIBRATION)
+            src=pose_tracker.ROOT,
+            dst=id(CALIBRATION)
         )
 
         # Extract only transformation component
@@ -557,9 +562,9 @@ class Robot(object):
             placeable = placeable[0]
 
         target = add(
-            pose_tracker.absolute(
+            pose_tracker.transform(
                 self.poses,
-                placeable
+                src=placeable
             ),
             offset.coordinates
         )
@@ -917,7 +922,7 @@ class Robot(object):
         well = container[0]
 
         # calibrate will well bottom, but track top of well
-        delta = pose_tracker.relative(
+        delta = pose_tracker.transform(
             self.poses,
             src=instrument,
             dst=well

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -176,25 +176,21 @@ class Robot(object):
             'left': {
                 'carriage': Mover(
                     driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst=id(CALIBRATION),
+                    reference=id(CALIBRATION),
                     axis_mapping={'z': 'Z'}),
                 'plunger': Mover(
                     driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst='volume-calibration-left',
+                    reference='volume-calibration-left',
                     axis_mapping={'x': 'B'})
             },
             'right': {
                 'carriage': Mover(
                     driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst=id(CALIBRATION),
+                    reference=id(CALIBRATION),
                     axis_mapping={'z': 'A'}),
                 'plunger': Mover(
                     driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst='volume-calibration-right',
+                    reference='volume-calibration-right',
                     axis_mapping={'x': 'C'})
             }
         }
@@ -279,8 +275,7 @@ class Robot(object):
         self.gantry = Mover(
             driver=driver,
             axis_mapping={'x': 'X', 'y': 'Y'},
-            src=pose_tracker.ROOT,
-            dst=id(CALIBRATION)
+            reference=id(CALIBRATION)
         )
 
         # Extract only transformation component
@@ -562,9 +557,9 @@ class Robot(object):
             placeable = placeable[0]
 
         target = add(
-            pose_tracker.transform(
+            pose_tracker.absolute(
                 self.poses,
-                src=placeable
+                placeable
             ),
             offset.coordinates
         )
@@ -922,7 +917,7 @@ class Robot(object):
         well = container[0]
 
         # calibrate will well bottom, but track top of well
-        delta = pose_tracker.transform(
+        delta = pose_tracker.relative(
             self.poses,
             src=instrument,
             dst=well

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -3,7 +3,7 @@ from threading import Event
 
 
 from opentrons.drivers.smoothie_drivers.v3_0_0 import driver_3_0
-from .gantry import Mover
+from opentrons.robot.mover import Mover
 
 import opentrons.util.calibration_functions as calib
 
@@ -562,9 +562,9 @@ class Robot(object):
             placeable = placeable[0]
 
         target = add(
-            pose_tracker.transform(
+            pose_tracker.absolute(
                 self.poses,
-                src=placeable
+                placeable
             ),
             offset.coordinates
         )
@@ -921,8 +921,8 @@ class Robot(object):
         '''Calibrates a container using the bottom of the first well'''
         well = container[0]
 
-        # calibrate will well bottom, but track top of well
-        delta = pose_tracker.transform(
+        # Get the relative position of well with respect to instrument
+        delta = pose_tracker.change_base(
             self.poses,
             src=instrument,
             dst=well

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -3,7 +3,7 @@ from threading import Event
 
 
 from opentrons.drivers.smoothie_drivers.v3_0_0 import driver_3_0
-from . import gantry
+from .gantry import Mover
 
 import opentrons.util.calibration_functions as calib
 
@@ -17,13 +17,40 @@ from opentrons import commands
 from opentrons.broker import subscribe
 from .robot_configs import config
 
-from numpy import add, subtract
+from numpy import add, subtract, array, insert
+from numpy.linalg import inv
 from functools import lru_cache
 
 log = get_logger(__name__)
 
 DECK_OFFSET = config.deck_offset
 MAX_INSTRUMENT_HEIGHT = 220.0000
+
+
+# World -> Smoothie calibration values for XY plane
+# use cli/main.py to perform factory calibration
+# TODO(artyom 20171017): move to config
+XY = \
+    array([[+9.98113208e-01,  -5.52486188e-03,  -3.46165381e+01],
+           [-3.77358491e-03,   1.00000000e+00,  -1.03084906e+01],
+           [-5.03305613e-19,   2.60208521e-18,   1.00000000e+00]])
+
+# Smoothie coordinate for Z axis when 200ul tip is touching the deck
+Z_OFFSET = 3.75
+# Can be used to compensate for Z steps/mm mismatch
+Z_SCALE = 1
+
+CALIBRATION = insert(
+        insert(XY, 2, [0, 0, 0], axis=1),
+        2,
+        [0, 0, Z_SCALE, Z_OFFSET],
+        axis=0
+    )
+
+MOUNT_OFFSETS = {
+    'right': pose_tracker.Point(0.0, 0.0, 0.0),
+    'left': pose_tracker.Point(-37.14, 32.12, -2.5)
+}
 
 
 class InstrumentMosfet(object):
@@ -164,6 +191,17 @@ class Robot(object):
         only once instance of a robot.
         """
         self._driver = driver_3_0.SmoothieDriver_3_0_0()
+
+        self._actuators = {
+            'left': Mover(self._driver, axis_mapping={'x': 'B'}),
+            'right': Mover(self._driver, axis_mapping={'x': 'C'})
+        }
+
+        self._movers = {
+            'left': Mover(driver=self._driver, axis_mapping={'z': 'Z'}),
+            'right': Mover(driver=self._driver, axis_mapping={'z': 'A'})
+        }
+
         self.dimensions = (395, 345, 228)
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
@@ -205,7 +243,7 @@ class Robot(object):
         self._unsubscribe_commands = None
         self.reset()
 
-    def reset(self):
+    def reset(self, calibration=CALIBRATION):
         """
         Resets the state of the robot and clears:
             * Deck
@@ -233,13 +271,32 @@ class Robot(object):
         return self
 
     def setup_gantry(self):
-        self.gantry = gantry.Gantry(self._driver)
-
-        self.poses = pose_tracker.add(
-            self.poses,
-            self.gantry,
+        driver = self._driver
+        left = self._movers['left']
+        right = self._movers['right']
+        gantry = Mover(
+            driver=driver,
+            axis_mapping={'x': 'X', 'y': 'Y'},
+            children=[left, right]
         )
-        self.poses = self.gantry._setup_mounts(self.poses)
+
+        # Extract only transformation component
+        transform = CALIBRATION * array([
+            [1, 1, 1, 0],
+            [1, 1, 1, 0],
+            [1, 1, 1, 0],
+            [0, 0, 0, 1],
+        ])
+
+        self.poses = pose_tracker.bind(self.poses) \
+            .add(obj=driver, transform=CALIBRATION) \
+            .add(obj=gantry, parent=driver) \
+            .add(obj=left, parent=gantry) \
+            .add(obj=right, parent=gantry) \
+            .add(obj='left', parent=left, transform=inv(transform)) \
+            .add(obj='right', parent=right, transform=inv(transform))
+
+        self.gantry = gantry
 
     def add_instrument(self, mount, instrument):
         """
@@ -265,8 +322,18 @@ class Robot(object):
         to attach the instrument.
         """
         self._instruments[mount] = instrument
-        self.poses = self.gantry.mount_instrument(
-            self.poses, instrument, mount)
+        instrument.instrument_actuator = self._actuators[mount]
+        instrument.instrument_mover = self._movers[mount]
+        # We are creating two pose_tracker entries for instrument
+        # one id(instrument) to store it's offset vector and another
+        # with zero offset, which can be increased/decreased by
+        # tip length for pickup and drop tip
+        self.poses = pose_tracker.add(
+            self.poses,
+            id(instrument),
+            parent=mount,
+            point=MOUNT_OFFSETS[mount]
+        ).add(instrument, parent=id(instrument))
 
     def add_warning(self, warning_msg):
         """
@@ -405,7 +472,6 @@ class Robot(object):
     # TODO (ben 20171030): refactor use this to use public methods
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)
-        self.poses = self.gantry._update_pose(self.poses)
 
     # DEPRECATED
     def move_plunger(self, *args, **kwargs):
@@ -622,8 +688,7 @@ class Robot(object):
         # Setup Deck as root object for pose tracker
         self.poses = pose_tracker.add(
             self.poses,
-            self._deck,
-            point=pose_tracker.Point(*DECK_OFFSET)
+            self._deck
         )
 
         for slot in self._deck:
@@ -842,8 +907,8 @@ class Robot(object):
         # calibrate will well bottom, but track top of well
         delta = pose_tracker.relative(
             self.poses,
-            well,
-            instrument
+            src=instrument,
+            dst=well
         )
 
         self.poses = calib.calibrate_container_with_delta(

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -281,7 +281,7 @@ class Robot(object):
 
         # Extract only transformation component
         inverse_transform = pose_tracker.inverse(
-            pose_tracker.transform(CALIBRATION))
+            pose_tracker.extract_transform(CALIBRATION))
 
         self.poses = pose_tracker.bind(self.poses) \
             .add(obj=id(CALIBRATION), transform=CALIBRATION) \

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -472,6 +472,9 @@ class Robot(object):
         """
         self.poses = self.gantry.home(self.poses)
 
+        self.poses = self._actuators['left']['plunger'].home(self.poses)
+        self.poses = self._actuators['right']['plunger'].home(self.poses)
+
     # TODO (ben 20171030): refactor use this to use public methods
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -17,8 +17,7 @@ from opentrons import commands
 from opentrons.broker import subscribe
 from .robot_configs import config
 
-from numpy import add, subtract, array, insert
-from numpy.linalg import inv
+from numpy import add, subtract
 from functools import lru_cache
 
 log = get_logger(__name__)
@@ -544,7 +543,6 @@ class Robot(object):
         # because the top position is what is tracked,
         # this checks if coordinates doesn't equal top
         offset = subtract(coordinates, placeable.top()[1])
-
         if isinstance(placeable, containers.WellSeries):
             placeable = placeable[0]
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -334,10 +334,10 @@ class Robot(object):
         # tip length for pickup and drop tip
         self.poses = pose_tracker.add(
             self.poses,
-            id(instrument),
+            instrument,
             parent=mount,
             point=MOUNT_OFFSETS[mount]
-        ).add(instrument, parent=id(instrument))
+        )
 
     def add_warning(self, warning_msg):
         """
@@ -471,7 +471,7 @@ class Robot(object):
         >>> robot.connect('Virtual Smoothie')
         >>> robot.home()
         """
-        self._driver.home()
+        self.poses = self.gantry.home(self.poses)
 
     # TODO (ben 20171030): refactor use this to use public methods
     def move_head(self, *args, **kwargs):

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -1,3 +1,7 @@
+# In this file we often align code for readability triggering PEP8 warnings
+# So...
+# pylama:skip=1
+
 # TODO: jmg 11/2 This file is meant to be a temporary
 # fix to make development easier and should be removed
 # once this configuration information is part of persistent robot data
@@ -44,14 +48,11 @@ Amedeo = robot_config(
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
-    gantry_calibration=[[  1.00283019e+00,  -4.83425414e-03,   0.00000000e+00,
-         -3.52323132e+01],
-       [ -1.13207547e-02,   9.97237569e-01,   0.00000000e+00,
-         -1.81761811e+00],
-       [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,
-          4.50000000e+00],
-       [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,
-          1.00000000e+00]],
+    gantry_calibration=[
+        [  1.00283019e+00,  -4.83425414e-03,   0.00000000e+00, -3.52323132e+01],
+        [ -1.13207547e-02,   9.97237569e-01,   0.00000000e+00, -1.81761811e+00],
+        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,  4.50000000e+00],
+        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,  1.00000000e+00]],
     probe_center=(289, 295, 55.0),
     instrument_offset=(-37.99669417,  30.15314473,  -0.25),  # left to right
     # X, Y and Z measurement of imaginary bounding box surrounding the probe
@@ -84,14 +85,11 @@ Rosalind = robot_config(
     # X, Y and Z measurement of imaginary bounding box surrounding the probe
     # giving safe distance to position for probing
     probe_dimensions=(60.0, 60.0, 60.0),
-    gantry_calibration=[[  9.99056604e-01,   4.83425414e-03,   0.00000000e+00,
-         -2.63882414e+01],
-       [ -9.43396226e-04,   1.00069061e+00,   0.00000000e+00,
-         -2.30371104e+00],
-       [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,
-          5.00000000e+00],
-       [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,
-          1.00000000e+00]],
+    gantry_calibration=[
+        [  9.99056604e-01,   4.83425414e-03,   0.00000000e+00, -2.63882414e+01],
+        [ -9.43396226e-04,   1.00069061e+00,   0.00000000e+00, -2.30371104e+00],
+        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,  5.00000000e+00],
+        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,  1.00000000e+00]],
     instrument_offset=(-37.43826124,  31.44202338,  -0.5)  # left to right
 )
 

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 PLUNGER_CURRENT_LOW = 0.1
 PLUNGER_CURRENT_HIGH = 0.5
 
-CURRENT_ROBOT = 'B2-5'
+CURRENT_ROBOT = 'B2-4'
 
 robot_config = namedtuple(
     'robot_config',
@@ -44,14 +44,19 @@ Amedeo = robot_config(
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
-    gantry_calibration=[
-            [ 1.00188679e+00,  -1.38121547e-03, 0.0,  -4.02423779e+01],   # NOQA
-            [-1.32075472e-02,   9.95856354e-01, 0.0,  -5.06868659e+00],   # NOQA
-            [            0.0,              0.0, 1.0,              4.5],   # NOQA
-            [-5.03305613e-19,   2.60208521e-18, 0.0,   1.00000000e+00]],  # NOQA
-    probe_center=(287.49022485728057, 295.14501721735377, 96.5),
-    instrument_offset=(-40.13513347,  28.33733321,  -0.25),  # left to right
-    probe_dimensions=(30.0, 30, 25.5),   # X, Y and Z measurements
+    gantry_calibration=[[  1.00283019e+00,  -4.83425414e-03,   0.00000000e+00,
+         -3.52323132e+01],
+       [ -1.13207547e-02,   9.97237569e-01,   0.00000000e+00,
+         -1.81761811e+00],
+       [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,
+          4.50000000e+00],
+       [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,
+          1.00000000e+00]],
+    probe_center=(289, 295, 55.0),
+    instrument_offset=(-37.99669417,  30.15314473,  -0.25),  # left to right
+    # X, Y and Z measurement of imaginary bounding box surrounding the probe
+    # giving safe distance to position for probing
+    probe_dimensions=(60.0, 60.0, 60.0),
     deck_offset=None
 )
 
@@ -75,8 +80,10 @@ Rosalind = robot_config(
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
     deck_offset=None,
-    probe_center=(287.49022485728057, 295.14501721735377, 0),
-    probe_dimensions=(40.0, 40.0, 53.0),
+    probe_center=(287, 295, 55.0),
+    # X, Y and Z measurement of imaginary bounding box surrounding the probe
+    # giving safe distance to position for probing
+    probe_dimensions=(50.0, 50.0, 53.0),
     gantry_calibration=[
         [  1.00094340e+00,  -3.45303867e-03,   0.00000000e+00,  -1.94897355e+01],    # NOQA
         [  1.88679245e-03,   9.97237569e-01,   0.00000000e+00,  -1.66290112e+00],    # NOQA

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -4,10 +4,10 @@
 
 from collections import namedtuple
 
-PLUNGER_CURRENT_LOW = '0.1'
-PLUNGER_CURRENT_HIGH = '0.5'
+PLUNGER_CURRENT_LOW = 0.1
+PLUNGER_CURRENT_HIGH = 0.5
 
-CURRENT_ROBOT = 'B2-4'
+CURRENT_ROBOT = 'B2-5'
 
 robot_config = namedtuple(
     'robot_config',
@@ -30,8 +30,7 @@ Ibn = robot_config(
     steps_per_mm='M92 X160 Y160 Z800 A800 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
-        PLUNGER_CURRENT_LOW),
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
     deck_offset=(-27, -14.5, 0),
     probe_center={'z': 68.0, 'x': 268.4, 'y': 291.8181},
     probe_dimensions={'length': 47.74, 'width': 38, 'height': 63},
@@ -61,8 +60,7 @@ Ada = robot_config(
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
-        PLUNGER_CURRENT_LOW),
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
     probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
@@ -75,13 +73,16 @@ Rosalind = robot_config(
     steps_per_mm='M92 X80.0254 Y80.16 Z400 A400 B767.38 C767.38',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
-        PLUNGER_CURRENT_LOW),
-    deck_offset=(-31.45, -20.1, 0),
-    probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
-    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
-    gantry_calibration=None,
-    instrument_offset=None
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
+    deck_offset=None,
+    probe_center=(287.49022485728057, 295.14501721735377, 0),
+    probe_dimensions=(40.0, 40.0, 53.0),
+    gantry_calibration=[
+        [  1.00094340e+00,  -3.45303867e-03,   0.00000000e+00,  -1.94897355e+01],    # NOQA
+        [  1.88679245e-03,   9.97237569e-01,   0.00000000e+00,  -1.66290112e+00],    # NOQA
+        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,   4.50000000e+00],    # NOQA
+        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,   1.00000000e+00]],   # NOQA
+    instrument_offset=(-40.13513347,  28.33733321,  -0.25)  # left to right
 )
 
 robots = {

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 PLUNGER_CURRENT_LOW = 0.1
 PLUNGER_CURRENT_HIGH = 0.5
 
-CURRENT_ROBOT = 'B2-4'
+CURRENT_ROBOT = 'B2-5'
 
 robot_config = namedtuple(
     'robot_config',
@@ -83,13 +83,16 @@ Rosalind = robot_config(
     probe_center=(287, 295, 55.0),
     # X, Y and Z measurement of imaginary bounding box surrounding the probe
     # giving safe distance to position for probing
-    probe_dimensions=(50.0, 50.0, 53.0),
-    gantry_calibration=[
-        [  1.00094340e+00,  -3.45303867e-03,   0.00000000e+00,  -1.94897355e+01],    # NOQA
-        [  1.88679245e-03,   9.97237569e-01,   0.00000000e+00,  -1.66290112e+00],    # NOQA
-        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,   4.50000000e+00],    # NOQA
-        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,   1.00000000e+00]],   # NOQA
-    instrument_offset=(-40.13513347,  28.33733321,  -0.25)  # left to right
+    probe_dimensions=(60.0, 60.0, 60.0),
+    gantry_calibration=[[  9.99056604e-01,   4.83425414e-03,   0.00000000e+00,
+         -2.63882414e+01],
+       [ -9.43396226e-04,   1.00069061e+00,   0.00000000e+00,
+         -2.30371104e+00],
+       [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,
+          5.00000000e+00],
+       [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,
+          1.00000000e+00]],
+    instrument_offset=(-37.43826124,  31.44202338,  -0.5)  # left to right
 )
 
 robots = {

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -18,6 +18,8 @@ robot_config = namedtuple(
         'acceleration',
         'current',
         'deck_offset',
+        'gantry_calibration',
+        'instrument_offset',
         'probe_center',
         'probe_dimensions'
     ]
@@ -32,19 +34,26 @@ Ibn = robot_config(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-27, -14.5, 0),
     probe_center={'z': 68.0, 'x': 268.4, 'y': 291.8181},
-    probe_dimensions={'length': 47.74, 'width': 38, 'height': 63}
+    probe_dimensions={'length': 47.74, 'width': 38, 'height': 63},
+    gantry_calibration=None,
+    instrument_offset=None
 )
 
-Amadeo = robot_config(
+Amedeo = robot_config(
     name='Amedeo Avogadro',
     steps_per_mm='M92 X80 Y80 Z400 A400 B767.38 C767.38',
-    max_speeds='M203.1 X600 Y400 Z120 A120 B50 C50',
-    acceleration='M204 S10000 X2000 Y2000 Z1500 A1500 B2000 C2000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(
-        PLUNGER_CURRENT_LOW),
-    deck_offset=(-31.45, -20.1, 0),
-    probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
-    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}
+    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
+    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
+    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    gantry_calibration=[
+            [ 1.00188679e+00,  -1.38121547e-03, 0.0,  -4.02423779e+01],   # NOQA
+            [-1.32075472e-02,   9.95856354e-01, 0.0,  -5.06868659e+00],   # NOQA
+            [            0.0,              0.0, 1.0,              4.5],   # NOQA
+            [-5.03305613e-19,   2.60208521e-18, 0.0,   1.00000000e+00]],  # NOQA
+    probe_center=(287.49022485728057, 295.14501721735377, 96.5),
+    instrument_offset=(-40.13513347,  28.33733321,  -0.25),  # left to right
+    probe_dimensions=(30.0, 30, 25.5),   # X, Y and Z measurements
+    deck_offset=None
 )
 
 Ada = robot_config(
@@ -56,7 +65,9 @@ Ada = robot_config(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
-    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}
+    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
+    gantry_calibration=None,
+    instrument_offset=None
 )
 
 Rosalind = robot_config(
@@ -68,12 +79,14 @@ Rosalind = robot_config(
         PLUNGER_CURRENT_LOW),
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
-    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81}
+    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
+    gantry_calibration=None,
+    instrument_offset=None
 )
 
 robots = {
     'B1': Ibn,
-    'B2-4': Amadeo,
+    'B2-4': Amedeo,
     'B2-6': Ada,
     'B2-5': Rosalind
 }

--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -65,7 +65,7 @@ class Server(object):
         self.monitor_events_task.cancel()
 
     async def on_shutdown(self, app):
-        for ws in self.clients:
+        for ws in self.clients.copy():
             await ws.close(code=WSCloseCode.GOING_AWAY,
                            message='Server shutdown')
         self.shutdown()

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -23,7 +23,7 @@ def translate(point) -> np.ndarray:
     ])
 
 
-def transform(matrix) -> np.ndarray:
+def extract_transform(matrix) -> np.ndarray:
     """Extract transformation elements from a matrix"""
     return matrix * np.array([
         [1, 1, 1, 0],

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -180,7 +180,7 @@ def stringify(state, root=None):
 
 
 def get(state, obj):
-    return relative(state, src=obj, dst=state[obj].parent)
+    return inv(state[obj].transform).dot((0, 0, 0, 1))[:-1]
 
 
 def bind(state):

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -1,9 +1,10 @@
-import numpy as np
+import functools
+import itertools
 from collections import namedtuple, UserDict
 from typing import Dict, List
-from functools import partial
+
+import numpy as np
 from numpy.linalg import inv
-from functools import reduce
 
 ROOT = 'root'
 
@@ -117,50 +118,45 @@ def descendants(state, obj, level=0):
     ], [])
 
 
-def ascend(state, obj, root=None) -> List[Node]:
-    if obj is root:
-        return []
-    parent = state[obj].parent
-    return [obj] + ascend(state, obj=parent, root=root)
+def ascend(state, start, finish=ROOT) -> List[Node]:
+    if start is finish:
+        return [finish]
+    return [start] + ascend(state, start=state[start].parent, finish=finish)
 
 
-def forward(state, obj, root=None):
-    return reduce(
-        lambda a, b: a.dot(b),
-        [
-            state[key].transform
-            for key in reversed(ascend(state, obj=obj, root=root))
-        ],
-        np.identity(4)
-    )
+def transform(state, point=Point(0, 0, 0), src=ROOT, dst=ROOT):
+    """
+    Transforms point from source coordinate system to destination.
+    Point(0, 0, 0) means the origin of the source.
+    """
+    def fold(objects):
+        return functools.reduce(
+            lambda a, b: a.dot(b),
+            [state[key].transform for key in objects],
+            np.identity(4)
+        )
 
+    up, down = ascend(state, src), list(reversed(ascend(state, dst)))
 
-def reverse(state, obj, root=None):
-    return inv(reduce(
-        lambda a, b: a.dot(b),
-        [
-            state[key].transform
-            for key in ascend(state, obj=obj, root=root)
-        ],
-        np.identity(4)
-    ))
+    # Find common prefix. Last item is common root
+    root = [n1 for n1, n2 in zip(reversed(up), down) if n1 is n2].pop()
 
+    # Nodes up to root, EXCLUDING root
+    up = list(itertools.takewhile(lambda node: node is not root, up))
 
-def absolute(state, obj, root=None, point=Point(0, 0, 0)):
-    """absolute position of an object in a sub-tree of a root"""
-    return reverse(state, obj, root).dot((*point, 1))[:-1]
+    # Nodes down from root, EXCLUDING root
+    down = list(itertools.dropwhile(lambda node: node is not root, down))[1:]
 
+    # Point in root's coordinate system
+    point_in_root = inv(fold(up)).dot((*point, 1))
 
-def relative(state, src, dst, root=None, src_point=Point(0, 0, 0)):
-    """Relative vector from src (source) to dst (destination)
-    in root's subtree. if root is none — in the entire tree"""
-    x, y, z = absolute(state, obj=src, root=root, point=src_point)
-    return forward(state, dst, root=root).dot((x, y, z, 1))[:-1]
+    # Return point in destination's coordinate system
+    return fold(down).dot(point_in_root)[:-1]
 
 
 def max_z(state, root):
     return max([
-        Point(*absolute(state, obj=obj, root=root)).z
+        Point(*transform(state, src=obj, dst=root)).z
         for obj, _ in descendants(state, root)
     ])
 
@@ -170,7 +166,7 @@ def stringify(state, root=None):
         root = ascend(state, next(iter(state)))[-1]
 
     info = [
-        (obj, level, get(state, obj), relative(state, src=obj, dst=root))
+        (obj, level, get(state, obj), transform(state, src=obj, dst=root))
         for obj, level in [(root, 0)] + descendants(state, root, level=1)]
 
     return '\n'.join([
@@ -179,13 +175,9 @@ def stringify(state, root=None):
     ])
 
 
-def get(state, obj):
-    return inv(state[obj].transform).dot((0, 0, 0, 1))[:-1]
-
-
 def bind(state):
     state = UserDict(state.copy())
     # add syntax sugar for chaining add operations
-    state.add = partial(add, state)
+    state.add = functools.partial(add, state)
 
     return state

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -164,8 +164,6 @@ def stringify(state, root=None):
 
 def get(state, obj):
     return relative(state, src=obj, dst=state[obj].parent)
-    # x, y, z, *_ = state[obj].transform.dot((0.0, 0.0, 0.0, 1.0))
-    # return Point(x, y, z)
 
 
 def bind(state):

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -124,7 +124,7 @@ def ascend(state, start, finish=ROOT) -> List[Node]:
     return [start] + ascend(state, start=state[start].parent, finish=finish)
 
 
-def transform(state, point=Point(0, 0, 0), src=ROOT, dst=ROOT):
+def change_base(state, point=Point(0, 0, 0), src=ROOT, dst=ROOT):
     """
     Transforms point from source coordinate system to destination.
     Point(0, 0, 0) means the origin of the source.
@@ -154,9 +154,16 @@ def transform(state, point=Point(0, 0, 0), src=ROOT, dst=ROOT):
     return fold(down).dot(point_in_root)[:-1]
 
 
+def absolute(state, obj):
+    """
+    Get the (x, y, z) position of an object relative to origin of the pose tree
+    """
+    return change_base(state, src=obj)
+
+
 def max_z(state, root):
     return max([
-        Point(*transform(state, src=obj, dst=root)).z
+        Point(*change_base(state, src=obj, dst=root)).z
         for obj, _ in descendants(state, root)
     ])
 
@@ -166,7 +173,7 @@ def stringify(state, root=None):
         root = ascend(state, next(iter(state)))[-1]
 
     info = [
-        (obj, level, get(state, obj), transform(state, src=obj, dst=root))
+        (obj, level, get(state, obj), change_base(state, src=obj, dst=root))
         for obj, level in [(root, 0)] + descendants(state, root, level=1)]
 
     return '\n'.join([

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -16,11 +16,25 @@ class Point(namedtuple('Point', 'x y z')):
 def translate(point) -> np.ndarray:
     x, y, z = point
     return np.array([
-        [1.0, 0.0, 0.0, x],
-        [0.0, 1.0, 0.0, y],
-        [0.0, 0.0, 1.0, z],
+        [1.0, 0.0, 0.0,   x],
+        [0.0, 1.0, 0.0,   y],
+        [0.0, 0.0, 1.0,   z],
         [0.0, 0.0, 0.0, 1.0]
     ])
+
+
+def transform(matrix) -> np.ndarray:
+    """Extract transformation elements from a matrix"""
+    return matrix * np.array([
+        [1, 1, 1, 0],
+        [1, 1, 1, 0],
+        [1, 1, 1, 0],
+        [0, 0, 0, 1],
+    ])
+
+
+def inverse(matrix) -> np.ndarray:
+    return inv(matrix)
 
 
 class Node(namedtuple('Node', 'parent children transform')):
@@ -53,6 +67,9 @@ def add(
         parent=ROOT,
         point=Point(0, 0, 0),
         transform=np.identity(4)) -> Dict[object, Node]:
+
+    if isinstance(transform, list):
+        transform = np.array(transform)
 
     state = bind(state)
 
@@ -129,15 +146,15 @@ def reverse(state, obj, root=None):
     ))
 
 
-def absolute(state, obj, root=None):
+def absolute(state, obj, root=None, point=Point(0, 0, 0)):
     """absolute position of an object in a sub-tree of a root"""
-    return reverse(state, obj, root).dot((0, 0, 0, 1))[:-1]
+    return reverse(state, obj, root).dot((*point, 1))[:-1]
 
 
-def relative(state, src, dst, root=None):
+def relative(state, src, dst, root=None, src_point=Point(0, 0, 0)):
     """Relative vector from src (source) to dst (destination)
     in root's subtree. if root is none — in the entire tree"""
-    x, y, z = absolute(state, obj=src, root=root)
+    x, y, z = absolute(state, obj=src, root=root, point=src_point)
     return forward(state, dst, root=root).dot((x, y, z, 1))[:-1]
 
 

--- a/api/opentrons/trackers/pose_tracker.py
+++ b/api/opentrons/trackers/pose_tracker.py
@@ -173,12 +173,12 @@ def stringify(state, root=None):
         root = ascend(state, next(iter(state)))[-1]
 
     info = [
-        (obj, level, get(state, obj), change_base(state, src=obj, dst=root))
+        (obj, level, change_base(state, src=obj, dst=root))
         for obj, level in [(root, 0)] + descendants(state, root, level=1)]
 
     return '\n'.join([
-        ' ' * level + '{} {} {}'.format(str(obj), relative, world)
-        for obj, level, relative, world in info
+        ' ' * level + '{} {}'.format(str(obj), world)
+        for obj, level, world in info
     ])
 
 

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -8,11 +8,11 @@ from ..robot.robot_configs import config
 
 
 # maximum distance to move during calibration attempt
-PROBE_TRAVEL_DISTANCE = 20
+PROBE_TRAVEL_DISTANCE = 30
 # size along X, Y and Z
 PROBE_SIZE = array(config.probe_dimensions)
 # coordinates of the top of the probe
-PROBE_BOTTOM_COORDINATES = array(config.probe_center)
+PROBE_TOP_COORDINATES = array(config.probe_center)
 
 
 def calibrate_container_with_delta(
@@ -40,8 +40,7 @@ def probe_instrument(instrument, robot):
 
     *_, height = PROBE_SIZE
 
-    center = PROBE_BOTTOM_COORDINATES + (0, 0, height / 2.0)
-    print('Center: ', center)
+    center = PROBE_TOP_COORDINATES * (1, 1, 0) + (0, 0, height / 2.0)
 
     #       Y ^
     #         * 1
@@ -61,16 +60,17 @@ def probe_instrument(instrument, robot):
     #   XY coordinate, or in the Z axis if both X and Y
     #   are zero
     switches = [
-        (-1, 0, -1, 1),
-        (1, 0, -1, -1),
-        (0, -1, -1, 1),
-        (0, 1, -1, -1),
-        (0, 0, 1, -1),
+        (-1, 0, -0.5,  1),
+        (1,  0, -0.5, -1),
+        (0, -1, -0.5,  1),
+        (0,  1, -0.5, -1),
+        (0,  0,    1, -1),
     ]
 
-    coords = [(PROBE_SIZE / 2.0) * array(switch[:-1]) + center for switch in switches]
-
+    coords = [switch[:-1] * PROBE_SIZE / 2.0 + center for switch in switches]
     instrument._add_tip(DEFAULT_TIP_LENGTH)
+
+    values = {'x': [], 'y': [], 'z': []}
 
     for coord, switch in zip(coords, switches):
         x, y, z = coord
@@ -82,18 +82,24 @@ def probe_instrument(instrument, robot):
         elif sy:
             axis = 'y'
 
-        # TODO(artyom, ben 20171026): fine tune correct probing sequence
-        robot.poses = instrument._move(
-            robot.poses,
-            z=z + 2 * height
-        )
+        robot.poses = instrument._move(robot.poses, z=height * 1.2)
 
         robot.poses = instrument._move(robot.poses, x=x, y=y)
         robot.poses = instrument._move(robot.poses, z=z)
-        instrument._probe(axis, direction * PROBE_TRAVEL_DISTANCE)
 
-        robot.poses = instrument._move(robot.poses, x=x, y=y)
+        values[axis].append(
+            instrument._probe(
+                axis,
+                direction * PROBE_TRAVEL_DISTANCE
+            )
+        )
 
+        robot.poses = instrument._move(
+            robot.poses,
+            x=(x + sx * 5),
+            y=(y + sy * 5))
+
+    print(values)
     instrument._remove_tip(DEFAULT_TIP_LENGTH)
 
     robot.home()

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -24,7 +24,7 @@ def calibrate_container_with_delta(
         delta_y, delta_z, save, new_container_name=None
 ):
     delta = Point(delta_x, delta_y, delta_z)
-    new_coordinates = get(pose_tree, container) - delta
+    new_coordinates = get(pose_tree, container) + delta
     pose_tree = update(pose_tree, container, new_coordinates)
     container._coordinates = Vector(*new_coordinates)
     # Since we are potentially changing Z, we want to

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -5,18 +5,15 @@ from opentrons.trackers.pose_tracker import (
 from opentrons.util.vector import Vector
 from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 from opentrons.data_storage import database
+from ..robot.robot_configs import config
 
-# TODO(artyom 20171031): for some reason was unable to share this
-# constant with opentrons.robot, thus copying it here, until
-# moved to config
-DECK_OFFSET = (-44.55, -11.9, 0)
 
 # maximum distance to move during calibration attempt
 PROBE_TRAVEL_DISTANCE = 20
 # size along X, Y and Z
-PROBE_SIZE = array((30.0, 30, 25.5))
+PROBE_SIZE = array(config.probe_dimensions)
 # coordinates of the top of the probe
-PROBE_TOP_COORDINATES = array((289.8, 296.4, 60.25)) + DECK_OFFSET
+PROBE_TOP_COORDINATES = array(config.probe_center)
 
 
 def calibrate_container_with_delta(

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -1,6 +1,6 @@
 from numpy import array
 from opentrons.trackers.pose_tracker import (
-    update, Point, transform
+    update, Point, change_base
 )
 from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 from opentrons.data_storage import database
@@ -20,7 +20,7 @@ def calibrate_container_with_delta(
         delta_y, delta_z, save, new_container_name=None
 ):
     delta = Point(delta_x, delta_y, delta_z)
-    new_coordinates = transform(
+    new_coordinates = change_base(
         pose_tree,
         src=container,
         dst=container.parent) + delta

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -1,6 +1,6 @@
 from numpy import array
 from opentrons.trackers.pose_tracker import (
-    update, Point, transform
+    update, Point, get
 )
 from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 from opentrons.data_storage import database
@@ -20,10 +20,7 @@ def calibrate_container_with_delta(
         delta_y, delta_z, save, new_container_name=None
 ):
     delta = Point(delta_x, delta_y, delta_z)
-    new_coordinates = transform(
-        pose_tree,
-        src=container,
-        dst=container.parent) + delta
+    new_coordinates = get(pose_tree, container) + delta
     pose_tree = update(pose_tree, container, new_coordinates)
     container._coordinates = container._coordinates + delta
     if save and new_container_name:
@@ -86,6 +83,7 @@ def probe_instrument(instrument, robot):
             axis = 'y'
 
         robot.poses = instrument._move(robot.poses, z=height * 1.2)
+
         robot.poses = instrument._move(robot.poses, x=x, y=y)
         robot.poses = instrument._move(robot.poses, z=z)
 
@@ -101,7 +99,9 @@ def probe_instrument(instrument, robot):
             x=(x + sx * 5),
             y=(y + sy * 5))
 
+    print(values)
     instrument._remove_tip(DEFAULT_TIP_LENGTH)
+
     robot.home()
 
 

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -1,6 +1,6 @@
 from numpy import array
 from opentrons.trackers.pose_tracker import (
-    update, Point, get
+    update, Point, transform
 )
 from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 from opentrons.data_storage import database
@@ -20,7 +20,10 @@ def calibrate_container_with_delta(
         delta_y, delta_z, save, new_container_name=None
 ):
     delta = Point(delta_x, delta_y, delta_z)
-    new_coordinates = get(pose_tree, container) + delta
+    new_coordinates = transform(
+        pose_tree,
+        src=container,
+        dst=container.parent) + delta
     pose_tree = update(pose_tree, container, new_coordinates)
     container._coordinates = container._coordinates + delta
     if save and new_container_name:
@@ -83,7 +86,6 @@ def probe_instrument(instrument, robot):
             axis = 'y'
 
         robot.poses = instrument._move(robot.poses, z=height * 1.2)
-
         robot.poses = instrument._move(robot.poses, x=x, y=y)
         robot.poses = instrument._move(robot.poses, z=z)
 
@@ -99,9 +101,7 @@ def probe_instrument(instrument, robot):
             x=(x + sx * 5),
             y=(y + sy * 5))
 
-    print(values)
     instrument._remove_tip(DEFAULT_TIP_LENGTH)
-
     robot.home()
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,7 +5,5 @@ pytest-cov
 pytest-aiohttp
 dill
 numpydoc==0.6.0
-# June 15 2017 (artyom) : https://github.com/pyinstaller/pyinstaller/issues/2434
-git+https://github.com/pyinstaller/pyinstaller.git@7e814646474efc868206beb8fb9dfe45af527109
 Sphinx==1.4.8
 twine==1.8.1

--- a/api/setup.py
+++ b/api/setup.py
@@ -32,7 +32,8 @@ PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
 INSTALL_REQUIRES = [
     'pyserial==3.2.1',
     'aiohttp==2.2.3',
-    'numpy==1.13.0']
+    'numpy==1.13.0',
+    'urwid==1.3.1']
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 

--- a/api/tests/opentrons/api/conftest.py
+++ b/api/tests/opentrons/api/conftest.py
@@ -29,7 +29,7 @@ def log_by_axis(log, axis):
 def model():
     from opentrons import instruments, containers
 
-    pipette = instruments.Pipette(mount='right')
+    pipette = instruments.Pipette(mount='left')
     plate = containers.load('96-flat', 'A1')
 
     instrument = models.Instrument(pipette)

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -104,7 +104,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
     from opentrons.trackers import pose_tracker
 
     container = model.container._container
-    pos1 = pose_tracker.transform(robot.poses, src=container, dst=robot.deck)
+    pos1 = pose_tracker.change_base(robot.poses, src=container, dst=robot.deck)
     coordinates1 = container.coordinates()
 
     main_router.calibration_manager.move_to(model.instrument, model.container)
@@ -117,7 +117,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
         model.instrument
     )
 
-    pos2 = pose_tracker.transform(robot.poses, src=container)
+    pos2 = pose_tracker.absolute(robot.poses, container)
     coordinates2 = container.coordinates()
 
     assert isclose(pos1 + (1, 2, 3), pos2).all()

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -104,7 +104,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
     from opentrons.trackers import pose_tracker
 
     container = model.container._container
-    pos1 = pose_tracker.relative(robot.poses, src=container, dst=robot.deck)
+    pos1 = pose_tracker.transform(robot.poses, src=container, dst=robot.deck)
     coordinates1 = container.coordinates()
 
     main_router.calibration_manager.move_to(model.instrument, model.container)
@@ -117,7 +117,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
         model.instrument
     )
 
-    pos2 = pose_tracker.absolute(robot.poses, container)
+    pos2 = pose_tracker.transform(robot.poses, src=container)
     coordinates2 = container.coordinates()
 
     assert isclose(pos1 + (1, 2, 3), pos2).all()

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -117,7 +117,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
         model.instrument
     )
 
-    pos2 = pose_tracker.relative(robot.poses, src=container, dst=robot.deck)
+    pos2 = pose_tracker.absolute(robot.poses, container)
     coordinates2 = container.coordinates()
 
     assert isclose(pos1 + (1, 2, 3), pos2).all()

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -104,7 +104,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
     from opentrons.trackers import pose_tracker
 
     container = model.container._container
-    pos1 = pose_tracker.transform(robot.poses, src=container, dst=robot.deck)
+    pos1 = pose_tracker.relative(robot.poses, src=container, dst=robot.deck)
     coordinates1 = container.coordinates()
 
     main_router.calibration_manager.move_to(model.instrument, model.container)
@@ -117,7 +117,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
         model.instrument
     )
 
-    pos2 = pose_tracker.transform(robot.poses, src=container)
+    pos2 = pose_tracker.absolute(robot.poses, container)
     coordinates2 = container.coordinates()
 
     assert isclose(pos1 + (1, 2, 3), pos2).all()

--- a/api/tests/opentrons/cli/test_solve.py
+++ b/api/tests/opentrons/cli/test_solve.py
@@ -1,23 +1,9 @@
-import numpy as np
-from numpy.linalg import inv
 from math import pi, sin, cos
+from opentrons.cli.solve import solve
+import numpy as np
 
 
-def solve(expected, actual):
-    A = np.array([
-            list(point) + [1]
-            for point in expected
-        ]).transpose()
-
-    B = np.array([
-            list(point) + [1]
-            for point in actual
-        ]).transpose()
-
-    return np.dot(B, inv(A))
-
-
-def test():
+def test_solve():
     theta = pi / 3.0  # 60 deg
     scale = 2.0
 
@@ -37,22 +23,3 @@ def test():
     result = np.dot(X, np.array([[0], [1], [1]])).transpose()
 
     return np.isclose(expected, result).all()
-
-
-def calc():
-    expected = [
-        (64,    354.70),  # 1
-        (329,   354.70),  # 3
-        (196.50, 83.70),  # 11
-    ]
-
-    actual = [
-        (33.0, 5.0),
-        (298.0, 6.0),
-        (169.0, 276.0),
-    ]
-    return solve(expected, actual)
-
-
-if __name__ == '__main__':
-    print('TEST: ' + repr(calc()))

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -174,7 +174,7 @@ def virtual_smoothie_env(monkeypatch):
 @pytest.fixture
 def main_router(
             loop,
-            # virtual_smoothie_env,
+            virtual_smoothie_env,
             monkeypatch
         ):
     from opentrons.api.routers import MainRouter

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -174,7 +174,7 @@ def virtual_smoothie_env(monkeypatch):
 @pytest.fixture
 def main_router(
             loop,
-            virtual_smoothie_env,
+            # virtual_smoothie_env,
             monkeypatch
         ):
     from opentrons.api.routers import MainRouter

--- a/api/tests/opentrons/data/bradford_assay.py
+++ b/api/tests/opentrons/data/bradford_assay.py
@@ -1,22 +1,19 @@
 from opentrons import containers, instruments
 
-# containers.robot.connect()
-# containers.robot.home()
-
-tiprack = containers.load('tiprack-200ul', 'B3')
-tiprack2 = containers.load('tiprack-200ul', 'B1')
+tiprack = containers.load('tiprack-200ul', 'C3')
+tiprack2 = containers.load('tiprack-200ul', 'B4')
 trash = containers.load('trash-box', 'C4')
 
-trough = containers.load('trough-12row', 'C1')
-plate = containers.load('96-PCR-flat', 'C2')
-tuberack = containers.load('tube-rack-2ml', 'B2')
+trough = containers.load('trough-12row', 'B2')
+plate = containers.load('96-PCR-flat', 'A1')
+tuberack = containers.load('tube-rack-2ml', 'A2')
 
 m50 = instruments.Pipette(
     name="p200",
     trash_container=trash,
-    tip_racks=[tiprack2],
+    tip_racks=[tiprack, tiprack2],
     max_volume=50,
-    mount='left',
+    mount="left",
     channels=8
 )
 
@@ -24,24 +21,22 @@ p200 = instruments.Pipette(
     name="p200S",
     trash_container=trash,
     tip_racks=[tiprack],
-    max_volume=200,
-    mount='right'
+    max_volume=300,
+    mount="right"
 )
-
 
 # dispense 6 standards from tube racks (A1, B1, C1, D1, A2, B2)
 # to first two rows of 96 well plate (duplicates, A1/A2, B1/B2 etc.)
-# for i in range(6):
-#    p200.distribute(
-#        25, tuberack.wells(i), plate.cols(i).wells('1', '2'))
+for i in range(6):
+    p200.distribute(
+        25, tuberack.wells(i), plate.cols(i).wells('1', '2'))
 
-# dispense 4 samples from tube rack (C2, D2, A3, B3)
-# to row 3 of 96 well plate (duplicates, A3/B3, C3/D3, E3/F3, G3/H3)
+# # dispense 4 samples from tube rack (C2, D2, A3, B3)
+# # to row 3 of 96 well plate (duplicates, A3/B3, C3/D3, E3/F3, G3/H3)
 p200.distribute(
     50,
     tuberack.wells('C2', 'D2', 'A3', 'B3'),
     plate.rows('3'))
-
 
 # fill rows 4 to 11 with 25 uL of dilutent each
 m50.distribute(

--- a/api/tests/opentrons/data/bradford_assay.py
+++ b/api/tests/opentrons/data/bradford_assay.py
@@ -1,20 +1,22 @@
 from opentrons import containers, instruments
 
+# containers.robot.connect()
+# containers.robot.home()
 
-tiprack = containers.load('tiprack-200ul', 'B1')
-tiprack2 = containers.load('tiprack-200ul', 'B2')
-trash = containers.load('trash-box', 'C2')
+tiprack = containers.load('tiprack-200ul', 'B3')
+tiprack2 = containers.load('tiprack-200ul', 'B1')
+trash = containers.load('trash-box', 'C4')
 
 trough = containers.load('trough-12row', 'C1')
-plate = containers.load('96-PCR-flat', 'A1')
-tuberack = containers.load('tube-rack-2ml', 'A2')
+plate = containers.load('96-PCR-flat', 'C2')
+tuberack = containers.load('tube-rack-2ml', 'B2')
 
 m50 = instruments.Pipette(
     name="p200",
     trash_container=trash,
-    tip_racks=[tiprack, tiprack2],
+    tip_racks=[tiprack2],
     max_volume=50,
-    mount="right",
+    mount='left',
     channels=8
 )
 
@@ -23,14 +25,15 @@ p200 = instruments.Pipette(
     trash_container=trash,
     tip_racks=[tiprack],
     max_volume=200,
-    mount="left"
+    mount='right'
 )
+
 
 # dispense 6 standards from tube racks (A1, B1, C1, D1, A2, B2)
 # to first two rows of 96 well plate (duplicates, A1/A2, B1/B2 etc.)
-for i in range(6):
-    p200.distribute(
-        25, tuberack.wells(i), plate.cols(i).wells('1', '2'))
+# for i in range(6):
+#    p200.distribute(
+#        25, tuberack.wells(i), plate.cols(i).wells('1', '2'))
 
 # dispense 4 samples from tube rack (C2, D2, A3, B3)
 # to row 3 of 96 well plate (duplicates, A3/B3, C3/D3, E3/F3, G3/H3)
@@ -38,6 +41,7 @@ p200.distribute(
     50,
     tuberack.wells('C2', 'D2', 'A3', 'B3'),
     plate.rows('3'))
+
 
 # fill rows 4 to 11 with 25 uL of dilutent each
 m50.distribute(

--- a/api/tests/opentrons/data/bradford_assay.py
+++ b/api/tests/opentrons/data/bradford_assay.py
@@ -1,5 +1,8 @@
 from opentrons import containers, instruments
 
+# containers.robot.connect()
+# containers.robot.home()
+
 tiprack = containers.load('tiprack-200ul', 'C3')
 tiprack2 = containers.load('tiprack-200ul', 'B4')
 trash = containers.load('trash-box', 'C4')
@@ -31,8 +34,8 @@ for i in range(6):
     p200.distribute(
         25, tuberack.wells(i), plate.cols(i).wells('1', '2'))
 
-# # dispense 4 samples from tube rack (C2, D2, A3, B3)
-# # to row 3 of 96 well plate (duplicates, A3/B3, C3/D3, E3/F3, G3/H3)
+# dispense 4 samples from tube rack (C2, D2, A3, B3)
+# to row 3 of 96 well plate (duplicates, A3/B3, C3/D3, E3/F3, G3/H3)
 p200.distribute(
     50,
     tuberack.wells('C2', 'D2', 'A3', 'B3'),

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -5,7 +5,7 @@ from opentrons import containers, instruments
 # robot.home()
 # print('homed')
 
-tiprack = containers.load('tiprack-200ul', 'C2')
+tiprack = containers.load('tiprack-200ul', 'A4')
 trough = containers.load('trough-12row', 'C3')
 trash = containers.load('trash-box', 'C4')
 plate = containers.load('96-flat', 'B2')

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -5,7 +5,7 @@ from opentrons import containers, instruments
 # robot.home()
 # print('homed')
 
-tiprack = containers.load('tiprack-200ul', 'A4')
+tiprack = containers.load('tiprack-200ul', 'B3')
 trough = containers.load('trough-12row', 'C3')
 trash = containers.load('trash-box', 'C4')
 plate = containers.load('96-flat', 'B2')

--- a/api/tests/opentrons/data/pickup-accuracy.py
+++ b/api/tests/opentrons/data/pickup-accuracy.py
@@ -1,0 +1,22 @@
+from opentrons import containers, instruments
+
+# from opentrons import robot
+# robot.connect()
+# robot.home()
+# print('homed')
+
+tipracks = [
+    containers.load('tiprack-200ul', slot)
+    for slot in ('A4', 'C1')]
+
+single = instruments.Pipette(
+    mount='right',
+    max_volume=300,
+    min_volume=10,
+    name="p200",
+    tip_racks=tipracks)
+
+for tiprack in tipracks:
+    for tip in (tiprack[0], tiprack[-1]):
+        single.pick_up_tip(tip)
+        single.drop_tip(tip)

--- a/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
@@ -43,7 +43,5 @@ def test_home(driver):
     )
 ])
 def test_move(target_movement, expected_new_position, homed_driver):
-    homed_driver.move(**{
-        target.lower(): value
-        for target, value in target_movement.items()})
+    homed_driver.move(target_movement)
     assert homed_driver.position == expected_new_position

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -37,8 +37,8 @@ def test_plunger_commands(smoothie, monkeypatch):
     monkeypatch.setattr(driver_3_0, '_parse_axis_values', _parse_axis_values)
 
     smoothie.home()
-    smoothie.move(x=0, y=1, z=2, a=3)
-    smoothie.move(x=0, y=1, z=2, a=3, b=4, c=5)
+    smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3})
+    smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3, 'B': 4, 'C': 5})
 
     fuzzy_assert(
         result=command_log,

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -37,8 +37,14 @@ def test_plunger_commands(smoothie, monkeypatch):
     monkeypatch.setattr(driver_3_0, '_parse_axis_values', _parse_axis_values)
 
     smoothie.home()
-    smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3})
-    smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3, 'B': 4, 'C': 5})
+    smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
+    smoothie.move({
+        'X': 10.987654321,
+        'Y': 1.12345678,
+        'Z': 2,
+        'A': 3,
+        'B': 4,
+        'C': 5})
 
     fuzzy_assert(
         result=command_log,
@@ -47,12 +53,11 @@ def test_plunger_commands(smoothie, monkeypatch):
             ['G4P0.05 M400'],                     # Dwell
             ['G28.2[ABCZ]+ G28.2X G28.2Y M400'],  # Home
             ['M907 B0.1 C0.1 M400'],              # Set plunger current low
-            ['G4P0.05 M400'],                       # Dwell
-            ['M114.2 M400'],                      # Get position
+            ['G4P0.05 M400'],                     # Dwell
             ['M114.2 M400'],                      # Get position
             ['G0.+ M400'],                        # Move (non-plunger)
             ['M907 B0.5 C0.5 M400'],              # Set plunger current high
-            ['G4P0.05 M400'],                       # Dwell
+            ['G4P0.05 M400'],                     # Dwell
             ['G0.+[BC].+ M400'],                  # Move (including BC)
             ['M907 B0.1 C0.1 M400'],              # Set plunger current low
             ['G4P0.05 M400']                      # Dwell

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -65,10 +65,10 @@ def test_functional(smoothie):
 
     assert smoothie.position == position(0, 0, 0, 0, 0, 0)
 
-    smoothie.move(x=0, y=1, z=2, a=3, b=4, c=5)
+    smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3, 'B': 4, 'C': 5})
     assert smoothie.position == position(0, 1, 2, 3, 4, 5)
 
-    smoothie.move(x=1, z=3, c=6)
+    smoothie.move({'X': 1, 'Z': 3, 'C': 6})
     assert smoothie.position == position(1, 1, 3, 3, 4, 6)
 
     smoothie.home(axis='abc', disabled='')

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -8,14 +8,14 @@ from opentrons.trackers import pose_tracker
 
 
 @pytest.fixture
-def smoke(virtual_smoothie_env):
+def smoke():
     robot.connect()
     robot.home()
     robot._driver.log.clear()
     from tests.opentrons.data import smoke  # NOQA
 
 
-def test_smoke(smoke):
+def test_smoke(virtual_smoothie_env, smoke):
     by_axis = log_by_axis(robot._driver.log, 'XYA')
     coords = [
         (x, y, z)
@@ -23,6 +23,20 @@ def test_smoke(smoke):
         in zip(by_axis['X'], by_axis['Y'], by_axis['A'])
     ]
     assert coords
+
+
+@pytest.mark.parametrize('protocol_file', ['multi-single.py'])
+async def test_multi_single(main_router, protocol, protocol_file, dummy_db):
+    robot.connect()
+    robot.home()
+
+    session = main_router.session_manager.create(
+        name='<blank>', text=protocol.text)
+    await main_router.wait_until(state('session', 'loaded'))
+
+    main_router.calibration_manager.move_to(
+        session.instruments[0],
+        session.containers[2])
 
     # print(coords)
     # Move to pick up tip
@@ -63,7 +77,7 @@ def test_smoke(smoke):
 #     await main_router.wait_until(state('session', 'finished'))
 
 
-@pytest.mark.parametrize('protocol_file', ['bradford_assay.py'])
+@pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(main_router, protocol, protocol_file, dummy_db):  # NOQA
     session = main_router.session_manager.create(
         name='<blank>', text=protocol.text)
@@ -101,14 +115,11 @@ async def test_load_jog_save_run(main_router, protocol, protocol_file, dummy_db)
         assert isclose(acc[1], [1.0, 1.0, 0.0]).all()
         assert isclose(acc[2], [1.0, 1.0, 1.0]).all()
 
-        # NOTE: can't save offset twice because container coordinates and
-        # pose deltas are being mutated simultaneously thus doubling actual
-        # shift
-        # main_router.calibration_manager.update_container_offset(
-        #     container=session.containers[0],
-        #     instrument=session.instruments[index])
-        #
-        # pos = position(session.instruments[index])
+        pos = position(session.instruments[index])
+
+        main_router.calibration_manager.update_container_offset(
+            container=session.containers[0],
+            instrument=session.instruments[index])
 
         # TODO (artyom 20171011): move home to a proper API endpoint
         robot.home()

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -91,9 +91,9 @@ async def test_load_jog_save_run(main_router, protocol, protocol_file, dummy_db)
 
     def instrument_procedure(index):
         def position(instrument):
-            return pose_tracker.absolute(
+            return pose_tracker.transform(
                 robot.poses,
-                instrument._instrument
+                src=instrument._instrument
             )
 
         main_router.calibration_manager.move_to(

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -48,34 +48,6 @@ async def test_multi_single(main_router, protocol, protocol_file, dummy_db):
     # assert (110.0, 135.0, 67.0) in coords
     # assert (110.0, 144.0, 58.0) in coords
 
-# @pytest.mark.parametrize('protocol_file', ['dinosaur.py'])
-# async def test_load_probe_run(main_router, protocol, protocol_file):
-#     session = main_router.session_manager.create(
-#         name='<blank>', text=protocol.text)
-
-#     await main_router.wait_until(state('session', 'loaded'))
-#     # Clear after simulation
-#     robot._driver.log.clear()
-
-#     main_router.calibration_manager.move_to_front(session.instruments[0])
-#     await main_router.wait_until(state('calibration', 'ready'))
-
-#     # TODO (artyom 20171011): instrument public interface of a pose tracker
-#     # to collect movement logs
-#     assert robot._driver.log == \
-#         [{'X': 150, 'B': 0, 'C': 0, 'Y': 150, 'A': 65.0, 'Z': 150}]
-
-#     main_router.calibration_manager.tip_probe(session.instruments[0])
-#     await main_router.wait_until(state('calibration', 'ready'))
-
-#     # Check the log for positions consistent with tip probe sequence
-#     assert robot._driver.log == \
-#         [{'X': 150, 'B': 0, 'C': 0, 'Y': 150, 'A': 65.0, 'Z': 150}]
-
-#     session.run()
-
-#     await main_router.wait_until(state('session', 'finished'))
-
 
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(main_router, protocol, protocol_file, dummy_db):  # NOQA

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -91,9 +91,9 @@ async def test_load_jog_save_run(main_router, protocol, protocol_file, dummy_db)
 
     def instrument_procedure(index):
         def position(instrument):
-            return pose_tracker.transform(
+            return pose_tracker.absolute(
                 robot.poses,
-                src=instrument._instrument
+                instrument._instrument
             )
 
         main_router.calibration_manager.move_to(

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -46,12 +46,10 @@ def test_aspirate_move_to(robot):
     robot.calibrate_container_with_instrument(plate, p200, False)
 
     p200.aspirate(100, location)
-    current_pos = pose_tracker.transform(
-        robot.poses,
-        src=p200.instrument_actuator)
+    current_pos = pose_tracker.absolute(robot.poses, p200.instrument_actuator)
     assert (current_pos == (9.5, 0.0, 0.0)).all()
 
-    current_pos = pose_tracker.transform(robot.poses, src=p200)
+    current_pos = pose_tracker.absolute(robot.poses, p200)
     assert isclose(current_pos, (175.34,  127.94,   10)).all()
 
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -313,6 +313,19 @@ class PipetteTest(unittest.TestCase):
     #         {'a': 0, 'b': 12.0}
     #     )
 
+    def test_add_tip(self):
+        """
+        This deals with z accrual behavior during tip add/remove, when +/- get
+        flipped in pose tracking logic
+        """
+        tip_length = 50
+        prior_position = pose_tracker.absolute(self.robot.poses, self.p200)
+        self.p200._add_tip(tip_length)
+        self.p200._remove_tip(tip_length)
+        new_position = pose_tracker.absolute(self.robot.poses, self.p200)
+
+        assert (new_position == prior_position).all()
+
     # # TODO (artyom, 20171102):  uncomment once calibration is fixed
     # def test_pick_up_tip(self):
     #     last_well = self.tiprack1[-1]

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -50,7 +50,7 @@ def test_aspirate_move_to(robot):
     assert (current_pos == (9.5, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p200)
-    assert isclose(current_pos, (175.34,  127.94,   10.25)).all()
+    assert isclose(current_pos, (175.34,  127.94,   10)).all()
 
 
 def test_blow_out_move_to(robot):

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -40,7 +40,6 @@ def test_aspirate_move_to(robot):
     plate = containers_load(robot, '96-flat', 'A1')
     well = plate[0]
     pos = well.from_center(x=0, y=0, z=-1, reference=plate)
-    print(well.properties)
     location = (plate, pos)
 
     robot.poses = p200._move(robot.poses, x=x, y=y, z=z)
@@ -48,11 +47,10 @@ def test_aspirate_move_to(robot):
 
     p200.aspirate(100, location)
     current_pos = pose_tracker.absolute(robot.poses, p200.instrument_actuator)
-    print(robot._driver.log)
-    assert (current_pos == (0.5, 0.0, 0.0)).all()
+    assert (current_pos == (9.5, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p200)
-    assert isclose(current_pos, (172.24, 131.04, 0)).all()
+    assert isclose(current_pos, (175.34,  127.94,   10.25)).all()
 
 
 def test_blow_out_move_to(robot):

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -7,8 +7,9 @@ from opentrons.containers import load as containers_load
 from opentrons.instruments import Pipette
 # from opentrons.util.vector import Vector
 from opentrons.containers.placeable import unpack_location, Container, Well
-# from opentrons.trackers import pose_tracker
+from opentrons.trackers import pose_tracker
 from tests.opentrons.conftest import fuzzy_assert
+from numpy import isclose
 
 
 def test_drop_tip_move_to(robot):
@@ -32,25 +33,26 @@ def test_drop_tip_move_to(robot):
     #     })
 
 
-# TODO(artyom, 20171101): uncomment once we have plunger tracking back
-# def test_aspirate_move_to(robot):
-#     p200 = Pipette(robot, mount='left', max_volume=200)
+def test_aspirate_move_to(robot):
+    p200 = Pipette(robot, mount='left', max_volume=200)
 
-#     x, y, z = (161.0, 116.7, 0)
-#     plate = containers_load(robot, '96-flat', 'A1')
-#     well = plate[0]
-#     pos = well.from_center(x=0, y=0, z=-1, reference=plate)
-#     location = (plate, pos)
+    x, y, z = (161.0, 116.7, 0)
+    plate = containers_load(robot, '96-flat', 'A1')
+    well = plate[0]
+    pos = well.from_center(x=0, y=0, z=-1, reference=plate)
+    print(well.properties)
+    location = (plate, pos)
 
-#     robot.poses = p200._move(robot.poses, x=x, y=y, z=z)
-#     robot.calibrate_container_with_instrument(plate, p200, False)
-#     p200.aspirate(100, location)
+    robot.poses = p200._move(robot.poses, x=x, y=y, z=z)
+    robot.calibrate_container_with_instrument(plate, p200, False)
 
-#     current_pos = pose_tracker.absolute(robot.poses, p200)
-#     assert isclose(current_pos, (172.24, 131.04, 0)).all()
-#     current_pos = robot._driver.get_plunger_positions()['current']
+    p200.aspirate(100, location)
+    current_pos = pose_tracker.absolute(robot.poses, p200.instrument_actuator)
+    print(robot._driver.log)
+    assert (current_pos == (0.5, 0.0, 0.0)).all()
 
-#     assert current_pos == {'a': 0, 'b': 5.0}
+    current_pos = pose_tracker.absolute(robot.poses, p200)
+    assert isclose(current_pos, (172.24, 131.04, 0)).all()
 
 
 def test_blow_out_move_to(robot):
@@ -1347,7 +1349,6 @@ class PipetteTest(unittest.TestCase):
         self.assertEquals(self.p200.current_volume, 50)
 
     def test_pipette_home(self):
-        self.robot._driver.home = mock.Mock()
         self.p200.home()
         self.assertEquals(len(self.robot.commands()), 1)
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -46,12 +46,12 @@ def test_aspirate_move_to(robot):
     robot.calibrate_container_with_instrument(plate, p200, False)
 
     p200.aspirate(100, location)
-    current_pos = pose_tracker.transform(
+    current_pos = pose_tracker.absolute(
         robot.poses,
-        src=p200.instrument_actuator)
+        p200.instrument_actuator)
     assert (current_pos == (9.5, 0.0, 0.0)).all()
 
-    current_pos = pose_tracker.transform(robot.poses, src=p200)
+    current_pos = pose_tracker.absolute(robot.poses, p200)
     assert isclose(current_pos, (175.34,  127.94,   10)).all()
 
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -46,10 +46,12 @@ def test_aspirate_move_to(robot):
     robot.calibrate_container_with_instrument(plate, p200, False)
 
     p200.aspirate(100, location)
-    current_pos = pose_tracker.absolute(robot.poses, p200.instrument_actuator)
+    current_pos = pose_tracker.transform(
+        robot.poses,
+        src=p200.instrument_actuator)
     assert (current_pos == (9.5, 0.0, 0.0)).all()
 
-    current_pos = pose_tracker.absolute(robot.poses, p200)
+    current_pos = pose_tracker.transform(robot.poses, src=p200)
     assert isclose(current_pos, (175.34,  127.94,   10)).all()
 
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -136,13 +136,12 @@ def test_create_arc(robot):
 
 
 def test_robot_move_to(robot):
-    p200 = pipette.Pipette(robot, mount='left', name='pipette')
+    p200 = pipette.Pipette(robot, mount='right', name='pipette')
     robot.move_to(instrument=p200, location=(robot._deck, (100, 0, 0)))
     assert isclose(
-        pose_tracker.relative(
+        pose_tracker.absolute(
             robot.poses,
-            src=p200,
-            dst=robot.deck),
+            p200),
         (100, 0, 0)
     ).all()
 
@@ -152,8 +151,8 @@ def test_move_head(robot):
     assert isclose(
         pose_tracker.absolute(
             robot.poses,
-            robot.gantry),
-        (100, 0, 0)
+            robot.gantry)[:2],
+        (100, 0, 0)[:2]
     ).all()
 
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -139,9 +139,9 @@ def test_robot_move_to(robot):
     p200 = pipette.Pipette(robot, mount='right', name='pipette')
     robot.move_to(instrument=p200, location=(robot._deck, (100, 0, 0)))
     assert isclose(
-        pose_tracker.absolute(
+        pose_tracker.transform(
             robot.poses,
-            p200),
+            src=p200),
         (100, 0, 0)
     ).all()
 
@@ -149,9 +149,9 @@ def test_robot_move_to(robot):
 def test_move_head(robot):
     robot.move_head(x=100, y=0)
     assert isclose(
-        pose_tracker.absolute(
+        pose_tracker.transform(
             robot.poses,
-            robot.gantry)[:2],
+            src=robot.gantry)[:2],
         (100, 0, 0)[:2]
     ).all()
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -139,9 +139,9 @@ def test_robot_move_to(robot):
     p200 = pipette.Pipette(robot, mount='right', name='pipette')
     robot.move_to(instrument=p200, location=(robot._deck, (100, 0, 0)))
     assert isclose(
-        pose_tracker.transform(
+        pose_tracker.absolute(
             robot.poses,
-            src=p200),
+            p200),
         (100, 0, 0)
     ).all()
 
@@ -149,9 +149,9 @@ def test_robot_move_to(robot):
 def test_move_head(robot):
     robot.move_head(x=100, y=0)
     assert isclose(
-        pose_tracker.transform(
+        pose_tracker.absolute(
             robot.poses,
-            src=robot.gantry)[:2],
+            robot.gantry)[:2],
         (100, 0, 0)[:2]
     ).all()
 

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,0 +1,75 @@
+import pytest
+from opentrons.trackers.pose_tracker import (
+    bind, add, Point, absolute, stringify, relative, init
+)
+from opentrons.instruments import Pipette
+from opentrons.robot.gantry import Mover
+from collections import namedtuple
+from numpy import array, isclose
+from numpy.linalg import inv
+
+
+@pytest.fixture
+def driver():
+    class Driver:
+        def move(self, target):
+            pass
+
+        def home(self, axis):
+            pass
+
+    return Driver()
+
+
+def test_functional(driver):
+    left = Mover(driver, axis_mapping={'z': 'Z'})
+    right = Mover(driver, axis_mapping={'z': 'A'})
+    gantry = Mover(
+        driver,
+        axis_mapping={'x': 'X', 'y': 'Y'},
+        children=[left, right]
+    )
+
+    scale = array([
+        [2, 0, 0, -1],
+        [0, 2, 0, -2],
+        [0, 0, 2, -3],
+        [0, 0, 0,  1],
+    ])
+
+    back = array([
+        [0.5,   0,   0, 0],
+        [0,   0.5,   0, 0],
+        [0,     0, 0.5, 0],
+        [0,     0,   0, 1],
+    ])
+
+    state = init() \
+        .add(driver, transform=scale) \
+        .add(gantry, driver) \
+        .add(left, gantry) \
+        .add(right, gantry) \
+        .add('left', left, transform=back) \
+        .add('right', right, transform=back)
+
+    state = left.move(state, 1, 1, 1)
+
+    assert isclose(absolute(state, 'left'), (1, 1, 1)).all()
+    assert isclose(absolute(state, 'right'), (1, 1, 1.5)).all()
+    state = right.move(state, 2, 2, 3)
+    assert isclose(absolute(state, 'left'), (2, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (2, 2, 3)).all()
+    state = right.jog(state, axis='x', distance=1)
+    assert isclose(absolute(state, 'left'), (3, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (3, 2, 3)).all()
+    state = right.jog(state, axis='z', distance=1)
+    assert isclose(absolute(state, 'left'), (3, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (3, 2, 4)).all()
+
+
+def test_integration(robot):
+    left = Pipette(robot, mount='left')
+    right = Pipette(robot, mount='right')
+    robot.home()
+    pose = left._move(robot.poses, 1, 1, 1)
+    assert isclose(absolute(pose, left), (1, 1, 1)).all()

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,12 +1,10 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    bind, add, Point, absolute, stringify, relative, init
+    absolute, init
 )
 from opentrons.instruments import Pipette
 from opentrons.robot.gantry import Mover
-from collections import namedtuple
 from numpy import array, isclose
-from numpy.linalg import inv
 
 
 @pytest.fixture
@@ -70,7 +68,6 @@ def test_functional(driver):
 
 def test_integration(robot):
     left = Pipette(robot, mount='left')
-    right = Pipette(robot, mount='right')
     robot.home()
     pose = left._move(robot.poses, 1, 1, 1)
     assert isclose(absolute(pose, left), (1, 1, 1)).all()

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,9 +1,9 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    transform, init, ROOT
+    change_base, init, ROOT
 )
 from opentrons.instruments import Pipette
-from opentrons.robot.gantry import Mover
+from opentrons.robot.mover import Mover
 from numpy import array, isclose
 
 
@@ -62,22 +62,22 @@ def test_functional(driver):
     state = gantry.move(state, x=1, y=1)
     state = left.move(state, z=1)
 
-    assert isclose(transform(state, src='left'), (1, 1, 1)).all()
-    assert isclose(transform(state, src='right'), (1, 1, 1.5)).all()
+    assert isclose(change_base(state, src='left'), (1, 1, 1)).all()
+    assert isclose(change_base(state, src='right'), (1, 1, 1.5)).all()
     state = gantry.move(state, x=2, y=2)
     state = right.move(state, z=3)
-    assert isclose(transform(state, src='left'), (2, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (2, 2, 3)).all()
+    assert isclose(change_base(state, src='left'), (2, 2, 1)).all()
+    assert isclose(change_base(state, src='right'), (2, 2, 3)).all()
     state = gantry.jog(state, axis='x', distance=1)
-    assert isclose(transform(state, src='left'), (3, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (3, 2, 3)).all()
+    assert isclose(change_base(state, src='left'), (3, 2, 1)).all()
+    assert isclose(change_base(state, src='right'), (3, 2, 3)).all()
     state = right.jog(state, axis='z', distance=1)
-    assert isclose(transform(state, src='left'), (3, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (3, 2, 4)).all()
+    assert isclose(change_base(state, src='left'), (3, 2, 1)).all()
+    assert isclose(change_base(state, src='right'), (3, 2, 4)).all()
 
 
 def test_integration(robot):
     left = Pipette(robot, mount='left')
     robot.home()
     pose = left._move(robot.poses, 1, 1, 1)
-    assert isclose(transform(pose, src=left), (1, 1, 1)).all()
+    assert isclose(change_base(pose, src=left), (1, 1, 1)).all()

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -22,14 +22,6 @@ def driver():
 
 
 def test_functional(driver):
-    left = Mover(driver, axis_mapping={'z': 'Z'})
-    right = Mover(driver, axis_mapping={'z': 'A'})
-    gantry = Mover(
-        driver,
-        axis_mapping={'x': 'X', 'y': 'Y'},
-        children=[left, right]
-    )
-
     scale = array([
         [2, 0, 0, -1],
         [0, 2, 0, -2],
@@ -44,9 +36,18 @@ def test_functional(driver):
         [0,     0,   0, 1],
     ])
 
+    left = Mover(driver=driver, axis_mapping={'z': 'Z'}, reference=id(scale))
+    right = Mover(driver=driver, axis_mapping={'z': 'A'}, reference=id(scale))
+    gantry = Mover(
+        driver=driver,
+        axis_mapping={'x': 'X', 'y': 'Y'},
+        reference=id(scale),
+        children=[left, right]
+    )
+
     state = init() \
-        .add(driver, transform=scale) \
-        .add(gantry, driver) \
+        .add(id(scale), transform=scale) \
+        .add(gantry, id(scale)) \
         .add(left, gantry) \
         .add(right, gantry) \
         .add('left', left, transform=back) \

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -40,7 +40,6 @@ def test_functional(driver):
         driver=driver,
         axis_mapping={'x': 'X', 'y': 'Y'},
         reference=id(scale),
-        children=[left, right]
     )
 
     state = init() \
@@ -51,14 +50,16 @@ def test_functional(driver):
         .add('left', left, transform=back) \
         .add('right', right, transform=back)
 
-    state = left.move(state, 1, 1, 1)
+    state = gantry.move(state, x=1, y=1)
+    state = left.move(state, z=1)
 
     assert isclose(absolute(state, 'left'), (1, 1, 1)).all()
     assert isclose(absolute(state, 'right'), (1, 1, 1.5)).all()
-    state = right.move(state, 2, 2, 3)
+    state = gantry.move(state, x=2, y=2)
+    state = right.move(state, z=3)
     assert isclose(absolute(state, 'left'), (2, 2, 1)).all()
     assert isclose(absolute(state, 'right'), (2, 2, 3)).all()
-    state = right.jog(state, axis='x', distance=1)
+    state = gantry.jog(state, axis='x', distance=1)
     assert isclose(absolute(state, 'left'), (3, 2, 1)).all()
     assert isclose(absolute(state, 'right'), (3, 2, 3)).all()
     state = right.jog(state, axis='z', distance=1)

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,6 +1,6 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    transform, init, ROOT
+    absolute, init
 )
 from opentrons.instruments import Pipette
 from opentrons.robot.gantry import Mover
@@ -34,21 +34,12 @@ def test_functional(driver):
         [0,     0,   0, 1],
     ])
 
-    left = Mover(
-        driver=driver,
-        axis_mapping={'z': 'Z'},
-        src=ROOT,
-        dst=id(scale))
-    right = Mover(
-        driver=driver,
-        axis_mapping={'z': 'A'},
-        src=ROOT,
-        dst=id(scale))
+    left = Mover(driver=driver, axis_mapping={'z': 'Z'}, reference=id(scale))
+    right = Mover(driver=driver, axis_mapping={'z': 'A'}, reference=id(scale))
     gantry = Mover(
         driver=driver,
         axis_mapping={'x': 'X', 'y': 'Y'},
-        src=ROOT,
-        dst=id(scale),
+        reference=id(scale),
     )
 
     state = init() \
@@ -62,22 +53,22 @@ def test_functional(driver):
     state = gantry.move(state, x=1, y=1)
     state = left.move(state, z=1)
 
-    assert isclose(transform(state, src='left'), (1, 1, 1)).all()
-    assert isclose(transform(state, src='right'), (1, 1, 1.5)).all()
+    assert isclose(absolute(state, 'left'), (1, 1, 1)).all()
+    assert isclose(absolute(state, 'right'), (1, 1, 1.5)).all()
     state = gantry.move(state, x=2, y=2)
     state = right.move(state, z=3)
-    assert isclose(transform(state, src='left'), (2, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (2, 2, 3)).all()
+    assert isclose(absolute(state, 'left'), (2, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (2, 2, 3)).all()
     state = gantry.jog(state, axis='x', distance=1)
-    assert isclose(transform(state, src='left'), (3, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (3, 2, 3)).all()
+    assert isclose(absolute(state, 'left'), (3, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (3, 2, 3)).all()
     state = right.jog(state, axis='z', distance=1)
-    assert isclose(transform(state, src='left'), (3, 2, 1)).all()
-    assert isclose(transform(state, src='right'), (3, 2, 4)).all()
+    assert isclose(absolute(state, 'left'), (3, 2, 1)).all()
+    assert isclose(absolute(state, 'right'), (3, 2, 4)).all()
 
 
 def test_integration(robot):
     left = Pipette(robot, mount='left')
     robot.home()
     pose = left._move(robot.poses, 1, 1, 1)
-    assert isclose(transform(pose, src=left), (1, 1, 1)).all()
+    assert isclose(absolute(pose, left), (1, 1, 1)).all()

--- a/api/tests/opentrons/trackers/test_pose_tracker.py
+++ b/api/tests/opentrons/trackers/test_pose_tracker.py
@@ -1,6 +1,6 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    Point, Node, add, descendants, ascend, transform, max_z,
+    Point, Node, add, descendants, ascend, change_base, max_z,
     update, remove, translate, init, ROOT
 )
 from numpy import isclose, array, ndarray
@@ -92,29 +92,33 @@ def test_ascend(state):
 
 def test_relative(state):
     from math import pi
-    assert (transform(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
+    assert (change_base(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
     state = \
         init() \
         .add('1', transform=rotate(pi / 2.0)) \
         .add('1-1', parent='1', point=Point(1, 0, 0)) \
         .add('2', point=Point(1, 0, 0))
 
-    assert isclose(transform(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
-    assert isclose(transform(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
+    assert isclose(
+        change_base(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
+    assert isclose(
+        change_base(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
 
     state = init() \
         .add('1', transform=scale(2, 1, 1)) \
         .add('1-1', parent='1', point=Point(1, 1, 1)) \
 
-    assert isclose(transform(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()  # NOQA
-    assert isclose(transform(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()  # NOQA
+    assert isclose(
+        change_base(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()
+    assert isclose(
+        change_base(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()
 
 
 def test_absolute(state):
-    assert (transform(state, src='1') == (1, 2, 3)).all()
-    assert (transform(state, src='1-1') == (12, 14, 16)).all()
-    assert (transform(state, src='2') == (-1, -2, -3)).all()
-    assert (transform(state, src='2-1') == (-12, -14, -16)).all()
+    assert (change_base(state, src='1') == (1, 2, 3)).all()
+    assert (change_base(state, src='1-1') == (12, 14, 16)).all()
+    assert (change_base(state, src='2') == (-1, -2, -3)).all()
+    assert (change_base(state, src='2-1') == (-12, -14, -16)).all()
 
 
 def test_max_z(state):
@@ -123,7 +127,7 @@ def test_max_z(state):
 
 def test_update(state):
     state = update(state, '1-1', Point(0, 0, 0))
-    assert (transform(state, src='1-1-1') == (1, 2, 3)).all()
+    assert (change_base(state, src='1-1-1') == (1, 2, 3)).all()
 
 
 def test_remove(state):
@@ -135,9 +139,9 @@ def test_remove(state):
     assert state == {}
 
 
-def test_transform():
+def test_change_base():
     state = init() \
         .add('1', parent=ROOT, transform=scale(2, 2, 2)) \
         .add('1-1', parent='1', point=Point(1, 0, 0))
 
-    assert isclose(transform(state, src='1-1'), (0.5, 0, 0)).all()
+    assert isclose(change_base(state, src='1-1'), (0.5, 0, 0)).all()

--- a/api/tests/opentrons/trackers/test_pose_tracker.py
+++ b/api/tests/opentrons/trackers/test_pose_tracker.py
@@ -1,6 +1,6 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    Point, Node, add, descendants, ascend, transform, max_z,
+    Point, Node, add, descendants, ascend, absolute, relative, max_z,
     update, remove, translate, init, ROOT
 )
 from numpy import isclose, array, ndarray
@@ -92,38 +92,38 @@ def test_ascend(state):
 
 def test_relative(state):
     from math import pi
-    assert (transform(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
+    assert (relative(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
     state = \
         init() \
         .add('1', transform=rotate(pi / 2.0)) \
         .add('1-1', parent='1', point=Point(1, 0, 0)) \
         .add('2', point=Point(1, 0, 0))
 
-    assert isclose(transform(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
-    assert isclose(transform(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
+    assert isclose(relative(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
+    assert isclose(relative(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
 
     state = init() \
         .add('1', transform=scale(2, 1, 1)) \
         .add('1-1', parent='1', point=Point(1, 1, 1)) \
 
-    assert isclose(transform(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()  # NOQA
-    assert isclose(transform(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()  # NOQA
+    assert isclose(relative(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()  # NOQA
+    assert isclose(relative(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()
 
 
 def test_absolute(state):
-    assert (transform(state, src='1') == (1, 2, 3)).all()
-    assert (transform(state, src='1-1') == (12, 14, 16)).all()
-    assert (transform(state, src='2') == (-1, -2, -3)).all()
-    assert (transform(state, src='2-1') == (-12, -14, -16)).all()
+    assert (absolute(state, '1') == (1, 2, 3)).all()
+    assert (absolute(state, '1-1') == (12, 14, 16)).all()
+    assert (absolute(state, '2') == (-1, -2, -3)).all()
+    assert (absolute(state, '2-1') == (-12, -14, -16)).all()
 
 
 def test_max_z(state):
-    assert max_z(state, '1') == 23.0
+    assert max_z(state, '1') == 23
 
 
 def test_update(state):
     state = update(state, '1-1', Point(0, 0, 0))
-    assert (transform(state, src='1-1-1') == (1, 2, 3)).all()
+    assert (absolute(state, '1-1-1') == (1, 2, 3)).all()
 
 
 def test_remove(state):
@@ -140,4 +140,4 @@ def test_transform():
         .add('1', parent=ROOT, transform=scale(2, 2, 2)) \
         .add('1-1', parent='1', point=Point(1, 0, 0))
 
-    assert isclose(transform(state, src='1-1'), (0.5, 0, 0)).all()
+    assert isclose(absolute(state, '1-1'), (0.5, 0, 0)).all()

--- a/api/tests/opentrons/trackers/test_pose_tracker.py
+++ b/api/tests/opentrons/trackers/test_pose_tracker.py
@@ -1,6 +1,6 @@
 import pytest
 from opentrons.trackers.pose_tracker import (
-    Point, Node, add, descendants, ascend, absolute, relative, max_z,
+    Point, Node, add, descendants, ascend, transform, max_z,
     update, remove, translate, init, ROOT
 )
 from numpy import isclose, array, ndarray
@@ -92,38 +92,38 @@ def test_ascend(state):
 
 def test_relative(state):
     from math import pi
-    assert (relative(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
+    assert (transform(state, src='1-1', dst='2-1') == (24., 28., 32.)).all()
     state = \
         init() \
         .add('1', transform=rotate(pi / 2.0)) \
         .add('1-1', parent='1', point=Point(1, 0, 0)) \
         .add('2', point=Point(1, 0, 0))
 
-    assert isclose(relative(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
-    assert isclose(relative(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
+    assert isclose(transform(state, src='1-1', dst='2'), (-1.0, -1.0, 0)).all()
+    assert isclose(transform(state, src='2', dst='1-1'), (0.0, 0.0, 0)).all()
 
     state = init() \
         .add('1', transform=scale(2, 1, 1)) \
         .add('1-1', parent='1', point=Point(1, 1, 1)) \
 
-    assert isclose(relative(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()  # NOQA
-    assert isclose(relative(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()
+    assert isclose(transform(state, src=ROOT, dst='1-1'), (-2.0, -1.0, -1.0)).all()  # NOQA
+    assert isclose(transform(state, src='1-1', dst=ROOT), (0.5, 1.0, 1.0)).all()  # NOQA
 
 
 def test_absolute(state):
-    assert (absolute(state, '1') == (1, 2, 3)).all()
-    assert (absolute(state, '1-1') == (12, 14, 16)).all()
-    assert (absolute(state, '2') == (-1, -2, -3)).all()
-    assert (absolute(state, '2-1') == (-12, -14, -16)).all()
+    assert (transform(state, src='1') == (1, 2, 3)).all()
+    assert (transform(state, src='1-1') == (12, 14, 16)).all()
+    assert (transform(state, src='2') == (-1, -2, -3)).all()
+    assert (transform(state, src='2-1') == (-12, -14, -16)).all()
 
 
 def test_max_z(state):
-    assert max_z(state, '1') == 23
+    assert max_z(state, '1') == 23.0
 
 
 def test_update(state):
     state = update(state, '1-1', Point(0, 0, 0))
-    assert (absolute(state, '1-1-1') == (1, 2, 3)).all()
+    assert (transform(state, src='1-1-1') == (1, 2, 3)).all()
 
 
 def test_remove(state):
@@ -140,4 +140,4 @@ def test_transform():
         .add('1', parent=ROOT, transform=scale(2, 2, 2)) \
         .add('1-1', parent='1', point=Point(1, 0, 0))
 
-    assert isclose(absolute(state, '1-1'), (0.5, 0, 0)).all()
+    assert isclose(transform(state, src='1-1'), (0.5, 0, 0)).all()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build: false # No need to run MSBuild
 
 build_script:
-  - '%BASH% -lc "export PATH=$CYG_PYTHON_PATH:$PATH && cd $APPVEYOR_BUILD_FOLDER/api && make test exe"'
+  - '%BASH% -lc "export PATH=$CYG_PYTHON_PATH:$PATH && cd $APPVEYOR_BUILD_FOLDER/api && make test"'
   # Note: we are not running test-e2e on Windows due to problems with ChromeDriver
   - '%BASH% -lc "cd $APPVEYOR_BUILD_FOLDER && source scripts/env-vars-appveyor && cd app && make -j 2 build test package"'
   - >


### PR DESCRIPTION
Per #397 

- Adds CLI tool for jogging the robot to calibration positions and
  calculating calibration parameters: `api/opentrons/cli/main.py`.
- Adds smoothie homing offsets for X and Y to avoid hitting endstops
  during calibration.
- `driver.move` now takes `target` a dictionary with axis values to
  move to.
- Adds coordinate rounding to 3rd digit before sending it to Smoothie
- Unifies motion dispatch and position update to fully utilise pose tracker
  refactoring `gantry.py` and consolidating Gantry, Mover, Actuator, Mount
  under Mover class. Plungers use mover too. Mover takes cartesian to driver
  coordinate mapping, coordinate system of origin and destination to.
  dispatch move commands to driver and update position.
- Refactors pipette and robot to use updated Mover.
- Utilizes `robot_config` to pull calibration values and offsets.
- Adds test for pickup accuracy.
- Adds calibration data for Avogadro and Franklin.

*TODO*

- README for CLI
- Tests for CLI