### PR TITLE
fix non-absolute import in CLI tool

### DIFF
--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -9,7 +9,7 @@ from numpy import dot, array, insert
 from opentrons import robot, instruments
 from opentrons.robot import robot_configs
 from opentrons.util.calibration_functions import probe_instrument
-from solve import solve
+from opentrons.solve import solve
 
 pipette = instruments.Pipette(mount='right')
 


### PR DESCRIPTION
A fix enable running using `python -m opentrons.cli.main`