### PR TITLE
Config management with persistence

### DIFF
--- a/api/opentrons/config/__init__.py
+++ b/api/opentrons/config/__init__.py
@@ -1,0 +1,3 @@
+from .config import merge, children, build
+
+__all__ = [merge, children, build]

--- a/api/opentrons/config/config.py
+++ b/api/opentrons/config/config.py
@@ -1,0 +1,34 @@
+def children(value, path=None):
+    path = path or []
+
+    return sum([
+        children(value=value, path=path+[key])
+        for key, value in value.items()
+    ], []) if isinstance(value, dict) and value else [
+        (tuple(path), value)
+    ]
+
+
+def build(pairs):
+    tree = {}
+
+    def append(tree, path, value):
+        if not path:
+            return
+
+        key, *tail = path
+
+        if tail:
+            tree[key] = tree.get(key, {})
+            append(tree[key], tail, value)
+        else:
+            tree[key] = value
+
+    for path, value in pairs:
+        append(tree, path, value)
+
+    return tree
+
+
+def merge(trees):
+    return build(sum([children(tree) for tree in trees], []))

--- a/api/opentrons/config/config.py
+++ b/api/opentrons/config/config.py
@@ -1,4 +1,11 @@
-def children(value, path=None):
+from typing import List, Tuple
+
+
+def children(value, path=None) -> List[Tuple[tuple, object]]:
+    """
+    Returns list of tuples containing the full path to the value
+    and the value itself
+    """
     path = path or []
 
     return sum([
@@ -9,7 +16,11 @@ def children(value, path=None):
     ]
 
 
-def build(pairs):
+def build(pairs: List[Tuple[tuple, object]]) -> dict:
+    """
+    Builds a tree out of key-value pairs consisting of full
+    path to the value and the value itself
+    """
     tree = {}
 
     def append(tree, path, value):
@@ -30,5 +41,9 @@ def build(pairs):
     return tree
 
 
-def merge(trees):
+def merge(trees: List[dict]) -> dict:
+    """
+    Merges trees observing the order,
+    adding new elements and overriding existing ones
+    """
     return build(sum([children(tree) for tree in trees], []))

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
@@ -1,18 +1,14 @@
 import serial
 from serial.tools import list_ports
-from opentrons.robot.robot_configs import config
 import contextlib
 
 DRIVER_ACK = b'ok\r\nok\r\n'
 RECOVERY_TIMEOUT = 10
 DEFAULT_SERIAL_TIMEOUT = 5
 DEFAULT_WRITE_TIMEOUT = 30
-SMOOTHIE_BOARD_NAME = 'FT232R'
 
 ERROR_KEYWORD = b'error'
 ALARM_KEYWORD = b'ALARM'
-
-BAUDRATE = config.serial_speed
 
 
 def get_ports(device_name):
@@ -95,11 +91,11 @@ def write_and_return(
     return response
 
 
-def connect(device_name=SMOOTHIE_BOARD_NAME):
+def connect(device_name, baudrate):
     '''
     Creates a serial connection
     :param device_name: defaults to 'Smoothieboard'
     :return: serial.Serial connection
     '''
     smoothie_port = get_ports(device_name=device_name)[0]
-    return _connect(port_name=smoothie_port, baudrate=BAUDRATE)
+    return _connect(port_name=smoothie_port, baudrate=baudrate)

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -809,7 +809,9 @@ class Pipette:
                     self.current_tip().top(0),
                     strategy='direct',
                     low_power_z=low_power_z)
-            self._add_tip()
+            self._add_tip(
+                length=self.robot.config.tip_length[self.mount][self.type]
+            )
             self.robot.poses = self.instrument_mover.home(self.robot.poses)
             return self
 
@@ -883,7 +885,9 @@ class Pipette:
 
             self.current_volume = 0
             self.current_tip(None)
-            self._remove_tip()
+            self._remove_tip(
+                length=self.robot.config.tip_length[self.mount][self.type]
+            )
             return self
         return _drop_tip(location)
 
@@ -1473,28 +1477,24 @@ class Pipette:
             value = self.instrument_mover.probe(axis, movement)
         return value
 
-    def _add_tip(self):
+    def _add_tip(self, length):
         x, y, z = pose_tracker.change_base(
             self.robot.poses,
             src=self,
             dst=self.mount)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
-                x, y, z - self.tip_length))
+                x, y, z - length))
 
-    def _remove_tip(self):
+    def _remove_tip(self, length):
         x, y, z = pose_tracker.change_base(
             self.robot.poses,
             src=self,
             dst=self.mount)
         self.robot.poses = pose_tracker.update(
             self.robot.poses, self, pose_tracker.Point(
-                x, y, z + self.tip_length))
+                x, y, z + length))
 
     @property
     def type(self):
         return 'single' if self.channels == 1 else 'multi'
-
-    @property
-    def tip_length(self):
-        return self.robot.config.tip_length[self.mount][self.type]

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -5,7 +5,6 @@ from numpy import add, subtract
 from opentrons import commands, containers, drivers, helpers
 from opentrons.drivers.smoothie_drivers.v3_0_0 import driver_3_0
 from opentrons.robot.mover import Mover
-from opentrons.robot.robot_configs import config
 from opentrons.containers import Container
 from opentrons.util.log import get_logger
 from opentrons.trackers import pose_tracker
@@ -13,16 +12,11 @@ from opentrons.data_storage import database
 from opentrons.broker import subscribe
 import opentrons.util.calibration_functions as calib
 
+from .robot_configs import load
+
 log = get_logger(__name__)
 
 TIP_CLEARANCE = 42
-
-CALIBRATION = config.gantry_calibration
-
-MOUNT_OFFSETS = {
-    'right': pose_tracker.Point(0.0, 0.0, 0.0),
-    'left': pose_tracker.Point(*config.instrument_offset)
-}
 
 
 class InstrumentMosfet(object):
@@ -152,7 +146,7 @@ class Robot(object):
     ['Aspirating 200 uL from <Well A1> at 1.0 speed']
     """
 
-    def __init__(self):
+    def __init__(self, config=None):
         """
         Initializes a robot instance.
 
@@ -162,14 +156,15 @@ class Robot(object):
         :func:`__init__` the same instance will be returned. There's
         only once instance of a robot.
         """
-        self._driver = driver_3_0.SmoothieDriver_3_0_0()
+        self.config = config or load()
+        self._driver = driver_3_0.SmoothieDriver_3_0_0(config=self.config)
 
         self._actuators = {
             'left': {
                 'carriage': Mover(
                     driver=self._driver,
                     src=pose_tracker.ROOT,
-                    dst=id(CALIBRATION),
+                    dst=id(self.config.gantry_calibration),
                     axis_mapping={'z': 'Z'}),
                 'plunger': Mover(
                     driver=self._driver,
@@ -181,7 +176,7 @@ class Robot(object):
                 'carriage': Mover(
                     driver=self._driver,
                     src=pose_tracker.ROOT,
-                    dst=id(CALIBRATION),
+                    dst=id(self.config.gantry_calibration),
                     axis_mapping={'z': 'A'}),
                 'plunger': Mover(
                     driver=self._driver,
@@ -229,7 +224,7 @@ class Robot(object):
         self._unsubscribe_commands = None
         self.reset()
 
-    def reset(self, calibration=CALIBRATION):
+    def reset(self):
         """
         Resets the state of the robot and clears:
             * Deck
@@ -269,16 +264,18 @@ class Robot(object):
             driver=driver,
             axis_mapping={'x': 'X', 'y': 'Y'},
             src=pose_tracker.ROOT,
-            dst=id(CALIBRATION)
+            dst=id(self.config.gantry_calibration)
         )
 
         # Extract only transformation component
         inverse_transform = pose_tracker.inverse(
-            pose_tracker.extract_transform(CALIBRATION))
+            pose_tracker.extract_transform(self.config.gantry_calibration))
 
         self.poses = pose_tracker.bind(self.poses) \
-            .add(obj=id(CALIBRATION), transform=CALIBRATION) \
-            .add(obj=self.gantry, parent=id(CALIBRATION)) \
+            .add(
+                obj=id(self.config.gantry_calibration),
+                transform=self.config.gantry_calibration) \
+            .add(obj=self.gantry, parent=id(self.config.gantry_calibration)) \
             .add(obj=left_carriage, parent=self.gantry) \
             .add(obj=right_carriage, parent=self.gantry) \
             .add(
@@ -329,7 +326,7 @@ class Robot(object):
             self.poses,
             instrument,
             parent=mount,
-            point=MOUNT_OFFSETS[mount]
+            point=self.config.instrument_offsets['left'][instrument.type]
         )
 
     def add_warning(self, warning_msg):

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -12,7 +12,7 @@ from opentrons.data_storage import database
 from opentrons.broker import subscribe
 import opentrons.util.calibration_functions as calib
 
-from .robot_configs import load
+from opentrons.robot.robot_configs import load
 
 log = get_logger(__name__)
 
@@ -326,7 +326,7 @@ class Robot(object):
             self.poses,
             instrument,
             parent=mount,
-            point=self.config.instrument_offsets['left'][instrument.type]
+            point=self.config.instrument_offsets[mount][instrument.type]
         )
 
     def add_warning(self, warning_msg):

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -2,12 +2,16 @@
 # So...
 # pylama:skip=1
 
-# TODO: jmg 11/2 This file is meant to be a temporary
-# fix to make development easier and should be removed
-# once this configuration information is part of persistent robot data
-
 from collections import namedtuple
+from opentrons.util import environment
+from opentrons.config import merge, children, build
+
+import json
 import os
+import logging
+
+log = logging.getLogger(__name__)
+
 
 PLUNGER_CURRENT_LOW = 0.1
 PLUNGER_CURRENT_HIGH = 0.5
@@ -28,8 +32,6 @@ DEFAULT_POWER = {
 DEFAULT_POWER_STRING = ' '.join(
     ['{}{}'.format(key, value) for key, value in DEFAULT_POWER.items()])
 
-current_robot = os.environ.get('OT_ROBOT_CONFIG', 'B2-5')
-
 robot_config = namedtuple(
     'robot_config',
     [
@@ -38,110 +40,84 @@ robot_config = namedtuple(
         'max_speeds',
         'acceleration',
         'current',
-        'deck_offset',
         'gantry_calibration',
-        'instrument_offset',
+        'instrument_offsets',
         'probe_center',
         'probe_dimensions',
-        'serial_speed'
+        'serial_speed',
+        'plunger_current_low',
+        'plunger_current_high',
+        'tip_length',
+        'default_power'
     ]
 )
 
-Ibn = robot_config(
-    name='Ibn al-Nafis',
-    steps_per_mm='M92 X160 Y160 Z800 A800 B768 C768',
-    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 ' + DEFAULT_POWER_STRING,
-    deck_offset=(-27, -14.5, 0),
-    probe_center={'z': 68.0, 'x': 268.4, 'y': 291.8181},
-    probe_dimensions={'length': 47.74, 'width': 38, 'height': 63},
-    gantry_calibration=None,
-    instrument_offset=None,
-    serial_speed=14400
-)
 
-Amedeo = robot_config(
-    name='Amedeo Avogadro',
-    steps_per_mm='M92 X80 Y80 Z400 A400 B768 C768',
-    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S1000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 ' + DEFAULT_POWER_STRING,
-    gantry_calibration=[
-        [  1.00283019e+00,  -4.83425414e-03,   0.00000000e+00, -3.52323132e+01],
-        [ -1.13207547e-02,   9.97237569e-01,   0.00000000e+00, -1.81761811e+00],
-        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,  4.50000000e+00],
-        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,  1.00000000e+00]],
-    probe_center=(289, 295, 55.0),
-    instrument_offset=(-37.99669417,  30.15314473,  -0.25),  # left to right
-    # X, Y and Z measurement of imaginary bounding box surrounding the probe
-    # giving safe distance to position for probing
-    probe_dimensions=(60.0, 60.0, 60.0),
-    deck_offset=None,
-    serial_speed=14400
-)
-
-Ada = robot_config(
+default = robot_config(
     name='Ada Lovelace',
-    steps_per_mm='M92 X80 Y80 Z400 A400 B768 C768',
+    steps_per_mm='M92 X80.00 Y80.00 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
     acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
     current='M907 ' + DEFAULT_POWER_STRING,
-    deck_offset=(-31.45, -20.1, 0),
-    probe_center={'z': 57.81, 'x': 259.8, 'y': 298.875},
-    probe_dimensions={'length': 41, 'width': 38.7, 'height': 67.81},
-    gantry_calibration=None,
-    instrument_offset=None,
-    serial_speed=14400
-)
-
-Rosalind = robot_config(
-    name='Rosalind Franklin',
-    steps_per_mm='M92 X80.0254 Y80.16 Z400 A400 B768 C768',
-    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 ' + DEFAULT_POWER_STRING,
-    deck_offset=None,
     probe_center=(287, 295, 55.0),
-    # X, Y and Z measurement of imaginary bounding box surrounding the probe
-    # giving safe distance to position for probing
     probe_dimensions=(60.0, 60.0, 60.0),
     gantry_calibration=[
-        [  1.00000000e+00,   2.48619898e-17,   0.00000000e+00,  -3.02300000e+01],
-        [  3.77358491e-04,   9.97928177e-01,   0.00000000e+00,  -5.28188575e+00],
-        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,   4.50000000e+00],
-        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,   1.00000000e+00]],
-    instrument_offset=(-37.43826124,  31.44202338,  -0.5),  # left to right
-    serial_speed=14400
+        [ 1.00, 0.00, 0.00, -35.23],
+        [ 0.00, 1.00, 0.00,  -1.81],
+        [ 0.00, 0.00, 1.00,   0.00],
+        [ 0.00, 0.00, 0.00,   1.00]
+    ],
+    # left relative to right
+    instrument_offsets={
+        'right': {
+            'single': (0.0, 0.0, 0.0),
+            'multi': (0.0, 31.5, -0.5)
+        },
+        'left': {
+            'multi': (-37.5,  31.5,  -0.5),
+            'single': (-37.5, 0.0, 0.0)
+        }
+    },
+    tip_length={
+        'left': {
+            'single': 51.5,
+            'multi': 51.5
+        },
+        'right': {
+            'single': 51.5,
+            'multi': 51.5
+        }
+    },
+    serial_speed=115200,
+    default_power=DEFAULT_POWER,
+    plunger_current_low=PLUNGER_CURRENT_LOW,
+    plunger_current_high=PLUNGER_CURRENT_HIGH
 )
 
-Korolev = robot_config(
-    name='Sergei Korolev',
-    steps_per_mm='M92 X80.0 Y80.0 Z400 A400 B768 C768',
-    max_speeds='M203.1 X300 Y200 Z50 A50 B8 C8',
-    acceleration='M204 S10000 X4000 Y3000 Z2000 A2000 B3000 C3000',
-    current='M907 ' + DEFAULT_POWER_STRING,
-    deck_offset=None,
-    probe_center=(287, 295, 55.0),
-    # X, Y and Z measurement of imaginary bounding box surrounding the probe
-    # giving safe distance to position for probing
-    probe_dimensions=(60.0, 60.0, 60.0),
-    gantry_calibration=[
-        [  1.00000000e+00,   2.48619898e-17,   0.00000000e+00,  -3.02300000e+01],
-        [  3.77358491e-04,   9.97928177e-01,   0.00000000e+00,  -5.28188575e+00],
-        [  0.00000000e+00,   0.00000000e+00,   1.00000000e+00,   4.50000000e+00],
-        [ -5.03305613e-19,   2.60208521e-18,   0.00000000e+00,   1.00000000e+00]],
-    instrument_offset=(-37.43826124,  31.44202338,  -0.5),  # left to right
-    serial_speed=115200
-)
 
-robots = {
-    'B1': Ibn,
-    'B2-1': Korolev,
-    'B2-4': Amedeo,
-    'B2-6': Ada,
-    'B2-5': Rosalind
-}
+def load(filename=None):
+    filename = filename or environment.get_path('OT_CONFIG_FILE')
+    config = default
+
+    try:
+        with open(filename, 'r') as file:
+            local = json.load(file)
+            return robot_config(**merge([default._asdict(), local]))
+    except FileNotFoundError as e:
+        log.info('Config {0} not found. Loading defaults'.format(filename))
+        return default
 
 
-config = robots[current_robot]
+def save(config, filename=None):
+    filename = filename or environment.get_path('OT_CONFIG_FILE')
+    default_dict = dict(children(default._asdict()))
+
+    diff = build([
+        (key, value)
+        for key, value in children(config._asdict())
+        if default_dict[key] != value
+    ])
+
+    with open(filename, 'w') as file:
+        json.dump(diff, file, sort_keys=True, indent=4)
+        return diff

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -97,15 +97,16 @@ default = robot_config(
 
 def load(filename=None):
     filename = filename or environment.get_path('OT_CONFIG_FILE')
-    config = default
+    result = default
 
     try:
         with open(filename, 'r') as file:
             local = json.load(file)
-            return robot_config(**merge([default._asdict(), local]))
+            result = robot_config(**merge([default._asdict(), local]))
     except FileNotFoundError as e:
         log.info('Config {0} not found. Loading defaults'.format(filename))
-        return default
+
+    return result
 
 
 def save(config, filename=None):

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -110,12 +110,11 @@ def load(filename=None):
 
 def save(config, filename=None):
     filename = filename or environment.get_path('OT_CONFIG_FILE')
-    default_dict = dict(children(default._asdict()))
+    _default = children(default._asdict())
 
     diff = build([
-        (key, value)
-        for key, value in children(config._asdict())
-        if default_dict[key] != value
+        item for item in children(config._asdict())
+        if item not in _default
     ])
 
     with open(filename, 'w') as file:

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -71,7 +71,9 @@ def probe_instrument(instrument, robot):
     ]
 
     coords = [switch[:-1] * probe_size / 2.0 + center for switch in switches]
-    instrument._add_tip()
+    tip_length = robot.config.tip_length[instrument.mount][instrument.type]
+
+    instrument._add_tip(tip_length)
 
     values = {'x': [], 'y': [], 'z': []}
 
@@ -101,17 +103,18 @@ def probe_instrument(instrument, robot):
             x=(x + sx * 5),
             y=(y + sy * 5))
 
-    instrument._remove_tip()
+    instrument._remove_tip(tip_length)
     robot.home()
 
 
 def move_instrument_for_probing_prep(instrument, robot):
+    tip_length = robot.config.tip_length[instrument.mount][instrument.type]
     # TODO(artyom, ben 20171026): calculate from robot dimensions
     robot.poses = instrument._move(
         robot.poses,
         x=191.5,
         y=75.0,
-        z=128 + instrument.tip_length
+        z=128 + tip_length
     )
 
 

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -2,17 +2,11 @@ from numpy import array
 from opentrons.trackers.pose_tracker import (
     update, Point, change_base
 )
-from opentrons.instruments.pipette import DEFAULT_TIP_LENGTH
 from opentrons.data_storage import database
-from ..robot.robot_configs import config
 
 
 # maximum distance to move during calibration attempt
 PROBE_TRAVEL_DISTANCE = 30
-# size along X, Y and Z
-PROBE_SIZE = array(config.probe_dimensions)
-# coordinates of the top of the probe
-PROBE_TOP_COORDINATES = array(config.probe_center)
 
 
 def calibrate_container_with_delta(
@@ -41,9 +35,15 @@ def calibrate_pipette(probing_values, probe):
 def probe_instrument(instrument, robot):
     robot.home()
 
-    *_, height = PROBE_SIZE
+    # size along X, Y and Z
+    probe_size = array(robot.config.probe_dimensions)
 
-    center = PROBE_TOP_COORDINATES * (1, 1, 0) + (0, 0, height / 2.0)
+    # coordinates of the top of the probe
+    probe_top_coordinates = array(robot.config.probe_center)
+
+    *_, height = probe_size
+
+    center = probe_top_coordinates * (1, 1, 0) + (0, 0, height / 2.0)
 
     #       Y ^
     #         * 1
@@ -70,8 +70,8 @@ def probe_instrument(instrument, robot):
         (0,  0,    1, -1),
     ]
 
-    coords = [switch[:-1] * PROBE_SIZE / 2.0 + center for switch in switches]
-    instrument._add_tip(DEFAULT_TIP_LENGTH)
+    coords = [switch[:-1] * probe_size / 2.0 + center for switch in switches]
+    instrument._add_tip()
 
     values = {'x': [], 'y': [], 'z': []}
 
@@ -101,7 +101,7 @@ def probe_instrument(instrument, robot):
             x=(x + sx * 5),
             y=(y + sy * 5))
 
-    instrument._remove_tip(DEFAULT_TIP_LENGTH)
+    instrument._remove_tip()
     robot.home()
 
 
@@ -111,7 +111,7 @@ def move_instrument_for_probing_prep(instrument, robot):
         robot.poses,
         x=191.5,
         y=75.0,
-        z=128 + DEFAULT_TIP_LENGTH
+        z=128 + instrument.tip_length
     )
 
 

--- a/api/opentrons/util/environment.py
+++ b/api/opentrons/util/environment.py
@@ -47,6 +47,7 @@ def refresh():
 
     settings.update({
         'APP_DATA_DIR': APP_DATA_DIR,
+        'OT_CONFIG_FILE': os.path.join(APP_DATA_DIR, 'config.json'),
         'LOG_DIR': os.path.join(APP_DATA_DIR, 'logs'),
         'LOG_FILE': os.path.join(APP_DATA_DIR, 'logs', 'api.log'),
         'CONTAINERS_DIR': os.path.join(APP_DATA_DIR, 'containers'),

--- a/api/tests/opentrons/config/test_config.py
+++ b/api/tests/opentrons/config/test_config.py
@@ -1,0 +1,70 @@
+from opentrons.config import merge, children, build
+
+
+def test_merge():
+    dict1 = {
+        'a': {
+            'b': 1,
+        },
+        'c': 2
+    }
+
+    dict2 = {
+        'a': {
+            'b': 10,
+            'c': 20
+        },
+        'd': 30
+    }
+
+    assert merge([dict1, dict2]) == {
+        'a': {
+            'b': 10,
+            'c': 20
+        },
+        'c': 2,
+        'd': 30
+    }
+
+
+def test_children():
+    tree = {
+        'a': {
+            'b': 1,
+            'c': {
+                'e': 2
+            },
+            'f': 3
+        },
+        'g': {
+            'h': 1,
+            'i': None
+        }
+    }
+
+    expected = [
+        (('a', 'b'), 1),
+        (('a', 'c', 'e'), 2),
+        (('a', 'f'), 3),
+        (('g', 'h'), 1),
+        (('g', 'i'), None),
+    ]
+    result = children(tree)
+
+    assert len(expected) == len(result)
+    assert set(children(tree)) == set(expected)
+
+    assert tree == build(expected)
+    assert build(expected + [(('g', 'h'), 10), (('a', 'c', 'e'), 20)]) == {
+        'a': {
+            'b': 1,
+            'c': {
+                'e': 20
+            },
+            'f': 3
+        },
+        'g': {
+            'h': 10,
+            'i': None
+        }
+    }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -246,4 +246,18 @@ def model(robot):
         )
 
 
+@pytest.fixture
+def smoothie(monkeypatch):
+    from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import \
+         SmoothieDriver_3_0_0 as SmoothieDriver
+    from opentrons.robot import robot_configs
+
+    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
+    driver = SmoothieDriver(robot_configs.load())
+    driver.connect()
+    yield driver
+    driver.disconnect()
+    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+
+
 setup_testing_env()

--- a/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
@@ -1,31 +1,19 @@
 import pytest
 
 from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import (
-    AXES, HOMED_POSITION, SmoothieDriver_3_0_0
+    AXES, HOMED_POSITION
 )
 
 POSITION_ON_BOOT = {axis: 0 for axis in AXES}
 
 
-@pytest.fixture
-def driver():
-    return SmoothieDriver_3_0_0()
+def test_driver_init(smoothie):
+    assert smoothie.position == POSITION_ON_BOOT
 
 
-@pytest.fixture
-def homed_driver():
-    driver = SmoothieDriver_3_0_0()
-    driver.home()
-    return driver
-
-
-def test_driver_init(driver):
-    assert driver.position == POSITION_ON_BOOT
-
-
-def test_home(driver):
-    driver.home()
-    assert driver.position == HOMED_POSITION
+def test_home(smoothie):
+    smoothie.home()
+    assert smoothie.position == HOMED_POSITION
 
 
 @pytest.mark.parametrize("target_movement, expected_new_position", [
@@ -42,6 +30,7 @@ def test_home(driver):
         {'X': 394, 'Y': 344, 'Z': 10, 'A': 227, 'B': 21, 'C': 1}
     )
 ])
-def test_move(target_movement, expected_new_position, homed_driver):
-    homed_driver.move(target_movement)
-    assert homed_driver.position == expected_new_position
+def test_move(target_movement, expected_new_position, smoothie):
+    smoothie.home()
+    smoothie.move(target_movement)
+    assert smoothie.position == expected_new_position

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -1,19 +1,5 @@
-import pytest
 from tests.opentrons.conftest import fuzzy_assert
 from threading import Thread
-
-
-@pytest.fixture
-def smoothie(monkeypatch):
-    from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import \
-         SmoothieDriver_3_0_0 as SmoothieDriver
-
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
-    driver = SmoothieDriver()
-    driver.connect()
-    yield driver
-    driver.disconnect()
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
 
 
 def position(x, y, z, a, b, c):
@@ -95,7 +81,6 @@ def test_low_power_z(model):
     from opentrons.robot.robot_configs import DEFAULT_POWER
     import types
     driver = model.robot._driver
-    smoothie.simulating = False
 
     set_power = driver.set_power
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -318,7 +318,6 @@ class PipetteTest(unittest.TestCase):
         This deals with z accrual behavior during tip add/remove, when +/- get
         flipped in pose tracking logic
         """
-        tip_length = 50
         prior_position = pose_tracker.absolute(self.robot.poses, self.p200)
         self.p200._add_tip()
         self.p200._remove_tip()

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -52,7 +52,7 @@ def test_aspirate_move_to(robot):
     assert (current_pos == (9.5, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p200)
-    assert isclose(current_pos, (175.34,  127.94,   10)).all()
+    assert isclose(current_pos, (175.34,  127.94,   10.5)).all()
 
 
 def test_blow_out_move_to(robot):
@@ -320,8 +320,8 @@ class PipetteTest(unittest.TestCase):
         """
         tip_length = 50
         prior_position = pose_tracker.absolute(self.robot.poses, self.p200)
-        self.p200._add_tip(tip_length)
-        self.p200._remove_tip(tip_length)
+        self.p200._add_tip()
+        self.p200._remove_tip()
         new_position = pose_tracker.absolute(self.robot.poses, self.p200)
 
         assert (new_position == prior_position).all()

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -319,8 +319,8 @@ class PipetteTest(unittest.TestCase):
         flipped in pose tracking logic
         """
         prior_position = pose_tracker.absolute(self.robot.poses, self.p200)
-        self.p200._add_tip()
-        self.p200._remove_tip()
+        self.p200._add_tip(42)
+        self.p200._remove_tip(42)
         new_position = pose_tracker.absolute(self.robot.poses, self.p200)
 
         assert (new_position == prior_position).all()

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,4 +1,3 @@
-import pytest
 from opentrons.trackers.pose_tracker import (
     change_base, init, ROOT
 )

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -8,12 +8,7 @@ from numpy import array, isclose
 from opentrons.drivers.smoothie_drivers.v3_0_0.driver_3_0 import SmoothieDriver_3_0_0  # NOQA
 
 
-@pytest.fixture
-def driver():
-    return SmoothieDriver_3_0_0()
-
-
-def test_functional(driver):
+def test_functional(smoothie):
     scale = array([
         [2, 0, 0, -1],
         [0, 2, 0, -2],
@@ -29,17 +24,17 @@ def test_functional(driver):
     ])
 
     left = Mover(
-        driver=driver,
+        driver=smoothie,
         axis_mapping={'z': 'Z'},
         src=ROOT,
         dst=id(scale))
     right = Mover(
-        driver=driver,
+        driver=smoothie,
         axis_mapping={'z': 'A'},
         src=ROOT,
         dst=id(scale))
     gantry = Mover(
-        driver=driver,
+        driver=smoothie,
         axis_mapping={'x': 'X', 'y': 'Y'},
         src=ROOT,
         dst=id(scale),

--- a/api/tests/opentrons/robot/test_robots_config.py
+++ b/api/tests/opentrons/robot/test_robots_config.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+@pytest.fixture
+def config(monkeypatch, tmpdir):
+    from collections import namedtuple
+    from opentrons.robot import robot_configs
+    from opentrons.util import environment
+
+    monkeypatch.setenv('APP_DATA_DIR', str(tmpdir))
+    environment.refresh()
+
+    test_config = namedtuple('test_config', 'key1, key2')
+
+    monkeypatch.setattr(
+        robot_configs,
+        'robot_config',
+        test_config
+    )
+
+    monkeypatch.setattr(
+        robot_configs,
+        'default',
+        test_config(key1='value1', key2='value2')
+    )
+
+    return robot_configs
+
+
+def test_config(config, tmpdir):
+    filename = str(tmpdir.join('config.json'))
+
+    settings = config.load()
+    settings = settings._replace(key1='new-value1')
+    assert config.save(settings) == {'key1': 'new-value1'}
+    with open(filename) as file:
+        assert ''.join(file) == \
+            '{\n    "key1": "new-value1"\n}'
+
+    settings = settings._replace(key2='new-value2')
+    assert config.save(settings) == {
+        'key1': 'new-value1',
+        'key2': 'new-value2'
+    }
+    with open(filename) as file:
+        assert ''.join(file) == \
+            '{\n    "key1": "new-value1",\n    "key2": "new-value2"\n}'


### PR DESCRIPTION
## Overview

This PR adds functionality to override default config settings with values stored locally in JSON file located in `APP_DATA_DIR/config.json`. It also adds functionality to save config values that are different from defaults into a local JSON. Default settings are assumed to be minimum sufficient settings to initiate factory calibration safely.

In addition to that I am also:
* further consolidating configurable values making them a part of config and passing instance around instead of accessing values by importing the robot.
* making tip length part of config with the intent that it will be overridden and saved after a tip probe. This might change in the future for scenarios when the same pipette is interacting with multiple tip types during in the same protocol.

## Review requests

@btmorr , i removed line 98 of the original `api/tests/opentrons/drivers/test_driver.py`. `smoothie` fixture was not passed to the test case and setting it's `simulating=False` means we were setting it for the fixture function that has no effect on a test case.

I understand handling of tip length is likely to change, but I see this as an incremental improvement compared to a hardcoded value. This will also allow us to store tip length value after calibration.