### PR TITLE
Fix gpio script path in start script

### DIFF
--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-python setup_gpio.py
+python /usr/local/bin/setup_gpio.py
 
 radvd --logmethod=stderr_syslog --pidfile=/run/radvd.pid
 


### PR DESCRIPTION
## overview

Fixes incorrect GPIO initialization script path in the compute start script.

## changelog

- (bugfix) Fix incorrect GPIO initialization script path in compute start script

## review requests

- Test on the robot and make sure the script is found correctly
