### PR TITLE
V3a resin devflow

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 
 .PHONY: test docs publish clean install exe dev info_device sync_device active_devices \
-	blink_devices ssh_device acquire_device release_device _check_user
+	blink_devices ssh_device acquire_device release_device _check_user set set_me
 
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -47,6 +47,7 @@ ssh_device: _check_user
 	resin ssh $(OT_DEVICE_ID)
 
 acquire_device:
+	$(eval OT_USER_ID = $(shell resin whoami |  awk '/USERNAME/{print $$2}'))
 	resin env add OT_USER $(OT_USER_ID) --device $(OT_DEVICE_ID)
 
 release_device:
@@ -57,13 +58,15 @@ release_device:
 
 _check_user:
 	@echo "verifying device ownership...";
-	$(eval DEVICE_USER = $(shell resin envs -v --device $(OT_DEVICE_ID) | awk '/OT_USER/{print $$3}'))
-	@if [ $(DEVICE_USER) = $(OT_USER_ID) ]; then\
+	$(eval OT_USER_ID = $(shell resin whoami |  awk '/USERNAME/{print $$2}'))
+	$(eval DEVICE_OWNER = $(shell resin envs -v --device $(OT_DEVICE_ID) | awk '/OT_USER/{print $$3}'))
+	@if [ $(DEVICE_OWNER) = $(OT_USER_ID) ]; then\
 		echo "device ownership confirmed"; \
 	else \
-		echo "Device user: $(DEVICE_USER) does not match OT_USER_ID: $(OT_USER_ID)";\
+		echo "Device user: $(DEVICE_OWNER) does not match OT_USER_ID: $(OT_USER_ID)";\
 		exit 1;\
   fi
+
 
 ########## [END] RESIN DEVICE ##########
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -2,8 +2,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: test docs publish clean install exe dev info_device sync_device active_devices \
-	blink_device ssh_device
+.PHONY: test docs publish clean install exe dev
 
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -30,18 +29,23 @@ dev:
 
 ########## [START] RESIN DEVICE ##########
 
+.PHONY: info_device
 info_device:
 	resin device $(OT_DEVICE_ID)
 
+.PHONY: sync_device
 sync_device: clean
 	resin sync $(OT_DEVICE_ID) --source ./ --destination /usr/src/api --progress
 
+.PHONY: blink_device
 blink_device:
 	resin device identify $(OT_DEVICE_ID)
 
+.PHONY: active_devices
 active_devices:
 	resin devices --app OTone | awk 'NR==1 || /true/'
 
+.PHONY: ssh_device
 ssh_device:
 	resin ssh $(OT_DEVICE_ID)
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -26,6 +26,21 @@ publish:
 dev:
 	python opentrons/server/main.py
 
+
+########## [START] RESIN DEVICE ##########
+
+device_info:
+	resin device $(OT_DEVICE_ID)
+
+device_sync:
+	resin sync $(OT_DEVICE_ID) -s ~/OpenTrons/opentrons-api/api -d /usr/src/api -p
+
+active_devices:
+	resin devices --app OTone | awk 'NR==1 || /true/'
+
+########## [END] RESIN DEVICE ##########
+
+
 clean:
 	rm -rf \
 		__pycache__ \

--- a/api/Makefile
+++ b/api/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 
 .PHONY: test docs publish clean install exe dev info_device sync_device active_devices \
-	blink_devices ssh_device acquire_device release_device _check_user set set_me
+	blink_device ssh_device
 
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -33,7 +33,7 @@ dev:
 info_device:
 	resin device $(OT_DEVICE_ID)
 
-sync_device: clean _check_user
+sync_device: clean
 	resin sync $(OT_DEVICE_ID) --source ~/OpenTrons/opentrons-api/api \
 		--destination /usr/src/api --progress
 
@@ -43,30 +43,8 @@ blink_device:
 active_devices:
 	resin devices --app OTone | awk 'NR==1 || /true/'
 
-ssh_device: _check_user
+ssh_device:
 	resin ssh $(OT_DEVICE_ID)
-
-acquire_device:
-	$(eval OT_USER_ID = $(shell resin whoami |  awk '/USERNAME/{print $$2}'))
-	resin env add OT_USER $(OT_USER_ID) --device $(OT_DEVICE_ID)
-
-release_device:
-	$(eval DEVICE_URL = $(shell resin device $(OT_DEVICE_ID) | awk '/DASHBOARD/{print $$3}' | sed 's:/[^/]*$$::'))
-	@echo "Release must be done through the Resin dashboard for now"
-	@echo "To release the device, delete the OT_USER enviornment variable through the resin dashboard at $(DEVICE_URL)/envvars"
-	@#resin env rm OT_USER --device $(OT_DEVICE_ID)
-
-_check_user:
-	@echo "verifying device ownership...";
-	$(eval OT_USER_ID = $(shell resin whoami |  awk '/USERNAME/{print $$2}'))
-	$(eval DEVICE_OWNER = $(shell resin envs -v --device $(OT_DEVICE_ID) | awk '/OT_USER/{print $$3}'))
-	@if [ $(DEVICE_OWNER) = $(OT_USER_ID) ]; then\
-		echo "device ownership confirmed"; \
-	else \
-		echo "Device user: $(DEVICE_OWNER) does not match OT_USER_ID: $(OT_USER_ID)";\
-		exit 1;\
-  fi
-
 
 ########## [END] RESIN DEVICE ##########
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -34,8 +34,7 @@ info_device:
 	resin device $(OT_DEVICE_ID)
 
 sync_device: clean
-	resin sync $(OT_DEVICE_ID) --source ~/OpenTrons/opentrons-api/api \
-		--destination /usr/src/api --progress
+	resin sync $(OT_DEVICE_ID) --source ./ --destination /usr/src/api --progress
 
 blink_device:
 	resin device identify $(OT_DEVICE_ID)

--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,8 @@
 
 SHELL := /bin/bash
 
-.PHONY: test docs publish clean install dev
+.PHONY: test docs publish clean install exe dev info_device sync_device active_devices \
+	blink_devices ssh_device acquire_device release_device _check_user
 
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -29,14 +30,40 @@ dev:
 
 ########## [START] RESIN DEVICE ##########
 
-device_info:
+info_device:
 	resin device $(OT_DEVICE_ID)
 
-device_sync:
-	resin sync $(OT_DEVICE_ID) -s ~/OpenTrons/opentrons-api/api -d /usr/src/api -p
+sync_device: clean _check_user
+	resin sync $(OT_DEVICE_ID) --source ~/OpenTrons/opentrons-api/api \
+		--destination /usr/src/api --progress
+
+blink_device:
+	resin device identify $(OT_DEVICE_ID)
 
 active_devices:
 	resin devices --app OTone | awk 'NR==1 || /true/'
+
+ssh_device: _check_user
+	resin ssh $(OT_DEVICE_ID)
+
+acquire_device:
+	resin env add OT_USER $(OT_USER_ID) --device $(OT_DEVICE_ID)
+
+release_device:
+	$(eval DEVICE_URL = $(shell resin device $(OT_DEVICE_ID) | awk '/DASHBOARD/{print $$3}' | sed 's:/[^/]*$$::'))
+	@echo "Release must be done through the Resin dashboard for now"
+	@echo "To release the device, delete the OT_USER enviornment variable through the resin dashboard at $(DEVICE_URL)/envvars"
+	@#resin env rm OT_USER --device $(OT_DEVICE_ID)
+
+_check_user:
+	@echo "verifying device ownership...";
+	$(eval DEVICE_USER = $(shell resin envs -v --device $(OT_DEVICE_ID) | awk '/OT_USER/{print $$3}'))
+	@if [ $(DEVICE_USER) = $(OT_USER_ID) ]; then\
+		echo "device ownership confirmed"; \
+	else \
+		echo "Device user: $(DEVICE_USER) does not match OT_USER_ID: $(OT_USER_ID)";\
+		exit 1;\
+  fi
 
 ########## [END] RESIN DEVICE ##########
 


### PR DESCRIPTION
## overview

Creates targets in the api Makefile that should make developing with devices easier

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

**Note**: If you did not check "Documentation updates" and/or "Test updates" then your PR may not be ready!

## changelog

1) The development process that these targets are defined around is as follows:
- `$ make active_devices` to find devices that are currently online  
- `export OT_DEVICE_ID=[uuid]` to select the device you want to use (uuid is found in the output from the above commands)
- `make sync_device` to sync your local `api/` to the devices `api/` and restart the application
- `make ssh_device` to enter the running container of the pi to debug or poke around
- `make info_device` to get basic info about the device




**Issues / improvements**
This is a work in progress but should serve as a robust enough flow to allow us to work on these devices as part of the api workflow.


## review requests

Requesting review from Artyom, Mike, and Ben 

Describe any specific requests for your reviewers here. Tag any people or groups as necessary.
