### PR TITLE
Robot config file and id protections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN ssh_key_gen.sh
 
 # Generate the id that we will later check to see if that's the
 # new container and that local Opentrons API package should be deleted
-ENV CONTAINER_ID=$(uuidgen)
+RUN echo "export CONTAINER_ID=$(uuidgen)" >> /etc/profile
 
 # Updates, HTTPS (for future use), API, SSH for link-local over USB
 EXPOSE 80 443 31950
@@ -114,5 +114,5 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # For interactive one-off use:
 #   docker run opentrons dumb-init python -c 'while True: pass'
 # or uncomment:
-# CMD ["python", "-c", "while True: pass"]
-CMD ["bash", "-c", "setup.sh && exec start.sh"]
+# CMD ["python", "-c", "source /etc/profile && while True: pass"]
+CMD ["bash", "-c", "source /etc/profile && setup.sh && exec start.sh"]

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -122,7 +122,9 @@ def save(config, filename=None):
         json.dump(diff, file, sort_keys=True, indent=4)
         return diff
 
+
 def clear(filename=None):
     filename = filename or environment.get_path('OT_CONFIG_FILE')
+    log.debug('Deleting config file: {}'.format(filename))
     if os.path.exists(filename):
         os.remove(filename)

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -19,7 +19,8 @@ def config(monkeypatch, tmpdir):
 def test_clear_config(config):
     # Clear should happen automatically after the following import, resetting
     # the robot config to the default value from robot_configs
-    from opentrons.cli.main import main  # NOQA
+    from opentrons.cli import main
+    main.clear_configuration_and_reload()
 
     from opentrons import robot
     from opentrons.robot.robot_configs import default

--- a/compute/scripts/setup.sh
+++ b/compute/scripts/setup.sh
@@ -22,10 +22,12 @@ nmcli --terse --fields uuid,device connection show | sed -rn 's/(.*):(eth0)/\1/p
 
 # Clean up opentrons package dir if it's a first start of a new container
 touch /data/id
-if [ '$(cat /data/id)' != $CONTAINER_ID ] ; then
+previous_id="$(cat /data/id)"
+current_id="$CONTAINER_ID"
+if [ $previous_id != $current_id ] ; then
   echo 'First start of a new container. Deleting local Opentrons API installation'
   rm -rf /data/packages/usr/local/lib/python3.6/site-packages/opentrons*
-  echo $CONTAINER_ID > /data/id
+  echo $current_id > /data/id
 fi
 
 # Set static address so we can find the device from host computer over

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -12,7 +12,15 @@ nginx
 inetd -e /etc/inetd.conf
 
 # Home robot
+echo "Homing Robot... this may take a few seconds."
 python -c "from opentrons import robot; robot.connect(); robot.home()"
 
-# Opentrons API Server
+# Check if config exists, and alert if not found
+config_path=`python -c "from opentrons.util import environment; print(environment.get_path('APP_DATA_DIR') + 'config.json')"`
+
+if [ ! -e "$config_path" ]; then
+    echo "Config file does not found. Please perform factory calibration and then restart robot"
+    while true; do sleep 1; done
+fi
+echo "Starting Opentrons API server"
 python -m opentrons.server.main -H :: -P $OT_API_PORT_NUMBER


### PR DESCRIPTION
## Description:

Add protections and checks related to startup and calibration data

Important change: if you start the robot and "$APP_DATA_DIR/config.json" does not exist, the server **will not start**. It goes into an infinite wait loop so that the developer will be able to ssh in and do factory calibration.

## Changelog:

- (feature) Add checks for config file on boot, prompt user to calibrate if not found and then go into wait loop
- (feature) Add confirmation before deleting calibration data, and restart after calibration
- (bugfix) Fix bash string comparison bugs in startup scripts
