### PR TITLE
(complib, app) Add icons to comp lib (and swap out one USB icon in the app)

### DIFF
--- a/app/ui/components/connect-panel/RobotItem.js
+++ b/app/ui/components/connect-panel/RobotItem.js
@@ -2,9 +2,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import {PrimaryButton} from '@opentrons/components'
+import {PrimaryButton, Icon, USB} from '@opentrons/components'
 
-import Icon, {USB} from '../Icon'
 import styles from './connect-panel.css'
 
 RobotItem.propTypes = {

--- a/components/.flowconfig
+++ b/components/.flowconfig
@@ -3,9 +3,11 @@
 [include]
 
 [libs]
+flow-typed
 
 [lints]
 
 [options]
+module.name_mapper.extension='css' -> '<PROJECT_ROOT>/types/CSSModule.js'
 
 [strict]

--- a/components/.gitignore
+++ b/components/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+flow-typed

--- a/components/Makefile
+++ b/components/Makefile
@@ -51,6 +51,14 @@ test:
 check:
 	$(bin)/flow
 
+.PHONY: install-types
+install-types:
+	$(bin)/flow-typed install --ignoreDeps dev
+
+.PHONY: uninstall-types
+uninstall-types:
+	rm -rf flow-typed
+
 .PHONY: lint
 lint:
 	$(bin)/standard --verbose --fix=$(fix) | $(bin)/snazzy

--- a/components/README.md
+++ b/components/README.md
@@ -2,39 +2,69 @@
 
 React components for Opentrons' applications. Designed to be used in `webpack` projects using `babel` and `babel-loader`.
 
+## example usage
+
+```javascript
+import {PrimaryButton} from '@opentrons/components'
+
+export default function CowButton (props) {
+  return (
+    <PrimaryButton onClick={() => console.log('🐄')} />
+  )
+}
+```
+
 ## setup
 
 Requirements:
 
-* Node lts/carbon (v8)
-* npm v5.6.0
+* Node lts/carbon (v8) and npm v5.6.0
 * React v16
 * `babel-loader` configured to run `babel-preset-react` on `.js` files
+* `jest` configured to:
+    * proxy `.css` imports to `identity-obj-proxy`
+    * transform `.js` files in `node_modules/@opentrons`
+
+### node/npm setup
+
+The root of the monorepo has an `.nvmrc` file with the correct Node version, so to make sure your Node and npm versions are correct:
+
+``` shell
+cd opentrons
+nvm use
+npm install -g npm@5.6.0
+```
 
 ### components library setup
 
-Since we're using a monorepo with symlink dependencies (thanks npm v5!), when you use the components library in a project, the library will pull dependencies from its own directory. Therefore, we need to install them first:
+Since we're using a monorepo with symlink dependencies (thanks npm v5!), when you use the components library in a project, the library will pull dependencies from its own directory. Therefore, we need to install them first.
 
 ```shell
 # install components library requirements
 cd components
 make install
+# if you'll be writing components
+make install-types
 ```
 
-### project setup
+### new project setup (optional)
 
-Once that's done, you should be ready to install and use the components library in another project
+If you ever need to set up a new project in the monorepo that depends on the components library:
 
 ```shell
-cd another-project
-npm install --save ./path/to/components
+cd new-project
+npm install --save ../components
 # or use save-dev depending on the project setup
-# npm install --save-dev ./path/to/components
+# npm install --save-dev ../components
 ```
 
-You'll also need to make sure webpack and babel are set up properly:
+You'll also need to make sure webpack, babel, and jest are set up properly. [`app`](../app) and [`protocol-designer`](../protocol-designer) are good to look at for examples of monorepo projects using the components library.
 
 **example webpack.config.js**
+
+```shell
+npm install --save-dev webpack babel-core babel-loader
+```
 
 ``` js
 module.exports = {
@@ -55,25 +85,41 @@ module.exports = {
 
 **example .babelrc**
 
+```shell
+npm install --save-dev babel-preset-react babel-preset-env babel-plugin-transform-es2015-modules-commonjs
+```
+
 ``` json
 {
   "presets": [
     "react",
     ["env", {"modules": false}]
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  },
 }
 ```
 
-## usage
+**example packkage.json**
 
-```javascript
-import {PrimaryButton} from '@opentrons/components'
+```shell
+npm install --save-dev jest babel-jest identity-obj-proxy
+```
 
-export default function CowButton (props) {
-  return (
-    <PrimaryButton onClick={() => console.log('🐄')} />
-  )
-}
+```json
+"jest": {
+  "moduleNameMapper": {
+    "\\.(css)$": "identity-obj-proxy"
+  },
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@opentrons/)"
+  ]
+},
 ```
 
 ## components
@@ -99,3 +145,57 @@ title     | string                     | no       | element title
 disabled  | bool                       | no       | disabled flag
 className | string                     | no       | additional class names
 children  | React.Node                 | no       | contents of the button
+
+### icons
+
+[icons.js](./src/icons.js)
+
+SVG icons that take `color` from their parent.
+
+```js
+import {Icon, BACK, REFRESH, USB, WIFI} from '@opentrons/components'
+```
+
+prop      | flow type                      | required | description
+--------- | ------------------------------ | -------- | ----------------------
+name      | BACK &#124; REFRESH &#124; ... | yes      | icon name
+className | string                         | no       | additional class names
+
+
+## contributing
+
+### flow
+
+We use [flow] for static type checking of our components. See flow's documentation for usage instructions and type definitions.
+
+If you need to add an external dependency to the components library for a component, it probably won't come with type definitions (for example, `classnames`). In that case, [flow-typed] probably has the type definitions you're looking for.
+
+```
+# install some dependency
+npm install --save classnames
+# install type definitions for all dependencies
+make install-types
+```
+
+You also may want to check out good [editor setups for flow][flow-editors].
+
+### unit tests
+
+Unit tests live in a `__tests__` directory in the same directory as the module under test. When writing unit tests for components, we've found the following tests to be the most useful:
+
+* DOM tests
+    * Make sure the component renders the correct node type
+    * Make sure DOM attributes are mapped correctly
+    * Make sure handlers fire correctly
+* Render tests
+    * Snapshot tests using [jest's snapshot functionality][jest-snapshots]
+    * To regenerate snapshots after an intentional rendering change, run:
+    
+    ``` shell
+    make test updateSnapshot=true
+    ```
+
+[flow]: https://flow.org/
+[flow-typed]: https://github.com/flowtype/flow-typed
+[flow-editors]: https://flow.org/en/docs/editors/
+[jest-snapshots]: https://facebook.github.io/jest/docs/en/snapshot-testing.html

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1020,6 +1020,25 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
@@ -1186,6 +1205,16 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -1243,6 +1272,12 @@
       "requires": {
         "node-int64": "0.4.0"
       }
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1327,6 +1362,15 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": "0.3.9"
+      }
+    },
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
@@ -1360,6 +1404,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
       "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "dev": true
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
       "dev": true
     },
     "ci-info": {
@@ -1456,6 +1506,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combined-stream": {
@@ -1558,6 +1614,12 @@
         "which": "1.3.0"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "cryptiles": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
@@ -1640,6 +1702,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1796,6 +1867,12 @@
       "requires": {
         "is-obj": "1.0.1"
       }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2480,6 +2557,190 @@
       "integrity": "sha512-n31idUasUQVqOYl8Tvig7kfmdcAdRC+J1Gt88J435DZm0saNfwqeYOMoZrehRD6JgaAGQ0PaJfoxWuL9lKZXpA==",
       "dev": true
     },
+    "flow-typed": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/flow-typed/-/flow-typed-2.2.3.tgz",
+      "integrity": "sha512-xCKOrKn/DnA4BPbNKyp3s2vW7Pzvff1zJhEdzNviTgwpiEkTG6uxQLjofcqvKdzTyZ/PjHBzkx02iyhP/2NrCg==",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "6.26.0",
+        "colors": "1.1.2",
+        "fs-extra": "4.0.3",
+        "github": "0.2.4",
+        "glob": "7.1.2",
+        "got": "7.1.0",
+        "md5": "2.2.1",
+        "mkdirp": "0.5.1",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
+        "semver": "5.4.1",
+        "table": "4.0.2",
+        "through": "2.3.8",
+        "unzip": "0.1.11",
+        "which": "1.3.0",
+        "yargs": "4.8.1"
+      },
+      "dependencies": {
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.1",
+            "ajv-keywords": "2.1.1",
+            "chalk": "2.3.0",
+            "lodash": "4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "2.1.1"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2516,6 +2777,17 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
+      }
+    },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -3542,6 +3814,29 @@
         }
       }
     },
+    "fstream": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "3.0.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true,
+          "requires": {
+            "natives": "1.1.1"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3588,6 +3883,15 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "github": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+      "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
+      "dev": true,
+      "requires": {
+        "mime": "1.6.0"
       }
     },
     "glob": {
@@ -3656,6 +3960,28 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
       "dev": true
+    },
+    "got": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.1",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3743,6 +4069,21 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "hawk": {
       "version": "6.0.2",
@@ -4119,6 +4460,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -4190,6 +4537,12 @@
       "requires": {
         "tryit": "1.0.3"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4383,6 +4736,16 @@
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
+      }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jest": {
@@ -4776,6 +5139,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -4890,6 +5262,12 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
@@ -4935,6 +5313,12 @@
         "signal-exit": "3.0.2"
       }
     },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -4972,11 +5356,58 @@
       "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw=",
       "dev": true
     },
+    "match-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+      "dev": true,
+      "requires": {
+        "buffers": "0.1.1",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "mathml-tag-names": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.0.1.tgz",
       "integrity": "sha1-jUEmgWi/htEQK5gQnijlMeejRXg=",
       "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
+      }
     },
     "mdast-util-compact": {
       "version": "1.0.1",
@@ -5050,6 +5481,12 @@
         "regex-cache": "0.4.4"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -5069,6 +5506,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
       "dev": true
     },
     "minimatch": {
@@ -5113,6 +5556,12 @@
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
+    },
+    "natives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5315,6 +5764,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "over": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg=",
+      "dev": true
+    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -5340,6 +5795,15 @@
       "dev": true,
       "requires": {
         "p-limit": "1.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "dev": true,
+      "requires": {
+        "p-finally": "1.0.0"
       }
     },
     "parse-entities": {
@@ -5793,6 +6257,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -5864,6 +6334,44 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pullstream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+      "dev": true,
+      "requires": {
+        "over": "0.0.5",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5",
+        "slice-stream": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -6404,6 +6912,41 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "slice-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "snazzy": {
       "version": "7.0.0",
@@ -7027,6 +7570,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -7052,6 +7601,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
     },
     "trim": {
@@ -7238,6 +7793,67 @@
       "requires": {
         "unist-util-is": "2.1.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
+    },
+    "unzip": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
+      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+      "dev": true,
+      "requires": {
+        "binary": "0.3.0",
+        "fstream": "0.1.31",
+        "match-stream": "0.0.2",
+        "pullstream": "0.4.1",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
     },
     "user-home": {
       "version": "2.0.0",

--- a/components/package.json
+++ b/components/package.json
@@ -27,7 +27,8 @@
       "flowtype"
     ],
     "globals": [
-      "SyntheticEvent"
+      "SyntheticEvent",
+      "$Keys"
     ],
     "env": [
       "browser",
@@ -54,6 +55,7 @@
     "cross-env": "^5.1.1",
     "eslint-plugin-flowtype": "^2.39.1",
     "flow-bin": "^0.60.1",
+    "flow-typed": "^2.2.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.2.1",
     "react-test-renderer": "^16.2.0",

--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`icons back icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M18 11.242v1.516H8.91l4.166 4.166L12 18l-6-6 6-6 1.076 1.076-4.167 4.166z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons refresh icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 200 200"
+>
+  <path
+    d="M121.9,31.3L129,4.6l56.7,56.7l-77.5,20.8c0,0,7.7-28.6,7.7-28.6c-5.7-1.8-11.7-2.7-17.9-2.7 c-33.5,0-60.8,27.3-60.8,60.8c0,33.5,27.3,60.8,60.8,60.8c26.5,0,50.5-17.7,58.1-43.1l22,6.7c-5.1,16.8-15.7,32-29.8,42.6 c-14.6,11-32,16.8-50.3,16.8c-46.2,0-83.8-37.6-83.8-83.8S51.8,27.9,98,27.9C106.1,27.9,114.1,29.1,121.9,31.3"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons usb icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M15.347 6.792v4.529h1.132v2.264h-3.396V4.528h2.264L11.951 0 8.555 4.528h2.264v9.057H7.423v-2.343c.792-.42 1.358-1.223 1.358-2.185 0-1.37-1.12-2.491-2.49-2.491S3.8 7.686 3.8 9.056c0 .963.566 1.767 1.358 2.186v2.343a2.256 2.256 0 0 0 2.265 2.264h3.396v3.453a2.492 2.492 0 0 0-1.359 2.207 2.49 2.49 0 0 0 4.982 0c0-.962-.555-1.788-1.359-2.207v-3.453h3.396a2.256 2.256 0 0 0 2.264-2.264V11.32h1.132V6.792h-4.528z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons wifi icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M0 9.414l2.182 2.182c5.422-5.422 14.214-5.422 19.636 0L24 9.414c-6.622-6.622-17.367-6.622-24 0zm8.727 8.727L12 21.414l3.273-3.273a4.622 4.622 0 0 0-6.546 0zm-4.363-4.363l2.181 2.181a7.717 7.717 0 0 1 10.91 0l2.181-2.181c-4.21-4.211-11.05-4.211-15.272 0z"
+    fillRule="evenodd"
+  />
+</svg>
+`;

--- a/components/src/__tests__/buttons.test.js
+++ b/components/src/__tests__/buttons.test.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Renderer from 'react-test-renderer'
 
-import {PrimaryButton} from '../buttons'
+import {PrimaryButton} from '..'
 
 describe('PrimaryButton', () => {
   test('creates a button with props', () => {

--- a/components/src/__tests__/icons.test.js
+++ b/components/src/__tests__/icons.test.js
@@ -1,0 +1,39 @@
+// icon components tests
+import React from 'react'
+import Renderer from 'react-test-renderer'
+
+import {Icon, BACK, REFRESH, USB, WIFI} from '..'
+
+describe('icons', () => {
+  test('back icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={BACK} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('refresh icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={REFRESH} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('usb icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={USB} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('wifi icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={WIFI} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/components/src/buttons.js
+++ b/components/src/buttons.js
@@ -1,5 +1,5 @@
-// button components
 // @flow
+// button components
 
 import * as React from 'react'
 import classnames from 'classnames'

--- a/components/src/icons.js
+++ b/components/src/icons.js
@@ -1,0 +1,53 @@
+// @flow
+// icon component and library
+
+import * as React from 'react'
+import classnames from 'classnames'
+
+// icon names
+export const BACK = 'back'
+export const REFRESH = 'refresh'
+export const USB = 'usb'
+export const WIFI = 'wifi'
+
+// icon data
+const ICON_DATA_BY_NAME = {
+  [BACK]: {
+    viewBox: '0 0 24 24',
+    path: 'M18 11.242v1.516H8.91l4.166 4.166L12 18l-6-6 6-6 1.076 1.076-4.167 4.166z'
+  },
+  [REFRESH]: {
+    viewBox: '0 0 200 200',
+    path: 'M121.9,31.3L129,4.6l56.7,56.7l-77.5,20.8c0,0,7.7-28.6,7.7-28.6c-5.7-1.8-11.7-2.7-17.9-2.7 c-33.5,0-60.8,27.3-60.8,60.8c0,33.5,27.3,60.8,60.8,60.8c26.5,0,50.5-17.7,58.1-43.1l22,6.7c-5.1,16.8-15.7,32-29.8,42.6 c-14.6,11-32,16.8-50.3,16.8c-46.2,0-83.8-37.6-83.8-83.8S51.8,27.9,98,27.9C106.1,27.9,114.1,29.1,121.9,31.3'
+  },
+  [USB]: {
+    viewBox: '0 0 24 24',
+    path: 'M15.347 6.792v4.529h1.132v2.264h-3.396V4.528h2.264L11.951 0 8.555 4.528h2.264v9.057H7.423v-2.343c.792-.42 1.358-1.223 1.358-2.185 0-1.37-1.12-2.491-2.49-2.491S3.8 7.686 3.8 9.056c0 .963.566 1.767 1.358 2.186v2.343a2.256 2.256 0 0 0 2.265 2.264h3.396v3.453a2.492 2.492 0 0 0-1.359 2.207 2.49 2.49 0 0 0 4.982 0c0-.962-.555-1.788-1.359-2.207v-3.453h3.396a2.256 2.256 0 0 0 2.264-2.264V11.32h1.132V6.792h-4.528z'
+  },
+  [WIFI]: {
+    viewBox: '0 0 24 24',
+    path: 'M0 9.414l2.182 2.182c5.422-5.422 14.214-5.422 19.636 0L24 9.414c-6.622-6.622-17.367-6.622-24 0zm8.727 8.727L12 21.414l3.273-3.273a4.622 4.622 0 0 0-6.546 0zm-4.363-4.363l2.181 2.181a7.717 7.717 0 0 1 10.91 0l2.181-2.181c-4.21-4.211-11.05-4.211-15.272 0z'
+  }
+}
+
+type Props = {
+  name: $Keys<typeof ICON_DATA_BY_NAME>,
+  className?: string
+}
+
+export function Icon (props: Props) {
+  const {viewBox, path} = ICON_DATA_BY_NAME[props.name]
+  const className = classnames(props.className)
+
+  return (
+    <svg
+      version='1.1'
+      aria-hidden='true'
+      viewBox={viewBox}
+      className={className}
+      fill='currentColor'
+    >
+      <path fillRule='evenodd' d={path} />
+    </svg>
+  )
+}

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -1,4 +1,5 @@
-// opentrons components library
 // @flow
+// opentrons components library
 
-export {PrimaryButton} from './buttons'
+export * from './buttons'
+export * from './icons'

--- a/components/types/CSSModule.js
+++ b/components/types/CSSModule.js
@@ -1,0 +1,3 @@
+// @flow
+
+declare export default { [key: string]: string }


### PR DESCRIPTION
## overview

This PR copies the baby SVG icon component out of the app and into the components library. At the moment, the icon data are generated by:

1. Exporting the icon symbol as SVG from Sketch
2. Running the SVG through `svgo`
3. Copying the `path` and `viewBox` data from the optimized SVG

Obviously this needs to be automated at some point, but for now it works.

```js
import {Icon, WIFI} from '@opentrons/components'

export function SomeComponent () {
  return (
    <Icon name={WIFI} className='foobar' />
  )
}
```

Still TODO in a followup:

* Replace all icons in app with `Icon` component
* Remove old `Icon.js`, `icons.js`, and `icons.css` in app

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [X] Documentation updates
- [X] Test updates

## changelog

- (Feature) Added `Icon` to components library
- (Docs) Improved the components library README instructions
- (Docs) Added `Icon` to README
- (Tests) Added some `Icon` snapshot tests

## review requests

Really curious as to what y'all think about:

* README improvements
* Usage of Icon component and icon name constants
* How we're exporting the Icon component and name constants from the library