### PR TITLE
Plunger movements based on uL/mm conversion

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -17,8 +17,6 @@ PLUNGER_POSITIONS = {
     'drop_tip': -7
 }
 
-P300_UL_PER_MM = 18.51
-
 
 class PipetteTip:
     def __init__(self, length):
@@ -94,6 +92,7 @@ class Pipette:
             channels=1,
             min_volume=0,
             max_volume=None,
+            ul_per_mm=18.51,
             trash_container=None,
             tip_racks=[],
             aspirate_speed=300,
@@ -136,10 +135,11 @@ class Pipette:
 
         self.plunger_positions = PLUNGER_POSITIONS.copy()
 
+        self.ul_per_mm = ul_per_mm
         self.min_volume = min_volume
         t = self._get_plunger_position('top')
         b = self._get_plunger_position('bottom')
-        self.max_volume = (t - b) * P300_UL_PER_MM
+        self.max_volume = (t - b) * self.ul_per_mm
 
     def reset(self):
         """
@@ -1232,7 +1232,7 @@ class Pipette:
         Calibration of the pipette motor's ul-to-mm conversion is required
         """
 
-        millimeters = ul / P300_UL_PER_MM
+        millimeters = ul / self.ul_per_mm
         destination_mm = self._get_plunger_position('bottom') + millimeters
         return round(destination_mm, 3)
 

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -11,7 +11,7 @@ from opentrons.trackers import pose_tracker
 
 
 PLUNGER_POSITIONS = {
-    'top': 17,
+    'top': 18.5,
     'bottom': 2,
     'blow_out': 0,
     'drop_tip': -7
@@ -134,17 +134,12 @@ class Pipette:
             'dispense': dispense_speed
         }
 
+        self.plunger_positions = PLUNGER_POSITIONS.copy()
+
         self.min_volume = min_volume
-        self.max_volume = max_volume or (min_volume + 1)
-
-        # FIXME
-        default_plunger_positions = PLUNGER_POSITIONS
-        self.plunger_positions = {}
-        self.plunger_positions.update(default_plunger_positions)
-
-        for key, val in self.plunger_positions.items():
-            if val is None:
-                self.plunger_positions[key] = default_plunger_positions[key]
+        t = self._get_plunger_position('top')
+        b = self._get_plunger_position('bottom')
+        self.max_volume = (t - b) * P300_UL_PER_MM
 
     def reset(self):
         """
@@ -1239,7 +1234,7 @@ class Pipette:
 
         millimeters = ul / P300_UL_PER_MM
         destination_mm = self._get_plunger_position('bottom') + millimeters
-        return destination_mm
+        return round(destination_mm, 3)
 
     def _volume_percentage(self, volume):
         """Returns the plunger percentage for a given volume.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
 pylama
 pyserial==3.2.1
-pytest
+pytest==3.2.5
 pytest-cov
 pytest-aiohttp
 dill

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -54,10 +54,6 @@ async def test_load_from_text(session_manager, protocol):
             acc.append(command)
             traverse(command['children'])
     traverse(session.commands)
-
-    from pprint import pprint as pp
-    pp(protocol.text)
-    pp(acc)
     assert len(acc) == 90
 
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -55,7 +55,10 @@ async def test_load_from_text(session_manager, protocol):
             traverse(command['children'])
     traverse(session.commands)
 
-    assert len(acc) == 105
+    from pprint import pprint as pp
+    pp(protocol.text)
+    pp(acc)
+    assert len(acc) == 90
 
 
 async def test_async_notifications(main_router):

--- a/api/tests/opentrons/containers/test_default_containers.py
+++ b/api/tests/opentrons/containers/test_default_containers.py
@@ -13,11 +13,10 @@ def test_new_containers(robot):
     p200 = pipette.Pipette(
         robot, mount='right', max_volume=1000, name='test-pipette'
     )
-    p200.aspirate(100, wheaton_vial_rack[0])
-    p200.aspirate(100, tube_rack_80well[0])
-    p200.aspirate(100, T75_flask[0])
-    p200.aspirate(100, T25_flask[0])
-    p200.dispense(trash_box)
+    p200.aspirate(100, wheaton_vial_rack[0]).dispense(trash_box)
+    p200.aspirate(100, tube_rack_80well[0]).dispense(trash_box)
+    p200.aspirate(100, T75_flask[0]).dispense(trash_box)
+    p200.aspirate(100, T25_flask[0]).dispense(trash_box)
 
 
 def test_fixed_trash(robot, dummy_db):

--- a/api/tests/opentrons/integration/test_server.py
+++ b/api/tests/opentrons/integration/test_server.py
@@ -54,7 +54,7 @@ async def test_notifications(session, session_manager, protocol, root, connect):
     await socket.receive_json()  # Skip ack
     res = await socket.receive_json()
 
-    assert len(res['data']['v']['command_log']['v']) == 105
+    assert len(res['data']['v']['command_log']['v']) == 90
     responses = [
         res for res in responses
         if res['data']['v']['name'] == 'state']

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -49,7 +49,7 @@ def test_aspirate_move_to(robot):
     current_pos = pose_tracker.absolute(
         robot.poses,
         p200.instrument_actuator)
-    assert (current_pos == (9.5, 0.0, 0.0)).all()
+    assert (current_pos == (7.402, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p200)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()


### PR DESCRIPTION
## Description:
`Pipette` calculates the distance (mm) to move the plunger based on a ul_per_mm value found through volumes tests (`18.51` ul/mm on p300).

Pipette is hardcoded to be a p300 pipette because of this value, which seems ok given all beta testing will be done with p300.

This means that the kwarg `max_volume=` on `Pipette` is now being ignored. This is a breaking change in API, however this kwarg doesn't make sense with electronic pipettes.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
