### PR TITLE
Fix #387 — don't emit state change if SessionManager.create errors out

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -115,9 +115,6 @@ class Session(object):
             # once robot / driver simulation flow is fixed
             robot._driver.disconnect()
             exec(self._protocol, {})
-        except Exception as e:
-            self.error_append(e)
-            raise e
         finally:
             robot._driver.connect()
             unsubscribe()

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -272,7 +272,7 @@ async def test_session_create_error(main_router):
 
     with pytest.raises(TimeoutError):
         # No state change is expected
-        await main_router.wait_until(state('loaded'))
+        await main_router.wait_until(lambda _: True)
 
     with pytest.raises(ZeroDivisionError):
         main_router.session_manager.create(
@@ -281,4 +281,4 @@ async def test_session_create_error(main_router):
 
     with pytest.raises(TimeoutError):
         # No state change is expected
-        await main_router.wait_until(state('loaded'))
+        await main_router.wait_until(lambda _: True)

--- a/app/scripts/advertise-local-api.js
+++ b/app/scripts/advertise-local-api.js
@@ -16,7 +16,7 @@ const service = {
   // TODO(mc, 2017-10-26): we're relying right now on the fact that resin
   // advertises an SSH service. Instead, we should be registering an HTTP
   // service on port 31950 and listening for that instead
-  type: 'ssh'
+  type: 'http'
 }
 
 bonjour.publish(service)


### PR DESCRIPTION
- Removed adding error to log on `_simulate`, allowing
  exception to propagate instead

- Fixed test to fail if ANY state change is emitted

- Updated app to advertise local API instance as `http`