### PR TITLE
(app) Update discovery to poll directly connected robots

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -111,6 +111,7 @@
     "stylelint": "~8.0.0",
     "stylelint-config-css-modules": "^1.1.0",
     "stylelint-config-standard": "^17.0.0",
+    "superagent": "^3.8.1",
     "url-loader": "^0.6.2",
     "webpack": "~2.6.1",
     "webpack-bundle-analyzer": "^2.8.2",

--- a/app/scripts/advertise-local-api.js
+++ b/app/scripts/advertise-local-api.js
@@ -2,6 +2,12 @@
 // TODO(mc, 2017-10-31): remove this file once API can advertise for itself
 const bonjour = require('bonjour')()
 const randomstring = require('randomstring')
+const request = require('superagent')
+
+const LOCAL_API_POLL_INTERVAL_MS = 5000
+const LOCAL_API_HOST = 'localhost'
+const LOCAL_API_PORT = 31950
+const LOCAL_API_HEALTH_URL = `http://${LOCAL_API_HOST}:${LOCAL_API_PORT}/health`
 
 const id = randomstring.generate({
   length: 6,
@@ -19,10 +25,30 @@ const service = {
   type: 'http'
 }
 
-bonjour.publish(service)
-  .on('up', () => {
-    console.log(`Published MDNS service "${service.name}" on ${service.host}`)
-  })
-  .on('error', (error) => {
-    console.error('Error publishing MDNS service', error)
-  })
+startPolling()
+
+function startPolling () {
+  setTimeout(pollAndPublish, LOCAL_API_POLL_INTERVAL_MS)
+}
+
+function pollAndPublish () {
+  request.get(LOCAL_API_HEALTH_URL)
+    .ok((response) => response.status === 200)
+    .then(() => {
+      console.log(`Found local API at ${LOCAL_API_HOST}:${LOCAL_API_PORT}`)
+      publish()
+    })
+    .catch(startPolling)
+}
+
+function publish () {
+  bonjour.publish(service)
+    .on('up', () => {
+      console.log(`Published MDNS service "${service.name}" on ${service.host}`)
+    })
+    .on('error', (error) => {
+      console.error('Error publishing MDNS service', error)
+      // retry
+      startPolling()
+    })
+}

--- a/app/ui/robot/api-client/discovery.js
+++ b/app/ui/robot/api-client/discovery.js
@@ -1,19 +1,34 @@
-// mdns-based api server discovery
+// mdns-based api server discovery with direct ethernet connection discovery
 import Bonjour from 'bonjour'
 
 import {actions} from '../actions'
 
+// mdns discovery constants
 const NAME_RE = /^opentrons/i
 const DISCOVERY_TIMEOUT_MS = 30000
 const UP_EVENT = 'up'
 const DOWN_EVENT = 'down'
+
+// direct discovery constants
+// see compute/scripts/setup.sh
+const DIRECT_HOST = '[fd00:0:cafe:fefe::1]'
+const DIRECT_PORT = 31950
+const DIRECT_HEALTH_URL = `http://${DIRECT_HOST}:${DIRECT_PORT}/health`
+const DIRECT_SERVICE = {
+  name: 'Opentrons USB',
+  host: DIRECT_HOST,
+  port: DIRECT_PORT
+}
+const DIRECT_POLL_INTERVAL_MS = 1000
 
 export function handleDiscover (dispatch, state, action) {
   // TODO(mc, 2017-10-26): we're relying right now on the fact that resin
   // advertises an SSH service. Instead, we should be registering an HTTP
   // service on port 31950 and listening for that instead
   const browser = Bonjour().find({type: 'http'})
+  let pollInterval
 
+  pollInterval = setInterval(pollDirectConnection, DIRECT_POLL_INTERVAL_MS)
   setTimeout(finishDiscovery, DISCOVERY_TIMEOUT_MS)
   browser.on(UP_EVENT, handleServiceUp)
   browser.on(DOWN_EVENT, handleServiceDown)
@@ -34,6 +49,15 @@ export function handleDiscover (dispatch, state, action) {
     browser.removeListener(UP_EVENT, handleServiceUp)
     browser.removeListener(DOWN_EVENT, handleServiceDown)
     browser.stop()
+    clearInterval(pollInterval)
     dispatch(actions.discoverFinish())
+  }
+
+  function pollDirectConnection () {
+    fetch(DIRECT_HEALTH_URL)
+      .then((response) => {
+        if (response.ok) dispatch(actions.addDiscovered(DIRECT_SERVICE))
+      })
+      .catch(() => {})
   }
 }


### PR DESCRIPTION
## overview

This PR updated the discovery machinery of the app to also poll for directly connected robots via repeated GET requests to `http://${FIXED_LINK_LOCAL_IPv6}:31950/health`.

Blocked by #480 

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

Write descriptions for your changes. If a change is related to a GitHub issue, please tag the issue in the description.

- (Feature) Updated discovery.js to poll /health at fixed local IP every sec
- (Chore) Updated MDNS dev script to only advertise if local API is found

## review requests

Nothing specific, but a Windows test would be helpful!

