### PR TITLE
(v3) Calculate run progress by counting leaves in the command list

### DIFF
--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -127,12 +127,20 @@ export function getCommands (state) {
   }
 }
 
-// TODO(mc, 2017-10-17): base this value on leaves rather than top level nodes
 export function getRunProgress (state) {
-  const commands = getCommands(state)
-  const currentCommand = commands.find((c) => c.isCurrent)
+  const leaves = getCommands(state).reduce(countLeaves, {handled: 0, total: 0})
 
-  return 100 * (commands.indexOf(currentCommand) + 1) / commands.length
+  if (!leaves.total) return 0
+
+  return 100 * (leaves.handled / leaves.total)
+
+  function countLeaves (result, cmd) {
+    if (cmd.children.length) return cmd.children.reduce(countLeaves, result)
+    if (cmd.handledAt) result.handled++
+    result.total++
+
+    return result
+  }
 }
 
 export function getStartTime (state) {

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -225,7 +225,16 @@ describe('robot selectors', () => {
     })
 
     test('getRunProgress', () => {
-      expect(getRunProgress(state)).toEqual(50)
+      // leaves: 2, 3, 4; processed: 2
+      expect(getRunProgress(state)).toEqual(1 / 3 * 100)
+    })
+
+    test('getRunProgress with no commands', () => {
+      const state = makeState({
+        session: {protocolCommands: [], protocolCommandsById: {}}
+      })
+
+      expect(getRunProgress(state)).toEqual(0)
     })
 
     test('getStartTime', () => {


### PR DESCRIPTION
## overview

Our previous run progress implementation was super naive and worked by counting command parents completed. Obviously this gave us super coarse results and wasn't awesome, so this PR switches to a leaves based calculation.

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Fix) Calculate run progress based on command list leaves

## review requests

Tiny straightforward PR. Will likely merge as soon as I get any approval unless I hear otherwise
