### PR TITLE
Memoize robot selectors and introduce flow to robot state

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -129,6 +129,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
+    "reselect": "^3.0.1",
     "winston": "^2.2.0"
   }
 }

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -1,21 +1,30 @@
+// @flow
 // robot redux module constants
 import PropTypes from 'prop-types'
 
 export const _NAME = 'robot'
 
 // connection states
+// TODO(mc, 2018-01-11): remove constant exports in favor of flowtype
 export const DISCONNECTED = 'disconnected'
 export const CONNECTING = 'connecting'
 export const CONNECTED = 'connected'
 export const DISCONNECTING = 'disconnecting'
+export type ConnectionStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
 
-// session states
-export const LOADED = 'loaded'
-export const RUNNING = 'running'
-export const PAUSED = 'paused'
-export const ERROR = 'error'
-export const FINISHED = 'finished'
-export const STOPPED = 'stopped'
+// session status (api/opentrons/api/session.py::VALID_STATES)
+export type SessionStatus =
+  | ''
+  | 'loaded'
+  | 'running'
+  | 'paused'
+  | 'error'
+  | 'finished'
+  | 'stopped'
 
 // tip probe calibration states
 export const UNPROBED = 'unprobed'
@@ -57,7 +66,8 @@ export const LABWARE_CONFIRMATION_TYPE = PropTypes.oneOf([
 ])
 
 // deck layout
-export const INSTRUMENT_AXES = ['left', 'right']
+export type InstrumentMount = 'left' | 'right'
+export const INSTRUMENT_AXES: InstrumentMount[] = ['left', 'right']
 export const DECK_SLOTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
 // pipette channels

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -4,6 +4,7 @@
 import {actionTypes} from '../actions'
 
 import {
+  type InstrumentMount,
   UNCONFIRMED,
   MOVING_TO_SLOT,
   OVER_SLOT,
@@ -29,7 +30,7 @@ type CalibrationRequestType =
 
 type CalibrationRequest = {
   type: CalibrationRequestType,
-  mount: string,
+  mount: InstrumentMount | '',
   inProgress: boolean,
   error: ?{message: string},
 }
@@ -42,11 +43,11 @@ type LabwareConfirmationRequest = {
   error: ?{message: string},
 }
 
-type State = {
+export type State = {
   labwareReviewed: boolean,
   jogDistance: number,
 
-  probedByAxis: {[string]: boolean},
+  probedByAxis: {[InstrumentMount]: boolean},
 
   labwareBySlot: {[number]: {}},
   confirmedBySlot: {[number]: boolean},
@@ -61,7 +62,7 @@ type State = {
   updateOffsetRequest: LabwareConfirmationRequest,
 }
 
-// TODO(mc, 2018-01-10): import this from elsewhere
+// TODO(mc, 2018-01-11): import union of discrete action types from actions
 type Action = {
   type: string,
   payload?: any,
@@ -69,6 +70,7 @@ type Action = {
   meta?: {}
 }
 
+// TODO(mc, 2018-01-11): replace actionType constants with Flow types
 const {
   SESSION,
   DISCONNECT_RESPONSE,
@@ -122,7 +124,7 @@ const INITIAL_STATE: State = {
 export default function calibrationReducer (
   state: State = INITIAL_STATE,
   action: Action
-) {
+): State {
   switch (action.type) {
     case DISCONNECT_RESPONSE: return handleDisconnectResponse(state, action)
     case SESSION: return handleSession(state, action)
@@ -216,6 +218,8 @@ function handleProbeTip (state, action) {
 function handleProbeTipResponse (state, action) {
   const {calibrationRequest: {mount}} = state
   const {payload, error} = action
+
+  if (mount !== 'left' && mount !== 'right') return state
 
   return {
     ...state,

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -1,8 +1,40 @@
+// @flow
 // robot connection state and reducer
 import omit from 'lodash/omit'
 import without from 'lodash/without'
 
 import {actionTypes} from '../actions'
+
+export type State = {
+  isScanning: boolean,
+  discovered: string[],
+  discoveredByName: {
+    [string]: {
+      name: String,
+      ip: String,
+      host: String,
+      port: number
+    }
+  },
+  connectedTo: string,
+  connectRequest: {
+    inProgress: boolean,
+    error: ?{message: string},
+    name: string
+  },
+  disconnectRequest: {
+    inProgress: boolean,
+    error: ?{message: string}
+  },
+}
+
+// TODO(mc, 2018-01-11): import union of discrete action types from actions
+type Action = {
+  type: string,
+  payload?: any,
+  error?: boolean,
+  meta?: {}
+}
 
 const {
   DISCOVER,
@@ -15,7 +47,7 @@ const {
   DISCONNECT_RESPONSE
 } = actionTypes
 
-const INITIAL_STATE = {
+const INITIAL_STATE: State = {
   isScanning: false,
   discovered: [],
   discoveredByName: {},
@@ -24,7 +56,10 @@ const INITIAL_STATE = {
   disconnectRequest: {inProgress: false, error: null}
 }
 
-export default function connectionReducer (state = INITIAL_STATE, action) {
+export default function connectionReducer (
+  state: State = INITIAL_STATE,
+  action: Action
+): State {
   switch (action.type) {
     case DISCOVER: return handleDiscover(state, action)
     case DISCOVER_FINISH: return handleDiscoverFinish(state, action)
@@ -54,6 +89,8 @@ function handleDiscoverFinish (state, action) {
 }
 
 function handleAddDiscovered (state, action) {
+  if (!action.payload) return state
+
   const {payload} = action
   const {name} = payload
   let {discovered, discoveredByName} = state
@@ -74,6 +111,8 @@ function handleAddDiscovered (state, action) {
 }
 
 function handleRemoveDiscovered (state, action) {
+  if (!action.payload) return state
+
   const {payload: {name}} = action
 
   return {
@@ -84,6 +123,8 @@ function handleRemoveDiscovered (state, action) {
 }
 
 function handleConnect (state, action) {
+  if (!action.payload) return state
+
   const {payload: {name}} = action
 
   return {...state, connectRequest: {inProgress: true, error: null, name}}

--- a/app/src/robot/reducer/index.js
+++ b/app/src/robot/reducer/index.js
@@ -1,3 +1,4 @@
+// @flow
 // robot reducer
 // TODO(mc, 2017-10-05): Split into sub-reducers or different redux modules
 import {combineReducers} from 'redux'

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -351,7 +351,7 @@ describe('robot selectors', () => {
       {
         axis: 'left',
         name: 'p200m',
-        channels: 'multi',
+        channels: 8,
         volume: 200,
         calibration: constants.PROBING,
         probed: true
@@ -359,7 +359,7 @@ describe('robot selectors', () => {
       {
         axis: 'right',
         name: 'p50s',
-        channels: 'single',
+        channels: 1,
         volume: 50,
         calibration: constants.UNPROBED,
         probed: false
@@ -565,9 +565,20 @@ describe('robot selectors', () => {
         confirmed: false
       })
 
-      state[NAME].calibration.confirmedBySlot[1] = true
+      const nextState = {
+        [NAME]: {
+          ...state[NAME],
+          calibration: {
+            ...state[NAME].calibration,
+            confirmedBySlot: {
+              ...state[NAME].calibration.confirmedBySlot,
+              1: true
+            }
+          }
+        }
+      }
 
-      expect(getNextLabware(state)).toEqual({
+      expect(getNextLabware(nextState)).toEqual({
         slot: 9,
         id: 'C3',
         name: 'c3',

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -20,6 +20,7 @@ describe('robot reducer - session', () => {
       errors: [],
       protocolText: '',
       protocolCommands: [],
+      protocolCommandsById: {},
       protocolInstrumentsByAxis: {},
       protocolLabwareBySlot: {},
 


### PR DESCRIPTION
## overview

This PR was originally intended to address #592, but as I introduced reselect and flow to the robot selectors, I found out:

- The problem the ticket is trying to solve isn't really a problem
    - Or rather, I don't think we'll understand the problems we have until we start to implement #595
    - I'm going to hold off on #592 for now, because if I keep swinging blindly this PR is gonna get huge
- Flow is really helpful to have in the reducers and selectors, so I went a little hog-wild 

What I ended up with is a PR that:

- Memoizes all the robot selectors
    - The robot module is the only part of the app that does computed state
- Adds flow to all of the robot reducers + selectors
    - This helps a non-trivial amount with understanding app state

Fixes #371
 
## changelog

- Performance refactor: Memoized robot selectors with reselect
- Refactor: Introduced initial flow types to the robot reducers

## review requests

I think this PR is right on the cusp of too big, so I apologize for that. The file to pay the most attention to is `app/robot/selectors.js`, which it looks like GH is hiding the diff for, so be careful.

