### PR TITLE
(v3) Wire run button in setup panel to run protocol

### DIFF
--- a/app/ui/components/InfoBox.css
+++ b/app/ui/components/InfoBox.css
@@ -1,0 +1,16 @@
+.info_box {
+  position: relative;
+  border: 2px solid silver;
+  border-radius: 0.25rem;
+  padding: 1rem 0.75rem;
+}
+
+.close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  padding: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}

--- a/app/ui/components/InfoBox.js
+++ b/app/ui/components/InfoBox.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
+import styles from './InfoBox.css'
+
+InfoBox.propTypes = {
+  className: PropTypes.string,
+  onCancelClick: PropTypes.func
+}
+
+export default function InfoBox (props) {
+  const {className, onCancelClick} = props
+  let cancelButton = null
+
+  if (onCancelClick) {
+    cancelButton = (
+      <span role='button' onClick={onCancelClick} className={styles.close}>
+        X
+      </span>
+    )
+  }
+
+  return (
+    <div className={classnames(styles.info_box, className)}>
+      {cancelButton}
+      {props.children}
+    </div>
+  )
+}

--- a/app/ui/components/SetupPanel.css
+++ b/app/ui/components/SetupPanel.css
@@ -51,7 +51,7 @@
 }
 
 .labware_group {
-  margin-top: 2rem;
+  margin-top: 1rem;
 }
 
 .labware_alert {
@@ -127,6 +127,20 @@ li:nth-child(odd) a.btn_labware {
 .type {
   display: block;
   line-height: 1rem;
+}
+
+.run_message {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.run_message_item {
+  margin-bottom: 0.5rem;
+}
+
+.run_message_item:last-child {
+  margin-bottom: 0;
 }
 
 .run_link {

--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -7,11 +7,14 @@ import ToolTip from './ToolTip'
 import styles from './SetupPanel.css'
 
 import {constants as robotConstants} from '../robot'
+import InfoBox from './InfoBox'
 
 function PipetteLinks (props) {
-  const {axis, name, volume, channels, probed, onClick} = props
+  const {axis, name, volume, channels, probed, isRunning, onClick} = props
   const isDisabled = name == null
-  const url = `/setup-instruments/${axis}`
+  const url = isRunning
+    ? '#'
+    : `/setup-instruments/${axis}`
 
   const linkStyle = classnames({[styles.disabled]: isDisabled})
 
@@ -88,11 +91,18 @@ export default function SetupPanel (props) {
     labwareConfirmed,
     tipracksConfirmed,
     setLabware,
-    clearLabwareReviewed
+    clearLabwareReviewed,
+    isRunning,
+    run
   } = props
 
   const instrumentList = instruments.map((i) => (
-    <PipetteLinks {...i} key={i.axis} onClick={clearLabwareReviewed} />
+    <PipetteLinks
+      {...i}
+      key={i.axis}
+      isRunning={isRunning}
+      onClick={!isRunning && clearLabwareReviewed}
+    />
   ))
 
   const {tiprackList, labwareList} = labware.reduce((result, lab) => {
@@ -105,7 +115,7 @@ export default function SetupPanel (props) {
         key={slot}
         instrumentsCalibrated={instrumentsCalibrated}
         tipracksConfirmed={tipracksConfirmed}
-        onClick={onClick}
+        onClick={!isRunning && onClick}
       />
     )
 
@@ -142,6 +152,14 @@ export default function SetupPanel (props) {
     ? '/run'
     : '#'
 
+  const runMessage = labwareConfirmed
+    ? <RunMessage />
+    : null
+
+  const onRunClick = labwareConfirmed && !isRunning
+    ? run
+    : null
+
   return (
     <div className={styles.setup_panel}>
       <h2 className={styles.title}>Prepare Robot for RUN</h2>
@@ -160,13 +178,28 @@ export default function SetupPanel (props) {
           </ul>
           {pipetteMsg}
           {labwareMsg}
+          {runMessage}
         </section>
       </section>
-      <NavLink to={runLinkUrl} className={runLinkStyles}>
+      <NavLink to={runLinkUrl} className={runLinkStyles} onClick={onRunClick}>
         Run Protocol
         {runWarning}
       </NavLink>
     </div>
+  )
+}
+
+function RunMessage () {
+  return (
+    <InfoBox className={styles.run_message}>
+      <p className={styles.run_message_item}>
+        Hurray, your robot is now ready! Click [RUN PROTOCOL] to start your run.
+      </p>
+      <p className={styles.run_message_item}>
+        Tip: Try a dry run prior to adding your samples and re-agents to avoid
+        wasting materials.
+      </p>
+    </InfoBox>
   )
 }
 
@@ -199,5 +232,7 @@ SetupPanel.propTypes = {
   clearLabwareReviewed: PropTypes.func.isRequired,
   instrumentsCalibrated: PropTypes.bool.isRequired,
   tipracksConfirmed: PropTypes.bool.isRequired,
-  labwareConfirmed: PropTypes.bool.isRequired
+  labwareConfirmed: PropTypes.bool.isRequired,
+  isRunning: PropTypes.bool.isRequired,
+  run: PropTypes.func.isRequired
 }

--- a/app/ui/components/TipProbe.css
+++ b/app/ui/components/TipProbe.css
@@ -1,12 +1,6 @@
 .info {
-  position: relative;
-  display: block;
-  border: 2px solid silver;
-  border-radius: 0.25rem;
   margin-top: 1rem;
-  padding: 1rem 0.75rem 0.5rem;
   font-size: 0.75rem;
-  min-height: 7.1rem;
 }
 
 .alert {
@@ -24,7 +18,7 @@
   height: 3rem;
   padding: 0 3rem;
   display: block;
-  margin: 1rem auto;
+  margin: 0 auto;
   line-height: 3rem;
   font-size: 1rem;
   font-family: 'trons';
@@ -55,8 +49,17 @@
   font-size: 1rem;
 }
 
+.message {
+  margin-bottom: 1rem;
+}
+
 .submessage {
   margin-bottom: 1rem;
+}
+
+.message:last-child,
+.submessage:last-child {
+  margin-bottom: 0;
 }
 
 .progress {

--- a/app/ui/components/TipProbe.js
+++ b/app/ui/components/TipProbe.js
@@ -2,8 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import {constants as robotConstants} from '../robot'
-import styles from './TipProbe.css'
 import {Spinner, Warning} from './icons'
+import InfoBox from './InfoBox'
+
+import styles from './TipProbe.css'
 
 const {
   UNPROBED,
@@ -32,32 +34,19 @@ TipProbe.propTypes = {
 }
 
 export default function TipProbe (props) {
+  const {instrument: {calibration}} = props
+  let onCancelClick
+
+  if (calibration === READY_TO_PROBE || calibration === PROBED) {
+    onCancelClick = props.onCancelClick
+  }
+
   return (
-    <InfoBox {...props}>
+    <InfoBox onCancelClick={onCancelClick} className={styles.info}>
       <TipProbeMessage {...props} />
       <TipProbeButtonOrSpinner {...props} />
       <TipProbeWarning {...props} />
     </InfoBox>
-  )
-}
-
-function InfoBox (props) {
-  const {instrument: {calibration}, onCancelClick} = props
-  let cancelButton = null
-
-  if (calibration === READY_TO_PROBE || calibration === PROBED) {
-    cancelButton = (
-      <span role='button' onClick={onCancelClick} className={styles.close}>
-        X
-      </span>
-    )
-  }
-
-  return (
-    <div className={styles.info}>
-      {cancelButton}
-      {props.children}
-    </div>
   )
 }
 
@@ -108,7 +97,7 @@ function TipProbeMessage (props) {
   }
 
   return (
-    <p>{icon}{message}</p>
+    <div className={message && styles.message}>{icon}{message}</div>
   )
 }
 

--- a/app/ui/containers/ConnectedSetupPanel.js
+++ b/app/ui/containers/ConnectedSetupPanel.js
@@ -14,13 +14,15 @@ const mapStateToProps = (state) => ({
   instrumentsCalibrated: robotSelectors.getInstrumentsCalibrated(state),
   tipracksConfirmed: robotSelectors.getTipracksConfirmed(state),
   labwareConfirmed: robotSelectors.getLabwareConfirmed(state),
-  singleChannel: robotSelectors.getSingleChannel(state)
+  singleChannel: robotSelectors.getSingleChannel(state),
+  isRunning: robotSelectors.getIsRunning(state)
 })
 
 const mapDispatchToProps = (dispatch) => ({
   clearLabwareReviewed: () => dispatch(robotActions.setLabwareReviewed(false)),
   setLabware: (slot) => () => dispatch(push(`/setup-deck/${slot}`)),
-  moveToLabware: (axis, slot) => () => dispatch(robotActions.moveTo(axis, slot))
+  moveToLabware: (axis, slot) => () => dispatch(robotActions.moveTo(axis, slot)),
+  run: () => dispatch(robotActions.run())
 })
 
 const mergeProps = (stateProps, dispatchProps) => {


### PR DESCRIPTION
## overview

Per request from UI/UX, this PR wires the "Run Protocol" button in the calibration setup panel to actually start the protocol run (as opposed to simply navigating the user to the run page where they can subsequently click "Run Job".

I'm not a huge fan of this change, but given that it's for testing I think it's valuable. Also, you may notice that SetupPanel.js is a huge mess. @Kadee80 and I are aware and will be tackling some cleanup work tomorrow.

This PR also adds a little "Hurray, you're ready to run!" message that was in the screens but missing from the app.

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

- (Feature) Wire "Run Protocol" button in SetupPanel to actually run the protocol
- (Feature) Add ready to run message to the SetupPanel after calibration is complete

## review requests

Standard review, keeping in mind that we're aware of the tech debt and will be tackling afterwards to get functionality in for testing sooner.
