### PR TITLE
Calibrate tipracks with inst. that uses them in protocol

### DIFF
--- a/api/tests/opentrons/data/calibration-validation.py
+++ b/api/tests/opentrons/data/calibration-validation.py
@@ -1,0 +1,48 @@
+# validate labware calibration instrument selection
+from opentrons import containers, instruments
+
+trash = containers.load('fixed-trash', '12')
+
+tiprack_s1 = containers.load('tiprack-200ul', '6', label='s1')
+tiprack_s2 = containers.load('tiprack-200ul', '3', label='s2')
+
+tiprack_m1 = containers.load('tiprack-200ul', '4', label='m1')
+tiprack_m2 = containers.load('tiprack-200ul', '1', label='m2')
+
+trough = containers.load('trough-12row', '8')
+plate = containers.load('96-PCR-flat', '5')
+
+multi = instruments.Pipette(
+    name="p200",
+    trash_container=trash,
+    tip_racks=[tiprack_m2, tiprack_m1],
+    mount="left",
+    channels=8
+)
+
+single = instruments.Pipette(
+    name="p200s",
+    trash_container=trash,
+    tip_racks=[tiprack_s2, tiprack_s1],
+    mount="right"
+)
+
+single.pick_up_tip(tiprack_s1[0])
+single.aspirate(25, trough[0])
+single.dispense(25, plate[0])
+single.return_tip()
+
+single.pick_up_tip(tiprack_s2[0])
+single.aspirate(25, trough[0])
+single.dispense(25, plate[0])
+single.return_tip()
+
+multi.pick_up_tip(tiprack_m1[0])
+multi.aspirate(25, trough[0])
+multi.dispense(25, plate[0])
+multi.return_tip()
+
+multi.pick_up_tip(tiprack_m2[0])
+multi.aspirate(25, trough[0])
+multi.dispense(25, plate[0])
+multi.return_tip()

--- a/app/src/components/deck/ConfirmCalibrationButtons.js
+++ b/app/src/components/deck/ConfirmCalibrationButtons.js
@@ -34,13 +34,17 @@ function ConfirmCalibrationButtons (props) {
 
 function mapStateToProps (state, ownProps) {
   const {slot} = ownProps
-  const isTiprack = robotSelectors.getLabwareBySlot(state)[slot].isTiprack
+  const labware = robotSelectors.getLabwareBySlot(state)[slot]
+  const isTiprack = labware.isTiprack
   const props = {isTiprack}
 
   // confirm tiprack action needs the instrument being used for confirmation
   // for now, hardcode this to the single-channel
   if (isTiprack) {
-    props._calibrator = robotSelectors.getCalibratorMount(state)
+    props._calibrator = (
+      labware.calibratorMount ||
+      robotSelectors.getCalibratorMount(state)
+    )
   }
 
   return props

--- a/app/src/components/deck/ConfirmCalibrationPrompt.js
+++ b/app/src/components/deck/ConfirmCalibrationPrompt.js
@@ -12,9 +12,9 @@ import styles from './deck.css'
 import tooltipStyles from '../ToolTip.css'
 
 ConfirmCalibrationPrompt.propTypes = {
-  slot: PropTypes.number.isRequired,
+  slot: PropTypes.string.isRequired,
   currentLabware: PropTypes.shape({
-    slot: PropTypes.number.isRequired,
+    slot: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     isTiprack: PropTypes.bool,
     calibration: robotConstants.LABWARE_CONFIRMATION_TYPE

--- a/app/src/components/deck/NextLabwareLink.js
+++ b/app/src/components/deck/NextLabwareLink.js
@@ -9,9 +9,13 @@ import {
 
 import CalibrationLink from './CalibrationLink'
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
+  const nextLabware = robotSelectors.getNextLabware(state)
+
   return {
-    _calibrator: robotSelectors.getCalibratorMount(state),
+    _calibrator: nextLabware && nextLabware.calibratorMount
+      ? nextLabware.calibratorMount
+      : robotSelectors.getCalibratorMount(state),
     nextLabware: robotSelectors.getNextLabware(state)
   }
 }

--- a/app/src/components/deck/ReviewLabware.js
+++ b/app/src/components/deck/ReviewLabware.js
@@ -9,6 +9,7 @@ import {
 import ReviewPrompt from './ReviewPrompt'
 
 const mapStateToProps = (state, ownProps) => {
+  // TODO(mc, 2018-01-26): getCurrentLabware selector
   const {slot} = ownProps
   const labware = robotSelectors.getLabware(state)
   const currentLabware = labware.find((lab) => lab.slot === slot)
@@ -16,7 +17,10 @@ const mapStateToProps = (state, ownProps) => {
   return {
     currentLabware,
     labware,
-    _calibrator: robotSelectors.getCalibratorMount(state)
+    _calibrator: (
+      currentLabware.calibratorMount ||
+      robotSelectors.getCalibratorMount(state)
+    )
   }
 }
 

--- a/app/src/components/setup-panel/LabwareList.js
+++ b/app/src/components/setup-panel/LabwareList.js
@@ -93,13 +93,15 @@ function mergeProps (stateProps, dispatchProps) {
       isRunning
     )
 
+    const calibrator = lw.calibratorMount || _calibrator
+
     return {
       ...lw,
       isDisabled,
       setLabware: () => {
         if (deckPopulated) {
           if (lw.isTiprack) {
-            return dispatch(robotActions.pickupAndHome(_calibrator, lw.slot))
+            return dispatch(robotActions.pickupAndHome(calibrator, lw.slot))
           }
           dispatch(robotActions.moveTo(_calibrator, lw.slot))
         }

--- a/app/src/containers/ConnectedJogModal.js
+++ b/app/src/containers/ConnectedJogModal.js
@@ -9,12 +9,18 @@ import JogModal from '../components/JogModal'
 
 export default connect(mapStateToProps, null, mergeProps)(JogModal)
 
-function mapStateToProps (state) {
+function mapStateToProps (state, ownProps) {
+  const {slot} = ownProps
+  const currentLabware = robotSelectors.getLabwareBySlot(state)[slot]
+
   return {
     jogDistance: robotSelectors.getJogDistance(state),
     isJogging: robotSelectors.getJogInProgress(state),
     isUpdating: robotSelectors.getOffsetUpdateInProgress(state),
-    _calibrator: robotSelectors.getCalibratorMount(state)
+    _calibrator: (
+      currentLabware.calibratorMount ||
+      robotSelectors.getCalibratorMount(state)
+    )
   }
 }
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -1,5 +1,6 @@
 // robot api client
 // takes a dispatch (send) function and returns a receive handler
+// TODO(mc, 2018-01-26): typecheck with flow
 import {push} from 'react-router-redux'
 
 import RpcClient from '../../rpc/client'
@@ -38,14 +39,14 @@ export default function client (dispatch) {
       case actionTypes.CONNECT: return connect(state, action)
       case actionTypes.DISCONNECT: return disconnect(state, action)
       case actionTypes.SESSION: return createSession(state, action)
-      case actionTypes.PICKUP_AND_HOME: return pickupAndHome(state, action)
-      case actionTypes.DROP_TIP_AND_HOME: return dropTipAndHome(state, action)
-      case actionTypes.CONFIRM_TIPRACK: return confirmTiprack(state, action)
+      case 'robot:PICKUP_AND_HOME': return pickupAndHome(state, action)
+      case 'robot:DROP_TIP_AND_HOME': return dropTipAndHome(state, action)
+      case 'robot:CONFIRM_TIPRACK': return confirmTiprack(state, action)
       case actionTypes.MOVE_TO_FRONT: return moveToFront(state, action)
       case actionTypes.PROBE_TIP: return probeTip(state, action)
       case actionTypes.MOVE_TO: return moveTo(state, action)
       case actionTypes.JOG: return jog(state, action)
-      case actionTypes.UPDATE_OFFSET: return updateOffset(state, action)
+      case 'robot:UPDATE_OFFSET': return updateOffset(state, action)
       case actionTypes.RUN: return run(state, action)
       case actionTypes.PAUSE: return pause(state, action)
       case actionTypes.RESUME: return resume(state, action)
@@ -144,8 +145,8 @@ export default function client (dispatch) {
   }
 
   function pickupAndHome (state, action) {
-    const {payload: {instrument: axis, labware: slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {mount, slot}} = action
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     remote.calibration_manager.pick_up_tip(instrument, labware)
@@ -154,8 +155,8 @@ export default function client (dispatch) {
   }
 
   function dropTipAndHome (state, action) {
-    const {payload: {instrument: axis, labware: slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {mount, slot}} = action
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     remote.calibration_manager.drop_tip(instrument, labware)
@@ -166,12 +167,12 @@ export default function client (dispatch) {
 
   // drop the tip unless the tiprack is the last one to be confirmed
   function confirmTiprack (state, action) {
-    const {payload: {instrument: axis, labware: slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {mount, slot}} = action
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     if (selectors.getUnconfirmedTipracks(state).length === 1) {
-      return dispatch(actions.confirmTiprackResponse())
+      return dispatch(actions.confirmTiprackResponse(null, true))
     }
 
     remote.calibration_manager.drop_tip(instrument, labware)
@@ -220,10 +221,10 @@ export default function client (dispatch) {
   }
 
   function updateOffset (state, action) {
-    const {payload: {instrument: axis, labware: slot}} = action
+    const {payload: {mount, slot}} = action
     const labwareObject = selectors.getLabwareBySlot(state)[slot]
 
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
     const labware = {_id: labwareObject._id}
     const isTiprack = labwareObject.isTiprack || false
 
@@ -361,8 +362,13 @@ export default function client (dispatch) {
     function apiContainerToContainer (apiContainer) {
       const {_id, name, type, slot} = apiContainer
       const isTiprack = RE_TIPRACK.test(type)
+      const labware = {_id, name, slot, type, isTiprack}
 
-      labwareBySlot[slot] = {_id, name, slot, type, isTiprack}
+      if (isTiprack && apiContainer.instruments.length > 0) {
+        labware.calibratorMount = apiContainer.instruments[0].mount
+      }
+
+      labwareBySlot[slot] = labware
     }
   }
 

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -157,23 +157,24 @@ describe('robot actions', () => {
     expect(actions.moveToFrontResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('pick up tip and home action', () => {
+  test('PICKUP_AND_HOME action', () => {
     const action = {
-      type: actionTypes.PICKUP_AND_HOME,
-      payload: {instrument: 'left', labware: '5'},
+      type: 'robot:PICKUP_AND_HOME',
+      payload: {mount: 'left', slot: '5'},
       meta: {robotCommand: true}
     }
 
     expect(actions.pickupAndHome('left', '5')).toEqual(action)
   })
 
-  test('pick up tip and home response action', () => {
+  test('PICKUP_AND_HOME_RESPONSE action', () => {
     const success = {
-      type: actionTypes.PICKUP_AND_HOME_RESPONSE,
-      error: false
+      type: 'robot:PICKUP_AND_HOME_RESPONSE',
+      error: false,
+      payload: {}
     }
     const failure = {
-      type: actionTypes.PICKUP_AND_HOME_RESPONSE,
+      type: 'robot:PICKUP_AND_HOME_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
@@ -182,24 +183,25 @@ describe('robot actions', () => {
     expect(actions.pickupAndHomeResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('drop tip and home action', () => {
+  test('DROP_TIP_AND_HOME action', () => {
     const action = {
-      type: actionTypes.DROP_TIP_AND_HOME,
-      payload: {instrument: 'right', labware: '5'},
+      type: 'robot:DROP_TIP_AND_HOME',
+      payload: {mount: 'right', slot: '5'},
       meta: {robotCommand: true}
     }
 
     expect(actions.dropTipAndHome('right', '5')).toEqual(action)
   })
 
-  test('drop tip and home response action', () => {
+  test('DROP_TIP_AND_HOME_RESPONSE action', () => {
     const success = {
-      type: actionTypes.DROP_TIP_AND_HOME_RESPONSE,
-      error: false
+      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
+      error: false,
+      payload: {}
     }
 
     const failure = {
-      type: actionTypes.DROP_TIP_AND_HOME_RESPONSE,
+      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
@@ -208,29 +210,30 @@ describe('robot actions', () => {
     expect(actions.dropTipAndHomeResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('confirm tiprack action', () => {
+  test('CONFIRM_TIPRACK action', () => {
     const action = {
-      type: actionTypes.CONFIRM_TIPRACK,
-      payload: {instrument: 'left', labware: '9'},
+      type: 'robot:CONFIRM_TIPRACK',
+      payload: {mount: 'left', slot: '9'},
       meta: {robotCommand: true}
     }
 
     expect(actions.confirmTiprack('left', '9')).toEqual(action)
   })
 
-  test('confirm tiprack response action', () => {
+  test('CONFIRM_TIPRACK_RESPONSE action', () => {
     const success = {
-      type: actionTypes.CONFIRM_TIPRACK_RESPONSE,
-      error: false
+      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
+      error: false,
+      payload: {tipOn: true}
     }
 
     const failure = {
-      type: actionTypes.CONFIRM_TIPRACK_RESPONSE,
+      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
 
-    expect(actions.confirmTiprackResponse()).toEqual(success)
+    expect(actions.confirmTiprackResponse(null, true)).toEqual(success)
     expect(actions.confirmTiprackResponse(new Error('AH'))).toEqual(failure)
   })
 
@@ -324,24 +327,24 @@ describe('robot actions', () => {
     expect(actions.jogResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('update offset action', () => {
+  test('UPDATE_OFFSET action', () => {
     const expected = {
-      type: actionTypes.UPDATE_OFFSET,
-      payload: {instrument: 'left', labware: '2'},
+      type: 'robot:UPDATE_OFFSET',
+      payload: {mount: 'left', slot: '2'},
       meta: {robotCommand: true}
     }
 
     expect(actions.updateOffset('left', '2')).toEqual(expected)
   })
 
-  test('update offset response action', () => {
+  test('UPDATE_OFFSET_RESPONSE action', () => {
     const success = {
-      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      type: 'robot:UPDATE_OFFSET_RESPONSE',
       error: false,
       payload: {isTiprack: true}
     }
     const failure = {
-      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      type: 'robot:UPDATE_OFFSET_RESPONSE',
       error: true,
       payload: new Error('AH')
     }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -280,14 +280,27 @@ describe('api client', () => {
     test('maps api containers to labware by slot', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
         labwareBySlot: {
-          1: {_id: 1, slot: '1', name: 'a', type: 'tiprack', isTiprack: true},
+          1: {
+            _id: 1,
+            slot: '1',
+            name: 'a',
+            type: 'tiprack',
+            isTiprack: true,
+            calibratorMount: 'right'
+          },
           5: {_id: 2, slot: '5', name: 'b', type: 'B', isTiprack: false},
           9: {_id: 3, slot: '9', name: 'c', type: 'C', isTiprack: false}
         }
       }))
 
       session.containers = [
-        {_id: 1, slot: '1', name: 'a', type: 'tiprack'},
+        {
+          _id: 1,
+          slot: '1',
+          name: 'a',
+          type: 'tiprack',
+          instruments: [{mount: 'right'}]
+        },
         {_id: 2, slot: '5', name: 'b', type: 'B'},
         {_id: 3, slot: '9', name: 'c', type: 'C'}
       ]
@@ -377,7 +390,7 @@ describe('api client', () => {
     })
 
     test('handles MOVE_TO success', () => {
-      const action = actions.moveTo('left', 5)
+      const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse()
 
       calibrationManager.move_to.mockReturnValue(Promise.resolve())
@@ -392,7 +405,7 @@ describe('api client', () => {
     })
 
     test('handles MOVE_TO failure', () => {
-      const action = actions.moveTo('left', 5)
+      const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse(new Error('AH'))
 
       calibrationManager.move_to
@@ -404,7 +417,7 @@ describe('api client', () => {
     })
 
     test('handles PICKUP_AND_HOME success', () => {
-      const action = actions.pickupAndHome('left', 5)
+      const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse()
 
       calibrationManager.pick_up_tip.mockReturnValue(Promise.resolve())
@@ -420,7 +433,7 @@ describe('api client', () => {
     })
 
     test('handles PICKUP_AND_HOME failure during pickup', () => {
-      const action = actions.pickupAndHome('left', 5)
+      const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse(new Error('AH'))
 
       calibrationManager.pick_up_tip
@@ -432,7 +445,7 @@ describe('api client', () => {
     })
 
     test('handles DROP_TIP_AND_HOME success', () => {
-      const action = actions.dropTipAndHome('right', 9)
+      const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse()
 
       calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
@@ -449,7 +462,7 @@ describe('api client', () => {
     })
 
     test('handles DROP_TIP_AND_HOME failure in drop_tip', () => {
-      const action = actions.dropTipAndHome('right', 9)
+      const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
       calibrationManager.drop_tip
@@ -461,7 +474,7 @@ describe('api client', () => {
     })
 
     test('handles DROP_TIP_AND_HOME failure in home', () => {
-      const action = actions.dropTipAndHome('right', 9)
+      const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
       calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
@@ -473,7 +486,7 @@ describe('api client', () => {
     })
 
     test('CONFIRM_TIPRACK drops tip if not last tiprack', () => {
-      const action = actions.confirmTiprack('left', 9)
+      const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse()
 
       calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
@@ -487,11 +500,11 @@ describe('api client', () => {
         })
     })
 
-    test('CONFIRM_TIPRACK noops if last tiprack', () => {
+    test('CONFIRM_TIPRACK noops and keeps tip if last tiprack', () => {
       state[NAME].calibration.confirmedBySlot[5] = true
 
-      const action = actions.confirmTiprack('left', 9)
-      const expectedResponse = actions.confirmTiprackResponse()
+      const action = actions.confirmTiprack('left', '9')
+      const expectedResponse = actions.confirmTiprackResponse(null, true)
 
       calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
 
@@ -504,7 +517,7 @@ describe('api client', () => {
     })
 
     test('handles CONFIRM_TIPRACK drop tip failure', () => {
-      const action = actions.confirmTiprack('left', 9)
+      const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse(new Error('AH'))
 
       calibrationManager.drop_tip

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -9,7 +9,10 @@ describe('robot reducer - calibration', () => {
       deckPopulated: true,
       jogDistance: constants.JOG_DISTANCE_SLOW_MM,
 
+      // intrument probed + basic tip-tracking state
+      // TODO(mc, 2018-01-22): combine these into subreducer
       probedByMount: {},
+      tipOnByMount: {},
 
       // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
       // slot. confirmedBySlot holds a flag for whether the labware has been
@@ -17,12 +20,10 @@ describe('robot reducer - calibration', () => {
       labwareBySlot: {},
       confirmedBySlot: {},
 
-      calibrationRequest: {type: '', inProgress: false, mount: '', error: null},
+      // TODO(mc, 2018-01-22): make this state a sub-reducer
+      calibrationRequest: {type: '', inProgress: false, error: null},
 
       // TODO(mc, 2018-01-10): collapse all these into calibrationRequest
-      pickupRequest: {inProgress: false, error: null, slot: ''},
-      homeRequest: {inProgress: false, error: null, slot: ''},
-      confirmTiprackRequest: {inProgress: false, error: null, slot: ''},
       moveToRequest: {inProgress: false, error: null},
       jogRequest: {inProgress: false, error: null},
       updateOffsetRequest: {inProgress: false, error: null}
@@ -74,18 +75,28 @@ describe('robot reducer - calibration', () => {
     const state = {
       calibration: {
         deckPopulated: false,
-        pickupRequest: {inProgress: false, error: new Error(), slot: ''},
+        calibrationRequest: {
+          type: '',
+          inProgress: false,
+          error: new Error()
+        },
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
 
     const action = {
-      type: actionTypes.PICKUP_AND_HOME,
-      payload: {instrument: 'left', labware: '5'}
+      type: 'robot:PICKUP_AND_HOME',
+      payload: {mount: 'left', slot: '5'}
     }
     expect(reducer(state, action).calibration).toEqual({
       deckPopulated: true,
-      pickupRequest: {inProgress: true, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'PICKUP_AND_HOME',
+        mount: 'left',
+        slot: '5',
+        inProgress: true,
+        error: null
+      },
       labwareBySlot: {5: constants.PICKING_UP}
     })
   })
@@ -93,26 +104,51 @@ describe('robot reducer - calibration', () => {
   test('handles PICKUP_AND_HOME_RESPONSE action', () => {
     const state = {
       calibration: {
-        pickupRequest: {inProgress: true, error: null, slot: '5'},
+        calibrationRequest: {
+          type: 'PICKUP_AND_HOME',
+          mount: 'left',
+          slot: '5',
+          inProgress: true,
+          error: null
+        },
+        tipOnByMount: {right: false},
         labwareBySlot: {5: constants.PICKING_UP}
       }
     }
 
-    const success = {type: actionTypes.PICKUP_AND_HOME_RESPONSE}
+    const success = {
+      type: 'robot:PICKUP_AND_HOME_RESPONSE',
+      error: false,
+      payload: {}
+    }
 
     const failure = {
-      type: actionTypes.PICKUP_AND_HOME_RESPONSE,
+      type: 'robot:PICKUP_AND_HOME_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      pickupRequest: {inProgress: false, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'PICKUP_AND_HOME',
+        mount: 'left',
+        slot: '5',
+        inProgress: false,
+        error: null
+      },
+      tipOnByMount: {left: true, right: false},
       labwareBySlot: {5: constants.HOMED}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
-      pickupRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
+      calibrationRequest: {
+        type: 'PICKUP_AND_HOME',
+        mount: 'left',
+        slot: '5',
+        inProgress: false,
+        error: new Error('AH')
+      },
+      tipOnByMount: {left: false, right: false},
       labwareBySlot: {5: constants.UNCONFIRMED}
     })
   })
@@ -120,17 +156,27 @@ describe('robot reducer - calibration', () => {
   test('handles DROP_TIP_AND_HOME action', () => {
     const state = {
       calibration: {
-        homeRequest: {inProgress: false, error: new Error('AH'), slot: ''},
+        calibrationRequest: {
+          type: '',
+          inProgress: false,
+          error: new Error('AH')
+        },
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
     const action = {
-      type: actionTypes.DROP_TIP_AND_HOME,
-      payload: {instrument: 'right', labware: '5'}
+      type: 'robot:DROP_TIP_AND_HOME',
+      payload: {mount: 'right', slot: '5'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
-      homeRequest: {inProgress: true, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'DROP_TIP_AND_HOME',
+        mount: 'right',
+        slot: '5',
+        inProgress: true,
+        error: null
+      },
       labwareBySlot: {5: constants.HOMING}
     })
   })
@@ -138,26 +184,51 @@ describe('robot reducer - calibration', () => {
   test('handles DROP_TIP_AND_HOME_RESPONSE action', () => {
     const state = {
       calibration: {
-        homeRequest: {inProgress: true, error: null, slot: '5'},
+        calibrationRequest: {
+          type: 'DROP_TIP_AND_HOME',
+          mount: 'right',
+          slot: '5',
+          inProgress: true,
+          error: null
+        },
+        tipOnByMount: {left: false, right: true},
         labwareBySlot: {5: constants.HOMING}
       }
     }
 
-    const success = {type: actionTypes.DROP_TIP_AND_HOME_RESPONSE}
+    const success = {
+      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
+      error: false,
+      payload: {}
+    }
 
     const failure = {
-      type: actionTypes.DROP_TIP_AND_HOME_RESPONSE,
+      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      homeRequest: {inProgress: false, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'DROP_TIP_AND_HOME',
+        mount: 'right',
+        slot: '5',
+        inProgress: false,
+        error: null
+      },
+      tipOnByMount: {left: false, right: false},
       labwareBySlot: {5: constants.HOMED}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
-      homeRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
+      calibrationRequest: {
+        type: 'DROP_TIP_AND_HOME',
+        mount: 'right',
+        slot: '5',
+        inProgress: false,
+        error: new Error('AH')
+      },
+      tipOnByMount: {left: false, right: true},
       labwareBySlot: {5: constants.UNCONFIRMED}
     })
   })
@@ -165,21 +236,29 @@ describe('robot reducer - calibration', () => {
   test('handles CONFIRM_TIPRACK action', () => {
     const state = {
       calibration: {
-        confirmTiprackRequest: {
+        calibrationRequest: {
+          type: '',
+          mount: 'right',
+          slot: '5',
           inProgress: false,
-          error: new Error('AH'),
-          slot: ''
+          error: new Error('AH')
         },
         labwareBySlot: {5: constants.UNCONFIRMED}
       }
     }
     const action = {
-      type: actionTypes.CONFIRM_TIPRACK,
-      payload: {instrument: 'right', labware: '5'}
+      type: 'robot:CONFIRM_TIPRACK',
+      payload: {mount: 'right', slot: '5'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
-      confirmTiprackRequest: {inProgress: true, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'CONFIRM_TIPRACK',
+        inProgress: true,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      },
       labwareBySlot: {5: constants.CONFIRMING}
     })
   })
@@ -187,32 +266,53 @@ describe('robot reducer - calibration', () => {
   test('handles CONFIRM_TIPRACK_RESPONSE action', () => {
     const state = {
       calibration: {
-        confirmTiprackRequest: {inProgress: true, error: null, slot: '5'},
+        calibrationRequest: {
+          type: 'CONFIRM_TIPRACK',
+          inProgress: true,
+          error: null,
+          mount: 'right',
+          slot: '5'
+        },
+        tipOnByMount: {right: true},
         labwareBySlot: {5: constants.CONFIRMING},
         confirmedBySlot: {5: false}
       }
     }
 
-    const success = {type: actionTypes.CONFIRM_TIPRACK_RESPONSE}
+    const success = {
+      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
+      error: false,
+      payload: {tipOn: false}
+    }
 
     const failure = {
-      type: actionTypes.CONFIRM_TIPRACK_RESPONSE,
+      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      confirmTiprackRequest: {inProgress: false, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'CONFIRM_TIPRACK',
+        inProgress: false,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      },
+      tipOnByMount: {right: false},
       labwareBySlot: {5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
-      confirmTiprackRequest: {
+      calibrationRequest: {
+        type: 'CONFIRM_TIPRACK',
         inProgress: false,
         error: new Error('AH'),
+        mount: 'right',
         slot: '5'
       },
+      tipOnByMount: {right: true},
       labwareBySlot: {5: constants.UNCONFIRMED},
       confirmedBySlot: {5: false}
     })
@@ -455,14 +555,27 @@ describe('robot reducer - calibration', () => {
   test('handles UPDATE_OFFSET action', () => {
     const state = {
       calibration: {
-        updateOffsetRequest: {inProgress: false, error: new Error()},
+        calibrationRequest: {
+          type: '',
+          inProgress: false,
+          error: new Error()
+        },
         labwareBySlot: {}
       }
     }
-    const action = {type: actionTypes.UPDATE_OFFSET, payload: {labware: '5'}}
+    const action = {
+      type: 'robot:UPDATE_OFFSET',
+      payload: {mount: 'right', slot: '5'}
+    }
 
     expect(reducer(state, action).calibration).toEqual({
-      updateOffsetRequest: {inProgress: true, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'UPDATE_OFFSET',
+        inProgress: true,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      },
       labwareBySlot: {5: constants.UPDATING}
     })
   })
@@ -470,40 +583,68 @@ describe('robot reducer - calibration', () => {
   test('handles UPDATE_OFFSET_RESPONSE action', () => {
     const state = {
       calibration: {
-        updateOffsetRequest: {inProgress: true, error: null, slot: '5'},
+        calibrationRequest: {
+          type: 'UPDATE_OFFSET',
+          inProgress: true,
+          error: null,
+          mount: 'right',
+          slot: '5'
+        },
+        tipOnByMount: {},
         labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATING},
         confirmedBySlot: {}
       }
     }
 
     const successNonTiprack = {
-      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      type: 'robot:UPDATE_OFFSET_RESPONSE',
       error: false,
       payload: {isTiprack: false}
     }
     const successTiprack = {
-      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      type: 'robot:UPDATE_OFFSET_RESPONSE',
       error: false,
       payload: {isTiprack: true}
     }
     const failure = {
-      type: actionTypes.UPDATE_OFFSET_RESPONSE,
+      type: 'robot:UPDATE_OFFSET_RESPONSE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, successNonTiprack).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'UPDATE_OFFSET',
+        inProgress: false,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      },
+      tipOnByMount: {},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
     expect(reducer(state, successTiprack).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: null, slot: '5'},
+      calibrationRequest: {
+        type: 'UPDATE_OFFSET',
+        inProgress: false,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      },
+      tipOnByMount: {right: true},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATED},
       confirmedBySlot: {}
     })
     expect(reducer(state, failure).calibration).toEqual({
-      updateOffsetRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
+      calibrationRequest: {
+        type: 'UPDATE_OFFSET',
+        inProgress: false,
+        error: new Error('AH'),
+        mount: 'right',
+        slot: '5'
+      },
+      tipOnByMount: {},
       labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED},
       confirmedBySlot: {5: false}
     })

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -95,9 +95,6 @@ export type Labware = {
   type: string,
   // user defined name of the labware
   name: string,
-  // A1 style slot ID
-  // TODO(mc, 2018-01-17): deprecate or rename to something less confusing
-  id: string,
   // whether or not the labware is a tiprack (implied from type)
   isTiprack: boolean,
   // intrument mount to use as the calibrator if isTiprack is true


### PR DESCRIPTION
## overview

First off: I'm sorry. This PR is too big. In hindsight:

- Adding flow typings and the required functionality changes in one PR wasn't necessary
- The functionality changes themselves could've been accomplished in two PRs
- Our request/response actions aren't well suited to flow and will need to be changed

Anyway, this PR closes #621 by using the following procedure to select a "calibrator":

- Tipracks will be calibrated by whichever pipette uses that tiprack
- Non-tipracks will be calibrated by whichever pipette still has a tip on it after tiprack calibration

## changelog

- Added pipette usage from API session response to tiprack state
- Added tip tracking to pipettes during tiprack calibration
- Refactored containers to use pipette from tiprack state as calibrator if it exists
- Refactored get calibrator selector to return whichever pipette has a tip on
- Updated unit tests accordingly
- Added `calibration-validation.py` protocol for manual e2e testing of new functionality

## review requests

This PR has been tested in virtual smoothie and on mike-bot.

@IanLondon and @Kadee80 let me know if it'll be helpful to have an in person walkthrough of this review. Also, GH is hiding the diffs on the calibration reducer + tests because they're "large". Sorry.
