### PR TITLE
Fix factory calibration persistance

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -159,33 +159,6 @@ class Robot(object):
         self.config = config or load()
         self._driver = driver_3_0.SmoothieDriver_3_0_0(config=self.config)
 
-        self._actuators = {
-            'left': {
-                'carriage': Mover(
-                    driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst=id(self.config.gantry_calibration),
-                    axis_mapping={'z': 'Z'}),
-                'plunger': Mover(
-                    driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst='volume-calibration-left',
-                    axis_mapping={'x': 'B'})
-            },
-            'right': {
-                'carriage': Mover(
-                    driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst=id(self.config.gantry_calibration),
-                    axis_mapping={'z': 'A'}),
-                'plunger': Mover(
-                    driver=self._driver,
-                    src=pose_tracker.ROOT,
-                    dst='volume-calibration-right',
-                    axis_mapping={'x': 'C'})
-            }
-        }
-
         self.dimensions = (395, 345, 228)
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
@@ -233,6 +206,34 @@ class Robot(object):
             * Runtime warnings
 
         """
+
+        self._actuators = {
+            'left': {
+                'carriage': Mover(
+                    driver=self._driver,
+                    src=pose_tracker.ROOT,
+                    dst=id(self.config.gantry_calibration),
+                    axis_mapping={'z': 'Z'}),
+                'plunger': Mover(
+                    driver=self._driver,
+                    src=pose_tracker.ROOT,
+                    dst='volume-calibration-left',
+                    axis_mapping={'x': 'B'})
+            },
+            'right': {
+                'carriage': Mover(
+                    driver=self._driver,
+                    src=pose_tracker.ROOT,
+                    dst=id(self.config.gantry_calibration),
+                    axis_mapping={'z': 'A'}),
+                'plunger': Mover(
+                    driver=self._driver,
+                    src=pose_tracker.ROOT,
+                    dst='volume-calibration-right',
+                    axis_mapping={'x': 'C'})
+            }
+        }
+
         self.poses = pose_tracker.init()
 
         self._runtime_warnings = []

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -4,7 +4,7 @@ export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 echo "[BOOT] Starting server"
 cd /usr/src/api
-python /usr/src/api/opentrons/server/main.py '0.0.0.0':31950 &
+python /usr/src/api/opentrons/server/main.py -H 0.0.0.0 -P 31950 &
 
 echo "[BOOT] Advertising local service"
 python /usr/src/compute/scripts/announce_mdns.py


### PR DESCRIPTION
# Overview

Fix off by one error and consequences that came after the fix: broken pose tree initialization on robot re-set.

Also updated compute start script to reflect new server command line arguments.

# Change log

- Increment point after the last point has been calibrated. This allows to re-calculate calibration matrix and reset the robot to reflect new calibration values to prepare for tip probe

- Updated startup script to use new command line arguments for `server/main.py`

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [X] Who is reviewing your code?
