### PR TITLE
(app) Change "Upload File" to "Open Protocol"

### DIFF
--- a/app/ui/components/Upload.js
+++ b/app/ui/components/Upload.js
@@ -8,8 +8,8 @@ import {Spinner, Success, Warning} from './icons'
 
 import styles from './Upload.css'
 
-const UPLOAD_ERROR_MESSAGE = 'Something went wrong while uploading your file.'
-const UPLOAD_SUCCESS_MESSAGE = 'Your file has uploaded successfully.'
+const UPLOAD_ERROR_MESSAGE = 'Your protocol could not be opened.'
+const UPLOAD_SUCCESS_MESSAGE = 'Your protocol has successfully loaded.'
 
 Upload.propTypes = {
   name: PropTypes.string.isRequired,

--- a/app/ui/components/upload-panel/UploadInput.js
+++ b/app/ui/components/upload-panel/UploadInput.js
@@ -13,7 +13,7 @@ export default function UploadInput (props) {
     ? styles.btn_upload
     : styles.file_drop
   const label = isButton
-    ? 'Upload'
+    ? 'Open'
     : 'Drag and drop protocol file here.'
 
   return (

--- a/app/ui/components/upload-panel/UploadWarning.js
+++ b/app/ui/components/upload-panel/UploadWarning.js
@@ -6,8 +6,10 @@ export default function UploadWarning (props) {
   return (
     <div className={styles.upload_warning}>
       <h3>Warning:</h3>
-      <p>Opening a new protocol will close the one you currently have open.
-       This will clear out current calibration data.</p>
+      <p>
+        Opening a new protocol will close the one you currently have open.
+        This will clear out current calibration data.
+      </p>
     </div>
   )
 }

--- a/app/ui/components/upload-panel/index.js
+++ b/app/ui/components/upload-panel/index.js
@@ -19,6 +19,7 @@ UploadPanel.propTypes = {
 
 function UploadPanel (props) {
   const warning = props.isSessionLoaded && (<UploadWarning />)
+
   return (
     <div>
       <UploadInput {...props} isButton />
@@ -46,6 +47,9 @@ function mapDispatchToProps (dispatch) {
       }
 
       dispatch(robotActions.session(files[0]))
+
+      // reset the state of the input to allow file re-uploads
+      event.target.value = null
     }
   }
 }

--- a/app/ui/interface/index.js
+++ b/app/ui/interface/index.js
@@ -6,7 +6,7 @@ export const NAME = 'interface'
 
 export const PANEL_NAMES = ['upload', 'setup', 'connect']
 export const PANEL_PROPS_BY_NAME = {
-  upload: {title: 'Upload File'},
+  upload: {title: 'Open Protocol'},
   setup: {title: 'Prep for Run'},
   connect: {title: 'Connect Robot'}
 }


### PR DESCRIPTION
## overview

Little PR to fix up some copy around uploading files vs opening protocols (the latter being preferred for UX). Since I was already touching the files, I also added a little fix for the bug that prevented uploading the same file more than once in a row using the click to upload button (was never an issue with the dropzone)

![2017-12-11 13 13 26](https://user-images.githubusercontent.com/2963448/33846508-2e5a704c-de75-11e7-8db8-b170947ef9e6.gif)

This PR includes:

- [X] Chore work
- [X] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates

## changelog

- (Chore) Updated various copy to match the "Open Protocol" language shift
- (Fix) Fixed the bug preventing multiple uploads of same file (#387)
