### PR TITLE
Change timestamp format in API and App to milliseconds-since-epoch

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -1,7 +1,7 @@
 import ast
 import logging
 from copy import copy
-from datetime import datetime
+from time import time
 from functools import reduce
 
 from opentrons.broker import publish, subscribe
@@ -197,7 +197,7 @@ class Session(object):
     def log_append(self):
         self.command_log.update({
             len(self.command_log): {
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': int(time() * 1000)
             }
         })
         self._on_state_changed()
@@ -205,7 +205,7 @@ class Session(object):
     def error_append(self, error):
         self.errors.append(
             {
-                'timestamp': datetime.utcnow().isoformat(),
+                'timestamp': int(time() * 1000),
                 'error': error
             }
         )

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -141,7 +141,7 @@ def test_log_append(run_session):
     run_log = {
         _id: value
         for _id, value in run_session.command_log.items()
-        if datetime.strptime(value.pop('timestamp'), '%Y-%m-%dT%H:%M:%S.%f')
+        if isinstance(value.pop('timestamp'), int)
     }
 
     assert run_log == {0: {}, 1: {}, 2: {}}
@@ -156,7 +156,7 @@ def test_error_append(run_session):
     errors = [
         value
         for value in run_session.errors
-        if datetime.strptime(value.pop('timestamp'), '%Y-%m-%dT%H:%M:%S.%f')
+        if isinstance(value.pop('timestamp'), int)
     ]
 
     assert errors == [

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -1,7 +1,6 @@
 import itertools
 import pytest
 
-from datetime import datetime
 from opentrons.broker import publish
 from opentrons.api import Session
 from opentrons.api.session import _accumulate, _get_labware, _dedupe

--- a/app/ui/robot/api-client/client.js
+++ b/app/ui/robot/api-client/client.js
@@ -338,7 +338,7 @@ export default function client (dispatch) {
         const {id, description} = command
         const logEntry = command_log[id]
         const children = Array.from(command.children)
-        let handledAt = ''
+        let handledAt = null
 
         if (logEntry) handledAt = logEntry.timestamp
         if (depth === 0) protocolCommands.push(id)

--- a/app/ui/robot/selectors.js
+++ b/app/ui/robot/selectors.js
@@ -142,18 +142,21 @@ export function getRunProgress (state) {
   }
 }
 
+// TODO(mc, 2018-01-04): inferring start time from handledAt of first command
+// is inadequate; robot starts moving before this timestamp is set
 export function getStartTime (state) {
   const commands = getCommands(state)
 
-  if (!commands.length) return ''
+  if (!commands.length) return null
   return commands[0].handledAt
 }
 
 export function getRunTime (state) {
   const {runTime} = getSessionState(state)
   const startTime = getStartTime(state)
-  const runTimeSeconds = (runTime && startTime)
-    ? Math.floor((runTime - Date.parse(startTime)) / 1000)
+  // TODO(mc, 2018-01-04): gt check is required because of the TODO above
+  const runTimeSeconds = (runTime && startTime && runTime > startTime)
+    ? Math.floor((runTime - startTime) / 1000)
     : 0
 
   const hours = padStart(Math.floor(runTimeSeconds / 3600), 2, '0')

--- a/app/ui/robot/test/api-client.test.js
+++ b/app/ui/robot/test/api-client.test.js
@@ -228,8 +228,8 @@ describe('api client', () => {
           0: {id: 0, description: 'a', handledAt: 0, children: [1]},
           1: {id: 1, description: 'b', handledAt: 1, children: [2, 3]},
           2: {id: 2, description: 'c', handledAt: 2, children: []},
-          3: {id: 3, description: 'd', handledAt: '', children: []},
-          4: {id: 4, description: 'e', handledAt: '', children: []}
+          3: {id: 3, description: 'd', handledAt: null, children: []},
+          4: {id: 4, description: 'e', handledAt: null, children: []}
         }
       }))
 

--- a/app/ui/robot/test/selectors.test.js
+++ b/app/ui/robot/test/selectors.test.js
@@ -195,31 +195,31 @@ describe('robot selectors', () => {
           0: {
             id: 0,
             description: 'foo',
-            handledAt: '2017-08-30T12:00:00Z',
+            handledAt: 42,
             children: [1]
           },
           1: {
             id: 1,
             description: 'bar',
-            handledAt: '2017-08-30T12:00:01Z',
+            handledAt: 43,
             children: [2, 3]
           },
           2: {
             id: 2,
             description: 'baz',
-            handledAt: '2017-08-30T12:00:02Z',
+            handledAt: 44,
             children: []
           },
           3: {
             id: 3,
             description: 'qux',
-            handledAt: '',
+            handledAt: null,
             children: []
           },
           4: {
             id: 4,
             description: 'fizzbuzz',
-            handledAt: '',
+            handledAt: null,
             children: []
           }
         }
@@ -240,12 +240,12 @@ describe('robot selectors', () => {
     })
 
     test('getStartTime', () => {
-      expect(getStartTime(state)).toEqual('2017-08-30T12:00:00Z')
+      expect(getStartTime(state)).toEqual(42)
     })
 
     test('getStartTime without commands', () => {
       expect(getStartTime(makeState({session: {protocolCommands: []}})))
-        .toEqual('')
+        .toEqual(null)
     })
 
     test('getRunTime', () => {
@@ -254,7 +254,7 @@ describe('robot selectors', () => {
           [NAME]: {
             session: {
               ...state[NAME].session,
-              runTime: Date.parse('2017-08-30T12:00:00.123Z') + (1000 * seconds)
+              runTime: 42 + (1000 * seconds)
             }
           }
         }
@@ -282,21 +282,21 @@ describe('robot selectors', () => {
         {
           id: 0,
           description: 'foo',
-          handledAt: '2017-08-30T12:00:00Z',
+          handledAt: 42,
           isCurrent: true,
           isLast: false,
           children: [
             {
               id: 1,
               description: 'bar',
-              handledAt: '2017-08-30T12:00:01Z',
+              handledAt: 43,
               isCurrent: true,
               isLast: false,
               children: [
                 {
                   id: 2,
                   description: 'baz',
-                  handledAt: '2017-08-30T12:00:02Z',
+                  handledAt: 44,
                   isCurrent: true,
                   isLast: true,
                   children: []
@@ -304,7 +304,7 @@ describe('robot selectors', () => {
                 {
                   id: 3,
                   description: 'qux',
-                  handledAt: '',
+                  handledAt: null,
                   isCurrent: false,
                   isLast: false,
                   children: []
@@ -316,7 +316,7 @@ describe('robot selectors', () => {
         {
           id: 4,
           description: 'fizzbuzz',
-          handledAt: '',
+          handledAt: null,
           isCurrent: false,
           isLast: false,
           children: []


### PR DESCRIPTION
## overview

Modify timestamp format in API to milliseconds-since-epoch

Related to #365 

## changelog

- (chore) Modify session tracker in API to use milliseconds-since-epoch for timestamps
