### PR TITLE
(complib) standardize CheckboxField & RadioGroup

### DIFF
--- a/components/src/__tests__/forms.test.js
+++ b/components/src/__tests__/forms.test.js
@@ -27,7 +27,7 @@ describe('CheckboxField', () => {
       <CheckboxField
         label='Check Box 1'
         className='foo'
-        checked
+        value
       />
     ).toJSON()
 
@@ -102,7 +102,7 @@ describe('RadioGroup', () => {
   test('renders correctly with checked value', () => {
     const tree = Renderer.create(
       <RadioGroup
-        checkedValue={'chocolate'}
+        value='chocolate'
         options={[
           {name: 'Hazelnut', value: 'hazelnut'},
           {name: 'Chocolate', value: 'chocolate'},
@@ -117,7 +117,7 @@ describe('RadioGroup', () => {
   test('renders correctly inline', () => {
     const tree = Renderer.create(
       <RadioGroup
-        checkedValue={'chocolate'}
+        value={'chocolate'}
         options={[
           {name: 'Hazelnut', value: 'hazelnut'},
           {name: 'Chocolate', value: 'chocolate'},

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -8,8 +8,8 @@ import styles from './forms.css'
 type Props = {
   /** change handler */
   onChange: (event: SyntheticEvent<>) => void,
-  /** checkbox is checked */
-  checked?: boolean,
+  /** checkbox is checked if value is true */
+  value?: boolean,
   /** classes to apply */
   className?: string,
   /** label text for checkbox */
@@ -20,12 +20,12 @@ export default function CheckboxField (props: Props) {
   return (
     <label className={cx(styles.form_field, props.className)}>
       <div className={styles.checkbox_icon}>
-        <Icon name={props.checked ? 'checked box' : 'unchecked box'} width='100%' />
+        <Icon name={props.value ? 'checked box' : 'unchecked box'} width='100%' />
       </div>
       <input
         className={cx(styles.input_field, styles.accessibly_hidden)}
         type='checkbox'
-        checked={props.checked || false}
+        checked={props.value || false}
         onChange={props.onChange}
       />
       <div className={styles.label_text}>{props.label}</div>

--- a/components/src/forms/CheckboxField.md
+++ b/components/src/forms/CheckboxField.md
@@ -6,13 +6,13 @@ initialState = {isChecked1: true, isChecked2: false}
     label="Check Box 1"
     className="display-block"
     onChange={() => setState({...state, isChecked1: !state.isChecked1})}
-    checked={state.isChecked1}
+    value={state.isChecked1}
   />
   <CheckboxField
     label="Check Box 2"
     className="display-block"
     onChange={() => setState({...state, isChecked2: !state.isChecked2})}
-    checked={state.isChecked2}
+    value={state.isChecked2}
   />
 </div>
 ```

--- a/components/src/forms/RadioGroup.js
+++ b/components/src/forms/RadioGroup.js
@@ -9,7 +9,7 @@ type Props = {
   /* change handler */
   onChange: (event: SyntheticEvent<>) => void,
   /* value that is checked */
-  checkedValue?: string,
+  value?: string,
   /* Array of {name, value} data */
   options?: Array<{
     name: string,
@@ -28,7 +28,7 @@ export default function RadioGroup (props: Props) {
         <label key={radio.value} className={cx(styles.form_field, props.className)}>
           <div className={styles.checkbox_icon}>
             <Icon
-              name={radio.value === props.checkedValue ? 'checked radio' : 'unchecked radio'}
+              name={radio.value === props.value ? 'checked radio' : 'unchecked radio'}
               width='100%'
             />
           </div>
@@ -37,7 +37,7 @@ export default function RadioGroup (props: Props) {
             className={cx(styles.input_field, styles.accessibly_hidden)}
             type='radio'
             value={radio.value}
-            checked={radio.value === props.checkedValue}
+            checked={radio.value === props.value}
             onChange={props.onChange}
           />
           <div className={styles.label_text}>{radio.name}</div>

--- a/components/src/forms/RadioGroup.md
+++ b/components/src/forms/RadioGroup.md
@@ -2,7 +2,7 @@
 initialState = {selectedValue: 'chocolate'}
 
 ;<RadioGroup
-  checkedValue={state.selectedValue}
+  value={state.selectedValue}
   options={[
     {name: 'Hazelnut', value: 'hazelnut'},
     {name: 'Chocolate', value: 'chocolate'},
@@ -18,7 +18,7 @@ Inline
 initialState = {selectedValue: 'chocolate'}
 
 ;<RadioGroup
-  checkedValue={state.selectedValue}
+  value={state.selectedValue}
   options={[
     {name: 'Hazelnut', value: 'hazelnut'},
     {name: 'Chocolate', value: 'chocolate'},

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -37,6 +37,7 @@
 .checkbox_icon {
   /* Icon for radiobutton and for checkbox */
   width: 1.25rem;
+  min-width: 1.25rem;
   fill: var(--c-med-gray);
 }
 


### PR DESCRIPTION
Tiny PR that shouldn't change much, but will help out #659 

## changelog

* `value` prop instead of `checked` / `checkedValue` to match other form fields -- this is initial step to build out form field helpers in react
* updated tests and .md's for CheckboxField & RadioGroup
* fixed CSS CheckboxField problem with shrinking checkbox icon in narrow-width div
