### PR TITLE
Fix 629 y homing switch avoidance

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -33,6 +33,8 @@ LOW_CURRENT_Z_SPEED = 30
 CURRENT_CHANGE_DELAY = 0.05
 
 Y_SWITCH_BACK_OFF_MM = 20
+Y_BACKOFF_LOW_CURRENT = 0.8
+Y_BACKOFF_SLOW_SPEED = 50
 
 DEFAULT_AXES_SPEED = 150
 
@@ -269,6 +271,21 @@ class SmoothieDriver_3_0_0:
 
             return ret_code
 
+    def _home_x(self):
+        # move the gantry forward on Y axis with low power
+        prior_y_current = float(self._current_settings['Y'])
+        self.set_current({'Y': Y_BACKOFF_LOW_CURRENT})
+        self.set_speed(Y_BACKOFF_SLOW_SPEED)
+
+        # move away from the Y endstop switch
+        target_coord = {'Y': self.position['Y'] - Y_SWITCH_BACK_OFF_MM}
+        self.move(target_coord)
+        self.set_current({'Y': prior_y_current})
+        self.default_speed()
+
+        # now it is safe to home the X axis
+        self._send_command(GCODES['HOME'] + 'X')
+
     def _setup(self):
         self._reset_from_error()
         self._send_command(self._config.acceleration)
@@ -361,22 +378,19 @@ class SmoothieDriver_3_0_0:
                 for group in HOME_SEQUENCE
             ]))
 
-        command = ' '.join([GCODES['HOME'] + axes for axes in home_sequence])
-        self._send_command(command, timeout=30)
-        did_home_y_axis = 'Y' in command
+        for axes in home_sequence:
+            if 'X' in axes:
+                self._home_x()
+            else:
+                command = GCODES['HOME'] + axes
+                self._send_command(command, timeout=30)
 
         # Only update axes that have been selected for homing
         homed = {
             ax: HOMED_POSITION.get(ax)
             for ax in ''.join(home_sequence)
         }
-        if 'Y' in homed:
-            homed['Y'] += Y_SWITCH_BACK_OFF_MM
         self.update_position(default=homed)
-
-        # back-off Y switch 20mm to avoid collisions if we home X afterwards
-        if did_home_y_axis:
-            self.move({'Y': self.position['Y'] - Y_SWITCH_BACK_OFF_MM})
 
         return homed
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -34,22 +34,30 @@ def test_plunger_commands(smoothie, monkeypatch):
         'B': 4,
         'C': 5})
     expected = [
-        ['M907 B0.5 C0.5 M400'],              # Set plunger current high
+        ['M907 B0.5 C0.5 M400'],               # Set plunger current high
         ['G4P0.05 M400'],                      # Dwell
-        ['G28.2[ABCZ]+ G28.2X G28.2Y M400'],  # Home
-        ['M907 B0.1 C0.1 M400'],              # Set plunger current low
+        ['G28.2[ABCZ]+ M400'],                 # Home
+        ['M907 B0.1 C0.1 M400'],               # Set plunger current low
         ['G4P0.05 M400'],                      # Dwell
-        ['M114.2 M400'],                      # Get position
-        ['G0Y-20 M400'],
-        ['G0.+ M400'],                        # Move (non-plunger)
-        ['M907 B0.5 C0.5 M400'],              # Set plunger current high
+        ['M907 Y0.8 M400'],                    # set Y motor to low current
+        ['G4P0.05 M400'],                      # delay for current
+        ['G0F3000 M400'],                      # set Y motor to low speed
+        ['G0Y-20 M400'],                       # move Y motor away from switch
+        ['M907 Y1.5 M400'],                    # set Y back to high current
+        ['G4P0.05 M400'],                      # delay for current
+        ['G0F9000 M400'],                      # set back to default speed
+        ['G28.2X M400'],                       # home X
+        ['G28.2Y M400'],                       # home Y
+        ['M114.2 M400'],                       # Get position
+        ['G0.+ M400'],                         # Move (non-plunger)
+        ['M907 B0.5 C0.5 M400'],               # Set plunger current high
         ['G4P0.05 M400'],                      # Dwell
-        ['G0.+[BC].+ M400'],                  # Move (including BC)
-        ['M907 B0.1 C0.1 M400'],              # Set plunger current low
+        ['G0.+[BC].+ M400'],                   # Move (including BC)
+        ['M907 B0.1 C0.1 M400'],               # Set plunger current low
         ['G4P0.05 M400']                       # Dwell
     ]
-    from pprint import pprint
-    pprint(command_log)
+    # from pprint import pprint
+    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 
@@ -103,7 +111,8 @@ def test_low_current_z(model):
 
 
 def test_fast_home(model):
-    from opentrons.drivers.smoothie_drivers.driver_3_0 import HOMED_POSITION
+    from opentrons.drivers.smoothie_drivers.driver_3_0 import HOMED_POSITION, \
+        Y_SWITCH_BACK_OFF_MM
     import types
     driver = model.robot._driver
 
@@ -115,11 +124,13 @@ def test_fast_home(model):
         coords.append(target)
         move(target)
 
+    target_y = driver.position['Y'] - Y_SWITCH_BACK_OFF_MM
+
     driver.move = types.MethodType(move_mock, driver)
 
     assert coords == []
     driver.fast_home(axis='X', safety_margin=12)
-    assert coords == [{'X': HOMED_POSITION['X'] - 12}]
+    assert coords == [{'X': HOMED_POSITION['X'] - 12}, {'Y': target_y}]
     assert driver.position['X'] == HOMED_POSITION['X']
 
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -40,6 +40,7 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M907 B0.1 C0.1 M400'],              # Set plunger current low
         ['G4P0.05 M400'],                      # Dwell
         ['M114.2 M400'],                      # Get position
+        ['G0Y-20 M400'],
         ['G0.+ M400'],                        # Move (non-plunger)
         ['M907 B0.5 C0.5 M400'],              # Set plunger current high
         ['G4P0.05 M400'],                      # Dwell
@@ -47,8 +48,8 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M907 B0.1 C0.1 M400'],              # Set plunger current low
         ['G4P0.05 M400']                       # Dwell
     ]
-    # from pprint import pprint
-    # pprint(command_log)
+    from pprint import pprint
+    pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

fixes #629 

While homing the `X` axis under some circumstances, the gantry will collide with the `Y` endstop. To avoid this collision, this PR moves the gantry 20 millimeters towards the front of the machine (negative `Y` axis movement) immediately before every `X` home.

This implementation creates the not-so-nice behavior of grinding against the front of machine if the gantry is <20 millimeters away from the front. This has been minimized by setting the current and speed low while performing this `Y` movement.