### PR TITLE
show re-upload warning on session creation

### DIFF
--- a/app/ui/components/NavPanel.css
+++ b/app/ui/components/NavPanel.css
@@ -57,3 +57,10 @@
   font-size: 1rem;
   text-align: center;
 }
+
+.confirm_reupload {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: black;
+}

--- a/app/ui/components/NavPanel.js
+++ b/app/ui/components/NavPanel.js
@@ -12,7 +12,8 @@ const UploadPanel = props => {
     warning = (
       <div className={styles.confirm_reupload}>
         <h3>Warning:</h3>
-        <p>Uploading a new protocol file will clear out current calibration data.</p>
+        <p>Opening a new protocol will close the one you currently have open.
+         This will clear out current calibration data.</p>
       </div>
     )
   }

--- a/app/ui/components/NavPanel.js
+++ b/app/ui/components/NavPanel.js
@@ -6,6 +6,17 @@ import Connection from '../containers/Connection'
 import styles from './NavPanel.css'
 
 const UploadPanel = props => {
+  const {isSessionLoaded} = props
+  let warning
+  if (isSessionLoaded) {
+    warning = (
+      <div className={styles.confirm_reupload}>
+        <h3>Warning:</h3>
+        <p>Uploading a new protocol file will clear out current calibration data.</p>
+      </div>
+    )
+  }
+
   return (
     <div className={styles.nav_panel}>
       <section className={styles.choose_file}>
@@ -27,8 +38,9 @@ const UploadPanel = props => {
             onChange={props.onUpload}
           />
         </label>
-
+        {warning}
       </section>
+
     </div>
   )
 }

--- a/app/ui/components/SideBar.js
+++ b/app/ui/components/SideBar.js
@@ -19,6 +19,6 @@ export default function SideBar (props) {
 }
 
 SideBar.propTypes = {
-  isPanelOpen: PropTypes.bool.isRequired,
+  isPanelOpen: PropTypes.bool,
   close: PropTypes.func.isRequired
 }

--- a/app/ui/containers/Nav.js
+++ b/app/ui/containers/Nav.js
@@ -7,14 +7,16 @@ import {
 } from '../interface'
 
 import {
-  actions as robotActions
+  actions as robotActions,
+  selectors as robotSelectors
 } from '../robot'
 
 import SideBar from '../components/SideBar'
 
 const mapStateToProps = (state) => ({
   isOpen: interfaceSelectors.getIsPanelOpen(state),
-  currentPanel: interfaceSelectors.getCurrentPanel(state)
+  currentPanel: interfaceSelectors.getCurrentPanel(state),
+  isSessionLoaded: robotSelectors.getSessionIsLoaded(state)
 })
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
## Description:

This PR implements a text warning on the upload panel once an initial session has been created. Text states:
```
WARNING:
Opening a new protocol will close the one you currently have open. This will clear out current calibration data.
```

This is a temporary workaround that can be addressed further in the sidepanel refactor with designs and possible modal.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
