### PR TITLE
Rename labwareReviewed flag to deckPopulated and default to true

### DIFF
--- a/app/src/components/deck/CalibrateDeck.js
+++ b/app/src/components/deck/CalibrateDeck.js
@@ -11,13 +11,13 @@ import styles from './deck.css'
 
 CalibrateDeck.propTypes = {
   slot: PropTypes.number.isRequired,
-  labwareReviewed: PropTypes.bool.isRequired
+  deckPopulated: PropTypes.bool.isRequired
 }
 
 export default function CalibrateDeck (props) {
-  const {labwareReviewed, slot} = props
-  const style = classnames({[styles.review_deck]: !labwareReviewed})
-  const Prompt = labwareReviewed
+  const {deckPopulated, slot} = props
+  const style = classnames({[styles.review_deck]: !deckPopulated})
+  const Prompt = deckPopulated
     ? CalibrationPrompt
     : ReviewLabware
 

--- a/app/src/components/deck/ConnectedLabwareItem.js
+++ b/app/src/components/deck/ConnectedLabwareItem.js
@@ -37,7 +37,7 @@ function mapStateToProps (state, ownProps) {
   const containerName = labware.name
 
   const nextLabware = robotSelectors.getNextLabware(state)
-  const labwareReviewed = robotSelectors.getLabwareReviewed(state)
+  const deckPopulated = robotSelectors.getDeckPopulated(state)
   const allTipracksConfirmed = robotSelectors.getTipracksConfirmed(state)
 
   const highlighted = slotName === (routeSlot || labwareToSlotName(nextLabware))
@@ -69,8 +69,8 @@ function mapStateToProps (state, ownProps) {
     containerName,
     wellContents,
     highlighted,
-    labwareReviewed,
-    canRevisit: labwareReviewed && !isMoving &&
+    deckPopulated,
+    canRevisit: deckPopulated && !isMoving &&
       allTipracksConfirmed &&
       !(isTiprack && confirmed), // user cannot revisit a confirmed tiprack
     isMoving,

--- a/app/src/components/deck/DeckConfig.js
+++ b/app/src/components/deck/DeckConfig.js
@@ -7,7 +7,7 @@ import {
 import CalibrateDeck from './CalibrateDeck'
 
 const mapStateToProps = (state) => ({
-  labwareReviewed: robotSelectors.getLabwareReviewed(state)
+  deckPopulated: robotSelectors.getDeckPopulated(state)
 })
 
 export default connect(mapStateToProps)(CalibrateDeck)

--- a/app/src/components/deck/LabwareItem.js
+++ b/app/src/components/deck/LabwareItem.js
@@ -16,7 +16,7 @@ type LabwareItemProps = {
   highlighted?: boolean,
   confirmed?: boolean,
   isMoving?: boolean,
-  labwareReviewed?: boolean, // `labwareReviewed` is false the first time a user is looking at the deck, true once they click "Continue" to proceed with calibration
+  deckPopulated?: boolean, // `deckPopulated` is false the first time a user is looking at the deck, true once they click "Continue" to proceed with calibration
   canRevisit?: boolean, // if true, wrap labware in a Link
   height: number,
   width: number,
@@ -32,7 +32,7 @@ export default function LabwareItem (props: LabwareItemProps) {
     highlighted,
     confirmed,
     isMoving,
-    labwareReviewed,
+    deckPopulated,
     canRevisit,
     height,
     width,
@@ -43,8 +43,8 @@ export default function LabwareItem (props: LabwareItemProps) {
     onLabwareClick
   } = props
 
-  const showNameOverlay = !isMoving && (!labwareReviewed || confirmed || highlighted)
-  const showUnconfirmed = labwareReviewed && !confirmed && !isMoving
+  const showNameOverlay = !isMoving && (!deckPopulated || confirmed || highlighted)
+  const showUnconfirmed = deckPopulated && !confirmed && !isMoving
 
   const PlateWithOverlay = (
     <g>

--- a/app/src/components/deck/ReviewLabware.js
+++ b/app/src/components/deck/ReviewLabware.js
@@ -28,7 +28,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {
     ...stateProps,
     ...ownProps,
-    setLabwareReviewed: () => dispatch(robotActions.setLabwareReviewed()),
+    setDeckPopulated: () => dispatch(robotActions.setDeckPopulated()),
     // TODO(mc, 2017-11-29): DRY (logic shared by NextLabware, ReviewLabware,
     // Deck, and ConnectedSetupPanel); could also move logic to the API client
     moveToLabware: () => {

--- a/app/src/components/deck/ReviewPrompt.js
+++ b/app/src/components/deck/ReviewPrompt.js
@@ -4,7 +4,7 @@ import Button from '../Button'
 import styles from './deck.css'
 
 ReviewPrompt.propTypes = {
-  setLabwareReviewed: PropTypes.func.isRequired,
+  setDeckPopulated: PropTypes.func.isRequired,
   moveToLabware: PropTypes.func.isRequired,
   currentLabware: PropTypes.shape({
     slot: PropTypes.number.isRequired

--- a/app/src/components/setup-panel/InstrumentList.js
+++ b/app/src/components/setup-panel/InstrumentList.js
@@ -30,6 +30,6 @@ function mapStateToProps (state, ownProps) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    clearLabwareReviewed: () => dispatch(robotActions.setLabwareReviewed(false))
+    clearDeckPopulated: () => dispatch(robotActions.setDeckPopulated(false))
   }
 }

--- a/app/src/components/setup-panel/InstrumentListItem.js
+++ b/app/src/components/setup-panel/InstrumentListItem.js
@@ -11,11 +11,11 @@ InstrumentListItem.propTypes = {
   volume: PropTypes.number,
   channels: PropTypes.number,
   probed: PropTypes.bool,
-  clearLabwareReviewed: PropTypes.func
+  clearDeckPopulated: PropTypes.func
 }
 
 export default function InstrumentListItem (props) {
-  const {isRunning, name, axis, volume, channels, probed, clearLabwareReviewed} = props
+  const {isRunning, name, axis, volume, channels, probed, clearDeckPopulated} = props
   const isDisabled = name == null
   const url = isRunning
   ? '#'
@@ -39,7 +39,7 @@ export default function InstrumentListItem (props) {
     <ListItem
       isDisabled={isDisabled || isRunning}
       url={url}
-      onClick={!isRunning && clearLabwareReviewed}
+      onClick={!isRunning && clearDeckPopulated}
       confirmed={confirmed}
       iconName={iconName}
     >

--- a/app/src/components/setup-panel/LabwareList.js
+++ b/app/src/components/setup-panel/LabwareList.js
@@ -66,7 +66,7 @@ function mapStateToProps (state, ownProps) {
   return {
     labware: robotSelectors.getLabware(state),
     labwareBySlot: robotSelectors.getLabwareBySlot(state),
-    labwareReviewed: robotSelectors.getLabwareReviewed(state),
+    deckPopulated: robotSelectors.getDeckPopulated(state),
     instrumentsCalibrated: robotSelectors.getInstrumentsCalibrated(state),
     tipracksConfirmed: robotSelectors.getTipracksConfirmed(state),
     labwareConfirmed: robotSelectors.getLabwareConfirmed(state),
@@ -78,7 +78,7 @@ function mapStateToProps (state, ownProps) {
 function mergeProps (stateProps, dispatchProps) {
   const {
     _calibrator,
-    labwareReviewed,
+    deckPopulated,
     instrumentsCalibrated,
     tipracksConfirmed,
     isRunning
@@ -96,7 +96,7 @@ function mergeProps (stateProps, dispatchProps) {
       ...lw,
       isDisabled,
       setLabware: () => {
-        if (labwareReviewed) {
+        if (deckPopulated) {
           if (lw.isTiprack) {
             return dispatch(robotActions.pickupAndHome(_calibrator, lw.slot))
           }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -24,7 +24,7 @@ export const actionTypes = {
   SESSION_RESPONSE: makeRobotActionName('SESSION_RESPONSE'),
 
   // calibration
-  SET_LABWARE_REVIEWED: makeRobotActionName('SET_LABWARE_REVIEWED'),
+  SET_DECK_POPULATED: makeRobotActionName('SET_DECK_POPULATED'),
   SET_CURRENT_LABWARE: makeRobotActionName('SET_CURRENT_LABWARE'),
   SET_CURRENT_INSTRUMENT: makeRobotActionName('SET_CURRENT_INSTRUMENT'),
   PICKUP_AND_HOME: makeRobotActionName('PICKUP_AND_HOME'),
@@ -120,8 +120,8 @@ export const actions = {
     }
   },
 
-  setLabwareReviewed (payload) {
-    return {type: actionTypes.SET_LABWARE_REVIEWED, payload}
+  setDeckPopulated (payload) {
+    return {type: actionTypes.SET_DECK_POPULATED, payload}
   },
 
   pickupAndHome (instrument, labware) {

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -44,7 +44,7 @@ type LabwareConfirmationRequest = {
 }
 
 export type State = {
-  labwareReviewed: boolean,
+  deckPopulated: boolean,
   jogDistance: number,
 
   probedByAxis: {[InstrumentMount]: boolean},
@@ -74,7 +74,7 @@ type Action = {
 const {
   SESSION,
   DISCONNECT_RESPONSE,
-  SET_LABWARE_REVIEWED,
+  SET_DECK_POPULATED,
   PICKUP_AND_HOME,
   PICKUP_AND_HOME_RESPONSE,
   DROP_TIP_AND_HOME,
@@ -97,7 +97,7 @@ const {
 } = actionTypes
 
 const INITIAL_STATE: State = {
-  labwareReviewed: false,
+  deckPopulated: true,
   jogDistance: JOG_DISTANCE_SLOW_MM,
 
   probedByAxis: {},
@@ -128,7 +128,7 @@ export default function calibrationReducer (
   switch (action.type) {
     case DISCONNECT_RESPONSE: return handleDisconnectResponse(state, action)
     case SESSION: return handleSession(state, action)
-    case SET_LABWARE_REVIEWED: return handleSetLabwareReviewed(state, action)
+    case SET_DECK_POPULATED: return handleSetDeckPopulated(state, action)
     case MOVE_TO_FRONT: return handleMoveToFront(state, action)
     case MOVE_TO_FRONT_RESPONSE: return handleMoveToFrontResponse(state, action)
     case PICKUP_AND_HOME: return handlePickupAndHome(state, action)
@@ -164,8 +164,8 @@ function handleSession (state, action) {
   return INITIAL_STATE
 }
 
-function handleSetLabwareReviewed (state, action) {
-  return {...state, labwareReviewed: action.payload}
+function handleSetDeckPopulated (state, action) {
+  return {...state, deckPopulated: action.payload}
 }
 
 function handleMoveToFront (state, action) {
@@ -251,7 +251,7 @@ function handleMoveTo (state, action) {
 
   return {
     ...state,
-    labwareReviewed: true,
+    deckPopulated: true,
     moveToRequest: {inProgress: true, error: null, slot},
     labwareBySlot: {...state.labwareBySlot, [slot]: MOVING_TO_SLOT}
   }
@@ -290,7 +290,7 @@ function handlePickupAndHome (state, action) {
 
   return {
     ...state,
-    labwareReviewed: true,
+    deckPopulated: true,
     pickupRequest: {inProgress: true, error: null, slot},
     labwareBySlot: {...state.labwareBySlot, [slot]: PICKING_UP}
   }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -264,8 +264,8 @@ export const getLabware = createSelector(
   }
 )
 
-export function getLabwareReviewed (state: State) {
-  return calibration(state).labwareReviewed
+export function getDeckPopulated (state: State) {
+  return calibration(state).deckPopulated
 }
 
 export const getUnconfirmedLabware = createSelector(

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -120,13 +120,16 @@ describe('robot actions', () => {
     expect(actions.sessionResponse(error)).toEqual(failure)
   })
 
-  test('set labware reviewed action', () => {
-    const expected = {
-      type: actionTypes.SET_LABWARE_REVIEWED,
+  test('set deck populated action', () => {
+    expect(actions.setDeckPopulated(false)).toEqual({
+      type: actionTypes.SET_DECK_POPULATED,
       payload: false
-    }
+    })
 
-    expect(actions.setLabwareReviewed(false)).toEqual(expected)
+    expect(actions.setDeckPopulated(true)).toEqual({
+      type: actionTypes.SET_DECK_POPULATED,
+      payload: true
+    })
   })
 
   test('move tip to front action', () => {

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -6,7 +6,7 @@ describe('robot reducer - calibration', () => {
     const state = reducer(undefined, {}).calibration
 
     expect(state).toEqual({
-      labwareReviewed: false,
+      deckPopulated: true,
       jogDistance: constants.JOG_DISTANCE_SLOW_MM,
 
       probedByAxis: {},
@@ -55,25 +55,25 @@ describe('robot reducer - calibration', () => {
     expect(reducer(state, action).calibration).toEqual(expected)
   })
 
-  test('handles SET_LABWARE_REVIEWED action', () => {
-    const setToTrue = {type: actionTypes.SET_LABWARE_REVIEWED, payload: true}
-    const setToFalse = {type: actionTypes.SET_LABWARE_REVIEWED, payload: false}
+  test('handles SET_DECK_POPULATED action', () => {
+    const setToTrue = {type: actionTypes.SET_DECK_POPULATED, payload: true}
+    const setToFalse = {type: actionTypes.SET_DECK_POPULATED, payload: false}
 
-    let state = {calibration: {labwareReviewed: false}}
+    let state = {calibration: {deckPopulated: false}}
     expect(reducer(state, setToTrue).calibration).toEqual({
-      labwareReviewed: true
+      deckPopulated: true
     })
 
-    state = {calibration: {labwareReviewed: true}}
+    state = {calibration: {deckPopulated: true}}
     expect(reducer(state, setToFalse).calibration).toEqual({
-      labwareReviewed: false
+      deckPopulated: false
     })
   })
 
   test('handles PICKUP_AND_HOME action', () => {
     const state = {
       calibration: {
-        labwareReviewed: false,
+        deckPopulated: false,
         pickupRequest: {inProgress: false, error: new Error(), slot: 0},
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
@@ -84,7 +84,7 @@ describe('robot reducer - calibration', () => {
       payload: {instrument: 'left', labware: 5}
     }
     expect(reducer(state, action).calibration).toEqual({
-      labwareReviewed: true,
+      deckPopulated: true,
       pickupRequest: {inProgress: true, error: null, slot: 5},
       labwareBySlot: {5: constants.PICKING_UP}
     })
@@ -369,7 +369,7 @@ describe('robot reducer - calibration', () => {
   test('handles MOVE_TO action', () => {
     const state = {
       calibration: {
-        labwareReviewed: false,
+        deckPopulated: false,
         moveToRequest: {inProgress: false, error: new Error()},
         labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED}
       }
@@ -380,7 +380,7 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, action).calibration).toEqual({
-      labwareReviewed: true,
+      deckPopulated: true,
       moveToRequest: {inProgress: true, error: null, slot: 3},
       labwareBySlot: {3: constants.MOVING_TO_SLOT, 5: constants.UNCONFIRMED}
     })


### PR DESCRIPTION
## overview

To support [this week's sprint's](https://github.com/Opentrons/opentrons/projects/3) calibration work, we decided to rename the confusingly named flag `labwareReviewed` to `deckPopulated` for clarity. Closes #594; see that issue for reasoning and future plans with this flag.

## changelog

- Refactor: renamed all instances of `labwareReviewed` to `deckPopulated`
- Refactor: switched default of `deckPopulated` from `false` to `true`
    - This is to drive future clear deck before tip probe `ContinueModal`
    - Does not change current functionality, as the first click on a Pipette for tip probe sets it to `false` (will change with modal)

## review requests

Standard review
