### PR TITLE
Issue 554 correct slot names

### DIFF
--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -12,21 +12,6 @@ def stringify_location(location):
             if isinstance(item, Slot):
                 return item
 
-    slot_number_mapping = {
-        'A1': '1',
-        'B1': '2',
-        'C1': '3',
-        'A2': '4',
-        'B2': '5',
-        'C2': '6',
-        'A3': '7',
-        'B3': '8',
-        'C3': '9',
-        'A4': '10',
-        'B4': '11',
-        'C4': '12',
-    }
-
     type_to_text = {
         Slot: 'slot',
         Container: 'container',
@@ -63,7 +48,7 @@ def stringify_location(location):
             suffix='s' if multiple else '',
             first=location[0].get_name(),
             last='...'+location[-1].get_name() if multiple else '',
-            slot_text=slot_number_mapping[get_slot(location[0]).get_name()]
+            slot_text=get_slot(location[0]).get_name()
         )
 
 

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -45,7 +45,7 @@ def load(robot, container_name, slot, label=None, share=False):
     columns_lookup = {'A': 0, 'B': 1, 'C': 2}
     if isinstance(slot, str) and slot[0] in columns_lookup:
         col = columns_lookup[slot[0]]
-        row = int(slot[1])
+        row = int(slot[1]) - 1
         index = col + (row * robot.get_max_robot_cols())
         old_slot = slot
         slot = str(index + 1)
@@ -54,9 +54,9 @@ def load(robot, container_name, slot, label=None, share=False):
             'Converting {0} to {1}'.format(old_slot, slot),
             DeprecationWarning
         )
-
-    # if user pass in slot name as number (eg: 3 instead of '3')
-    slot = str(slot)
+    elif isinstance(slot, (int, float, complex)):
+        # if user pass in slot name as number (eg: 3 instead of '3')
+        slot = str(slot)
 
     return robot.add_container(container_name, slot, label, share)
 

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -47,13 +47,10 @@ def load(robot, container_name, slot, label=None, share=False):
         col = columns_lookup[slot[0]]
         row = int(slot[1]) - 1
         index = col + (row * robot.get_max_robot_cols())
-        old_slot = slot
+        _s = slot
         slot = str(index + 1)
-        warnings.warn(
-            'Please reference slots as numbers 1-11. '
-            'Converting {0} to {1}'.format(old_slot, slot),
-            DeprecationWarning
-        )
+        msg = 'Slot name is "{0}", format "{1}" is deprecated'.format(slot, _s)
+        warnings.warn(msg)
     elif isinstance(slot, (int, float, complex)):
         # if user pass in slot name as number (eg: 3 instead of '3')
         slot = str(slot)

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import json
 import os
+import warnings
 
 from opentrons.data_storage import database
 from opentrons.containers.placeable import (
@@ -41,12 +42,18 @@ def load(robot, container_name, slot, label=None, share=False):
 
     # OT-One users specify columns in the A1, B3 fashion
     # below checks for this naming scheme, and converts to the 1, 2, etc names
-    columns_lookup = {'A':0, 'B': 1, 'C': 2}
+    columns_lookup = {'A': 0, 'B': 1, 'C': 2}
     if isinstance(slot, str) and slot[0] in columns_lookup:
         col = columns_lookup[slot[0]]
         row = int(slot[1])
         index = col + (row * robot.get_max_robot_cols())
+        old_slot = slot
         slot = str(index + 1)
+        warnings.warn(
+            'Please reference slots on OT2 as numbers 1-11. '
+            'Converting {0} to {1}'.format(old_slot, slot),
+            DeprecationWarning
+        )
 
     # if user pass in slot name as number (eg: 3 instead of '3')
     slot = str(slot)

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -14,6 +14,7 @@ from opentrons.containers.placeable import (
     get_container
 )
 from opentrons.containers.calibrator import apply_calibration
+from opentrons.helpers import helpers
 from opentrons.util import environment
 
 __all__ = [
@@ -61,6 +62,7 @@ def load(robot, container_name, slot, label=None, share=False):
             if is_ot_one_slot_name(slot):
                 slot = convert_ot_one_slot_names(slot)
 
+    if helpers.is_number(slot):
         # test that it is within correct range
         if not (1 <= slot <= len(robot.deck)):
             raise ValueError('Unknown slot: {}'.format(slot))

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -50,7 +50,7 @@ def load(robot, container_name, slot, label=None, share=False):
         old_slot = slot
         slot = str(index + 1)
         warnings.warn(
-            'Please reference slots on OT2 as numbers 1-11. '
+            'Please reference slots as numbers 1-11. '
             'Converting {0} to {1}'.format(old_slot, slot),
             DeprecationWarning
         )

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -38,6 +38,19 @@ def load(robot, container_name, slot, label=None, share=False):
     >>> containers.load('non-existent-type', 'A2') # doctest: +ELLIPSIS
     Exception: Container type "non-existent-type" not found in file ...
     """
+
+    # OT-One users specify columns in the A1, B3 fashion
+    # below checks for this naming scheme, and converts to the 1, 2, etc names
+    columns_lookup = {'A':0, 'B': 1, 'C': 2}
+    if isinstance(slot, str) and slot[0] in columns_lookup:
+        col = columns_lookup[slot[0]]
+        row = int(slot[1])
+        index = col + (row * robot.get_max_robot_cols())
+        slot = str(index + 1)
+
+    # if user pass in slot name as number (eg: 3 instead of '3')
+    slot = str(slot)
+
     return robot.add_container(container_name, slot, label, share)
 
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -684,10 +684,10 @@ class Robot(object):
     def get_slot_offsets(self):
         """
         col_offset
-        - from bottom left corner of A to bottom corner of B
+        - from bottom left corner of 1 to bottom corner of 2
 
         row_offset
-        - from bottom left corner of 1 to bottom corner of 2
+        - from bottom left corner of 1 to bottom corner of 4
 
         TODO: figure out actual X and Y offsets (from origin)
         """
@@ -704,18 +704,23 @@ class Robot(object):
         col_offset = slot_settings.get('col_offset')
         x_offset = slot_settings.get('x_offset')
         y_offset = slot_settings.get('y_offset')
-        return (row_offset, col_offset, x_offset, y_offset)
+        return (row_offset, col_offset)
 
     def get_max_robot_rows(self):
         # TODO: dynamically figure out robot rows
         return 4
 
-    def add_slots_to_deck(self):
-        robot_rows = self.get_max_robot_rows()
-        row_offset, col_offset, x_offset, y_offset = self.get_slot_offsets()
+    def get_max_robot_cols(self):
+        # TODO: dynamically figure out robot rows
+        return 3
 
-        for col_index, col in enumerate('ABC'):
-            for row_index, row in enumerate(range(1, robot_rows + 1)):
+    def add_slots_to_deck(self):
+        row_offset, col_offset = self.get_slot_offsets()
+        row_count = self.get_max_robot_rows()
+        col_count = self.get_max_robot_cols()
+
+        for row_index in range(row_count):
+            for col_index in range(col_count):
                 properties = {
                     'width': col_offset,
                     'length': row_offset,
@@ -723,11 +728,12 @@ class Robot(object):
                 }
                 slot = containers.Slot(properties=properties)
                 slot_coordinates = (
-                    (col_offset * col_index) + x_offset,
-                    (row_offset * row_index) + y_offset,
-                    0  # TODO: should z always be zero?
+                    (col_offset * col_index),
+                    (row_offset * row_index),
+                    0
                 )
-                slot_name = "{}{}".format(col, row)
+                slot_index = col_index + (row_index * col_count)
+                slot_name = str(slot_index + 1)
                 self._deck.add(slot, slot_name, slot_coordinates)
 
     def setup_deck(self):

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -693,8 +693,6 @@ class Robot(object):
         """
         SLOT_OFFSETS = {
             'slots': {
-                'x_offset': 0,
-                'y_offset': 0,
                 'col_offset': 132.50,
                 'row_offset': 90.5
             }
@@ -702,8 +700,6 @@ class Robot(object):
         slot_settings = SLOT_OFFSETS.get(self.get_deck_slot_types())
         row_offset = slot_settings.get('row_offset')
         col_offset = slot_settings.get('col_offset')
-        x_offset = slot_settings.get('x_offset')
-        y_offset = slot_settings.get('y_offset')
         return (row_offset, col_offset)
 
     def get_max_robot_rows(self):
@@ -711,7 +707,7 @@ class Robot(object):
         return 4
 
     def get_max_robot_cols(self):
-        # TODO: dynamically figure out robot rows
+        # TODO: dynamically figure out robot cols
         return 3
 
     def add_slots_to_deck(self):

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -15,9 +15,9 @@ def labware_setup():
     from opentrons import containers, instruments
 
     tip_racks = \
-        [containers.load('tiprack-200ul', slot, slot) for slot in ['A1', 'A2']]
+        [containers.load('tiprack-200ul', slot, slot) for slot in ['1', '4']]
     plates = \
-        [containers.load('96-PCR-flat', slot, slot) for slot in ['B1', 'B2']]
+        [containers.load('96-PCR-flat', slot, slot) for slot in ['2', '5']]
 
     p100 = instruments.Pipette(
         name='p100', mount='right', channels=8, tip_racks=tip_racks)

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -185,11 +185,11 @@ def test_get_instruments_and_containers(labware_setup, virtual_smoothie_env):
     assert [i.axis for i in instruments] == ['a', 'b']
     assert [i.id for i in instruments] == [id(p100), id(p1000)]
     assert [[t.slot for t in i.tip_racks] for i in instruments] == \
-        [['A1', 'A2'], ['A1', 'A2']]
+        [['1', '4'], ['1', '4']]
     assert [[c.slot for c in i.containers] for i in instruments] == \
-        [['B1'], ['B1', 'B2']]
+        [['2'], ['2', '5']]
 
-    assert [c.slot for c in containers] == ['B1', 'B2']
+    assert [c.slot for c in containers] == ['2', '5']
     assert [[i.id for i in c.instruments] for c in containers] == \
         [[id(p100), id(p1000)], [id(p1000)]]
     assert [c.id for c in containers] == [id(plates[0]), id(plates[1])]

--- a/api/tests/opentrons/commands/test_description.py
+++ b/api/tests/opentrons/commands/test_description.py
@@ -8,8 +8,8 @@ def containers():
     from opentrons import containers
     robot.reset()
     return {
-        '1': containers.load('96-flat', 'A1'),
-        '11': containers.load('96-flat', 'B4')
+        '1': containers.load('96-flat', '1'),
+        '11': containers.load('96-flat', '11')
     }
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -233,7 +233,7 @@ def model(robot):
     from opentrons.instruments.pipette import Pipette
 
     pipette = Pipette(robot, mount='right')
-    plate = load(robot, '96-flat', 'A1')
+    plate = load(robot, '96-flat', '1')
 
     instrument = models.Instrument(pipette)
     container = models.Container(plate)

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -93,6 +93,35 @@ class ContainerTestCase(unittest.TestCase):
             self.robot, 'trough-12row', slot, share=True)
         self.assertEquals(len(self.robot.get_containers()), 3)
 
+    def test_load_legacy_slot_names(self):
+        slots_old = [
+            'A1', 'B1', 'C1',
+            'A2', 'B2', 'C2',
+            'A3', 'B3', 'C3',
+            'A4', 'B4', 'C4'
+        ]
+        slots_new = [
+            '1', '2', '3',
+            '4', '5', '6',
+            '7', '8', '9',
+            '10', '11', '12'
+        ]
+        import warnings
+        warnings.filterwarnings('ignore')
+
+        def test_slot_name(slot_name, expected_name):
+            self.robot.reset()
+            p = containers_load(self.robot, '96-flat', slot_name)
+            slot_name = p.get_parent().get_name()
+            assert slot_name == expected_name
+
+        for i in range(len(slots_old)):
+            test_slot_name(slots_new[i], slots_new[i])
+            test_slot_name(int(slots_new[i]), slots_new[i])
+            test_slot_name(slots_old[i], slots_new[i])
+
+        warnings.filterwarnings('default')
+
     def test_containers_list(self):
         res = containers_list()
         self.assertTrue(len(res))

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -31,7 +31,7 @@ def test_containers_create(robot):
     assert len(p) == 96
     assert len(p.rows) == 12
     assert len(p.cols) == 8
-    assert p.get_parent() == robot.deck['A1']
+    assert p.get_parent() == robot.deck['1']
     assert p['C3'] == p[18]
     assert p['C3'].max_volume() == 1000
     for i, w in enumerate(p):

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -27,7 +27,7 @@ def test_containers_create(robot):
         volume=1000,
         save=True)
 
-    p = containers_load(robot, container_name, 'A1')
+    p = containers_load(robot, container_name, '1')
     assert len(p) == 96
     assert len(p.rows) == 12
     assert len(p.cols) == 8
@@ -65,7 +65,7 @@ class ContainerTestCase(unittest.TestCase):
 
     def test_load_same_slot_force(self):
         container_name = '96-flat'
-        slot = 'A1'
+        slot = '1'
         containers_load(self.robot, container_name, slot)
         self.assertEquals(len(self.robot.get_containers()), 1)
 

--- a/api/tests/opentrons/containers/test_default_containers.py
+++ b/api/tests/opentrons/containers/test_default_containers.py
@@ -5,12 +5,12 @@ from numpy import isclose
 
 
 def test_new_containers(robot):
-    trash_box = containers_load(robot, 'trash-box', 'A1')
-    tip_rack = containers_load(robot, 'tiprack-200ul', 'C1')
-    wheaton_vial_rack = containers_load(robot, 'wheaton_vial_rack', 'A2')
-    tube_rack_80well = containers_load(robot, 'tube-rack-80well', 'A3')
-    T75_flask = containers_load(robot, 'T75-flask', 'B1')
-    T25_flask = containers_load(robot, 'T25-flask', 'B2')
+    trash_box = containers_load(robot, 'trash-box', '1')
+    tip_rack = containers_load(robot, 'tiprack-200ul', '3')
+    wheaton_vial_rack = containers_load(robot, 'wheaton_vial_rack', '4')
+    tube_rack_80well = containers_load(robot, 'tube-rack-80well', '7')
+    T75_flask = containers_load(robot, 'T75-flask', '2')
+    T25_flask = containers_load(robot, 'T25-flask', '5')
     p200 = pipette.Pipette(
         robot,
         mount='right',
@@ -29,7 +29,7 @@ def test_fixed_trash(robot, dummy_db):
     p200 = pipette.Pipette(
         robot, mount='right', name='test-pipette'
     )
-    trash = containers_load(robot, 'fixed-trash', 'C4')
+    trash = containers_load(robot, 'fixed-trash', '12')
     p200.move_to(trash[0])
     assert isclose(
             pose_tracker.absolute(robot.poses, p200),

--- a/api/tests/opentrons/containers/test_grid.py
+++ b/api/tests/opentrons/containers/test_grid.py
@@ -8,7 +8,7 @@ from opentrons import Robot
 class GridTestCase(unittest.TestCase):
     def setUp(self):
         self.robot = Robot()
-        self.plate = load(self.robot, '96-flat', 'A2')
+        self.plate = load(self.robot, '96-flat', '4')
 
     def tearDown(self):
         del self.robot
@@ -42,28 +42,28 @@ class GridTestCase(unittest.TestCase):
         plate = load(
             self.robot,
             '96-flat',
-            'B1',
+            '2',
             'plate'
         )
 
         tiprack = load(
             self.robot,
             'tiprack-200ul',  # container type from library
-            'A1',             # slot on deck
+            '1',             # slot on deck
             'tiprack'         # calibration reference for 1.2 compatibility
         )
 
         trough = load(
             self.robot,
             'trough-12row',
-            'B2',
+            '5',
             'trough'
         )
 
         trash = load(
             self.robot,
             'point',
-            'C1',
+            '3',
             'trash'
         )
 

--- a/api/tests/opentrons/data/bradford_assay.py
+++ b/api/tests/opentrons/data/bradford_assay.py
@@ -3,13 +3,13 @@ from opentrons import containers, instruments
 # containers.robot.connect()
 # containers.robot.home()
 
-tiprack = containers.load('tiprack-200ul', 'C3')
-tiprack2 = containers.load('tiprack-200ul', 'B4')
+tiprack = containers.load('tiprack-200ul', '9')
+tiprack2 = containers.load('tiprack-200ul', '11')
 trash = containers.load('trash-box', 'C4')
 
-trough = containers.load('trough-12row', 'B2')
-plate = containers.load('96-PCR-flat', 'A1')
-tuberack = containers.load('tube-rack-2ml', 'A2')
+trough = containers.load('trough-12row', '5')
+plate = containers.load('96-PCR-flat', '1')
+tuberack = containers.load('tube-rack-2ml', '4')
 
 m50 = instruments.Pipette(
     name="p200",

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -2,11 +2,11 @@ from opentrons import containers, instruments
 
 
 # a 12 row trough for sources, and 96 well plate for output
-trough = containers.load('trough-12row', 'C1', 'trough')
-plate = containers.load('96-PCR-flat', 'A1', 'plate')
+trough = containers.load('trough-12row', '3', 'trough')
+plate = containers.load('96-PCR-flat', '1', 'plate')
 
 # a tip rack for our pipette
-p200rack = containers.load('tiprack-200ul', 'B1', 'tiprack')
+p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
 
 # create a p200 pipette on robot axis B
 p200 = instruments.Pipette(

--- a/api/tests/opentrons/data/multi-only.py
+++ b/api/tests/opentrons/data/multi-only.py
@@ -1,9 +1,9 @@
 from opentrons import containers, instruments
 
-tiprack = containers.load('tiprack-200ul', 'B3')
-trough = containers.load('trough-12row', 'C3')
-trash = containers.load('trash-box', 'C4')
-plate = containers.load('96-flat', 'B2')
+tiprack = containers.load('tiprack-200ul', '8')
+trough = containers.load('trough-12row', '9')
+trash = containers.load('trash-box', '12')
+plate = containers.load('96-flat', '5')
 
 multi = instruments.Pipette(
     mount='left',

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -5,10 +5,10 @@ from opentrons import containers, instruments
 # robot.home()
 # print('homed')
 
-tiprack = containers.load('tiprack-200ul', 'B3')
-trough = containers.load('trough-12row', 'C3')
-trash = containers.load('trash-box', 'C4')
-plate = containers.load('96-flat', 'B2')
+tiprack = containers.load('tiprack-200ul', '8')
+trough = containers.load('trough-12row', '9')
+trash = containers.load('trash-box', '12')
+plate = containers.load('96-flat', '5')
 
 single = instruments.Pipette(
     mount='right',

--- a/api/tests/opentrons/data/pickup-accuracy.py
+++ b/api/tests/opentrons/data/pickup-accuracy.py
@@ -7,7 +7,7 @@ from opentrons import containers, instruments
 
 tipracks = [
     containers.load('tiprack-200ul', slot)
-    for slot in ('A4', 'C1')]
+    for slot in ('10', '3')]
 
 single = instruments.Pipette(
     mount='right',

--- a/api/tests/opentrons/data/smoke.py
+++ b/api/tests/opentrons/data/smoke.py
@@ -1,8 +1,8 @@
 from opentrons import containers, instruments
 
-tiprack = containers.load('tiprack-200ul', 'B3')
-trash = containers.load('trash-box', 'C4')
-plate = containers.load('96-PCR-flat', 'B2')
+tiprack = containers.load('tiprack-200ul', '8')
+trash = containers.load('trash-box', '12')
+plate = containers.load('96-PCR-flat', '5')
 
 pipette = instruments.Pipette(
     name="p200",

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -1,6 +1,6 @@
 from opentrons import containers, instruments, robot
 
-p200rack = containers.load('tiprack-200ul', 'B2', 'tiprack')
+p200rack = containers.load('tiprack-200ul', '5', 'tiprack')
 
 # create a p200 pipette on robot axis B
 p200 = instruments.Pipette(
@@ -15,12 +15,12 @@ p200.pick_up_tip()
 containers = [
     containers.load('96-PCR-flat', slot)
     for slot
-    in ('B3', 'C3')
+    in ('8', '11')
 ]
 
 # Uncomment these to test precision
-p200.move_to(robot.deck['B4'])
-p200.move_to(robot.deck['C2'])
+p200.move_to(robot.deck['11'])
+p200.move_to(robot.deck['6'])
 
 for container in containers:
     p200.aspirate(10, container[0]).dispense(10, container[-1].top(5))

--- a/api/tests/opentrons/helpers/test_helpers.py
+++ b/api/tests/opentrons/helpers/test_helpers.py
@@ -13,7 +13,7 @@ class HelpersTest(unittest.TestCase):
         # when it doesnt use them in any test cases?
         self.robot = Robot()
         self.p200 = pipette.Pipette(self.robot, mount='left')
-        self.plate = containers_load(self.robot, '96-flat', 'C1')
+        self.plate = containers_load(self.robot, '96-flat', '3')
 
     def test_break_down_travel(self):
         # with 3-dimensional points

--- a/api/tests/opentrons/integration/move_robot.py
+++ b/api/tests/opentrons/integration/move_robot.py
@@ -11,9 +11,9 @@ robot = Robot.get_instance()
 
 robot._driver = SmoothieDriver1()
 
-plate = containers.load('96-flat', 'A2', 'magbead')
-trash = containers.load('point', 'A1', 'trash')
-tiprack = containers.load('tiprack-200ul', 'B2', 'p200-rack')
+plate = containers.load('96-flat', '4', 'magbead')
+trash = containers.load('point', '1', 'trash')
+tiprack = containers.load('tiprack-200ul', '5', 'p200-rack')
 
 # tipracks need a Well height equal to the tip length
 for tip in tiprack:

--- a/api/tests/opentrons/integration/test_protocol.py
+++ b/api/tests/opentrons/integration/test_protocol.py
@@ -12,8 +12,8 @@ class ProtocolTestCase(unittest.TestCase):
         self.robot = Robot()
 
     def test_protocol_container_setup(self):
-        plate = containers_load(self.robot, '96-flat', 'A1', 'myPlate')
-        tiprack = containers_load(self.robot, 'tiprack-10ul', 'B2')
+        plate = containers_load(self.robot, '96-flat', '1', 'myPlate')
+        tiprack = containers_load(self.robot, 'tiprack-10ul', '5')
 
         containers_list = self.robot.get_containers()
         self.assertEqual(len(containers_list), 2)
@@ -25,8 +25,8 @@ class ProtocolTestCase(unittest.TestCase):
         self.assertTrue(tiprack in containers_list)
 
     def test_protocol_head(self):
-        trash = containers_load(self.robot, 'point', 'A1', 'myTrash')
-        tiprack = containers_load(self.robot, 'tiprack-10ul', 'B2')
+        trash = containers_load(self.robot, 'point', '1', 'myTrash')
+        tiprack = containers_load(self.robot, 'tiprack-10ul', '5')
 
         p200 = pipette.Pipette(
             self.robot,
@@ -47,8 +47,8 @@ class ProtocolTestCase(unittest.TestCase):
     def test_deck_setup(self):
         deck = self.robot.deck
 
-        trash = containers_load(self.robot, 'point', 'A1', 'myTrash')
-        tiprack = containers_load(self.robot, 'tiprack-10ul', 'B2')
+        trash = containers_load(self.robot, 'point', '1', 'myTrash')
+        tiprack = containers_load(self.robot, 'tiprack-10ul', '5')
 
         self.assertTrue(isinstance(tiprack, Container))
         self.assertTrue(isinstance(deck, Deck))

--- a/api/tests/opentrons/integration/test_protocol.py
+++ b/api/tests/opentrons/integration/test_protocol.py
@@ -18,8 +18,8 @@ class ProtocolTestCase(unittest.TestCase):
         containers_list = self.robot.get_containers()
         self.assertEqual(len(containers_list), 2)
 
-        self.assertEqual(self.robot._deck['A1']['myPlate'], plate)
-        self.assertEqual(self.robot._deck['B2']['tiprack-10ul'], tiprack)
+        self.assertEqual(self.robot._deck['1']['myPlate'], plate)
+        self.assertEqual(self.robot._deck['5']['tiprack-10ul'], tiprack)
 
         self.assertTrue(plate in containers_list)
         self.assertTrue(tiprack in containers_list)

--- a/api/tests/opentrons/labware/test_module_placement.py
+++ b/api/tests/opentrons/labware/test_module_placement.py
@@ -3,13 +3,13 @@ from opentrons.instruments.temp_plate import TemperaturePlate
 
 
 def test_tempPlate_added(robot):
-    temp_plate = TemperaturePlate(robot, 'A4')
+    temp_plate = TemperaturePlate(robot, '10')
     assert temp_plate in robot.get_containers()
 
 
 def test_container_added(robot):
-    temp_plate = TemperaturePlate(robot, 'A4')
-    well_plate1 = containers_load(robot, '96-flat', 'B4')
+    temp_plate = TemperaturePlate(robot, '10')
+    well_plate1 = containers_load(robot, '96-flat', '11')
     well_plate2 = containers_load(robot, '96-flat', temp_plate)
     assert temp_plate in robot.get_containers()
     assert well_plate1 in robot.get_containers()
@@ -17,13 +17,13 @@ def test_container_added(robot):
 
 
 def test_container_tree(robot):
-    temp_plate = TemperaturePlate(robot, 'A4')
+    temp_plate = TemperaturePlate(robot, '10')
     well_plate = containers_load(robot, '96-flat', temp_plate)
     assert robot.poses[temp_plate].children == [well_plate]
 
 
 def test_sharing(robot):
-    temp_plate = TemperaturePlate(robot, 'A4')
+    temp_plate = TemperaturePlate(robot, '10')
     well_plate1 = containers_load(robot, '96-flat', temp_plate, label="plate1")
     well_plate2 = containers_load(robot, '96-flat', temp_plate, share=True)
     assert robot.poses[temp_plate].children == [well_plate1, well_plate2]
@@ -32,7 +32,7 @@ def test_sharing(robot):
 
 
 def test_module_in_posetracker(robot):
-    temp_plate = TemperaturePlate(robot, 'A4')
+    temp_plate = TemperaturePlate(robot, '10')
     well_plate = containers_load(robot, '96-flat', temp_plate)
     assert temp_plate in robot.poses
     assert well_plate in robot.poses

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -13,8 +13,8 @@ from numpy import isclose
 
 
 def test_drop_tip_move_to(robot):
-    plate = containers_load(robot, '96-flat', 'A1')
-    tiprack = containers_load(robot, 'tiprack-200ul', 'C1')
+    plate = containers_load(robot, '96-flat', '1')
+    tiprack = containers_load(robot, 'tiprack-200ul', '3')
     p200 = Pipette(robot, mount='left', tip_racks=[tiprack])
     p200.tip_attached = True
     x, y, z = (161.0, 116.7, 3.0)
@@ -36,13 +36,13 @@ def test_drop_tip_move_to(robot):
 
 
 def test_aspirate_move_to(robot):
-    tip_rack = containers_load(robot, 'tiprack-200ul', 'C1')
+    tip_rack = containers_load(robot, 'tiprack-200ul', '3')
     p200 = Pipette(robot,
                    mount='left',
                    tip_racks=[tip_rack])
 
     x, y, z = (161.0, 116.7, 0.0)
-    plate = containers_load(robot, '96-flat', 'A1')
+    plate = containers_load(robot, '96-flat', '1')
     well = plate[0]
     pos = well.from_center(x=0, y=0, z=-1, reference=plate)
     location = (plate, pos)
@@ -62,11 +62,11 @@ def test_aspirate_move_to(robot):
 
 
 def test_blow_out_move_to(robot):
-    tiprack = containers_load(robot, 'tiprack-200ul', 'C1')
+    tiprack = containers_load(robot, 'tiprack-200ul', '3')
     p200 = Pipette(robot, mount='left', tip_racks=[tiprack])
     p200.pick_up_tip()
 
-    plate = containers_load(robot, '96-flat', 'A1')
+    plate = containers_load(robot, '96-flat', '1')
     x, y, z = (161.0, 116.7, 3.0)
     well = plate[0]
     pos = well.from_center(x=0, y=0, z=-1, reference=plate)
@@ -85,13 +85,13 @@ def test_blow_out_move_to(robot):
 
 
 def test_dispense_move_to(robot):
-    tip_rack = containers_load(robot, 'tiprack-200ul', 'C1')
+    tip_rack = containers_load(robot, 'tiprack-200ul', '3')
     p200 = Pipette(robot,
                    mount='left',
                    tip_racks=[tip_rack])
 
     x, y, z = (161.0, 116.7, 0.0)
-    plate = containers_load(robot, '96-flat', 'A1')
+    plate = containers_load(robot, '96-flat', '1')
     well = plate[0]
     pos = well.from_center(x=0, y=0, z=-1, reference=plate)
     location = (plate, pos)
@@ -115,11 +115,11 @@ class PipetteTest(unittest.TestCase):
     def setUp(self):
         self.robot = Robot()
         self.robot.home()
-        self.trash = containers_load(self.robot, 'point', 'A1')
-        self.tiprack1 = containers_load(self.robot, 'tiprack-10ul', 'B2')
-        self.tiprack2 = containers_load(self.robot, 'tiprack-10ul', 'B3')
+        self.trash = containers_load(self.robot, 'point', '1')
+        self.tiprack1 = containers_load(self.robot, 'tiprack-10ul', '5')
+        self.tiprack2 = containers_load(self.robot, 'tiprack-10ul', '8')
 
-        self.plate = containers_load(self.robot, '96-flat', 'A2')
+        self.plate = containers_load(self.robot, '96-flat', '4')
 
         self.p200 = Pipette(
             self.robot,

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1508,8 +1508,8 @@ class PipetteTest(unittest.TestCase):
             total_tips_per_plate, 2, (5, 5), (0, 0), 5)
         self.tiprack2 = generate_plate(
             total_tips_per_plate, 2, (5, 5), (0, 0), 5)
-        self.robot._deck['A1'].add(self.tiprack1, 'tiprack1')
-        self.robot._deck['B1'].add(self.tiprack2, 'tiprack2')
+        self.robot._deck['1'].add(self.tiprack1, 'tiprack1')
+        self.robot._deck['2'].add(self.tiprack2, 'tiprack2')
 
         self.p200 = Pipette(
             self.robot,

--- a/api/tests/opentrons/labware/test_temp_plate.py
+++ b/api/tests/opentrons/labware/test_temp_plate.py
@@ -13,7 +13,7 @@ def plate(robot):
     def buffer_gcodes(command, timeout=None):
         gcode_buffer.append(command)
 
-    temp_plate = TemperaturePlate(robot, 'A1', min_temp=4, max_temp=70)
+    temp_plate = TemperaturePlate(robot, '1', min_temp=4, max_temp=70)
     setattr(temp_plate.driver, '_send_command', buffer_gcodes)
     setattr(temp_plate, 'test_buffer', gcode_buffer)
     temp_plate.driver.simulating = False
@@ -22,7 +22,7 @@ def plate(robot):
 
 @pytest.fixture
 def sim_plate(robot):
-    temp_plate = TemperaturePlate(robot, 'A1', min_temp=4, max_temp=70)
+    temp_plate = TemperaturePlate(robot, '1', min_temp=4, max_temp=70)
     return temp_plate
 
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -23,7 +23,7 @@ def test_pos_tracker_persistance(robot):
     p200 = pipette.Pipette(
         robot, mount='left', name='my-fancy-pancy-pipette'
     )
-    plate = containers_load(robot, 'trough-12row', 'B2')
+    plate = containers_load(robot, 'trough-12row', '5')
     # TODO(artyom, 20171030): re-visit once z-value is back into container data
     assert robot.max_deck_height() == 40.0
 
@@ -91,8 +91,8 @@ def test_create_arc(robot):
     p200 = pipette.Pipette(
         robot, mount='left', name='my-fancy-pancy-pipette'
     )
-    plate = containers_load(robot, '96-flat', 'A1')
-    plate2 = containers_load(robot, '96-flat', 'B1')
+    plate = containers_load(robot, '96-flat', '1')
+    plate2 = containers_load(robot, '96-flat', '2')
     robot.poses = p200._move(robot.poses, x=10, y=10, z=10)
     robot.calibrate_container_with_instrument(plate, p200, save=False)
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -38,7 +38,7 @@ def test_calibrated_max_z(robot):
     p200 = pipette.Pipette(
         robot, mount='left', name='my-fancy-pancy-pipette'
     )
-    plate = containers_load(robot, '96-flat', 'A1')
+    plate = containers_load(robot, '96-flat', '1')
     # TODO(artyom, 20171030): re-visit once z-value is back into container data
     assert robot.max_deck_height() == 10.5
 
@@ -62,12 +62,12 @@ def test_get_serial_ports_list(robot, monkeypatch):
 
 
 def test_add_container(robot):
-    c1 = robot.add_container('96-flat', 'A1')
+    c1 = robot.add_container('96-flat', '1')
     res = robot.get_containers()
     expected = [c1]
     assert res == expected
 
-    c2 = robot.add_container('96-flat', 'A2', 'my-special-plate')
+    c2 = robot.add_container('96-flat', '4', 'my-special-plate')
     res = robot.get_containers()
     expected = [c1, c2]
     assert res == expected

--- a/api/tests/opentrons/server/test_serialize.py
+++ b/api/tests/opentrons/server/test_serialize.py
@@ -39,11 +39,11 @@ def type_id(instance):
 
 def test_robot():
     robot.reset()
-    containers.load('trough-12row', 'C1', 'trough')
-    containers.load('96-PCR-flat', 'A1', 'plate')
+    containers.load('trough-12row', '3', 'trough')
+    containers.load('96-PCR-flat', '1', 'plate')
 
     # a tip rack for our pipette
-    p200rack = containers.load('tiprack-200ul', 'B1', 'tiprack')
+    p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
 
     # create a p200 pipette on robot axis B
     instruments.Pipette(

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -359,9 +359,8 @@ export default function client (dispatch) {
     }
 
     function apiContainerToContainer (apiContainer) {
-      const {_id, name, type, slot: id} = apiContainer
+      const {_id, name, type, slot} = apiContainer
       const isTiprack = RE_TIPRACK.test(type)
-      const slot = letterSlotToNumberSlot(id)
 
       labwareBySlot[slot] = {_id, name, slot, type, isTiprack}
     }
@@ -382,21 +381,4 @@ export default function client (dispatch) {
   function handleClientError (error) {
     console.error(error)
   }
-}
-
-// swap OT1 protocol slot to OT2 protocol slot
-// TODO(mc, 2017-10-03): be less "clever" about this
-// 4 10|11|_t
-// 3 _7|_8|_9
-// 2 _4|_5|_6
-// 1 _1|_2|_3
-//    A  B  C
-function letterSlotToNumberSlot (slot) {
-  // split two-char string into charcodes
-  const [col, row] = Array.from(slot.toUpperCase()).map((c) => c.charCodeAt(0))
-
-  // slot = (col where A === 1, B === 2, C === 3) + 3 * (row - 1)
-  // 'A'.charCodeAt(0) === 65, '1'.charCodeAt(0) === 49
-  // before simplification: 3 * (row - 49) + (col - 64)
-  return `${(3 * row + col - 211)}`
 }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -287,9 +287,9 @@ describe('api client', () => {
       }))
 
       session.containers = [
-        {_id: 1, slot: 'A1', name: 'a', type: 'tiprack'},
-        {_id: 2, slot: 'B2', name: 'b', type: 'B'},
-        {_id: 3, slot: 'C3', name: 'c', type: 'C'}
+        {_id: 1, slot: '1', name: 'a', type: 'tiprack'},
+        {_id: 2, slot: '5', name: 'b', type: 'B'},
+        {_id: 3, slot: '9', name: 'c', type: 'C'}
       ]
 
       return sendConnect()


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
Fixes #631 

Changes deck-slot naming from the `'A1', 'B2', etc.` scheme to the new `'1', '2', etc.` scheme.

If a container is added using `container.load()` and the slot is referenced using the old scheme, it will be automatically converted to the new numbering, and will throw a deprecation warning.

Most of the work involved in this PR was editing tests so that they no longer check for slots with the old names.

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## tests pass on machine 👍 

<!--
  Describe any requests for your reviewers here.
-->
