### PR TITLE
lower tip clearance to allow taller containers

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -15,7 +15,11 @@ from opentrons.util.log import get_logger
 
 log = get_logger(__name__)
 
-TIP_CLEARANCE = 42
+# TODO (andy) this is the height the tip will travel above the deck's tallest
+# container. This should not be a single value, but should be optimized given
+# the movements context (ie sterility vs speed). This is being set to 20mm
+# to allow containers >150mm to be usable on the deck for the tiem being.
+TIP_CLEARANCE = 20
 
 
 class InstrumentMosfet(object):

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -100,7 +100,7 @@ def test_create_arc(robot):
     # TODO(artyom 20171030): confirm expected values are correct after merging
     # calibration work
     expected = [
-        {'z': 52.5},
+        {'z': 30.5},
         {'x': 0, 'y': 0},
         {'z': 0}
     ]
@@ -115,7 +115,7 @@ def test_create_arc(robot):
     # TODO(artyom 20171030): confirm expected values are correct after merging
     # calibration work
     expected = [
-        {'z': 52.5},
+        {'z': 30.5},
         {'x': 0, 'y': 0},
         {'z': 0}
     ]


### PR DESCRIPTION
## Description:

This is a temporary adjustment to allow a beta machine to run protocol with a container of height 170mm. This issue was the robot was colliding with Z limit switch while running, so this PR simply lowers `robot`'s tip clearance from `42`mm down to `20`mm, and also leaves a TODO emphasizing that this clearance should be determined by the context of that movement, not a context.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
