### PR TITLE
Fix smoothie id override

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/driver_3_0.py
@@ -45,7 +45,6 @@ GCODES = {'HOME': 'G28.2',
 # Number of digits after the decimal point for coordinates being sent
 # to Smoothie
 GCODE_ROUNDING_PRECISION = 3
-SMOOTHIE_BOARD_NAME = 'FT232R'
 
 
 def _parse_axis_values(raw_axis_values):
@@ -109,8 +108,9 @@ class SmoothieDriver_3_0_0:
             self.simulating = True
             return
 
+        smoothie_id = environ.get('OT_SMOOTHIE_ID', 'FT232R')
         self._connection = serial_communication.connect(
-            device_name=SMOOTHIE_BOARD_NAME,
+            device_name=smoothie_id,
             baudrate=self._config.serial_speed
         )
         self._setup()

--- a/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/v3_0_0/serial_communication.py
@@ -1,18 +1,11 @@
 import serial
 from serial.tools import list_ports
 import contextlib
-import os
 
 DRIVER_ACK = b'ok\r\nok\r\n'
 RECOVERY_TIMEOUT = 10
 DEFAULT_SERIAL_TIMEOUT = 5
 DEFAULT_WRITE_TIMEOUT = 30
-
-# Note: FT232R is the chip id for the serial-to-UART cables used to connect to
-# the robot. This value will usually be correct, if using a usb-to-UART cable
-# with this chip. Otherwise, set the env var to whatever identifier is used for
-# the serial connection.
-smoothie_id = os.environ.get('OT_SMOOTHIE_ID', 'FT232R')
 
 ERROR_KEYWORD = b'error'
 ALARM_KEYWORD = b'ALARM'
@@ -98,7 +91,7 @@ def write_and_return(
     return response
 
 
-def connect(device_name=smoothie_id, baudrate=115200):
+def connect(device_name, baudrate=115200):
     '''
     Creates a serial connection
     :param device_name: defaults to 'Smoothieboard'


### PR DESCRIPTION
## overview

Move env var check into driver at callsite, so the env var doesn't get overridden by a constant (functional change is only on the robot, hence no changes in docs or tests.

This PR includes:

- [ ] Chore work
- [x] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

- (Fix) Move environment variable check from default parameter check to the call-site, so that it does not get overridden with a constant in driver

## review requests

Check that it runs on the robot as expected