### PR TITLE
Full flow typing for PD 'steplist' module

### DIFF
--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -1,7 +1,10 @@
 // @flow
 import {connect} from 'react-redux'
+import type {Dispatch} from 'redux'
+import type {ActionType} from 'redux-actions'
 
 import {selectors} from '../steplist/reducers'
+import {selectStep, toggleStepCollapsed} from '../steplist/actions'
 import StepList from '../components/StepList'
 
 function mapStateToProps (state) {
@@ -11,10 +14,13 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
+function mapDispatchToProps (dispatch: Dispatch<
+  | ActionType<typeof selectStep>
+  | ActionType<typeof toggleStepCollapsed>
+>) {
   return {
-    handleStepItemClickById: id => e => dispatch({type: 'SELECT_STEP', payload: id}),
-    handleStepItemCollapseToggleById: id => e => dispatch({type: 'TOGGLE_STEP_COLLAPSED', payload: id})
+    handleStepItemClickById: id => e => dispatch(selectStep(id)),
+    handleStepItemCollapseToggleById: id => e => dispatch(toggleStepCollapsed(id))
   }
 }
 

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -1,4 +1,5 @@
 // @flow
+import {createAction} from 'redux-actions'
 import type {
   // Store as ReduxStore,
   Dispatch as ReduxDispatch
@@ -40,7 +41,7 @@ export const addStep = (payload: NewStepPayload) =>
     stepIdCounter += 1
   }
 
-export type ExpandAddStepButtonAction = {
+type ExpandAddStepButtonAction = {
   type: 'EXPAND_ADD_STEP_BUTTON',
   payload: boolean
 }
@@ -50,8 +51,8 @@ export const expandAddStepButton = (payload: boolean): ExpandAddStepButtonAction
   payload
 })
 
-// TODO use action creator!!
-export type ToggleStepCollapsedAction = {
+// TODO use action creator instead of manual dispatch elsewhere!!
+type ToggleStepCollapsedAction = {
   type: 'TOGGLE_STEP_COLLAPSED',
   payload: StepIdType
 }
@@ -61,16 +62,5 @@ export const toggleStepCollapsed = (payload: StepIdType): ToggleStepCollapsedAct
   payload
 })
 
-// TODO use action creator!!
-export type SelectStepAction = {
-  type: 'SELECT_STEP',
-  payload: StepIdType
-}
-
-export const selectStep = (payload: StepIdType): SelectStepAction => ({
-  type: 'SELECT_STEP',
-  payload
-})
-
-// TODO VERY SOON export Actions as union of all action types,
-// use Action here and in reducers.js instead of individual types.
+// TODO use action creator instead of manual dispatch elsewhere!!
+export const selectStep = createAction('SELECT_STEP', (stepId: StepIdType) => stepId)

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -7,7 +7,7 @@ import type {
 import type {StepType, StepIdType} from './types'
 
 // TODO Ian 2018-01-19 import GenericAction from some "general Redux types" file
-type GenericAction = {
+export type GenericAction = {
   type: string,
   payload?: any,
   meta?: any

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -1,14 +1,76 @@
-// addStep thunk adds an incremental integer ID for Step reducers.
-let stepIdCounter = 0
-export const addStep = payload => (dispatch, getState) => {
-  dispatch({
-    type: 'ADD_STEP',
-    payload: {
-      ...payload,
-      id: stepIdCounter
-    }
-  })
-  stepIdCounter += 1
+// @flow
+import type {
+  // Store as ReduxStore,
+  Dispatch as ReduxDispatch
+} from 'redux'
+import type {StepType, StepIdType} from './types'
+
+// TODO Ian 2018-01-19 import GenericAction from some "general Redux types" file
+type GenericAction = {
+  type: string,
+  payload?: any,
+  meta?: any
 }
 
-export const expandAddStepButton = payload => ({type: 'EXPAND_ADD_STEP_BUTTON', payload}) // TODO use action creator helper
+export type AddStepAction = {
+  type: 'ADD_STEP',
+  payload: {
+    id: StepIdType,
+    stepType: StepType
+  }
+}
+
+type NewStepPayload = {
+  stepType: StepType
+}
+
+type StepListState = {}
+
+// addStep thunk adds an incremental integer ID for Step reducers.
+let stepIdCounter = 0
+export const addStep = (payload: NewStepPayload) =>
+  (dispatch: ReduxDispatch<GenericAction>, getState: StepListState) => {
+    dispatch({
+      type: 'ADD_STEP',
+      payload: {
+        ...payload,
+        id: stepIdCounter
+      }
+    })
+    stepIdCounter += 1
+  }
+
+export type ExpandAddStepButtonAction = {
+  type: 'EXPAND_ADD_STEP_BUTTON',
+  payload: boolean
+}
+
+export const expandAddStepButton = (payload: boolean): ExpandAddStepButtonAction => ({
+  type: 'EXPAND_ADD_STEP_BUTTON',
+  payload
+})
+
+// TODO use action creator!!
+export type ToggleStepCollapsedAction = {
+  type: 'TOGGLE_STEP_COLLAPSED',
+  payload: StepIdType
+}
+
+export const toggleStepCollapsed = (payload: StepIdType): ToggleStepCollapsedAction => ({
+  type: 'TOGGLE_STEP_COLLAPSED',
+  payload
+})
+
+// TODO use action creator!!
+export type SelectStepAction = {
+  type: 'SELECT_STEP',
+  payload: StepIdType
+}
+
+export const selectStep = (payload: StepIdType): SelectStepAction => ({
+  type: 'SELECT_STEP',
+  payload
+})
+
+// TODO VERY SOON export Actions as union of all action types,
+// use Action here and in reducers.js instead of individual types.

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -6,13 +6,6 @@ import type {
 } from 'redux'
 import type {StepType, StepIdType} from './types'
 
-// TODO Ian 2018-01-19 import GenericAction from some "general Redux types" file
-export type GenericAction = {
-  type: string,
-  payload?: any,
-  meta?: any
-}
-
 export type AddStepAction = {
   type: 'ADD_STEP',
   payload: {
@@ -30,7 +23,7 @@ type StepListState = {}
 // addStep thunk adds an incremental integer ID for Step reducers.
 let stepIdCounter = 0
 export const addStep = (payload: NewStepPayload) =>
-  (dispatch: ReduxDispatch<GenericAction>, getState: StepListState) => {
+  (dispatch: ReduxDispatch<AddStepAction>, getState: StepListState) => {
     dispatch({
       type: 'ADD_STEP',
       payload: {
@@ -51,7 +44,6 @@ export const expandAddStepButton = (payload: boolean): ExpandAddStepButtonAction
   payload
 })
 
-// TODO use action creator instead of manual dispatch elsewhere!!
 type ToggleStepCollapsedAction = {
   type: 'TOGGLE_STEP_COLLAPSED',
   payload: StepIdType
@@ -62,5 +54,4 @@ export const toggleStepCollapsed = (payload: StepIdType): ToggleStepCollapsedAct
   payload
 })
 
-// TODO use action creator instead of manual dispatch elsewhere!!
 export const selectStep = createAction('SELECT_STEP', (stepId: StepIdType) => stepId)

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -182,7 +182,7 @@ const rootReducer = combineReducers({
   stepCreationButtonExpanded
 })
 
-// TODO: Rethink the hard-coded 'steplist' key in Redux root
+// TODO Ian 2018-01-19 Rethink the hard-coded 'steplist' key in Redux root
 type BaseState = {steplist: RootState}
 const rootSelector = (state: BaseState): RootState => state.steplist
 

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -1,15 +1,12 @@
 // @flow
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
+import type { ActionType } from 'redux-actions'
 import { createSelector } from 'reselect'
 
 import type {StepItemData, StepIdType} from './types'
-import type {
-  AddStepAction,
-  ExpandAddStepButtonAction,
-  ToggleStepCollapsedAction,
-  SelectStepAction
-} from './actions'
+import type {AddStepAction} from './actions' // Thunk action creators
+import {expandAddStepButton, selectStep, toggleStepCollapsed} from './actions'
 
 // TODO move to test
 /*
@@ -138,9 +135,9 @@ const collapsedSteps = handleActions({
     ...state,
     [action.payload.id]: false
   }),
-  TOGGLE_STEP_COLLAPSED: (state: CollapsedStepsState, action: ToggleStepCollapsedAction) => ({
+  TOGGLE_STEP_COLLAPSED: (state: CollapsedStepsState, {payload}: ActionType<typeof toggleStepCollapsed>) => ({
     ...state,
-    [action.payload]: !state[action.payload]
+    [payload]: !state[payload]
   })
 }, {})
 
@@ -155,15 +152,18 @@ type SelectedStepState = null | StepIdType
 
 const selectedStep = handleActions({
   ADD_STEP: (state: SelectedStepState, action: AddStepAction) => action.payload.id,
-  SELECT_STEP: (state: SelectedStepState, action: SelectStepAction) => action.payload
+  SELECT_STEP: (state: SelectedStepState, {payload}: ActionType<typeof selectStep>) => payload
 }, null)
 
 type StepCreationButtonExpandedState = boolean
 
 const stepCreationButtonExpanded = handleActions({
   ADD_STEP: () => false,
-  EXPAND_ADD_STEP_BUTTON: (state: StepCreationButtonExpandedState, action: ExpandAddStepButtonAction) =>
-    action.payload
+  EXPAND_ADD_STEP_BUTTON: (
+    state: StepCreationButtonExpandedState,
+    {payload}: ActionType<typeof expandAddStepButton>
+  ) =>
+    payload
 }, false)
 
 export type RootState = {
@@ -183,17 +183,18 @@ const rootReducer = combineReducers({
 })
 
 // TODO: Rethink the hard-coded 'steplist' key in Redux root
-const rootSelector = (state: {steplist: RootState}) => state.steplist
+type BaseState = {steplist: RootState}
+const rootSelector = (state: BaseState): RootState => state.steplist
 
 export const selectors = {
   stepCreationButtonExpanded: createSelector(
     rootSelector,
-    state => state.stepCreationButtonExpanded
+    (state: RootState) => state.stepCreationButtonExpanded
   ),
   allSteps: createSelector(
-    state => rootSelector(state).steps,
-    state => rootSelector(state).orderedSteps,
-    state => rootSelector(state).collapsedSteps,
+    (state: BaseState) => rootSelector(state).steps,
+    (state: BaseState) => rootSelector(state).orderedSteps,
+    (state: BaseState) => rootSelector(state).collapsedSteps,
     (steps, orderedSteps, collapsedSteps) => orderedSteps.map(id => ({
       ...steps[id],
       collapsed: collapsedSteps[id]
@@ -201,7 +202,7 @@ export const selectors = {
   ),
   selectedStepId: createSelector(
     rootSelector,
-    state => state.selectedStep
+    (state: RootState) => state.selectedStep
   )
 }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -11,6 +11,8 @@ export const stepIconsByType = {
 
 export type StepType = $Keys<typeof stepIconsByType>
 
+export type StepIdType = number
+
 export type StepSubItemData = {
   sourceIngredientName?: string,
   destIngredientName?: string,
@@ -19,7 +21,7 @@ export type StepSubItemData = {
 }
 
 export type StepItemData = {
-  id: number,
+  id: StepIdType,
   title: string,
   stepType: StepType,
   substeps: Array<StepSubItemData>,


### PR DESCRIPTION
## overview

Related to #583 -- I meant to do a few unit tests, but wound up flowifying this module. Jest tests in a smaller PR will finally close the issue.

Since we don't have deep flow coverage of Redux stuff yet in our JS project, this smaller-scope fluxification is an example that we *could* build off of, or could totally change.

Things to notice:
* from `redux-actions` it uses the utility functions `createAction` and `handleActions`. I took advantage of `flow-typed` definitions for `redux-actions`
* typed selectors with `reselect`
* It includes a thunk creator (`addStep`) which has different typing concerns than a normal action creator

## changelog

* add flow types everywhere in `steplist` module of PD
* use new action creator functions instead of manually doing `dispatch({type: 'ADD_STEP', ...stuff})` in `ConnectedStepList` container

## review requests

Generally: do you think these are good patterns I should continue to apply to PD Redux stuff?

What in here is a good approach to typed Redux stuff, and what is scary/verbose/weird?