### PR TITLE
App setup panel refactor org

### DIFF
--- a/app/ui/components/setup-panel/InstrumentListItem.js
+++ b/app/ui/components/setup-panel/InstrumentListItem.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import {NavLink} from 'react-router-dom'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+import capitalize from 'lodash/capitalize'
+
+import ToolTip, {BOTTOM_RIGHT} from '../ToolTip'
+
+import styles from './setup-panel.css'
+import tooltipStyles from '../ToolTip.css'
+
+// TODO(ka 2017-12-8) This will move to LinkItem in component lib
+// with more generic proptypes and props.children
+InstrumentListItem.propTypes = {
+  to: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+  style: PropTypes.string
+}
+
+export default function InstrumentListItem (props) {
+  const {axis, name, volume, channels, probed, isRunning, onClick} = props
+  const isDisabled = name == null
+  const url = isRunning
+    ? '#'
+    : `/setup-instruments/${axis}`
+
+  const linkStyle = classnames({[styles.disabled]: isDisabled})
+
+  const statusStyle = isDisabled || probed
+    ? styles.confirmed
+    : styles.alert
+
+  const description = !isDisabled
+    ? `${capitalize(channels)}-channel (${volume} ul)`
+    : 'N/A'
+
+  return (
+    <li>
+      <NavLink
+        to={url}
+        onClick={onClick}
+        className={linkStyle}
+        activeClassName={styles.active}
+        disabled={isDisabled}
+      >
+        <span className={classnames(statusStyle, tooltipStyles.parent)}>
+          <ToolTip style={BOTTOM_RIGHT}>Tip not found</ToolTip>
+        </span>
+        <span className={styles.axis}>{axis}</span>
+        <span className={styles.type}>{description}</span>
+      </NavLink>
+    </li>
+  )
+}

--- a/app/ui/components/setup-panel/LabwareListItem.js
+++ b/app/ui/components/setup-panel/LabwareListItem.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
+import ToolTip, {BOTTOM_RIGHT} from '../ToolTip'
+
+import styles from './setup-panel.css'
+import tooltipStyles from '../ToolTip.css'
+
+LabwareListItem.propTypes = {
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+  style: PropTypes.string
+}
+
+export default function LabwareListItem (props) {
+  const {
+    name,
+    confirmed,
+    isTiprack,
+    instrumentsCalibrated,
+    tipracksConfirmed,
+    onClick
+  } = props
+
+  const isDisabled = !instrumentsCalibrated || !(isTiprack || tipracksConfirmed)
+
+  const buttonStyle = classnames(styles.btn_labware, {
+    // tipracks can only be confirmed once because of the whole pick-up process
+    [styles.disabled]: isDisabled || (isTiprack && confirmed)
+  })
+
+  const statusStyle = classnames({
+    [styles.confirmed]: confirmed,
+    [styles.alert]: !confirmed
+  })
+
+  return (
+    <li>
+      <button
+        className={buttonStyle}
+        onClick={onClick}
+        disabled={isDisabled}
+      >
+        <span className={classnames(statusStyle, tooltipStyles.parent)}>
+          <ToolTip style={BOTTOM_RIGHT}>Position unconfirmed</ToolTip>
+        </span>
+        {name}
+      </button>
+    </li>
+  )
+}

--- a/app/ui/components/setup-panel/LabwareListItem.js
+++ b/app/ui/components/setup-panel/LabwareListItem.js
@@ -34,7 +34,8 @@ export default function LabwareListItem (props) {
     [styles.confirmed]: confirmed,
     [styles.alert]: !confirmed
   })
-
+  // TODO(ka 2017-12-12) convert labware items to navlink and wrap component lib list item
+  // leaving this here for now to avoid lapse in functionality
   return (
     <li>
       <button

--- a/app/ui/components/setup-panel/SetupPanel.js
+++ b/app/ui/components/setup-panel/SetupPanel.js
@@ -1,0 +1,152 @@
+import React from 'react'
+import {NavLink} from 'react-router-dom'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+
+import {constants as robotConstants} from '../../robot'
+import ToolTip, {TOP} from '../ToolTip'
+
+import InfoBox from '../InfoBox'
+import InstrumentListItem from './InstrumentListItem'
+import LabwareListItem from './LabwareListItem'
+
+import styles from './setup-panel.css'
+import tooltipStyles from '../ToolTip.css'
+
+export default function SetupPanel (props) {
+  const {
+    instruments,
+    labware,
+    instrumentsCalibrated,
+    labwareConfirmed,
+    tipracksConfirmed,
+    setLabware,
+    clearLabwareReviewed,
+    isRunning,
+    run
+  } = props
+
+  const instrumentList = instruments.map((i) => (
+    <InstrumentListItem
+      {...i}
+      key={i.axis}
+      isRunning={isRunning}
+      onClick={!isRunning && clearLabwareReviewed}
+    />
+  ))
+
+  const {tiprackList, labwareList} = labware.reduce((result, lab) => {
+    const {slot, name, isTiprack} = lab
+    const onClick = setLabware(slot)
+
+    const links = (
+      <LabwareListItem
+        {...lab}
+        key={slot}
+        instrumentsCalibrated={instrumentsCalibrated}
+        tipracksConfirmed={tipracksConfirmed}
+        onClick={!isRunning && onClick}
+      />
+    )
+
+    if (name && isTiprack) {
+      result.tiprackList.push(links)
+    } else if (name) {
+      result.labwareList.push(links)
+    }
+
+    return result
+  }, {tiprackList: [], labwareList: []})
+
+  const runLinkStyles = classnames(
+    'btn',
+    'btn_dark',
+    styles.run_link,
+    tooltipStyles.parent,
+    {[styles.inactive]: !labwareConfirmed}
+  )
+
+  const runLinkWarning = 'Pipette and labware setup\nmust be complete before\nyou can RUN protocol'
+  const labwareMsg = !instrumentsCalibrated
+    ? <p className={styles.labware_alert}>Labware setup is disabled until pipette setup is complete.</p>
+    : null
+  const pipetteMsg = !tipracksConfirmed && instrumentsCalibrated
+    ? <p className={styles.labware_alert}>Tipracks must be setup first.</p>
+    : null
+
+  const runWarning = !labwareConfirmed
+    ? <ToolTip style={TOP}>{runLinkWarning}</ToolTip>
+    : null
+
+  const runLinkUrl = labwareConfirmed
+    ? '/run'
+    : '#'
+
+  const runMessage = labwareConfirmed && (<RunMessage />)
+
+  const onRunClick = (labwareConfirmed && !isRunning) && run
+
+  return (
+    <div className={styles.setup_panel}>
+      <section className={styles.links}>
+        <section className={styles.pipette_group}>
+          <h3>Pipette Setup</h3>
+          <ul className={styles.step_list}>
+            {instrumentList}
+          </ul>
+        </section>
+        <section className={styles.labware_group}>
+          <h3>Labware Setup</h3>
+          <ul className={styles.step_list}>
+            {tiprackList}
+            {labwareList}
+          </ul>
+          {pipetteMsg}
+          {labwareMsg}
+          {runMessage}
+        </section>
+      </section>
+      <NavLink to={runLinkUrl} className={runLinkStyles} onClick={onRunClick}>
+        Run Protocol
+        {runWarning}
+      </NavLink>
+    </div>
+  )
+}
+
+function RunMessage () {
+  return (
+    <InfoBox className={styles.run_message}>
+      <p className={styles.run_message_item}>
+        Hurray, your robot is now ready! Click [RUN PROTOCOL] to start your run.
+      </p>
+      <p className={styles.run_message_item}>
+        Tip: Try a dry run prior to adding your samples and re-agents to avoid
+        wasting materials.
+      </p>
+    </InfoBox>
+  )
+}
+
+SetupPanel.propTypes = {
+  instruments: PropTypes.arrayOf(PropTypes.shape({
+    axis: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    channels: PropTypes.string,
+    volume: PropTypes.number,
+    calibration: robotConstants.INSTRUMENT_CALIBRATION_TYPE
+  })).isRequired,
+  labware: PropTypes.arrayOf(PropTypes.shape({
+    slot: PropTypes.number.isRequired,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    isTiprack: PropTypes.bool,
+    calibration: robotConstants.LABWARE_CONFIRMATION_TYPE
+  })).isRequired,
+  clearLabwareReviewed: PropTypes.func.isRequired,
+  instrumentsCalibrated: PropTypes.bool.isRequired,
+  tipracksConfirmed: PropTypes.bool.isRequired,
+  labwareConfirmed: PropTypes.bool.isRequired,
+  isRunning: PropTypes.bool.isRequired,
+  run: PropTypes.func.isRequired
+}

--- a/app/ui/components/setup-panel/SetupPanel.js
+++ b/app/ui/components/setup-panel/SetupPanel.js
@@ -13,6 +13,8 @@ import LabwareListItem from './LabwareListItem'
 import styles from './setup-panel.css'
 import tooltipStyles from '../ToolTip.css'
 
+// TODO(ka 2017-12-12) break down setup panel into 3 containers
+// InstrumentList LabwareList and Run
 export default function SetupPanel (props) {
   const {
     instruments,

--- a/app/ui/components/setup-panel/index.js
+++ b/app/ui/components/setup-panel/index.js
@@ -1,0 +1,57 @@
+import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+
+import {
+  selectors as robotSelectors,
+  actions as robotActions
+} from '../robot'
+
+import SetupPanel from './SetupPanel'
+
+export default connect(
+  mapStateToProps,
+  null,
+  mergeProps
+)(SetupPanel)
+
+function mapStateToProps (state) {
+  return {
+    instruments: robotSelectors.getInstruments(state),
+    labware: robotSelectors.getLabware(state),
+    labwareBySlot: robotSelectors.getLabwareBySlot(state),
+    labwareReviewed: robotSelectors.getLabwareReviewed(state),
+    instrumentsCalibrated: robotSelectors.getInstrumentsCalibrated(state),
+    tipracksConfirmed: robotSelectors.getTipracksConfirmed(state),
+    labwareConfirmed: robotSelectors.getLabwareConfirmed(state),
+    singleChannel: robotSelectors.getSingleChannel(state),
+    isRunning: robotSelectors.getIsRunning(state)
+  }
+}
+
+function mergeProps (stateProps, dispatchProps) {
+  const {labwareReviewed, labwareBySlot, singleChannel} = stateProps
+  const {dispatch} = dispatchProps
+
+  return {
+    ...stateProps,
+    run: () => dispatch(robotActions.run()),
+    clearLabwareReviewed: () => {
+      dispatch(robotActions.setLabwareReviewed(false))
+    },
+    setLabware: (slot) => () => {
+      const {isTiprack} = labwareBySlot[slot] || {}
+
+      // TODO(mc, 2017-10-06): use nav link instead of double dispatch (PR 426)
+      dispatch(push(`/setup-deck/${slot}`))
+
+      // TODO(mc, 2017-11-29): DRY (logic shared by NextLabware, ReviewLabware,
+      // Deck, and ConnectedSetupPanel); could also move logic to the API client
+      if (labwareReviewed) {
+        if (isTiprack) {
+          return dispatch(robotActions.pickupAndHome(singleChannel.axis, slot))
+        }
+        dispatch(robotActions.moveTo(singleChannel.axis, slot))
+      }
+    }
+  }
+}

--- a/app/ui/components/setup-panel/setup-panel.css
+++ b/app/ui/components/setup-panel/setup-panel.css
@@ -1,0 +1,168 @@
+.setup_panel {
+  display: grid;
+  grid-template:
+    'details' 41rem
+    'btn_bottom' auto;
+  font-family: 'sans';
+  font-size: 14px;
+  line-height: 2rem;
+  color: grey;
+  padding: 1rem;
+}
+
+.close {
+  position: absolute;
+  right: 0.25rem;
+  top: 0.25rem;
+}
+
+.title {
+  grid-area: title;
+  padding: 0;
+  margin: 0;
+  line-height: 3.5rem;
+  font-size: 1.25rem;
+  border-bottom: none;
+}
+
+.links {
+  grid-area: details;
+}
+
+.pipette_group h3,
+.labware_group h3 {
+  color: gray;
+  text-decoration: none;
+  font-size: 1rem;
+  background-color: #eee;
+  display: block;
+  height: 3rem;
+  line-height: 3rem;
+  padding-left: 1rem;
+}
+
+.pipette_group li,
+.labware_group li {
+  list-style-type: none;
+  margin: 0;
+}
+
+.labware_group {
+  margin-top: 1rem;
+}
+
+.labware_alert {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background-color: #eee;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-style: italic;
+}
+
+.step_list button,
+.step_list a {
+  color: black;
+  background-color: #eee;
+  width: 100%;
+  display: block;
+  height: 3rem;
+  padding: 0.5rem;
+  text-align: left;
+  line-height: 1.5rem;
+  font-size: 0.75rem;
+}
+
+.step_list button:hover,
+.step_list a:hover {
+  background-color: #cdcdcd;
+}
+
+button.disabled,
+a.disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.step_list button.btn_labware {
+  line-height: 2rem;
+}
+
+li:nth-child(odd) a.btn_labware {
+  background-color: #ccc;
+}
+
+.alert,
+.confirmed {
+  position: relative;
+  display: block;
+  float: left;
+  border-radius: 0.5rem;
+  color: white;
+  text-align: center;
+  height: 1rem;
+  width: 1rem;
+  margin: 0.5rem 0.5rem 1rem 1rem;
+  background-color: silver;
+  line-height: 1rem;
+}
+
+.alert::before {
+  content: '!';
+}
+
+.confirmed {
+  visibility: hidden;
+}
+
+.axis {
+  text-transform: uppercase;
+  display: block;
+  line-height: 1rem;
+}
+
+.type {
+  display: block;
+  line-height: 1rem;
+}
+
+.run_message {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.run_message_item {
+  margin-bottom: 0.5rem;
+}
+
+.run_message_item:last-child {
+  margin-bottom: 0;
+}
+
+.run_link {
+  text-align: center;
+  width: 100%;
+  display: block;
+  height: 2.5rem;
+  line-height: 2.5rem;
+  background-color: #999;
+  color: white;
+  position: relative;
+}
+
+.run_link:hover {
+  background-color: #777;
+}
+
+.run_link.inactive,
+.run_link.inactive:hover {
+  background-color: transparent;
+  border: 1px solid silver;
+  color: silver;
+}
+
+.step_list li a.active,
+li:nth-child(odd) a.btn_labware.active {
+  background-color: #ddd;
+}


### PR DESCRIPTION
## Description:
This PR is the first of many touching the SetupPanel which contains probably the most state/actions in the app. Mike and I had worked on a monster PR a few weeks back which rapidly diverged from v3a as different calibration work was implemented. In an effort to avoid this, this is a smaller PR which only moves existing setup panel container and components into our new organizational system.

This PR Does:
- Replaces `containers/ConnectedSetupPanel` with `components/setup-panel/index.js`
- Moves existing style sheets for setup panel into `setup-panel/`
- SetupPanel component was and still is a monstrous file, but this PR breaks out `LabwareListItem` and `PipetteListItem` in anticipation of 3 containers (instead of 1) and using `TitledList` and `ListItem` components to be built in the component library

This PR Does Not:
- Refactor the exisitng container's state/actions
- Refactor styles
- Remove old files yet

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
@IanLondon @mike we can call this a WIP for now. Trying to figure out what the best cutoff point for the first of many PRs. Any thoughts welcome.