### PR TITLE
(app) Fix flaky RPC client notification test

### DIFF
--- a/app/rpc/test/client.test.js
+++ b/app/rpc/test/client.test.js
@@ -288,7 +288,6 @@ describe('rpc client', () => {
     const mockRemote = {foo: 'bar', baz: 'qux'}
 
     sendControlAndResolveRemote()
-    setTimeout(() => ws.send(notification), 10)
     RemoteObject.mockReturnValue(Promise.resolve(mockRemote))
 
     Client(url)
@@ -298,6 +297,8 @@ describe('rpc client', () => {
           expect(message).toEqual(mockRemote)
           done()
         })
+
+        setTimeout(() => ws.send(notification), 10)
       })
   })
 


### PR DESCRIPTION
## overview

We've been seeing intermittent RPC client failures in the notification test. When looking at the code, there was a race condition where the test notification could be sent before the client had actually resolved and had its notification listener attached. This PR removes that race condition to hopefully remove the test flakiness.

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Tests) Delay RPC test notification until after the client has definitely resolved

## review requests

Tiny PR, so a quick 👍 would be appreciated
