### PR TITLE
containers.create() behavior is non-breaking with documentation, kwar…

### DIFF
--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -75,7 +75,7 @@ def list():
     return database.list_all_containers()
 
 
-def create(name, grid, spacing, diameter, depth, volume, save=False):
+def create(name, grid, spacing, diameter, depth, volume=0, save=False):
     columns, rows = grid
     col_spacing, row_spacing = spacing
     custom_container = Container()

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -42,6 +42,16 @@ def test_containers_create(robot):
     database.delete_container(container_name)
     assert container_name not in containers_list()
 
+    container_name = 'other_plate_for_testing_containers_create'
+    p = containers_create(
+        name=container_name,
+        grid=(8, 12),
+        spacing=(9, 9),
+        diameter=4,
+        depth=8,
+        save=False)
+    assert p['C3'].max_volume() == 0
+
 
 class ContainerTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
…g 'volume' defaults to 0ul; adds test

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

fixes #639 

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->
