### PR TITLE
Highlight active setup panel list item

### DIFF
--- a/app/ui/components/setup-panel/LabwareList.js
+++ b/app/ui/components/setup-panel/LabwareList.js
@@ -26,7 +26,6 @@ function LabwareList (props) {
 
   const {tiprackList, labwareList} = labware.reduce((result, lab) => {
     const {slot, name, isTiprack, setLabware} = lab
-
     const links = (
       <LabwareListItem
         {...lab}
@@ -63,7 +62,7 @@ function LabwareList (props) {
     </TitledList>
   )
 }
-function mapStateToProps (state) {
+function mapStateToProps (state, ownProps) {
   return {
     labware: robotSelectors.getLabware(state),
     labwareBySlot: robotSelectors.getLabwareBySlot(state),

--- a/app/ui/components/setup-panel/LabwareListItem.js
+++ b/app/ui/components/setup-panel/LabwareListItem.js
@@ -31,7 +31,7 @@ export default function LabwareListItem (props) {
       onClick={onClick}
       confirmed={confirmed}
     >
-      <span>{name}</span>
+      <span>{name} </span>
     </ListItem>
   )
 }

--- a/app/ui/components/setup-panel/ListItem.js
+++ b/app/ui/components/setup-panel/ListItem.js
@@ -12,8 +12,9 @@ ListItem.propTypes = {
 }
 
 export default function ListItem (props) {
-  const {key, url, isDisabled, onClick, confirmed} = props
+  const {key, url, isDisabled, onClick, confirmed, active} = props
   // TODO(ka 2017-12-12) replace span with icon style with icon from comp lib
+  const style = active && styles.active
   const iconStyle = confirmed
     ? classnames(styles.icon, styles.confirmed)
     : styles.icon
@@ -35,7 +36,7 @@ export default function ListItem (props) {
   }
 
   return (
-    <li onClick={onClick}>
+    <li onClick={onClick} className={style}>
       <span className={iconStyle} />
       <span className={styles.info}>
         {props.children}

--- a/app/ui/components/setup-panel/ListItem.js
+++ b/app/ui/components/setup-panel/ListItem.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Link} from 'react-router-dom'
+import {NavLink} from 'react-router-dom'
 import classnames from 'classnames'
 import styles from './link-list.css'
 
@@ -21,14 +21,15 @@ export default function ListItem (props) {
   if (url) {
     return (
       <li key={key}>
-        <Link
+        <NavLink
           to={url}
           onClick={onClick}
           disabled={isDisabled}
+          activeClassName={styles.active}
           >
           <span className={iconStyle} />
           <span className={styles.info}>{props.children}</span>
-        </Link>
+        </NavLink>
       </li>
     )
   }

--- a/app/ui/components/setup-panel/index.js
+++ b/app/ui/components/setup-panel/index.js
@@ -8,7 +8,7 @@ export default function SetupPanel (props) {
   return (
     <div>
       <Route path='/setup-instruments/:side' children={renderInstrumentList} />
-      <Route path='/setup-labware/:slot' children={renderLabwareList} />
+      <Route path='/setup-labware/:slots' children={renderLabwareList} />
       <RunPanel />
     </div>
   )

--- a/app/ui/components/setup-panel/index.js
+++ b/app/ui/components/setup-panel/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {Route} from 'react-router'
 import InstrumentList from './InstrumentList'
 import LabwareList from './LabwareList'
 import RunPanel from './RunPanel'
@@ -6,9 +7,27 @@ import RunPanel from './RunPanel'
 export default function SetupPanel (props) {
   return (
     <div>
-      <InstrumentList />
-      <LabwareList />
+      <Route path='/setup-instruments/:side' children={renderInstrumentList} />
+      <Route path='/setup-labware/:slot' children={renderLabwareList} />
       <RunPanel />
     </div>
+  )
+}
+
+function renderInstrumentList (props) {
+  const {match} = props
+  const {params} = match || {}
+
+  return (
+    <InstrumentList {...params} />
+  )
+}
+
+function renderLabwareList (props) {
+  const {match} = props
+  const {params} = match || {}
+
+  return (
+    <LabwareList {...params} />
   )
 }

--- a/app/ui/components/setup-panel/link-list.css
+++ b/app/ui/components/setup-panel/link-list.css
@@ -32,10 +32,6 @@
   background-color: #eee;
 }
 
-li.active {
-  background-color: blue;
-}
-
 .labeled_list a {
   color: black;
   display: block;

--- a/app/ui/components/side-panel/index.js
+++ b/app/ui/components/side-panel/index.js
@@ -16,7 +16,7 @@ import SidePanel from './SidePanel'
 // naming and organization refactors to follow
 import ConnectPanel from '../connect-panel'
 import UploadPanel from '../upload-panel'
-import ConnectedSetupPanel from '../setup-panel'
+import SetupPanel from '../setup-panel'
 
 export default withRouter(
   connect(mapStateToProps, mapDispatchToProps)(NavPanel)
@@ -25,7 +25,7 @@ export default withRouter(
 const PANELS_BY_NAME = {
   connect: ConnectPanel,
   upload: UploadPanel,
-  setup: ConnectedSetupPanel
+  setup: SetupPanel
 }
 
 NavPanel.propTypes = {

--- a/app/ui/components/side-panel/index.js
+++ b/app/ui/components/side-panel/index.js
@@ -1,5 +1,6 @@
 // side nav panel container
 import React from 'react'
+import {withRouter} from 'react-router'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
 
@@ -17,7 +18,9 @@ import ConnectPanel from '../connect-panel'
 import UploadPanel from '../upload-panel'
 import ConnectedSetupPanel from '../setup-panel'
 
-export default connect(mapStateToProps, mapDispatchToProps)(NavPanel)
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(NavPanel)
+)
 
 const PANELS_BY_NAME = {
   connect: ConnectPanel,


### PR DESCRIPTION
## Description:

Currently, we are not highlighting the active step in setup panel. This PR uses `NavLink` and `activeClassName` to do so. Additional fallback `active` prop and styling logic for non `NavLink` ListItems is present but not needed for SetupPanel.

- implement withRouter in NavPanel container
- use router for SetupPanel and children
- active list item style
- still missing logic to highlight non `NavLink` `ListItems`, this will be handled in the `ListItem` and `TitledList` component library PR coming soon.

Check List:

- [ ] Are there breaking changes in the API and how are they being communicated?
- [ ] Who is reviewing your code?

This is a small one, please check to see SetupPanel links in Sidebar highlight active instrument/labware properly.