### PR TITLE
(app) Kickoff robot discovery on app launch

### DIFF
--- a/app/.flowconfig
+++ b/app/.flowconfig
@@ -1,4 +1,7 @@
 [ignore]
+<PROJECT_ROOT>/scripts/.*
+.*/dist/.*
+.*/test/.*
 
 [include]
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+flow-typed

--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,8 @@
       "!**/webpack*",
       "!**/webpack/**",
       "!**/coverage/**",
-      "!**/test/**"
+      "!**/test/**",
+      "!**/flow-typed/**"
     ],
     "coverageReporters": [
       "lcov",
@@ -45,7 +46,8 @@
   "standard": {
     "parser": "babel-eslint",
     "ignore": [
-      "dist/"
+      "dist/",
+      "flow-typed/"
     ],
     "globals": [
       "SyntheticEvent",

--- a/app/ui/components/deck/ConnectedLabwareItem.js
+++ b/app/ui/components/deck/ConnectedLabwareItem.js
@@ -1,4 +1,3 @@
-// @flow
 // import * as React from 'react'
 import {connect} from 'react-redux'
 

--- a/app/ui/index.js
+++ b/app/ui/index.js
@@ -50,7 +50,7 @@ const reducer = combineReducers({
 const history = createHistory()
 
 const middleware = applyMiddleware(
-  robotApiMiddleware,
+  robotApiMiddleware(),
   analyticsMiddleware(analyticsEventsMap),
   alertMiddleware(window),
   routerMiddleware(history),

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -31,8 +31,13 @@ export default function client (dispatch) {
   // TODO(mc, 2017-09-22): build some sort of timer middleware instead?
   let runTimerInterval = NO_INTERVAL
 
+  // kickoff a discovery run immediately
+  // dispatching a discover action (rather than calling handleDiscover) ensures
+  // proper state handling (action will run thru the full middleware pipeline)
+  dispatch(actions.discover())
+
   // return an action handler
-  return function receive (state, action) {
+  return function receive (state = {}, action = {}) {
     const {type} = action
 
     switch (type) {

--- a/app/ui/robot/api-client/discovery.js
+++ b/app/ui/robot/api-client/discovery.js
@@ -2,6 +2,7 @@
 import Bonjour from 'bonjour'
 
 import {actions} from '../actions'
+import {getIsScanning} from '../selectors'
 
 // mdns discovery constants
 const NAME_RE = /^opentrons/i
@@ -22,6 +23,9 @@ const DIRECT_SERVICE = {
 const DIRECT_POLL_INTERVAL_MS = 1000
 
 export function handleDiscover (dispatch, state, action) {
+  // don't duplicate discovery requests
+  if (getIsScanning(state)) return
+
   // TODO(mc, 2017-10-26): we're relying right now on the fact that resin
   // advertises an SSH service. Instead, we should be registering an HTTP
   // service on port 31950 and listening for that instead

--- a/app/ui/robot/api-client/worker.js
+++ b/app/ui/robot/api-client/worker.js
@@ -2,10 +2,13 @@
 // handles message stringification and destructuring
 import client from './client'
 
-// client function takes a dispatch function and returns a receive handler
-const receive = client(dispatchFromWorker)
+let receive
 
 self.onmessage = function handleIncoming (event) {
+  // client function takes a dispatch function and returns a receive handler
+  // receive function is lazy loaded for efficiency + modularity
+  if (!receive) receive = client(dispatchFromWorker)
+
   const {state, action} = event.data
 
   receive(state, action)


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

This is an easy-win PR to launch discovery immediately upon API client startup. It also contains a little bit of chore work to the flow config (I was unable to run `make check` on my machine because flow was digging into files it didn't need to).

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- (Feature) Added discovery kickoff to client initialization
- (Fix) Added already scanning guard to prevent discovery spamming
- (Chore) Cleaned up flow, standard, and jest config in app to fix up typechecking 

## review requests

<!--
  Describe any requests for your reviewers here.
-->

Nothing special! @btmorr a Windows test would be useful and much appreciated