### PR TITLE
Add disabled prop to TitledList and get list styles closer to screens

### DIFF
--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ListAlert list alert renders correctly 1`] = `
 <li
-  className="alert"
+  className="list_alert"
 >
    alert alert
 </li>
@@ -10,11 +10,12 @@ exports[`ListAlert list alert renders correctly 1`] = `
 
 exports[`ListItem renders ListItem with icon correctly 1`] = `
 <li
+  className="list_item disabled"
   onClick={undefined}
 >
   <svg
     aria-hidden="true"
-    className="icon"
+    className="item_icon"
     fill="currentColor"
     height={undefined}
     version="1.1"
@@ -36,6 +37,7 @@ exports[`ListItem renders ListItem with icon correctly 1`] = `
 
 exports[`ListItem renders ListItem without icon correctly 1`] = `
 <li
+  className="list_item disabled"
   onClick={undefined}
 >
   <span
@@ -49,17 +51,17 @@ exports[`TitledList renders TitledList with children correctly 1`] = `
   className=""
 >
   <div
-    className="list_title_bar"
+    className="title_bar"
     onClick={undefined}
   >
     <h3
-      className="list_title"
+      className="title"
     >
       foo
     </h3>
   </div>
   <ol
-    className="titled_list"
+    className="list"
   >
     <li>
       Woop
@@ -73,11 +75,11 @@ exports[`TitledList renders TitledList with optional icon correctly 1`] = `
   className=""
 >
   <div
-    className="list_title_bar"
+    className="title_bar"
     onClick={undefined}
   >
     <h3
-      className="list_title"
+      className="title"
     >
       foo
     </h3>
@@ -90,11 +92,11 @@ exports[`TitledList renders TitledList without icon correctly 1`] = `
   className=""
 >
   <div
-    className="list_title_bar"
+    className="title_bar"
     onClick={undefined}
   >
     <h3
-      className="list_title"
+      className="title"
     >
       foo
     </h3>
@@ -107,19 +109,19 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
   className=""
 >
   <div
-    className="list_title_bar"
+    className="title_bar"
     onClick={undefined}
   >
     <h3
-      className="list_title"
+      className="title"
     />
     <div
-      className="accordion_carat"
+      className="title_bar_carat"
       onClick={[Function]}
     >
       <svg
         aria-hidden="true"
-        className=""
+        className="title_bar_icon"
         fill="currentColor"
         height={undefined}
         version="1.1"
@@ -143,19 +145,19 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
   className=""
 >
   <div
-    className="list_title_bar"
+    className="title_bar"
     onClick={undefined}
   >
     <h3
-      className="list_title"
+      className="title"
     />
     <div
-      className="accordion_carat"
+      className="title_bar_carat"
       onClick={[Function]}
     >
       <svg
         aria-hidden="true"
-        className=""
+        className="title_bar_icon"
         fill="currentColor"
         height={undefined}
         version="1.1"
@@ -175,7 +177,7 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
     Description
   </span>
   <ol
-    className="titled_list"
+    className="list"
   >
     <li>
       1

--- a/components/src/index.css
+++ b/components/src/index.css
@@ -3,3 +3,8 @@
 @import './styles/colors.css';
 @import './styles/typography.css';
 @import './styles/borders.css';
+@import './styles/cursors.css';
+
+:global(*) {
+  box-sizing: border-box;
+}

--- a/components/src/lists/ListAlert.js
+++ b/components/src/lists/ListAlert.js
@@ -1,5 +1,5 @@
 // @flow
-// list alert items
+// ListAlert component to be used as the first child of a TitleList
 import * as React from 'react'
 import classnames from 'classnames'
 import styles from './lists.css'
@@ -15,7 +15,7 @@ type ListAlertProps = {
  * A List item to be used for alerts
  */
 export default function ListAlert (props: ListAlertProps) {
-  const className = classnames(styles.alert, props.className)
+  const className = classnames(styles.list_alert, props.className)
   return (
     <li className={className}>{props.children}</li>
   )

--- a/components/src/lists/ListAlert.md
+++ b/components/src/lists/ListAlert.md
@@ -1,7 +1,9 @@
 ListAlert example:
 
 ```js
-;<TitledList title='List with Alert'>
-  <ListAlert>Warning: something you should know about</ListAlert>
+<TitledList title='List with Alert'>
+  <ListAlert>
+    Warning: something you should know about
+  </ListAlert>
 </TitledList>
 ```

--- a/components/src/lists/ListItem.js
+++ b/components/src/lists/ListItem.js
@@ -1,7 +1,8 @@
 // @flow
-// list components
+// ListItem component to be used as a child of TitledList
 import * as React from 'react'
 import {NavLink} from 'react-router-dom'
+import classnames from 'classnames'
 
 import styles from './lists.css'
 import {type IconName, Icon} from '../icons'
@@ -12,7 +13,7 @@ type ListItemProps = {
   /** if URL is specified, ListItem is wrapped in a React Router NavLink */
   url?: string,
   className?: string,
-  /** if disabled, the NavLink will be disabled */
+  /** if disabled, the onClick handler / NavLink will be disabled */
   isDisabled: boolean,
   /** name constant of the icon to display */
   iconName?: IconName,
@@ -24,8 +25,26 @@ type ListItemProps = {
  *
  */
 export default function ListItem (props: ListItemProps) {
-  const {url, isDisabled, onClick, iconName} = props
-  const itemIcon = iconName && (<Icon className={styles.icon} name={iconName} />)
+  const {url, isDisabled, iconName} = props
+  const onClick = props.onClick && !isDisabled
+    ? props.onClick
+    : undefined
+
+  const className = classnames(props.className, styles.list_item, {
+    [styles.list_item_link]: url,
+    [styles.disabled]: isDisabled,
+    [styles.clickable]: onClick
+  })
+
+  const itemIcon = iconName && (
+    <Icon className={styles.item_icon} name={iconName} />
+  )
+
+  const children = (
+    <span className={styles.info}>
+      {props.children}
+    </span>
+  )
 
   if (url) {
     return (
@@ -34,21 +53,20 @@ export default function ListItem (props: ListItemProps) {
           to={url}
           onClick={onClick}
           disabled={isDisabled}
+          className={className}
           activeClassName={styles.active}
-          >
+        >
           {itemIcon}
-          <span className={styles.info}>{props.children}</span>
+          {children}
         </NavLink>
       </li>
     )
   }
 
   return (
-    <li onClick={onClick}>
+    <li onClick={onClick} className={className}>
       {itemIcon}
-      <span className={styles.info}>
-        {props.children}
-      </span>
+      {children}
     </li>
   )
 }

--- a/components/src/lists/ListItem.md
+++ b/components/src/lists/ListItem.md
@@ -1,11 +1,36 @@
 ListItem example:
 
 ```js
-;<TitledList title='List Title Here'>
-  <ListItem>Plain ListItem</ListItem>
-  <ListItem iconName='flask'>This has an icon</ListItem>
-  {/* <ListItem url='http://www.example.com/'>
-    To use URL prop, you need to be inside a react router Route component
-  </ListItem> */}
+<TitledList title='List Title'>
+  <ListItem>
+    Plain item
+  </ListItem>
+  <ListItem iconName='flask'>
+    This item has an icon
+  </ListItem>
+  <ListItem onClick={() => alert('clicked!')}>
+    This item is clickable
+  </ListItem>
+  <ListItem onClick={() => alert('clicked!')} isDisabled>
+    This clickable item is disabled
+  </ListItem>
 </TitledList>
+```
+
+If the ListItem is passed a `url` prop, it will wrap its children in a `react-router-dom` `NavLink`:
+
+```js
+// <StaticRouter> used here for example purposes
+const {StaticRouter} = require('react-router-dom')
+
+;<StaticRouter>
+  <TitledList title='List Title Here'>
+    <ListItem url='#'>
+      Go somewhere
+    </ListItem>
+    <ListItem url='#' isDisabled>
+      Cannot go here
+    </ListItem>
+  </TitledList>
+</StaticRouter>
 ```

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -1,76 +1,94 @@
 // @flow
-// list components
-
+// TitledList component
 import * as React from 'react'
 import cx from 'classnames'
 
 import styles from './lists.css'
-import styleIndex from '../styles/index.css'
 import {type IconName, Icon, CHEVRON_DOWN, CHEVRON_RIGHT} from '../icons'
 
 type ListProps = {
   /** text of title */
   title: string,
+  /** optional icon left of the title */
+  iconName?: IconName,
+  // TOD(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */
   children?: React.Node,
   /** additional classnames */
   className?: string,
-  /** sets collapsed appearance. List is expanded by default. */
-  collapsed?: boolean,
   /** component with descriptive text about the list */
   description?: React.Node,
-  /** optional icon before h3 */
-  iconName?: IconName,
   /** optional click action (on title div, not children) */
   onClick?: (event: SyntheticEvent<>) => void,
-  /** optional click action (on carat click only, not rest of title div).
-   * If defined, the TitledList is expandable and the carat is visible
-   */
+  /** caret click action; if defined, list is expandable and carat is visible */
   onCollapseToggle?: (event: SyntheticEvent<>) => void,
+  /** collapse the list if true (false by default) */
+  collapsed?: boolean,
   /** highlights the whole TitledList if true */
-  selected?: boolean
+  selected?: boolean,
+  /** disables the whole TitledList if true */
+  disabled?: boolean
 }
 
 /**
  * An ordered list with optional title, icon, and description.
  */
 export default function TitledList (props: ListProps) {
-  const {onCollapseToggle} = props
-  const titleIcon = props.iconName && (<Icon className={styles.list_title_icon} name={props.iconName} />)
-  const collapsible = onCollapseToggle !== undefined
+  const {iconName, disabled, onCollapseToggle} = props
+  const collapsible = onCollapseToggle != null
+
+  const onClick = !disabled
+    ? props.onClick
+    : undefined
 
   // clicking on the carat will not call props.onClick,
   // so prevent bubbling up if there is an onCollapseToggle fn
   const handleCollapseToggle = e => {
-    if (onCollapseToggle) {
+    if (onCollapseToggle && !disabled) {
       e.stopPropagation()
       onCollapseToggle(e)
     }
   }
 
-  const hasValidChildren = React.Children.toArray(props.children).some(child => child)
+  const hasValidChildren = React.Children.toArray(props.children)
+    .some(child => child)
+
+  const className = cx(props.className, {
+    [styles.disabled]: disabled,
+    [styles.titled_list_selected]: !disabled && props.selected
+  })
+
+  const titleBarClass = cx(styles.title_bar, {
+    [styles.clickable]: props.onClick
+  })
 
   return (
-    <div className={cx({[styles.list_selected]: props.selected}, props.className)}>
-      <div onClick={props.onClick}
-        className={cx(styles.list_title_bar, {[styleIndex.clickable]: props.onClick})}
-      >
-        {titleIcon}
-        <h3 className={styles.list_title}>{props.title}</h3>
-        {collapsible &&
-          <div onClick={handleCollapseToggle}
-            className={styles.accordion_carat}
+    <div className={className}>
+      <div onClick={onClick} className={titleBarClass}>
+        {iconName && (
+          <Icon className={styles.title_bar_icon} name={iconName} />
+        )}
+        <h3 className={styles.title}>
+          {props.title}
+        </h3>
+        {collapsible && (
+          <div
+            onClick={handleCollapseToggle}
+            className={styles.title_bar_carat}
           >
-            <Icon name={props.collapsed ? CHEVRON_DOWN : CHEVRON_RIGHT} />
+            <Icon
+              className={styles.title_bar_icon}
+              name={props.collapsed ? CHEVRON_DOWN : CHEVRON_RIGHT}
+            />
           </div>
-        }
+        )}
       </div>
       {!props.collapsed && props.description}
-      {!props.collapsed && hasValidChildren &&
-        <ol className={styles.titled_list}>
+      {!props.collapsed && hasValidChildren && (
+        <ol className={styles.list}>
           {props.children}
         </ol>
-      }
+      )}
     </div>
   )
 }

--- a/components/src/lists/TitledList.md
+++ b/components/src/lists/TitledList.md
@@ -1,7 +1,8 @@
+Basic usage:
+
 ```js
 <TitledList
-  title='TitledList With Icon'
-  onClick={e => window.alert('You clicked the title')}
+  title='Titled List With Icon'
   iconName='flask'
 >
   <ListItem>Something 1</ListItem>
@@ -9,41 +10,47 @@
 </TitledList>
 ```
 
-Selected:
+Using the onClick and selected props:
+
+```js
+initialState = {selected: false}
+
+;<TitledList
+  title='Selectable Titled List'
+  onClick={() => setState({selected: !state.selected})}
+  selected={state.selected}
+>
+  <ListItem>Something 1</ListItem>
+  <ListItem>Something 2</ListItem>
+</TitledList>
+```
+
+If `onCollapseToggle` prop is given a function, the TitledList will be collapsible, dictated by the `collapsed` prop. `onCollapseToggle` will only fire on caret clicks, not title clicks:
+
+```js
+initialState = {selected: false, collapsed: false}
+
+;<TitledList
+  title='Collapsible Titled List'
+  onClick={() => setState({selected: !state.selected})}
+  onCollapseToggle={() => setState({collapsed: !state.collapsed})}
+  selected={state.selected}
+  collapsed={state.collapsed}
+>
+  <ListItem>Something 1</ListItem>
+  <ListItem>Something 2</ListItem>
+</TitledList>
+```
+
+The entire TitledList may be disabled with the `disabled` prop. The `selected` prop will be ignored while the `collapsed` prop will be respected. `onClick` and `onCollapseToggle` will not fire:
 
 ```js
 <TitledList
-  title='Selected TitledList'
+  title='Disabled Titled List'
+  onClick={() => alert("this won't happen")}
+  onCollapseToggle={() => alert("this won't happen")}
   selected
->
-  <ListItem>Something 1</ListItem>
-  <ListItem>Something 2</ListItem>
-</TitledList>
-```
-
-#### If `onCollapseToggle` prop is given a function, the TitledList will be collapsible.
-
-##### Expanded:
-
-```js
-<TitledList
-  title='Collapsible TitledList'
-  onClick={e => window.alert('You clicked the title')}
-  onCollapseToggle={e => window.alert('You clicked collapse/expand')}
->
-  <ListItem>Something 1</ListItem>
-  <ListItem>Something 2</ListItem>
-</TitledList>
-```
-
-##### Collapsed:
-
-```js
-<TitledList
-  title='Collapsible TitledList'
-  onClick={e => window.alert('You clicked the title')}
-  onCollapseToggle={e => window.alert('You clicked collapse/expand')}
-  collapsed
+  disabled
 >
   <ListItem>Something 1</ListItem>
   <ListItem>Something 2</ListItem>

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -1,79 +1,84 @@
 @import '..';
 
-.titled_list {
-  list-style-type: none;
-  margin: 1rem;
-  padding-left: 0;
+:root {
+  --list-padding-large: 1rem;
+  --list-padding-small: 0.75rem;
 }
 
-.list_title_bar {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  color: var(--c-font-dark);
-  text-decoration: none;
-  font-size: var(--fs-body-2);
-  background-color: var(--c-bg-light);
-  height: 3rem;
-  padding-left: 0.5rem;
+.clickable {
+  @apply --clickable;
 }
 
-.list_title_icon {
-  width: 2rem;
-  vertical-align: middle;
-}
-
-.list_title {
-  padding-left: 0.5rem;
-}
-
-div.list_selected {
-  border: 2px solid var(--c-blue);
-}
-
-.accordion_carat {
-  margin-left: auto;
-  margin-right: 1rem;
-}
-
-.accordion_carat svg {
-  height: 2rem;
-  width: 2rem;
-}
-
-/* List Items */
-.titled_list li {
-  margin: 0;
-  border-bottom: 2px solid var(--c-light-gray);
-}
-
-.titled_list a {
-  width: 100%;
-  display: block;
-  height: 3rem;
-  background-color: var(--c-bg-light);
-  font-size: var(--fs-body-1);
-  color: var(--c-font-dark);
-  line-height: 3rem;
-  padding: 0 0.5rem;
-}
-
-a:hover,
-a.active {
-  background-color: var(--c-bg-selected);
-}
-
-a[disabled] {
+.disabled {
   opacity: 0.3;
   pointer-events: none;
 }
 
-.icon {
-  width: 1.5rem;
+.titled_list_selected {
+  border: 2px solid var(--c-blue);
+}
+
+.title_bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  text-decoration: none;
+  padding: var(--list-padding-large) var(--list-padding-small);
+}
+
+.title {
+  @apply --font-body-2-dark;
+
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.title_bar_icon {
+  color: var(--c-font-dark);
   height: 1.5rem;
-  margin: 0.75rem 0.5rem 0 0;
+  margin-right: 0.5rem;
+}
+
+.title_bar_carat {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+.list {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.list_item {
+  @apply --font-body-1-dark;
+
+  display: block;
+  width: 100%;
+  line-height: 1.25;
+  border-bottom: 2px solid var(--c-light-gray);
+  margin: 0;
+  padding: var(--list-padding-small);
+
+  &:hover,
+  &.active {
+    background-color: var(--c-bg-selected-light);
+  }
+}
+
+.list_alert {
+  @apply --font-body-1-dark;
+
+  width: 100%;
+  padding: var(--list-padding-small);
+  background-color: var(--c-bg-light);
+  font-style: italic;
+}
+
+.item_icon {
+  height: calc(1.25 * var(--fs-body-1));
   color: var(--c-dark-gray);
-  align-self: center;
+  padding-right: 0.5rem;
 }
 
 .info {
@@ -83,13 +88,4 @@ a[disabled] {
   justify-content: space-between;
   align-items: center;
   vertical-align: top;
-}
-
-.titled_list li.alert {
-  width: 100%;
-  padding: 0.5rem 1rem;
-  background-color: var(--c-bg-light);
-  font-size: var(--fs-body-1);
-  line-height: 1rem;
-  font-style: italic;
 }

--- a/components/src/structure/navbar.css
+++ b/components/src/structure/navbar.css
@@ -46,5 +46,5 @@ revisit once we have a need for more than one icon aligned to bottom.
   max-width: 100%;
   height: 100%;
   padding: 1.25rem;
-  color: var(---c-med-gray);
+  color: var(--c-med-gray);
 }

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -14,6 +14,7 @@
   --c-bg-dark: #4a4a4a;
   --c-bg-light: #fcfcfc;
   --c-bg-selected: #d1d1d1;
+  --c-bg-selected-light: #f1f1f1;
 
   /* Misc */
   --c-overlay: rgba(0, 0, 0, 0.7);

--- a/components/src/styles/cursors.css
+++ b/components/src/styles/cursors.css
@@ -1,0 +1,11 @@
+/* cursor styling */
+
+:root {
+  --clickable: {
+    cursor: pointer;
+  };
+
+  --click-disabled: {
+    cursor: default;
+  };
+}

--- a/components/styleguide.config.js
+++ b/components/styleguide.config.js
@@ -62,6 +62,9 @@ module.exports = {
   },
   styles: {
     StyleGuide: {
+      '@global body': {
+        fontFamily: "'Open Sans', sans-serif"
+      },
       '@global .display-block': {
         display: 'block'
       },


### PR DESCRIPTION
## overview

This PR closes #654 by adding a `disabled` prop to the `TitledList` component.

While I was touching the TitledList stuff, I touched up the style to get things a little closer to the screens, and I **defaulted the styleguide configuration to sans-serif** :taco:.

Also, I totally named this branch completely wrong. I only noticed right now, though, and I'm too far into writing this pull-request. Anyway, component library review link:

https://s3-us-west-2.amazonaws.com/opentrons-components/app_disable-titled-list/index.html

## changelog

- Feature: add `disabled` prop to TitledList component
- Chore: adjust `lists.css` so that list styles more closely match our library screens

## review requests

Standard review. It looked OK to me but @IanLondon could you double check that my futzing around hasn't messed with PD? Happy to revert the vast majority of the style changes if need be.

@pantslakz and @howisthisnamenottakenyet please check out the review link!
