### PR TITLE
(repo) Fix README CI and coverage badges for new base

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ See the [App README][app-readme] for instructions.
 
 Enjoy!
 
-[travis]: https://travis-ci.org/OpenTrons/opentrons/branches
-[travis-badge]: https://img.shields.io/travis/OpenTrons/opentrons/app-3-0.svg?style=flat-square&maxAge=3600
-[codecov]: https://codecov.io/gh/OpenTrons/opentrons/branches
-[codecov-badge]: https://img.shields.io/codecov/c/github/OpenTrons/opentrons/app-3-0.svg?style=flat-square&maxAge=3600
+[travis]: https://travis-ci.org/Opentrons/opentrons/branches
+[travis-badge]: https://img.shields.io/travis/Opentrons/opentrons/v3a.svg?style=flat-square&maxAge=3600
+[codecov]: https://codecov.io/gh/Opentrons/opentrons/branches
+[codecov-badge]: https://img.shields.io/codecov/c/github/Opentrons/opentrons/v3a.svg?style=flat-square&maxAge=3600
 [app-readme]: ./app/README.md


### PR DESCRIPTION
## overview

The org. rename to Opentrons (from OpenTrons) and base branch switch to `v3a` threw off our CI and coverage badges in the main README.

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

- (Chore) Updated CI and coverage badges to Opentrons/opentrons and `v3a`

## review requests

Note: The README in `api` is still in `.rst` and using badges from a while ago. I elected not to touch it because that documentation in general seems like a different discussion.