### PR TITLE
(pd) add Jest tests for steplist reducers

### DIFF
--- a/protocol-designer/src/steplist/index.js
+++ b/protocol-designer/src/steplist/index.js
@@ -1,0 +1,10 @@
+// @flow
+// TODO Ian 2018-01-23 use this index.js for all `steplist` imports across PD
+import rootReducer, {selectors} from './reducers'
+import * as actions from './actions'
+
+export {
+  actions,
+  rootReducer,
+  selectors
+}

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -8,9 +8,9 @@ import type {StepItemData, StepIdType} from './types'
 import type {AddStepAction} from './actions' // Thunk action creators
 import {expandAddStepButton, selectStep, toggleStepCollapsed} from './actions'
 
-// TODO move to test
+// TODO move to test once substeps selector is implemented
 /*
-const initialSteps = {
+{
   0: {
     title: 'Transfer X',
     stepType: 'transfer',
@@ -112,7 +112,7 @@ const initialStepOrder = [0, 2, 3, 4, 5]
 */
 
 // Add default title (and later, other default values) to newly-created Step
-export function createDefaultStep (action: AddStepAction) {
+function createDefaultStep (action: AddStepAction) {
   const {stepType} = action.payload
   return {...action.payload, title: stepType}
 }
@@ -174,13 +174,15 @@ export type RootState = {
   stepCreationButtonExpanded: StepCreationButtonExpandedState
 }
 
-const rootReducer = combineReducers({
+export const _allReducers = {
   steps,
   collapsedSteps,
   orderedSteps,
   selectedStep,
   stepCreationButtonExpanded
-})
+}
+
+const rootReducer = combineReducers(_allReducers)
 
 // TODO Ian 2018-01-19 Rethink the hard-coded 'steplist' key in Redux root
 type BaseState = {steplist: RootState}

--- a/protocol-designer/src/steplist/test/reducers.test.js
+++ b/protocol-designer/src/steplist/test/reducers.test.js
@@ -1,0 +1,178 @@
+// @flow
+import {_allReducers} from '../reducers.js'
+
+const {
+  steps,
+  collapsedSteps,
+  orderedSteps,
+  selectedStep,
+  stepCreationButtonExpanded
+} = _allReducers
+
+describe('steps reducer', () => {
+  test('initial add step', () => {
+    const state = {}
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 123, stepType: 'transfer'}
+    }
+
+    expect(steps(state, action)).toEqual({
+      '123': {
+        id: 123,
+        stepType: 'transfer',
+        title: 'transfer' // title gets added
+      }
+    })
+  })
+
+  test('second add step', () => {
+    const state = {
+      '333': {
+        id: 333,
+        stepType: 'mix',
+        title: 'mix'
+      }
+    }
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 123, stepType: 'transfer'}
+    }
+
+    expect(steps(state, action)).toEqual({
+      '333': {
+        id: 333,
+        stepType: 'mix',
+        title: 'mix'
+      },
+      '123': {
+        id: 123,
+        stepType: 'transfer',
+        title: 'transfer'
+      }
+    })
+  })
+})
+
+describe('collapsedSteps reducer', () => {
+  test('add step', () => {
+    const state = {}
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 1, stepType: 'transfer'}
+    }
+    expect(collapsedSteps(state, action)).toEqual({
+      '1': false // default is false: not collapsed
+    })
+  })
+
+  test('toggle step on->off', () => {
+    const state = {
+      '1': true,
+      '2': false,
+      '3': true,
+      '4': true
+    }
+    const action = {
+      type: 'TOGGLE_STEP_COLLAPSED',
+      payload: 3
+    }
+    expect(collapsedSteps(state, action)).toEqual({
+      '1': true,
+      '2': false,
+      '3': false,
+      '4': true
+    })
+  })
+
+  test('toggle step off-> on', () => {
+    const state = {
+      '1': true,
+      '2': false,
+      '3': true,
+      '4': true
+    }
+    const action = {
+      type: 'TOGGLE_STEP_COLLAPSED',
+      payload: 2
+    }
+    expect(collapsedSteps(state, action)).toEqual({
+      '1': true,
+      '2': true,
+      '3': true,
+      '4': true
+    })
+  })
+})
+
+describe('orderedSteps reducer', () => {
+  test('initial add step', () => {
+    const state = []
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 123, stepType: 'transfer'}
+    }
+    expect(orderedSteps(state, action)).toEqual([123])
+  })
+
+  test('second add step', () => {
+    const state = [123]
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 22, stepType: 'transfer'}
+    }
+    expect(orderedSteps(state, action)).toEqual([123, 22])
+  })
+})
+
+describe('selectedStep reducer', () => {
+  test('select newly added step', () => {
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 123, stepType: 'transfer'}
+    }
+    expect(selectedStep(5, action)).toEqual(123)
+    expect(selectedStep(null, action)).toEqual(123)
+  })
+
+  test('select step action: deselect with null', () => {
+    const action = {
+      type: 'SELECT_STEP',
+      payload: null
+    }
+    expect(selectedStep(123, action)).toEqual(null)
+    expect(selectedStep(null, action)).toEqual(null)
+  })
+
+  test('select step action: select by id', () => {
+    const action = {
+      type: 'SELECT_STEP',
+      payload: 123
+    }
+    expect(selectedStep(5, action)).toEqual(123)
+    expect(selectedStep(null, action)).toEqual(123)
+  })
+})
+
+describe('stepCreationButtonExpanded reducer', () => {
+  test('close (or stay closed) on newly added step', () => {
+    const action = {
+      type: 'ADD_STEP',
+      payload: {id: 123, stepType: 'transfer'}
+    }
+    expect(stepCreationButtonExpanded(true, action)).toEqual(false)
+    expect(stepCreationButtonExpanded(false, action)).toEqual(false)
+  })
+
+  test('update with EXPAND_ADD_STEP_BUTTON action payload', () => {
+    expect(stepCreationButtonExpanded(false, {
+      type: 'EXPAND_ADD_STEP_BUTTON',
+      payload: true
+    })).toEqual(true)
+
+    expect(stepCreationButtonExpanded(true, {
+      type: 'EXPAND_ADD_STEP_BUTTON',
+      payload: false
+    })).toEqual(false)
+  })
+})


### PR DESCRIPTION
closes #583 

## overview

* jest tests for reducers
* Also added `index.js` for future `steplist/` imports (TODO later: `import {actions} from '../steplist'` instead of `import {actions} from '../steplist/actions'` in all imports)

## review requests

We haven't really chatted much about tests. I tried to follow what I saw in the app. How's it look?