### PR TITLE
Rename axis to mount and change slot type to string

### DIFF
--- a/app/src/components/RunControl.js
+++ b/app/src/components/RunControl.js
@@ -96,7 +96,7 @@ export default function RunControl (props) {
 
 RunControl.propTypes = {
   sessionName: PropTypes.string.isRequired,
-  startTime: PropTypes.string.isRequired,
+  startTime: PropTypes.number,
   runTime: PropTypes.string.isRequired,
   isRunning: PropTypes.bool.isRequired,
   isPaused: PropTypes.bool.isRequired,

--- a/app/src/components/deck/CalibrateDeck.js
+++ b/app/src/components/deck/CalibrateDeck.js
@@ -1,5 +1,5 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import {Deck} from '@opentrons/components'
@@ -9,12 +9,12 @@ import ReviewLabware from './ReviewLabware'
 import CalibrationPrompt from './CalibrationPrompt'
 import styles from './deck.css'
 
-CalibrateDeck.propTypes = {
-  slot: PropTypes.number.isRequired,
-  deckPopulated: PropTypes.bool.isRequired
+type Props = {
+  slot: string,
+  deckPopulated: boolean
 }
 
-export default function CalibrateDeck (props) {
+export default function CalibrateDeck (props: Props) {
   const {deckPopulated, slot} = props
   const style = classnames({[styles.review_deck]: !deckPopulated})
   const Prompt = deckPopulated

--- a/app/src/components/setup-instruments/InstrumentGroup.js
+++ b/app/src/components/setup-instruments/InstrumentGroup.js
@@ -15,7 +15,7 @@ export default function InstrumentGroup (props: Props) {
     <section className={styles.pipette_group}>
       {instruments.map((instrument) => {
         return (
-          <InstrumentInfo {...instrument} key={instrument.axis} />
+          <InstrumentInfo key={instrument.mount} {...instrument} />
         )
       })}
     </section>

--- a/app/src/components/setup-instruments/InstrumentInfo.js
+++ b/app/src/components/setup-instruments/InstrumentInfo.js
@@ -2,13 +2,14 @@
 import React from 'react'
 import classnames from 'classnames'
 
+import type {Mount} from '../../robot'
 import InfoItem from './InfoItem.js' // move to comp lib?
 import InstrumentDiagram from './InstrumentDiagram.js'
 
 import styles from './instrument.css'
 
 export type InstrumentInfoProps = {
-  axis: string,
+  mount: Mount,
   description: string,
   tipType: string,
   isDisabled: boolean,
@@ -17,7 +18,7 @@ export type InstrumentInfoProps = {
 }
 
 export default function InstrumentInfo (props: InstrumentInfoProps) {
-  const className = classnames(styles.pipette, styles[props.axis], {
+  const className = classnames(styles.pipette, styles[props.mount], {
     [styles.disabled]: props.isDisabled
   })
 

--- a/app/src/components/setup-instruments/InstrumentTabs.js
+++ b/app/src/components/setup-instruments/InstrumentTabs.js
@@ -1,18 +1,23 @@
+// @flow
 // instrument tabs bar container
 // used for left/right pipette selection during pipette calibration
 
 import {connect} from 'react-redux'
-import {PageTabs} from '@opentrons/components'
-import {selectors as robotSelectors} from '../../robot'
+import {PageTabs, type PageTabProps} from '@opentrons/components'
+import {selectors as robotSelectors, type Mount} from '../../robot'
 
 export default connect(mapStateToProps)(PageTabs)
 
-function mapStateToProps (state, ownProps) {
+type OwnProps = {
+  mount: Mount
+}
+
+function mapStateToProps (state, ownProps: OwnProps): PageTabProps {
   const pages = robotSelectors.getInstruments(state).map((inst) => ({
-    title: inst.axis,
-    href: `/setup-instruments/${inst.axis}`,
-    isActive: inst.axis === ownProps.mount,
-    isDisabled: inst.name == null
+    title: inst.mount,
+    href: `/setup-instruments/${inst.mount}`,
+    isActive: inst.mount === ownProps.mount,
+    isDisabled: !('name' in inst)
   }))
 
   return {pages}

--- a/app/src/components/setup-instruments/Instruments.js
+++ b/app/src/components/setup-instruments/Instruments.js
@@ -9,7 +9,9 @@ export default connect(mapStateToProps, null, mergeProps)(InstrumentGroup)
 
 function mapStateToProps (state, ownProps) {
   const instruments = robotSelectors.getInstruments(state)
-  const currentInstrument = instruments.find((inst) => inst.axis === ownProps.mount)
+  const currentInstrument = instruments.find((inst) => (
+    inst.mount && inst.mount === ownProps.mount
+  ))
 
   return {
     currentInstrument,
@@ -20,7 +22,7 @@ function mapStateToProps (state, ownProps) {
 function mergeProps (stateProps) {
   const instruments = stateProps.instruments.map(inst => {
     const isUsed = inst.name != null
-    const isDisabled = inst.axis !== stateProps.currentInstrument.axis
+    const isDisabled = inst.mount !== stateProps.currentInstrument.mount
     const description = isUsed
       ? `${capitalize(inst.channels)}-channel (${inst.volume} ul)`
       : 'N/A'

--- a/app/src/components/setup-panel/InstrumentList.js
+++ b/app/src/components/setup-panel/InstrumentList.js
@@ -1,5 +1,8 @@
+// @flow
 import React from 'react'
 import {connect} from 'react-redux'
+import type {Dispatch} from 'redux'
+
 import {
   actions as robotActions,
   selectors as robotSelectors
@@ -12,23 +15,24 @@ export default connect(mapStateToProps, mapDispatchToProps)(InstrumentList)
 
 function InstrumentList (props) {
   const title = 'Pipette Setup'
+
   return (
     <TitledList title={title}>
-      {props.instruments.map((instrument) => (
-        <InstrumentListItem key={instrument.axis} {...props} {...instrument} />
+      {props.instruments.map((inst) => (
+        <InstrumentListItem key={inst.mount} {...props} {...inst} />
       ))}
     </TitledList>
   )
 }
 
-function mapStateToProps (state, ownProps) {
+function mapStateToProps (state) {
   return {
     instruments: robotSelectors.getInstruments(state),
     isRunning: robotSelectors.getIsRunning(state)
   }
 }
 
-function mapDispatchToProps (dispatch) {
+function mapDispatchToProps (dispatch: Dispatch<*>) {
   return {
     clearDeckPopulated: () => dispatch(robotActions.setDeckPopulated(false))
   }

--- a/app/src/components/setup-panel/InstrumentListItem.js
+++ b/app/src/components/setup-panel/InstrumentListItem.js
@@ -1,28 +1,53 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
 import capitalize from 'lodash/capitalize'
 
-import {ListItem, CHECKED, UNCHECKED} from '@opentrons/components'
+import {
+  ListItem,
+  CHECKED,
+  UNCHECKED,
+  type
+  IconName
+} from '@opentrons/components'
 
-InstrumentListItem.propTypes = {
-  isRunning: PropTypes.bool.isRequired,
-  name: PropTypes.string,
-  axis: PropTypes.string,
-  volume: PropTypes.number,
-  channels: PropTypes.number,
-  probed: PropTypes.bool,
-  clearDeckPopulated: PropTypes.func
+import type {Mount, Channels} from '../../robot'
+
+type Props = {
+  isRunning: boolean,
+  mount: Mount,
+  clearDeckPopulated: () => void,
+  name: ?string,
+  volume: ?number,
+  channels: ?Channels,
+  probed: ?boolean,
 }
 
-export default function InstrumentListItem (props) {
-  const {isRunning, name, axis, volume, channels, probed, clearDeckPopulated} = props
-  const isDisabled = name == null
-  const url = isRunning
-  ? '#'
-  : `/setup-instruments/${axis}`
+export default function InstrumentListItem (props: Props) {
+  const {
+    isRunning,
+    name,
+    mount,
+    volume,
+    channels,
+    probed,
+    clearDeckPopulated
+  } = props
+
+  const isUsed = name != null
+  const isDisabled = !isUsed || isRunning
+
+  const url = !isDisabled
+    ? `/setup-instruments/${mount}`
+    : '#'
+
+  const onClick = !isDisabled
+    ? clearDeckPopulated
+    : undefined
+
   // TODO (ka 2018-1-17): Move this up to container mergeProps in upcoming update setup panel ticket
   const confirmed = probed
-  const iconName = confirmed
+
+  const iconName: IconName = confirmed
     ? CHECKED
     : UNCHECKED
 
@@ -30,20 +55,23 @@ export default function InstrumentListItem (props) {
     ? 'multi'
     : 'single'
 
-  const description = !isDisabled
+  const description = isUsed
     ? `${capitalize(pipetteType)}-channel`
     : 'N/A'
 
-  const units = !isDisabled ? 'ul' : null
+  const units = !isDisabled
+    ? 'ul'
+    : null
+
   return (
     <ListItem
-      isDisabled={isDisabled || isRunning}
+      isDisabled={isDisabled}
       url={url}
-      onClick={!isRunning && clearDeckPopulated}
+      onClick={onClick}
       confirmed={confirmed}
       iconName={iconName}
     >
-      <span>{capitalize(axis)}</span>
+      <span>{capitalize(mount)}</span>
       <span>{description}</span>
       <span>{volume} {units}</span>
     </ListItem>

--- a/app/src/components/setup-panel/LabwareList.js
+++ b/app/src/components/setup-panel/LabwareList.js
@@ -26,6 +26,7 @@ function LabwareList (props) {
 
   const {tiprackList, labwareList} = labware.reduce((result, lab) => {
     const {slot, name, isTiprack, setLabware} = lab
+    // TODO(mc, 2018-01-19): remove all these extra props (see LabwareListItem)
     const links = (
       <LabwareListItem
         {...lab}

--- a/app/src/components/setup-panel/LabwareListItem.js
+++ b/app/src/components/setup-panel/LabwareListItem.js
@@ -1,16 +1,16 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
 import {ListItem, CHECKED, UNCHECKED} from '@opentrons/components'
 
-LabwareListItem.propTypes = {
-  name: PropTypes.string,
-  slot: PropTypes.number.isRequired,
-  confirmed: PropTypes.bool,
-  isDisabled: PropTypes.bool.isRequired,
-  onClick: PropTypes.func
+type Props = {
+  slot: string,
+  isDisabled: boolean,
+  onClick: () => void,
+  name: ?string,
+  confirmed: ?boolean
 }
 
-export default function LabwareListItem (props) {
+export default function LabwareListItem (props: Props) {
   const {
     name,
     slot,

--- a/app/src/containers/ConnectedTipProbe.js
+++ b/app/src/containers/ConnectedTipProbe.js
@@ -1,5 +1,8 @@
+// @flow
+import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 
+import type {Mount} from '../robot'
 import TipProbe from '../components/TipProbe'
 
 import {
@@ -7,16 +10,23 @@ import {
   selectors as robotSelectors
 } from '../robot'
 
-const mapStateToProps = (state, ownProps) => {
+type OwnProps = {
+  mount: Mount
+}
+
+const mapStateToProps = (state, ownProps: OwnProps) => {
+  const mount = ownProps.mount
   const instruments = robotSelectors.getInstruments(state)
-  const currentInstrument = instruments.find((inst) => inst.axis === ownProps.mount)
+  const currentInstrument = instruments.find((inst) => inst.mount === mount)
+
   return {
     currentInstrument
   }
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch: Dispatch<*>, ownProps: OwnProps) => {
   const mount = ownProps.mount
+
   return {
     onPrepareClick: () => dispatch(robotActions.moveToFront(mount)),
     onProbeTipClick: () => dispatch(robotActions.probeTip(mount)),

--- a/app/src/pages/SetupDeck.js
+++ b/app/src/pages/SetupDeck.js
@@ -8,9 +8,7 @@ import SessionHeader from '../containers/SessionHeader'
 import ConnectedJogModal from '../containers/ConnectedJogModal'
 
 export default function SetupDeckPage (props) {
-  const {match: {url}, match: {params}} = props
-  // TODO(mc, 2017-10-18): use strings for slot for consitency
-  const slot = parseInt(params.slot) || 1
+  const {match: {url}, match: {params: {slot}}} = props
 
   return (
     <Page>

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -2,6 +2,8 @@
 // robot redux module constants
 import PropTypes from 'prop-types'
 
+import type {Mount, Slot} from './types'
+
 export const _NAME = 'robot'
 
 // connection states
@@ -45,7 +47,7 @@ export const INSTRUMENT_CALIBRATION_TYPE = PropTypes.oneOf([
 ])
 
 // labware confirmation states
-// several are redundant and could be collapsed into something like MOVING
+// TODO(mc, 2018-01-11): remove constant exports in favor of types.js
 export const UNCONFIRMED = 'unconfirmed'
 export const MOVING_TO_SLOT = 'moving-to-slot'
 export const OVER_SLOT = 'over-slot'
@@ -70,9 +72,20 @@ export const LABWARE_CONFIRMATION_TYPE = PropTypes.oneOf([
 ])
 
 // deck layout
-export type InstrumentMount = 'left' | 'right'
-export const INSTRUMENT_AXES: InstrumentMount[] = ['left', 'right']
-export const DECK_SLOTS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+export const INSTRUMENT_AXES: Mount[] = ['left', 'right']
+export const DECK_SLOTS: Slot[] = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11'
+]
 
 // pipette channels
 export const SINGLE_CHANNEL = 'single'

--- a/app/src/robot/index.js
+++ b/app/src/robot/index.js
@@ -1,3 +1,4 @@
+// @flow
 // robot state module
 // split up into reducer.js, action.js, etc if / when necessary
 import reducer from './reducer'
@@ -5,6 +6,7 @@ import * as selectors from './selectors'
 import * as constants from './constants'
 import apiClientMiddleware from './api-client'
 
+export * from './types'
 export {_NAME as NAME} from './constants'
 export {actions, actionTypes} from './actions'
 export {constants, reducer, selectors, apiClientMiddleware}

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -1,10 +1,10 @@
 // @flow
 // robot calibration state and reducer
 // TODO(mc, 2018-01-10): refactor to use combineReducers
+import type {Mount, Slot, LabwareCalibrationStatus} from '../types'
 import {actionTypes} from '../actions'
 
 import {
-  type InstrumentMount,
   UNCONFIRMED,
   MOVING_TO_SLOT,
   OVER_SLOT,
@@ -30,7 +30,7 @@ type CalibrationRequestType =
 
 type CalibrationRequest = {
   type: CalibrationRequestType,
-  mount: InstrumentMount | '',
+  mount: Mount | '',
   inProgress: boolean,
   error: ?{message: string},
 }
@@ -38,8 +38,8 @@ type CalibrationRequest = {
 // TODO(mc, 2018-01-10): replace with CalibrationRequest
 type LabwareConfirmationRequest = {
   inProgress: boolean,
-  axis?: string,
-  slot?: number,
+  mount?: Mount | '',
+  slot?: Slot | '',
   error: ?{message: string},
 }
 
@@ -47,10 +47,10 @@ export type State = {
   deckPopulated: boolean,
   jogDistance: number,
 
-  probedByAxis: {[InstrumentMount]: boolean},
+  probedByMount: {[Mount]: boolean},
 
-  labwareBySlot: {[number]: {}},
-  confirmedBySlot: {[number]: boolean},
+  labwareBySlot: {[Slot]: LabwareCalibrationStatus},
+  confirmedBySlot: {[Slot]: boolean},
 
   calibrationRequest: CalibrationRequest,
 
@@ -100,7 +100,7 @@ const INITIAL_STATE: State = {
   deckPopulated: true,
   jogDistance: JOG_DISTANCE_SLOW_MM,
 
-  probedByAxis: {},
+  probedByMount: {},
 
   // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
   // slot. confirmedBySlot holds a flag for whether the labware has been
@@ -113,9 +113,9 @@ const INITIAL_STATE: State = {
   // TODO(mc, 2017-11-22): collapse all these into a single
   // instrumentRequest object. We can't have simultaneous instrument
   // movements so split state hurts us without benefit
-  pickupRequest: {inProgress: false, error: null, slot: 0},
-  homeRequest: {inProgress: false, error: null, slot: 0},
-  confirmTiprackRequest: {inProgress: false, error: null, slot: 0},
+  pickupRequest: {inProgress: false, error: null, slot: ''},
+  homeRequest: {inProgress: false, error: null, slot: ''},
+  confirmTiprackRequest: {inProgress: false, error: null, slot: ''},
   moveToRequest: {inProgress: false, error: null},
   jogRequest: {inProgress: false, error: null},
   updateOffsetRequest: {inProgress: false, error: null}
@@ -230,9 +230,9 @@ function handleProbeTipResponse (state, action) {
         ? payload
         : null
     },
-    probedByAxis: {
-      ...state.probedByAxis,
-      [mount]: state.probedByAxis[mount] || !error
+    probedByMount: {
+      ...state.probedByMount,
+      [mount]: state.probedByMount[mount] || !error
     }
   }
 }

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -1,20 +1,12 @@
 // @flow
 // robot session (protocol) state and reducer
-import type {InstrumentMount, SessionStatus} from '../constants'
+import type {Command, Instrument, Labware, Mount, Slot} from '../types'
+import type {SessionStatus} from '../constants'
 import {actionTypes} from '../actions'
-
-type Channels = 1 | 8
 
 type Request = {
   inProgress: boolean,
   error: ?{message: string}
-}
-
-type Command = {
-  id: number,
-  description: string,
-  handledAt: ?number,
-  children: number[]
 }
 
 export type State = {
@@ -28,25 +20,11 @@ export type State = {
   protocolCommandsById: {
     [number]: Command
   },
-  protocolInstrumentsByAxis: {
-    [InstrumentMount]: {
-      _id: number,
-      axis: InstrumentMount,
-      channels: Channels,
-      name: string,
-      volume: number
-    }
+  instrumentsByMount: {
+    [Mount]: Instrument
   },
-  protocolLabwareBySlot: {
-    // TODO(mc, 2018-01-11): slot IDs should be strings
-    [number]: {
-      _id: number,
-      slot: number,
-      type: string,
-      name: string,
-      id: string,
-      isTiprack: boolean
-    }
+  labwareBySlot: {
+    [Slot]: Labware
   },
   runRequest: Request,
   pauseRequest: Request,
@@ -88,8 +66,10 @@ const INITIAL_STATE: State = {
   protocolText: '',
   protocolCommands: [],
   protocolCommandsById: {},
-  protocolInstrumentsByAxis: {},
-  protocolLabwareBySlot: {},
+
+  // deck setup from protocol
+  instrumentsByMount: {},
+  labwareBySlot: {},
 
   // running a protocol
   runRequest: {inProgress: false, error: null},

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -10,7 +10,6 @@ import type {State as SessionState} from './reducer/session'
 import {
   type ConnectionStatus,
   type SessionStatus,
-  type InstrumentMount,
   _NAME,
   UNPROBED,
   PREPARING_TO_PROBE,
@@ -21,6 +20,8 @@ import {
   INSTRUMENT_AXES,
   DECK_SLOTS
 } from './constants'
+
+import type {Mount} from './types'
 
 type State = {
   robot: {
@@ -184,18 +185,18 @@ export const getRunTime = createSelector(
   }
 )
 
-export function getInstrumentsByAxis (state: State) {
-  return session(state).protocolInstrumentsByAxis
+export function getInstrumentsByMount (state: State) {
+  return session(state).instrumentsByMount
 }
 
 export const getInstruments = createSelector(
-  getInstrumentsByAxis,
-  (state: State) => calibration(state).probedByAxis,
+  getInstrumentsByMount,
+  (state: State) => calibration(state).probedByMount,
   (state: State) => calibration(state).calibrationRequest,
   (instrumentsByMount, probedByMount, calibrationRequest) => {
     return INSTRUMENT_AXES.map((mount) => {
       const instrument = instrumentsByMount[mount]
-      if (!instrument || !instrument.name) return {axis: mount}
+      if (!instrument || !instrument.name) return {mount}
 
       let calibration = UNPROBED
 
@@ -225,13 +226,13 @@ export const getInstruments = createSelector(
 // TODO(mc, 2018-01-03): select pipette based on deckware props
 export const getCalibratorMount = createSelector(
   getInstruments,
-  (instruments): InstrumentMount | '' => {
+  (instruments): Mount | '' => {
     const single = instruments.find((i) => i.channels && i.channels === 1)
     const multi = instruments.find((i) => i.channels && i.channels > 1)
 
-    const calibrator = single || multi || {axis: ''}
+    const calibrator = single || multi || {mount: ''}
 
-    return calibrator.axis
+    return calibrator.mount
   }
 )
 
@@ -241,7 +242,7 @@ export const getInstrumentsCalibrated = createSelector(
 )
 
 export function getLabwareBySlot (state: State) {
-  return session(state).protocolLabwareBySlot
+  return session(state).labwareBySlot
 }
 
 export const getLabware = createSelector(

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -160,11 +160,11 @@ describe('robot actions', () => {
   test('pick up tip and home action', () => {
     const action = {
       type: actionTypes.PICKUP_AND_HOME,
-      payload: {instrument: 'left', labware: 5},
+      payload: {instrument: 'left', labware: '5'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.pickupAndHome('left', 5)).toEqual(action)
+    expect(actions.pickupAndHome('left', '5')).toEqual(action)
   })
 
   test('pick up tip and home response action', () => {
@@ -185,11 +185,11 @@ describe('robot actions', () => {
   test('drop tip and home action', () => {
     const action = {
       type: actionTypes.DROP_TIP_AND_HOME,
-      payload: {instrument: 'right', labware: 5},
+      payload: {instrument: 'right', labware: '5'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.dropTipAndHome('right', 5)).toEqual(action)
+    expect(actions.dropTipAndHome('right', '5')).toEqual(action)
   })
 
   test('drop tip and home response action', () => {
@@ -211,11 +211,11 @@ describe('robot actions', () => {
   test('confirm tiprack action', () => {
     const action = {
       type: actionTypes.CONFIRM_TIPRACK,
-      payload: {instrument: 'left', labware: 9},
+      payload: {instrument: 'left', labware: '9'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.confirmTiprack('left', 9)).toEqual(action)
+    expect(actions.confirmTiprack('left', '9')).toEqual(action)
   })
 
   test('confirm tiprack response action', () => {
@@ -271,11 +271,11 @@ describe('robot actions', () => {
   test('move to action', () => {
     const expected = {
       type: actionTypes.MOVE_TO,
-      payload: {instrument: 'left', labware: 3},
+      payload: {instrument: 'left', labware: '3'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.moveTo('left', 3)).toEqual(expected)
+    expect(actions.moveTo('left', '3')).toEqual(expected)
   })
 
   test('move to response action', () => {
@@ -327,11 +327,11 @@ describe('robot actions', () => {
   test('update offset action', () => {
     const expected = {
       type: actionTypes.UPDATE_OFFSET,
-      payload: {instrument: 'left', labware: 2},
+      payload: {instrument: 'left', labware: '2'},
       meta: {robotCommand: true}
     }
 
-    expect(actions.updateOffset('left', 2)).toEqual(expected)
+    expect(actions.updateOffset('left', '2')).toEqual(expected)
   })
 
   test('update offset response action', () => {
@@ -353,10 +353,10 @@ describe('robot actions', () => {
   test('confirm labware action', () => {
     const expected = {
       type: actionTypes.CONFIRM_LABWARE,
-      payload: {labware: 2}
+      payload: {labware: '2'}
     }
 
-    expect(actions.confirmLabware(2)).toEqual(expected)
+    expect(actions.confirmLabware('2')).toEqual(expected)
   })
 
   test('run action', () => {

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -204,8 +204,8 @@ describe('api client', () => {
         protocolText: session.protocol_text,
         protocolCommands: [],
         protocolCommandsById: {},
-        protocolInstrumentsByAxis: {},
-        protocolLabwareBySlot: {}
+        instrumentsByMount: {},
+        labwareBySlot: {}
       })
 
       return sendConnect()
@@ -260,17 +260,17 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
-    test('maps api instruments and intruments by axis', () => {
+    test('maps api instruments and intruments by mount', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
-        protocolInstrumentsByAxis: {
-          left: {_id: 2, axis: 'left', name: 'p200', channels: 1, volume: 200},
-          right: {_id: 1, axis: 'right', name: 'p50', channels: 8, volume: 50}
+        instrumentsByMount: {
+          left: {_id: 2, mount: 'left', name: 'p200', channels: 1, volume: 200},
+          right: {_id: 1, mount: 'right', name: 'p50', channels: 8, volume: 50}
         }
       }))
 
       session.instruments = [
-        {_id: 1, axis: 'a', name: 'p50', channels: 8},
-        {_id: 2, axis: 'b', name: 'p200', channels: 1}
+        {_id: 1, mount: 'right', name: 'p50', channels: 8},
+        {_id: 2, mount: 'left', name: 'p200', channels: 1}
       ]
 
       return sendConnect()
@@ -279,10 +279,10 @@ describe('api client', () => {
 
     test('maps api containers to labware by slot', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
-        protocolLabwareBySlot: {
-          1: {_id: 1, id: 'A1', slot: 1, name: 'a', type: 'tiprack', isTiprack: true},
-          5: {_id: 2, id: 'B2', slot: 5, name: 'b', type: 'B', isTiprack: false},
-          9: {_id: 3, id: 'C3', slot: 9, name: 'c', type: 'C', isTiprack: false}
+        labwareBySlot: {
+          1: {_id: 1, slot: '1', name: 'a', type: 'tiprack', isTiprack: true},
+          5: {_id: 2, slot: '5', name: 'b', type: 'B', isTiprack: false},
+          9: {_id: 3, slot: '9', name: 'c', type: 'C', isTiprack: false}
         }
       }))
 
@@ -308,11 +308,11 @@ describe('api client', () => {
             jogDistance: constants.JOG_DISTANCE_FAST_MM
           },
           session: {
-            protocolInstrumentsByAxis: {
+            instrumentsByMount: {
               left: {_id: 'inst-2'},
               right: {_id: 'inst-1'}
             },
-            protocolLabwareBySlot: {
+            labwareBySlot: {
               1: {_id: 'lab-1', type: '96-flat'},
               5: {_id: 'lab-2', type: 'tiprack-200ul', isTiprack: true},
               9: {_id: 'lab-3', type: 'tiprack-200ul', isTiprack: true}

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -9,7 +9,7 @@ describe('robot reducer - calibration', () => {
       deckPopulated: true,
       jogDistance: constants.JOG_DISTANCE_SLOW_MM,
 
-      probedByAxis: {},
+      probedByMount: {},
 
       // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
       // slot. confirmedBySlot holds a flag for whether the labware has been
@@ -20,9 +20,9 @@ describe('robot reducer - calibration', () => {
       calibrationRequest: {type: '', inProgress: false, mount: '', error: null},
 
       // TODO(mc, 2018-01-10): collapse all these into calibrationRequest
-      pickupRequest: {inProgress: false, error: null, slot: 0},
-      homeRequest: {inProgress: false, error: null, slot: 0},
-      confirmTiprackRequest: {inProgress: false, error: null, slot: 0},
+      pickupRequest: {inProgress: false, error: null, slot: ''},
+      homeRequest: {inProgress: false, error: null, slot: ''},
+      confirmTiprackRequest: {inProgress: false, error: null, slot: ''},
       moveToRequest: {inProgress: false, error: null},
       jogRequest: {inProgress: false, error: null},
       updateOffsetRequest: {inProgress: false, error: null}
@@ -74,18 +74,18 @@ describe('robot reducer - calibration', () => {
     const state = {
       calibration: {
         deckPopulated: false,
-        pickupRequest: {inProgress: false, error: new Error(), slot: 0},
+        pickupRequest: {inProgress: false, error: new Error(), slot: ''},
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
 
     const action = {
       type: actionTypes.PICKUP_AND_HOME,
-      payload: {instrument: 'left', labware: 5}
+      payload: {instrument: 'left', labware: '5'}
     }
     expect(reducer(state, action).calibration).toEqual({
       deckPopulated: true,
-      pickupRequest: {inProgress: true, error: null, slot: 5},
+      pickupRequest: {inProgress: true, error: null, slot: '5'},
       labwareBySlot: {5: constants.PICKING_UP}
     })
   })
@@ -93,7 +93,7 @@ describe('robot reducer - calibration', () => {
   test('handles PICKUP_AND_HOME_RESPONSE action', () => {
     const state = {
       calibration: {
-        pickupRequest: {inProgress: true, error: null, slot: 5},
+        pickupRequest: {inProgress: true, error: null, slot: '5'},
         labwareBySlot: {5: constants.PICKING_UP}
       }
     }
@@ -107,12 +107,12 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      pickupRequest: {inProgress: false, error: null, slot: 5},
+      pickupRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {5: constants.HOMED}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
-      pickupRequest: {inProgress: false, error: new Error('AH'), slot: 5},
+      pickupRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
       labwareBySlot: {5: constants.UNCONFIRMED}
     })
   })
@@ -120,17 +120,17 @@ describe('robot reducer - calibration', () => {
   test('handles DROP_TIP_AND_HOME action', () => {
     const state = {
       calibration: {
-        homeRequest: {inProgress: false, error: new Error('AH'), slot: 0},
+        homeRequest: {inProgress: false, error: new Error('AH'), slot: ''},
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
     const action = {
       type: actionTypes.DROP_TIP_AND_HOME,
-      payload: {instrument: 'right', labware: 5}
+      payload: {instrument: 'right', labware: '5'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
-      homeRequest: {inProgress: true, error: null, slot: 5},
+      homeRequest: {inProgress: true, error: null, slot: '5'},
       labwareBySlot: {5: constants.HOMING}
     })
   })
@@ -138,7 +138,7 @@ describe('robot reducer - calibration', () => {
   test('handles DROP_TIP_AND_HOME_RESPONSE action', () => {
     const state = {
       calibration: {
-        homeRequest: {inProgress: true, error: null, slot: 5},
+        homeRequest: {inProgress: true, error: null, slot: '5'},
         labwareBySlot: {5: constants.HOMING}
       }
     }
@@ -152,12 +152,12 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      homeRequest: {inProgress: false, error: null, slot: 5},
+      homeRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {5: constants.HOMED}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
-      homeRequest: {inProgress: false, error: new Error('AH'), slot: 5},
+      homeRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
       labwareBySlot: {5: constants.UNCONFIRMED}
     })
   })
@@ -168,18 +168,18 @@ describe('robot reducer - calibration', () => {
         confirmTiprackRequest: {
           inProgress: false,
           error: new Error('AH'),
-          slot: 0
+          slot: ''
         },
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
     const action = {
       type: actionTypes.CONFIRM_TIPRACK,
-      payload: {instrument: 'right', labware: 5}
+      payload: {instrument: 'right', labware: '5'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
-      confirmTiprackRequest: {inProgress: true, error: null, slot: 5},
+      confirmTiprackRequest: {inProgress: true, error: null, slot: '5'},
       labwareBySlot: {5: constants.CONFIRMING}
     })
   })
@@ -187,7 +187,7 @@ describe('robot reducer - calibration', () => {
   test('handles CONFIRM_TIPRACK_RESPONSE action', () => {
     const state = {
       calibration: {
-        confirmTiprackRequest: {inProgress: true, error: null, slot: 5},
+        confirmTiprackRequest: {inProgress: true, error: null, slot: '5'},
         labwareBySlot: {5: constants.CONFIRMING},
         confirmedBySlot: {5: false}
       }
@@ -202,7 +202,7 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      confirmTiprackRequest: {inProgress: false, error: null, slot: 5},
+      confirmTiprackRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
@@ -211,7 +211,7 @@ describe('robot reducer - calibration', () => {
       confirmTiprackRequest: {
         inProgress: false,
         error: new Error('AH'),
-        slot: 5
+        slot: '5'
       },
       labwareBySlot: {5: constants.UNCONFIRMED},
       confirmedBySlot: {5: false}
@@ -317,7 +317,7 @@ describe('robot reducer - calibration', () => {
           inProgress: true,
           error: null
         },
-        probedByAxis: {}
+        probedByMount: {}
       }
     }
     const success = {type: actionTypes.PROBE_TIP_RESPONSE, error: false}
@@ -334,7 +334,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: null
       },
-      probedByAxis: {
+      probedByMount: {
         right: true
       }
     })
@@ -345,7 +345,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: new Error('AH')
       },
-      probedByAxis: {
+      probedByMount: {
         right: false
       }
     })
@@ -376,12 +376,12 @@ describe('robot reducer - calibration', () => {
     }
     const action = {
       type: actionTypes.MOVE_TO,
-      payload: {labware: 3}
+      payload: {labware: '3'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
       deckPopulated: true,
-      moveToRequest: {inProgress: true, error: null, slot: 3},
+      moveToRequest: {inProgress: true, error: null, slot: '3'},
       labwareBySlot: {3: constants.MOVING_TO_SLOT, 5: constants.UNCONFIRMED}
     })
   })
@@ -389,7 +389,7 @@ describe('robot reducer - calibration', () => {
   test('handles MOVE_TO_RESPONSE action', () => {
     const state = {
       calibration: {
-        moveToRequest: {inProgress: true, error: null, slot: 5},
+        moveToRequest: {inProgress: true, error: null, slot: '5'},
         labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.MOVING_TO_SLOT}
       }
     }
@@ -402,11 +402,11 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      moveToRequest: {inProgress: false, error: null, slot: 5},
+      moveToRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
     })
     expect(reducer(state, failure).calibration).toEqual({
-      moveToRequest: {inProgress: false, error: new Error('AH'), slot: 5},
+      moveToRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED}
     })
   })
@@ -461,10 +461,10 @@ describe('robot reducer - calibration', () => {
         labwareBySlot: {}
       }
     }
-    const action = {type: actionTypes.UPDATE_OFFSET, payload: {labware: 5}}
+    const action = {type: actionTypes.UPDATE_OFFSET, payload: {labware: '5'}}
 
     expect(reducer(state, action).calibration).toEqual({
-      updateOffsetRequest: {inProgress: true, error: null, slot: 5},
+      updateOffsetRequest: {inProgress: true, error: null, slot: '5'},
       labwareBySlot: {5: constants.UPDATING}
     })
   })
@@ -472,7 +472,7 @@ describe('robot reducer - calibration', () => {
   test('handles UPDATE_OFFSET_RESPONSE action', () => {
     const state = {
       calibration: {
-        updateOffsetRequest: {inProgress: true, error: null, slot: 5},
+        updateOffsetRequest: {inProgress: true, error: null, slot: '5'},
         labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATING},
         confirmedBySlot: {}
       }
@@ -495,17 +495,17 @@ describe('robot reducer - calibration', () => {
     }
 
     expect(reducer(state, successNonTiprack).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: null, slot: 5},
+      updateOffsetRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
     expect(reducer(state, successTiprack).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: null, slot: 5},
+      updateOffsetRequest: {inProgress: false, error: null, slot: '5'},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATED},
       confirmedBySlot: {}
     })
     expect(reducer(state, failure).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: new Error('AH'), slot: 5},
+      updateOffsetRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED},
       confirmedBySlot: {5: false}
     })
@@ -518,7 +518,7 @@ describe('robot reducer - calibration', () => {
         confirmedBySlot: {}
       }
     }
-    const action = {type: actionTypes.CONFIRM_LABWARE, payload: {labware: 5}}
+    const action = {type: actionTypes.CONFIRM_LABWARE, payload: {labware: '5'}}
 
     expect(reducer(state, action).calibration).toEqual({
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -329,9 +329,9 @@ describe('robot selectors', () => {
   test('get instruments', () => {
     const state = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          left: {axis: 'left', name: 'p200m', channels: 8, volume: 200},
-          right: {axis: 'right', name: 'p50s', channels: 1, volume: 50}
+        instrumentsByMount: {
+          left: {mount: 'left', name: 'p200m', channels: 8, volume: 200},
+          right: {mount: 'right', name: 'p50s', channels: 1, volume: 50}
         }
       },
       calibration: {
@@ -341,7 +341,7 @@ describe('robot selectors', () => {
           inProgress: true,
           error: null
         },
-        probedByAxis: {
+        probedByMount: {
           left: true
         }
       }
@@ -349,7 +349,7 @@ describe('robot selectors', () => {
 
     expect(getInstruments(state)).toEqual([
       {
-        axis: 'left',
+        mount: 'left',
         name: 'p200m',
         channels: 8,
         volume: 200,
@@ -357,7 +357,7 @@ describe('robot selectors', () => {
         probed: true
       },
       {
-        axis: 'right',
+        mount: 'right',
         name: 'p50s',
         channels: 1,
         volume: 50,
@@ -378,14 +378,14 @@ describe('robot selectors', () => {
   test('get calibrator mount with single channel installed', () => {
     const state = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          left: {axis: 'left', name: 'p200m', channels: 8, volume: 200},
-          right: {axis: 'right', name: 'p50s', channels: 1, volume: 50}
+        instrumentsByMount: {
+          left: {mount: 'left', name: 'p200m', channels: 8, volume: 200},
+          right: {mount: 'right', name: 'p50s', channels: 1, volume: 50}
         }
       },
       calibration: {
         calibrationRequest: {},
-        probedByAxis: {}
+        probedByMount: {}
       }
     })
 
@@ -395,13 +395,13 @@ describe('robot selectors', () => {
   test('get calibrator mount with only multi channel installed', () => {
     const state = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          left: {axis: 'left', name: 'p200m', channels: 8, volume: 200}
+        instrumentsByMount: {
+          left: {mount: 'left', name: 'p200m', channels: 8, volume: 200}
         }
       },
       calibration: {
         calibrationRequest: {},
-        probedByAxis: {}
+        probedByMount: {}
       }
     })
 
@@ -411,39 +411,39 @@ describe('robot selectors', () => {
   test('get instruments are calibrated', () => {
     const twoPipettesCalibrated = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          left: {name: 'p200', axis: 'left', channels: 8, volume: 200},
-          right: {name: 'p50', axis: 'right', channels: 1, volume: 50}
+        instrumentsByMount: {
+          left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
+          right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
       },
       calibration: {
         calibrationRequest: {},
-        probedByAxis: {left: true, right: true}
+        probedByMount: {left: true, right: true}
       }
     })
 
     const twoPipettesNotCalibrated = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          left: {name: 'p200', axis: 'left', channels: 8, volume: 200},
-          right: {name: 'p50', axis: 'right', channels: 1, volume: 50}
+        instrumentsByMount: {
+          left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
+          right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
       },
       calibration: {
         calibrationRequest: {},
-        probedByAxis: {left: false, right: false}
+        probedByMount: {left: false, right: false}
       }
     })
 
     const onePipetteCalibrated = makeState({
       session: {
-        protocolInstrumentsByAxis: {
-          right: {name: 'p50', axis: 'right', channels: 1, volume: 50}
+        instrumentsByMount: {
+          right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
       },
       calibration: {
         calibrationRequest: {},
-        probedByAxis: {right: true}
+        probedByMount: {right: true}
       }
     })
 
@@ -458,10 +458,10 @@ describe('robot selectors', () => {
     beforeEach(() => {
       state = makeState({
         session: {
-          protocolLabwareBySlot: {
-            1: {id: 'A1', slot: 1, name: 'a1', type: 'a', isTiprack: true},
-            5: {id: 'B2', slot: 5, name: 'b2', type: 'b', isTiprack: false},
-            9: {id: 'C3', slot: 9, name: 'c3', type: 'c', isTiprack: false}
+          labwareBySlot: {
+            1: {id: 'A1', slot: '1', name: 'a1', type: 'a', isTiprack: true},
+            5: {id: 'B2', slot: '5', name: 'b2', type: 'b', isTiprack: false},
+            9: {id: 'C3', slot: '9', name: 'c3', type: 'c', isTiprack: false}
           }
         },
         calibration: {
@@ -480,7 +480,7 @@ describe('robot selectors', () => {
     test('get labware', () => {
       expect(getLabware(state)).toEqual([
         {
-          slot: 1,
+          slot: '1',
           id: 'A1',
           name: 'a1',
           type: 'a',
@@ -488,11 +488,11 @@ describe('robot selectors', () => {
           calibration: constants.UNCONFIRMED,
           confirmed: false
         },
-        {slot: 2},
-        {slot: 3},
-        {slot: 4},
+        {slot: '2'},
+        {slot: '3'},
+        {slot: '4'},
         {
-          slot: 5,
+          slot: '5',
           id: 'B2',
           name: 'b2',
           type: 'b',
@@ -500,11 +500,11 @@ describe('robot selectors', () => {
           calibration: constants.OVER_SLOT,
           confirmed: true
         },
-        {slot: 6},
-        {slot: 7},
-        {slot: 8},
+        {slot: '6'},
+        {slot: '7'},
+        {slot: '8'},
         {
-          slot: 9,
+          slot: '9',
           id: 'C3',
           name: 'c3',
           type: 'c',
@@ -512,15 +512,15 @@ describe('robot selectors', () => {
           calibration: constants.UNCONFIRMED,
           confirmed: false
         },
-        {slot: 10},
-        {slot: 11}
+        {slot: '10'},
+        {slot: '11'}
       ])
     })
 
     test('get unconfirmed tipracks', () => {
       expect(getUnconfirmedTipracks(state)).toEqual([
         {
-          slot: 1,
+          slot: '1',
           id: 'A1',
           name: 'a1',
           type: 'a',
@@ -534,7 +534,7 @@ describe('robot selectors', () => {
     test('get unconfirmed labware', () => {
       expect(getUnconfirmedLabware(state)).toEqual([
         {
-          slot: 1,
+          slot: '1',
           id: 'A1',
           name: 'a1',
           type: 'a',
@@ -543,7 +543,7 @@ describe('robot selectors', () => {
           confirmed: false
         },
         {
-          slot: 9,
+          slot: '9',
           id: 'C3',
           name: 'c3',
           type: 'c',
@@ -556,7 +556,7 @@ describe('robot selectors', () => {
 
     test('get next labware', () => {
       expect(getNextLabware(state)).toEqual({
-        slot: 1,
+        slot: '1',
         id: 'A1',
         name: 'a1',
         type: 'a',
@@ -579,7 +579,7 @@ describe('robot selectors', () => {
       }
 
       expect(getNextLabware(nextState)).toEqual({
-        slot: 9,
+        slot: '9',
         id: 'C3',
         name: 'c3',
         type: 'c',

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -21,8 +21,10 @@ describe('robot reducer - session', () => {
       protocolText: '',
       protocolCommands: [],
       protocolCommandsById: {},
-      protocolInstrumentsByAxis: {},
-      protocolLabwareBySlot: {},
+
+      // deck setup from protocol
+      instrumentsByMount: {},
+      labwareBySlot: {},
 
       // running a protocol
       runRequest: {inProgress: false, error: null},

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,0 +1,79 @@
+// @flow
+// common robot types
+
+export type Channels = 1 | 8
+
+export type Mount = 'left' | 'right'
+
+export type Slot =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+
+// TODO(mc, 2018-01-11): collapse a bunch of these into something like MOVING
+export type LabwareCalibrationStatus =
+  | 'unconfirmed'
+  | 'moving-to-slot'
+  | 'over-slot'
+  | 'picking-up'
+  | 'homing'
+  | 'homed'
+  | 'updating'
+  | 'updated'
+  | 'confirming'
+  | 'confirmed'
+
+// protocol command as returned by the API
+export type Command = {
+  // command identifier
+  id: number,
+  // user readable description of the command
+  description: string,
+  // timestamp of when the command was handled by the robot during a run
+  handledAt: ?number,
+  // subcommands
+  children: number[]
+}
+
+// instrument as returned by the robot API
+export type Instrument = {
+  // resource ID
+  _id: number,
+  // robot mount instrument is installed on
+  mount: Mount,
+  // number of liquid channels
+  channels: Channels,
+  // user-given name of the intrument
+  name: string,
+  // volume of the instrument
+  // TODO(mc, 2018-01-17): this is used to drive tip propbe setup
+  // instructions which is incorrect and needs to be rethought
+  volume: number
+}
+
+// labware as returned by the robot API
+export type Labware = {
+  // resource ID
+  _id: number,
+  // slot labware is installed in
+  slot: Slot,
+  // unique type of the labware
+  type: string,
+  // user defined name of the labware
+  name: string,
+  // A1 style slot ID
+  // TODO(mc, 2018-01-17): deprecate or rename to something less confusing
+  id: string,
+  // whether or not the labware is a tiprack (implied from type)
+  isTiprack: boolean,
+  // intrument mount to use as the calibrator if isTiprack is true
+  calibratorMount: ?Mount
+}

--- a/components/src/structure/PageTabs.js
+++ b/components/src/structure/PageTabs.js
@@ -14,11 +14,11 @@ type TabProps = {
   isDisabled: bool
 }
 
-type Props = {
+export type PageTabProps = {
   pages: Array<TabProps>
 }
 
-export default function PageTabs (props: Props) {
+export default function PageTabs (props: PageTabProps) {
   return (
     <nav className={styles.page_tabs}>
       {props.pages.map((page) => (

--- a/components/src/structure/index.js
+++ b/components/src/structure/index.js
@@ -6,4 +6,7 @@ import VerticalNavBar from './VerticalNavBar'
 import NavButton from './NavButton'
 import SidePanel from './SidePanel'
 
+// types
+export type {PageTabProps} from './PageTabs'
+
 export {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel}


### PR DESCRIPTION
## overview

To help unblock work on #631 and #621, this PR changes the type of `slot` in the app to a string, removes all usage of legacy slot format in the app, and changes remaining instances of `axis` to `mount`.

## changelog

- Refactor: changed type of `slot` to string
- Refactor: renamed all remaining instrument `axis` selectors, props, etc. to `mount`
- Chore: replaced PropTypes with flow in components that I touched where it was easy

## review requests

Please make sure this still runs!