### PR TITLE
(app) Go to /run on connect to running bot

### DIFF
--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -62,9 +62,18 @@ export default function client (dispatch) {
           .on('error', handleClientError)
 
         remote = rpcClient.remote
+        const session = remote.session_manager.session
 
-        if (remote.session_manager.session) {
-          handleApiSession(remote.session_manager.session)
+        // TODO(mc, 2017-12-07): handle this with fewer dispatches
+        if (session) {
+          handleApiSession(session)
+
+          if (
+            session.state === constants.RUNNING ||
+            session.state === constants.PAUSED
+          ) {
+            dispatch(push('/run'))
+          }
         }
 
         dispatch(actions.connectResponse())

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -1,4 +1,6 @@
 // tests for the api client
+import {push} from 'react-router-redux'
+
 import {delay} from '../../util'
 import client from '../api-client/client'
 import RpcClient from '../../../rpc/client'
@@ -131,6 +133,22 @@ describe('api client', () => {
 
       return sendConnect()
         .then(() => sendDisconnect())
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('dispatch push to /run if connect to running session', () => {
+      const expected = push('/run')
+      session.state = constants.RUNNING
+
+      return sendConnect()
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('dispatch push to /run if connect to paused session', () => {
+      const expected = push('/run')
+      session.state = constants.PAUSED
+
+      return sendConnect()
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
   })


### PR DESCRIPTION
## overview

Simple PR to get the app to automagically jump to the run screen if it connects to a running robot. Not in love with the implementation but it's kind of tied to how we deal with the robot API at the moment. Got a TODO in there to keep an eye on it.

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [X] Test updates

## changelog

- (Feature, Tests) Added push action on connect if session.state is running or paused

## review requests

Tested on a robot, but would appreciate if you could do the same!

