### PR TITLE
Add return_tip method to calibration manager

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -79,6 +79,13 @@ class CalibrationManager:
         inst.drop_tip(container._container[0], home_after=True)
         self._set_state('ready')
 
+    def return_tip(self, instrument):
+        inst = instrument._instrument
+        log.debug('Returning tip from {}'.format(instrument.name))
+        self._set_state('moving')
+        inst.return_tip(home_after=True)
+        self._set_state('ready')
+
     def move_to_front(self, instrument):
         inst = instrument._instrument
         log.debug('Moving {}'.format(instrument.name))

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -71,6 +71,16 @@ async def test_drop_tip(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+async def test_return_tip(main_router, model):
+    with mock.patch.object(model.instrument._instrument, 'return_tip') as return_tip:  # NOQA
+        main_router.calibration_manager.return_tip(model.instrument)
+
+        return_tip.assert_called_with(home_after=True)
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
 async def test_home(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'home') as home:
         main_router.calibration_manager.home(


### PR DESCRIPTION
## overview

Expose `return_tip` method in calibration manager. Unblocks #536 

## changelog

- (feature) Add `return_tip` method to calibration manager
