### PR TITLE
Add some light control endpoints to server

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -189,6 +189,15 @@ class Session(object):
 
         return self
 
+    def identify(self):
+        robot.identify()
+
+    def turn_on_rail_lights(self):
+        robot.turn_on_rail_lights()
+
+    def turn_off_rail_lights(self):
+        robot.turn_off_rail_lights()
+
     def set_state(self, state):
         log.info("State set to {}".format(state))
         if state not in VALID_STATES:

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -452,12 +452,16 @@ class SmoothieDriver_3_0_0:
             raise RuntimeError("Cant probe axis {}".format(axis))
 
     def turn_on_button_light(self):
-        log.debug("Turning on the button")
         gpio.set_high(gpio.OUTPUT_PINS['BLUE_BUTTON'])
 
     def turn_off_button_light(self):
-        log.debug("Turning off the button")
         gpio.set_low(gpio.OUTPUT_PINS['BLUE_BUTTON'])
+
+    def turn_on_rail_lights(self):
+        gpio.set_high(gpio.OUTPUT_PINS['FRAME_LEDS'])
+
+    def turn_off_rail_lights(self):
+        gpio.set_low(gpio.OUTPUT_PINS['FRAME_LEDS'])
 
     def kill(self):
         """

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -286,6 +286,23 @@ class Robot(object):
     def turn_off_button_light(self):
         self._driver.turn_off_button_light()
 
+    def turn_on_rail_lights(self):
+        self._driver.turn_on_rail_lights()
+
+    def turn_off_rail_lights(self):
+        self._driver.turn_off_rail_lights()
+
+    def identify(self, seconds):
+        """
+        Identify a robot by flashing the light around the frame button for 10s
+        """
+        from time import sleep
+        for i in range(seconds):
+            self.turn_off_button_light()
+            sleep(0.25)
+            self.turn_on_button_light()
+            sleep(0.25)
+
     def setup_gantry(self):
         driver = self._driver
 

--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import subprocess
+from threading import Thread
 from aiohttp import web
 from opentrons import robot, __version__
 
@@ -116,3 +117,19 @@ async def wifi_status(request):
     return web.json_response(
         body=json.dumps(connectivity)
     )
+
+
+async def identify(request):
+    Thread(target=lambda: robot.identify(
+        int(request.query.get('seconds', '10')))).run()
+    return web.Response(text='Ok')
+
+
+async def turn_on_rail_lights(request):
+    robot.turn_on_rail_lights()
+    return web.Response(text='Ok')
+
+
+async def turn_off_rail_lights(request):
+    robot.turn_off_rail_lights()
+    return web.Response(text='Ok')

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -6,7 +6,7 @@ import os
 from aiohttp import web
 from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
-from opentrons.server.endpoints import health, wifi_configure, wifi_list, wifi_status  # NOQA
+from opentrons.server import endpoints as endp
 from logging.config import dictConfig
 
 from argparse import ArgumentParser
@@ -77,10 +77,13 @@ def init(loop=None):
     routes for methods defined in opentrons.server.endpoints
     """
     server = Server(MainRouter(), loop=loop)
-    server.app.router.add_get('/health', health)
-    server.app.router.add_get('/wifi/list', wifi_list)
-    server.app.router.add_post('/wifi/configure', wifi_configure)
-    server.app.router.add_get('/wifi/status', wifi_status)
+    server.app.router.add_get('/health', endp.health)
+    server.app.router.add_get('/wifi/list', endp.wifi_list)
+    server.app.router.add_post('/wifi/configure', endp.wifi_configure)
+    server.app.router.add_get('/wifi/status', endp.wifi_status)
+    server.app.router.add_get('/identify', endp.identify)
+    server.app.router.add_get('/lights/on', endp.turn_on_rail_lights)
+    server.app.router.add_get('/lights/off', endp.turn_off_rail_lights)
     return server.app
 
 


### PR DESCRIPTION
## overview

Adds endpoints for identifying robot (by blinking the button light) and turning the rail lights on and off

## changelog

- (feature) Add endpoints for identifying robot and turning rail lights on and off

## review requests

To identify:

```
curl <robot_ip>:31950/identify?seconds=10
```

To turn lights on and off:

```
curl <robot_ip>:31950/lights/on
curl <robot_ip>:31950/lights/off
```

Code on `son-of-moon-moon` has these endpoints available if you want to test