### PR TITLE
(pd) Page navigation -- Redux and Container foundation

### DIFF
--- a/protocol-designer/src/components/ProtocolEditor.css
+++ b/protocol-designer/src/components/ProtocolEditor.css
@@ -6,11 +6,6 @@
   width: 100%;
 }
 
-.nav_bar {
-  /* TODO Ian 2018-01-23 Why does VerticalNavBar color and height not match app? */
-  height: 100vh;
-}
-
 .main_page_wrapper {
   flex: 1;
   height: 100vh;

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react'
-import {Icon, TitleBar, VerticalNavBar} from '@opentrons/components'
+import {TitleBar} from '@opentrons/components'
 import styles from './ProtocolEditor.css'
 import ConnectedStepEditForm from '../containers/ConnectedStepEditForm'
 import ConnectedStepList from '../containers/ConnectedStepList'
+import ConnectedNav from '../containers/ConnectedNav'
 
 const SelectorDebugger = process.env.NODE_ENV === 'development'
   ? require('../containers/SelectorDebugger').default
@@ -15,10 +16,7 @@ export default function ProtocolEditor () {
       <SelectorDebugger />
 
       <div className={styles.wrapper}>
-        <VerticalNavBar className={styles.nav_bar}>
-          <Icon name='file' />
-          <Icon name='cog' />
-        </VerticalNavBar>
+        <ConnectedNav />
         <ConnectedStepList />
         <div className={styles.main_page_wrapper}>
           {/* TODO Ian 2018-01-24 Connect TitleBar, figure out when it changes */}

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -3,6 +3,7 @@ import thunk from 'redux-thunk'
 
 import labwareIngredRootReducer from './labware-ingred/reducers'
 import steplistRootReducer from './steplist/reducers'
+import {rootReducer as navigationRootReducer} from './navigation'
 
 // TODO: Ian 2018-01-15 how to make this more DRY with hot reloading?
 function getRootReducer () {
@@ -15,7 +16,8 @@ function getRootReducer () {
 export default function configureStore () {
   const reducer = combineReducers({
     labwareIngred: labwareIngredRootReducer,
-    steplist: steplistRootReducer
+    steplist: steplistRootReducer,
+    navigation: navigationRootReducer
   })
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux'
 
 import {NavButton, VerticalNavBar} from '@opentrons/components'
 import {type Page, actions, selectors} from '../navigation'
+import styles from './NavBar.css'
 
 type Props = {
   currentPage: Page,
@@ -13,7 +14,7 @@ type Props = {
 
 function Nav (props: Props) {
   return (
-    <VerticalNavBar>
+    <VerticalNavBar className={styles.nav_bar}>
       <NavButton
         iconName='file'
         isCurrent={props.currentPage === 'file page'}

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -1,0 +1,42 @@
+// @flow
+import * as React from 'react'
+import type {Dispatch} from '../types'
+import {connect} from 'react-redux'
+
+import {NavButton, VerticalNavBar} from '@opentrons/components'
+import {type Page, actions, selectors} from '../navigation'
+
+type Props = {
+  currentPage: Page,
+  handleClick: Page => (e: ?SyntheticEvent<>) => void
+}
+
+function Nav (props: Props) {
+  return (
+    <VerticalNavBar>
+      <NavButton
+        iconName='file'
+        isCurrent={props.currentPage === 'file page'}
+        onClick={props.handleClick('file page')} />
+
+      <NavButton
+        iconName='cog'
+        isCurrent={props.currentPage === 'editor page'}
+        onClick={props.handleClick('editor page')} />
+    </VerticalNavBar>
+  )
+}
+
+function mapStateToProps (state) {
+  return {
+    currentPage: selectors.currentPage(state)
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch<*>) {
+  return {
+    handleClick: (pageName: Page) => () => dispatch(actions.navigateToPage(pageName))
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Nav)

--- a/protocol-designer/src/containers/NavBar.css
+++ b/protocol-designer/src/containers/NavBar.css
@@ -1,0 +1,3 @@
+.nav_bar {
+  height: 100vh;
+}

--- a/protocol-designer/src/navigation/actions.js
+++ b/protocol-designer/src/navigation/actions.js
@@ -1,0 +1,7 @@
+// @flow
+import type {Page} from './types'
+
+export const navigateToPage = (payload: Page) => ({
+  type: 'NAVIGATE_TO_PAGE',
+  payload
+})

--- a/protocol-designer/src/navigation/index.js
+++ b/protocol-designer/src/navigation/index.js
@@ -1,0 +1,15 @@
+// @flow
+import * as actions from './actions'
+import rootReducer, {selectors, type RootState} from './reducers'
+// TODO export types from reducers
+export * from './types'
+
+export {
+  actions,
+  rootReducer,
+  selectors
+}
+
+export type {
+  RootState
+}

--- a/protocol-designer/src/navigation/reducers.js
+++ b/protocol-designer/src/navigation/reducers.js
@@ -1,0 +1,28 @@
+// @flow
+import { combineReducers } from 'redux'
+import { handleActions } from 'redux-actions'
+import type { ActionType } from 'redux-actions'
+
+import type {BaseState} from '../types'
+import {navigateToPage} from './actions'
+import type {Page} from './types'
+
+const page = handleActions({
+  NAVIGATE_TO_PAGE: (state, action: ActionType<typeof navigateToPage>) => action.payload
+}, 'file page')
+
+export const _allReducers = {
+  page
+}
+
+export type RootState = {page: Page}
+
+const rootReducer = combineReducers(_allReducers)
+
+export default rootReducer
+
+const rootSelector = (state: BaseState) => state.navigation
+
+export const selectors = {
+  currentPage: (state: BaseState) => rootSelector(state).page
+}

--- a/protocol-designer/src/navigation/types.js
+++ b/protocol-designer/src/navigation/types.js
@@ -1,0 +1,2 @@
+// @flow
+export type Page = 'file page' | 'editor page' // TODO rename once pages have real names

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -1,8 +1,10 @@
 // @flow
 import type {RootState as StepList} from './steplist/reducers'
+import type {RootState as Navigation} from './navigation'
 
 export type BaseState = {
-  steplist: StepList
+  steplist: StepList,
+  navigation: Navigation
 }
 
 export type Dispatch<A> = (action: A | ThunkAction<A>) => any


### PR DESCRIPTION
## overview

Boilerplate stuff for page navigation in PD.

## changelog

* Add new `navigation/` module with Redux stuff for page navigation. My plan is that other navigation-related stuff, like "labware & ingredient setup" mode vs "step editing" mode, and modal states, will go in here too. (Probably header state as well, although that might be its own mini-module, TBD.)

* Use NavIcon instead of Icon in nav panel
* `ConnectedNav`

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_style_nav/index.html#/

* Clicking the 2 NavIcons should visually toggle their "selected" state. The actual "main page" on the right side of the screen doesn't change.