### PR TITLE
Added home and pick_up_tip routes to server for new calibration process

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -51,6 +51,19 @@ class CalibrationManager:
         inst.pick_up_tip(container._container[0])
         self._set_state('ready')
 
+    def drop_tip(self, instrument, container):
+        if not isinstance(container, Container):
+            raise ValueError(
+                'Invalid object type {0}. Expected models.Container'
+                .format(type(container)))
+
+        inst = instrument._instrument
+        log.debug('Dropping tip from {} in {} with {}'.format(
+            container.name, container.slot, instrument.name))
+        self._set_state('moving')
+        inst.drop_tip(container._container[0], home_after=False)
+        self._set_state('ready')
+
     def move_to_front(self, instrument):
         inst = instrument._instrument
         log.debug('Moving {}'.format(instrument.name))

--- a/api/opentrons/api/models.py
+++ b/api/opentrons/api/models.py
@@ -23,6 +23,7 @@ class Instrument:
         self.mount = instrument.mount
         # TODO(artyom, 20171006): with axis removed from the instrument
         # we still need to pass it to the UI for now
+        # Warning: this does not correspond to the Smoothie axis!
         self.axis = 'a' if self.mount == 'right' else 'b'
         self.tip_racks = [
             Container(container)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -300,8 +300,9 @@ class Robot(object):
 
         Parameters
         ----------
-        axis : str
+        mount : str
             Specifies which axis the instruments is attached to.
+            Valid options are "left" or "right".
         instrument : Instrument
             An instance of a :class:`Pipette` to attached to the axis.
 
@@ -312,7 +313,7 @@ class Robot(object):
         ::
 
             from opentrons.instruments.pipette import Pipette
-            p200 = Pipette(axis='a')
+            p200 = Pipette(mount='left')
 
         This will create a pipette and call :func:`add_instrument`
         to attach the instrument.
@@ -798,7 +799,8 @@ class Robot(object):
         """
         Stops execution of the protocol.
         """
-        raise NotImplementedError
+        self._driver.pause()
+        self.reset()
 
     def resume(self):
         """
@@ -810,6 +812,7 @@ class Robot(object):
         """
         Stops execution of both the protocol and the Smoothie board immediately
         """
+        # TODO (ben 20171116): make smoothie actions interruptable (no M400)
         raise NotImplementedError
 
     def get_serial_ports_list(self):

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -61,6 +61,10 @@ def log_init():
             'opentrons.server': {
                 'handlers': ['debug'],
                 'level': logging.INFO
+            },
+            'opentrons.api': {
+                'handlers': ['debug'],
+                'level': logging.DEBUG
             }
         }
     )

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -62,6 +62,19 @@ async def test_pick_up_tip(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+async def test_drop_tip(main_router, model):
+    with mock.patch.object(model.instrument._instrument, 'drop_tip') as drop_tip:  # NOQA
+        main_router.calibration_manager.drop_tip(
+            model.instrument,
+            model.container)
+
+        drop_tip.assert_called_with(
+            model.container._container[0], home_after=False)
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
 async def test_home(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'home') as home:
         main_router.calibration_manager.home(

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -50,6 +50,29 @@ async def test_move_to_front(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+async def test_pick_up_tip(main_router, model):
+    with mock.patch.object(model.instrument._instrument, 'pick_up_tip') as pick_up_tip:  # NOQA
+        main_router.calibration_manager.pick_up_tip(
+            model.instrument,
+            model.container)
+
+        pick_up_tip.assert_called_with(model.container._container[0])
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
+async def test_home(main_router, model):
+    with mock.patch.object(model.instrument._instrument, 'home') as home:
+        main_router.calibration_manager.home(
+            model.instrument)
+
+        home.assert_called_with()
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
 async def test_move_to(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
         main_router.calibration_manager.move_to(


### PR DESCRIPTION
## overview

Expose server functions (home and pick_up_tip) for new calibration process, and add debug logging to all routes

This PR includes:

- [x] Chore work
- [ ] Bug fixes
- [x] Backwards-compatible feature additions
- [ ] Breaking changes
- [x] Documentation updates
- [x] Test updates

## changelog

- (Chore) Add debug logging to server routes
- (Feature) Add pick_up_tip and home routes to server
- (Docs) Add docstring to calibration manager to point to use site in App
- (Tests) Add contract tests for new server routes
