### PR TITLE
(repo) Disable AppVeyor test disc. for faster builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,9 @@ install:
 
 build: false # No need to run MSBuild
 
+# do not run automatic test discovery
+test: off
+
 build_script:
   - '%BASH% -lc "export PATH=$CYG_PYTHON_PATH:$PATH && cd $APPVEYOR_BUILD_FOLDER/api && make test"'
   # Note: we are not running test-e2e on Windows due to problems with ChromeDriver


### PR DESCRIPTION
## overview

Disable automatic AppVeyor test detection because we don't use it and it _drastically_ increases our build time for no reason.

This PR includes:

- [X] Chore work
- [ ] Bug fixes
- [ ] Backwards-compatible feature additions
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Test updates