### PR TITLE
Verify constraints for the execution plan by comparing max volume aga…

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1050,6 +1050,11 @@ class Pipette:
         <opentrons.instruments.pipette.Pipette object at ...>
         """
 
+        if self.max_volume <= kwargs.get('air_gap', 0):
+            error_message = 'Air gap value({}) should be less than max volume({}).'.format(
+                kwargs.get('air_gap', 0), self.max_volume)
+            raise ValueError(error_message)
+
         kwargs['mode'] = kwargs.get('mode', 'transfer')
 
         touch_tip = kwargs.get('touch_tip', False)

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -715,6 +715,22 @@ class PipetteTest(unittest.TestCase):
                      expected=expected)
         self.robot.clear_commands()
 
+    def test_transfer_air_gap_bigger_than_max_volume(self):
+        self.p200.reset()
+        self.assertRaises(
+            ValueError, self.p200.transfer,
+            30,
+            self.plate[0:8],
+            self.plate[1:9],
+            new_tip='always',
+            air_gap=10000,
+            disposal_vol=20,  # ignored by transfer
+            touch_tip=True,
+            blow_out=True,
+            trash=True
+        )
+        self.robot.clear_commands()
+
     def test_bad_transfer(self):
         self.p200.reset()
 


### PR DESCRIPTION
…inst air gap. Constraints are feasible if and only if amount of the transferable liquid volume is bigger than zero.

## overview

Write a high level description of the pull request.

This PR includes:

- [ ] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

Fix to the problem i found while debugging github issue https://github.com/Opentrons/opentrons/issues/364, i was not able to reproduce the one mentioned, though it's possible to get into infinite loop when air gap is bigger or equal to the amount of the volume in pipette.

The one thing is not clear whether we want to have such scenarios or not. There might be a case for gas transferring when we would like to have a pipette to be full of the air. That case should require a bit more changes.

## review requests

Describe any specific requests for your reviewers here. Tag any people or groups as necessary.
