### PR TITLE
Shorten well representation in commands list

### DIFF
--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -62,7 +62,7 @@ def stringify_location(location):
             object_text=type_to_text[type(location[0])],
             suffix='s' if multiple else '',
             first=location[0].get_name(),
-            last='..'+location[-1].get_name() if multiple else '',
+            last='...'+location[-1].get_name() if multiple else '',
             slot_text=slot_number_mapping[get_slot(location[0]).get_name()]
         )
 

--- a/api/tests/opentrons/commands/test_description.py
+++ b/api/tests/opentrons/commands/test_description.py
@@ -15,9 +15,10 @@ def containers():
 
 def test_all(containers):
     assert stringify_location(containers['1'][0]) == 'well A1 in "1"'
-    assert stringify_location(containers['1'].rows(0)) == 'wells A1..H1 in "1"'
+    assert stringify_location(containers['1'].rows(0)) == \
+        'wells A1...H1 in "1"'
     assert stringify_location(containers['11'][95]) == 'well H12 in "11"'
     assert stringify_location(containers['11'].cols(0)) == \
-        'wells A1..A12 in "11"'
+        'wells A1...A12 in "11"'
     assert stringify_location(containers['11'].cols('A', 'B')) == \
-        'wells A1..B12 in "11"'
+        'wells A1...B12 in "11"'

--- a/api/tests/opentrons/commands/test_description.py
+++ b/api/tests/opentrons/commands/test_description.py
@@ -1,0 +1,24 @@
+from opentrons.containers import Well, WellSeries
+import pytest
+from opentrons.commands import stringify_location
+
+
+@pytest.fixture
+def containers():
+    from opentrons import robot
+    from opentrons import containers
+    robot.reset()
+    return {
+        '1': containers.load('96-flat', 'A1'),
+        '11': containers.load('96-flat', 'B4')
+    }
+
+
+def test_all(containers):
+    assert stringify_location(containers['1'][0]) == 'well A1 in "1"'
+    assert stringify_location(containers['1'].rows(0)) == 'wells A1..H1 in "1"'
+    assert stringify_location(containers['11'][95]) == 'well H12 in "11"'
+    assert stringify_location(containers['11'].cols(0)) == \
+        'wells A1..A12 in "11"'
+    assert stringify_location(containers['11'].cols('A', 'B')) == \
+        'wells A1..B12 in "11"'

--- a/api/tests/opentrons/commands/test_description.py
+++ b/api/tests/opentrons/commands/test_description.py
@@ -1,4 +1,3 @@
-from opentrons.containers import Well, WellSeries
 import pytest
 from opentrons.commands import stringify_location
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -141,7 +141,7 @@ class PipetteTest(unittest.TestCase):
     def test_aspirate_zero_volume(self):
         assert self.robot.commands() == []
         self.p200.aspirate(0)
-        assert self.robot.commands() == ['Aspirating 0 uL from None at 1.0 speed']  # noqa
+        assert self.robot.commands() == ['Aspirating 0 uL from ? at 1.0 speed']  # noqa
 
     def test_get_plunger_position(self):
 
@@ -394,23 +394,23 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
-            ['Distributing', '30', 'Well A1', 'Well B1'],
+            ['Distributing', '30', 'well A1', 'wells B1..A2'],
             ['Transferring'],
             ['Picking up tip'],
-            ['Aspirating', '190', 'Well A1'],
-            ['Dispensing', '30', 'Well B1'],
-            ['Dispensing', '30', 'Well C1'],
-            ['Dispensing', '30', 'Well D1'],
-            ['Dispensing', '30', 'Well E1'],
-            ['Dispensing', '30', 'Well F1'],
-            ['Dispensing', '30', 'Well G1'],
-            ['Blow', 'Well A1'],
+            ['Aspirating', '190', 'well A1'],
+            ['Dispensing', '30', 'well B1'],
+            ['Dispensing', '30', 'well C1'],
+            ['Dispensing', '30', 'well D1'],
+            ['Dispensing', '30', 'well E1'],
+            ['Dispensing', '30', 'well F1'],
+            ['Dispensing', '30', 'well G1'],
+            ['Blow', 'well A1'],
             ['Drop'],
             ['Pick'],
-            ['Aspirating', '70', 'Well A1'],
-            ['Dispensing', '30', 'Well H1'],
-            ['Dispensing', '30', 'Well A2'],
-            ['Blow', 'Well A1'],
+            ['Aspirating', '70', 'well A1'],
+            ['Dispensing', '30', 'well H1'],
+            ['Dispensing', '30', 'well A2'],
+            ['Blow', 'well A1'],
             ['Drop']
         ]
         fuzzy_assert(self.robot.commands(), expected=expected)
@@ -425,20 +425,20 @@ class PipetteTest(unittest.TestCase):
         )
 
         expected = [
-            ['Distributing', '30', 'Well A1', 'Well B1'],
+            ['Distributing', '30', 'well A1', 'wells B1..A2'],
             ['Transferring'],
-            ['Aspirating', '190', 'Well A1'],
-            ['Dispensing', '30', 'Well B1'],
-            ['Dispensing', '30', 'Well C1'],
-            ['Dispensing', '30', 'Well D1'],
-            ['Dispensing', '30', 'Well E1'],
-            ['Dispensing', '30', 'Well F1'],
-            ['Dispensing', '30', 'Well G1'],
-            ['Blow', 'Well A1'],
-            ['Aspirating', '70', 'Well A1'],
-            ['Dispensing', '30', 'Well H1'],
-            ['Dispensing', '30', 'Well A2'],
-            ['Blow', 'Well A1'],
+            ['Aspirating', '190', 'well A1'],
+            ['Dispensing', '30', 'well B1'],
+            ['Dispensing', '30', 'well C1'],
+            ['Dispensing', '30', 'well D1'],
+            ['Dispensing', '30', 'well E1'],
+            ['Dispensing', '30', 'well F1'],
+            ['Dispensing', '30', 'well G1'],
+            ['Blow', 'well A1'],
+            ['Aspirating', '70', 'well A1'],
+            ['Dispensing', '30', 'well H1'],
+            ['Dispensing', '30', 'well A2'],
+            ['Blow', 'well A1'],
         ]
         fuzzy_assert(self.robot.commands(), expected=expected)
         self.robot.clear_commands()
@@ -466,24 +466,24 @@ class PipetteTest(unittest.TestCase):
         )
 
         expected = [
-            ['Transferring', '30', 'Well A1'],
+            ['Transferring', '30', 'well A1'],
             ['Pick'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well B1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well C1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well D1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well E1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well F1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well G1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well H1'],
-            ['Aspirating', '30', 'Well A1'],
-            ['Dispensing', '30', 'Well A2'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well B1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well C1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well D1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well E1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well F1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well G1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well H1'],
+            ['Aspirating', '30', 'well A1'],
+            ['Dispensing', '30', 'well A2'],
             ['Return'],
             ['Drop']
         ]
@@ -831,13 +831,13 @@ class PipetteTest(unittest.TestCase):
             blow_out=False
         )
         expected = [
-            'Transferring 300 from <Well A1> to <Well B1>',
-            'Picking up tip <Well A1>',
-            'Aspirating 150.0 uL from <Well A1> at 1 speed',
-            'Dispensing 150.0 uL into <Well B1>',
-            'Aspirating 150.0 uL from <Well A1> at 1 speed',
-            'Dispensing 150.0 uL into <Well B1>',
-            'Dropping tip <Well A1>']
+            'Transferring 300 from well A1 in "4" to well B1 in "4"',
+            'Picking up tip well A1 in "5"',
+            'Aspirating 150.0 uL from well A1 in "4" at 1 speed',
+            'Dispensing 150.0 uL into well B1 in "4"',
+            'Aspirating 150.0 uL from well A1 in "4" at 1 speed',
+            'Dispensing 150.0 uL into well B1 in "4"',
+            'Dropping tip well A1 in "1"']
 
         assert expected == list(filter(
             lambda s: 'Moving to' not in s,
@@ -1189,8 +1189,8 @@ class PipetteTest(unittest.TestCase):
         expected = [
             ['Transferring', '200'],
             ['pick'],
-            ['aspirating', '200', 'Well A1'],
-            ['dispensing', '200', 'Well A2'],
+            ['aspirating', '200', 'wells A1..H1'],
+            ['dispensing', '200', 'wells A2..H2'],
             ['return'],
             ['drop']
         ]

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -394,7 +394,7 @@ class PipetteTest(unittest.TestCase):
         # print('\n\n***\n')
         # pprint(self.robot.commands())
         expected = [
-            ['Distributing', '30', 'well A1', 'wells B1..A2'],
+            ['Distributing', '30', 'well A1', 'wells B1...A2'],
             ['Transferring'],
             ['Picking up tip'],
             ['Aspirating', '190', 'well A1'],
@@ -425,7 +425,7 @@ class PipetteTest(unittest.TestCase):
         )
 
         expected = [
-            ['Distributing', '30', 'well A1', 'wells B1..A2'],
+            ['Distributing', '30', 'well A1', 'wells B1...A2'],
             ['Transferring'],
             ['Aspirating', '190', 'well A1'],
             ['Dispensing', '30', 'well B1'],
@@ -1189,8 +1189,8 @@ class PipetteTest(unittest.TestCase):
         expected = [
             ['Transferring', '200'],
             ['pick'],
-            ['aspirating', '200', 'wells A1..H1'],
-            ['dispensing', '200', 'wells A2..H2'],
+            ['aspirating', '200', 'wells A1...H1'],
+            ['dispensing', '200', 'wells A2...H2'],
             ['return'],
             ['drop']
         ]


### PR DESCRIPTION
- Adds `stringify_location` to `commands/commands.py` to turn location
  into a string containing an abbreviated list of wells (i.e. 'A1..H12')
  and a position on a deck it is located at. Exact wording and mentioning
  of labware type is subject to user testing.
- Adds trivial tests and updates existing tests where string representation
  of a location is being used.

__NOTE:__ Calls like `container.rows(0, 1, 2)` would produce `WellSeries` of `WellSeries`
this is handled in a suboptimal way (if using lists of lists this could be folding).
This should be re-visited once we phase out `WellSeries`.

# Review request

Please think of any common cases not addressed by this representation.

Here's an excerpt from Bradford Assay with the change in place:
![image](https://user-images.githubusercontent.com/1032174/32520080-c4a16a14-c3dc-11e7-8502-2141cc09e8f8.png)
 
