### PR TITLE
Error if pipette mount already occupied

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -348,6 +348,10 @@ class Robot(object):
         This will create a pipette and call :func:`add_instrument`
         to attach the instrument.
         """
+        if mount in self._instruments:
+            prev_instr = self._instruments[mount]
+            raise RuntimeError('Instrument {0} already on {1} mount'.format(
+                prev_instr.name, mount))
         self._instruments[mount] = instrument
         instrument.instrument_actuator = self._actuators[mount]['plunger']
         instrument.instrument_mover = self._actuators[mount]['carriage']

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -143,6 +143,11 @@ class PipetteTest(unittest.TestCase):
     def test_bad_volume_percentage(self):
         self.assertRaises(RuntimeError, self.p200._volume_percentage, -1)
 
+    def test_add_instrument(self):
+        self.robot.reset()
+        Pipette(self.robot, mount='left')
+        self.assertRaises(RuntimeError, Pipette, self.robot, mount='left')
+
     def test_aspirate_zero_volume(self):
         assert self.robot.commands() == []
         self.p200.tip_attached = True
@@ -168,7 +173,7 @@ class PipetteTest(unittest.TestCase):
         warnings.filterwarnings('error')
         self.assertRaises(UserWarning, self.p200.set_max_volume, 200)
         self.assertRaises(
-            UserWarning, Pipette, self.robot, mount='left', max_volume=200)
+            UserWarning, Pipette, self.robot, mount='right', max_volume=200)
         warnings.filterwarnings('default')
 
     # TODO: (artyom, 20171101): bring back once plunger position is being tracked
@@ -400,7 +405,7 @@ class PipetteTest(unittest.TestCase):
 
     def test_set_flow_rate(self):
         ul_per_mm = 20
-        self.p200 = Pipette(self.robot, mount='left', ul_per_mm=ul_per_mm)
+        self.p200 = Pipette(self.robot, mount='right', ul_per_mm=ul_per_mm)
 
         self.p200.set_flow_rate(aspirate=100)
         expected_mm_per_sec = 100 / ul_per_mm


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

A bug was found (fixes #660 ) which results in pipettes moving strangely. To recreate, you create a protocol which uses a pipette that has been overwritten by the robot.

```python
p1 = instruments.Pipette(mount='left')
p2= instruments.Pipette(mount='left')
p1.pick_up_tip().aspirate().dispense().return_tip()
```
SOLUTION: Raise a `RuntimeError` if a pipette is attempting to attach to an already occupied mount, resulting in the following:

```python

p1 = instruments.Pipette(mount='left')
# protocol execution stops during below line, because of exception raised
p2 = instruments.Pipette(mount='left')
p1.pick_up_tip().aspirate().dispense().return_tip()
```

