### PR TITLE
App highlight current labware

### DIFF
--- a/app/ui/components/setup-panel/InstrumentList.js
+++ b/app/ui/components/setup-panel/InstrumentList.js
@@ -8,7 +8,7 @@ import {
 import TitledList from './TitledList'
 import InstrumentListItem from './InstrumentListItem'
 
-export default connect(mapStateToProps, mapDispatchToProps)(InstrumentList)
+export default connect(mapStateToProps, null, mergeProps)(InstrumentList)
 
 function InstrumentList (props) {
   const title = 'Pipette Setup'
@@ -23,13 +23,27 @@ function InstrumentList (props) {
 
 function mapStateToProps (state, ownProps) {
   return {
+    currentInstrument: robotSelectors.getCurrentInstrument(state),
     instruments: robotSelectors.getInstruments(state),
     isRunning: robotSelectors.getIsRunning(state)
   }
 }
 
-function mapDispatchToProps (dispatch) {
+function mergeProps (stateProps, dispatchProps) {
+  const {currentInstrument} = stateProps
+  const {dispatch} = dispatchProps
+  const instruments = stateProps.instruments.map(inst => {
+    const isActive = inst.axis === currentInstrument
+    return {
+      ...inst,
+      isActive,
+      setInstrument: () => {
+        dispatch(robotActions.setCurrentInstrument(inst.axis))
+      }
+    }
+  })
   return {
-    clearLabwareReviewed: () => dispatch(robotActions.setLabwareReviewed(false))
+    ...stateProps,
+    instruments
   }
 }

--- a/app/ui/components/setup-panel/InstrumentListItem.js
+++ b/app/ui/components/setup-panel/InstrumentListItem.js
@@ -15,7 +15,7 @@ InstrumentListItem.propTypes = {
 }
 
 export default function InstrumentListItem (props) {
-  const {isRunning, name, axis, volume, channels, probed, setInstrument} = props
+  const {isRunning, name, axis, volume, channels, probed, isActive, setInstrument} = props
   const isDisabled = name == null
   const url = isRunning
   ? '#'
@@ -34,6 +34,7 @@ export default function InstrumentListItem (props) {
       url={url}
       onClick={!isRunning && setInstrument}
       confirmed={confirmed}
+      active={isActive}
     >
       <span>{axis}</span>
       <span>{description}</span>

--- a/app/ui/components/setup-panel/InstrumentListItem.js
+++ b/app/ui/components/setup-panel/InstrumentListItem.js
@@ -11,11 +11,11 @@ InstrumentListItem.propTypes = {
   volume: PropTypes.number,
   channels: PropTypes.string,
   probed: PropTypes.bool,
-  clearLabwareReviewed: PropTypes.func
+  onClick: PropTypes.func
 }
 
 export default function InstrumentListItem (props) {
-  const {isRunning, name, axis, volume, channels, probed, clearLabwareReviewed} = props
+  const {isRunning, name, axis, volume, channels, probed, setInstrument} = props
   const isDisabled = name == null
   const url = isRunning
   ? '#'
@@ -32,7 +32,7 @@ export default function InstrumentListItem (props) {
     <ListItem
       isDisabled={isDisabled || isRunning}
       url={url}
-      onClick={!isRunning && clearLabwareReviewed}
+      onClick={!isRunning && setInstrument}
       confirmed={confirmed}
     >
       <span>{axis}</span>

--- a/app/ui/components/setup-panel/LabwareList.js
+++ b/app/ui/components/setup-panel/LabwareList.js
@@ -65,6 +65,7 @@ function LabwareList (props) {
 }
 function mapStateToProps (state) {
   return {
+    currentLabware: robotSelectors.getCurrentLabware(state),
     labware: robotSelectors.getLabware(state),
     labwareBySlot: robotSelectors.getLabwareBySlot(state),
     labwareReviewed: robotSelectors.getLabwareReviewed(state),
@@ -78,6 +79,7 @@ function mapStateToProps (state) {
 
 function mergeProps (stateProps, dispatchProps) {
   const {
+    currentLabware,
     singleChannel: {axis},
     labwareReviewed,
     instrumentsCalibrated,
@@ -90,10 +92,12 @@ function mergeProps (stateProps, dispatchProps) {
     (lw.isTiprack && lw.confirmed) ||
     !(lw.isTiprack || tipracksConfirmed) ||
     isRunning
+    const isActive = lw.slot === currentLabware
 
     return {
       ...lw,
       isDisabled,
+      isActive,
       setLabware: () => {
         if (labwareReviewed) {
           if (lw.isTiprack) {

--- a/app/ui/components/setup-panel/LabwareListItem.js
+++ b/app/ui/components/setup-panel/LabwareListItem.js
@@ -17,6 +17,7 @@ export default function LabwareListItem (props) {
     slot,
     confirmed,
     isDisabled,
+    isActive,
     onClick
   } = props
 
@@ -30,6 +31,7 @@ export default function LabwareListItem (props) {
       url={url}
       onClick={onClick}
       confirmed={confirmed}
+      active={isActive}
     >
       <span>{name}</span>
     </ListItem>

--- a/app/ui/components/setup-panel/ListItem.js
+++ b/app/ui/components/setup-panel/ListItem.js
@@ -12,8 +12,11 @@ ListItem.propTypes = {
 }
 
 export default function ListItem (props) {
-  const {key, url, isDisabled, onClick, confirmed} = props
+  const {key, url, isDisabled, onClick, confirmed, active} = props
   // TODO(ka 2017-12-12) replace span with icon style with icon from comp lib
+  const style = active
+    ? styles.active_item
+    : null
   const iconStyle = confirmed
     ? classnames(styles.icon, styles.confirmed)
     : styles.icon
@@ -25,6 +28,7 @@ export default function ListItem (props) {
           to={url}
           onClick={onClick}
           disabled={isDisabled}
+          className={style}
           >
           <span className={iconStyle} />
           <span className={styles.info}>{props.children}</span>

--- a/app/ui/components/setup-panel/link-list.css
+++ b/app/ui/components/setup-panel/link-list.css
@@ -28,11 +28,11 @@
 }
 
 .labeled_list a:hover,
-.active {
+.labeled_list a.active_item {
   background-color: #eee;
 }
 
-li.active {
+.active {
   background-color: blue;
 }
 

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -119,8 +119,8 @@ export const actions = {
     }
   },
 
-  setCurrentInstrument (payload) {
-    return {type: actionTypes.SET_CURRENT_INSTRUMENT, payload}
+  setCurrentInstrument (axis) {
+    return {type: actionTypes.SET_CURRENT_INSTRUMENT, payload: axis}
   },
 
   setLabwareReviewed (payload) {

--- a/app/ui/robot/actions.js
+++ b/app/ui/robot/actions.js
@@ -119,6 +119,10 @@ export const actions = {
     }
   },
 
+  setCurrentInstrument (payload) {
+    return {type: actionTypes.SET_CURRENT_INSTRUMENT, payload}
+  },
+
   setLabwareReviewed (payload) {
     return {type: actionTypes.SET_LABWARE_REVIEWED, payload}
   },

--- a/app/ui/robot/reducer/calibration.js
+++ b/app/ui/robot/reducer/calibration.js
@@ -122,10 +122,9 @@ function handleSession (state, action) {
 }
 
 function handleSetCurrentInstrument (state, action) {
-  const {payload: {instrument: axis}} = action
   return {
     ...state,
-    currentInstrument: axis,
+    currentInstrument: action.payload,
     labwareReviewed: false,
     currentLabware: null
   }
@@ -226,6 +225,7 @@ function handleMoveTo (state, action) {
 
   return {
     ...state,
+    currentInstrument: null,
     labwareReviewed: true,
     moveToRequest: {inProgress: true, error: null, slot},
     labwareBySlot: {...state.labwareBySlot, [slot]: MOVING_TO_SLOT}

--- a/app/ui/robot/reducer/calibration.js
+++ b/app/ui/robot/reducer/calibration.js
@@ -26,6 +26,7 @@ import {
 const {
   SESSION,
   DISCONNECT_RESPONSE,
+  SET_CURRENT_INSTRUMENT,
   SET_LABWARE_REVIEWED,
   PICKUP_AND_HOME,
   PICKUP_AND_HOME_RESPONSE,
@@ -55,12 +56,14 @@ const INITIAL_STATE = {
   // TODO(mc, 2017-11-03): instrumentsByAxis holds calibration status by
   // axis. probedByAxis holds a flag for whether the instrument has been
   // probed at least once by axis. Rethink or combine these states
+  currentInstrument: null,
   instrumentsByAxis: {},
   probedByAxis: {},
 
   // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
   // slot. confirmedBySlot holds a flag for whether the labware has been
   // confirmed at least once. Rethink or combine these states
+  currentLabware: null,
   labwareBySlot: {},
   confirmedBySlot: {},
 
@@ -81,6 +84,7 @@ export default function calibrationReducer (state = INITIAL_STATE, action) {
   switch (action.type) {
     case DISCONNECT_RESPONSE: return handleDisconnectResponse(state, action)
     case SESSION: return handleSession(state, action)
+    case SET_CURRENT_INSTRUMENT: return handleSetCurrentInstrument(state, action)
     case SET_LABWARE_REVIEWED: return handleSetLabwareReviewed(state, action)
     case MOVE_TO_FRONT: return handleMoveToFront(state, action)
     case MOVE_TO_FRONT_RESPONSE: return handleMoveToFrontResponse(state, action)
@@ -115,6 +119,16 @@ function handleDisconnectResponse (state, action) {
 
 function handleSession (state, action) {
   return INITIAL_STATE
+}
+
+function handleSetCurrentInstrument (state, action) {
+  const {payload: {instrument: axis}} = action
+  return {
+    ...state,
+    currentInstrument: axis,
+    labwareReviewed: false,
+    currentLabware: null
+  }
 }
 
 function handleSetLabwareReviewed (state, action) {
@@ -224,6 +238,7 @@ function handleMoveToResponse (state, action) {
 
   return {
     ...state,
+    currentLabware: slot,
     moveToRequest: {
       ...state.moveToRequest,
       inProgress: false,

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -233,6 +233,14 @@ export function getLabware (state) {
   })
 }
 
+export function getCurrentInstrument (state) {
+  return getCalibrationState(state).currentInstrument
+}
+
+export function getCurrentLabware (state) {
+  return getCalibrationState(state).currentLabware
+}
+
 export function getLabwareReviewed (state) {
   return getCalibrationState(state).labwareReviewed
 }

--- a/app/ui/robot/test/actions.test.js
+++ b/app/ui/robot/test/actions.test.js
@@ -120,6 +120,15 @@ describe('robot actions', () => {
     expect(actions.sessionResponse(error)).toEqual(failure)
   })
 
+  test('set current instrument action', () => {
+    const expected = {
+      type: actionTypes.SET_CURRENT_INSTRUMENT,
+      payload: 'right'
+    }
+
+    expect(actions.setCurrentInstrument('right')).toEqual(expected)
+  })
+
   test('set labware reviewed action', () => {
     const expected = {
       type: actionTypes.SET_LABWARE_REVIEWED,

--- a/app/ui/robot/test/calibration-reducer.test.js
+++ b/app/ui/robot/test/calibration-reducer.test.js
@@ -397,6 +397,7 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, action).calibration).toEqual({
+      currentInstrument: null,
       labwareReviewed: true,
       moveToRequest: {inProgress: true, error: null, slot: 3},
       labwareBySlot: {3: constants.MOVING_TO_SLOT, 5: constants.UNCONFIRMED}

--- a/app/ui/robot/test/calibration-reducer.test.js
+++ b/app/ui/robot/test/calibration-reducer.test.js
@@ -11,12 +11,14 @@ describe('robot reducer - calibration', () => {
       // TODO(mc, 2017-11-03): instrumentsByAxis holds calibration status by
       // axis. probedByAxis holds a flag for whether the instrument has been
       // probed at least once by axis. Rethink or combine these states
+      currentInstrument: null,
       instrumentsByAxis: {},
       probedByAxis: {},
 
       // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
       // slot. confirmedBySlot holds a flag for whether the labware has been
-      // confirmed at least once. Rethink or combine these states
+      // confirmed at least once. Rethink or combine these states,
+      currentLabware: null,
       labwareBySlot: {},
       confirmedBySlot: {},
 
@@ -404,12 +406,13 @@ describe('robot reducer - calibration', () => {
   test('handles MOVE_TO_RESPONSE action', () => {
     const state = {
       calibration: {
+        currentLabware: 5,
         moveToRequest: {inProgress: true, error: null, slot: 5},
         labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.MOVING_TO_SLOT}
       }
     }
 
-    const success = {type: actionTypes.MOVE_TO_RESPONSE, error: false}
+    const success = {type: actionTypes.MOVE_TO_RESPONSE, payload: {labware: 5}, error: false}
     const failure = {
       type: actionTypes.MOVE_TO_RESPONSE,
       error: true,
@@ -417,10 +420,12 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, success).calibration).toEqual({
+      currentLabware: 5,
       moveToRequest: {inProgress: false, error: null, slot: 5},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
     })
     expect(reducer(state, failure).calibration).toEqual({
+      currentLabware: 5,
       moveToRequest: {inProgress: false, error: new Error('AH'), slot: 5},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED}
     })


### PR DESCRIPTION
## Description:

Because the sidebar does not have direct access to routes in an elegant way, this WIP  PR reintroduces `currentLabware` and `currentInstrument` to calibration state. 

- add `setInstrument ` action to `LabwareList` container, this sets the `currentInstrument` via axis, reducer also sets `labwareReviewed` + `currentLabware` to false
- update `moveToResponse` reducer to set `currentInstrument` to null and sets `currentLabware` in `LabwareList` container
- add `isActive` prop to mergeProps for  both `InstrumentList` and `LabwareList`
- add `active` to listItem props
- highlight list item when active === true
- update tests
- still missing actions for pipette tabs to highlight list item.
- still missing remove active labware/instrument in run reducer

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?
Not sure this is the ideal solution to this issue. I updated reducers to avoid double dispatches. Any feedback welcome as always.