### PR TITLE
(complib) invalid+selected states for form fields

### DIFF
--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -78,7 +78,7 @@ exports[`CheckboxField renders correctly when unchecked 1`] = `
 
 exports[`DropdownField renders correctly with a falsey value 1`] = `
 <div
-  className={false}
+  className={undefined}
 >
   <div
     className="dropdown_field"
@@ -140,7 +140,7 @@ exports[`DropdownField renders correctly with a falsey value 1`] = `
 
 exports[`DropdownField renders correctly with a value 1`] = `
 <div
-  className={false}
+  className={undefined}
 >
   <div
     className="dropdown_field"

--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -78,101 +78,119 @@ exports[`CheckboxField renders correctly when unchecked 1`] = `
 
 exports[`DropdownField renders correctly with a falsey value 1`] = `
 <div
-  className="dropdown_field"
+  className={false}
 >
-  <select
-    className="dropdown"
-    onChange={undefined}
-    value=""
+  <div
+    className="dropdown_field"
   >
-    <option
+    <select
+      className="dropdown"
+      onChange={undefined}
       value=""
     >
-      
-    </option>
-    <option
-      value="dna"
+      <option
+        value=""
+      >
+        
+      </option>
+      <option
+        value="dna"
+      >
+        DNA
+      </option>
+      <option
+        value="rna"
+      >
+        RNA
+      </option>
+      <option
+        value="protein"
+      >
+        Protein
+      </option>
+    </select>
+    <div
+      className="dropdown_icon"
     >
-      DNA
-    </option>
-    <option
-      value="rna"
-    >
-      RNA
-    </option>
-    <option
-      value="protein"
-    >
-      Protein
-    </option>
-  </select>
+      <svg
+        aria-hidden="true"
+        className=""
+        fill="currentColor"
+        height={undefined}
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="100%"
+        x={undefined}
+        y={undefined}
+      >
+        <path
+          d="M7,10L12,15L17,10H7Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </div>
+  </div>
   <div
-    className="dropdown_icon"
+    className="input_caption"
   >
-    <svg
-      aria-hidden="true"
-      className=""
-      fill="currentColor"
-      height={undefined}
-      version="1.1"
-      viewBox="0 0 24 24"
-      width="100%"
-      x={undefined}
-      y={undefined}
-    >
-      <path
-        d="M7,10L12,15L17,10H7Z"
-        fillRule="evenodd"
-      />
-    </svg>
+    <span />
   </div>
 </div>
 `;
 
 exports[`DropdownField renders correctly with a value 1`] = `
 <div
-  className="dropdown_field"
+  className={false}
 >
-  <select
-    className="dropdown"
-    onChange={undefined}
-    value="rna"
+  <div
+    className="dropdown_field"
   >
-    <option
-      value="dna"
-    >
-      DNA
-    </option>
-    <option
+    <select
+      className="dropdown"
+      onChange={undefined}
       value="rna"
     >
-      RNA
-    </option>
-    <option
-      value="protein"
+      <option
+        value="dna"
+      >
+        DNA
+      </option>
+      <option
+        value="rna"
+      >
+        RNA
+      </option>
+      <option
+        value="protein"
+      >
+        Protein
+      </option>
+    </select>
+    <div
+      className="dropdown_icon"
     >
-      Protein
-    </option>
-  </select>
+      <svg
+        aria-hidden="true"
+        className=""
+        fill="currentColor"
+        height={undefined}
+        version="1.1"
+        viewBox="0 0 24 24"
+        width="100%"
+        x={undefined}
+        y={undefined}
+      >
+        <path
+          d="M7,10L12,15L17,10H7Z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </div>
+  </div>
   <div
-    className="dropdown_icon"
+    className="input_caption"
   >
-    <svg
-      aria-hidden="true"
-      className=""
-      fill="currentColor"
-      height={undefined}
-      version="1.1"
-      viewBox="0 0 24 24"
-      width="100%"
-      x={undefined}
-      y={undefined}
-    >
-      <path
-        d="M7,10L12,15L17,10H7Z"
-        fillRule="evenodd"
-      />
-    </svg>
+    <span />
   </div>
 </div>
 `;
@@ -204,19 +222,29 @@ exports[`InputField renders correctly 1`] = `
   >
     Input field
   </div>
-  <div
-    className="input_field"
-  >
-    <input
-      onChange={undefined}
-      placeholder="Placeholder Text"
-      type="text"
-      value=""
-    />
+  <div>
     <div
-      className="suffix"
+      className="input_field"
     >
-      μL
+      <input
+        onChange={undefined}
+        placeholder="Placeholder Text"
+        type="text"
+        value=""
+      />
+      <div
+        className="suffix"
+      >
+        μL
+      </div>
+    </div>
+    <div
+      className="input_caption"
+    >
+      <span />
+      <span
+        className="right"
+      />
     </div>
   </div>
 </label>

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -13,13 +13,15 @@ type Props = {
   /** classes to apply */
   className?: string,
   /** label text for checkbox */
-  label?: string
+  label?: string,
+  /** if is included, checkbox will use error style. The content of the string is ignored. */
+  error?: string
 }
 
 export default function CheckboxField (props: Props) {
   return (
     <label className={cx(styles.form_field, props.className)}>
-      <div className={styles.checkbox_icon}>
+      <div className={cx(styles.checkbox_icon, {[styles.error]: props.error !== undefined})}>
         <Icon name={props.value ? 'checked box' : 'unchecked box'} width='100%' />
       </div>
       <input

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -15,13 +15,14 @@ type Props = {
   /** label text for checkbox */
   label?: string,
   /** if is included, checkbox will use error style. The content of the string is ignored. */
-  error?: string
+  error?: ?string
 }
 
 export default function CheckboxField (props: Props) {
+  const error = props.error != null
   return (
     <label className={cx(styles.form_field, props.className)}>
-      <div className={cx(styles.checkbox_icon, {[styles.error]: props.error !== undefined})}>
+      <div className={cx(styles.checkbox_icon, {[styles.error]: error})}>
         <Icon name={props.value ? 'checked box' : 'unchecked box'} width='100%' />
       </div>
       <input

--- a/components/src/forms/CheckboxField.md
+++ b/components/src/forms/CheckboxField.md
@@ -1,5 +1,5 @@
 ```js
-initialState = {isChecked1: true, isChecked2: false}
+initialState = {isChecked1: false, isChecked2: true}
 
 ;<div>
   <CheckboxField
@@ -9,10 +9,11 @@ initialState = {isChecked1: true, isChecked2: false}
     value={state.isChecked1}
   />
   <CheckboxField
-    label="Check Box 2"
+    label="Check Box 2 (with error)"
     className="display-block"
     onChange={() => setState({...state, isChecked2: !state.isChecked2})}
     value={state.isChecked2}
+    error='error string example'
   />
 </div>
 ```

--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -18,7 +18,7 @@ type Props = {
   /** optional caption. hidden when `error` is given */
   caption?: string,
   /** if included, DropdownField will use error style and display error instead of caption */
-  error?: string
+  error?: ?string
 }
 
 export default function DropdownField (props: Props) {
@@ -27,10 +27,10 @@ export default function DropdownField (props: Props) {
     ? props.options
     : [{name: '', value: ''}, ...props.options]
 
-  const error = props.error !== undefined
+  const error = props.error != null
 
   return (
-    <div className={error && styles.error}>
+    <div className={error ? styles.error : undefined}>
       <div className={styles.dropdown_field}>
         <select value={props.value || ''} onChange={props.onChange} className={styles.dropdown}>
           {options.map(opt =>

--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -14,7 +14,11 @@ type Props = {
     value: string
   }>,
   /** classes to apply */
-  className?: string
+  className?: string,
+  /** optional caption. hidden when `error` is given */
+  caption?: string,
+  /** if included, DropdownField will use error style and display error instead of caption */
+  error?: string
 }
 
 export default function DropdownField (props: Props) {
@@ -23,18 +27,25 @@ export default function DropdownField (props: Props) {
     ? props.options
     : [{name: '', value: ''}, ...props.options]
 
-  return (
-    <div className={styles.dropdown_field}>
-      <select value={props.value || ''} onChange={props.onChange} className={styles.dropdown}>
-        {options.map(opt =>
-          <option key={opt.value} value={opt.value}>
-            {opt.name}
-          </option>
-        )}
-      </select>
+  const error = props.error !== undefined
 
-      <div className={styles.dropdown_icon}>
-        <Icon name='menu down' width='100%' />
+  return (
+    <div className={error && styles.error}>
+      <div className={styles.dropdown_field}>
+        <select value={props.value || ''} onChange={props.onChange} className={styles.dropdown}>
+          {options.map(opt =>
+            <option key={opt.value} value={opt.value}>
+              {opt.name}
+            </option>
+          )}
+        </select>
+
+        <div className={styles.dropdown_icon}>
+          <Icon name='menu down' width='100%' />
+        </div>
+      </div>
+      <div className={styles.input_caption}>
+        <span>{error ? props.error : props.caption}</span>
       </div>
     </div>
   )

--- a/components/src/forms/FormGroup.js
+++ b/components/src/forms/FormGroup.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
+import {Icon} from '../icons'
 import styles from './forms.css'
 
 type Props = {
@@ -8,13 +10,23 @@ type Props = {
   /** form content */
   children?: React.Node,
   /** classes to apply */
-  className?: string
+  className?: string,
+  /** if is included, FormGroup title will use error style. The content of the string is ignored. */
+  error?: string
 }
 
 export default function FormGroup (props: Props) {
+  const error = props.error !== undefined
   return (
     <div className={props.className}>
-      <div className={styles.formgroup_label}>{props.label}</div>
+      <div className={cx(styles.formgroup_label, {[styles.error]: error})}>
+        {error &&
+          <div className={styles.error_icon}>
+            <Icon name='alert' />
+          </div>
+        }
+        {props.label}
+      </div>
       {props.children}
     </div>
   )

--- a/components/src/forms/FormGroup.js
+++ b/components/src/forms/FormGroup.js
@@ -12,11 +12,11 @@ type Props = {
   /** classes to apply */
   className?: string,
   /** if is included, FormGroup title will use error style. The content of the string is ignored. */
-  error?: string
+  error?: ?string
 }
 
 export default function FormGroup (props: Props) {
-  const error = props.error !== undefined
+  const error = props.error != null
   return (
     <div className={props.className}>
       <div className={cx(styles.formgroup_label, {[styles.error]: error})}>

--- a/components/src/forms/FormGroup.md
+++ b/components/src/forms/FormGroup.md
@@ -1,17 +1,24 @@
 ```js
-initialState = {checkbox1: true, inputfield1: null}
+initialState = {checkbox1: true, inputfield1: ''}
 
-;<FormGroup label='This is a FormGroup'>
+function isError(state) {
+  return ((state.inputfield1 === '') || (parseFloat(state.inputfield1) > 0))
+    ? undefined
+    : 'volume must be a positive number'
+}
+
+;<FormGroup label='This is a FormGroup' error={isError(state)}>
   <CheckboxField
     label="Check Box 1"
-    onChange={e => setState({checkbox1: !state.checkbox1})}
-    checked={state.checkbox1}
+    onChange={() => setState({...state, checkbox1: !state.checkbox1})}
+    value={state.checkbox1}
   />
   <InputField
     placeholder='Placeholder Text'
-    onChange={e => setState({inputfield1: e.target.value})}
+    onChange={e => setState({...state, inputfield1: e.target.value})}
     value={state.inputfield1}
     units='μL'
+    error={isError(state)}
   />
 </FormGroup>
 ```

--- a/components/src/forms/FormGroup.md
+++ b/components/src/forms/FormGroup.md
@@ -1,13 +1,13 @@
 ```js
 initialState = {checkbox1: true, inputfield1: ''}
 
-function isError(state) {
+function getError (state) {
   return ((state.inputfield1 === '') || (parseFloat(state.inputfield1) > 0))
-    ? undefined
+    ? null
     : 'volume must be a positive number'
 }
 
-;<FormGroup label='This is a FormGroup' error={isError(state)}>
+;<FormGroup label='This is a FormGroup' error={getError(state)}>
   <CheckboxField
     label="Check Box 1"
     onChange={() => setState({...state, checkbox1: !state.checkbox1})}
@@ -18,7 +18,7 @@ function isError(state) {
     onChange={e => setState({...state, inputfield1: e.target.value})}
     value={state.inputfield1}
     units='μL'
-    error={isError(state)}
+    error={getError(state)}
   />
 </FormGroup>
 ```

--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
+import {Icon} from '../icons'
 // import globalStyles from '../styles/index.css'
 import styles from './forms.css'
 
@@ -9,28 +10,48 @@ type Props = {
   onChange: (event: SyntheticEvent<>) => void,
   /** classes to apply */
   className?: string,
-  /** label text */
+  /** inline label text */
   label?: string,
   /** placeholder text */
   placeholder?: string,
   /** optional units string, appears to the right of input text */
   units?: string,
   /** current value of text in box, defaults to '' */
-  value?: string
+  value?: string,
+  /** if included, InputField will use error style and display error instead of caption */
+  error?: string,
+  /** optional caption. hidden when `error` is given */
+  caption?: string,
+  /** appears to the right of the caption. Used for character limits, eg '0/45' */
+  secondaryCaption?: string
 }
 
 export default function InputField (props: Props) {
+  const error = props.error !== undefined
   return (
-    <label className={cx(styles.form_field, props.className)}>
-      <div className={styles.label_text}>{props.label}</div>
-      <div className={styles.input_field}>
-        <input
-          type='text' /* TODO: support number ? */
-          value={props.value || ''}
-          placeholder={props.placeholder}
-          onChange={props.onChange}
-        />
-        {props.units && <div className={styles.suffix}>{props.units}</div>}
+    <label className={cx(styles.form_field, props.className, {[styles.error]: error})}>
+      <div className={styles.label_text}>
+        {props.label && error &&
+          <div className={styles.error_icon}>
+            <Icon name='alert' />
+          </div>
+        }
+        {props.label}
+      </div>
+      <div>
+        <div className={styles.input_field}>
+          <input
+            type='text' /* TODO: support number ? */
+            value={props.value || ''}
+            placeholder={props.placeholder}
+            onChange={props.onChange}
+          />
+          {props.units && <div className={styles.suffix}>{props.units}</div>}
+        </div>
+        <div className={styles.input_caption}>
+          <span>{error ? props.error : props.caption}</span>
+          <span className={styles.right}>{props.secondaryCaption}</span>
+        </div>
       </div>
     </label>
   )

--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -19,7 +19,7 @@ type Props = {
   /** current value of text in box, defaults to '' */
   value?: string,
   /** if included, InputField will use error style and display error instead of caption */
-  error?: string,
+  error?: ?string,
   /** optional caption. hidden when `error` is given */
   caption?: string,
   /** appears to the right of the caption. Used for character limits, eg '0/45' */
@@ -27,7 +27,7 @@ type Props = {
 }
 
 export default function InputField (props: Props) {
-  const error = props.error !== undefined
+  const error = props.error != null
   return (
     <label className={cx(styles.form_field, props.className, {[styles.error]: error})}>
       <div className={styles.label_text}>

--- a/components/src/forms/InputField.md
+++ b/components/src/forms/InputField.md
@@ -1,8 +1,14 @@
 ```js
-initialState = {inputValue: null}
+initialState = {inputValue: ''}
 
 function handleChange (e) {
   setState({inputValue: e.target.value})
+}
+
+function getError (state) {
+  return state.inputValue.length > 12
+    ? 'Too many characters'
+    : undefined
 }
 
 ;<InputField
@@ -11,6 +17,9 @@ function handleChange (e) {
   onChange={handleChange}
   value={state.inputValue}
   units='μL'
+  caption='caption here'
+  secondaryCaption={state.inputValue.length + '/12'}
+  error={getError(state)}
 />
 ```
 

--- a/components/src/forms/RadioGroup.js
+++ b/components/src/forms/RadioGroup.js
@@ -20,11 +20,11 @@ type Props = {
   /** classes to apply */
   className?: string,
   /** if is included, RadioGroup will use error style. The content of the string is ignored. */
-  error?: string
+  error?: ?string
 }
 
 export default function RadioGroup (props: Props) {
-  const error = props.error !== undefined
+  const error = props.error != null
   return (
     <div className={cx({[styles.inline]: props.inline, [styles.error]: error})}>
       {props.options && props.options.map(radio =>

--- a/components/src/forms/RadioGroup.js
+++ b/components/src/forms/RadioGroup.js
@@ -6,24 +6,27 @@ import {Icon} from '../icons'
 import styles from './forms.css'
 
 type Props = {
-  /* change handler */
+  /** change handler */
   onChange: (event: SyntheticEvent<>) => void,
-  /* value that is checked */
+  /** value that is checked */
   value?: string,
-  /* Array of {name, value} data */
+  /** Array of {name, value} data */
   options?: Array<{
     name: string,
     value: string
   }>,
-  /* Show radio buttons inline instead of stacked */
+  /** Show radio buttons inline instead of stacked */
   inline?: boolean,
-  /* classes to apply */
-  className?: string
+  /** classes to apply */
+  className?: string,
+  /** if is included, RadioGroup will use error style. The content of the string is ignored. */
+  error?: string
 }
 
 export default function RadioGroup (props: Props) {
+  const error = props.error !== undefined
   return (
-    <div className={cx({[styles.inline]: props.inline})}>
+    <div className={cx({[styles.inline]: props.inline, [styles.error]: error})}>
       {props.options && props.options.map(radio =>
         <label key={radio.value} className={cx(styles.form_field, props.className)}>
           <div className={styles.checkbox_icon}>

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -38,7 +38,11 @@
   /* Icon for radiobutton and for checkbox */
   width: 1.25rem;
   min-width: 1.25rem;
-  fill: var(--c-med-gray);
+  color: var(--c-dark-gray);
+
+  &.error {
+    color: var(--c-mustard);
+  }
 }
 
 .input_field {
@@ -53,12 +57,11 @@
     border-radius: inherit;
     border: none;
     flex: 1 1 auto;
-    color: inherit;
+    color: var(--c-dark-gray);
   }
 
   & input:focus {
     outline: none;
-    color: inherit;
   }
 
   & input::placeholder {
@@ -66,7 +69,7 @@
   }
 
   &:focus-within {
-    border: 2px solid var(--c-med-gray);
+    background-color: var(--c-light-blue);
   }
 
   & .suffix {
@@ -74,6 +77,17 @@
     flex: 1 0;
     font-weight: var(--fw-semibold);
     text-align: right;
+    color: var(--c-dark-gray);
+  }
+}
+
+.input_caption {
+  font-size: var(--fs-caption);
+  min-height: var(--fs-caption);
+  color: var(--c-med-gray);
+
+  & .right {
+    float: right;
   }
 }
 
@@ -107,7 +121,30 @@
     top: 0.2rem;
     right: 0.25rem;
     width: 1.25rem;
-    color: var(--c-dark-gray);
     pointer-events: none;
+
+    & svg {
+      color: var(--c-dark-gray);
+    }
   }
+}
+
+.error div,
+.error span {
+  color: var(--c-mustard);
+}
+
+.error select {
+  background-color: var(--c-mustard);
+}
+
+.error .input_field {
+  background-color: var(--c-mustard);
+}
+
+.error_icon {
+  display: inline-block;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  padding-right: 0.5rem;
 }

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -2,8 +2,8 @@
   /* ot brand */
   --c-mustard: #ffd252;
   --c-blue: #006fff;
+  --c-light-blue: color(var(--c-blue) lightness(85%));
   --c-teal: #05c1b3;
-  --c-mustard: #ffd252;
 
   /* grays */
   --c-dark-gray: #4a4a4a;


### PR DESCRIPTION
closes #712 

## changelog

* selected state of form fields matches design (light blue, no border)
* uniform `error?: ?string` prop for all form components
* `caption` prop for InputField & DropdownField
* `secondaryCaption` for InputField
* new `--c-light-blue` added to colors.css
* error state examples in styleguidist .md's

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-components/complib_invalid-form-state/index.html

Type non-positive-numbers into "This is a FormGroup" example's input field to see error

Type too many characters into the "0/12" InputField example

Try popping an `error='nooo'` prop into the different form field examples in styleguide to see error states

And `caption='something'` to InputField / DropdownField (+ `secondaryCaption='99/100'` etc to InputField)

Select fields and see they're blue