### PR TITLE
Don't emit Session notification even if creation fails

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -135,19 +135,16 @@ class Session(object):
     def refresh(self):
         self._reset()
 
-        try:
-            parsed = ast.parse(self.protocol_text)
-            self._protocol = compile(parsed, filename=self.name, mode='exec')
-            commands = self._simulate()
-            self.commands = tree.from_list(commands)
-        finally:
-            if self.errors:
-                raise Exception(*self.errors)
+        parsed = ast.parse(self.protocol_text)
+        self._protocol = compile(parsed, filename=self.name, mode='exec')
+        commands = self._simulate()
+        self.commands = tree.from_list(commands)
 
-            self.containers = self.get_containers()
-            self.instruments = self.get_instruments()
+        self.containers = self.get_containers()
+        self.instruments = self.get_instruments()
 
-            self.set_state('loaded')
+        self.set_state('loaded')
+
         return self
 
     def stop(self):

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -196,6 +196,7 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
         done, pending = await asyncio.wait([coro], timeout=timeout)
 
         if pending:
+            [task.cancel() for task in pending]
             raise TimeoutError('Notifications: {0}'.format(result))
 
         result += [done.pop().result()]


### PR DESCRIPTION
- fixes #380
- adds test simulating the behavior
- moves protocol load out of try-finally block
- tear down async test fixture gracefully
- fix existing test in light of new behavior