### PR TITLE
Add mac target to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   # - > # Make docs on linux only
   #   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then (make -C api docs > /dev/null) fi;
   # TODO(mc, 2017-08-28): use top level `make test`
-  - make -C app package test && make -C app dist-osx dist-linux
+  - make -C app package test && make -C app dist-posix
   # Clean up. This will leave only single-file build artifacts
   - find ./app/dist/** ! -name 'opentrons-v*' -exec rm -rf {} +
 
@@ -70,7 +70,7 @@ deploy:
     bucket: ot-app-builds
     skip_cleanup: true
     local-dir: $(pwd)/app/dist
-    upload-dir: osx-linux
+    upload-dir: ci-builds
     acl: public_read
     on:
       condition: $TRAVIS_TEST_RESULT = 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
       sudo: false
       python: "3.5"
       env:
-        - DEPLOY_DIR="linux"
         - PUBLIC_REPO="$(git remote -v | tail -n 1 | sed s/.*opentrons\.git.*/true/g)"
       addons:
         apt:
@@ -26,8 +25,6 @@ matrix:
     # revisit OSX CI in the near future
     # - os: osx
     #   language: generic
-    #   env:
-    #     - DEPLOY_DIR="mac"
 
 # More: https://docs.travis-ci.com/user/caching/
 cache:
@@ -58,8 +55,7 @@ script:
   # - > # Make docs on linux only
   #   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then (make -C api docs > /dev/null) fi;
   # TODO(mc, 2017-08-28): use top level `make test`
-  # TODO(mc, 2017-09-13): handle cross-platform distributables
-  - make -C app package test && make -C app dist-${TRAVIS_OS_NAME}
+  - make -C app package test && make -C app dist-osx dist-linux
   # Clean up. This will leave only single-file build artifacts
   - find ./app/dist/** ! -name 'opentrons-v*' -exec rm -rf {} +
 
@@ -74,11 +70,11 @@ deploy:
     bucket: ot-app-builds
     skip_cleanup: true
     local-dir: $(pwd)/app/dist
-    upload-dir: $DEPLOY_DIR
+    upload-dir: osx-linux
     acl: public_read
     on:
       condition: $TRAVIS_TEST_RESULT = 0
-      repo: OpenTrons/opentrons
+      repo: Opentrons/opentrons
       all_branches: true
 
   # Publish API to PyPI and Anaconda

--- a/app/Makefile
+++ b/app/Makefile
@@ -60,6 +60,10 @@ $(ui_target): $(ui_source)
 package: $(ui_target) $(shell_source)
 	$(set_package_env) $(bin)/electron-builder --dir
 
+.PHONY: dist-posix
+dist-posix: $(ui_target) $(shell_source)
+	$(set_package_env) $(bin)/electron-builder --linux --mac --publish never
+
 .PHONY: dist-osx
 dist-osx: $(ui_target) $(shell_source)
 	$(set_package_env) $(bin)/electron-builder --mac --publish never

--- a/app/electron-builder.json
+++ b/app/electron-builder.json
@@ -28,7 +28,6 @@
   },
   "mac": {
     "target": [
-      "dmg",
       "zip"
     ],
     "category": "productivity"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,5 +47,5 @@ deploy:
     secret_access_key: $(AWS_SECRET_KEY)
     bucket: ot-app-builds
     set_public: true
-    folder: win
+    folder: ci-builds
     artifact: OTAppWin


### PR DESCRIPTION
Since we don't have any native platform dependencies, we can successfully build both OSX and Linux targets in Travis Linux container.

For releases, we should build and sign on a real OSX machine.

Note the directory change. We are gonna be putting both builds into `osx-linux`. Eventually, I suggest to put all three into something like 'ci-builds'