### PR TITLE
pin pytest version to 3.2.5

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
 pylama
 pyserial==3.2.1
-pytest
+pytest==3.2.5
 pytest-cov
 pytest-aiohttp
 dill


### PR DESCRIPTION
## Description:

Pin pytest version to 3.2.5 to prevent breaks on auto-update
