### PR TITLE
PD: Create, select, collapse/expand Steps in Step List

### DIFF
--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -1,12 +1,8 @@
 // @flow
 import * as React from 'react'
 
-import {Icon, TitledList, VerticalNavBar} from '@opentrons/components'
-import StepItem from './StepItem'
-import StepSubItem from './StepSubItem'
-import StepCreationButton from '../containers/StepCreationButton'
-
-import styles from './StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
+import {Icon, VerticalNavBar} from '@opentrons/components'
+import ConnectedStepList from '../containers/ConnectedStepList'
 
 export default function ProtocolEditor () {
   return (
@@ -17,79 +13,7 @@ export default function ProtocolEditor () {
           <Icon name='cog' />
         </VerticalNavBar>
       </div>
-      <div className={styles.fake_sidepanel_standin}>
-        {/* TODO: Ian 2018-01-11 ^^^^ this div will be <SidePanel> once that is factored out of App */}
-        <h3>Protocol Step List</h3> {/* TODO: Ian 2018-01-11 <-- this h3 will be SidePanel title. */}
-        <TitledList className={styles.step_item} iconName='flask' title='Labware & Ingredient Setup' />
-
-        <StepItem title='Transfer 1' stepType='transfer' sourceLabwareName='DNA Plate' destLabwareName='Output Plate' description='This is a transfer. Lorem ipsum delorom sic blah blah blaaaah.'>
-          <StepSubItem
-            sourceIngredientName='DNA'
-            sourceWell='B1'
-            destIngredientName='ddH2O'
-            destWell='B2'
-          />
-          <StepSubItem
-            sourceIngredientName='DNA'
-            sourceWell='C1'
-            destIngredientName='ddH2O'
-            destWell='C2'
-          />
-          <StepSubItem
-            sourceIngredientName='DNA'
-            sourceWell='D1'
-            destIngredientName='ddH2O'
-            destWell='D2'
-          />
-        </StepItem>
-
-        <StepItem title='Pause 1' stepType='pause' />
-
-        <StepItem title='Distribute 1' stepType='distribute' sourceLabwareName='LB Plate' destLabwareName='Output Tubes' selected>
-          <StepSubItem
-            sourceIngredientName='LB'
-            sourceWell='A1'
-            destIngredientName='ddH2O'
-            destWell='B1'
-          />
-          <StepSubItem
-            sourceIngredientName='LB'
-            destIngredientName='ddH2O'
-            destWell='B2'
-          />
-          <StepSubItem
-            sourceIngredientName='LB'
-            destIngredientName='ddH2O'
-            destWell='B3'
-          />
-          <StepSubItem
-            sourceIngredientName='LB'
-            sourceWell='A1'
-            destIngredientName='ddH2O'
-            destWell='B4'
-          />
-        </StepItem>
-
-        <StepItem title='Pause 2' stepType='pause' description='Wait until operator adds new tip rack.' />
-
-        <StepItem title='Consolidate 1' stepType='consolidate' sourceLabwareName='Labware 1' destLabwareName='Labware 2'>
-          <StepSubItem
-            sourceIngredientName='Cells'
-            sourceWell='A1'
-          />
-          <StepSubItem
-            sourceIngredientName='Cells'
-            sourceWell='A2'
-          />
-          <StepSubItem
-            sourceIngredientName='Cells'
-            sourceWell='A3'
-            destIngredientName='LB Broth'
-            destWell='H1'
-          />
-        </StepItem>
-        <StepCreationButton />
-      </div>
+      <ConnectedStepList />
     </div>
   )
 }

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -7,16 +7,11 @@ import {Icon, TitledList} from '@opentrons/components'
 import StepDescription from './StepDescription'
 import styles from './StepItem.css'
 
-const stepIconsByType = { // TODO Ian 2018-01-11 revisit this
-  'transfer': 'arrow right',
-  'consolidate': 'consolidate',
-  'distribute': 'distribute',
-  'pause': 'pause',
-  'mix': 'mix'
-}
+import {stepIconsByType} from '../steplist/types'
+import type {StepType} from '../steplist/types'
 
-export type StepItemProps = {
-  stepType: $Keys<typeof stepIconsByType>,
+type StepItemProps = {
+  stepType: StepType,
   title?: string,
   description?: string,
   collapsed?: boolean,
@@ -43,7 +38,9 @@ export default function StepItem (props: StepItemProps) {
   } = props
 
   const iconName = stepIconsByType[stepType]
-  const showHeader = ['transfer', 'distribute', 'consolidate'].includes(stepType)
+  const showLabwareHeader = ['transfer', 'distribute', 'consolidate'].includes(stepType) &&
+    sourceLabwareName &&
+    destLabwareName
 
   const Description = <StepDescription description={description} />
 
@@ -53,7 +50,7 @@ export default function StepItem (props: StepItemProps) {
       description={Description}
       {...{iconName, title, selected, onClick, onCollapseToggle: onCollapseToggle || noop, collapsed}}
     >
-      {showHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
+      {showLabwareHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <span>{sourceLabwareName}</span>
         <Icon name={iconName} />
         <span>{destLabwareName}</span>

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -15,7 +15,7 @@ const stepIconsByType = { // TODO Ian 2018-01-11 revisit this
   'mix': 'mix'
 }
 
-type StepItemProps = {
+export type StepItemProps = {
   stepType: $Keys<typeof stepIconsByType>,
   title?: string,
   description?: string,

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -1,0 +1,78 @@
+// @flow
+import * as React from 'react'
+import isNil from 'lodash/isNil'
+import pick from 'lodash/pick'
+import {SidePanel, TitledList} from '@opentrons/components'
+
+// import type {StepItemProps} from '../components/StepItem'
+import StepItem from '../components/StepItem'
+// import type {StepSubItemProps} from '../components/StepSubItem'
+import StepSubItem from '../components/StepSubItem'
+import StepCreationButton from '../containers/StepCreationButton'
+
+import styles from '../components/StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
+
+// TODO move types to a place where React can import them
+// and also add them into StepSubItem and StepItem props types.
+type StepSubItemData = {
+  sourceIngredientName?: string,
+  destIngredientName?: string,
+  sourceWell?: string,
+  destWell?: string,
+}
+
+type StepItemData = {
+  id: number,
+  title: string,
+  stepType: string, // TODO should be union string literal
+  substeps: Array<StepSubItemData>,
+  description?: string,
+  sourceLabwareName?: string,
+  destLabwareName?: string
+}
+
+type StepListProps = {
+  selectedStep?: number,
+  steps: Array<StepItemData>,
+  handleStepItemClickById?: number => (event?: SyntheticEvent<>) => void,
+  handleStepItemCollapseToggleById?: number => (event?: SyntheticEvent<>) => void
+}
+
+export default function StepList (props: StepListProps) {
+  return (
+    <SidePanel title='Protocol Step List'>
+
+      {/* TODO: Ian 2018-01-16 figure out if 'Labware & Ingred Setup' is a Step or something else... */}
+      <TitledList className={styles.step_item} iconName='flask' title='Labware & Ingredient Setup' />
+
+      {props.steps && props.steps.map((step, key) => (
+        <StepItem key={key}
+          onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
+          onCollapseToggle={props.handleStepItemCollapseToggleById && props.handleStepItemCollapseToggleById(step.id)}
+          selected={!isNil(props.selectedStep) && step.id === props.selectedStep}
+          {...pick(step, [
+            'title',
+            'stepType',
+            'sourceLabwareName',
+            'sourceWell',
+            'destLabwareName',
+            'destWell',
+            'description',
+            'collapsed'
+          ])}
+        >
+          {step && step.substeps && step.substeps.map((substep, key) =>
+            <StepSubItem {...pick(substep, [
+              'sourceIngredientName',
+              'sourceWell',
+              'destIngredientName',
+              'destWell'
+            ])} />
+          )}
+        </StepItem>
+      ))}
+
+      <StepCreationButton />
+    </SidePanel>
+  )
+}

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -4,35 +4,15 @@ import isNil from 'lodash/isNil'
 import pick from 'lodash/pick'
 import {SidePanel, TitledList} from '@opentrons/components'
 
-// import type {StepItemProps} from '../components/StepItem'
+import type {StepItemData} from '../steplist/types'
 import StepItem from '../components/StepItem'
-// import type {StepSubItemProps} from '../components/StepSubItem'
 import StepSubItem from '../components/StepSubItem'
 import StepCreationButton from '../containers/StepCreationButton'
 
 import styles from '../components/StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
 
-// TODO move types to a place where React can import them
-// and also add them into StepSubItem and StepItem props types.
-type StepSubItemData = {
-  sourceIngredientName?: string,
-  destIngredientName?: string,
-  sourceWell?: string,
-  destWell?: string,
-}
-
-type StepItemData = {
-  id: number,
-  title: string,
-  stepType: string, // TODO should be union string literal
-  substeps: Array<StepSubItemData>,
-  description?: string,
-  sourceLabwareName?: string,
-  destLabwareName?: string
-}
-
 type StepListProps = {
-  selectedStep?: number,
+  selectedStepId?: number,
   steps: Array<StepItemData>,
   handleStepItemClickById?: number => (event?: SyntheticEvent<>) => void,
   handleStepItemCollapseToggleById?: number => (event?: SyntheticEvent<>) => void
@@ -49,7 +29,7 @@ export default function StepList (props: StepListProps) {
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
           onCollapseToggle={props.handleStepItemCollapseToggleById && props.handleStepItemCollapseToggleById(step.id)}
-          selected={!isNil(props.selectedStep) && step.id === props.selectedStep}
+          selected={!isNil(props.selectedStepId) && step.id === props.selectedStepId}
           {...pick(step, [
             'title',
             'stepType',

--- a/protocol-designer/src/components/StepSubItem.js
+++ b/protocol-designer/src/components/StepSubItem.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import {Icon} from '@opentrons/components'
 import styles from './StepItem.css'
 
-type StepSubItemProps = {
+export type StepSubItemProps = {
   sourceIngredientName?: string,
   destIngredientName?: string,
   sourceWell?: string,

--- a/protocol-designer/src/components/StepSubItem.js
+++ b/protocol-designer/src/components/StepSubItem.js
@@ -2,13 +2,10 @@
 import * as React from 'react'
 
 import {Icon} from '@opentrons/components'
+import type {StepSubItemData} from '../steplist/types'
 import styles from './StepItem.css'
 
-export type StepSubItemProps = {
-  sourceIngredientName?: string,
-  destIngredientName?: string,
-  sourceWell?: string,
-  destWell?: string,
+export type StepSubItemProps = StepSubItemData & {
   onMouseOver?: (event: SyntheticEvent<>) => void,
 }
 

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -1,0 +1,118 @@
+// @flow
+import {connect} from 'react-redux'
+
+import StepList from '../components/StepList'
+
+const steps = [
+  {
+    title: 'Transfer X',
+    stepType: 'transfer',
+    sourceLabwareName: 'X Plate',
+    sourceWell: 'X2',
+    destLabwareName: 'Dest X',
+    destWell: 'Y2',
+    id: 0,
+    collapsed: false,
+    substeps: [
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'B1',
+        destIngredientName: 'ddH2O',
+        destWell: 'B2'
+      },
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'C1',
+        destIngredientName: 'ddH2O',
+        destWell: 'C2'
+      },
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'D1',
+        destIngredientName: 'ddH2O',
+        destWell: 'D2'
+      }
+    ]
+  },
+  {
+    title: 'Pause 1',
+    stepType: 'pause',
+    id: 2
+  },
+  {
+    title: 'Distribute X',
+    description: 'Description is here',
+    stepType: 'distribute',
+    sourceLabwareName: 'X Plate',
+    destLabwareName: 'Dest X',
+    id: 3,
+    substeps: [
+      {
+        sourceIngredientName: 'LB',
+        sourceWell: 'A1',
+        destIngredientName: 'ddH2O',
+        destWell: 'B1'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B2'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B3'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B4'
+      }
+    ]
+  },
+  {
+    title: 'Pause 2',
+    stepType: 'pause',
+    id: 4,
+    description: 'Wait until operator adds new tip rack.'
+  },
+  {
+    title: 'Consolidate X',
+    stepType: 'consolidate',
+    sourceLabwareName: 'Labware A',
+    destLabwareName: 'Labware B',
+    id: 5,
+    substeps: [
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A1'
+      },
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A2'
+      },
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A3',
+        destIngredientName: 'LB Broth',
+        destWell: 'H1'
+      }
+    ]
+  }
+]
+
+function mapStateToProps (state) {
+  return {
+    steps: steps, // TODO
+    selectedStep: 2 // TODO
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    handleStepItemClickById: id => e => console.log('clicked step', id),
+    handleStepItemCollapseToggleById: id => e => console.log('clicked toggle', id)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(StepList)

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -1,117 +1,20 @@
 // @flow
 import {connect} from 'react-redux'
 
+import {selectors} from '../steplist/reducers'
 import StepList from '../components/StepList'
-
-const steps = [
-  {
-    title: 'Transfer X',
-    stepType: 'transfer',
-    sourceLabwareName: 'X Plate',
-    sourceWell: 'X2',
-    destLabwareName: 'Dest X',
-    destWell: 'Y2',
-    id: 0,
-    collapsed: false,
-    substeps: [
-      {
-        sourceIngredientName: 'DNA',
-        sourceWell: 'B1',
-        destIngredientName: 'ddH2O',
-        destWell: 'B2'
-      },
-      {
-        sourceIngredientName: 'DNA',
-        sourceWell: 'C1',
-        destIngredientName: 'ddH2O',
-        destWell: 'C2'
-      },
-      {
-        sourceIngredientName: 'DNA',
-        sourceWell: 'D1',
-        destIngredientName: 'ddH2O',
-        destWell: 'D2'
-      }
-    ]
-  },
-  {
-    title: 'Pause 1',
-    stepType: 'pause',
-    id: 2
-  },
-  {
-    title: 'Distribute X',
-    description: 'Description is here',
-    stepType: 'distribute',
-    sourceLabwareName: 'X Plate',
-    destLabwareName: 'Dest X',
-    id: 3,
-    substeps: [
-      {
-        sourceIngredientName: 'LB',
-        sourceWell: 'A1',
-        destIngredientName: 'ddH2O',
-        destWell: 'B1'
-      },
-      {
-        sourceIngredientName: 'LB',
-        destIngredientName: 'ddH2O',
-        destWell: 'B2'
-      },
-      {
-        sourceIngredientName: 'LB',
-        destIngredientName: 'ddH2O',
-        destWell: 'B3'
-      },
-      {
-        sourceIngredientName: 'LB',
-        destIngredientName: 'ddH2O',
-        destWell: 'B4'
-      }
-    ]
-  },
-  {
-    title: 'Pause 2',
-    stepType: 'pause',
-    id: 4,
-    description: 'Wait until operator adds new tip rack.'
-  },
-  {
-    title: 'Consolidate X',
-    stepType: 'consolidate',
-    sourceLabwareName: 'Labware A',
-    destLabwareName: 'Labware B',
-    id: 5,
-    substeps: [
-      {
-        sourceIngredientName: 'Cells',
-        sourceWell: 'A1'
-      },
-      {
-        sourceIngredientName: 'Cells',
-        sourceWell: 'A2'
-      },
-      {
-        sourceIngredientName: 'Cells',
-        sourceWell: 'A3',
-        destIngredientName: 'LB Broth',
-        destWell: 'H1'
-      }
-    ]
-  }
-]
 
 function mapStateToProps (state) {
   return {
-    steps: steps, // TODO
-    selectedStep: 2 // TODO
+    steps: selectors.allSteps(state),
+    selectedStepId: selectors.selectedStepId(state)
   }
 }
 
 function mapDispatchToProps (dispatch) {
   return {
-    handleStepItemClickById: id => e => console.log('clicked step', id),
-    handleStepItemCollapseToggleById: id => e => console.log('clicked toggle', id)
+    handleStepItemClickById: id => e => dispatch({type: 'SELECT_STEP', payload: id}),
+    handleStepItemCollapseToggleById: id => e => dispatch({type: 'TOGGLE_STEP_COLLAPSED', payload: id})
   }
 }
 

--- a/protocol-designer/src/containers/StepCreationButton.js
+++ b/protocol-designer/src/containers/StepCreationButton.js
@@ -36,12 +36,13 @@ class StepCreationButton extends React.Component<StepCreationButtonProps> {
   }
 
   render () {
-    const {expanded, onExpandClick, onStepClick} = this.props
+    const {expanded, onExpandClick, onStepClick, onClickAway} = this.props
     return (
       <div ref={ref => { this.ref = ref }}>
-        <PrimaryButton onClick={onExpandClick}>+ Add Action</PrimaryButton>
+        <PrimaryButton onClick={expanded ? onClickAway : onExpandClick}>+ Add Action</PrimaryButton>
         {expanded && map(stepIconsByType, (iconName, stepType) =>
           <PrimaryButton
+            key={stepType}
             onClick={onStepClick(stepType)}
             iconName={iconName}
           >

--- a/protocol-designer/src/containers/StepCreationButton.js
+++ b/protocol-designer/src/containers/StepCreationButton.js
@@ -1,17 +1,12 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
+import map from 'lodash/map'
 
 import {PrimaryButton} from '@opentrons/components'
 import {addStep, expandAddStepButton} from '../steplist/actions'
 import {selectors} from '../steplist/reducers'
-
-// TODO factor out Step types
-type StepType = 'transfer'
-  | 'distribute'
-  | 'consolidate'
-  | 'mix'
-  | 'pause'
-  | 'deck setup'
+import {stepIconsByType} from '../steplist/types'
+import type {StepType} from '../steplist/types'
 
 type StepCreationButtonProps = {
   onStepClick?: StepType => (event?: SyntheticEvent<>) => void,
@@ -28,7 +23,7 @@ class StepCreationButton extends React.Component<StepCreationButtonProps> {
 
   handleAllClicks (e) {
     if (this.ref && !this.ref.contains(e.target)) {
-      this.props.onClickAway(e)
+      this.props.expanded && this.props.onClickAway(e)
     }
   }
 
@@ -45,20 +40,14 @@ class StepCreationButton extends React.Component<StepCreationButtonProps> {
     return (
       <div ref={ref => { this.ref = ref }}>
         <PrimaryButton onClick={onExpandClick}>+ Add Action</PrimaryButton>
-        {expanded && <React.Fragment>
+        {expanded && map(stepIconsByType, (iconName, stepType) =>
           <PrimaryButton
-            onClick={onStepClick('transfer')}
-            iconName='arrow right'
-            >
-              Transfer
+            onClick={onStepClick(stepType)}
+            iconName={iconName}
+          >
+            {stepType}
           </PrimaryButton>
-          <PrimaryButton
-            onClick={onStepClick('distribute')}
-            iconName='distribute'
-            >Distribute
-          </PrimaryButton>
-        </React.Fragment>
-        }
+        )}
       </div>
     )
   }
@@ -72,7 +61,7 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    onStepClick: stepType => e => dispatch(addStep({type: stepType, collapsed: false})),
+    onStepClick: stepType => e => dispatch(addStep({stepType})),
     onExpandClick: e => dispatch(expandAddStepButton(true)),
     onClickAway: e => dispatch(expandAddStepButton(false))
   }

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -1,4 +1,4 @@
-import { containers } from './reducers'
+import { containers } from '../reducers'
 
 const containersInitialState = {}
 

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -1,4 +1,4 @@
-import { ingredients } from './reducers'
+import { ingredients } from '../reducers'
 
 const ingredientsInitialState = {}
 

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -2,8 +2,135 @@ import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import { createSelector } from 'reselect'
 
+import type {StepType} from './types'
+
+// TODO move to test
+/*
+const initialSteps = {
+  0: {
+    title: 'Transfer X',
+    stepType: 'transfer',
+    sourceLabwareName: 'X Plate',
+    sourceWell: 'X2',
+    destLabwareName: 'Dest X',
+    destWell: 'Y2',
+    id: 0,
+    collapsed: false,
+    substeps: [
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'B1',
+        destIngredientName: 'ddH2O',
+        destWell: 'B2'
+      },
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'C1',
+        destIngredientName: 'ddH2O',
+        destWell: 'C2'
+      },
+      {
+        sourceIngredientName: 'DNA',
+        sourceWell: 'D1',
+        destIngredientName: 'ddH2O',
+        destWell: 'D2'
+      }
+    ]
+  },
+  2: {
+    title: 'Pause 1',
+    stepType: 'pause',
+    id: 2
+  },
+  3: {
+    title: 'Distribute X',
+    description: 'Description is here',
+    stepType: 'distribute',
+    sourceLabwareName: 'X Plate',
+    destLabwareName: 'Dest X',
+    id: 3,
+    substeps: [
+      {
+        sourceIngredientName: 'LB',
+        sourceWell: 'A1',
+        destIngredientName: 'ddH2O',
+        destWell: 'B1'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B2'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B3'
+      },
+      {
+        sourceIngredientName: 'LB',
+        destIngredientName: 'ddH2O',
+        destWell: 'B4'
+      }
+    ]
+  },
+  4: {
+    title: 'Pause 2',
+    stepType: 'pause',
+    id: 4,
+    description: 'Wait until operator adds new tip rack.'
+  },
+  5: {
+    title: 'Consolidate X',
+    stepType: 'consolidate',
+    sourceLabwareName: 'Labware A',
+    destLabwareName: 'Labware B',
+    id: 5,
+    substeps: [
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A1'
+      },
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A2'
+      },
+      {
+        sourceIngredientName: 'Cells',
+        sourceWell: 'A3',
+        destIngredientName: 'LB Broth',
+        destWell: 'H1'
+      }
+    ]
+  }
+}
+
+const initialStepOrder = [0, 2, 3, 4, 5]
+*/
+
+type AddStepType = {
+  stepType: StepType,
+  id: number
+}
+
+export function createDefaultStep (payload: AddStepType) {
+  const {stepType} = payload
+  return {...payload, title: stepType}
+}
+
 const steps = handleActions({
-  ADD_STEP: (state, action) => ({...state, [action.payload.id]: action.payload})
+  ADD_STEP: (state, action) => ({
+    ...state,
+    [action.payload.id]: createDefaultStep(action.payload)
+  })
+}, {})
+
+// Payload is ID. TODO: type that
+const collapsedSteps = handleActions({
+  ADD_STEP: (state, action) => ({...state, [action.payload]: false}),
+  TOGGLE_STEP_COLLAPSED: (state, action) => ({
+    ...state,
+    [action.payload]: !state[action.payload]
+  })
 }, {})
 
 const orderedSteps = handleActions({
@@ -11,7 +138,8 @@ const orderedSteps = handleActions({
 }, [])
 
 const selectedStep = handleActions({
-  ADD_STEP: (state, action) => action.payload.id
+  ADD_STEP: (state, action) => action.payload.id,
+  SELECT_STEP: (state, action) => action.payload
 }, null)
 
 const stepCreationButtonExpanded = handleActions({
@@ -21,6 +149,7 @@ const stepCreationButtonExpanded = handleActions({
 
 const rootReducer = combineReducers({
   steps,
+  collapsedSteps,
   orderedSteps,
   selectedStep,
   stepCreationButtonExpanded
@@ -36,10 +165,15 @@ export const selectors = {
   allSteps: createSelector(
     state => rootSelector(state).steps,
     state => rootSelector(state).orderedSteps,
-    (steps, orderedSteps) => orderedSteps.map(id => steps[id])
+    state => rootSelector(state).collapsedSteps,
+    (steps, orderedSteps, collapsedSteps) => orderedSteps.map(id => ({
+      ...steps[id],
+      collapsed: collapsedSteps[id]
+    }))
   ),
-  selectedStep: createSelector(
-    state => rootReducer(state).selectedStep
+  selectedStepId: createSelector(
+    rootSelector,
+    state => state.selectedStep
   )
 }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,0 +1,29 @@
+// @flow
+
+// TODO Ian 2018-01-16 factor out to steplist/constants.js ?
+export const stepIconsByType = {
+  'transfer': 'arrow right',
+  'distribute': 'distribute',
+  'consolidate': 'consolidate',
+  'mix': 'mix',
+  'pause': 'pause'
+}
+
+export type StepType = $Keys<typeof stepIconsByType>
+
+export type StepSubItemData = {
+  sourceIngredientName?: string,
+  destIngredientName?: string,
+  sourceWell?: string,
+  destWell?: string,
+}
+
+export type StepItemData = {
+  id: number,
+  title: string,
+  stepType: StepType,
+  substeps: Array<StepSubItemData>,
+  description?: string,
+  sourceLabwareName?: string,
+  destLabwareName?: string
+}


### PR DESCRIPTION
## overview

Most of #583 will be done with this PR (finally! :smiley: ), only last-touch styling will be left

## changelog

* `StepCreationButton` container only calls `onClickAway` when it's expanded (less Redux logging spam)
* `StepCreationButton` - clicking "+ Add Action" when expanded will collapse it
* `StepList` no longer hard-coded
* `StepItem` no longer shows "labware header" unless both source and dest labwares are assigned
* Moved `labware-ingred/` tests into `labware-ingred/__tests__/` dir
* New Steps are named after their stepType by default, with no other default properties
* Can select a Step by clicking its title
* Can collapse/expand Steps by clicking the carat

## review requests

1. What should the minimum be for testing this now? I feel conservative about writing new tests for this because I'm not sure how much will change as we make this actually function.

2. Opinions about Flow+Redux setup?

3. Design team (offline): is this on track? I'd like to put off colors until a later PR, but otherwise is it correct?