### PR TITLE
(v3, feature) Display upload error on Upload page

### DIFF
--- a/app/rpc/client.js
+++ b/app/rpc/client.js
@@ -6,6 +6,7 @@ import EventEmitter from 'events'
 
 import WebSocketClient from './websocket-client'
 import RemoteObject from './remote-object'
+import RemoteError from './remote-error'
 import {
   statuses,
   RESULT,
@@ -66,10 +67,10 @@ class RpcContext extends EventEmitter {
 
       const handleError = (reason) => {
         cleanup()
-        reject(new Error(`Error in ${name}(${args.join(', ')}): ${reason}`))
+        reject(new RemoteError(reason, name, args))
       }
 
-      const handleFailure = (result) => handleError(new Error(result))
+      const handleFailure = (result) => handleError(result)
       const handleNack = (reason) => handleError(`Received NACK with ${reason}`)
 
       const handleAck = () => {

--- a/app/rpc/remote-error.js
+++ b/app/rpc/remote-error.js
@@ -1,0 +1,9 @@
+// remote call error object
+export default class RemoteError extends Error {
+  constructor (message, methodName, args) {
+    super(message)
+    this.name = this.constructor.name
+    this.methodName = methodName
+    this.args = args
+  }
+}

--- a/app/ui/components/App.global.css
+++ b/app/ui/components/App.global.css
@@ -52,18 +52,6 @@ body {
   display: inline-block;
 }
 
-.flex {
-  display: flex;
-}
-
-.flex__items_center {
-  align-items: center;
-}
-
-.flex__justify_center {
-  justify-content: center;
-}
-
 /*** TYPOGRAPHY ***/
 @font-face {
   font-family: 'trons';

--- a/app/ui/components/CenteredContent.css
+++ b/app/ui/components/CenteredContent.css
@@ -1,6 +1,9 @@
 /* CenteredContent component style */
 
 .container {
+  display: flex;
   width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
 }

--- a/app/ui/components/CenteredContent.js
+++ b/app/ui/components/CenteredContent.js
@@ -1,17 +1,11 @@
 // vertically and horizontally CenteredContent component
 import React from 'react'
-import classnames from 'classnames'
 
 import styles from './CenteredContent.css'
 
-const STYLE = classnames(
-  'flex flex__items_center flex__justify_center',
-  styles.container
-)
-
 export default function CenteredContent (props) {
   return (
-    <div className={STYLE}>
+    <div className={styles.container}>
       <div>
         {props.children}
       </div>

--- a/app/ui/components/Upload.css
+++ b/app/ui/components/Upload.css
@@ -1,6 +1,11 @@
 /* Upload component styles */
 @value red, blue from './App.global.css';
 
+.status_bar {
+  display: flex;
+  align-items: center;
+}
+
 .spinner {
   width: 8rem;
 }
@@ -33,6 +38,12 @@
   padding-left: 8rem;
   font-size: 1rem;
   color: grey;
+}
+
+.error {
+  margin-bottom: 1rem;
+  font-weight: bold;
+  color: red;
 }
 
 .file_details_title {

--- a/app/ui/components/Upload.js
+++ b/app/ui/components/Upload.js
@@ -11,8 +11,6 @@ import styles from './Upload.css'
 const UPLOAD_ERROR_MESSAGE = 'Something went wrong while uploading your file.'
 const UPLOAD_SUCCESS_MESSAGE = 'Your file has uploaded successfully.'
 
-const STATUS_BAR_STYLE = 'flex flex__items_center'
-
 Upload.propTypes = {
   name: PropTypes.string.isRequired,
   inProgress: PropTypes.bool.isRequired,
@@ -53,10 +51,13 @@ function UploadResults (props) {
     // instructions for an unsuccessful upload
     instructions = (
       <div className={styles.details}>
+        <p className={styles.error}>
+          {error.message}
+        </p>
         <p>
           Looks like there might be a problem with your protocol file. Please
           check your file for errors. If you need help, contact support
-          and provide them with your protocol file.
+          and provide them with your protocol file and the error message above.
         </p>
       </div>
     )
@@ -106,7 +107,7 @@ function StatusBar (props) {
     : Warning
 
   return (
-    <div className={STATUS_BAR_STYLE}>
+    <div className={styles.status_bar}>
       <StatusIcon className={styles.status_icon} />
       {props.children}
     </div>

--- a/app/ui/robot/api-client/worker.js
+++ b/app/ui/robot/api-client/worker.js
@@ -14,7 +14,12 @@ self.onmessage = function handleIncoming (event) {
 function dispatchFromWorker (action) {
   // webworkers cannot post Error objects, so convert them to plain objects
   if (action.error === true) {
-    action.payload = {message: action.payload.message}
+    const {payload} = action
+
+    action.payload = Object.assign(
+      {name: payload.name, message: payload.message},
+      payload
+    )
   }
 
   self.postMessage(action)


### PR DESCRIPTION
## overview

This PR tweaks the errors returned by the RPC client to be more useful, and displays any errors from `session_manager.create` on the upload page.

![2017-11-14 15 41 03](https://user-images.githubusercontent.com/2963448/32803670-4e4fa198-c952-11e7-841b-54e001c41b15.gif)

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.

- (Feature) Added session upload error display to Upload page
- (Chore) Took the opportunity to remove some global CSS per discussions with @Kadee80 

## review requests

Standard review. Related to #428 
