### PR TITLE
(repo) Add simplified PR/issue templates from develop

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+  Thanks for taking the time to file an issue. Before continuing, please
+  consider the following questions:
+
+  - Is this issue for a bug, a feature request, or something else?
+  - Has this issue already been filed in another issue ticket?
+    - If yes, please comment on the existing thread instead
+  - Is this a support request?
+    - If yes, please check our support page and/or contact our support team
+    - https://support.opentrons.com/
+
+  To ensure your issue can be addressed quickly, please fill out the sections
+  below to the best of your ability!
+-->
+
+## overview
+
+<!--
+  Use this section to describe your issue at a high level. Please include the
+  type of issue (bug, feature request, other) as well as any issues you could
+  find that may be related.
+-->
+
+## behavior
+
+<!--
+  Describe how the software currently behaves and how that differs from how you
+  think the software should behave
+-->
+
+## steps to reproduce
+
+<!--
+  If this is a bug report and there are specific steps we can take to reproduce
+  the bug, please list them here. This is a good place to put things like
+  software version, hardware version, and operating system
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,42 @@
-## Description:
+<!--
+  Thanks for taking the time to open a pull request. Before continuing, please
+  consider the following questions:
 
+  - Does this PR address an already open issue?
+    - If not, please consider opening an issue first to ensure you don't end up
+      duplicating work or wasting time on a PR that won't be accepted
+  - Does this PR incorporate many different changes?
+    - If yes, would the PR work better as a series of smaller PRs?
+  - Does this PR include code changes without test and/or documentation updates?
+    - If yes, the PR may not be ready to open
 
-Check List:
+  To ensure your code is reviewed quickly and thoroughly, please fill out the
+  sections below to the best of your ability!
+-->
 
-- [ ] Are there breaking changes in the API and how are they being communicated?
-- [ ] Who is reviewing your code?
+## overview
+
+<!--
+  Use this section to describe your pull-request at a high level. If the PR
+  addresses any open issues, please tag the issues here.
+-->
+
+## changelog
+
+<!--
+  List out the changes to the code in this PR. Please try your best to
+  categorize your changes and describe what has changed and why.
+
+  Example changelog:
+  - Fixed app crash when trying to calibrate an illegal pipette
+  - Added state to API to track pipette usage
+  - Updated API docs to mention only two pipettes are supported
+
+  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
+-->
+
+## review requests
+
+<!--
+  Describe any requests for your reviewers here.
+-->


### PR DESCRIPTION
## overview

Per our discussions about moving to GitHub issues as our primary ticketing system, this PR is a refresh of the pull-request and issue templates from #340 (base branch has changed since that PR).

I simplified the stuff that was there in the interest of decreasing duplicate information and also moved all instructions to HTML comments because that made more sense.

## changelog

- (repo) Add simplified PR/issue templates from develop 

## review requests

I think the top commented out section is too wordy in both these templates and is information that probably belongs more in a contribution guide. I'm also curious as to what everyone thinks about how the changelog and commit log should / shouldn't be related