### PR TITLE
(v3) Track labware confirmation separately from instantaneous status

### DIFF
--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -45,7 +45,7 @@ function PipetteLinks (props) {
 function LabwareLinks (props) {
   const {
     name,
-    calibration,
+    confirmed,
     isTiprack,
     instrumentsCalibrated,
     tipracksConfirmed,
@@ -53,15 +53,14 @@ function LabwareLinks (props) {
   } = props
 
   const isDisabled = !instrumentsCalibrated || !(isTiprack || tipracksConfirmed)
-  const isConfirmed = calibration === robotConstants.CONFIRMED
 
   const buttonStyle = classnames(styles.btn_labware, {
     [styles.disabled]: isDisabled
   })
 
   const statusStyle = classnames({
-    [styles.confirmed]: isConfirmed,
-    [styles.alert]: !isConfirmed
+    [styles.confirmed]: confirmed,
+    [styles.alert]: !confirmed
   })
 
   return (

--- a/app/ui/robot/reducer/calibration.js
+++ b/app/ui/robot/reducer/calibration.js
@@ -37,9 +37,18 @@ const {
 
 const INITIAL_STATE = {
   labwareReviewed: false,
+
+  // TODO(mc, 2017-11-03): instrumentsByAxis holds calibration status by
+  // axis. probedByAxis holds a flag for whether the instrument has been
+  // probed at least once by axis. Rethink or combine these states
   instrumentsByAxis: {},
   probedByAxis: {},
+
+  // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
+  // slot. confirmedBySlot holds a flag for whether the labware has been
+  // confirmed at least once. Rethink or combine these states
   labwareBySlot: {},
+  confirmedBySlot: {},
 
   // homeRequest: {inProgress: false, error: null},
   moveToFrontRequest: {inProgress: false, error: null},
@@ -230,6 +239,9 @@ function handleUpdateOffset (state, action) {
 function handleUpdateResponse (state, action) {
   const {updateOffsetRequest: {slot}} = state
   const {error, payload} = action
+  const confirmationStatus = !error
+    ? CONFIRMED
+    : OVER_SLOT
 
   return {
     ...state,
@@ -240,17 +252,17 @@ function handleUpdateResponse (state, action) {
         ? payload
         : null
     },
-    labwareBySlot: {
-      ...state.labwareBySlot,
-      [slot]: !error
-        ? CONFIRMED
-        : OVER_SLOT
-    }
+    labwareBySlot: {...state.labwareBySlot, [slot]: confirmationStatus},
+    confirmedBySlot: {...state.confirmedBySlot, [slot]: !error}
   }
 }
 
 function handleConfirmLabware (state, action) {
   const {payload: {labware: slot}} = action
 
-  return {...state, labwareBySlot: {...state.labwareBySlot, [slot]: CONFIRMED}}
+  return {
+    ...state,
+    labwareBySlot: {...state.labwareBySlot, [slot]: CONFIRMED},
+    confirmedBySlot: {...state.confirmedBySlot, [slot]: true}
+  }
 }

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -15,7 +15,6 @@ import {
   FINISHED,
   STOPPED,
   UNPROBED,
-  CONFIRMED,
   UNCONFIRMED,
   INSTRUMENT_AXES,
   DECK_SLOTS,
@@ -206,7 +205,10 @@ export function getLabwareBySlot (state) {
 
 export function getLabware (state) {
   const protocolLabwareBySlot = getLabwareBySlot(state)
-  const {labwareBySlot: calibrationBySlot} = getCalibrationState(state)
+  const {
+    confirmedBySlot,
+    labwareBySlot: calibrationBySlot
+  } = getCalibrationState(state)
 
   return DECK_SLOTS.map((slot) => {
     let labware = protocolLabwareBySlot[slot] || {slot}
@@ -214,7 +216,8 @@ export function getLabware (state) {
     if (labware.name) {
       labware = {
         ...labware,
-        calibration: calibrationBySlot[slot] || UNCONFIRMED
+        calibration: calibrationBySlot[slot] || UNCONFIRMED,
+        confirmed: confirmedBySlot[slot] || false
       }
     }
 
@@ -227,10 +230,7 @@ export function getLabwareReviewed (state) {
 }
 
 export function getUnconfirmedLabware (state) {
-  return getLabware(state).filter((lw) => (
-    lw.type != null &&
-    lw.calibration !== CONFIRMED
-  ))
+  return getLabware(state).filter((lw) => (lw.type != null && !lw.confirmed))
 }
 
 export function getUnconfirmedTipracks (state) {

--- a/app/ui/robot/test/calibration-reducer.test.js
+++ b/app/ui/robot/test/calibration-reducer.test.js
@@ -7,15 +7,21 @@ describe('robot reducer - calibration', () => {
 
     expect(state).toEqual({
       labwareReviewed: false,
+
       // TODO(mc, 2017-11-03): instrumentsByAxis holds calibration status by
       // axis. probedByAxis holds a flag for whether the instrument has been
       // probed at least once by axis. Rethink or combine these states
       instrumentsByAxis: {},
       probedByAxis: {},
-      labwareBySlot: {},
 
+      // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
+      // slot. confirmedBySlot holds a flag for whether the labware has been
+      // confirmed at least once. Rethink or combine these states
+      labwareBySlot: {},
+      confirmedBySlot: {},
+
+      // TODO(mc, 2017-11-07): figure out what's happening with home
       // homeRequest: {inProgress: false, error: null},
-      // TODO(mc, 2017-10-17): collapse moveToFront and probeTip request state
       moveToFrontRequest: {inProgress: false, error: null},
       probeTipRequest: {inProgress: false, error: null},
       moveToRequest: {inProgress: false, error: null},
@@ -319,7 +325,8 @@ describe('robot reducer - calibration', () => {
     const state = {
       calibration: {
         updateOffsetRequest: {inProgress: true, error: null, slot: 5},
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
+        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT},
+        confirmedBySlot: {}
       }
     }
 
@@ -332,24 +339,28 @@ describe('robot reducer - calibration', () => {
 
     expect(reducer(state, success).calibration).toEqual({
       updateOffsetRequest: {inProgress: false, error: null, slot: 5},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED}
+      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
+      confirmedBySlot: {5: true}
     })
     expect(reducer(state, failure).calibration).toEqual({
       updateOffsetRequest: {inProgress: false, error: new Error('AH'), slot: 5},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
+      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT},
+      confirmedBySlot: {5: false}
     })
   })
 
   test('handles CONFIRM_LABWARE action', () => {
     const state = {
       calibration: {
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
+        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT},
+        confirmedBySlot: {}
       }
     }
     const action = {type: actionTypes.CONFIRM_LABWARE, payload: {labware: 5}}
 
     expect(reducer(state, action).calibration).toEqual({
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED}
+      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
+      confirmedBySlot: {5: true}
     })
   })
 })

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -435,7 +435,11 @@ describe('robot selectors', () => {
         calibration: {
           labwareBySlot: {
             1: constants.UNCONFIRMED,
-            5: constants.CONFIRMED
+            5: constants.OVER_SLOT
+          },
+          confirmedBySlot: {
+            1: false,
+            5: true
           }
         }
       })
@@ -449,7 +453,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED
+          calibration: constants.UNCONFIRMED,
+          confirmed: false
         },
         {slot: 2},
         {slot: 3},
@@ -460,7 +465,8 @@ describe('robot selectors', () => {
           name: 'b2',
           type: 'b',
           isTiprack: false,
-          calibration: constants.CONFIRMED
+          calibration: constants.OVER_SLOT,
+          confirmed: true
         },
         {slot: 6},
         {slot: 7},
@@ -471,7 +477,8 @@ describe('robot selectors', () => {
           name: 'c3',
           type: 'c',
           isTiprack: false,
-          calibration: constants.UNCONFIRMED
+          calibration: constants.UNCONFIRMED,
+          confirmed: false
         },
         {slot: 10},
         {slot: 11}
@@ -486,7 +493,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED
+          calibration: constants.UNCONFIRMED,
+          confirmed: false
         }
       ])
     })
@@ -499,7 +507,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED
+          calibration: constants.UNCONFIRMED,
+          confirmed: false
         },
         {
           slot: 9,
@@ -507,7 +516,8 @@ describe('robot selectors', () => {
           name: 'c3',
           type: 'c',
           isTiprack: false,
-          calibration: constants.UNCONFIRMED
+          calibration: constants.UNCONFIRMED,
+          confirmed: false
         }
       ])
     })


### PR DESCRIPTION
## overview

During labware confirmation, we had been combining the questions of "has this labware been confirmed?" and "what is the status of the confirmation process on this container?". This PR is a quick and dirty separation of those concerns to aid user testing, in the same vein as what #399 did for intrument probing state.

The end result is that re-doing confirmation on a given container doesn't wipe out the fact that confirmation has occurred at least once (this is important because confirmation of non-tiprack labware is gated by confirmation of tiprack labware).

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Fix) Split instantaneous labware confirmation status from whether or not the labware has been confirmed at all

## review requests

As you should note from my `TODO`s, I believe this (and the instrument work in #399) is a sub-optimal solution. The priority is to get this in for testing, but if you have any ideas on how to improve the organization in a future PR please share. I would like to go in with @IanLondon soon and reorganize the subreducers (more `combineReducers` plz) along with pulling in `reselect`, so heads up Ian. Otherwise reviews are appreciated!
