### PR TITLE
Add line number to rpc error message

### DIFF
--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -271,11 +271,22 @@ class Server(object):
                 self.executor, self.call_and_serialize, func)
             response['$']['status'] = 'success'
         except Exception as e:
+            trace = traceback.format_exc()
             log.warning(
                 'Exception while dispatching a method call: {0}'
-                .format(traceback.format_exc()))
+                .format(trace))
+            try:
+                line_no = [
+                    l.split(',')[0].strip()
+                    for l in trace.split('line')
+                    if '<module>' in l][0]
+            except Exception as exc:
+                log.debug(
+                    "Exception while getting line no: {}".format(type(exc)))
+                line_no = 'unknown'
             response['$']['status'] = 'error'
-            call_result = '{0}: {1}'.format(e.__class__.__name__, str(e))
+            call_result = '{0} [line {1}]: {2}'.format(
+                e.__class__.__name__, line_no, str(e))
         finally:
             log.debug('Call result: {0}'.format(call_result))
             response['data'] = call_result

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -203,7 +203,7 @@ async def test_exception_on_call(session, root):
                     'token': session.token,
                     'status': 'error',
                     'type': rpc.CALL_RESULT_MESSAGE},
-                'data': 'Exception: Kaboom!'}
+                'data': 'Exception [line unknown]: Kaboom!'}
 
     assert res == expected
 


### PR DESCRIPTION
## overview

When a protocol file contains a syntax error, include the line number of the error in the message returned by the RPC server (to be displayed in the run app). Fixes #669 

## changelog

- (feature) Add line number to error message from RPC server

## review requests

Create a protocol with a syntax error, try to run it through the run app, get the error message with a line number that correctly corresponds to the line number from the protocol.
