### PR TITLE
Refactor cli app to remove use of global state

### DIFF
--- a/api/opentrons/cli/linal.py
+++ b/api/opentrons/cli/linal.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy import insert
+from numpy import insert, dot
 from numpy.linalg import inv
 from typing import List, Tuple
 
@@ -112,3 +112,16 @@ def add_z(xy, z):
     # [ 0  0  0  1 ]
 
     return xyz
+
+
+def apply_transform(
+        t: List[List[float]], pos: (int, int, int)) -> (int, int, int, int):
+    """
+    Change of base using a transform matrix. Primarily used to render a point
+    in space in a way that is more readable for the user.
+
+    :param t: A transformation matrix from one 3D space [A] to another [B]
+    :param pos: XYZ point in space A
+    :return: corresponding XYZ1 point in space B
+    """
+    return tuple(dot(inv(t), list(pos) + [1])[:-1])

--- a/api/opentrons/cli/linal.py
+++ b/api/opentrons/cli/linal.py
@@ -74,19 +74,19 @@ def solve(expected: List[Tuple[float, float]],
     return transform
 
 
-def add_z(xy, z):
+def add_z(xy: np.ndarray, z: float) -> np.ndarray:
     """
     Turn a 2-D transform matrix into a 3-D transform matrix (scale/shift only,
     no rotation).
 
-    :param xy: A two-dimensional matrix transform matrix (a 3x3 matrix in the
+    :param xy: A two-dimensional transform matrix (a 3x3 numpy ndarray) in the
         following form:
             [ 1  0  x ]
             [ 0  1  y ]
             [ 0  0  1 ]
-    :param z: an integer for the z component
-    :return: a three-dimensional transformation matrix with x, y, and z from
-        the inputs, in the following form:
+    :param z: a float for the z component
+    :return: a three-dimensional transformation matrix (a 4x4 numpy ndarray)
+        with x, y, and z from the function parameters, in the following form:
             [ 1  0  0  x ]
             [ 0  1  0  y ]
             [ 0  0  1  z ]

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -2,7 +2,6 @@
 
 # pylama:ignore=C901
 
-# erase previous calibration file before opentrons.robot instantiates
 import asyncio
 import urwid
 import atexit
@@ -13,249 +12,264 @@ from numpy import dot, array
 from opentrons.robot import robot_configs
 from opentrons import robot, instruments
 from opentrons.util.calibration_functions import probe_instrument
-from opentrons.cli.linal import solve, add_z
+from opentrons.cli.linal import solve, add_z, apply_transform
 
 
-# Distance increments for jog
-steps = [0.1, 0.25, 0.5, 1, 5, 10, 20, 40, 80]
-# Index of selected step
-step_index = 2
-
+# Application constants
 SAFE_HEIGHT = 130
 
 left = 'Z'
 right = 'A'
-current_pipette = right
 
-status_text = urwid.Text('')  # type 'urwid.Text'
-current_position = (0, 0, 0)
-
-# 200uL tip. Used during calibration process
-# The actual calibration represents end of a pipette
-# without tip on
-TIP_LENGTH = 51.7
-
-# Reference point being calibrated
-point_number = -1
-
-# (0, 0) is in bottom-left corner
-
-slot_1_lower_left = (12.13, 6.0)
-slot_3_lower_right = (380.87, 6.0)
-slot_10_upper_left = (12.13, 351.5)
-expected_dots = [
-    slot_1_lower_left,
-    slot_3_lower_right,
-    slot_10_upper_left
-]
-
-# for machines that cannot reach the calibration dots, use the screw holes
-slot_4_screw_hole = (108.75, 92.8)
-slot_6_screw_hole = (373.75, 92.8)
-slot_11_screw_hole = (241.25, 273.80)
-expected_holes = [
-    slot_4_screw_hole,
-    slot_6_screw_hole,
-    slot_11_screw_hole
-]
-
-# Expected reference points
-expected = []
-test_points = []
-
-# Actuals get overridden when ENTER is pressed
-actual = [(0, 0)] * 3
-
-T = robot.config.gantry_calibration
-XY = None
+dots = 'dots'
+holes = 'holes'
 
 
-def generate_test_points():
-    global test_points, expected_dots, expected_holes, expected
-    # older machines cannot reach deck points, use the screw holes instead
-    res = input('Are you calibrating to the screw holes? (y/n)')
-    if 'y' in res.lower():
-        expected = expected_holes
-    else:
-        expected = expected_dots
-    # Accessible through 1,2,3 ... keyboard keys to test
-    # calibration by moving to known locations
-    test_points = [(x, y, TIP_LENGTH) for x, y in expected] + \
-        [
-            (132.50, 90.50, TIP_LENGTH),        # Slot 5
-            (332.13, 47.41, TIP_LENGTH),        # Corner of 3
-            (190.65, 227.57, TIP_LENGTH),       # Corner of 8
-            (330.14, 222.78, TIP_LENGTH),       # Corner of 9
-        ]
-
-
-def current_step() -> float:
+# TODO: add tests for methods, split out current point behavior per comment
+# TODO:   below, and total result on robot against prior version of this app
+class CLITool:
     """
-    Given current step index return step value in mm
+    Dev notes:
+        This is still done in very OO-style. Instead of using global variables
+        for state, this is captured with members of this class, and methods
+        on the class capture the ways of modifying that state. The main entry-
+        point for the URWID-based app is the `_on_key_press` method, which
+        dispatches via the `key_map` dictionary.
+
+        Each value in the `key_map` is a lambda that performs whatever action
+        is required for the key press, and then returns a string that can be
+        used to update the text box accordingly. Most or all of these lambdas
+        call methods on this class, which in turn utilize members of the class
+        in a side-effecting manner.
+
+        In a further refactor, this will make it easier to extract the methods
+        into functions that take all needed input as parameters, and return
+        a tuple with a status string and any results of computation. This
+        class can then catch the return values and keep track of state. The
+        behavior of this class will be the same in that case, but those
+        extracted functions could also be used to support and alternate app,
+        such as a web-server that would be able to call those functions behind
+        HTTP endpoints.
     """
-    return steps[step_index]
+    def __init__(self, point_set, tip_length, loop=None):
+        # URWID user interface objects
+        if not loop:
+            loop = urwid.main_loop.AsyncioEventLoop(
+                loop=asyncio.get_event_loop())
+        self._tip_text_box = urwid.Text('')
+        self._status_text_box = urwid.Text('')
+        self._pile = urwid.Pile([self._tip_text_box, self._status_text_box])
+        self._filler = urwid.Filler(self._pile, 'top')
 
-
-def position():
-    """
-    Read position from driver into a tuple and map 3-rd value
-    to the axis of a pipette currently used
-    """
-    try:
-        p = robot._driver.position
-        res = (p['X'], p['Y'], p[current_pipette.upper()])
-    except KeyError:
-        # for some reason we are sometimes getting
-        # key error in dict returned from driver
-        pass
-    else:
-        return res
-
-
-def status(text_box: urwid.Text, text: str):
-    """
-    Refresh status in a text box
-    """
-
-    points = '\n'.join([
-        # Highlight point being calibrated
-        ('* ' if point_number == point else '') + "{0} {1}"
-        # Display actual and expected coordinates
-        .format(coord[0], coord[1])
-        for point, coord in enumerate(zip(actual, expected))
-    ])
-
-    text = '\n'.join([
-        points,
-        'Smoothie: {0}'.format(current_position),
-        'World: {0}'.format(tuple(dot(inv(T), list(current_position) + [1])[:-1])),  # NOQA
-        'Step: {0}'.format(current_step()),
-        'Current stage: ' + current_pipette,
-        'Message: ' + text
-    ])
-
-    text_box.set_text(text)
-
-
-def jog(axis, direction, step):
-    global current_position
-    robot._driver.move({axis: robot._driver.position[axis] + direction * step})
-    current_position = position()
-    status(status_text, 'Jog: ' + repr([axis, str(direction), str(step)]))
-
-
-key_mappings = {
-    'q': lambda: jog(current_pipette, +1, current_step()),
-    'a': lambda: jog(current_pipette, -1, current_step()),
-    'up': lambda: jog('Y', +1, current_step()),
-    'down': lambda: jog('Y', -1, current_step()),
-    'left': lambda: jog('X', -1, current_step()),
-    'right': lambda: jog('X', +1, current_step()),
-}
-
-
-def key_pressed(key):
-    global current_position, current_pipette, step_index, point_number, XY, T
-
-    if key == 'z':
-        current_pipette = left if current_pipette == right else right
-        status(status_text, 'current pipette axis: ' + repr(current_pipette))
-    elif key.isnumeric():
-        validate(int(key) - 1)
-    # less travel
-    elif key == '-':
-        if step_index > 0:
-            step_index -= 1
-        status(status_text, 'step: ' + repr(current_step()))
-    # more travel
-    elif key == '=':
-        if step_index < len(steps) - 1:
-            step_index += 1
-        status(status_text, 'step: ' + repr(current_step()))
-    # skip calibration point
-    elif key == 's':
-        if (point_number < len(actual) - 1):
-            point_number += 1
-        status(status_text, 'skipped #{0}'.format(point_number))
-    # run tip probe
-    elif key == 'p':
-
-        robot.reset()
-
-        pipette = instruments.Pipette(mount='right', channels=1)
-        probe_center = tuple(probe_instrument(
-            pipette, robot, tip_length=TIP_LENGTH))
-        robot.config = robot.config._replace(
-            probe_center=probe_center
+        self.ui_loop = urwid.MainLoop(
+            self._filler,
+            handle_mouse=False,
+            unhandled_input=self._on_key_press,
+            event_loop=loop
         )
-        status(status_text, 'Tip probe')
-    # save calibration point and move to next
-    elif key == 'enter':
-        if point_number >= len(actual):
-            return
 
-        if point_number < 0:
-            actual_z = position()[-1]
-            expected_z = T[2][3] + TIP_LENGTH
-            T[2][3] += actual_z - expected_z
-            point_number += 1
-            status(status_text, 'saved Z-Offset: {0}'.format(T[2][3]))
-            return
+        # Other state
+        self._tip_length = tip_length
+        self.current_position = (0, 0, 0)
+        self._steps = [0.1, 0.25, 0.5, 1, 5, 10, 20, 40, 80]
+        self._steps_index = 2
+        self._current_pipette = right
+        self._current_point = 1
+        self._calibration_matrix = robot.config.gantry_calibration
 
-        actual[point_number] = position()[:-1]
-        point_number += 1
-        status(status_text, 'saved #{0}: {1}'.format(
-            point_number, actual[point_number-1]))
+        self._expected_points = point_set
+        self._actual_points = {}
+        self._test_points = {
+            'slot5': (132.50, 90.50, self._tip_length),
+            'corner3': (332.13, 47.41, self._tip_length),
+            'corner8': (190.65, 227.57, self._tip_length),
+            'corner9': (330.14, 222.78, self._tip_length)}
 
-        # On last point update gantry calibration
-        if point_number == len(actual):
-            XY = solve(expected, actual)
-            T = add_z(XY, T[2][3])
-            robot.config = robot.config._replace(
-                    gantry_calibration=list(map(lambda i: list(i), T)),
-                )
-            status(status_text, str(robot.config))
+        self.key_map = {
+            '-': lambda: self.decrease_step(),
+            '=': lambda: self.increase_step(),
+            'z': lambda: self.save_z_value(),
+            'p': lambda: probe(self._tip_length),
+            'enter': lambda: self.save_point(),
+            '\\': lambda: self.home(),
+            ' ': lambda: save_config(),
+            'esc': lambda: self.exit(),
+            'q': lambda: self.jog(
+                self._current_pipette, +1, self.current_step()),
+            'a': lambda: self.jog(
+                self._current_pipette, -1, self.current_step()),
+            'up': lambda: self.jog('Y', +1, self.current_step()),
+            'down': lambda: self.jog('Y', -1, self.current_step()),
+            'left': lambda: self.jog('X', -1, self.current_step()),
+            'right': lambda: self.jog('X', +1, self.current_step()),
+            '1': lambda: self.validate(self._expected_points[1]),
+            '2': lambda: self.validate(self._expected_points[2]),
+            '3': lambda: self.validate(self._expected_points[3]),
+            '4': lambda: self.validate(self._test_points['slot5']),
+            '5': lambda: self.validate(self._test_points['corner3']),
+            '6': lambda: self.validate(self._test_points['corner8']),
+            '7': lambda: self.validate(self._test_points['corner9'])
+        }
 
-    # move to previous calibration point
-    elif key == 'backspace':
-        if point_number > 0:
-            point_number -= 1
-        status(status_text, '')
-    # home
-    elif key == '\\':
-        robot.home()
-        current_position = position()
-        status(status_text, 'Homed')
-    # calculate transformation matrix
-    elif key == 'esc':
-        raise urwid.ExitMainLoop
-    elif key == ' ':
+    def current_step(self):
+        return self._steps[self._steps_index]
+
+    def position(self):
+        """
+        Read position from driver into a tuple and map 3-rd value
+        to the axis of a pipette currently used
+        """
         try:
-            diff = robot_configs.save(robot.config)
-            status(status_text, 'Saved')
-        except Exception as e:
-            status(status_text, repr(e))
-        else:
-            status(status_text, str(diff))
-    else:
-        try:
-            key_mappings[key]()
+            p = robot._driver.position
+            res = (p['X'], p['Y'], p[self._current_pipette.upper()])
         except KeyError:
-            status(status_text, 'invalid key: ' + repr(key))
+            # for some reason we are sometimes getting
+            # key error in dict returned from driver
+            pass
+        else:
+            return res
+
+    # Methods for backing key-press
+    def increase_step(self) -> str:
+        """
+        Increase the jog resolution without overrunning the list of values
+        """
+        if self._steps_index < len(self._steps):
+            self._steps_index = self._steps_index + 1
+        return 'step: {}'.format(self.current_step())
+
+    def decrease_step(self) -> str:
+        """
+        Decrease the jog resolution without overrunning the list of values
+        """
+        if self._steps_index > 0:
+            self._steps_index = self._steps_index - 1
+        return 'step: {}'.format(self.current_step())
+
+    def jog(self, axis, direction, step) -> str:
+        """
+        Move the pipette on `axis` in `direction` by `step` and update the
+        position tracker
+        """
+        robot._driver.move(
+            {axis: robot._driver.position[axis] + direction * step})
+        self.current_position = self.position()
+        return 'Jog: {}'.format([axis, str(direction), str(step)])
+
+    def home(self) -> str:
+        """
+        Return the robot to the home position and update the position tracker
+        """
+        robot.home()
+        self.current_position = self.position()
+        return 'Homed'
+
+    def save_point(self) -> str:
+        self._actual_points[self._current_point] = self.position()[:-1]
+
+        if self._current_point == 3:
+            expected = [self._expected_points[p] for p in [1, 2, 3]]
+            actual = [self._actual_points[p] for p in [1, 2, 3]]
+            # Generate a 2 dimensional transform matrix from the two matricies
+            flat_matrix = solve(expected, actual)
+            current_z = self._calibration_matrix[2][3]
+            # Add the z component to form the 3 dimensional transform
+            self._calibration_matrix = add_z(flat_matrix, current_z)
+
+            robot.config = robot.config._replace(
+                gantry_calibration=list(
+                    map(lambda i: list(i), self._calibration_matrix)))
+            msg = str(robot.config)
+        else:
+            msg = 'saved #{}: {}'.format(
+                self._current_point, self._actual_points[self._current_point])
+            # There's probably a much better way to handle "current point".
+            # Should probably be linked to which of the "expected points" was
+            # last fed to `validate`, but then we'll need a separate key for
+            # Checking if all actual points have been confirmed and saving the
+            # final calibration matrix. More keys to keep track of, but
+            # ultimately better anyway, so that each key has only one behavior
+            # rather than being as dependent on state.
+            self._current_point += 1
+        return msg
+
+    def save_z_value(self) -> str:
+        actual_z = self.position()[-1]
+        expected_z = self._calibration_matrix[2][3] + self._tip_length
+        new_z = self._calibration_matrix[2][3] + actual_z - expected_z
+        self._calibration_matrix[2][3] = new_z
+        return 'saved Z-Offset: {}'.format(new_z)
+
+    def validate(self, point: (float, float, float)):
+        # TODO (ben 20180201): create a function in linal module so we don't
+        # TODO                 have to do dot product & etc here
+        v = array(list(point) + [1])
+        x, y, z, _ = dot(
+            inv(self._calibration_matrix), list(self.position()) + [1])
+
+        if z < SAFE_HEIGHT:
+            _, _, z, _ = dot(self._calibration_matrix, [x, y, SAFE_HEIGHT, 1])
+            robot._driver.move({self._current_pipette: z})
+
+        x, y, z, _ = dot(self._calibration_matrix, v)
+        robot._driver.move({'X': x, 'Y': y})
+        robot._driver.move({self._current_pipette: z})
+        return 'moving to point {}'.format(point)
+
+    def exit(self):
+        raise urwid.ExitMainLoop
+
+    # Private methods for URWID
+    def _on_key_press(self, key: str):
+        try:
+            result = self.key_map[key]()
+        except KeyError:
+            result = 'invalid input: {}'.format(key)
+        self._update_text_box(result)
+
+    def _update_text_box(self, msg):
+        expected = [self._expected_points[p] for p in [1, 2, 3]]
+        actual = [self._actual_points[p] for p in [1, 2, 3]]
+        points = '\n'.join([
+            # Highlight point being calibrated
+            # Display actual and expected coordinates
+            ('* ' if self._current_point == point else '') + "{0} {1}".format(
+                coord[0], coord[1])
+            for point, coord in enumerate(zip(actual, expected))
+        ])
+
+        text = '\n'.join([
+            points,
+            'Smoothie: {}'.format(self.current_position),
+            'World: {}'.format(apply_transform(
+                self._calibration_matrix, self.current_position)),
+            'Step: {}'.format(self.current_step()),
+            'Current stage: ' + self._current_pipette,
+            'Message: {}'.format(msg)
+        ])
+
+        self._status_text_box.set_text(text)
 
 
-# move to test points based on current matrix value
-def validate(index):
-    v = array(list(test_points[index]) + [1])
-    x, y, z, _ = dot(inv(T), list(position()) + [1])
+# Functions for backing key-press
+def probe(tip_length: float) -> str:
+    robot.reset()
 
-    if z < SAFE_HEIGHT:
-        _, _, z, _ = dot(T, [x, y, SAFE_HEIGHT, 1])
-        robot._driver.move({current_pipette: z})
+    pipette = instruments.Pipette(mount='right', channels=1)
+    probe_center = tuple(probe_instrument(
+        pipette, robot, tip_length=tip_length))
+    robot.config = robot.config._replace(
+        probe_center=probe_center
+    )
+    return 'Tip probe'
 
-    x, y, z, _ = dot(T, v)
-    robot._driver.move({'X': x, 'Y': y})
-    robot._driver.move({current_pipette: z})
+
+def save_config() -> str:
+    try:
+        result = robot_configs.save(robot.config)
+    except Exception as e:
+        result = repr(e)
+    return result
 
 
 def clear_configuration_and_reload():
@@ -264,15 +278,57 @@ def clear_configuration_and_reload():
     robot.reset()
 
 
-def backup_configuration_and_reload(tag=None):
+def backup_configuration(tag):
     from datetime import datetime
     if not tag:
         tag = datetime.now().isoformat(timespec="seconds")
     robot_configs.save(robot.config, tag=tag)
+
+
+def backup_configuration_and_reload(tag=None):
+    backup_configuration(tag)
     clear_configuration_and_reload()
 
 
+slot_1_lower_left = (12.13, 6.0)
+slot_3_lower_right = (380.87, 6.0)
+slot_10_upper_left = (12.13, 351.5)
+expected_dots = {
+    1: slot_1_lower_left,
+    2: slot_3_lower_right,
+    3: slot_10_upper_left
+}
+
+# for machines that cannot reach the calibration dots, use the screw holes
+# TODO (ben 20180131): remove this once all robots can reach engraved points
+slot_4_screw_hole = (108.75, 92.8)
+slot_6_screw_hole = (373.75, 92.8)
+slot_11_screw_hole = (241.25, 273.80)
+expected_holes = {
+    1: slot_4_screw_hole,
+    2: slot_6_screw_hole,
+    3: slot_11_screw_hole
+}
+
+
 def main():
+    """
+    A CLI application for performing factory calibration of an Opentrons robot
+
+    Instructions:
+        - Robot must be set up with a single-channel pipette installed on the
+          right-hand mount.
+        - Put a 200ul tip onto the pipette.
+        - Use the arrow keys to jog the robot over an open area of the deck
+          (the base deck surface, not over a ridge or numeral ingraving). You
+          can use the '-' and '=' keys to decrease or increase the amount of
+          distance moved with each jog action.
+        - Use the 'q' and 'a' keys to jog the pipette up and down respectively
+          until the tip is just touching the deck surface, then press 'z'.
+        - Press '1' to automatically go to the expected location of the first
+          calibration point. Jog the robot until the tip is actually at
+          the point, then press 'enter'.
+    """
     prompt = input(
         ">>> Warning! Running this tool backup and clear any previous calibration data. Proceed (y/[n])? ")  # NOQA
     if prompt not in ['y', 'Y', 'yes']:
@@ -280,22 +336,22 @@ def main():
         sys.exit()
     backup_configuration_and_reload()
 
-    generate_test_points()
+    # older machines cannot reach deck points, use the screw holes instead
+    res = input('Are you calibrating to the screw holes? (y/[n])')
+    if res in ['y', 'Y', 'yes']:
+        calibration_points = expected_holes
+    else:
+        calibration_points = expected_dots
 
     robot.connect()
-    tip = urwid.Text(u"X/Y/Z: left,right/up,down/q,a; Pipette (swap): z; Steps: -/=; Test points: 1, 2, 3")   # NOQA
-    pile = urwid.Pile([tip, status_text])
-    root = urwid.Filler(pile, 'top')
-    event_loop = urwid.main_loop.AsyncioEventLoop(
-        loop=asyncio.get_event_loop()
-    )
-    ui_loop = urwid.MainLoop(
-        root,
-        handle_mouse=False,
-        unhandled_input=key_pressed,
-        event_loop=event_loop)
-    status(status_text, 'Hello!')
-    ui_loop.run()
+
+    # Notes:
+    #  - 200ul tip is 51.7mm long when attached to a pipette
+    #  - For xyz coordinates, (0, 0, 0) is the lower-left corner of the robot
+    cli = CLITool(
+        point_set=calibration_points,
+        tip_length=51.7)
+    cli.ui_loop.run()
 
     print('Robot config: \n', robot.config)
 

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -349,7 +349,7 @@ def main():
     Instructions:
         - Robot must be set up with a 300ul single-channel pipette installed on
           the right-hand mount.
-        - Put a 300ul tip onto the pipette.
+        - Put a GEB 300ul tip onto the pipette.
         - Use the arrow keys to jog the robot over an open area of the deck
           (the base deck surface, not over a ridge or numeral engraving). You
           can use the '-' and '=' keys to decrease or increase the amount of
@@ -360,20 +360,22 @@ def main():
           calibration point. Jog the robot until the tip is actually at
           the point, then press 'enter'.
         - Repeat with '2' and '3'.
-        - Press space to save the configuration.
+        - After calibrating all three points, press the space bar to save the
+          configuration.
         - Optionally, press 4,5,6 or 7 to validate the new configuration.
         - Press 'p' to perform tip probe.
         - Press 'esc' to exit the program.
     """
     prompt = input(
-        ">>> Warning! Running this tool backup and clear any previous calibration data. Proceed (y/[n])? ")  # NOQA
+        ">>> Warning! Running this tool backup and clear any previous "
+        "calibration data. Proceed (y/[n])? ")
     if prompt not in ['y', 'Y', 'yes']:
         print('Exiting--prior configuration data not changed')
         sys.exit()
     backup_configuration_and_reload()
 
     # older machines cannot reach deck points, use the screw holes instead
-    res = input('Are you calibrating to the screw holes? (y/[n])')
+    res = input('Are you calibrating to the screw holes (y/[n])? ')
     if res in ['y', 'Y', 'yes']:
         calibration_points = expected_holes
     else:

--- a/api/opentrons/cli/main.py
+++ b/api/opentrons/cli/main.py
@@ -56,7 +56,17 @@ class CLITool:
         if not loop:
             loop = urwid.main_loop.AsyncioEventLoop(
                 loop=asyncio.get_event_loop())
-        self._tip_text_box = urwid.Text('X/Y/Z: left,right/up,down/q,a; Steps: -/=; Test points: 1, 2, 3')  # NOQA
+        controls = '\n'.join([
+            'arrow keys: move the gantry',
+            'q/a:        move the pipette up/down',
+            '=/-:        increase/decrease the distance moved on each step',
+            '1/2/3:      go to calibration point 1/2/3',
+            'enter:      confirm current calibration point position',
+            'space:      save data (after confirming all 3 points)',
+            'p:          perform tip probe (after saving calibration data)',
+            'esc:        exit calibration tool'
+        ])
+        self._tip_text_box = urwid.Text(controls)
         self._status_text_box = urwid.Text('')
         self._pile = urwid.Pile([self._tip_text_box, self._status_text_box])
         self._filler = urwid.Filler(self._pile, 'top')
@@ -262,7 +272,7 @@ class CLITool:
 
         text = '\n'.join([
             points,
-            'Smoothie: {}'.format(self.current_position),
+            # 'Smoothie: {}'.format(self.current_position),
             'World: {}'.format(apply_transform(
                 self._calibration_matrix, self.current_position)),
             'Step: {}'.format(self.current_step()),
@@ -337,9 +347,9 @@ def main():
     A CLI application for performing factory calibration of an Opentrons robot
 
     Instructions:
-        - Robot must be set up with a single-channel pipette installed on the
-          right-hand mount.
-        - Put a 200ul tip onto the pipette.
+        - Robot must be set up with a 300ul single-channel pipette installed on
+          the right-hand mount.
+        - Put a 300ul tip onto the pipette.
         - Use the arrow keys to jog the robot over an open area of the deck
           (the base deck surface, not over a ridge or numeral engraving). You
           can use the '-' and '=' keys to decrease or increase the amount of
@@ -352,6 +362,7 @@ def main():
         - Repeat with '2' and '3'.
         - Press space to save the configuration.
         - Optionally, press 4,5,6 or 7 to validate the new configuration.
+        - Press 'p' to perform tip probe.
         - Press 'esc' to exit the program.
     """
     prompt = input(

--- a/api/tests/opentrons/cli/test_linal.py
+++ b/api/tests/opentrons/cli/test_linal.py
@@ -1,5 +1,5 @@
 from math import pi, sin, cos
-from opentrons.cli.linal import solve
+from opentrons.cli.linal import solve, add_z, apply_transform
 import numpy as np
 
 
@@ -23,3 +23,47 @@ def test_solve():
     result = np.dot(X, np.array([[0], [1], [1]])).transpose()
 
     return np.isclose(expected, result).all()
+
+
+def test_add_z():
+    x = 5
+    y = 10
+    z = 20
+
+    xy_array = np.array([
+        [1, 0, x],
+        [0, 1, y],
+        [0, 0, 1]])
+
+    expected = np.array([
+        [1, 0, 0, x],
+        [0, 1, 0, y],
+        [0, 0, 1, z],
+        [0, 0, 0, 1]])
+
+    result = add_z(xy_array, z)
+    assert (result == expected).all()
+
+
+def test_apply_transform():
+    x = 1
+    y = 2
+    z = 3
+
+    x_delta = -0.1
+    y_delta = -0.2
+    z_delta = 0.3
+
+    transform = [
+        [1, 0, 0, x_delta],
+        [0, 1, 0, y_delta],
+        [0, 0, 1, z_delta],
+        [0, 0, 0, 1]]
+
+    expected = (
+        round(x - x_delta, 2),
+        round(y - y_delta, 2),
+        round(z - z_delta, 2))
+
+    result = apply_transform(transform, (x, y, z))
+    assert result == expected


### PR DESCRIPTION
## overview

First pass refactoring the factory calibration CLI app. Removes use of global state and separates out functionality into methods that will be possible to unit test. Changes to functionality of tool should be very minor.

## changelog

- (refactor) Move current factory calibration functionality from script into class
- (docs) Add documentation to factory calibration app
- (refactor) Add tests to CLI methods

## review requests

Perform calibration on a robot using the prior version of the CLI, save the data, and then re-do calibration with this CLI. Compare the results.
