### PR TITLE
Shrink connection type icon in robot item

### DIFF
--- a/app/ui/components/ConnectPanel.css
+++ b/app/ui/components/ConnectPanel.css
@@ -1,12 +1,13 @@
 .connect_panel {
   color: silver;
   height: 100%;
-  width: 17.2rem;
+  width: 275px;
 }
 
 .robot_results {
   height: calc(100vh - 62px);
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .robot_results.centered {
@@ -57,10 +58,10 @@ h1 {
 }
 
 .connection_type {
-  margin: -1rem 1rem 0;
-  height: 3rem;
+  margin: 0 0.5rem;
+  height: 2.5rem;
   display: inline-block;
-  vertical-align: baseline;
+  padding-bottom: 0.5rem;
 }
 
 .connection_info {


### PR DESCRIPTION
## Description:
Windows scrollbar width on discovered robots list was causing robot name/icon to stack vertically. This PR shrinks the discovered robot item icon, and allows for scrollbar space in discovered robots list. Tested dev version on @btmorr windows laptop to confirm this fixes the issue.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
