### PR TITLE
reduces droptip distance on plunger by 3.5mm

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -15,7 +15,7 @@ PLUNGER_POSITIONS = {
     'top': 18.5,
     'bottom': 2,
     'blow_out': 0,
-    'drop_tip': -7
+    'drop_tip': -3.5
 }
 
 DEFAULT_ASPIRATE_SPEED = 20


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Small PR, changes drop_tip plunger position to `-3.5` millimeters (former it was `-7mm`). That addition 3.5mm were previously traveling was creating an internal collision inside the pipette, and breaking them over time.

This new value `-3.5` millimeters, has been running on life-testing machines for a month.


NOTE: the's hard-coded values will eventually need to be auto configured per pipette model