### PR TITLE
Remove `repr` from wifi endpoints

### DIFF
--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -16,7 +16,7 @@ async def health(request):
     }
     return web.json_response(
         headers={'Access-Control-Allow-Origin': '*'},
-        body=repr(json.dumps(res)))
+        body=json.dumps(res))
 
 
 async def wifi_list(request):
@@ -43,7 +43,7 @@ async def wifi_list(request):
             splitres = proc.stdout.decode().split("\n")
             ssids = repr(json.dumps([x.split(":")[0] for x in splitres]))
     else:
-        ssids = repr(json.dumps(['a', 'b', 'c']))
+        ssids = json.dumps(['a', 'b', 'c'])
     return web.json_response(
         body=ssids
     )
@@ -114,5 +114,5 @@ async def wifi_status(request):
     else:
         connectivity['status'] = "testing"
     return web.json_response(
-        body=repr(json.dumps(connectivity))
+        body=json.dumps(connectivity)
     )

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -6,7 +6,7 @@ async def test_wifi_status(virtual_smoothie_env, loop, test_client):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    expected = repr(json.dumps({'status': 'testing'}))
+    expected = json.dumps({'status': 'testing'})
     resp = await cli.get('/wifi/status')
     text = await resp.text()
     assert resp.status == 200
@@ -17,7 +17,7 @@ async def test_wifi_list(virtual_smoothie_env, loop, test_client):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    expected = repr(json.dumps(['a', 'b', 'c']))
+    expected = json.dumps(['a', 'b', 'c'])
     resp = await cli.get('/wifi/list')
     text = await resp.text()
     assert resp.status == 200


### PR DESCRIPTION
## overview

Return a json packet NOT wrapped in quote marks. Fixes #646 

## changelog

- (fix) Return json packet not wrapped in quote marks

