### PR TITLE
Add endpoints for wifi networking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ COPY ./compute/avahi_tools /tmp/avahi_tools
 
 # When adding more python packages make sure to use setuptools to keep
 # packaging consistent across environments
+ENV PIPENV_VENV_IN_PROJECT=true
 RUN pip install pipenv && \
     pipenv install /tmp/api --system && \
-    pipenv shell && \
     pip install /tmp/avahi_tools && \
     rm -rf /tmp/api && \
     rm -rf /tmp/avahi_tools

--- a/api/Makefile
+++ b/api/Makefile
@@ -28,7 +28,7 @@ publish:
 
 .PHONY: dev
 dev:
-	python opentrons/server/main.py -P 31950
+	python opentrons/server/main.py -P 31950 opentrons.server.main:init
 
 dist/update.base64: clean
 	rm -rf dist/* && \

--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -1,6 +1,9 @@
 import serial
 from serial.tools import list_ports
 import contextlib
+import logging
+
+log = logging.getLogger(__name__)
 
 DRIVER_ACK = b'ok\r\nok\r\n'
 RECOVERY_TIMEOUT = 10
@@ -70,11 +73,13 @@ def _write_to_device_and_return(cmd, device_connection):
 
 
 def _connect(port_name, baudrate):
-    return serial.Serial(
+    ser = serial.Serial(
         port=port_name,
         baudrate=baudrate,
         timeout=DEFAULT_SERIAL_TIMEOUT
     )
+    log.debug(ser)
+    return ser
 
 
 def _attempt_command_recovery(command, serial_conn):
@@ -106,4 +111,5 @@ def connect(device_name, baudrate=115200):
     :return: serial.Serial connection
     '''
     smoothie_port = get_ports_by_name(device_name=device_name)[0]
+    log.debug("Device name: {}, Port: {}".format(device_name, smoothie_port))
     return _connect(port_name=smoothie_port, baudrate=baudrate)

--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -1,0 +1,115 @@
+import os
+import json
+import logging
+import subprocess
+from aiohttp import web
+
+
+log = logging.getLogger(__name__)
+ENABLE_NMCLI = os.environ.get('ENABLE_NETWORKING_ENDPOINTS', '')
+
+
+async def health(request):
+    return web.json_response(
+        headers={
+            'Access-Control-Allow-Origin': '*'
+        })
+
+
+async def wifi_list(request):
+    """
+    Get request will return a list of discovered ssids.
+
+    If the environment variable ENABLE_NETWORKING_ENDPOINTS is set, this list
+    is discovered using `nmcli`. If it is not set, then a dummy list of strings
+    is returned. The environment variable will be set on the robot running the
+    server, but will not be set during development on a laptop, or while
+    running the server during test on CI.
+    """
+    ssids = ''
+    if ENABLE_NMCLI:
+        try:
+            proc = subprocess.run(["nmcli", "-terse", "--fields",
+                                   "ssid,signal", "device", "wifi", "list"],
+                                  stdout=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            ssids = "CalledProcessError: {}".format(e.stdout)
+        except FileNotFoundError as e:
+            ssids = "FileNotFoundError: {}".format(e)
+        else:
+            splitres = proc.stdout.decode().split("\n")
+            ssids = repr(json.dumps([x.split(":")[0] for x in splitres]))
+    else:
+        ssids = repr(json.dumps(['a', 'b', 'c']))
+    return web.json_response(
+        body=ssids
+    )
+
+
+async def wifi_configure(request):
+    """
+    Post request should include a json body with fields "ssid" and "psk" for
+    network name and password respectively. Robot will attempt to connect to
+    this network and respond with Ok if successful or an error code if not.
+
+    If the environment variable ENABLE_NETWORKING_ENDPOINTS is set, this is
+    perfomed using `nmcli`. If it is not set, then a dummy status is returned.
+    The environment variable will be set on the robot running the server, but
+    will not be set during development on a laptop, or while running the server
+    during test on CI.
+    """
+    result = '...'
+    try:
+        body = await request.text()
+        jbody = json.loads(body)
+    except Exception as e:
+        result = "Error: {}, type: {}".format(e, type(e))
+        log.debug(result)
+    else:
+        if ENABLE_NMCLI:
+            cmd = 'nmcli device wifi connect {} password "{}"'.format(
+                jbody['ssid'], jbody['psk'])
+            proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
+            result = proc.stdout.decode().strip().split("\r")[-1]
+        else:
+            result = "Configuration successful. SSID: {}, PSK: {}".format(
+                jbody['ssid'], jbody['psk'])
+    log.debug("Wifi configure result: {}".format(result))
+    return web.Response(text=result)
+
+
+async def wifi_status(request):
+    """
+    Get request will return the status of the wifi connection from the
+    RaspberryPi to the internet.
+
+    Options are:
+      "none" - no connection to router or network
+      "portal" - this device is acting as a network portal
+      "limited" - connection to router but not internet
+      "full" - connection to router and internet
+      "unknown" - an exception occured while trying to determine status
+
+    If the environment variable ENABLE_NETWORKING_ENDPOINTS is set, this list
+    is discovered using `nmcli`. If it is not set, then "testing" is returned.
+    The environment variable will be set on the robot running the server, but
+    will not be set during development on a laptop, or while running the server
+    during test on CI.
+    """
+    connectivity = {"status": "unknown"}
+    if ENABLE_NMCLI:
+        try:
+            proc = subprocess.run(["nmcli", "networking", "connectivity"],
+                                  stdout=subprocess.PIPE)
+            res = proc.stdout.decode().strip()
+            log.debug("Connectivity: {}".format(res))
+            connectivity["status"] = res
+        except subprocess.CalledProcessError as e:
+            log.error("CalledProcessError: {}".format(e.stdout))
+        except FileNotFoundError as e:
+            log.error("FileNotFoundError: {}".format(e))
+    else:
+        connectivity['status'] = "testing"
+    return web.json_response(
+        body=repr(json.dumps(connectivity))
+    )

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -6,8 +6,10 @@ import os
 from aiohttp import web
 from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
+from opentrons.server.endpoints import health, wifi_configure, wifi_list, wifi_status  # NOQA
 from logging.config import dictConfig
 
+from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
 
@@ -67,26 +69,59 @@ def log_init():
     dictConfig(logging_config)
 
 
-async def health(request):
-    return web.json_response(
-        headers={
-            'Access-Control-Allow-Origin': '*'
-        })
-
-
 # Support for running using aiohttp CLI.
 # See: https://docs.aiohttp.org/en/stable/web.html#command-line-interface-cli  # NOQA
-def init(argv):
-    log_init()
-    server = Server(MainRouter())
-    # TODO (artyom, 20171205): find a better place for health check
-    # as requirements evolve
+def init(loop=None):
+    """
+    Builds an application including the RPC server, and also configures HTTP
+    routes for methods defined in opentrons.server.endpoints
+    """
+    server = Server(MainRouter(), loop=loop)
     server.app.router.add_get('/health', health)
+    server.app.router.add_get('/wifi/list', wifi_list)
+    server.app.router.add_post('/wifi/configure', wifi_configure)
+    server.app.router.add_get('/wifi/status', wifi_status)
     return server.app
 
 
+def main():
+    """
+    This application creates and starts the server for both the RPC routes
+    handled by opentrons.server.rpc and HTTP endpoints defined here
+    """
+    log_init()
+
+    arg_parser = ArgumentParser(
+        description="Opentrons application server",
+        prog="opentrons.server.main"
+    )
+    arg_parser.add_argument(
+        "-H", "--hostname",
+        help="TCP/IP hostname to serve on (default: %(default)r)",
+        default="localhost"
+    )
+    arg_parser.add_argument(
+        "-P", "--port",
+        help="TCP/IP port to serve on (default: %(default)r)",
+        type=int,
+        default="8080"
+    )
+    arg_parser.add_argument(
+        "-U", "--path",
+        help="Unix file system path to serve on. Specifying a path will cause "
+             "hostname and port arguments to be ignored.",
+    )
+    args, _ = arg_parser.parse_known_args(sys.argv[1:])
+
+    if args.path:
+        log.debug("Starting Opentrons server application on {}".format(
+            args.path))
+    else:
+        log.debug("Starting Opentrons server application on {}:{}".format(
+            args.hostname, args.port))
+    web.run_app(init(), host=args.hostname, port=args.port, path=args.path)
+    arg_parser.exit(message="Stopped\n")
+
+
 if __name__ == "__main__":
-    # TODO(artyom, 20170828): consider moving class name definition into
-    # command line arguments, so one could us as a shell starting various
-    # RPC servers with different root objects from a command line
-    web.main(sys.argv[1:] + ['opentrons.server.main:init'])
+    main()

--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -39,7 +39,7 @@ class Server(object):
         self.clients = {}
         self.tasks = []
 
-        self.app = web.Application()
+        self.app = web.Application(loop=loop)
         self.app.router.add_get('/', self.handler)
         self.app.on_shutdown.append(self.on_shutdown)
 
@@ -58,6 +58,7 @@ class Server(object):
     def start(self, host, port):
         # This call will block while server is running
         # run_app is capable of catching SIGINT and shutting down
+        log.info("Starting server on {}:{}".format(host, port))
         web.run_app(self.app, host=host, port=port)
 
     def shutdown(self):
@@ -65,6 +66,11 @@ class Server(object):
         self.monitor_events_task.cancel()
 
     async def on_shutdown(self, app):
+        """
+        Graceful shutdown handler
+
+        See https://docs.aiohttp.org/en/stable/web.html#graceful-shutdown
+        """
         for ws in self.clients.copy():
             await ws.close(code=WSCloseCode.GOING_AWAY,
                            message='Server shutdown')

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -1,0 +1,36 @@
+import json
+from opentrons.server.main import init
+
+
+async def test_wifi_status(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    expected = repr(json.dumps({'status': 'testing'}))
+    resp = await cli.get('/wifi/status')
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected
+
+
+async def test_wifi_list(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    expected = repr(json.dumps(['a', 'b', 'c']))
+    resp = await cli.get('/wifi/list')
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected
+
+
+async def test_wifi_configure(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    expected = "Configuration successful. SSID: this, PSK: that"
+    resp = await cli.post('/wifi/configure',
+                          json={'ssid': 'this', 'psk': 'that'})
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -26,5 +26,6 @@ if [ ! -e "$config_path" ]; then
     while true; do sleep 1; done
 fi
 
+export ENABLE_NETWORKING_ENDPOINTS=true
 echo "Starting Opentrons API server"
-python -m opentrons.server.main -U $OT_SERVER_UNIX_SOCKET_PATH
+python -m opentrons.server.main -U $OT_SERVER_UNIX_SOCKET_PATH opentrons.server.main:init


### PR DESCRIPTION
## overview

Adds wifi endpoints to list available SSIDs, check connectivity status, and configure credentials.

Related to #526 
Fixes #640 

## changelog

- (feature) Add endpoints to list available SSIDs, check connectivity status, and configure credentials.
- (refactor) Make server entrypoint more readable
- (docs) Some explanatory material added to method docstrings
- (bugfix) Add missing environment variable to Dockerfile and remove unnecessary shell command

## review requests

Tested on moon-moon. Feel free to use that or another robot, or test on a laptop. On a laptop, endpoints will return dummy responses that are formatted in a way that is consistent with real responses. If testing on a robot, endpoints will actually execute networking commands--be aware of what you're doing! :)
