### PR TITLE
Erase "config.json" at beginning of deck calibration

### DIFF
--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -3,18 +3,17 @@
 # pylama:ignore=C901
 
 # erase previous calibration file before opentrons.robot instantiates
-import os
-from opentrons.util import environment
-config_file_path = environment.get_path('OT_CONFIG_FILE')
-if os.path.exists(config_file_path):
-    os.remove(config_file_path)
+from opentrons import robot
+from opentrons.robot import robot_configs
+robot_configs.clear()
+robot.config = robot_configs.load()
+robot.reset()
 
 import asyncio                                                          # NOQA
 import urwid                                                            # NOQA
 from numpy.linalg import inv                                            # NOQA
 from numpy import dot, array, insert                                    # NOQA
 from opentrons import robot, instruments                                # NOQA
-from opentrons.robot import robot_configs                               # NOQA
 from opentrons.util.calibration_functions import probe_instrument       # NOQA
 from opentrons.cli.solve import solve                                   # NOQA
 

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -2,20 +2,21 @@
 
 # pylama:ignore=C901
 
-import asyncio
-import urwid
-from numpy.linalg import inv
-from numpy import dot, array, insert
-from opentrons import robot, instruments
-from opentrons.robot import robot_configs
-from opentrons.util.calibration_functions import probe_instrument
-from opentrons.cli.solve import solve
+# erase previous calibration file before opentrons.robot instantiates
+import os
+from opentrons.util import environment
+config_file_path = environment.get_path('OT_CONFIG_FILE')
+if os.path.exists(config_file_path):
+    os.remove(config_file_path)
 
-
-# TODO (andy - 2017/12/05) Run deck calibration (XYZ) seperately from Probe
-#     After calibrating the Z axis and 3 points on deck, quit and restart
-#     this CLI tool before running tip-probe ('p')
-#     Without restarting, pipette collides with probe
+import asyncio                                                          # NOQA
+import urwid                                                            # NOQA
+from numpy.linalg import inv                                            # NOQA
+from numpy import dot, array, insert                                    # NOQA
+from opentrons import robot, instruments                                # NOQA
+from opentrons.robot import robot_configs                               # NOQA
+from opentrons.util.calibration_functions import probe_instrument       # NOQA
+from opentrons.cli.solve import solve                                   # NOQA
 
 
 # Distance increments for jog

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -121,3 +121,8 @@ def save(config, filename=None):
     with open(filename, 'w') as file:
         json.dump(diff, file, sort_keys=True, indent=4)
         return diff
+
+def clear(filename=None):
+    filename = filename or environment.get_path('OT_CONFIG_FILE')
+    if os.path.exists(filename):
+        os.remove(filename)

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture
+def config(monkeypatch, tmpdir):
+    from opentrons.robot import robot_configs
+    from opentrons.util import environment
+
+    monkeypatch.setenv('APP_DATA_DIR', str(tmpdir))
+    environment.refresh()
+
+    test_config = robot_configs.load()
+    test_config = test_config._replace(name='new-value1')
+    robot_configs.save(test_config)
+
+    return robot_configs
+
+
+def test_clear_config(config):
+    # Clear should happen automatically after the following import, resetting
+    # the robot config to the default value from robot_configs
+    from opentrons.cli.main import main  # NOQA
+
+    from opentrons import robot
+    from opentrons.robot.robot_configs import default
+
+    assert robot.config == default


### PR DESCRIPTION
## Description:

This PR for avoiding collisions caused by using any previously calibrated `tip_length`, `instrument_offset`, and `gantry_calibration`.

We erase the deck-calibration data file at the beginning of deck calibration procedure, using a method `robot_config.clear()` which erases the environments config.json file. We then call `opentrons.reset()` to re-initialize robot with an default config setting.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
