### PR TITLE
fix build for linux

### DIFF
--- a/app/electron-builder.json
+++ b/app/electron-builder.json
@@ -38,7 +38,6 @@
     ]
   },
   "squirrelWindows": {
-    "useAppIdAsId": true,
     "iconUrl": "https://s3.amazonaws.com/ot-app-builds/win/icon.ico"
   },
   "linux": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ot-app",
+  "private": true,
   "version": "3.0.0-alpha",
   "description": "Opentrons desktop application",
   "main": "shell/main.js",

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opentrons/ot-app",
+  "name": "ot-app",
   "version": "3.0.0-alpha",
   "description": "Opentrons desktop application",
   "main": "shell/main.js",

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -8,6 +8,7 @@
     "email": "engineering@opentrons.com"
   },
   "name": "protocol-designer",
+  "private": true,
   "version": "1.0.0",
   "description": "Protocol designer app",
   "main": "index.js",

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -7,7 +7,7 @@
     "name": "Opentrons Labworks",
     "email": "engineering@opentrons.com"
   },
-  "name": "@opentrons/protocol-designer",
+  "name": "protocol-designer",
   "version": "1.0.0",
   "description": "Protocol designer app",
   "main": "index.js",


### PR DESCRIPTION
## overview

Fix build for linux!

installing with `sudo dpkg -i opentrons-v3.0.0-etc-etc.deb` gave error: 'invalid package name (must start with an alphanumeric character)'

Package name was @opentrons/desktop-app, '@' symbol is not allowed by debian package manager.

This PR includes:

- [ ] Chore work
- [x] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog


In this PR:    
    * removed '@opentrons/' prefixes in package.json name field
    * also removed ""useAppIdAsId": true" for windows build
