### PR TITLE
Pin docker source image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Use this for local development on intel machines
-# FROM resin/amd64-alpine-python:3.6-slim
+# FROM resin/amd64-alpine-python:3.6-slim-20180123
 
 # Use this for running on a robot
-FROM resin/raspberrypi3-alpine-python:3.6-slim
+FROM resin/raspberrypi3-alpine-python:3.6-slim-20180120
 
 # TODO (artyom, 20171205): remove this and set all relevant environment
 # variables (such as APP_DATA_DIR) explicitly


### PR DESCRIPTION
## overview

Alpine updated in an upstream un-pinned dependency, which included a new build of `busybox` that did not include `inetd`, which in turn broke both our ssh access over ethernet and the "update" endpoint. 

This PR pins the version of our Resin source container to a specific nightly build with the correct version of `busybox`.

## changelog

- Pin version of Resin source Docker container to prevent changes in dependencies, specifically in this case fixing the version of Alpine to 3.6 and busybox to 1.26.2 (the build of busybox v1.27.2 that shipped with Alpine v3.6 does not include inetd, which is required for this project)

## review requests

Tested on moon-moon
