### PR TITLE
(v3) Cleanup nav sidebar

### DIFF
--- a/app/ui/components/App.global.css
+++ b/app/ui/components/App.global.css
@@ -4,6 +4,11 @@
 @value green: #7ed321;
 @value red: #F00000;
 
+/* backgrounds */
+@value light_grey: #fafafa;
+@value grey: #d9d9d9;
+@value dark_grey: #9b9b9b;
+
 * {
   box-sizing: border-box;
 }
@@ -81,123 +86,6 @@ body {
 .trons {
   font-family: trons;
 }
-
-/*** TOOLTIPS ***/
-.tooltip_parent:hover .tooltip {
-  visibility: visible;
-}
-
-.tooltip {
-  visibility: hidden;
-  position: absolute;
-  z-index: 100;
-  border-radius: 6px;
-  background-color: black;
-  font-size: 1rem;
-  line-height: 3rem;
-  color: #fff;
-  text-align: center;
-  text-transform: uppercase;
-}
-
-[disabled] .tooltip {
-  background-color: silver;
-}
-
-.tooltip_left {
-  top: 15%;
-  left: 80%;
-  width: 10rem;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
-.tooltip_left::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  right: 100%;
-  margin-top: -1.5rem;
-  border-width: 1.5rem;
-  border-style: solid;
-  border-color: transparent black transparent transparent;
-}
-
-[disabled] .tooltip_left::after {
-  border-color: transparent silver transparent transparent;
-}
-
-.tooltip_bottom {
-  top: 75%;
-  left: -80%;
-  width: 10rem;
-  font-size: 0.75rem;
-  line-height: 2rem;
-}
-
-.tooltip_bottom::after {
-  content: " ";
-  position: absolute;
-  bottom: 100%;
-  left: 13%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent transparent black;
-}
-
-[disabled] .tooltip_bottom::after {
-  border-color: transparent transparent silver;
-}
-
-.tooltip_top,
-.tooltip_diagram {
-  bottom: 100%;
-  left: 0;
-  width: 15rem;
-  line-height: 1rem;
-  padding: 1rem;
-  font-size: 0.75rem;
-}
-
-.tooltip_top::after,
-.tooltip_diagram::after {
-  content: " ";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: black transparent transparent;
-}
-
-.tooltip_diagram {
-  bottom: 130%;
-  left: -90%;
-  width: 35rem;
-  padding: 2rem;
-  background-color: white;
-  border: 2px solid black;
-}
-
-.tooltip_diagram img {
-  width: 100%;
-  height: auto;
-}
-
-.tooltip_diagram::after {
-  margin-left: -10px;
-  border-width: 10px;
-}
-
-[disabled] .tooltip_top::after {
-  border-color: silver transparent transparent;
-}
-
-/* .tooltip_hidden .tooltip_left {
-  display: none;
-} */
 
 /*** BUTTONS ***/
 button {

--- a/app/ui/components/App.js
+++ b/app/ui/components/App.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import {Switch, Route} from 'react-router'
+
 import Nav from '../containers/Nav'
+import NavBar from './nav/NavBar'
 
 import Home from '../pages/Home'
 import Upload from '../pages/Upload'
@@ -13,7 +15,8 @@ import styles from './App.css'
 
 export default function App () {
   return (
-    <div className={styles.wrapper} onDragOver={onDragOver} onDrop={onDrop}>
+    <div className={styles.wrapper} onDragOver={stopEvent} onDrop={stopEvent}>
+      <NavBar />
       <Nav />
       <Switch>
         <Route exact path='/' component={Home} />
@@ -26,10 +29,6 @@ export default function App () {
   )
 }
 
-function onDragOver (event) {
-  event.preventDefault()
-}
-
-function onDrop (event) {
+function stopEvent (event) {
   event.preventDefault()
 }

--- a/app/ui/components/DeckConfig.js
+++ b/app/ui/components/DeckConfig.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types'
 import {Link} from 'react-router-dom'
 import classnames from 'classnames'
 
+import {constants as robotConstants} from '../robot'
 import Labware from './Labware'
-import ToolTip from './ToolTip'
+import ToolTip, {TOP} from './ToolTip'
 import Diagram from './Diagram'
 import styles from './DeckConfig.css'
-import {constants as robotConstants} from '../robot'
+import tooltipStyles from './ToolTip.css'
 
 const {UNCONFIRMED, MOVING_TO_SLOT, OVER_SLOT, CONFIRMED} = robotConstants
 
@@ -149,9 +150,9 @@ function ConfirmCalibrationPrompt (props) {
     <div className={styles.prompt}>
       <h3>
         <strong>Is Pipette &nbsp;</strong>
-        <span className={classnames(styles.centered_prompt, 'tooltip_parent')}>
+        <span className={classnames(styles.centered_prompt, tooltipStyles.parent)}>
           accurately centered
-          <ToolTip msg={toolTipMessage} pos='diagram' className={styles.centered_diagram} />
+          <ToolTip style={TOP}>{toolTipMessage}</ToolTip>
         </span>
          &nbsp; over the A1 well of slot {slot}?
       </h3>

--- a/app/ui/components/Diagram.css
+++ b/app/ui/components/Diagram.css
@@ -1,0 +1,7 @@
+.diagram {
+  display: block;
+  width: 35rem;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  background-color: white;
+}

--- a/app/ui/components/Diagram.js
+++ b/app/ui/components/Diagram.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import classnames from 'classnames'
 import PropTypes from 'prop-types'
 
+import styles from './Diagram.css'
 import plateSingleSrc from '../img/labware/plate_single.png'
 import troughSingleSrc from '../img/labware/trough_single.png'
 import tubeSingleSrc from '../img/labware/tuberack_single.png'
@@ -14,8 +14,8 @@ Diagram.propTypes = {
 
 export default function Diagram (props) {
   const {isTiprack, type} = props
-  const style = classnames('flex', 'flex__items_center', 'flex__justify_center')
   let labwareSrc
+
   if (isTiprack) {
     labwareSrc = tiprackSingleSrc
   } else if (type.includes('trough')) {
@@ -27,8 +27,6 @@ export default function Diagram (props) {
   }
 
   return (
-    <div className={style}>
-      <img src={labwareSrc} />
-    </div>
+    <img className={styles.diagram} src={labwareSrc} />
   )
 }

--- a/app/ui/components/NavPanel.css
+++ b/app/ui/components/NavPanel.css
@@ -1,7 +1,7 @@
 .nav_panel {
   position: relative;
   height: 100%;
-  width: 275px;
+  width: 100%;
   padding: 0 1rem;
   font-family: 'sans';
   font-size: 0.75rem;

--- a/app/ui/components/NavPanel.js
+++ b/app/ui/components/NavPanel.js
@@ -40,11 +40,11 @@ const PANELS_BY_NAME = {
 }
 
 export default function NavPanel (props) {
-  const {currentNavPanelTask} = props
+  const {currentPanel} = props
 
-  if (!(currentNavPanelTask in PANELS_BY_NAME)) return null
+  if (!(currentPanel in PANELS_BY_NAME)) return null
 
-  const Panel = PANELS_BY_NAME[currentNavPanelTask]
+  const Panel = PANELS_BY_NAME[currentPanel]
 
   return (
     <Panel {...props} />
@@ -52,7 +52,6 @@ export default function NavPanel (props) {
 }
 
 NavPanel.propTypes = {
-  isConnected: PropTypes.bool.isRequired,
-  currentNavPanelTask: PropTypes.string.isRequired,
+  currentPanel: PropTypes.string.isRequired,
   onUpload: PropTypes.func.isRequired
 }

--- a/app/ui/components/Page.css
+++ b/app/ui/components/Page.css
@@ -1,5 +1,4 @@
 .task {
   flex: 1 1;
-  border-left: 1px solid silver;
   position: relative;
 }

--- a/app/ui/components/SetupPanel.js
+++ b/app/ui/components/SetupPanel.js
@@ -3,11 +3,12 @@ import {NavLink} from 'react-router-dom'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import capitalize from 'lodash/capitalize'
-import ToolTip from './ToolTip'
-import styles from './SetupPanel.css'
 
 import {constants as robotConstants} from '../robot'
+import ToolTip, {TOP, BOTTOM_RIGHT} from './ToolTip'
 import InfoBox from './InfoBox'
+import styles from './SetupPanel.css'
+import tooltipStyles from './ToolTip.css'
 
 function PipetteLinks (props) {
   const {axis, name, volume, channels, probed, isRunning, onClick} = props
@@ -35,8 +36,8 @@ function PipetteLinks (props) {
         activeClassName={styles.active}
         disabled={isDisabled}
       >
-        <span className={classnames(statusStyle, 'tooltip_parent')}>
-          <ToolTip msg='Tip not found' pos='bottom' />
+        <span className={classnames(statusStyle, tooltipStyles.parent)}>
+          <ToolTip style={BOTTOM_RIGHT}>Tip not found</ToolTip>
         </span>
         <span className={styles.axis}>{axis}</span>
         <span className={styles.type}>{description}</span>
@@ -73,8 +74,8 @@ function LabwareLinks (props) {
         onClick={onClick}
         disabled={isDisabled}
       >
-        <span className={classnames(statusStyle, 'tooltip_parent')}>
-          <ToolTip msg='Position unconfirmed' pos='bottom' />
+        <span className={classnames(statusStyle, tooltipStyles.parent)}>
+          <ToolTip style={BOTTOM_RIGHT}>Position unconfirmed</ToolTip>
         </span>
         {name}
       </button>
@@ -128,14 +129,14 @@ export default function SetupPanel (props) {
   }, {tiprackList: [], labwareList: []})
 
   const runLinkStyles = classnames(
-    'tooltip_parent',
     'btn',
     'btn_dark',
     styles.run_link,
+    tooltipStyles.parent,
     {[styles.inactive]: !labwareConfirmed}
   )
 
-  const runLinkWarning = 'Pipette and labware setup must be complete before you can RUN protocol'
+  const runLinkWarning = 'Pipette and labware setup\nmust be complete before\nyou can RUN protocol'
   const labwareMsg = !instrumentsCalibrated
     ? <p className={styles.labware_alert}>Labware setup is disabled until pipette setup is complete.</p>
     : null
@@ -144,7 +145,7 @@ export default function SetupPanel (props) {
     : null
 
   const runWarning = !labwareConfirmed
-    ? <ToolTip msg={runLinkWarning} pos='top' />
+    ? <ToolTip style={TOP}>{runLinkWarning}</ToolTip>
     : null
 
   const runLinkUrl = labwareConfirmed

--- a/app/ui/components/SideBar.css
+++ b/app/ui/components/SideBar.css
@@ -1,119 +1,28 @@
-@value colors: './App.global.css';
-@value green, red, blue from colors;
-
-* {
-  box-sizing: border-box;
-}
+@value grey from './App.global.css';
 
 .sidebar {
-  display: grid;
-  grid-template-columns: 75px 275px;
-  width: 75px;
-  transition: width 0.5s ease-in-out;
+  overflow: hidden;
+  width: 275px;
+  border-right: 2px solid grey;
+  transition: all 0.5s ease-in-out;
 }
 
-.sidebar.open {
-  width: 350px;
+.sidebar.closed {
+  width: 0;
+  border-right-width: 0;
 }
 
 .close {
   position: absolute;
-  right: 0.25rem;
-  top: 0.25rem;
+  top: 0;
+  right: 0;
+  padding: 0.5rem;
   cursor: pointer;
   color: silver;
   z-index: 100;
 }
 
-.sidebar .nav_info {
-  width: 0;
-  overflow: hidden;
-  transition: width 0.5s ease-in-out;
+.nav_info {
   position: relative;
-}
-
-.sidebar.open .nav_info {
   width: 275px;
-}
-
-.nav_icons {
-  position: relative;
-  border-right: 1px solid silver;
-}
-
-.nav_icon_list {
-  list-style: none;
-  padding-left: 0;
-  text-align: center;
-}
-
-.nav_icon_list li {
-  height: 4rem;
-  line-height: 4rem;
-  margin: 0;
-  position: relative;
-}
-
-.nav_icon {
-  display: block;
-  width: 100%;
-  height: 100%;
-  position: relative;
-  padding: 0.75rem;
-  background-color: inherit;
-  border-bottom: solid 2px rgba(151, 151, 151, 0.1);
-  text-align: center;
-  transition: all 100 linear;
-  cursor: pointer;
-}
-
-.nav_icon[disabled] img {
-  filter: opacity(40%);
-  cursor: default;
-}
-
-.active {
-  background-color: #ddd;
-}
-
-.nav_icon img {
-  height: 2.5rem;
-}
-
-.connection_status {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  cursor: pointer;
-  width: 75px;
-  height: 70px;
-  border-top: solid 2px rgba(151, 151, 151, 0.1);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.status {
-  width: 35px;
-  height: 35px;
-  padding: 5px;
-  border-radius: 50%;
-  background-color: #bbb;
-}
-
-.connected {
-  width: 25px;
-  height: 25px;
-  background-color: blue;
-  border-radius: 50%;
-  box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.5);
-}
-
-.disconnected {
-  width: 25px;
-  height: 25px;
-  background-color: #eee;
-  border-radius: 50%;
-  box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.5);
 }

--- a/app/ui/components/SideBar.js
+++ b/app/ui/components/SideBar.js
@@ -2,66 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import NavPanel from './NavPanel'
-import {Discover, ControlledUSB} from './icons'
-import ToolTip from './ToolTip'
 import styles from './SideBar.css'
 
-function NavLink (props) {
-  const {name, iconSrc, onClick, isDisabled, isActive, msg} = props
-  return (
-    <li key={name} className='tooltip_parent'>
-      <button
-        onClick={onClick}
-        disabled={isDisabled}
-        className={classnames({[styles.active]: isActive}, styles.nav_icon)}
-      >
-        <img src={iconSrc} alt={name} />
-        <ToolTip msg={msg} pos='left' />
-      </button>
-
-    </li>
-  )
-}
-
-const ConnectionIndicator = props => {
-  const {isConnected, onNavIconClick, isActive} = props
-  // TODO(mc): handle connection in progress (state is in place for this)
-  const controlledIcon = isConnected
-    ? <ControlledUSB />
-    : <Discover />
-  const toolTipMessage = 'Connect Robot'
-  return (
-    <div className={classnames({[styles.active]: isActive}, styles.connection_status, 'tooltip_parent')} onClick={onNavIconClick('connect')}>
-      {controlledIcon}
-      <ToolTip msg={toolTipMessage} pos='left' />
-    </div>
-  )
-}
-
-ConnectionIndicator.propTypes = {
-  isConnected: PropTypes.bool.isRequired
-}
-
 export default function SideBar (props) {
-  const {isNavPanelOpen, onNavIconClick, currentNavPanelTask, toggleNavOpen} = props
-  const style = classnames(styles.sidebar, {[styles.open]: isNavPanelOpen, 'tooltip_hidden': isNavPanelOpen})
-  const navLinks = props.navLinks.map((link) => NavLink({
-    onClick: onNavIconClick(link.name),
-    ...link
-  }))
-
-  const connectIsActive = isNavPanelOpen && currentNavPanelTask === 'connect'
+  const {isOpen, close} = props
+  const style = classnames(styles.sidebar, {[styles.closed]: !isOpen})
 
   return (
     <div className={style}>
-      <nav className={styles.nav_icons} >
-        <ol className={styles.nav_icon_list}>
-          {navLinks}
-        </ol>
-        <ConnectionIndicator {...props} isActive={connectIsActive} />
-      </nav>
       <section className={styles.nav_info}>
-        <span className={styles.close} onClick={toggleNavOpen}>X</span>
+        <span className={styles.close} onClick={close}>X</span>
         <NavPanel {...props} />
       </section>
     </div>
@@ -69,14 +19,6 @@ export default function SideBar (props) {
 }
 
 SideBar.propTypes = {
-  navLinks: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    iconSrc: PropTypes.string.isRequired,
-    isDisabled: PropTypes.bool.isRequired
-  })).isRequired,
-  isConnected: PropTypes.bool.isRequired,
-  isNavPanelOpen: PropTypes.bool.isRequired,
-  toggleNavOpen: PropTypes.func.isRequired,
-  onNavIconClick: PropTypes.func.isRequired,
-  currentNavPanelTask: PropTypes.string.isRequired
+  isPanelOpen: PropTypes.bool.isRequired,
+  close: PropTypes.func.isRequired
 }

--- a/app/ui/components/ToolTip.css
+++ b/app/ui/components/ToolTip.css
@@ -15,16 +15,11 @@
   z-index: 999;
   line-height: 1.25;
   border-radius: 0.5rem;
-  padding: 0.625rem;
   white-space: pre;
   text-align: center;
   text-transform: uppercase;
   background-color: black;
   color: white;
-}
-
-.medium.tooltip {
-  padding: 0.875rem;
 }
 
 [disabled] .tooltip,
@@ -33,13 +28,17 @@
 }
 
 .small {
+  /* min-height == font-size * line-height + 2 * padding */
   min-height: 2rem;
   font-size: 0.75rem;
+  padding: 0.625rem;
 }
 
 .medium {
+  /* min-height == font-size * line-height + 2 * padding */
   min-height: 3rem;
   font-size: 1rem;
+  padding: 0.875rem;
 }
 
 .top,

--- a/app/ui/components/ToolTip.css
+++ b/app/ui/components/ToolTip.css
@@ -1,0 +1,158 @@
+/* tooltip styles */
+@value grey from './App.global.css';
+
+.parent {
+  position: relative;
+}
+
+.parent:hover .tooltip {
+  display: block;
+}
+
+.tooltip {
+  display: none;
+  position: absolute;
+  z-index: 999;
+  line-height: 1.25;
+  border-radius: 0.5rem;
+  padding: 0.625rem;
+  white-space: pre;
+  text-align: center;
+  text-transform: uppercase;
+  background-color: black;
+  color: white;
+}
+
+.medium.tooltip {
+  padding: 0.875rem;
+}
+
+[disabled] .tooltip,
+.disabled .tooltip {
+  background-color: grey;
+}
+
+.small {
+  min-height: 2rem;
+  font-size: 0.75rem;
+}
+
+.medium {
+  min-height: 3rem;
+  font-size: 1rem;
+}
+
+.top,
+.bottom,
+.bottom_right {
+  left: 50%;
+}
+
+.top,
+.bottom {
+  transform: translateX(-50%);
+}
+
+.bottom_right {
+  transform: translateX(-20%);
+}
+
+.left,
+.right {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.top {
+  bottom: calc(50% + 0.5rem);
+}
+
+.bottom {
+  top: calc(50% + 0.5rem);
+}
+
+.right {
+  left: calc(50% + 1rem);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.medium.right {
+  left: calc(50% + 1.5rem);
+}
+
+.left {
+  right: calc(50% + 1rem);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.medium.left {
+  right: calc(50% + 1.5rem);
+}
+
+.tooltip::after {
+  content: "";
+  position: absolute;
+  border-style: solid;
+  border-color: black;
+}
+
+[disabled] .tooltip::after,
+.disabled .tooltip::after {
+  border-color: grey;
+}
+
+.tooltip.top::after,
+.tooltip.bottom::after,
+.tooltip.bottom_right::after {
+  margin-left: -0.5rem;
+  border-width: 0.5rem;
+  border-right-color: transparent;
+  border-left-color: transparent;
+}
+
+.tooltip.top::after,
+.tooltip.bottom::after {
+  left: 50%;
+}
+
+.tooltip.bottom_right::after {
+  left: 20%;
+}
+
+.tooltip.top::after {
+  top: 100%;
+  border-bottom-color: transparent;
+}
+
+.tooltip.bottom::after,
+.tooltip.bottom_right::after {
+  bottom: 100%;
+  border-top-color: transparent;
+}
+
+.tooltip.right::after,
+.tooltip.left::after {
+  top: 50%;
+  margin-top: -1rem;
+  border-width: 1rem;
+  border-top-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.medium.right::after,
+.medium.left::after {
+  margin-top: -1.5rem;
+  border-width: 1.5rem;
+}
+
+.tooltip.right::after {
+  right: 100%;
+  border-left-color: transparent;
+}
+
+.tooltip.left::after {
+  left: 100%;
+  border-right-color: transparent;
+}

--- a/app/ui/components/ToolTip.js
+++ b/app/ui/components/ToolTip.js
@@ -24,7 +24,7 @@ export default function ToolTip (props) {
   const className = classnames(styles.tooltip, style, size || SMALL)
 
   return (
-    <div className={className}>
+    <div className={className} role='tooltip'>
       {props.children}
     </div>
   )

--- a/app/ui/components/ToolTip.js
+++ b/app/ui/components/ToolTip.js
@@ -1,16 +1,31 @@
+// tool tip component
 import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-export default function ToolTip (props) {
-  const {msg, pos} = props
-  const style = `tooltip_${pos}`
-  return (
-    <span className={classnames('tooltip', style)}>{msg}</span>
-  )
-}
+import styles from './ToolTip.css'
+
+export const TOP = styles.top
+export const BOTTOM = styles.bottom
+export const BOTTOM_RIGHT = styles.bottom_right
+export const LEFT = styles.left
+export const RIGHT = styles.right
+
+export const SMALL = styles.small
+export const MEDIUM = styles.medium
 
 ToolTip.propTypes = {
-  msg: PropTypes.string.isRequired,
-  pos: PropTypes.string.isRequired
+  style: PropTypes.oneOf([TOP, BOTTOM, BOTTOM_RIGHT, LEFT, RIGHT]).isRequired,
+  size: PropTypes.oneOf([SMALL, MEDIUM])
+}
+
+export default function ToolTip (props) {
+  const {style, size} = props
+  const className = classnames(styles.tooltip, style, size || SMALL)
+
+  return (
+    <div className={className}>
+      {props.children}
+    </div>
+  )
 }

--- a/app/ui/components/nav/NavBar.js
+++ b/app/ui/components/nav/NavBar.js
@@ -1,0 +1,19 @@
+// nav bar component
+import React from 'react'
+
+import NavButton from './NavButton'
+import styles from './nav.css'
+
+const PANELS = [
+  {name: 'upload', title: 'Upload File'},
+  {name: 'setup', title: 'Prep for Run'},
+  {name: 'connect', title: 'Connect Robot'}
+]
+
+export default function NavBar (props) {
+  return (
+    <nav className={styles.navbar}>
+      {PANELS.map((panel) => <NavButton key={panel.name} {...panel} />)}
+    </nav>
+  )
+}

--- a/app/ui/components/nav/NavButton.js
+++ b/app/ui/components/nav/NavButton.js
@@ -1,0 +1,67 @@
+// nav button container
+import {connect} from 'react-redux'
+
+import {
+  actions as interfaceActions,
+  selectors as interfaceSelectors
+} from '../../interface'
+
+import {
+  selectors as robotSelectors,
+  constants as robotConstants
+} from '../../robot'
+
+import SideBarButton from './SideBarButton'
+
+import uploadIconSrc from '../../img/icon_file.png'
+import setupIconSrc from '../../img/icon_setup.svg'
+import controlledUSBSrc from '../../img/icon_usb_controlled.png'
+import discoverSrc from '../../img/icon_discover.png'
+
+export default connect(mapStateToProps, null, mergeProps)(SideBarButton)
+
+function mapStateToProps (state, ownProps) {
+  const {name} = ownProps
+  const isPanelOpen = interfaceSelectors.getIsPanelOpen(state)
+  const currentPanel = interfaceSelectors.getCurrentPanel(state)
+  const isSessionLoaded = robotSelectors.getSessionIsLoaded(state)
+  const isConnected = (
+    robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
+  )
+
+  let disabled = false
+  let src
+
+  if (name === 'upload') {
+    disabled = !isConnected
+    src = uploadIconSrc
+  } else if (name === 'setup') {
+    disabled = !isSessionLoaded
+    src = setupIconSrc
+  } else if (name === 'connect') {
+    src = isConnected
+      ? controlledUSBSrc
+      : discoverSrc
+  }
+
+  return {
+    src,
+    disabled,
+    isCurrent: isPanelOpen && name === currentPanel
+  }
+}
+
+function mergeProps (stateProps, dispatchProps, ownProps) {
+  const {dispatch} = dispatchProps
+  const {isCurrent} = stateProps
+  const {name} = ownProps
+  const clickAction = isCurrent
+    ? interfaceActions.closePanel()
+    : interfaceActions.setCurrentPanel(name)
+
+  return {
+    ...ownProps,
+    ...stateProps,
+    onClick: () => dispatch(clickAction)
+  }
+}

--- a/app/ui/components/nav/SideBarButton.js
+++ b/app/ui/components/nav/SideBarButton.js
@@ -1,0 +1,31 @@
+// side bar link
+import React from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
+import ToolTip, {MEDIUM, RIGHT} from '../ToolTip'
+import styles from './nav.css'
+
+SideBarButton.propTypes = {
+  title: PropTypes.string.isRequired,
+  isCurrent: PropTypes.bool.isRequired,
+  src: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool
+}
+
+export default function SideBarButton (props) {
+  const {title, isCurrent, src, onClick, disabled} = props
+  const className = classnames(styles.button, {[styles.active]: isCurrent})
+
+  return (
+    <button
+      className={className}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <img aria-hidden='true' className={styles.icon} src={src} />
+      <ToolTip size={MEDIUM} style={RIGHT}>{title}</ToolTip>
+    </button>
+  )
+}

--- a/app/ui/components/nav/nav.css
+++ b/app/ui/components/nav/nav.css
@@ -1,0 +1,47 @@
+@value light_grey, grey from '../App.global.css';
+@value border: 2px solid grey;
+
+.navbar {
+  position: relative;
+  flex: none;
+  width: 5rem;
+  height: 100%;
+  background-color: light_grey;
+  border-right: border;
+}
+
+.button {
+  composes: parent from '../ToolTip.css';
+  display: block;
+  width: 100%;
+  height: 5rem;
+  background-color: transparent;
+  border-bottom: border;
+  cursor: pointer;
+}
+
+.button:last-child {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border-bottom-width: 0;
+  border-top: border;
+}
+
+.button[disabled] {
+  cursor: default;
+}
+
+.button[disabled] .icon {
+  opacity: 0.3;
+}
+
+.active {
+  background-color: grey;
+}
+
+.icon {
+  max-width: 100%;
+  height: 100%;
+  padding: 1.25rem;
+}

--- a/app/ui/containers/DiscoveredRobot.js
+++ b/app/ui/containers/DiscoveredRobot.js
@@ -6,7 +6,7 @@ import {
   actions as robotActions
 } from '../robot'
 
-const mapStateToProps = (state, ownProps) => ownProps
+const mapStateToProps = (state, ownProps) => ({})
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   // only allow disconnect if connected and vice versa

--- a/app/ui/containers/Nav.js
+++ b/app/ui/containers/Nav.js
@@ -1,5 +1,4 @@
 // top-level container
-import React from 'react'
 import {connect} from 'react-redux'
 
 import {
@@ -8,86 +7,30 @@ import {
 } from '../interface'
 
 import {
-  actions as robotActions,
-  selectors as robotSelectors,
-  constants as robotConstants
+  actions as robotActions
 } from '../robot'
-
-import uploadIconSrc from '../img/icon_file.svg'
-import setupIconSrc from '../img/icon_setup.svg'
 
 import SideBar from '../components/SideBar'
 
-const mapStateToProps = (state) => {
-  const connectionStatus = robotSelectors.getConnectionStatus(state)
-  const isConnected = connectionStatus === robotConstants.CONNECTED
-  const sessionIsLoaded = robotSelectors.getSessionIsLoaded(state)
-  const isOpen = interfaceSelectors.getIsNavPanelOpen(state)
-  const activeTask = interfaceSelectors.getCurrentNavPanelTask(state)
+const mapStateToProps = (state) => ({
+  isOpen: interfaceSelectors.getIsPanelOpen(state),
+  currentPanel: interfaceSelectors.getCurrentPanel(state)
+})
 
-  return {
-    // interface
-    isNavPanelOpen: isOpen,
-    currentNavPanelTask: activeTask,
-    navLinks: [
-      {
-        name: 'upload',
-        iconSrc: uploadIconSrc,
-        isDisabled: !isConnected,
-        isActive: isOpen && activeTask === 'upload',
-        msg: 'Upload File'
-      },
-      {
-        name: 'setup',
-        iconSrc: setupIconSrc,
-        // TODO(mc, 2017-10-11): this needs a selector
-        isDisabled: !sessionIsLoaded,
-        isActive: isOpen && activeTask === 'setup',
-        msg: 'Prep For Run'
-      }
-    ],
+const mapDispatchToProps = (dispatch) => ({
+  close: () => dispatch(interfaceActions.closePanel()),
 
-    // robot
-    isReadyToRun: robotSelectors.getIsReadyToRun(state),
-    isRunning: robotSelectors.getIsRunning(state),
-    connectionStatus: robotSelectors.getConnectionStatus(state),
-    isConnected
-  }
-}
+  onUpload: (event) => {
+    let files
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    // interface
-    toggleNavOpen: () => dispatch(interfaceActions.toggleNavPanel()),
-    onNavIconClick: (panel) => () => {
-      dispatch(interfaceActions.setCurrentNavPanel(panel))
-    },
-
-    // robot
-    // TODO(mc): revisit when robot discovery / multiple robots is addressed
-    onConnectClick: () => dispatch(robotActions.connect()),
-    onDisconnectClick: () => dispatch(robotActions.disconnect()),
-    onRunClick: () => dispatch(robotActions.run()),
-
-    // session
-    onUpload: (event) => {
-      let files
-
-      if (event.dataTransfer) {
-        files = event.dataTransfer.files
-      } else {
-        files = event.target.files
-      }
-
-      dispatch(robotActions.session(files[0]))
+    if (event.dataTransfer) {
+      files = event.dataTransfer.files
+    } else {
+      files = event.target.files
     }
+
+    dispatch(robotActions.session(files[0]))
   }
-}
+})
 
-function Nav (props) {
-  return (
-    <SideBar {...props} />
-  )
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Nav)
+export default connect(mapStateToProps, mapDispatchToProps)(SideBar)

--- a/app/ui/containers/UploadStatus.js
+++ b/app/ui/containers/UploadStatus.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-  openSetupPanel: () => dispatch(interfaceActions.setCurrentNavPanel('setup'))
+  openSetupPanel: () => dispatch(interfaceActions.setCurrentPanel('setup'))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Upload)

--- a/app/ui/interface/index.js
+++ b/app/ui/interface/index.js
@@ -8,32 +8,32 @@ const makeInterfaceActionName = (action) => makeActionName(NAME, action)
 const getModuleState = (state) => state[NAME]
 
 const INITIAL_STATE = {
-  isNavPanelOpen: false,
-  currentNavPanelTask: ''
+  isPanelOpen: false,
+  currentPanel: ''
 }
 
 export const selectors = {
-  getIsNavPanelOpen (allState) {
-    return getModuleState(allState).isNavPanelOpen
+  getIsPanelOpen (state) {
+    return getModuleState(state).isPanelOpen
   },
-  getCurrentNavPanelTask (allState) {
-    return getModuleState(allState).currentNavPanelTask
+
+  getCurrentPanel (state) {
+    return getModuleState(state).currentPanel
   }
 }
 
 export const actionTypes = {
-  TOGGLE_NAV_PANEL: makeInterfaceActionName('TOGGLE_NAV_PANEL'),
-  SET_CURRENT_NAV_PANEL: makeInterfaceActionName('SET_CURRENT_NAV_PANEL')
+  CLOSE_PANEL: makeInterfaceActionName('CLOSE_PANEL'),
+  SET_CURRENT_PANEL: makeInterfaceActionName('SET_CURRENT_PANEL')
 }
 
 export const actions = {
-  toggleNavPanel () {
-    return {
-      type: actionTypes.TOGGLE_NAV_PANEL
-    }
+  closePanel () {
+    return {type: actionTypes.CLOSE_PANEL}
   },
-  setCurrentNavPanel (panel) {
-    return {type: actionTypes.SET_CURRENT_NAV_PANEL, payload: {panel}}
+
+  setCurrentPanel (panel = '') {
+    return {type: actionTypes.SET_CURRENT_PANEL, payload: {panel}}
   }
 }
 
@@ -41,18 +41,12 @@ export function reducer (state = INITIAL_STATE, action) {
   const {type, payload} = action
 
   switch (type) {
-    case actionTypes.TOGGLE_NAV_PANEL:
-      return {...state, isNavPanelOpen: !state.isNavPanelOpen}
+    case actionTypes.CLOSE_PANEL:
+      return {...state, isPanelOpen: false}
 
-    case actionTypes.SET_CURRENT_NAV_PANEL:
-      return {
-        ...state,
-        currentNavPanelTask: payload.panel,
-        isNavPanelOpen: (
-          !state.isNavPanelOpen ||
-          payload.panel !== state.currentNavPanelTask
-        )
-      }
+    case actionTypes.SET_CURRENT_PANEL:
+      return {...state, isPanelOpen: true, currentPanel: payload.panel}
   }
+
   return state
 }

--- a/app/ui/interface/test/actions.test.js
+++ b/app/ui/interface/test/actions.test.js
@@ -3,15 +3,15 @@
 import {actions, actionTypes} from '../'
 
 describe('interface actions', () => {
-  test('toggle nav panel', () => {
-    const expected = {type: actionTypes.TOGGLE_NAV_PANEL}
+  test('close nav panel', () => {
+    const expected = {type: actionTypes.CLOSE_PANEL}
 
-    expect(actions.toggleNavPanel()).toEqual(expected)
+    expect(actions.closePanel()).toEqual(expected)
   })
 
   test('set current nav panel', () => {
-    const expected = {type: actionTypes.SET_CURRENT_NAV_PANEL, payload: {panel: 'upload'}}
+    const expected = {type: actionTypes.SET_CURRENT_PANEL, payload: {panel: 'upload'}}
 
-    expect(actions.setCurrentNavPanel('upload')).toEqual(expected)
+    expect(actions.setCurrentPanel('upload')).toEqual(expected)
   })
 })

--- a/app/ui/interface/test/reducer.test.js
+++ b/app/ui/interface/test/reducer.test.js
@@ -7,40 +7,31 @@ describe('interface reducer', () => {
     const state = reducer(undefined, {})
 
     expect(state).toEqual({
-      isNavPanelOpen: false,
-      currentNavPanelTask: ''
+      isPanelOpen: false,
+      currentPanel: ''
     })
   })
 
-  test('handles toggleNavPanel', () => {
-    const action = {type: actionTypes.TOGGLE_NAV_PANEL}
-
-    let state = {isNavPanelOpen: false}
-    expect(reducer(state, action)).toEqual({isNavPanelOpen: true})
-
-    state = {isNavPanelOpen: true}
-    expect(reducer(state, action)).toEqual({isNavPanelOpen: false})
-  })
-
-  test('handles setCurrentNavPanel with nav panel closed', () => {
-    const state = {currentNavPanelTask: 'upload', isNavPanelOpen: false}
-    const panel = 'connect'
-    const action = {type: actionTypes.SET_CURRENT_NAV_PANEL, payload: {panel}}
+  test('handles closePanel', () => {
+    const state = {isPanelOpen: true, currentPanel: 'upload'}
+    const action = {type: actionTypes.CLOSE_PANEL}
 
     expect(reducer(state, action)).toEqual({
-      currentNavPanelTask: 'connect',
-      isNavPanelOpen: true
+      isPanelOpen: false,
+      currentPanel: 'upload'
     })
   })
 
-  test('handles setCurrentNavPanel with nav panel open', () => {
-    const state = {currentNavPanelTask: 'upload', isNavPanelOpen: true}
-    const panel = 'upload'
-    const action = {type: actionTypes.SET_CURRENT_NAV_PANEL, payload: {panel}}
+  test('handles setCurrentPanel', () => {
+    const state = {isPanelOpen: false, currentPanel: 'upload'}
+    const action = {
+      type: actionTypes.SET_CURRENT_PANEL,
+      payload: {panel: 'connect'}
+    }
 
     expect(reducer(state, action)).toEqual({
-      currentNavPanelTask: 'upload',
-      isNavPanelOpen: false
+      isPanelOpen: true,
+      currentPanel: 'connect'
     })
   })
 })

--- a/app/ui/interface/test/selectors.test.js
+++ b/app/ui/interface/test/selectors.test.js
@@ -3,15 +3,17 @@
 import {NAME, selectors} from '../'
 
 describe('user interface selectors', () => {
-  test('get is nav panel open', () => {
-    const state = {[NAME]: {isNavPanelOpen: true}}
+  test('get is panel open', () => {
+    let state = {[NAME]: {isPanelOpen: true}}
+    expect(selectors.getIsPanelOpen(state)).toBe(true)
 
-    expect(selectors.getIsNavPanelOpen(state)).toBe(true)
+    state = {[NAME]: {isPanelOpen: false}}
+    expect(selectors.getIsPanelOpen(state)).toBe(false)
   })
 
-  test('get current nav panel', () => {
-    const state = {[NAME]: {currentNavPanelTask: 'upload'}}
+  test('get active panel', () => {
+    const state = {[NAME]: {currentPanel: 'upload'}}
 
-    expect(selectors.getCurrentNavPanelTask(state)).toBe('upload')
+    expect(selectors.getCurrentPanel(state)).toBe('upload')
   })
 })


### PR DESCRIPTION
## overview

This PR cleans up the nav sidebar a little to have:

- More specifically scoped React containers
- A more specific file organization
- CSS consolidation and consistence w.r.t. scoped modules and global styles

This PR includes:

- [X] Chore work (feature-neutral refactoring)
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Refactor) Refactored nav sidebar with more container use
- (Refactor) Refactored tooltips to use scoped CSS
- (Tests) Removed an unneeded interface action so updated tests accordingly

## review requests

Standard review. Please try it out on your machine to make sure everything still works. If you haven't run the app since #414 please remember to run `make install` before running to pick up new dev deps.