### PR TITLE
refactor(app): Collapse tip-probe tracking state

### DIFF
--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -33,6 +33,7 @@ export const actionTypes = {
   DROP_TIP_AND_HOME_RESPONSE: makeRobotActionName('DROP_TIP_AND_HOME_RESPONSE'),
   CONFIRM_TIPRACK: makeRobotActionName('CONFIRM_TIPRACK'),
   CONFIRM_TIPRACK_RESPONSE: makeRobotActionName('CONFIRM_TIPRACK_RESPONSE'),
+  // TODO(mc, 2018-01-10): rename MOVE_TO_FRONT to PREPARE_TO_PROBE?
   MOVE_TO_FRONT: makeRobotActionName('MOVE_TO_FRONT'),
   MOVE_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
   PROBE_TIP: makeRobotActionName('PROBE_TIP'),

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -325,6 +325,7 @@ describe('robot selectors', () => {
     })
   })
 
+  // TODO(mc: 2018-01-10): rethink the instrument level "calibration" prop
   test('get instruments', () => {
     const state = makeState({
       session: {
@@ -334,8 +335,11 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {
-          left: constants.PROBING
+        calibrationRequest: {
+          type: 'PROBE_TIP',
+          mount: 'left',
+          inProgress: true,
+          error: null
         },
         probedByAxis: {
           left: true
@@ -380,7 +384,7 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {},
+        calibrationRequest: {},
         probedByAxis: {}
       }
     })
@@ -396,7 +400,7 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {},
+        calibrationRequest: {},
         probedByAxis: {}
       }
     })
@@ -413,7 +417,7 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {},
+        calibrationRequest: {},
         probedByAxis: {left: true, right: true}
       }
     })
@@ -426,7 +430,7 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {},
+        calibrationRequest: {},
         probedByAxis: {left: false, right: false}
       }
     })
@@ -438,7 +442,7 @@ describe('robot selectors', () => {
         }
       },
       calibration: {
-        instrumentsByAxis: {},
+        calibrationRequest: {},
         probedByAxis: {right: true}
       }
     })


### PR DESCRIPTION
## overview

This PR collapses the following `robot.calibration` subtrees

- `moveToFrontRequest` - Status of a `calibration_manager.move_to_front` request
- `tipProbeRequest` - Status of a `calibration_manager.tip_probe` request
- `instrumentByAxis` - Individual calibration "status" of each instrument, like `PROBING`
    - This is not the same as the `probedByAxis` subtree, which is a latched boolean flag for if an instrument has been probed

Into the single subtree: `calibrationRequest`. This will simplify logic as we iterate on the tip probe experience.

I also took the opportunity to introduce `flow` to the `calibration` reducer. There's a lot of flow work to be done in our Redux stuff but right off the bat the encouraged me to program more defensively so I'm going to try to stay in the habit of adding flow to files I touch.

Fixes #593

## changelog

- Refactor: collapsed tip probe request and status tracking into single `calibrationRequest` object

## review requests

Looks good on my machine with `mike-bot` but please verify on yours, too.
