### PR TITLE
Add low power setting parameters for movement in Z and A axes

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -48,7 +48,7 @@ class CalibrationManager:
         log.debug('Picking up tip from {} in {} with {}'.format(
             container.name, container.slot, instrument.name))
         self._set_state('moving')
-        inst.pick_up_tip(container._container[0])
+        inst.pick_up_tip(container._container[0], low_power_z=True)
         self._set_state('ready')
 
     def drop_tip(self, instrument, container):

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -156,7 +156,7 @@ class SmoothieDriver_3_0_0:
         '''
         self._power_settings.update(settings)
         values = ['{}{}'.format(axis, value)
-                  for axis, value in settings.items()]
+                  for axis, value in sorted(settings.items())]
         command = '{} {}'.format(
             GCODES['SET_CURRENT'],
             ' '.join(values)
@@ -229,11 +229,11 @@ class SmoothieDriver_3_0_0:
             )
 
         coords = [axis + str(round(coords, GCODE_ROUNDING_PRECISION))
-                  for axis, coords in target.items()
+                  for axis, coords in sorted(target.items())
                   if valid_movement(coords, axis)]
 
         low_power_axes = [axis
-                          for axis, _ in target.items()
+                          for axis, _ in sorted(target.items())
                           if axis in 'ZA']
         prior_power = copy(self._power_settings)
 

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -1,9 +1,10 @@
 from opentrons.drivers.smoothie_drivers.v3_0_0 import serial_communication
 from os import environ
 from opentrons.robot.robot_configs import (
-    config, PLUNGER_CURRENT_LOW, PLUNGER_CURRENT_HIGH
+    config, PLUNGER_CURRENT_LOW, PLUNGER_CURRENT_HIGH, DEFAULT_POWER
 )
 from threading import Event
+from copy import copy
 
 
 '''
@@ -64,6 +65,7 @@ class SmoothieDriver_3_0_0:
         self.run_flag.set()
 
         self._position = {}
+        self._power_settings = DEFAULT_POWER
         self.log = []
         self._update_position({axis: 0 for axis in AXES})
         self.simulating = True
@@ -133,8 +135,8 @@ class SmoothieDriver_3_0_0:
         return self._send_command(GCODES['LIMIT_SWITCH_STATUS'])
 
     @property
-    def current(self):
-        pass
+    def power(self):
+        return self._power_settings
 
     @property
     def speed(self):
@@ -146,9 +148,15 @@ class SmoothieDriver_3_0_0:
         command = GCODES['SET_SPEED'] + str(speed)
         self._send_command(command)
 
-    def set_current(self, axes, value):
-        ''' set total movement speed in mm/second'''
-        values = ['{}{}'.format(axis, value) for axis in axes]
+    def set_power(self, settings):
+        ''' set total movement speed in mm/second
+        settings
+            Dict with axes as valies (e.g.: 'X', 'Y', 'Z', 'A', 'B', or 'C')
+            and floating point number for setting (generally between 0.1 and 2)
+        '''
+        self._power_settings.update(settings)
+        values = ['{}{}'.format(axis, value)
+                  for axis, value in settings.items()]
         command = '{} {}'.format(
             GCODES['SET_CURRENT'],
             ' '.join(values)
@@ -167,21 +175,34 @@ class SmoothieDriver_3_0_0:
 
     # Potential place for command optimization (buffering, flushing, etc)
     def _send_command(self, command, timeout=None):
+        """
+        Submit a GCODE command to the robot, followed by M400 to block until
+        done. This method also ensures that any command on the B or C axis
+        (the axis for plunger control) do current ramp-up and ramp-down, so
+        that plunger motors rest at a low current to prevent burn-out.
+
+        :param command: the GCODE to submit to the robot
+        :param timeout: the time to wait before returning (indefinite wait if
+            this is set to none
+        """
         if self.simulating:
             pass
         else:
+            # TODO (ben 20171117): modify all axes to dwell at low current
             moving_plunger = ('B' in command or 'C' in command) \
                 and (GCODES['MOVE'] in command or GCODES['HOME'] in command)
 
             if moving_plunger:
-                self.set_current('BC', PLUNGER_CURRENT_HIGH)
+                self.set_power({axis: PLUNGER_CURRENT_HIGH
+                                for axis in 'BC'})
 
             command_line = command + ' M400'
             ret_code = serial_communication.write_and_return(
                 command_line, self._connection, timeout)
 
             if moving_plunger:
-                self.set_current('BC', PLUNGER_CURRENT_LOW)
+                self.set_power({axis: PLUNGER_CURRENT_LOW
+                                for axis in 'BC'})
 
             return ret_code
 
@@ -195,7 +216,7 @@ class SmoothieDriver_3_0_0:
     # ----------- END Private functions ----------- #
 
     # ----------- Public interface ---------------- #
-    def move(self, target):
+    def move(self, target, low_power_z=False):
         from numpy import isclose
 
         self.run_flag.wait()
@@ -211,10 +232,23 @@ class SmoothieDriver_3_0_0:
                   for axis, coords in target.items()
                   if valid_movement(coords, axis)]
 
+        low_power_axes = [axis
+                          for axis, _ in target.items()
+                          if axis in 'ZA']
+        prior_power = copy(self._power_settings)
+
+        if low_power_z:
+            new_power = {axis: 0.1
+                         for axis in low_power_axes}
+            self.set_power(new_power)
+
         if coords:
             command = GCODES['MOVE'] + ''.join(coords)
             self._send_command(command)
             self._update_position(target)
+
+        if low_power_z:
+            self.set_power(prior_power)
 
     def home(self, axis=AXES, disabled=DISABLE_AXES):
 

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -24,7 +24,7 @@ class Mover:
 
         return self.move(pose_tree, **target)
 
-    def move(self, pose_tree, x=None, y=None, z=None):
+    def move(self, pose_tree, x=None, y=None, z=None, low_power_z=False):
         """
         Dispatch move command to the driver changing base of
         x, y and z from source coordinate system to destination.
@@ -57,7 +57,7 @@ class Mover:
             assert z is not None, "Value must be set for each axis mapped"
             driver_target[self._axis_mapping['z']] = dst_z
 
-        self._driver.move(target=driver_target)
+        self._driver.move(driver_target, low_power_z)
 
         # Update pose with the new value. Since stepper motors are open loop
         # there is no need to to query diver for position

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -11,8 +11,24 @@ import os
 
 PLUNGER_CURRENT_LOW = 0.1
 PLUNGER_CURRENT_HIGH = 0.5
+MOUNT_CURRENT_LOW = 0.1
+MOUNT_CURRENT_HIGH = 0.8
+X_CURRENT_HIGH = 1.2
+Y_CURRENT_HIGH = 1.5
 
-current_robot  = os.environ.get('OT_ROBOT_CONFIG', 'B2-5')
+DEFAULT_POWER = {
+    'X': X_CURRENT_HIGH,
+    'Y': Y_CURRENT_HIGH,
+    'Z': MOUNT_CURRENT_HIGH,
+    'A': MOUNT_CURRENT_HIGH,
+    'B': PLUNGER_CURRENT_LOW,
+    'C': PLUNGER_CURRENT_LOW
+}
+
+DEFAULT_POWER_STRING = ' '.join(
+    ['{}{}'.format(key, value) for key, value in DEFAULT_POWER.items()])
+
+current_robot = os.environ.get('OT_ROBOT_CONFIG', 'B2-5')
 
 robot_config = namedtuple(
     'robot_config',
@@ -36,7 +52,7 @@ Ibn = robot_config(
     steps_per_mm='M92 X160 Y160 Z800 A800 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
+    current='M907 ' + DEFAULT_POWER_STRING,
     deck_offset=(-27, -14.5, 0),
     probe_center={'z': 68.0, 'x': 268.4, 'y': 291.8181},
     probe_dimensions={'length': 47.74, 'width': 38, 'height': 63},
@@ -50,7 +66,7 @@ Amedeo = robot_config(
     steps_per_mm='M92 X80 Y80 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B0.25 C0.25',
+    current='M907 ' + DEFAULT_POWER_STRING,
     gantry_calibration=[
         [  1.00283019e+00,  -4.83425414e-03,   0.00000000e+00, -3.52323132e+01],
         [ -1.13207547e-02,   9.97237569e-01,   0.00000000e+00, -1.81761811e+00],
@@ -70,7 +86,7 @@ Ada = robot_config(
     steps_per_mm='M92 X80 Y80 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
+    current='M907 ' + DEFAULT_POWER_STRING,
     deck_offset=(-31.45, -20.1, 0),
     probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
     probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
@@ -84,7 +100,7 @@ Rosalind = robot_config(
     steps_per_mm='M92 X80.0254 Y80.16 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
+    current='M907 ' + DEFAULT_POWER_STRING,
     deck_offset=None,
     probe_center=(287, 295, 55.0),
     # X, Y and Z measurement of imaginary bounding box surrounding the probe
@@ -104,7 +120,7 @@ Korolev = robot_config(
     steps_per_mm='M92 X80.0 Y80.0 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 X1.2 Y1.5 Z0.8 A0.8 B{0} C{0}'.format(PLUNGER_CURRENT_LOW),
+    current='M907 ' + DEFAULT_POWER_STRING,
     deck_offset=None,
     probe_center=(287, 295, 55.0),
     # X, Y and Z measurement of imaginary bounding box surrounding the probe

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -56,7 +56,8 @@ async def test_pick_up_tip(main_router, model):
             model.instrument,
             model.container)
 
-        pick_up_tip.assert_called_with(model.container._container[0])
+        pick_up_tip.assert_called_with(
+            model.container._container[0], low_power_z=True)
 
         await main_router.wait_until(state('moving'))
         await main_router.wait_until(state('ready'))

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -544,9 +544,9 @@ class PipetteTest(unittest.TestCase):
             self.plate['A2'],
             new_tip='never'
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Consolidating', '30'],
             ['Transferring', '30'],
@@ -625,9 +625,9 @@ class PipetteTest(unittest.TestCase):
             blow_out=True,
             trash=True
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['Transferring', '30'],
             ['pick'],
@@ -1278,44 +1278,74 @@ class PipetteTest(unittest.TestCase):
         self.p200.touch_tip(self.plate[1], radius=0.5)
 
         expected = [
-            mock.call(self.plate[0], instrument=self.p200, strategy='arc'),
+            mock.call(self.plate[0],
+                      instrument=self.p200,
+                      low_power_z=False,
+                      strategy='arc'),
             mock.call(
                 (self.plate[0], (6.40, 3.20, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (0.00, 3.20, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 6.40, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 0.00, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (6.40, 3.20, 7.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (0.00, 3.20, 7.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 6.40, 7.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 0.00, 7.50)),
-                instrument=self.p200, strategy='direct'),
-            mock.call(self.plate[1], instrument=self.p200, strategy='arc'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
+            mock.call(self.plate[1],
+                      instrument=self.p200,
+                      low_power_z=False,
+                      strategy='arc'),
             mock.call(
                 (self.plate[1], (4.80, 3.20, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[1], (1.60, 3.20, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[1], (3.20, 4.80, 10.50)),
-                instrument=self.p200, strategy='direct'),
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct'),
             mock.call(
                 (self.plate[1], (3.20, 1.60, 10.50)),
-                instrument=self.p200, strategy='direct')
+                instrument=self.p200,
+                low_power_z=False,
+                strategy='direct')
         ]
 
         self.assertEquals(expected, self.p200.robot.move_to.mock_calls)
@@ -1464,6 +1494,11 @@ class PipetteTest(unittest.TestCase):
         for i in range(0, total_tips_per_plate):
             expected.extend(self.build_move_to_bottom(self.tiprack2[i]))
 
+        # from pprint import pprint
+        # print('Mock calls')
+        # pprint(self.p200.move_to.mock_calls)
+        # print('Expected')
+        # pprint(expected)
         self.assertEqual(
             self.p200.move_to.mock_calls,
             expected
@@ -1501,6 +1536,10 @@ class PipetteTest(unittest.TestCase):
         for i in range(0, 12):
             expected.extend(self.build_move_to_bottom(self.tiprack2.rows[i]))
 
+        # print('Mock calls')
+        # pprint(p200_multi.move_to.mock_calls)
+        # print('Expected')
+        # pprint(expected)
         self.assertEqual(
             p200_multi.move_to.mock_calls,
             expected
@@ -1529,11 +1568,12 @@ class PipetteTest(unittest.TestCase):
 
     def build_move_to_bottom(self, well):
         plunge = -7
-        return [mock.call(well.top(), strategy='arc')] + \
-            [
-                mock.call(well.top(plunge * (i % 2)),
-                          strategy='direct')
-                for i in range(1, 5)
+        return [
+            mock.call(well.top(), strategy='arc'),
+            mock.call(well.top(plunge), strategy='direct'),
+            mock.call(well.top(), low_power_z=False, strategy='direct'),
+            mock.call(well.top(plunge), strategy='direct'),
+            mock.call(well.top(), low_power_z=False, strategy='direct')
         ]
 
     def test_drop_tip_to_trash(self):
@@ -1543,10 +1583,10 @@ class PipetteTest(unittest.TestCase):
         self.p200.drop_tip()
 
         assert self.p200.move_to.mock_calls[0] == \
-            mock.call(self.tiprack1[0].top(), strategy='arc')
+            mock.call(self.tiprack1[0].top(),
+                      strategy='arc')
 
         assert self.p200.move_to.mock_calls[-1] == \
             mock.call(
                 self.trash[0].top(self.p200._drop_tip_offset),
-                strategy='arc'
-            )
+                strategy='arc')

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -5,18 +5,12 @@ from opentrons.trackers.pose_tracker import (
 from opentrons.instruments import Pipette
 from opentrons.robot.mover import Mover
 from numpy import array, isclose
+from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import SmoothieDriver_3_0_0  # NOQA
 
 
 @pytest.fixture
 def driver():
-    class Driver:
-        def move(self, target):
-            pass
-
-        def home(self, axis):
-            pass
-
-    return Driver()
+    return SmoothieDriver_3_0_0()
 
 
 def test_functional(driver):


### PR DESCRIPTION
## overview

Add a parameter to allow for low power movement in vertical axes, to enable requested workflow changes that prevent damaging pipette during tiprack calibration

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [x] Backwards-compatible feature additions
- [ ] Breaking changes
- [x] Documentation updates
- [x] Test updates

## changelog

- Add parameter to all levels of move commands to enable low power operation of vertical axes
- Fix test mocks to work with new signatures
- Update documentation with new parameters
- Add tests to ensure that low power mode is honored
- Place relevant power configuration parameters into robot_config
- Track last known power settings in driver so they can be restored after commands that request low power
- Remove unused parameter in `_create_arc`