### PR TITLE
Add simulating checks for pause and resume

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -362,10 +362,12 @@ class SmoothieDriver_3_0_0:
         return self.home(axis=axis, disabled=disabled)
 
     def pause(self):
-        self.run_flag.clear()
+        if not self.simulating:
+            self.run_flag.clear()
 
     def resume(self):
-        self.run_flag.set()
+        if not self.simulating:
+            self.run_flag.set()
 
     def delay(self, seconds):
         # per http://smoothieware.org/supported-g-codes:

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -123,6 +123,12 @@ def test_fast_home(model):
 
 
 def test_pause_resume(model):
+    """
+    This test has to use an ugly work-around with the `simulating` member of
+    the driver. When issuing movement commands in test, `simulating` should be
+    True, but when testing whether `pause` actually pauses and `resume`
+    resumes, `simulating` must be False.
+    """
     from numpy import isclose
     from opentrons.trackers import pose_tracker
     from time import sleep
@@ -133,7 +139,9 @@ def test_pause_resume(model):
     robot.home()
     homed_coords = pose_tracker.absolute(robot.poses, pipette)
 
+    robot._driver.simulating = False
     robot.pause()
+    robot._driver.simulating = True
 
     def _move_head():
         robot.poses = pipette._move(robot.poses, x=100, y=0, z=0)
@@ -147,7 +155,9 @@ def test_pause_resume(model):
     coords = pose_tracker.absolute(robot.poses, pipette)
     assert isclose(coords, homed_coords).all()
 
+    robot._driver.simulating = False
     robot.resume()
+    robot._driver.simulating = True
     thread.join()
 
     coords = pose_tracker.absolute(robot.poses, pipette)
@@ -181,3 +191,11 @@ def test_speed_change(model, monkeypatch):
         ['G0F9000 M400']
     ]
     fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_pause_in_protocol(model):
+    model.robot._driver.simulating = True
+
+    model.robot.pause()
+
+    assert model.robot._driver.run_flag.is_set()


### PR DESCRIPTION
## Description:

When uploading a protocol in the app, the app first runs the protocol in simulating mode. The `pause` and `resume` functions did not check for simulating status, which means that a `pause` in a protocol followed by any command other than `resume` would cause the script to block forever. This PR modified `pause` and `resume` to pass if simulating.

Updated tests and documentation

## Changelog:

- (bugfix) `pause` and `resume` do not block execution when in simulating mode
