### PR TITLE
Move gpio init and button light init to start script in container

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -83,7 +83,6 @@ class SmoothieDriver_3_0_0:
         self._connection = None
         self._config = config
         self._current_settings = config.default_current
-        gpio.initialize()
 
     def _update_position(self, target):
         self._position.update({

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -188,7 +188,6 @@ class Robot(object):
         """
         self.config = config or load()
         self._driver = driver_3_0.SmoothieDriver_3_0_0(config=self.config)
-        self.turn_on_button_light()
         self.modules = []
 
         # TODO (andy) should come from a config file

--- a/compute/scripts/setup_gpio.py
+++ b/compute/scripts/setup_gpio.py
@@ -1,0 +1,5 @@
+from opentrons.drivers.rpi_drivers import gpio
+from opentrons import robot
+
+gpio.initialize()
+robot.turn_on_button_light()

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+python setup_gpio.py
+
 radvd --logmethod=stderr_syslog --pidfile=/run/radvd.pid
 
 # mdns announcement


### PR DESCRIPTION
## overview

Move gpio pin initialization and turn on blue button into compute start script. This should quiet down false error messages, and turn the light on sooner.

## changelog

- Move gpio initialization into start script
- Move initialization of button light to start script

## review requests

- Verify on a robot
