### PR TITLE
(complib, app) Add PageTabs and use it for pip. selection

### DIFF
--- a/app/ui/components/PipetteConfig.css
+++ b/app/ui/components/PipetteConfig.css
@@ -36,22 +36,6 @@
   pointer-events: none;
 }
 
-.pipette_toggle {
-  grid-area: toggle;
-  width: 100%;
-  height: 4rem;
-  margin-bottom: 1rem;
-  border-radius: 0.25rem;
-  background-color: #777;
-  font-size: 2rem;
-  color: white;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  line-height: 4rem;
-  cursor: pointer;
-}
-
 .pipette_info {
   grid-area: info;
   min-height: 375px;

--- a/app/ui/components/PipetteConfig.js
+++ b/app/ui/components/PipetteConfig.js
@@ -8,6 +8,18 @@ import styles from './PipetteConfig.css'
 import singlePipetteSrc from '../img/pipette_single.png'
 import multiPipetteSrc from '../img/pipette_multi.png'
 
+PipetteConfig.propTypes = {
+  currentInstrument: PropTypes.shape({
+    axis: PropTypes.string.isRequired
+  }),
+  instruments: PropTypes.arrayOf(PropTypes.shape({
+    axis: PropTypes.string.isRequired,
+    channels: PropTypes.string,
+    volume: PropTypes.number,
+    isProbed: PropTypes.bool
+  })).isRequired
+}
+
 export default function PipetteConfig (props) {
   const {instruments, side} = props
 
@@ -24,11 +36,6 @@ export default function PipetteConfig (props) {
       [styles.inactive]: axis !== side
     })
 
-    const linkStyle = classnames(
-      styles.pipette_toggle,
-      styles[`toggle_${axis}`]
-    )
-
     const description = isUsed
       ? `${capitalize(channels)}-channel (${volume} ul)`
       : 'N/A'
@@ -39,9 +46,6 @@ export default function PipetteConfig (props) {
 
     return (
       <div className={style} key={axis}>
-        <div className={linkStyle}>
-          {axis}
-        </div>
         <div className={styles.pipette_info}>
           <h2 className={styles.title}>
             Pipette
@@ -70,17 +74,4 @@ export default function PipetteConfig (props) {
       {pipettes}
     </section>
   )
-}
-
-PipetteConfig.propTypes = {
-  onPrepareClick: PropTypes.func.isRequired,
-  currentInstrument: PropTypes.shape({
-    axis: PropTypes.string.isRequired
-  }),
-  instruments: PropTypes.arrayOf(PropTypes.shape({
-    axis: PropTypes.string.isRequired,
-    channels: PropTypes.string,
-    volume: PropTypes.number,
-    isProbed: PropTypes.bool
-  })).isRequired
 }

--- a/app/ui/components/setup-instruments/InstrumentTabs.js
+++ b/app/ui/components/setup-instruments/InstrumentTabs.js
@@ -1,0 +1,19 @@
+// instrument tabs bar container
+// used for left/right pipette selection during pipette calibration
+
+import {connect} from 'react-redux'
+import {PageTabs} from '@opentrons/components'
+import {selectors as robotSelectors} from '../../robot'
+
+export default connect(mapStateToProps)(PageTabs)
+
+function mapStateToProps (state, ownProps) {
+  const pages = robotSelectors.getInstruments(state).map((inst) => ({
+    title: inst.axis,
+    href: `/setup-instruments/${inst.axis}`,
+    isActive: inst.axis === ownProps.side,
+    isDisabled: inst.name == null
+  }))
+
+  return {pages}
+}

--- a/app/ui/components/setup-instruments/index.js
+++ b/app/ui/components/setup-instruments/index.js
@@ -1,0 +1,4 @@
+// instrument setup components
+import InstrumentTabs from './InstrumentTabs'
+
+export {InstrumentTabs}

--- a/app/ui/containers/ConnectedPipetteConfig.js
+++ b/app/ui/containers/ConnectedPipetteConfig.js
@@ -1,19 +1,15 @@
+// container wrapping PipetteConfig component
+// displays pipettes and tip probe controls during pipette setup
+
 import {connect} from 'react-redux'
 
-import {
-  actions as robotActions,
-  selectors as robotSelectors
-} from '../robot'
-
+import {selectors as robotSelectors} from '../robot'
 import PipetteConfig from '../components/PipetteConfig'
 
-const mapStateToProps = (state) => ({
-  instruments: robotSelectors.getInstruments(state)
-})
+export default connect(mapStateToProps)(PipetteConfig)
 
-const mapDispatchToProps = (dispatch) => ({
-  // TODO(mc, 2017-10-05): pass axis in via props to ease GC pressure
-  onPrepareClick: (axis) => () => dispatch(robotActions.moveToFront(axis))
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(PipetteConfig)
+function mapStateToProps (state) {
+  return {
+    instruments: robotSelectors.getInstruments(state)
+  }
+}

--- a/app/ui/pages/SetupInstruments.js
+++ b/app/ui/pages/SetupInstruments.js
@@ -1,17 +1,23 @@
 // setup instruments component
 import React from 'react'
+
 import Page from '../components/Page'
+import {InstrumentTabs} from '../components/setup-instruments'
+
 import SessionHeader from '../containers/SessionHeader'
 import ConnectedPipetteConfig from '../containers/ConnectedPipetteConfig'
 
+const PAGE_TITLE = 'Setup Instruments'
 const DEFAULT_SIDE = 'left'
 
 export default function SetupInstrumentsPage (props) {
   const {match} = props
   const side = match.params.side || DEFAULT_SIDE
+
   return (
     <Page>
-      <SessionHeader subtitle='Setup Instruments' />
+      <SessionHeader subtitle={PAGE_TITLE} />
+      <InstrumentTabs side={side} />
       <ConnectedPipetteConfig side={side} />
     </Page>
   )

--- a/components/.flowconfig
+++ b/components/.flowconfig
@@ -3,7 +3,6 @@
 [include]
 
 [libs]
-flow-typed
 
 [lints]
 

--- a/components/README.md
+++ b/components/README.md
@@ -18,12 +18,12 @@ export default function CowButton (props) {
 
 Requirements:
 
-* Node lts/carbon (v8) and npm v5.6.0
-* React v16
-* `babel-loader` configured to run `babel-preset-react` on `.js` files
-* `jest` configured to:
-    * proxy `.css` imports to `identity-obj-proxy`
-    * transform `.js` files in `node_modules/@opentrons`
+*   Node lts/carbon (v8) and npm v5.6.0
+*   React v16
+*   `babel-loader` configured to run `babel-preset-react` on `.js` files
+*   `jest` configured to:
+    *   proxy `.css` imports to `identity-obj-proxy`
+    *   transform `.js` files in `node_modules/@opentrons`
 
 ### node/npm setup
 
@@ -105,7 +105,7 @@ npm install --save-dev babel-preset-react babel-preset-env babel-plugin-transfor
 }
 ```
 
-**example packkage.json**
+**example package.json**
 
 ```shell
 npm install --save-dev jest babel-jest identity-obj-proxy
@@ -138,13 +138,13 @@ Primary application button with dark background and white text
 import {PrimaryButton} from '@opentrons/components'
 ```
 
-prop      | flow type                  | required | description
---------- | -------------------------- | -------- | ----------------------
-onClick   | (SyntheticEvent<>) => void | yes      | click event handler
-title     | string                     | no       | element title
-disabled  | bool                       | no       | disabled flag
-className | string                     | no       | additional class names
-children  | React.Node                 | no       | contents of the button
+ prop      | flow type                  | required | description
+---------- | -------------------------- | -------- | ----------------------
+ onClick   | (SyntheticEvent<>) => void | yes      | click event handler
+ title     | string                     | no       | element title
+ disabled  | bool                       | no       | disabled flag
+ className | string                     | no       | additional class names
+ children  | React.Node                 | no       | contents of the button
 
 ### icons
 
@@ -175,8 +175,29 @@ import type {IconName} from '@opentrons/components'
 *   `USB`
 *   `WIFI`
 
-
 ### structure
+
+#### PageTabs
+
+Sub-page tabs to sit underneath the title bar
+
+```js
+import {PageTabs} from '@opentrons/components'
+```
+
+ prop      | flow type              | required | description
+---------- | ---------------------- | -------- | ------------------------------
+ pages     | Array&lt;TabProps&gt; | yes      | Array of pages that need tabs
+
+**TabProps**
+
+ prop       | flow type | required | description
+----------- | --------- | -------- | ------------------------------
+ title      | string    | yes      | Link title (displayed on tab)
+ href       | string    | yes      | Link target
+ isDisabled | bool      | yes      | Is the link disabled?
+ isActive   | bool      | yes      | Is the link active?
+
 
 #### TitleBar
 
@@ -186,18 +207,18 @@ Top title bar with optional subtitle
 import {TitleBar} from '@opentrons/components'
 ```
 
-prop      | flow type  | required | description
---------- | ---------- | -------- | ------------
-title     | React.Node | yes      | h1 child
-subtitle  | React.Node | no       | h2 child
+ prop      | flow type  | required | description
+---------- | ---------- | -------- | ------------
+ title     | React.Node | yes      | h1 child
+ subtitle  | React.Node | no       | h2 child
 
 ## contributing
 
 ### flow
 
-We use [flow] for static type checking of our components. See flow's documentation for usage instructions and type definitions.
+We use [flow][] for static type checking of our components. See flow's documentation for usage instructions and type definitions.
 
-If you need to add an external dependency to the components library for a component, it probably won't come with type definitions (for example, `classnames`). In that case, [flow-typed] probably has the type definitions you're looking for.
+If you need to add an external dependency to the components library for a component, it probably won't come with type definitions (for example, `classnames`). In that case, [flow-typed][] probably has the type definitions you're looking for.
 
 ```
 # install some dependency
@@ -212,13 +233,13 @@ You also may want to check out good [editor setups for flow][flow-editors].
 
 Unit tests live in a `__tests__` directory in the same directory as the module under test. When writing unit tests for components, we've found the following tests to be the most useful:
 
-* DOM tests
-    * Make sure the component renders the correct node type
-    * Make sure DOM attributes are mapped correctly
-    * Make sure handlers fire correctly
-* Render tests
-    * Snapshot tests using [jest's snapshot functionality][jest-snapshots]
-    * To regenerate snapshots after an intentional rendering change, run:
+*   DOM tests
+    *   Make sure the component renders the correct node type
+    *   Make sure DOM attributes are mapped correctly
+    *   Make sure handlers fire correctly
+*   Render tests
+    *   Snapshot tests using [jest's snapshot functionality][jest-snapshots]
+    *   To regenerate snapshots after an intentional rendering change, run:
 
     ``` shell
     make test updateSnapshot=true

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -4097,11 +4097,28 @@
         "sntp": "2.1.0"
       }
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "requires": {
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
+      }
+    },
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
       "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
+      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4286,7 +4303,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -5877,6 +5893,21 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -6437,6 +6468,33 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-router": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
+      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+      "requires": {
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.3.1",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
+      "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
+      "requires": {
+        "history": "4.7.2",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "react-router": "4.2.0",
+        "warning": "3.0.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
@@ -6759,6 +6817,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -7886,6 +7949,11 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -7931,6 +7999,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.11"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
       }
     },
     "watch": {

--- a/components/package.json
+++ b/components/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "react": "^16.2.0"
+    "react": "^16.2.0",
+    "react-router-dom": "^4.2.2"
   }
 }

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PageTabs renders PageTabs correctly 1`] = `
+<nav
+  className="page_tabs"
+>
+  <a
+    className="active_tab_link"
+    href="/page1"
+    onClick={[Function]}
+  >
+    <h3
+      className="tab_title"
+    >
+      Page1
+    </h3>
+  </a>
+  <span
+    className="tab_link"
+    to="/page2"
+  >
+    <h3
+      className="tab_title"
+    >
+      Page2
+    </h3>
+  </span>
+</nav>
+`;
+
 exports[`TitleBar renders TitleBar with subtitle correctly 1`] = `
 <header
   className="title_bar"

--- a/components/src/__tests__/buttons.test.js
+++ b/components/src/__tests__/buttons.test.js
@@ -18,7 +18,7 @@ describe('PrimaryButton', () => {
     ).root.findByType('button')
 
     button.props.onClick()
-    expect(button.props.className).toMatch(/class/)
+    expect(button.props.className).toMatch(/\bclass\b/)
     expect(button.props.title).toBe('title')
     expect(button.props.disabled).toBe(false)
     expect(button.children).toEqual(['children'])

--- a/components/src/__tests__/structure.test.js
+++ b/components/src/__tests__/structure.test.js
@@ -1,8 +1,9 @@
 // structure components tests
 import React from 'react'
+import {MemoryRouter} from 'react-router'
 import Renderer from 'react-test-renderer'
 
-import {TitleBar} from '..'
+import {PageTabs, TitleBar} from '..'
 
 describe('TitleBar', () => {
   test('adds an h1 with the title', () => {
@@ -34,6 +35,73 @@ describe('TitleBar', () => {
   test('renders TitleBar with subtitle correctly', () => {
     const tree = Renderer.create(
       <TitleBar title='foo' subtitle='bar' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('PageTabs', () => {
+  test('renders h3 links for each page', () => {
+    const pages = [
+      {title: 'Page1', href: '/page1', isActive: false, isDisabled: false},
+      {title: 'Page2', href: '/page2', isActive: false, isDisabled: false}
+    ]
+
+    const root = Renderer.create(
+      <MemoryRouter>
+        <PageTabs pages={pages} />
+      </MemoryRouter>
+    ).root
+
+    const links = root.findAllByType('a')
+    expect(links).toHaveLength(2)
+
+    links.forEach((link, index) => {
+      const {title, href} = pages[index]
+      expect(link.props.href).toBe(href)
+      expect(link.findByType('h3').children).toEqual([title])
+    })
+  })
+
+  test('does not create a link if disabled', () => {
+    const pages = [
+      {title: 'Page1', href: '/page1', isActive: false, isDisabled: true}
+    ]
+
+    const notLink = Renderer.create(
+      <MemoryRouter>
+        <PageTabs pages={pages} />
+      </MemoryRouter>
+    ).root.findByType('span')
+
+    expect(notLink.findByType('h3').children).toEqual([pages[0].title])
+  })
+
+  test('adds active class if active', () => {
+    const pages = [
+      {title: 'Page1', href: '/page1', isActive: true, isDisabled: false}
+    ]
+
+    const link = Renderer.create(
+      <MemoryRouter>
+        <PageTabs pages={pages} />
+      </MemoryRouter>
+    ).root.findByType('a')
+
+    expect(link.props.className).toMatch(/active/)
+  })
+
+  test('renders PageTabs correctly', () => {
+    const pages = [
+      {title: 'Page1', href: '/page1', isActive: true, isDisabled: false},
+      {title: 'Page2', href: '/page2', isActive: false, isDisabled: true}
+    ]
+
+    const tree = Renderer.create(
+      <MemoryRouter>
+        <PageTabs pages={pages} />
+      </MemoryRouter>
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/structure/PageTabs.js
+++ b/components/src/structure/PageTabs.js
@@ -1,0 +1,48 @@
+// @flow
+// page tabs bar
+
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+import styles from './structure.css'
+
+type TabProps = {
+  title: string,
+  href: string,
+  isActive: bool,
+  isDisabled: bool
+}
+
+type Props = {
+  pages: Array<TabProps>
+}
+
+export default function PageTabs (props: Props) {
+  return (
+    <nav className={styles.page_tabs}>
+      {props.pages.map((page) => (
+        <Tab key={page.title} {...page} />
+      ))}
+    </nav>
+  )
+}
+
+function Tab (props: TabProps) {
+  const {isDisabled} = props
+  const tabLinkClass = props.isActive
+    ? styles.active_tab_link
+    : styles.tab_link
+
+  // TODO(mc, 2017-12-14): make a component for proper disabling of links
+  const MaybeLink = !isDisabled
+    ? Link
+    : 'span'
+
+  return (
+    <MaybeLink to={props.href} className={tabLinkClass}>
+      <h3 className={styles.tab_title}>
+        {props.title}
+      </h3>
+    </MaybeLink>
+  )
+}

--- a/components/src/structure/index.js
+++ b/components/src/structure/index.js
@@ -1,5 +1,6 @@
 // @flow
 // structure components
+import PageTabs from './PageTabs'
 import TitleBar from './TitleBar'
 
-export {TitleBar}
+export {PageTabs, TitleBar}

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -2,10 +2,13 @@
 
 /* TODO(mc, 2017-12-13): move colors to colors.css */
 @value color_dark_grey: #4a4a4a;
+@value color_mid_grey: #9b9b9b;
 
 /* TODO(mc, 2017-12-13): move font sizes and weights to typography.css */
+@value font_size_huge: 3rem;
 @value font_size_header: 1.125rem;
 @value font_weight_semibold: 600;
+@value font_weight_bold: 700;
 
 .title_bar {
   padding: 1rem;
@@ -36,4 +39,33 @@
 
 .separator {
   padding: 0 1.75rem;
+}
+
+.page_tabs {
+  width: 100%;
+  text-align: center;
+}
+
+.tab_link {
+  display: inline-block;
+  width: 50%;
+  padding: 0.25rem 0;
+  font-size: font_size_huge;
+  opacity: 0.2;
+  background-color: color_mid_grey;
+  color: white;
+  text-transform: uppercase;
+}
+
+.active_tab_link {
+  composes: tab_link;
+  opacity: 1;
+}
+
+.tab_title {
+  font-weight: normal;
+}
+
+.active_tab_link .tab_title {
+  font-weight: font_weight_bold;
 }


### PR DESCRIPTION
## overview

Incremental PR of ongoing calibration screen alignment. I've added a `PageTabs` component ("Structure / Page / Tabs" in Sketch) and wired it to the pipette selection for instrument calibration:

![2017-12-14 14 20 06](https://user-images.githubusercontent.com/2963448/34010250-fd983f22-e0d9-11e7-9f01-92d3fe76bab1.gif)

A few things to note:

* Currently hardwired in CSS to two tabs (with `width: 50%;`)
    * Pipette calibration is the only place we use this component for now
    * Talked this through with UI/UX and everyone thought this was fine
* We're handling `active` manually rather than using `react-router` `NavLinks`
    * State tracking with `NavLink` has been super flaky for us
    * Happy to revisit if/when we figure out the flakiness
    * For now manual tracking is completely reliable
* I started an `app/components/setup-instruments` directory
    * For instrument setup specific components, naturally

This PR includes:

- [ ] Chore work
- [ ] Bug fixes
- [X] Backwards-compatible feature additions
- [ ] Breaking changes
- [X] Documentation updates
- [X] Test updates

## changelog

- (Feature, docs, tests) Added `PageTabs` component to library
- (Refactor) Replace PipetteConfig titles in app with `InstrumentTabs` (container wrapper around `PageTabs`)

## review requests

Standard review. I just installed `linter-markdown` in Atom so I apologize for the README diff noise...