### PR TITLE
Add OutlineButton and IconButton components

### DIFF
--- a/app/src/components/connect-panel/ScanButton.js
+++ b/app/src/components/connect-panel/ScanButton.js
@@ -1,28 +1,33 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Button from '../Button'
-import Icon, {REFRESH} from '../Icon'
+// @flow
+import * as React from 'react'
+import {IconButton, REFRESH, SPINNER} from '@opentrons/components'
 
 import styles from './connect-panel.css'
 
-ScanButton.propTypes = {
-  onScanClick: PropTypes.func.isRequired,
-  titleBtn: PropTypes.bool
+type Props = {
+  isScanning: boolean,
+  onScanClick: () => void,
+  inTitleBar?: boolean
 }
 
-export default function ScanButton (props) {
-  const {onScanClick, titleBtn} = props
-  const style = titleBtn
-    ? styles.title_button
+export default function ScanButton (props: Props) {
+  const {isScanning} = props
+  const iconName = isScanning
+    ? SPINNER
+    : REFRESH
+
+  const className = props.inTitleBar
+    ? styles.title_scan_button
     : styles.scan_button
 
   return (
-    <Button
-      style={style}
-      onClick={onScanClick}
+    <IconButton
       title='Scan for robots'
-    >
-      <Icon name={REFRESH} className={styles.refresh} />
-    </Button>
+      onClick={props.onScanClick}
+      className={className}
+      name={iconName}
+      spin={isScanning}
+      disabled={isScanning}
+    />
   )
 }

--- a/app/src/components/connect-panel/ScanStatus.js
+++ b/app/src/components/connect-panel/ScanStatus.js
@@ -1,18 +1,17 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+// @flow
+import * as React from 'react'
 
-import {Spinner} from '../icons'
 import ScanButton from './ScanButton'
 
 import styles from './connect-panel.css'
 
-ScanStatus.propTypes = {
-  onScanClick: PropTypes.func.isRequired,
-  isScanning: PropTypes.bool.isRequired,
-  found: PropTypes.bool.isRequired
+type Props = {
+  onScanClick: () => void,
+  isScanning: boolean,
+  found: boolean
 }
 
-export default function ScanStatus (props) {
+export default function ScanStatus (props: Props) {
   const {found, isScanning} = props
 
   const notFoundMessage = !isScanning && !found && (
@@ -21,14 +20,11 @@ export default function ScanStatus (props) {
       <p>Connect a robot via USB and click the scan button</p>
     </div>
   )
-  const scanBtn = !isScanning
-    ? <ScanButton {...props} />
-    : <Spinner className={styles.scan_button} />
 
   return (
     <div className={styles.scan_status}>
       {notFoundMessage}
-      {scanBtn}
+      <ScanButton {...props} />
     </div>
   )
 }

--- a/app/src/components/connect-panel/connect-panel.css
+++ b/app/src/components/connect-panel/connect-panel.css
@@ -49,12 +49,7 @@
 }
 
 .scan_button {
-  display: block;
   width: 5rem;
-  height: auto;
-  font-size: 5rem;
-  line-height: 1;
-  margin: 0.5rem auto;
 }
 
 .refresh {
@@ -65,13 +60,10 @@
   color: #888;
 }
 
-.title_button {
+.title_scan_button {
   position: absolute;
-  right: 2rem;
-  top: -0.25rem;
-  width: 2.25rem;
-  height: 2.25rem;
-  padding: 0.5rem;
-  line-height: 0.5;
-  cursor: pointer;
+  top: 0;
+  right: 2.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
 }

--- a/app/src/components/connect-panel/index.js
+++ b/app/src/components/connect-panel/index.js
@@ -16,7 +16,7 @@ export default connect(mapStateToProps, null, mergeProps)(ConnectPanel)
 function ConnectPanel (props) {
   return (
     <div>
-      <ScanButton {...props} titleBtn />
+      <ScanButton {...props} inTitleBar />
       <RobotList>
         {props.robots.map((robot) => (
           <RobotItem key={robot.name} {...robot} />

--- a/components/.babelrc
+++ b/components/.babelrc
@@ -6,6 +6,9 @@
       ]
     }
   },
+  "plugins": [
+    "transform-object-rest-spread"
+  ],
   "presets": [
     "react",
     ["env", {"modules": false}]

--- a/components/package.json
+++ b/components/package.json
@@ -60,6 +60,7 @@
     "babel-eslint": "8.0.3",
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",

--- a/components/src/__tests__/__snapshots__/buttons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/buttons.test.js.snap
@@ -20,7 +20,7 @@ exports[`buttons Button with iconName renders correctly 1`] = `
 >
   <svg
     aria-hidden="true"
-    className="button_icon"
+    className="icon"
     fill="currentColor"
     height={undefined}
     version="1.1"
@@ -58,7 +58,71 @@ exports[`buttons FlatButton with iconName renders correctly 1`] = `
 >
   <svg
     aria-hidden="true"
-    className="button_icon"
+    className="icon"
+    fill="currentColor"
+    height={undefined}
+    version="1.1"
+    viewBox="0 0 24 24"
+    width={undefined}
+    x={undefined}
+    y={undefined}
+  >
+    <path
+      d="M2.44444444,20.4 C2.44444444,21.0627417 2.99165197,21.6 3.66666667,21.6 L18.3333333,21.6 C19.008348,21.6 19.5555556,21.0627417 19.5555556,20.4 C19.5555556,20.148 19.47,19.908 19.3355556,19.716 L12.2222222,7.62 L12.2222222,2.4 L9.77777778,2.4 L9.77777778,7.62 L2.66444444,19.716 C2.53,19.908 2.44444444,20.148 2.44444444,20.4 Z M3.66666667,24 C1.64162258,24 0,22.3882251 0,20.4 C0,19.68 0.22,19.008 0.611111111,18.444 L7.33333333,6.972 L7.33333333,4.8 C6.65831864,4.8 6.11111111,4.2627417 6.11111111,3.6 L6.11111111,2.4 C6.11111111,1.0745166 7.20552617,0 8.55555556,0 L13.4444444,0 C14.7944738,0 15.8888889,1.0745166 15.8888889,2.4 L15.8888889,3.6 C15.8888889,4.2627417 15.3416814,4.8 14.6666667,4.8 L14.6666667,6.972 L21.3888889,18.444 C21.78,19.008 22,19.68 22,20.4 C22,22.3882251 20.3583774,24 18.3333333,24 L3.66666667,24 Z M12.2222222,16.8 L13.86,15.192 L16.2188889,19.2 L5.78111111,19.2 L9.03222222,13.668 L12.2222222,16.8 Z M11.6111111,12 C11.9486185,12 12.2222222,12.2686292 12.2222222,12.6 C12.2222222,12.9313708 11.9486185,13.2 11.6111111,13.2 C11.2736038,13.2 11,12.9313708 11,12.6 C11,12.2686292 11.2736038,12 11.6111111,12 Z"
+      fillRule="evenodd"
+    />
+  </svg>
+  children
+</button>
+`;
+
+exports[`buttons IconButton renders correctly 1`] = `
+<button
+  className="button_flat button_icon c"
+  disabled={true}
+  onClick={undefined}
+  title="t"
+>
+  <svg
+    aria-hidden="true"
+    className="button_only_icon spin"
+    fill="currentColor"
+    height={undefined}
+    version="1.1"
+    viewBox="0 0 24 24"
+    width={undefined}
+    x={undefined}
+    y={undefined}
+  >
+    <path
+      d="M18 7.209L16.791 6 12 10.791 7.209 6 6 7.209 10.791 12 6 16.791 7.209 18 12 13.209 16.791 18 18 16.791 13.209 12z"
+      fillRule="evenodd"
+    />
+  </svg>
+</button>
+`;
+
+exports[`buttons OutlineButton renders correctly 1`] = `
+<button
+  className="button_primary button_outline c"
+  disabled={undefined}
+  onClick={[Function]}
+  title="t"
+>
+  children
+</button>
+`;
+
+exports[`buttons OutlineButton with iconName renders correctly 1`] = `
+<button
+  className="button_primary button_outline c"
+  disabled={undefined}
+  onClick={[Function]}
+  title="t"
+>
+  <svg
+    aria-hidden="true"
+    className="icon"
     fill="currentColor"
     height={undefined}
     version="1.1"
@@ -96,7 +160,7 @@ exports[`buttons PrimaryButton with iconName renders correctly 1`] = `
 >
   <svg
     aria-hidden="true"
-    className="button_icon"
+    className="icon"
     fill="currentColor"
     height={undefined}
     version="1.1"

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -66,14 +66,14 @@ exports[`SidePanel renders SidePanel correctly 1`] = `
       title
     </h2>
     <button
-      className="button_flat button_close"
+      className="button_flat button_icon button_close"
       disabled={undefined}
       onClick={[Function]}
-      title={undefined}
+      title="close panel"
     >
       <svg
         aria-hidden="true"
-        className="button_close_icon"
+        className="button_only_icon"
         fill="currentColor"
         height={undefined}
         version="1.1"

--- a/components/src/__tests__/buttons.test.js
+++ b/components/src/__tests__/buttons.test.js
@@ -3,7 +3,7 @@ import React from 'react'
 import Renderer from 'react-test-renderer'
 
 import {FLASK} from '../icons'
-import {Button, FlatButton, PrimaryButton} from '..'
+import {Button, FlatButton, PrimaryButton, OutlineButton, IconButton} from '..'
 
 describe('buttons', () => {
   const onClick = () => {}
@@ -92,6 +92,41 @@ describe('buttons', () => {
       <FlatButton onClick={onClick} title='t' className='c' iconName={FLASK}>
         children
       </FlatButton>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('OutlineButton renders correctly', () => {
+    const tree = Renderer.create(
+      <OutlineButton onClick={onClick} title='t' className='c'>
+        children
+      </OutlineButton>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('OutlineButton with iconName renders correctly', () => {
+    const tree = Renderer.create(
+      <OutlineButton onClick={onClick} title='t' className='c' iconName={FLASK}>
+        children
+      </OutlineButton>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('IconButton renders correctly', () => {
+    const tree = Renderer.create(
+      <IconButton
+        onClick={onClick}
+        title='t'
+        className='c'
+        name='close'
+        spin
+        disabled
+      />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -30,7 +30,7 @@ export type ButtonProps = {
  */
 export default function Button (props: ButtonProps) {
   const {disabled} = props
-  const onClick = disabled ? undefined : props.onClick
+  const onClick = !disabled ? props.onClick : undefined
 
   return (
     <button
@@ -40,7 +40,7 @@ export default function Button (props: ButtonProps) {
       className={props.className}
     >
       {props.iconName && (
-        <Icon name={props.iconName} className={styles.button_icon} />
+        <Icon name={props.iconName} className={styles.icon} />
       )}
       {props.children}
     </button>

--- a/components/src/buttons/FlatButton.md
+++ b/components/src/buttons/FlatButton.md
@@ -21,15 +21,3 @@ With icon:
   {'Click me!'}
 </FlatButton>
 ```
-
-To create a flat button that's just a single icon, pass the `<Icon>` as a child. Do not use `iconName`, because `iconName`  positions the icon absolutely, which is probably not what you want. You should also:
-
-*   Override the width of the flat button to `auto` (default is `9rem`)
-*   Give the icon a specific size dimension
-*   Set the icon to `display: block` for line-height reasons
-
-```js
-<FlatButton onClick={() => alert('you clicked me')} className='width-auto'>
-  <Icon name='close' className='display-block width-3-rem'/>
-</FlatButton>
-```

--- a/components/src/buttons/IconButton.js
+++ b/components/src/buttons/IconButton.js
@@ -1,0 +1,27 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+
+import {Icon, type IconProps} from '../icons'
+import type {ButtonProps} from './Button'
+import FlatButton from './FlatButton'
+
+import styles from './buttons.css'
+
+type Props =
+  & ButtonProps
+  & IconProps
+
+/**
+ * FlatButton variant for a button that is a single icon. Takes props of
+ * both Button _and_ Icon. Use `name` to specify icon name.
+ */
+export default function IconButton (props: Props) {
+  const className = cx(styles.button_icon, props.className)
+
+  return (
+    <FlatButton {...props} className={className} iconName={undefined}>
+      <Icon {...props} className={styles.button_only_icon} />
+    </FlatButton>
+  )
+}

--- a/components/src/buttons/IconButton.md
+++ b/components/src/buttons/IconButton.md
@@ -1,0 +1,23 @@
+**Important** - Please be sure to:
+
+*   Specify a concrete width or height for the button style
+*   Use `<Icon>` prop `name`, _not_ `<Button>` prop `iconName`
+
+```js
+<div>
+  <IconButton
+    onClick={() => alert('you clicked me')}
+    title='left'
+    name='chevron left'
+    className='height-3-rem'
+  />
+  <IconButton
+    onClick={() => alert("can't click")}
+    title='in progress'
+    name='spinner'
+    className='width-3-rem'
+    disabled
+    spin
+  />
+</div>
+```

--- a/components/src/buttons/OutlineButton.js
+++ b/components/src/buttons/OutlineButton.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+
+import type {ButtonProps} from './Button'
+import PrimaryButton from './PrimaryButton'
+import styles from './buttons.css'
+
+/**
+ * `<PrimaryButton>` variant with no background fill and a light border
+ */
+export default function OutlineButton (props: ButtonProps) {
+  const className = cx(styles.button_outline, props.className)
+
+  return (
+    <PrimaryButton {...props} className={className}>
+      {props.children}
+    </PrimaryButton>
+  )
+}

--- a/components/src/buttons/OutlineButton.md
+++ b/components/src/buttons/OutlineButton.md
@@ -1,0 +1,23 @@
+You can use an `<OutlineButton>` in exactly the same manner as a `<PrimaryButton>`
+
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.5)'}}>
+  <div style={{padding: '2rem', width: '20rem'}}>
+    <OutlineButton onClick={() => alert('you clicked me')}>
+      {'Click for alert'}
+    </OutlineButton>
+  </div>
+</div>
+```
+
+Disabled:
+
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.5)'}}>
+  <div style={{padding: '2rem', width: '20rem'}}>
+    <OutlineButton onClick={() => alert("can't click")} disabled>
+      {'Disabled'}
+    </OutlineButton>
+  </div>
+</div>
+```

--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -19,6 +19,15 @@
   cursor: pointer;
 }
 
+.button_primary[disabled],
+.button_primary.disabled,
+.button_flat[disabled],
+.button_flat.disabled {
+  font-weight: normal;
+  color: var(--c-font-disabled);
+  cursor: default;
+}
+
 .button_primary {
   width: 100%;
   border-radius: 2px;
@@ -29,58 +38,82 @@
   box-shadow:
     0 0 2px rgba(0, 0, 0, 0.12),
     0 2px 2px rgba(0, 0, 0, 0.24);
+
+  &:hover {
+    background-color: color(var(--c-bg-dark) shade(30%));
+  }
+
+  &:active {
+    font-weight: var(--fw-regular);
+    background-color: color(var(--c-bg-dark) tint(30%));
+
+    /* TODO(mc, 2017-12-07): pull shadows out to central file */
+    box-shadow:
+      0 0 8px rgba(0, 0, 0, 0.12),
+      0 8px 8px rgba(0, 0, 0, 0.24);
+  }
+
+  &:disabled,
+  &.disabled {
+    background-color: color(var(--c-bg-dark) tint(70%));
+    box-shadow: none;
+  }
 }
 
 .button_flat {
   width: 9rem;
   color: var(--c-font-dark);
   background-color: transparent;
+
+  &:hover {
+    background-color: color(var(--c-bg-light) shade(5%));
+  }
+
+  &:active {
+    font-weight: var(--fw-regular);
+    background-color: color(var(--c-bg-light) shade(10%));
+  }
+
+  &:disabled,
+  &.disabled {
+    background-color: initial;
+  }
 }
 
-.button_primary:hover {
-  background-color: color(var(--c-bg-dark) shade(30%));
-}
-
-.button_flat:hover {
-  background-color: color(var(--c-bg-light) shade(5%));
-}
-
-.button_primary:active {
-  font-weight: var(--fw-regular);
-  background-color: color(var(--c-bg-dark) tint(30%));
-
-  /* TODO(mc, 2017-12-07): pull shadows out to central file */
-  box-shadow:
-    0 0 8px rgba(0, 0, 0, 0.12),
-    0 8px 8px rgba(0, 0, 0, 0.24);
-}
-
-.button_flat:active {
-  font-weight: var(--fw-regular);
-  background-color: color(var(--c-bg-light) shade(10%));
-}
-
-.button_primary[disabled],
-.button_primary.disabled,
-.button_flat[disabled],
-.button_flat.disabled {
-  font-weight: normal;
-  color: var(--c-font-disabled);
-  cursor: default;
-}
-
-.button_primary[disabled],
-.button_primary.disabled {
-  background-color: color(var(--c-bg-dark) tint(70%));
+.button_outline {
+  background-color: transparent;
   box-shadow: none;
+  border: 1px solid var(--c-font-light);
+
+  &:hover,
+  &:active {
+    color: color(var(--c-font-light) shade(10%));
+    border-color: color(var(--c-font-light) shade(10%));
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  &:disabled,
+  &.disabled {
+    color: color(var(--c-font-light) shade(20%));
+    border-color: color(var(--c-font-light) shade(20%));
+    background-color: initial;
+  }
 }
 
-.button_flat[disabled],
-.button_flat.disabled {
-  background-color: initial;
-}
-
+/* style for IconButton */
 .button_icon {
+  width: auto;
+
+  & > * {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}
+
+/* style for the supplementary icon displayed by Button */
+.icon {
   position: absolute;
   top: var(--button-pad);
   left: var(--button-pad);

--- a/components/src/buttons/index.js
+++ b/components/src/buttons/index.js
@@ -4,6 +4,8 @@
 import Button from './Button'
 import FlatButton from './FlatButton'
 import PrimaryButton from './PrimaryButton'
+import IconButton from './IconButton'
+import OutlineButton from './OutlineButton'
 
 export * from './Button'
-export {Button, FlatButton, PrimaryButton}
+export {Button, FlatButton, PrimaryButton, IconButton, OutlineButton}

--- a/components/src/icons/Icon.js
+++ b/components/src/icons/Icon.js
@@ -5,7 +5,7 @@ import classnames from 'classnames'
 import ICON_DATA_BY_NAME, {type IconName} from './icon-data'
 import styles from './icons.css'
 
-type Props = {
+export type IconProps = {
   /** name constant of the icon to display */
   name: IconName,
   /** classes to apply */
@@ -30,7 +30,7 @@ type Props = {
  * import {type IconName} from '@opentrons/components'
  * ```
  */
-export default function Icon (props: Props) {
+export default function Icon (props: IconProps) {
   const {x, y, height, width} = props
   const {viewBox, path} = ICON_DATA_BY_NAME[props.name]
   const className = classnames(props.className, {

--- a/components/src/icons/index.js
+++ b/components/src/icons/index.js
@@ -5,4 +5,5 @@ import Icon from './Icon'
 
 // export all icon names (without unnecessary default icon data)
 export * from './icon-data'
+export * from './Icon'
 export {Icon}

--- a/components/src/structure/SidePanel.css
+++ b/components/src/structure/SidePanel.css
@@ -1,7 +1,7 @@
 @import '..';
 
 :root {
-  --w-sidebar: 18rem;
+  --sidebar-width: 18rem;
 }
 
 .panel {
@@ -20,7 +20,7 @@
 .title_bar {
   display: flex;
   align-items: center;
-  width: var(--w-sidebar);
+  width: var(--sidebar-width);
   border-bottom: var(--bd-light);
 }
 
@@ -44,10 +44,5 @@
  * hot reloads. Try to figure out why that's the case.
  */
 button.button_close {
-  width: auto;
-}
-
-.button_close_icon {
-  display: block;
-  width: 1.5rem;
+  width: 2.5rem;
 }

--- a/components/src/structure/SidePanel.js
+++ b/components/src/structure/SidePanel.js
@@ -3,8 +3,8 @@
 import * as React from 'react'
 import classnames from 'classnames'
 
-import {FlatButton} from '../buttons'
-import {Icon, CLOSE} from '../icons'
+import {IconButton} from '../buttons'
+import {CLOSE} from '../icons'
 import styles from './SidePanel.css'
 
 type SidePanelProps= {
@@ -17,12 +17,12 @@ type SidePanelProps= {
 export default function SidePanel (props: SidePanelProps) {
   const open = !props.isClosed || props.onCloseClick == null
   const closeButton = props.onCloseClick && (
-    <FlatButton
+    <IconButton
+      title='close panel'
       onClick={props.onCloseClick}
       className={styles.button_close}
-    >
-      <Icon name={CLOSE} className={styles.button_close_icon} />
-    </FlatButton>
+      name={CLOSE}
+    />
   )
   const className = classnames(styles.panel, {[styles.closed]: !open})
 

--- a/components/styleguide.config.js
+++ b/components/styleguide.config.js
@@ -72,10 +72,10 @@ module.exports = {
         width: 'auto !important'
       },
       '@global .width-3-rem': {
-        width: '3rem'
+        width: '3rem !important'
       },
       '@global .height-3-rem': {
-        height: '3rem'
+        height: '3rem !important'
       }
     }
   }


### PR DESCRIPTION
## overview

(Re)adds `IconButton` component per discussion in #664 and adds `OutlineButton` component as part of #677.

## changelog

- Added `IconButton` component (`FlatButton` variant) that melds `ButtonProps` and `IconProps`
- Added `OutlineButton` component (`PrimaryButton` variant) as seen in new calibration screens
- Refactored `ScanButton` in the app to use new `IconButton`
- Refactored `buttons.css` to use fancy cssnext nesting (makes it all a bit easier to read)

## review requests

Standard review!
