### PR TITLE
Deploy component library & PD to S3 for design reviews

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,10 @@ script:
   - make -C app test && make -C app-shell dist-posix
   # Clean up. This will leave only single-file build artifacts
   - find ./app-shell/dist/** ! -name 'opentrons-v*' -exec rm -rf {} +
-  # protocol designer
-  - make -C protocol-designer test build
+  # protocol designer build
+  - make -C protocol-designer build
+  # component library build
+  - make -C components build
 
 after_success:
   - make coverage
@@ -90,6 +92,20 @@ deploy:
     bucket: opentrons-protocol-designer
     skip_cleanup: true
     local-dir: $(pwd)/protocol-designer/dist/
+    upload-dir: $TRAVIS_BRANCH
+    acl: public_read
+    region: us-west-2
+    on:
+      condition: $TRAVIS_TEST_RESULT = 0
+      repo: Opentrons/opentrons
+      all_branches: true
+
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY
+    secret_access_key: $AWS_SECRET_KEY
+    bucket: opentrons-components
+    skip_cleanup: true
+    local-dir: $(pwd)/components/dist/
     upload-dir: $TRAVIS_BRANCH
     acl: public_read
     region: us-west-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,13 @@ script:
   #   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then (make -C api docs > /dev/null) fi;
   # components library
   # TODO(mc, 2017-12-07): seriously figure out that top-level Makefile
-  - make -C components test
+  - make -C components test build
   # TODO(mc, 2017-08-28): use top level `make test`
   - make -C app test && make -C app-shell dist-posix
   # Clean up. This will leave only single-file build artifacts
   - find ./app-shell/dist/** ! -name 'opentrons-v*' -exec rm -rf {} +
   # protocol designer build
-  - make -C protocol-designer build
-  # component library build
-  - make -C components build
+  - make -C protocol-designer test build
 
 after_success:
   - make coverage

--- a/components/Makefile
+++ b/components/Makefile
@@ -20,7 +20,7 @@ ifeq ($(watch), true)
 	cover := false
 endif
 
-# stardard targets
+# standard targets
 #####################################################################
 
 .PHONY: install
@@ -30,6 +30,13 @@ install:
 .PHONY: uninstall
 uninstall:
 	rm -rf node_modules
+
+	# artifacts
+	#####################################################################
+
+.PHONY: build
+build:
+	$(env)=production $(bin)/styleguidist build
 
 # development
 #####################################################################

--- a/components/package.json
+++ b/components/package.json
@@ -50,6 +50,7 @@
       "stylelint-config-css-modules"
     ],
     "ignoreFiles": [
+      "**/dist/**",
       "**/coverage/**"
     ]
   },

--- a/components/styleguide.config.js
+++ b/components/styleguide.config.js
@@ -5,14 +5,26 @@ const path = require('path')
 // TODO(mc, 2017-12-22): Create common webpack config
 const {rules} = require('@opentrons/webpack-config')
 
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const DEV = process.env.NODE_ENV !== 'production'
+const CSS_OUTPUT_NAME = 'style.css'
+
 module.exports = {
+  styleguideDir: 'dist',
   webpackConfig: {
     module: {
       rules: [
         rules.js,
         rules.localCss
       ]
-    }
+    },
+    plugins: [
+      new ExtractTextPlugin({
+        filename: CSS_OUTPUT_NAME,
+        disable: DEV,
+        ignoreOrder: true
+      })
+    ]
   },
   showUsage: true,
   showCode: true,

--- a/protocol-designer/index.html
+++ b/protocol-designer/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Opentrons Protocol Designer Prototype</title>
-    <link rel="stylesheet" src="/bundle.css">
+    <link rel="stylesheet" href="./bundle.css" type="text/css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## overview

Closes #628.

However:
- I'm deploying to S3 for non-failing builds on **all branches**, not just PRs.
- Old branches stay on S3 after the branch is deleted. If that's undesirable to you, please bring it up in the review.

## changelog

- Fix dumb HTML typo in `protocol-designer/index.html` which was breaking production build page
- Stop running tests for protocol designer twice (`make -C protocol-designer test build` in travis)
- Mess with styleguidist webpack config so that `node_modules/.bin/styleguidist build` works
- `stylelint` ignores `**/dist/**` -- otherwise CSS module classnames violate the `"selector-class-pattern": "^[a-z0-9_]+$"` rule.

## review requests

### 1. Check out the 2 builds:

Component Library:
https://s3-us-west-2.amazonaws.com/opentrons-components/complib_pd-deploy-pd-and-complib-to-s3/index.html

Protocol Designer WIP:
https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/complib_pd-deploy-pd-and-complib-to-s3/index.html#/

Also, FYI, the old PD prototype is around with a different hash route (as before, works in Chrome only!):
https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/complib_pd-deploy-pd-and-complib-to-s3/index.html#/old-ingredient-selector

### 2. Double-check `.travis.yml`

The fragmented Makefiles tripped me up the first time I messed with `.travis.yml` and I was running tests twice. Please double-check for sanity.