### PR TITLE
Rename 'power' to 'current' in driver and related settings

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -63,7 +63,7 @@ class CalibrationManager:
         log.debug('Picking up tip from {} in {} with {}'.format(
             container.name, container.slot, instrument.name))
         self._set_state('moving')
-        inst.pick_up_tip(container._container[0], low_power_z=True)
+        inst.pick_up_tip(container._container[0], low_current_z=True)
         self._set_state('ready')
 
     def drop_tip(self, instrument, container):

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -29,8 +29,8 @@ HOMED_POSITION = {
 }
 
 PLUNGER_BACKLASH_MM = 0.3
-LOW_POWER_Z_SPEED = 30
-POWER_CHANGE_DELAY = 0.05
+LOW_CURRENT_Z_SPEED = 30
+CURRENT_CHANGE_DELAY = 0.05
 
 DEFAULT_AXES_SPEED = 150
 
@@ -82,7 +82,7 @@ class SmoothieDriver_3_0_0:
         self.simulating = True
         self._connection = None
         self._config = config
-        self._power_settings = config.default_power
+        self._current_settings = config.default_current
         gpio.initialize()
 
     def _update_position(self, target):
@@ -152,8 +152,8 @@ class SmoothieDriver_3_0_0:
         return self._send_command(GCODES['LIMIT_SWITCH_STATUS'])
 
     @property
-    def power(self):
-        return self._power_settings
+    def current(self):
+        return self._current_settings
 
     @property
     def speed(self):
@@ -169,13 +169,15 @@ class SmoothieDriver_3_0_0:
         ''' set total axes movement speed in mm/second back to default'''
         self.set_speed(DEFAULT_AXES_SPEED)
 
-    def set_power(self, settings):
-        ''' set total movement speed in mm/second
+    def set_current(self, settings):
+        '''
+        Sets the current in mA by axis.
+
         settings
             Dict with axes as valies (e.g.: 'X', 'Y', 'Z', 'A', 'B', or 'C')
-            and floating point number for setting (generally between 0.1 and 2)
+            and floating point number for current (generally between 0.1 and 2)
         '''
-        self._power_settings.update(settings)
+        self._current_settings.update(settings)
         values = ['{}{}'.format(axis, value)
                   for axis, value in sorted(settings.items())]
         command = '{} {}'.format(
@@ -183,7 +185,7 @@ class SmoothieDriver_3_0_0:
             ' '.join(values)
         )
         self._send_command(command)
-        self.delay(POWER_CHANGE_DELAY)
+        self.delay(CURRENT_CHANGE_DELAY)
 
     # ----------- Private functions --------------- #
 
@@ -219,8 +221,8 @@ class SmoothieDriver_3_0_0:
                 and (GCODES['MOVE'] in command or GCODES['HOME'] in command)
 
             if moving_plunger:
-                self.set_power({axis: self._config.plunger_current_high
-                               for axis in 'BC'})
+                self.set_current({axis: self._config.plunger_current_high
+                                  for axis in 'BC'})
 
             command_line = command + ' M400'
             ret_code = serial_communication.write_and_return(
@@ -231,8 +233,8 @@ class SmoothieDriver_3_0_0:
                 raise RuntimeError('Smoothieware Error: {}'.format(ret_code))
 
             if moving_plunger:
-                self.set_power({axis: self._config.plunger_current_low
-                               for axis in 'BC'})
+                self.set_current({axis: self._config.plunger_current_low
+                                  for axis in 'BC'})
 
             return ret_code
 
@@ -248,7 +250,7 @@ class SmoothieDriver_3_0_0:
     # ----------- END Private functions ----------- #
 
     # ----------- Public interface ---------------- #
-    def move(self, target, low_power_z=False):
+    def move(self, target, low_current_z=False):
         from numpy import isclose
 
         self.run_flag.wait()
@@ -277,16 +279,15 @@ class SmoothieDriver_3_0_0:
         target_coords = create_coords_list(target)
         backlash_coords = create_coords_list(backlash_target)
 
-        low_power_axes = [axis
-                          for axis, _ in sorted(target.items())
-                          if axis in 'ZA']
-        prior_power = copy(self._power_settings)
+        low_current_axes = [axis
+                            for axis, _ in sorted(target.items())
+                            if axis in 'ZA']
+        prior_current = copy(self._current_settings)
 
-        if low_power_z:
-            new_power = {axis: 0.1
-                         for axis in low_power_axes}
-            self.set_power(new_power)
-            self.set_speed(LOW_POWER_Z_SPEED)
+        if low_current_z:
+            new_current = {axis: 0.1 for axis in low_current_axes}
+            self.set_current(new_current)
+            self.set_speed(LOW_CURRENT_Z_SPEED)
 
         if target_coords:
             command = ''
@@ -296,8 +297,8 @@ class SmoothieDriver_3_0_0:
             self._send_command(command)
             self._update_position(target)
 
-        if low_power_z:
-            self.set_power(prior_power)
+        if low_current_z:
+            self.set_current(prior_current)
             self.default_speed()
 
     def home(self, axis=AXES, disabled=DISABLE_AXES):

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -226,7 +226,7 @@ class Pipette:
         if not self.placeables or (placeable != self.placeables[-1]):
             self.placeables.append(placeable)
 
-    def move_to(self, location, strategy='arc', low_power_z=False):
+    def move_to(self, location, strategy='arc', low_current_z=False):
         """
         Move this :any:`Pipette` to a :any:`Placeable` on the :any:`Deck`
 
@@ -247,8 +247,8 @@ class Pipette:
             "direct" strategies will simply move in a straight line from
             the current position
 
-        low_power_z : bool
-            Setting this to True will cause the pipette to move at a low power
+        low_current_z : bool
+            Setting this to True will cause the pipette to move at low current
             setting **in the Z axis only**, primarily to prevent damage to the
             pipette in case of collision during calibration.
 
@@ -265,7 +265,7 @@ class Pipette:
             location,
             instrument=self,
             strategy=strategy,
-            low_power_z=low_power_z)
+            low_current_z=low_current_z)
 
         return self
 
@@ -776,7 +776,7 @@ class Pipette:
         self.drop_tip(self.current_tip(), home_after=home_after)
         return self
 
-    def pick_up_tip(self, location=None, presses=3, low_power_z=True):
+    def pick_up_tip(self, location=None, presses=3, low_current_z=True):
         """
         Pick up a tip for the Pipette to run liquid-handling commands with
 
@@ -797,8 +797,8 @@ class Pipette:
             picking up a tip, to ensure a good seal (0 [zero] will result in
             the pipette hovering over the tip but not picking it up--generally
             not desireable, but could be used for dry-run)
-        low_power_z: : :any:bool
-            The power setting for picking up a tip. Should be False for normal
+        low_current_z: : :any:bool
+            The current setting for picking up tip. Should be False for normal
             operation. Should be set to True for calibration where it is
             possible for the pipette to collide with the tip rack, which could
             damate the pipette.
@@ -851,7 +851,7 @@ class Pipette:
                 self.move_to(
                     self.current_tip().top(plunge_depth),
                     strategy='direct',
-                    low_power_z=low_power_z)
+                    low_current_z=low_current_z)
                 # move nozzle back up
                 self.move_to(
                     self.current_tip().top(0),
@@ -1497,7 +1497,7 @@ class Pipette:
             self.speeds[key] = kwargs.get(key)
         return self
 
-    def _move(self, pose_tree, x=None, y=None, z=None, low_power_z=False):
+    def _move(self, pose_tree, x=None, y=None, z=None, low_current_z=False):
         current_x, current_y, current_z = pose_tracker.absolute(
             pose_tree,
             self)
@@ -1523,7 +1523,7 @@ class Pipette:
             pose_tree = self.instrument_mover.move(
                 pose_tree,
                 z=_z,
-                low_power_z=low_power_z)
+                low_current_z=low_current_z)
 
         return pose_tree
 

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -24,7 +24,7 @@ class Mover:
 
         return self.move(pose_tree, **target)
 
-    def move(self, pose_tree, x=None, y=None, z=None, low_power_z=False):
+    def move(self, pose_tree, x=None, y=None, z=None, low_current_z=False):
         """
         Dispatch move command to the driver changing base of
         x, y and z from source coordinate system to destination.
@@ -57,7 +57,7 @@ class Mover:
             assert z is not None, "Value must be set for each axis mapped"
             driver_target[self._axis_mapping['z']] = dst_z
 
-        self._driver.move(driver_target, low_power_z)
+        self._driver.move(driver_target, low_current_z)
 
         # Update pose with the new value. Since stepper motors are open loop
         # there is no need to to query diver for position

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -543,7 +543,7 @@ class Robot(object):
             location,
             instrument,
             strategy='arc',
-            low_power_z=False,
+            low_current_z=False,
             **kwargs):
         """
         Move an instrument to a coordinate, container or a coordinate within
@@ -569,10 +569,10 @@ class Robot(object):
 
             ``direct`` : move to the point in a straight line.
 
-        low_power_z : bool
+        low_current_z : bool
             Setting this to True will cause the instrument to move at a low
-            power setting for vertical motions, primarily to prevent damage to
-            the pipette in case of collision during calibration.
+            current setting for vertical motions, primarily to prevent damage
+            to the pipette in case of collision during calibration.
 
         Examples
         --------
@@ -614,14 +614,14 @@ class Robot(object):
             for coord in arc_coords:
                 self.poses = instrument._move(
                     self.poses,
-                    low_power_z=low_power_z,
+                    low_current_z=low_current_z,
                     **coord)
 
         elif strategy == 'direct':
             position = {'x': target[0], 'y': target[1], 'z': target[2]}
             self.poses = instrument._move(
                 self.poses,
-                low_power_z=low_power_z,
+                low_current_z=low_current_z,
                 **position)
         else:
             raise RuntimeError(

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -20,7 +20,7 @@ MOUNT_CURRENT_HIGH = 0.8
 X_CURRENT_HIGH = 1.2
 Y_CURRENT_HIGH = 1.5
 
-DEFAULT_POWER = {
+DEFAULT_CURRENT = {
     'X': X_CURRENT_HIGH,
     'Y': Y_CURRENT_HIGH,
     'Z': MOUNT_CURRENT_HIGH,
@@ -29,8 +29,8 @@ DEFAULT_POWER = {
     'C': PLUNGER_CURRENT_LOW
 }
 
-DEFAULT_POWER_STRING = ' '.join(
-    ['{}{}'.format(key, value) for key, value in DEFAULT_POWER.items()])
+DEFAULT_CURRENT_STRING = ' '.join(
+    ['{}{}'.format(key, value) for key, value in DEFAULT_CURRENT.items()])
 
 robot_config = namedtuple(
     'robot_config',
@@ -48,7 +48,7 @@ robot_config = namedtuple(
         'plunger_current_low',
         'plunger_current_high',
         'tip_length',
-        'default_power'
+        'default_current'
     ]
 )
 
@@ -58,7 +58,7 @@ default = robot_config(
     steps_per_mm='M92 X80.00 Y80.00 Z400 A400 B768 C768',
     max_speeds='M203.1 X300 Y200 Z90 A90 B40 C40',
     acceleration='M204 S10000 X3000 Y2000 Z1500 A1500 B2000 C2000',
-    current='M907 ' + DEFAULT_POWER_STRING,
+    current='M907 ' + DEFAULT_CURRENT_STRING,
     probe_center=(295.0, 300.0, 55.0),
     probe_dimensions=(35.0, 40.0, 60.0),
     gantry_calibration=[  # "safe" offset, overwrote in factory calibration
@@ -89,7 +89,7 @@ default = robot_config(
         }
     },
     serial_speed=115200,
-    default_power=DEFAULT_POWER,
+    default_current=DEFAULT_CURRENT,
     plunger_current_low=PLUNGER_CURRENT_LOW,
     plunger_current_high=PLUNGER_CURRENT_HIGH
 )

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -52,7 +52,7 @@ async def test_pick_up_tip(main_router, model):
             model.container)
 
         pick_up_tip.assert_called_with(
-            model.container._container[0], low_power_z=True)
+            model.container._container[0], low_current_z=True)
 
         await main_router.wait_until(state('moving'))
         await main_router.wait_until(state('ready'))

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -74,31 +74,31 @@ def test_functional(smoothie):
     assert smoothie.position == HOMED_POSITION
 
 
-power = []
+current = []
 
 
-def test_low_power_z(model):
-    from opentrons.robot.robot_configs import DEFAULT_POWER
+def test_low_current_z(model):
+    from opentrons.robot.robot_configs import DEFAULT_CURRENT
     import types
     driver = model.robot._driver
 
-    set_power = driver.set_power
+    set_current = driver.set_current
 
-    def set_power_mock(self, target):
-        global power
-        power.append(target)
+    def set_current_mock(self, target):
+        global current
+        current.append(target)
 
-        set_power(target)
+        set_current(target)
 
-    driver.set_power = types.MethodType(set_power_mock, driver)
+    driver.set_current = types.MethodType(set_current_mock, driver)
 
-    driver.move({'A': 100}, low_power_z=False)
+    driver.move({'A': 100}, low_current_z=False)
     # Instrument in `model` is configured to right mount, which is the A axis
     # on the Smoothie (see `Robot._actuators`)
-    assert power == []
+    assert current == []
 
-    driver.move({'A': 10}, low_power_z=True)
-    assert power == [{'A': 0.1}, DEFAULT_POWER]
+    driver.move({'A': 10}, low_current_z=True)
+    assert current == [{'A': 0.1}, DEFAULT_CURRENT]
 
 
 def test_fast_home(model):

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1310,71 +1310,71 @@ class PipetteTest(unittest.TestCase):
         expected = [
             mock.call(self.plate[0],
                       instrument=self.p200,
-                      low_power_z=False,
+                      low_current_z=False,
                       strategy='arc'),
             mock.call(
                 (self.plate[0], (6.40, 3.20, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (0.00, 3.20, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 6.40, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 0.00, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (6.40, 3.20, 7.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (0.00, 3.20, 7.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 6.40, 7.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 0.00, 7.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(self.plate[1],
                       instrument=self.p200,
-                      low_power_z=False,
+                      low_current_z=False,
                       strategy='arc'),
             mock.call(
                 (self.plate[1], (4.80, 3.20, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[1], (1.60, 3.20, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[1], (3.20, 4.80, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct'),
             mock.call(
                 (self.plate[1], (3.20, 1.60, 10.50)),
                 instrument=self.p200,
-                low_power_z=False,
+                low_current_z=False,
                 strategy='direct')
         ]
 
@@ -1625,11 +1625,11 @@ class PipetteTest(unittest.TestCase):
         plunge = -10
         return [
             mock.call(well.top(), strategy='arc'),
-            mock.call(well.top(plunge), low_power_z=True, strategy='direct'),
+            mock.call(well.top(plunge), low_current_z=True, strategy='direct'),
             mock.call(well.top(), strategy='direct'),
-            mock.call(well.top(plunge), low_power_z=True, strategy='direct'),
+            mock.call(well.top(plunge), low_current_z=True, strategy='direct'),
             mock.call(well.top(), strategy='direct'),
-            mock.call(well.top(plunge), low_power_z=True, strategy='direct'),
+            mock.call(well.top(plunge), low_current_z=True, strategy='direct'),
             mock.call(well.top(), strategy='direct')
         ]
 


### PR DESCRIPTION
## overview

Changes the term 'power' to 'current' in the Smoothie driver and related files. This setting deals with current in mA, so the prior name was confusing. No functional changes

Resolves #565 

## changelog

- (chore) Change 'power' to 'current' in driver and related files

## review requests

- Ensure that updated code and documentation are sufficiently clear