### PR TITLE
Adds deprecation warning to axis parameter for pipette constructor

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -94,7 +94,8 @@ class Pipette:
     def __init__(
             self,
             robot,
-            mount,
+            mount=None,
+            axis=None,
             mount_obj=None,
             name=None,
             channels=1,
@@ -109,6 +110,19 @@ class Pipette:
             dispense_flow_rate=None):
 
         self.robot = robot
+
+        # Uses information from axis to decide if a pipette is on the left
+        # or right mount
+        if axis:
+            warnings.warn(
+                "'axis' is deprecated, please use 'mount' in constructor"
+            )
+
+        if axis == 'a':
+            mount = 'right'
+        elif axis == 'b':
+            mount = 'left'
+
         self.mount = mount
         self.channels = channels
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -766,7 +766,7 @@ class Robot(object):
 
     def get_instruments(self, name=None):
         """
-        :returns: sorted list of (axis, instrument)
+        :returns: sorted list of (mount, instrument)
         """
         if name:
             return self.get_instruments_by_name(name)

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -183,6 +183,20 @@ class PipetteTest(unittest.TestCase):
     #     self.p200.calibrate('bottom')
     #     self.assertEquals(self.p200.plunger_positions['bottom'], 9)
 
+    def test_deprecated_axis_call(self):
+        import warnings
+
+        warnings.filterwarnings('error')
+        # Check that user warning occurs when axis is called
+        self.assertRaises(
+            UserWarning, Pipette, self.robot, axis='a')
+
+        # Check that the warning is still valid when max_volume is also used
+        self.assertRaises(
+            UserWarning, Pipette, self.robot, axis='a', max_volume=300)
+
+        warnings.filterwarnings('default')
+
     def test_get_instruments_by_name(self):
         self.p1000 = Pipette(
             self.robot,


### PR DESCRIPTION
## overview

Previously if the axis parameter was utilized in the pipette constructor, an exception would be thrown.

## changelog

-Added warning to pipette constructor that the axis parameter is depreciated
-If the axis parameter is used, sets mount to proper value
-Updated tests to check that the warning is being properly executed

-Un-breaks axis exception error. Fixes #571 .

## review requests

Please double check I am not writing over other's work!