### PR TITLE
(v3) Robot connection tweaks

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -92,6 +92,7 @@
     "lodash": "^4.17.4",
     "portfinder": "^1.0.13",
     "prop-types": "^15.5.10",
+    "randomstring": "^1.1.5",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-hot-loader": "^3.0.0-beta.7",

--- a/app/scripts/advertise-local-api.js
+++ b/app/scripts/advertise-local-api.js
@@ -1,19 +1,28 @@
 // simple script to advertise a MDNS service for local API
 // TODO(mc, 2017-10-31): remove this file once API can advertise for itself
 const bonjour = require('bonjour')()
+const randomstring = require('randomstring')
 
-console.log('Publishing local MDNS service for API')
-
-const service = bonjour.publish({
-  name: 'opentrons-local-api',
+const id = randomstring.generate({
+  length: 6,
+  charset: 'hex',
+  capitalization: 'uppercase'
+})
+const name = `Opentrons Beta ${id}`
+const service = {
+  name,
   host: 'localhost',
   port: 31950,
   // TODO(mc, 2017-10-26): we're relying right now on the fact that resin
   // advertises an SSH service. Instead, we should be registering an HTTP
   // service on port 31950 and listening for that instead
   type: 'ssh'
-})
+}
 
-service.on('error', (error) => {
-  console.error('Error advertising MDNS service for local API', error)
-})
+bonjour.publish(service)
+  .on('up', () => {
+    console.log(`Published MDNS service "${service.name}" on ${service.host}`)
+  })
+  .on('error', (error) => {
+    console.error('Error publishing MDNS service', error)
+  })

--- a/app/ui/components/ConnectPanel.css
+++ b/app/ui/components/ConnectPanel.css
@@ -74,7 +74,6 @@ h1 {
 
 .connection_name,
 .connection_btn {
-  width: 10rem;
   display: block;
   text-align: center;
 }
@@ -107,4 +106,3 @@ h1 {
   color: grey;
   background-color: transparent;
 }
-

--- a/app/ui/components/RobotItem.js
+++ b/app/ui/components/RobotItem.js
@@ -7,14 +7,14 @@ import {ControlledUSB, AvailableUSB} from './icons'
 import styles from './ConnectPanel.css'
 
 RobotItem.propTypes = {
-  hostname: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   isConnected: PropTypes.bool.isRequired,
   onConnectClick: PropTypes.func,
   onDisconnectClick: PropTypes.func
 }
 
 export default function RobotItem (props) {
-  const {hostname, isConnected, onConnectClick, onDisconnectClick} = props
+  const {name, isConnected, onConnectClick, onDisconnectClick} = props
   let connectionToggle
   let connectionStatus
 
@@ -26,7 +26,7 @@ export default function RobotItem (props) {
           onClick={onDisconnectClick}
           style={classnames('btn', 'btn_dark', styles.btn_connect)}
         >
-          Release Control
+          Disconnect Robot
         </Button>
       </span>
     )
@@ -37,7 +37,7 @@ export default function RobotItem (props) {
         onClick={onConnectClick}
         style={classnames('btn', 'btn_dark', styles.btn_connect)}
       >
-        Take Control
+        Connect to Robot
       </Button>
     )
   }
@@ -46,7 +46,7 @@ export default function RobotItem (props) {
     <li>
       {connectionStatus}
       <div className={styles.connection_info}>
-        <span className={styles.connection_name}>{hostname}</span>
+        <span className={styles.connection_name}>{name}</span>
         <span className={styles.connection_btn}>{connectionToggle}</span>
       </div>
     </li>

--- a/app/ui/containers/DiscoveredRobot.js
+++ b/app/ui/containers/DiscoveredRobot.js
@@ -15,7 +15,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   }
 
   return {
-    onConnectClick: () => dispatch(robotActions.connect(ownProps.hostname))
+    onConnectClick: () => dispatch(robotActions.connect(ownProps.host))
   }
 }
 

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -62,8 +62,8 @@ export const actions = {
     return {type: actionTypes.DISCOVER_FINISH}
   },
 
-  connect (hostname) {
-    return makeRobotAction({type: actionTypes.CONNECT, payload: {hostname}})
+  connect (host) {
+    return makeRobotAction({type: actionTypes.CONNECT, payload: {host}})
   },
 
   connectResponse (error) {
@@ -86,12 +86,12 @@ export const actions = {
     return action
   },
 
-  addDiscovered (hostname) {
-    return {type: actionTypes.ADD_DISCOVERED, payload: {hostname}}
+  addDiscovered (service) {
+    return {type: actionTypes.ADD_DISCOVERED, payload: service}
   },
 
-  removeDiscovered (hostname) {
-    return {type: actionTypes.REMOVE_DISCOVERED, payload: {hostname}}
+  removeDiscovered (host) {
+    return {type: actionTypes.REMOVE_DISCOVERED, payload: {host}}
   },
 
   // get session or make new session with protocol file
@@ -99,7 +99,6 @@ export const actions = {
     return makeRobotAction({type: actionTypes.SESSION, payload: {file}})
   },
 
-  // TODO(mc, 2017-10-04): make this action FSA compliant (error [=] bool)
   sessionResponse (error, session) {
     const didError = error != null
 

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -54,7 +54,7 @@ export default function client (dispatch) {
   function connect (state, action) {
     if (rpcClient) return dispatch(actions.connectResponse())
 
-    RpcClient(`ws://${action.payload.hostname}:${PORT}`)
+    RpcClient(`ws://${action.payload.host}:${PORT}`)
       .then((c) => {
         rpcClient = c
         rpcClient

--- a/app/ui/robot/api-client/discovery.js
+++ b/app/ui/robot/api-client/discovery.js
@@ -3,7 +3,7 @@ import Bonjour from 'bonjour'
 
 import {actions} from '../actions'
 
-const NAME_RE = /^opentrons/
+const NAME_RE = /^opentrons/i
 const DISCOVERY_TIMEOUT_MS = 30000
 const UP_EVENT = 'up'
 const DOWN_EVENT = 'down'
@@ -20,7 +20,7 @@ export function handleDiscover (dispatch, state, action) {
 
   function handleServiceUp (service) {
     if (NAME_RE.test(service.name)) {
-      dispatch(actions.addDiscovered(service.host))
+      dispatch(actions.addDiscovered(service))
     }
   }
 

--- a/app/ui/robot/reducer/connection.js
+++ b/app/ui/robot/reducer/connection.js
@@ -18,9 +18,9 @@ const {
 const INITIAL_STATE = {
   isScanning: false,
   discovered: [],
-  discoveredByHostname: {},
+  discoveredByHost: {},
   connectedTo: '',
-  connectRequest: {inProgress: false, error: null, hostname: ''},
+  connectRequest: {inProgress: false, error: null, host: ''},
   disconnectRequest: {inProgress: false, error: null}
 }
 
@@ -55,56 +55,56 @@ function handleDiscoverFinish (state, action) {
 
 function handleAddDiscovered (state, action) {
   const {payload} = action
-  const {hostname} = payload
-  let {discovered, discoveredByHostname} = state
+  const {host} = payload
+  let {discovered, discoveredByHost} = state
 
-  if (discovered.indexOf(hostname) < 0) {
-    discovered = discovered.concat(hostname)
+  if (discovered.indexOf(host) < 0) {
+    discovered = discovered.concat(host)
   }
 
-  discoveredByHostname = {
-    ...discoveredByHostname,
-    [hostname]: {
-      ...discoveredByHostname[hostname],
+  discoveredByHost = {
+    ...discoveredByHost,
+    [host]: {
+      ...discoveredByHost[host],
       ...payload
     }
   }
 
-  return {...state, discovered, discoveredByHostname}
+  return {...state, discovered, discoveredByHost}
 }
 
 function handleRemoveDiscovered (state, action) {
-  const {payload: {hostname}} = action
+  const {payload: {host}} = action
 
   return {
     ...state,
-    discovered: without(state.discovered, hostname),
-    discoveredByHostname: omit(state.discoveredByHostname, hostname)
+    discovered: without(state.discovered, host),
+    discoveredByHost: omit(state.discoveredByHost, host)
   }
 }
 
 function handleConnect (state, action) {
-  const {payload: {hostname}} = action
+  const {payload: {host}} = action
 
-  return {...state, connectRequest: {inProgress: true, error: null, hostname}}
+  return {...state, connectRequest: {inProgress: true, error: null, host}}
 }
 
 function handleConnectResponse (state, action) {
   const {error: didError} = action
-  let connectedTo = state.connectRequest.hostname
+  let connectedTo = state.connectRequest.host
   let error = null
-  let requestHostname = ''
+  let requestHost = ''
 
   if (didError) {
     error = action.payload
-    requestHostname = connectedTo
+    requestHost = connectedTo
     connectedTo = ''
   }
 
   return {
     ...state,
     connectedTo,
-    connectRequest: {error, inProgress: false, hostname: requestHostname}
+    connectRequest: {error, inProgress: false, host: requestHost}
   }
 }
 

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -34,13 +34,13 @@ export function getIsScanning (state) {
 export function getDiscovered (state) {
   const {
     discovered,
-    discoveredByHostname,
+    discoveredByHost,
     connectedTo
   } = getConnectionState(state)
 
-  return discovered.map((hostname) => ({
-    ...discoveredByHostname[hostname],
-    isConnected: connectedTo === hostname
+  return discovered.map((host) => ({
+    ...discoveredByHost[host],
+    isConnected: connectedTo === host
   }))
 }
 

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -21,29 +21,30 @@ describe('robot actions', () => {
   })
 
   test('ADD_DISCOVERED action', () => {
-    const hostname = '123456.local'
+    const name = 'Opentrons XYZ123'
+    const host = '123456.local'
     const expected = {
       type: actionTypes.ADD_DISCOVERED,
-      payload: {hostname}
+      payload: {host, name}
     }
 
-    expect(actions.addDiscovered(hostname)).toEqual(expected)
+    expect(actions.addDiscovered({host, name})).toEqual(expected)
   })
 
   test('REMOVE_DISCOVERED action', () => {
-    const hostname = '123456.local'
+    const host = '123456.local'
     const expected = {
       type: actionTypes.REMOVE_DISCOVERED,
-      payload: {hostname}
+      payload: {host}
     }
 
-    expect(actions.removeDiscovered(hostname)).toEqual(expected)
+    expect(actions.removeDiscovered(host)).toEqual(expected)
   })
 
   test('CONNECT action', () => {
     const expected = {
       type: actionTypes.CONNECT,
-      payload: {hostname: 'ot.local'},
+      payload: {host: 'ot.local'},
       meta: {robotCommand: true}
     }
 

--- a/app/ui/robot/test/api-client-discovery.test.js
+++ b/app/ui/robot/test/api-client-discovery.test.js
@@ -68,7 +68,7 @@ describe('api client - discovery', () => {
     return sendToClient({}, actions.discover())
       .then(() => services.forEach((s) => browser.emit('up', s)))
       .then(() => services.forEach((s) => {
-        expect(dispatch).toHaveBeenCalledWith(actions.addDiscovered(s.host))
+        expect(dispatch).toHaveBeenCalledWith(actions.addDiscovered(s))
       }))
   })
 
@@ -83,7 +83,8 @@ describe('api client - discovery', () => {
     return sendToClient({}, actions.discover())
       .then(() => services.forEach((s) => browser.emit('down', s)))
       .then(() => services.forEach((s) => {
-        expect(dispatch).toHaveBeenCalledWith(actions.removeDiscovered(s.host))
+        expect(dispatch)
+          .toHaveBeenCalledWith(actions.removeDiscovered(s.host))
       }))
   })
 
@@ -125,7 +126,7 @@ describe('api client - discovery', () => {
     return sendToClient({}, actions.discover())
       .then(() => services.forEach((s) => browser.emit('up', s)))
       .then(() => expect(dispatch).not.toHaveBeenCalledWith(
-        actions.addDiscovered('nope.local')
+        actions.addDiscovered({host: 'nope.local'})
       ))
       .then(() => services.forEach((s) => browser.emit('down', s)))
       .then(() => expect(dispatch).not.toHaveBeenCalledWith(

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -65,7 +65,8 @@ describe('api client', () => {
     RpcClient.mockReset()
   })
 
-  const sendConnect = () => sendToClient({}, actions.connect())
+  const HOST = 'ot.local'
+  const sendConnect = () => sendToClient({}, actions.connect(HOST))
   const sendDisconnect = () => sendToClient({}, actions.disconnect())
 
   describe('connect and disconnect', () => {
@@ -76,7 +77,7 @@ describe('api client', () => {
 
       return sendConnect()
         .then(() => {
-          expect(RpcClient).toHaveBeenCalledTimes(1)
+          expect(RpcClient).toHaveBeenCalledWith(`ws://${HOST}:31950`)
           expect(dispatch).toHaveBeenCalledWith(expectedResponse)
         })
     })

--- a/app/ui/robot/test/connection-reducer.test.js
+++ b/app/ui/robot/test/connection-reducer.test.js
@@ -10,9 +10,9 @@ describe('robot reducer - connection', () => {
     expect(getState(state)).toEqual({
       isScanning: false,
       discovered: [],
-      discoveredByHostname: {},
+      discoveredByHost: {},
       connectedTo: '',
-      connectRequest: {inProgress: false, error: null, hostname: ''},
+      connectRequest: {inProgress: false, error: null, host: ''},
       disconnectRequest: {inProgress: false, error: null}
     })
   })
@@ -46,18 +46,18 @@ describe('robot reducer - connection', () => {
         connectRequest: {
           inProgress: false,
           error: new Error('AH'),
-          hostname: ''
+          host: ''
         }
       }
     }
     const action = {
       type: actionTypes.CONNECT,
-      payload: {hostname: 'ot.local'}
+      payload: {host: 'ot.local'}
     }
 
     expect(getState(reducer(state, action))).toEqual({
       connectedTo: '',
-      connectRequest: {inProgress: true, error: null, hostname: 'ot.local'}
+      connectRequest: {inProgress: true, error: null, host: 'ot.local'}
     })
   })
 
@@ -68,7 +68,7 @@ describe('robot reducer - connection', () => {
         connectRequest: {
           inProgress: true,
           error: null,
-          hostname: 'ot.local'
+          host: 'ot.local'
         }
       }
     }
@@ -76,7 +76,7 @@ describe('robot reducer - connection', () => {
 
     expect(getState(reducer(state, action))).toEqual({
       connectedTo: 'ot.local',
-      connectRequest: {inProgress: false, error: null, hostname: ''}
+      connectRequest: {inProgress: false, error: null, host: ''}
     })
   })
 
@@ -87,7 +87,7 @@ describe('robot reducer - connection', () => {
         connectRequest: {
           inProgress: true,
           error: null,
-          hostname: 'ot.local'
+          host: 'ot.local'
         }
       }
     }
@@ -102,7 +102,7 @@ describe('robot reducer - connection', () => {
       connectRequest: {
         inProgress: false,
         error: new Error('AH'),
-        hostname: 'ot.local'
+        host: 'ot.local'
       }
     })
   })
@@ -114,7 +114,7 @@ describe('robot reducer - connection', () => {
         disconnectRequest: {
           inProgress: false,
           error: new Error('AH'),
-          hostname: ''
+          host: ''
         }
       }
     }
@@ -164,21 +164,21 @@ describe('robot reducer - connection', () => {
     const state = {
       connection: {
         discovered: ['abcdef.local'],
-        discoveredByHostname: {
-          'abcdef.local': {hostname: 'abcdef.local'}
+        discoveredByHost: {
+          'abcdef.local': {host: 'abcdef.local', name: 'foo'}
         }
       }
     }
     const action = {
       type: actionTypes.ADD_DISCOVERED,
-      payload: {hostname: '123456.local'}
+      payload: {host: '123456.local', name: 'bar'}
     }
 
     expect(getState(reducer(state, action))).toEqual({
       discovered: ['abcdef.local', '123456.local'],
-      discoveredByHostname: {
-        'abcdef.local': {hostname: 'abcdef.local'},
-        '123456.local': {hostname: '123456.local'}
+      discoveredByHost: {
+        'abcdef.local': {host: 'abcdef.local', name: 'foo'},
+        '123456.local': {host: '123456.local', name: 'bar'}
       }
     })
   })
@@ -187,20 +187,20 @@ describe('robot reducer - connection', () => {
     const state = {
       connection: {
         discovered: ['abcdef.local'],
-        discoveredByHostname: {
-          'abcdef.local': {hostname: 'abcdef.local'}
+        discoveredByHost: {
+          'abcdef.local': {host: 'abcdef.local', name: 'foo'}
         }
       }
     }
     const action = {
       type: actionTypes.ADD_DISCOVERED,
-      payload: {hostname: 'abcdef.local'}
+      payload: {host: 'abcdef.local', name: 'foo'}
     }
 
     expect(getState(reducer(state, action))).toEqual({
       discovered: ['abcdef.local'],
-      discoveredByHostname: {
-        'abcdef.local': {hostname: 'abcdef.local'}
+      discoveredByHost: {
+        'abcdef.local': {host: 'abcdef.local', name: 'foo'}
       }
     })
   })
@@ -209,21 +209,21 @@ describe('robot reducer - connection', () => {
     const state = {
       connection: {
         discovered: ['abcdef.local', '123456.local'],
-        discoveredByHostname: {
-          'abcdef.local': {hostname: 'abcdef.local'},
-          '123456.local': {hostname: '123456.local'}
+        discoveredByHost: {
+          'abcdef.local': {host: 'abcdef.local', name: 'foo'},
+          '123456.local': {host: '123456.local', name: 'bar'}
         }
       }
     }
     const action = {
       type: actionTypes.REMOVE_DISCOVERED,
-      payload: {hostname: 'abcdef.local'}
+      payload: {host: 'abcdef.local'}
     }
 
     expect(getState(reducer(state, action))).toEqual({
       discovered: ['123456.local'],
-      discoveredByHostname: {
-        '123456.local': {hostname: '123456.local'}
+      discoveredByHost: {
+        '123456.local': {host: '123456.local', name: 'bar'}
       }
     })
   })

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -41,16 +41,16 @@ describe('robot selectors', () => {
       connection: {
         connectedTo: 'abcdef.local',
         discovered: ['abcdef.local', '123456.local'],
-        discoveredByHostname: {
-          'abcdef.local': {hostname: 'abcdef.local'},
-          '123456.local': {hostname: '123456.local'}
+        discoveredByHost: {
+          'abcdef.local': {host: 'abcdef.local', name: 'foo'},
+          '123456.local': {host: '123456.local', name: 'bar'}
         }
       }
     }
 
     expect(getDiscovered(makeState(state))).toEqual([
-      {hostname: 'abcdef.local', isConnected: true},
-      {hostname: '123456.local', isConnected: false}
+      {host: 'abcdef.local', name: 'foo', isConnected: true},
+      {host: '123456.local', name: 'bar', isConnected: false}
     ])
   })
 


### PR DESCRIPTION
## overview

This PR adds the entire MDNS service (including both host and name) to the application state rather than just the host. It also adjusts some button copy per UI/UX request.

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Fix) Adjust connect button copy to say "Connect" and "Disconnect"
- (Feature) Grab whole MDNS service for the state instead of cherrypicking host

## review requests

Standard review. If you're wondering why I changed every `hostname` to `host`, it's because the MDNS library we're using uses `host`, so I figured alignment there would just make everything a little more straightforward. Plus, it's fewer characters without losing meaning
