### PR TITLE
build(make): Refactor Makefiles to play nicer with Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ test:
 # upload coverage reports
 # uses codecov's bash upload script
 # TODO(mc, 2018-08-28): add test as a task dependency once travis is setup to
-# use this Makefile for tests
+#   use this Makefile for tests
+# TODO(mc, 2018-01-09): using the codecov bash reporter is not cross-platform
+#   friendly; evaluate whether this is ok, because only CI uses this target
 .PHONY: coverage
 coverage:
 	$(SHELL) <(curl -s https://codecov.io/bash) -X coveragepy

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,5 @@
 # opentrons api makefile
 
-SHELL := /bin/bash
-
 .PHONY: install
 install:
 	pip install -r requirements.txt && pip install -e .
@@ -48,6 +46,9 @@ term:
 
 ########## [START] RESIN DEVICE ##########
 
+# TODO(mc, 2018-01-09): resin cli may not be cross-platform compatible
+#   see https://github.com/resin-io/resin-cli#windows-support
+#   also, the resin cli isn't listed as a dependency anywhere
 .PHONY: info_device
 info_device:
 	resin device $(OT_DEVICE_ID)

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -1,18 +1,16 @@
 # opentrons app desktop shell makefile
 
-# use bash
-SHELL := bash
+# add node_modules/.bin to the path
+PATH := $(shell yarn bin):$(PATH)
 
-# source files
-source := $(shell find lib -type f -name '*.js')
+# ui directory to build bundle for app shell distributable
 ui_dir := ../app
 
-# use devDependency CLIs with $(bin)/command
 # set NODE_ENV for a command with $(env)=environment
-bin := node_modules/.bin
-env := $(bin)/cross-env NODE_ENV
+env := cross-env NODE_ENV
 
-set_package_env := $(bin)/cross-env \
+set_package_env := cross-env \
+	NODE_ENV=production \
 	OT_TIME_SUFFIX=$(OT_TIME_SUFFIX) \
 	OT_BRANCH_SUFFIX=$(OT_BRANCH_SUFFIX) \
 	OT_COMMIT_SUFFIX=$(OT_COMMIT_SUFFIX)
@@ -43,35 +41,35 @@ ui:
 	$(MAKE) -C $(ui_dir)
 
 .PHONY: package
-package: $(source) ui
-	$(set_package_env) $(bin)/electron-builder --dir
+package: ui
+	$(set_package_env) electron-builder --dir
 
 .PHONY: dist-posix
-dist-posix: $(source) ui
-	$(set_package_env) $(bin)/electron-builder --linux --mac --publish never
+dist-posix: ui
+	$(set_package_env) electron-builder --linux --mac --publish never
 
 .PHONY: dist-osx
-dist-osx: $(source) ui
-	$(set_package_env) $(bin)/electron-builder --mac --publish never
+dist-osx: ui
+	$(set_package_env) electron-builder --mac --publish never
 
 .PHONY: dist-linux
-dist-linux: $(source) ui
-	$(set_package_env) $(bin)/electron-builder --linux --publish never
+dist-linux: ui
+	$(set_package_env) electron-builder --linux --publish never
 
 .PHONY: dist-win
 dist-win: $(source) ui
-	$(set_package_env) $(bin)/electron-builder --win --x64 --publish never
+	$(set_package_env) electron-builder --win --x64 --publish never
 
 # development
 #####################################################################
 
 .PHONY: dev
 dev:
-	$(env)=development PORT=$(port) $(bin)/electron lib/main.js
+	$(env)=development PORT=$(port) electron lib/main.js
 
 # checks
 #####################################################################
 
 .PHONY: lint
 lint:
-	$(bin)/standard --verbose --fix=$(fix) | $(bin)/snazzy
+	standard --verbose --fix=$(fix) | snazzy

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,21 +1,18 @@
 # opentrons app makefile
 
-# use bash
-SHELL := bash
+# add node_modules/.bin to the path
+PATH := $(shell yarn bin):$(PATH)
 
-# source files
-source := $(shell find src -type f -name '*')
+# desktop shell directory for running the app in development
 shell_dir := ../app-shell
 
-# use devDependency CLIs with $(bin)/command
 # set NODE_ENV for a command with $(env)=environment
-bin := node_modules/.bin
-env := $(bin)/cross-env NODE_ENV
+env := cross-env NODE_ENV
 
 # dev server port
 port ?= 8090
 
-# watch, coverage, and fix variables for tests and linting
+# test and lint options
 watch ?= false
 cover ?= true
 fix ?= false
@@ -46,22 +43,22 @@ clean:
 #####################################################################
 
 .PHONY: dist
-dist: $(source)
-	$(env)=production $(bin)/webpack --profile
+dist:
+	$(env)=production webpack --profile
 
 # development
 #####################################################################
 
 .PHONY: dev
 dev:
-	$(bin)/concurrently \
+	concurrently \
 		"$(MAKE) dev-server" \
 		"$(MAKE) dev-mdns" \
-		"sleep 3 && $(MAKE) -C $(shell_dir) dev port=$(port)"
+		"wait-on http-get://localhost:$(port) && $(MAKE) -C $(shell_dir) dev port=$(port)"
 
 .PHONY: dev-server
 dev-server:
-	$(env)=development PORT=$(port) $(bin)/webpack-dev-server --hot
+	$(env)=development PORT=$(port) webpack-dev-server --hot
 
 # TODO(mc, 2017-10-31): remove when API is capable of advertising itself
 .PHONY: dev-mdns
@@ -77,21 +74,22 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit:
-	$(env)=test $(bin)/jest '.*\.test\.js' --coverage=$(cover) --watch=$(watch)
+	$(env)=test jest '.*\.test\.js' --coverage=$(cover) --watch=$(watch)
 
 .PHONY: check
 check:
-	$(bin)/flow
+	flow
 
 .PHONY: lint
 lint:
-	$(bin)/standard --verbose --fix=$(fix) | $(bin)/snazzy
-	$(bin)/stylelint '**/*.css' --fix=$(fix) --verbose
+	standard --verbose --fix=$(fix) | snazzy
+	stylelint '**/*.css' --fix=$(fix) --verbose
 
 .PHONY: install-types
 install-types:
-	$(bin)/flow-typed install --ignoreDeps dev
+	flow-typed install --ignoreDeps dev
 
+# TODO(mc, 2018-01-09): rm -rf is not cross-platform
 .PHONY: uninstall-types
 uninstall-types:
 	rm -rf flow-typed

--- a/app/package.json
+++ b/app/package.json
@@ -105,6 +105,7 @@
     "stylelint-config-standard": "^17.0.0",
     "superagent": "^3.8.1",
     "url-loader": "^0.6.2",
+    "wait-on": "^2.0.2",
     "webpack": "~2.6.1",
     "webpack-bundle-analyzer": "^2.8.2",
     "webpack-dev-server": "~2.4.5",

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,12 +1,7 @@
 # opentrons component library makefile
 
-# use bash
-SHELL := bash
-
-# use devDependency CLIs with $(bin)/command
-# set NODE_ENV for a command with $(env)=environment
-bin := node_modules/.bin
-env := $(bin)/cross-env NODE_ENV
+# add node_modules/.bin to the path
+PATH := $(shell yarn bin):$(PATH)
 
 # dev server port
 port ?= 8081
@@ -19,6 +14,9 @@ fix ?= false
 ifeq ($(watch), true)
 	cover := false
 endif
+
+# set NODE_ENV for a command with $(env)=environment
+env := cross-env NODE_ENV
 
 # stardard targets
 #####################################################################
@@ -36,14 +34,14 @@ uninstall:
 
 .PHONY: dev
 dev:
-	$(env)=development $(bin)/styleguidist server
+	$(env)=development styleguidist server
 
 # checks
 #####################################################################
 
 .PHONY: test
 test:
-	$(env)=test $(bin)/jest \
+	$(env)=test jest \
 		--coverage=$(cover) \
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)
@@ -51,11 +49,11 @@ test:
 
 .PHONY: check
 check:
-	$(bin)/flow
+	flow
 
 .PHONY: install-types
 install-types:
-	$(bin)/flow-typed install --ignoreDeps dev
+	flow-typed install --ignoreDeps dev
 
 .PHONY: uninstall-types
 uninstall-types:
@@ -63,5 +61,5 @@ uninstall-types:
 
 .PHONY: lint
 lint:
-	$(bin)/standard --verbose --fix=$(fix) | $(bin)/snazzy
-	$(bin)/stylelint '**/*.css' --fix=$(fix) --verbose
+	standard --verbose --fix=$(fix) | snazzy
+	stylelint '**/*.css' --fix=$(fix) --verbose

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -1,12 +1,7 @@
 # opentrons protocol designer makefile
 
-# use bash
-SHELL := bash
-
-# use devDependency CLIs with $(bin)/command
-# set NODE_ENV for a command with $(env)=environment
-bin := node_modules/.bin
-env := $(bin)/cross-env NODE_ENV
+# add node_modules/.bin to the path
+PATH := $(shell yarn bin):$(PATH)
 
 # dev server port
 port ?= 8080
@@ -19,6 +14,9 @@ fix ?= false
 ifeq ($(watch), true)
 	cover := false
 endif
+
+# set NODE_ENV for a command with $(env)=environment
+env := cross-env NODE_ENV
 
 # standard targets
 #####################################################################
@@ -34,9 +32,10 @@ uninstall:
 # artifacts
 #####################################################################
 
+# TODO(mc, 2018-01-09): use html-webpack-plugin for index.html
 .PHONY: build
 build:
-	$(env)=production $(bin)/webpack -p
+	$(env)=production webpack -p
 	cp index.html dist/
 
 # development
@@ -49,7 +48,7 @@ build:
 
 .PHONY: test
 test:
-	$(env)=test $(bin)/jest \
+	$(env)=test jest \
 		--coverage=$(cover) \
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)
@@ -57,17 +56,18 @@ test:
 
 .PHONY: check
 check:
-	$(bin)/flow
+	flow
 
 .PHONY: install-types
 install-types:
-	$(bin)/flow-typed install --ignoreDeps dev
+	flow-typed install --ignoreDeps dev
 
+# TODO(mc, 2018-01-09): rm -rf is not cross-platform
 .PHONY: uninstall-types
 uninstall-types:
 	rm -rf flow-typed
 
 .PHONY: lint
 lint:
-	$(bin)/standard --verbose --fix=$(fix) | $(bin)/snazzy
-	$(bin)/stylelint '**/*.css' --fix=$(fix) --verbose
+	standard --verbose --fix=$(fix) | snazzy
+	stylelint '**/*.css' --fix=$(fix) --verbose

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,6 +4393,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isemail@2.x.x:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -4487,6 +4491,10 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+items@2.x.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
 
 javascript-stringify@^1.6.0:
   version "1.6.0"
@@ -4927,6 +4935,16 @@ jest@^21.2.1:
   resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
   dependencies:
     jest-cli "^21.2.1"
+
+joi@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-9.2.0.tgz#3385ac790192130cbe230e802ec02c9215bbfeda"
+  dependencies:
+    hoek "4.x.x"
+    isemail "2.x.x"
+    items "2.x.x"
+    moment "2.x.x"
+    topo "2.x.x"
 
 js-base64@^2.1.9:
   version "2.4.0"
@@ -5592,7 +5610,7 @@ mkdirp@0.5, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp
   dependencies:
     minimist "0.0.8"
 
-moment@^2.19.1:
+moment@2.x.x, moment@^2.19.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
@@ -7386,7 +7404,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@^2.78.0, request@^2.79.0, request@^2.81.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -7559,6 +7577,10 @@ rx-lite@^3.1.2:
 rx@2.3.24:
   version "2.3.24"
   resolved "https://registry.yarnpkg.com/rx/-/rx-2.3.24.tgz#14f950a4217d7e35daa71bbcbe58eff68ea4b2b7"
+
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -8539,6 +8561,12 @@ to-regex@^3.0.1:
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
 
+topo@2.x.x:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
+  dependencies:
+    hoek "4.x.x"
+
 toposort@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
@@ -8952,6 +8980,16 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+wait-on@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-2.0.2.tgz#0a84fd07024c6fc268cb0eabe585be217aaf2baa"
+  dependencies:
+    core-js "^2.4.1"
+    joi "^9.2.0"
+    minimist "^1.2.0"
+    request "^2.78.0"
+    rx "^4.1.0"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## overview

As I've been spending time testing my changes in Windows, I noticed our Makefiles (front-end especially) didn't play particularly nicely with Git Bash and Command Prompt. This PR makes a few easy tweaks to up our compatibility.

All targets that call POSIX stuff (e.g. `make clean` > `rm -rf`) can only be run in Git Bash or similar, but an important subset of our targets (including `make install`, `make test`, and `make dev`) can all run natively in Command Prompt or PowerShell!

(FYI: In GNU Make for Windows, the default shell is Command Prompt, so even if you run `make` from PowerShell, the commands will be running in `cmd.exe`. This is good, because `cmd` supports `&&` while PowerShell inexplicably does not).

## changelog

- Build: Refactored Makefiles to fix up path and separator issues on Windows

## review requests

Give this a shot in all your OS's to make sure everything still works! Please not that I added exactly one dev dependency for the app, so remember to run `yarn` after you clone.

Also, my Windows setup involves using the  [Chocolatey](https://chocolatey.org/) package manager to manage build dependencies. Once Chocolatey is installed, you can easily install our build dependencies in an elevated shell with:

```shell
choco install git.install -y
choco install python --version=3.5.4 -y
choco install nodejs.install --version=8.9.4 -y
choco install yarn -y
choco install make -y
```

Once you've done that, all the tools will be in your PATH in the Windows shells and Git Bash!
