### PR TITLE
Add metadata to body of health endpoint return

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -132,6 +132,13 @@ class SmoothieDriver_3_0_0:
     def disconnect(self):
         self.simulating = True
 
+    def get_fw_version(self):
+        version = 'Virtual Smoothie'
+        if not self.simulating:
+            version = serial_communication.write_and_return(
+                "version\n", self._connection).split('\r')[0]
+        return version
+
     @property
     def position(self):
         """

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -189,6 +189,7 @@ class Robot(object):
         self.config = config or load()
         self._driver = driver_3_0.SmoothieDriver_3_0_0(config=self.config)
         self.modules = []
+        self.fw_version = self._driver.get_fw_version()
 
         # TODO (andy) should come from a config file
         self.dimensions = (395, 345, 228)
@@ -449,6 +450,7 @@ class Robot(object):
         self._driver.connect()
         for module in self.modules:
             module.connect()
+        self.fw_version = self._driver.get_fw_version()
 
         # device = None
         # if not port or port == drivers.VIRTUAL_SMOOTHIE_PORT:

--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -3,17 +3,20 @@ import json
 import logging
 import subprocess
 from aiohttp import web
-
+from opentrons import robot, __version__
 
 log = logging.getLogger(__name__)
 ENABLE_NMCLI = os.environ.get('ENABLE_NETWORKING_ENDPOINTS', '')
 
 
 async def health(request):
+    res = {
+        'api_version': __version__,
+        'fw_version': robot.fw_version
+    }
     return web.json_response(
-        headers={
-            'Access-Control-Allow-Origin': '*'
-        })
+        headers={'Access-Control-Allow-Origin': '*'},
+        body=repr(json.dumps(res)))
 
 
 async def wifi_list(request):


### PR DESCRIPTION
## overview

Add version number of API and Smoothie FW to body of response to health endpoint. FW version is memoized when `robot.connect()` is called, so this does not result in repeated additional queries to Smoothie.

Unblocks #528 

## changelog

- (feature) Add method to driver for retrieving FW version from Smoothie
- (feature) Add body to health endpoint with version of API and FW

## review requests

Tested on the robot. 
