### PR TITLE
V3a jog screen alignment

### DIFF
--- a/app/ui/components/App.global.css
+++ b/app/ui/components/App.global.css
@@ -247,3 +247,12 @@ button:focus {
 .btn_dark:hover {
   background-color: #777;
 }
+
+.btn_blue {
+  background-color: #006fff;
+  color: white;
+}
+
+.btn_blue:hover {
+  background-color: #00f;
+}

--- a/app/ui/components/DeckConfig.js
+++ b/app/ui/components/DeckConfig.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Link} from 'react-router-dom'
 import classnames from 'classnames'
+
 import Labware from './Labware'
 import ToolTip from './ToolTip'
 import Diagram from './Diagram'
@@ -119,7 +120,7 @@ function NextCalibrationPrompt (props) {
   return (
     <div className={styles.prompt}>
       <h3>{title}</h3>
-      <button className={styles.robot_action} onClick={onClick}>
+      <button className={classnames('btn_blue', styles.robot_action)} onClick={onClick}>
         Move to next labware
         ({nextLabware.type}, slot {nextLabware.slot})
       </button>

--- a/app/ui/components/JogModal.css
+++ b/app/ui/components/JogModal.css
@@ -37,11 +37,11 @@ a.close {
 }
 
 .jog_controls {
-  margin: 1rem auto;
+  margin: 2rem auto 1rem;
   width: 16rem;
   display: grid;
   grid-gap: 0.25rem;
-  grid-template-rows: repeat(2, [row] 3rem);
+  grid-template-rows: repeat(2, [row] 3rem) 1rem;
   grid-template-columns: repeat(5, [col] 3rem);
 }
 

--- a/app/ui/components/JogModal.css
+++ b/app/ui/components/JogModal.css
@@ -41,7 +41,7 @@ a.close {
   width: 16rem;
   display: grid;
   grid-gap: 0.25rem;
-  grid-template-rows: repeat(2, [row] 3rem) 1rem;
+  grid-template-rows: repeat(2, [row] 3rem) 2rem;
   grid-template-columns: repeat(5, [col] 3rem);
 }
 
@@ -51,6 +51,10 @@ a.close {
   color: white;
   font-size: 1rem;
   cursor: pointer;
+}
+
+.btn:hover {
+  background-color: #111;
 }
 
 .btn[disabled],
@@ -99,6 +103,22 @@ a.close {
   margin: 1rem 0;
 }
 
+.jog_xy {
+  grid-column: 1 / 4;
+  grid-row: 3;
+  text-align: center;
+  text-transform: uppercase;
+  line-height: 2rem;
+}
+
+.jog_z {
+  grid-column: 5;
+  grid-row: 3;
+  text-align: center;
+  text-transform: uppercase;
+  line-height: 2rem;
+}
+
 .btn_confirm {
   margin: 1rem;
   font-size: 1rem;
@@ -113,6 +133,10 @@ a.close {
   text-decoration: none;
   text-transform: uppercase;
   cursor: pointer;
+}
+
+.btn_confirm:hover {
+  background-color: #555;
 }
 
 .spinner {

--- a/app/ui/components/JogModal.js
+++ b/app/ui/components/JogModal.js
@@ -68,6 +68,8 @@ export default function JogModal (props) {
           >
             ↓
           </button>
+          <label className={styles.jog_xy}>X-Y Axis</label>
+          <label className={styles.jog_z}>Z Axis</label>
         </div>
         <Link to={url} className={styles.close}>X</Link>
         <button

--- a/app/ui/components/JogModal.js
+++ b/app/ui/components/JogModal.js
@@ -23,6 +23,9 @@ export default function JogModal (props) {
   return (
     <div className={styles.modal_wrapper}>
       <div className={styles.jog_modal}>
+        <p>Using the arrow buttons, jog the pipette along the x, y and z
+        axis to improve accuracy. Press confirm position to save.
+        </p>
         <div className={styles.jog_controls}>
           <button
             className={styles.btn_left}
@@ -74,9 +77,6 @@ export default function JogModal (props) {
         >
           {confirmButtonContents}
         </button>
-        <p>Using the arrow buttons, jog the pipette along the x, y and z
-        axis to improve accuracy. Press confirm position to save.
-        </p>
       </div>
     </div>
   )

--- a/app/ui/components/SetupPanel.css
+++ b/app/ui/components/SetupPanel.css
@@ -144,8 +144,8 @@ li:nth-child(odd) a.btn_labware {
   background-color: #777;
 }
 
-.inactive,
-.inactive:hover {
+.run_link.inactive,
+.run_link.inactive:hover {
   background-color: transparent;
   border: 1px solid silver;
   color: silver;

--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -137,6 +137,11 @@ export default function SetupPanel (props) {
   const runWarning = !labwareConfirmed
     ? <ToolTip msg={runLinkWarning} pos='top' />
     : null
+
+  const runLinkUrl = labwareConfirmed
+    ? '/run'
+    : '#'
+
   return (
     <div className={styles.setup_panel}>
       <h2 className={styles.title}>Prepare Robot for RUN</h2>
@@ -157,7 +162,7 @@ export default function SetupPanel (props) {
           {labwareMsg}
         </section>
       </section>
-      <NavLink to='/run' className={runLinkStyles}>
+      <NavLink to={runLinkUrl} className={runLinkStyles}>
         Run Protocol
         {runWarning}
       </NavLink>


### PR DESCRIPTION
## overview

This PR implements the following updates to better align with designed UI.
- Label jog axes
- Move jog instructions to top
- Jog button hover styles
- Move to next labware button now blue
- Disable run link when not calibrated

This PR includes:

- [x] Chore work
- [x] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

**Note**: If you did not check "Documentation updates" and/or "Test updates" then your PR may not be ready!

## changelog

Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.

- (Chore) Match jog modal to design, css updated
- (Fix) Disable run link until all labware is calibrated

**Note**: If your PR incorporates many changes, or many different types of changes, please consider splitting it up into smaller PRs.

## review requests
This is generally CSS/organizational chore work. @mcous please double check my disable run link logic.
