### PR TITLE
refactor(app): Rework calibration actions and responses to remove cruft

### DIFF
--- a/app/src/components/deck/ConfirmCalibrationPrompt.js
+++ b/app/src/components/deck/ConfirmCalibrationPrompt.js
@@ -21,11 +21,18 @@ ConfirmCalibrationPrompt.propTypes = {
   }).isRequired
 }
 
-const {MOVING_TO_SLOT, PICKING_UP, HOMING, UPDATING, CONFIRMED} = robotConstants
+const {
+  MOVING_TO_SLOT,
+  OVER_SLOT,
+  PICKING_UP,
+  HOMING,
+  UPDATING,
+  CONFIRMED
+} = robotConstants
 
 export default function ConfirmCalibrationPrompt (props) {
   const {currentLabware, slot} = props
-  const {calibration, isTiprack, type} = currentLabware
+  const {confirmed, calibration, isTiprack, type} = currentLabware
   const toolTipMessage = <Diagram isTiprack={isTiprack} type={type} />
 
   // TODO(mc, 2017-11-27): spinner?
@@ -37,7 +44,10 @@ export default function ConfirmCalibrationPrompt (props) {
     calibration === UPDATING
   ) return null
 
-  if (calibration === CONFIRMED) {
+  if (
+    calibration === CONFIRMED ||
+    (calibration === OVER_SLOT && confirmed)
+  ) {
     return (
       <div className={styles.prompt}>
         <NextLabwareLink />

--- a/app/src/components/deck/ConnectedLabwareItem.js
+++ b/app/src/components/deck/ConnectedLabwareItem.js
@@ -5,18 +5,9 @@ import {withRouter} from 'react-router'
 import LabwareItem from './LabwareItem'
 
 import {
-  constants as robotConstants,
   selectors as robotSelectors,
   actions as robotActions
 } from '../../robot'
-
-const {
-  MOVING_TO_SLOT,
-  PICKING_UP,
-  HOMING,
-  UPDATING,
-  CONFIRMING
-} = robotConstants
 
 export default withRouter(connect(mapStateToProps, null, mergeProps)(LabwareItem))
 
@@ -37,7 +28,6 @@ function mapStateToProps (state, ownProps) {
     type,
     name,
     confirmed,
-    calibration,
     isTiprack,
     calibratorMount
   } = labware
@@ -53,13 +43,7 @@ function mapStateToProps (state, ownProps) {
   const wellContents = highlighted ? {'A1': {selected: true, groupId: 6}} : {}
 
   // TODO Ian 2017-12-14 another selector candidate
-  const isMoving = highlighted && (
-    calibration === MOVING_TO_SLOT ||
-    calibration === PICKING_UP ||
-    calibration === HOMING ||
-    calibration === UPDATING ||
-    calibration === CONFIRMING
-  )
+  const isMoving = highlighted && labware.isMoving
 
   return {
     containerType: type,

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -19,36 +19,73 @@ const tagForRobotApi = (action) => ({...action, meta: {robotCommand: true}})
 
 type Error = {message: string}
 
-export type ConfirmProbedAction = {
+export type ConfirmProbedAction = {|
   type: 'robot:CONFIRM_PROBED',
   payload: Mount
-}
+|}
 
-export type LabwareCalibrationAction = {
+export type PipetteCalibrationAction = {|
   type:
+    | 'robot:JOG'
+  ,
+  payload: {|
+    mount: Mount,
+    axis?: Axis,
+    direction?: Direction
+  |},
+  meta: {|
+    robotCommand: true
+  |}
+|}
+
+export type LabwareCalibrationAction = {|
+  type:
+    | 'robot:MOVE_TO'
     | 'robot:PICKUP_AND_HOME'
     | 'robot:DROP_TIP_AND_HOME'
     | 'robot:CONFIRM_TIPRACK'
     | 'robot:UPDATE_OFFSET'
   ,
-  payload: {mount: Mount, slot: Slot},
-  meta: {robotCommand: true}
-}
+  payload: {|
+    mount: Mount,
+    slot: Slot
+  |},
+  meta: {|
+    robotCommand: true
+  |}
+|}
 
-// TODO(mc, 2018-01-29): split success and failure action types
-//   union types for payload make things difficult
-export type CalibrationResponseAction = {
+export type CalibrationSuccessAction = {
   type:
-    | 'robot:PICKUP_AND_HOME_RESPONSE'
-    | 'robot:DROP_TIP_AND_HOME_RESPONSE'
-    | 'robot:CONFIRM_TIPRACK_RESPONSE'
-    | 'robot:UPDATE_OFFSET_RESPONSE',
-  error: boolean,
-  payload: Error | {
+    | 'robot:MOVE_TO_SUCCESS'
+    | 'robot:JOG_SUCCESS'
+    | 'robot:PICKUP_AND_HOME_SUCCESS'
+    | 'robot:DROP_TIP_AND_HOME_SUCCESS'
+    | 'robot:CONFIRM_TIPRACK_SUCCESS'
+    | 'robot:UPDATE_OFFSET_SUCCESS'
+  ,
+  payload: {
     isTiprack?: boolean,
     tipOn?: boolean
   }
 }
+
+export type CalibrationFailureAction = {|
+  type:
+    | 'robot:MOVE_TO_FAILURE'
+    | 'robot:JOG_FAILURE'
+    | 'robot:PICKUP_AND_HOME_FAILURE'
+    | 'robot:DROP_TIP_AND_HOME_FAILURE'
+    | 'robot:CONFIRM_TIPRACK_FAILURE'
+    | 'robot:UPDATE_OFFSET_FAILURE'
+  ,
+  error: true,
+  payload: Error
+|}
+
+export type CalibrationResponseAction =
+  | CalibrationSuccessAction
+  | CalibrationFailureAction
 
 // TODO(mc, 2018-01-23): refactor to use type above
 //   DO NOT ADD NEW ACTIONS HERE
@@ -69,18 +106,12 @@ export const actionTypes = {
 
   // calibration
   SET_DECK_POPULATED: makeRobotActionName('SET_DECK_POPULATED'),
-  SET_CURRENT_LABWARE: makeRobotActionName('SET_CURRENT_LABWARE'),
-  SET_CURRENT_INSTRUMENT: makeRobotActionName('SET_CURRENT_INSTRUMENT'),
   // TODO(mc, 2018-01-10): rename MOVE_TO_FRONT to PREPARE_TO_PROBE?
   MOVE_TO_FRONT: makeRobotActionName('MOVE_TO_FRONT'),
   MOVE_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
   PROBE_TIP: makeRobotActionName('PROBE_TIP'),
   PROBE_TIP_RESPONSE: makeRobotActionName('PROBE_TIP_RESPONSE'),
-  MOVE_TO: makeRobotActionName('MOVE_TO'),
-  MOVE_TO_RESPONSE: makeRobotActionName('MOVE_TO_RESPONSE'),
   TOGGLE_JOG_DISTANCE: makeRobotActionName('TOGGLE_JOG_DISTANCE'),
-  JOG: makeRobotActionName('JOG'),
-  JOG_RESPONSE: makeRobotActionName('JOG_RESPONSE'),
   CONFIRM_LABWARE: makeRobotActionName('CONFIRM_LABWARE'),
 
   // protocol run controls
@@ -99,8 +130,10 @@ export const actionTypes = {
 // TODO(mc, 2018-01-23): NEW ACTION TYPES GO HERE
 export type Action =
   | ConfirmProbedAction
+  | PipetteCalibrationAction
   | LabwareCalibrationAction
   | CalibrationResponseAction
+  | CalibrationFailureAction
 
 export const actions = {
   discover () {
@@ -181,10 +214,17 @@ export const actions = {
 
   // response for pickup and home
   pickupAndHomeResponse (error: ?Error = null): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:PICKUP_AND_HOME_FAILURE',
+        error: true,
+        payload: error
+      }
+    }
+
     return {
-      type: 'robot:PICKUP_AND_HOME_RESPONSE',
-      error: error != null,
-      payload: error || {}
+      type: 'robot:PICKUP_AND_HOME_SUCCESS',
+      payload: {}
     }
   },
 
@@ -199,10 +239,17 @@ export const actions = {
 
   // response for drop tip and home
   dropTipAndHomeResponse (error: ?Error = null): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:DROP_TIP_AND_HOME_FAILURE',
+        error: true,
+        payload: error
+      }
+    }
+
     return {
-      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
-      error: error != null,
-      payload: error || {}
+      type: 'robot:DROP_TIP_AND_HOME_SUCCESS',
+      payload: {}
     }
   },
 
@@ -221,10 +268,17 @@ export const actions = {
     error: ?Error = null,
     tipOn: boolean = false
   ): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:CONFIRM_TIPRACK_FAILURE',
+        error: true,
+        payload: error
+      }
+    }
+
     return {
-      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
-      error: error != null,
-      payload: error || {tipOn}
+      type: 'robot:CONFIRM_TIPRACK_SUCCESS',
+      payload: {tipOn}
     }
   },
 
@@ -263,42 +317,52 @@ export const actions = {
     return {type: 'robot:CONFIRM_PROBED', payload: instrument}
   },
 
-  moveTo (instrument: Mount, labware: Slot) {
-    return tagForRobotApi({
-      type: actionTypes.MOVE_TO,
-      payload: {instrument, labware}
-    })
+  moveTo (mount: Mount, slot: Slot): LabwareCalibrationAction {
+    return {
+      type: 'robot:MOVE_TO',
+      payload: {mount, slot},
+      meta: {robotCommand: true}
+    }
   },
 
-  moveToResponse (error: ?Error = null) {
-    const action: {type: string, error: boolean, payload?: Error} = {
-      type: actionTypes.MOVE_TO_RESPONSE,
-      error: error != null
+  moveToResponse (error: ?Error = null): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:MOVE_TO_FAILURE',
+        error: true,
+        payload: error
+      }
     }
-    if (error) action.payload = error
 
-    return action
+    return {type: 'robot:MOVE_TO_SUCCESS', payload: {}}
   },
 
   toggleJogDistance () {
     return {type: actionTypes.TOGGLE_JOG_DISTANCE}
   },
 
-  jog (instrument: Mount, axis: Axis, direction: Direction) {
-    return tagForRobotApi({
-      type: actionTypes.JOG,
-      payload: {instrument, axis, direction}
-    })
+  jog (
+    mount: Mount,
+    axis: Axis,
+    direction: Direction
+  ): PipetteCalibrationAction {
+    return {
+      type: 'robot:JOG',
+      payload: {mount, axis, direction},
+      meta: {robotCommand: true}
+    }
   },
 
-  jogResponse (error: ?Error = null) {
-    const action: {type: string, error: boolean, payload?: Error} = {
-      type: actionTypes.JOG_RESPONSE,
-      error: error != null
+  jogResponse (error: ?Error = null): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:JOG_FAILURE',
+        error: true,
+        payload: error
+      }
     }
-    if (error) action.payload = error
 
-    return action
+    return {type: 'robot:JOG_SUCCESS', payload: {}}
   },
 
   // update the offset of labware in slot using position of pipette on mount
@@ -316,10 +380,17 @@ export const actions = {
     error: ?Error = null,
     isTiprack: boolean
   ): CalibrationResponseAction {
+    if (error) {
+      return {
+        type: 'robot:UPDATE_OFFSET_FAILURE',
+        error: true,
+        payload: error
+      }
+    }
+
     return {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
-      error: error != null,
-      payload: error || {isTiprack}
+      type: 'robot:UPDATE_OFFSET_SUCCESS',
+      payload: {isTiprack}
     }
   },
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -44,8 +44,8 @@ export default function client (dispatch) {
       case 'robot:CONFIRM_TIPRACK': return confirmTiprack(state, action)
       case actionTypes.MOVE_TO_FRONT: return moveToFront(state, action)
       case actionTypes.PROBE_TIP: return probeTip(state, action)
-      case actionTypes.MOVE_TO: return moveTo(state, action)
-      case actionTypes.JOG: return jog(state, action)
+      case 'robot:MOVE_TO': return moveTo(state, action)
+      case 'robot:JOG': return jog(state, action)
       case 'robot:UPDATE_OFFSET': return updateOffset(state, action)
       case actionTypes.RUN: return run(state, action)
       case actionTypes.PAUSE: return pause(state, action)
@@ -193,8 +193,8 @@ export default function client (dispatch) {
   }
 
   function moveTo (state, action) {
-    const {payload: {instrument: axis, labware: slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {mount, slot}} = action
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME - MORE DEBUG CODE
@@ -205,10 +205,8 @@ export default function client (dispatch) {
       .catch((error) => dispatch(actions.moveToResponse(error)))
   }
 
-  // TODO(mc, 2017-10-06): signature is instrument, distance, axis
-  // axis is x, y, z, not left and right (which we will call mount)
   function jog (state, action) {
-    const {payload: {instrument: mount, axis, direction}} = action
+    const {payload: {mount, axis, direction}} = action
     const instrument = selectors.getInstrumentsByMount(state)[mount]
     const distance = selectors.getJogDistance(state) * direction
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -3,7 +3,13 @@
 import padStart from 'lodash/padStart'
 import {createSelector} from 'reselect'
 
-import type {Mount, InstrumentCalibrationStatus, Labware} from './types'
+import type {
+  Mount,
+  InstrumentCalibrationStatus,
+  Labware,
+  LabwareCalibrationStatus
+} from './types'
+
 import type {State as CalibrationState} from './reducer/calibration'
 import type {State as ConnectionState} from './reducer/connection'
 import type {State as SessionState} from './reducer/session'
@@ -12,7 +18,6 @@ import {
   type ConnectionStatus,
   type SessionStatus,
   _NAME,
-  UNCONFIRMED,
   INSTRUMENT_AXES
 } from './constants'
 
@@ -178,6 +183,10 @@ export const getRunTime = createSelector(
   }
 )
 
+export function getCalibrationRequest (state: State) {
+  return calibration(state).calibrationRequest
+}
+
 export function getInstrumentsByMount (state: State) {
   return session(state).instrumentsByMount
 }
@@ -186,7 +195,7 @@ export const getInstruments = createSelector(
   getInstrumentsByMount,
   (state: State) => calibration(state).probedByMount,
   (state: State) => calibration(state).tipOnByMount,
-  (state: State) => calibration(state).calibrationRequest,
+  (state: State) => getCalibrationRequest(state),
   (instrumentsByMount, probedByMount, tipOnByMount, calibrationRequest) => {
     return INSTRUMENT_AXES.map((mount) => {
       const instrument = instrumentsByMount[mount]
@@ -247,18 +256,41 @@ export function getLabwareBySlot (state: State) {
 
 export const getLabware = createSelector(
   getLabwareBySlot,
-  (state: State) => calibration(state).labwareBySlot,
   (state: State) => calibration(state).confirmedBySlot,
-  (labwareBySlot, statusBySlot, confirmedBySlot): Labware[] => {
+  (state: State) => getCalibrationRequest(state),
+  (labwareBySlot, confirmedBySlot, calibrationRequest): Labware[] => {
     return Object.keys(labwareBySlot)
       .map((slot) => {
         const labware = labwareBySlot[slot]
+        const confirmed = confirmedBySlot[slot] || false
+        let calibration: LabwareCalibrationStatus = 'unconfirmed'
+        let isMoving = false
 
-        return {
-          ...labware,
-          calibration: statusBySlot[slot] || UNCONFIRMED,
-          confirmed: confirmedBySlot[slot] || false
+        // TODO(mc: 2018-01-10): rethink the labware level "calibration" prop
+        if (calibrationRequest.slot === slot && !calibrationRequest.error) {
+          const {type, inProgress} = calibrationRequest
+          isMoving = inProgress
+
+          if (type === 'MOVE_TO' || type === 'DROP_TIP_AND_HOME') {
+            calibration = inProgress
+              ? 'moving-to-slot'
+              : 'over-slot'
+          } else if (
+            type === 'PICKUP_AND_HOME' ||
+            // update offset picks up and homes with tipracks
+            (type === 'UPDATE_OFFSET' && labware.isTiprack)
+          ) {
+            calibration = inProgress
+              ? 'picking-up'
+              : 'picked-up'
+          } else if (type === 'CONFIRM_TIPRACK' || type === 'UPDATE_OFFSET') {
+            calibration = inProgress
+              ? 'confirming'
+              : 'confirmed'
+          }
         }
+
+        return {...labware, calibration, confirmed, isMoving}
       })
   }
 )
@@ -304,11 +336,15 @@ export const getLabwareConfirmed = createSelector(
 )
 
 export function getJogInProgress (state: State): boolean {
-  return calibration(state).jogRequest.inProgress
+  const request = getCalibrationRequest(state)
+
+  return request.type === 'JOG' && request.inProgress
 }
 
 export function getOffsetUpdateInProgress (state: State): boolean {
-  return calibration(state).updateOffsetRequest.inProgress
+  const request = getCalibrationRequest(state)
+
+  return request.type === 'UPDATE_OFFSET' && request.inProgress
 }
 
 export function getJogDistance (state: State): number {

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -167,14 +167,13 @@ describe('robot actions', () => {
     expect(actions.pickupAndHome('left', '5')).toEqual(action)
   })
 
-  test('PICKUP_AND_HOME_RESPONSE action', () => {
+  test('PICKUP_AND_HOME response actions', () => {
     const success = {
-      type: 'robot:PICKUP_AND_HOME_RESPONSE',
-      error: false,
+      type: 'robot:PICKUP_AND_HOME_SUCCESS',
       payload: {}
     }
     const failure = {
-      type: 'robot:PICKUP_AND_HOME_RESPONSE',
+      type: 'robot:PICKUP_AND_HOME_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -193,15 +192,14 @@ describe('robot actions', () => {
     expect(actions.dropTipAndHome('right', '5')).toEqual(action)
   })
 
-  test('DROP_TIP_AND_HOME_RESPONSE action', () => {
+  test('DROP_TIP_AND_HOME response actions', () => {
     const success = {
-      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
-      error: false,
+      type: 'robot:DROP_TIP_AND_HOME_SUCCESS',
       payload: {}
     }
 
     const failure = {
-      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
+      type: 'robot:DROP_TIP_AND_HOME_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -220,15 +218,14 @@ describe('robot actions', () => {
     expect(actions.confirmTiprack('left', '9')).toEqual(action)
   })
 
-  test('CONFIRM_TIPRACK_RESPONSE action', () => {
+  test('CONFIRM_TIPRACK response actions', () => {
     const success = {
-      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
-      error: false,
+      type: 'robot:CONFIRM_TIPRACK_SUCCESS',
       payload: {tipOn: true}
     }
 
     const failure = {
-      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
+      type: 'robot:CONFIRM_TIPRACK_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -271,23 +268,23 @@ describe('robot actions', () => {
     expect(actions.confirmProbed('left')).toEqual(expected)
   })
 
-  test('move to action', () => {
+  test('MOVE_TO action', () => {
     const expected = {
-      type: actionTypes.MOVE_TO,
-      payload: {instrument: 'left', labware: '3'},
+      type: 'robot:MOVE_TO',
+      payload: {mount: 'left', slot: '3'},
       meta: {robotCommand: true}
     }
 
     expect(actions.moveTo('left', '3')).toEqual(expected)
   })
 
-  test('move to response action', () => {
+  test('MOVE_TO response actions', () => {
     const success = {
-      type: actionTypes.MOVE_TO_RESPONSE,
-      error: false
+      type: 'robot:MOVE_TO_SUCCESS',
+      payload: {}
     }
     const failure = {
-      type: actionTypes.MOVE_TO_RESPONSE,
+      type: 'robot:MOVE_TO_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -302,10 +299,10 @@ describe('robot actions', () => {
     expect(actions.toggleJogDistance()).toEqual(expected)
   })
 
-  test('jog action', () => {
+  test('JOG action', () => {
     const expected = {
-      type: actionTypes.JOG,
-      payload: {instrument: 'left', axis: 'x', direction: -1},
+      type: 'robot:JOG',
+      payload: {mount: 'left', axis: 'x', direction: -1},
       meta: {robotCommand: true}
     }
 
@@ -314,11 +311,11 @@ describe('robot actions', () => {
 
   test('jog response action', () => {
     const success = {
-      type: actionTypes.JOG_RESPONSE,
-      error: false
+      type: 'robot:JOG_SUCCESS',
+      payload: {}
     }
     const failure = {
-      type: actionTypes.JOG_RESPONSE,
+      type: 'robot:JOG_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -337,14 +334,13 @@ describe('robot actions', () => {
     expect(actions.updateOffset('left', '2')).toEqual(expected)
   })
 
-  test('UPDATE_OFFSET_RESPONSE action', () => {
+  test('UPDATE_OFFSET response actions', () => {
     const success = {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
-      error: false,
+      type: 'robot:UPDATE_OFFSET_SUCCESS',
       payload: {isTiprack: true}
     }
     const failure = {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
+      type: 'robot:UPDATE_OFFSET_FAILURE',
       error: true,
       payload: new Error('AH')
     }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -316,6 +316,7 @@ describe('api client', () => {
       state = {
         [NAME]: {
           calibration: {
+            calibrationRequest: {},
             confirmedBySlot: {},
             labwareBySlot: {},
             jogDistance: constants.JOG_DISTANCE_FAST_MM

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -9,24 +9,16 @@ describe('robot reducer - calibration', () => {
       deckPopulated: true,
       jogDistance: constants.JOG_DISTANCE_SLOW_MM,
 
-      // intrument probed + basic tip-tracking state
+      // intrument probed + basic tip-tracking flags
       // TODO(mc, 2018-01-22): combine these into subreducer
       probedByMount: {},
       tipOnByMount: {},
 
-      // TODO(mc, 2017-11-07): labwareBySlot holds confirmation status by
-      // slot. confirmedBySlot holds a flag for whether the labware has been
-      // confirmed at least once. Rethink or combine these states
-      labwareBySlot: {},
+      // labware confirmed flags
       confirmedBySlot: {},
 
       // TODO(mc, 2018-01-22): make this state a sub-reducer
-      calibrationRequest: {type: '', inProgress: false, error: null},
-
-      // TODO(mc, 2018-01-10): collapse all these into calibrationRequest
-      moveToRequest: {inProgress: false, error: null},
-      jogRequest: {inProgress: false, error: null},
-      updateOffsetRequest: {inProgress: false, error: null}
+      calibrationRequest: {type: '', inProgress: false, error: null}
     })
   })
 
@@ -79,8 +71,7 @@ describe('robot reducer - calibration', () => {
           type: '',
           inProgress: false,
           error: new Error()
-        },
-        labwareBySlot: {5: constants.UNCONFIRMED}
+        }
       }
     }
 
@@ -96,12 +87,11 @@ describe('robot reducer - calibration', () => {
         slot: '5',
         inProgress: true,
         error: null
-      },
-      labwareBySlot: {5: constants.PICKING_UP}
+      }
     })
   })
 
-  test('handles PICKUP_AND_HOME_RESPONSE action', () => {
+  test('handles PICKUP_AND_HOME response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -111,19 +101,17 @@ describe('robot reducer - calibration', () => {
           inProgress: true,
           error: null
         },
-        tipOnByMount: {right: false},
-        labwareBySlot: {5: constants.PICKING_UP}
+        tipOnByMount: {right: false}
       }
     }
 
     const success = {
-      type: 'robot:PICKUP_AND_HOME_RESPONSE',
-      error: false,
+      type: 'robot:PICKUP_AND_HOME_SUCCESS',
       payload: {}
     }
 
     const failure = {
-      type: 'robot:PICKUP_AND_HOME_RESPONSE',
+      type: 'robot:PICKUP_AND_HOME_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -136,8 +124,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: null
       },
-      tipOnByMount: {left: true, right: false},
-      labwareBySlot: {5: constants.HOMED}
+      tipOnByMount: {left: true, right: false}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
@@ -148,8 +135,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: new Error('AH')
       },
-      tipOnByMount: {left: false, right: false},
-      labwareBySlot: {5: constants.UNCONFIRMED}
+      tipOnByMount: {right: false}
     })
   })
 
@@ -160,8 +146,7 @@ describe('robot reducer - calibration', () => {
           type: '',
           inProgress: false,
           error: new Error('AH')
-        },
-        labwareBySlot: {5: constants.UNCONFIRMED}
+        }
       }
     }
     const action = {
@@ -176,12 +161,11 @@ describe('robot reducer - calibration', () => {
         slot: '5',
         inProgress: true,
         error: null
-      },
-      labwareBySlot: {5: constants.HOMING}
+      }
     })
   })
 
-  test('handles DROP_TIP_AND_HOME_RESPONSE action', () => {
+  test('handles DROP_TIP_AND_HOME response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -191,19 +175,17 @@ describe('robot reducer - calibration', () => {
           inProgress: true,
           error: null
         },
-        tipOnByMount: {left: false, right: true},
-        labwareBySlot: {5: constants.HOMING}
+        tipOnByMount: {left: false, right: true}
       }
     }
 
     const success = {
-      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
-      error: false,
+      type: 'robot:DROP_TIP_AND_HOME_SUCCESS',
       payload: {}
     }
 
     const failure = {
-      type: 'robot:DROP_TIP_AND_HOME_RESPONSE',
+      type: 'robot:DROP_TIP_AND_HOME_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -216,8 +198,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: null
       },
-      tipOnByMount: {left: false, right: false},
-      labwareBySlot: {5: constants.HOMED}
+      tipOnByMount: {left: false, right: false}
     })
 
     expect(reducer(state, failure).calibration).toEqual({
@@ -228,8 +209,7 @@ describe('robot reducer - calibration', () => {
         inProgress: false,
         error: new Error('AH')
       },
-      tipOnByMount: {left: false, right: true},
-      labwareBySlot: {5: constants.UNCONFIRMED}
+      tipOnByMount: {left: false, right: true}
     })
   })
 
@@ -242,8 +222,7 @@ describe('robot reducer - calibration', () => {
           slot: '5',
           inProgress: false,
           error: new Error('AH')
-        },
-        labwareBySlot: {5: constants.UNCONFIRMED}
+        }
       }
     }
     const action = {
@@ -258,12 +237,11 @@ describe('robot reducer - calibration', () => {
         error: null,
         mount: 'right',
         slot: '5'
-      },
-      labwareBySlot: {5: constants.CONFIRMING}
+      }
     })
   })
 
-  test('handles CONFIRM_TIPRACK_RESPONSE action', () => {
+  test('handles CONFIRM_TIPRACK response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -274,19 +252,17 @@ describe('robot reducer - calibration', () => {
           slot: '5'
         },
         tipOnByMount: {right: true},
-        labwareBySlot: {5: constants.CONFIRMING},
         confirmedBySlot: {5: false}
       }
     }
 
     const success = {
-      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
-      error: false,
+      type: 'robot:CONFIRM_TIPRACK_SUCCESS',
       payload: {tipOn: false}
     }
 
     const failure = {
-      type: 'robot:CONFIRM_TIPRACK_RESPONSE',
+      type: 'robot:CONFIRM_TIPRACK_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -300,7 +276,6 @@ describe('robot reducer - calibration', () => {
         slot: '5'
       },
       tipOnByMount: {right: false},
-      labwareBySlot: {5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
 
@@ -313,7 +288,6 @@ describe('robot reducer - calibration', () => {
         slot: '5'
       },
       tipOnByMount: {right: true},
-      labwareBySlot: {5: constants.UNCONFIRMED},
       confirmedBySlot: {5: false}
     })
   })
@@ -468,44 +442,67 @@ describe('robot reducer - calibration', () => {
     const state = {
       calibration: {
         deckPopulated: false,
-        moveToRequest: {inProgress: false, error: new Error()},
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED}
+        calibrationRequest: {
+          type: '',
+          inProgress: false,
+          error: new Error('AH')
+        }
       }
     }
     const action = {
-      type: actionTypes.MOVE_TO,
-      payload: {labware: '3'}
+      type: 'robot:MOVE_TO',
+      payload: {mount: 'left', slot: '3'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
       deckPopulated: true,
-      moveToRequest: {inProgress: true, error: null, slot: '3'},
-      labwareBySlot: {3: constants.MOVING_TO_SLOT, 5: constants.UNCONFIRMED}
+      calibrationRequest: {
+        type: 'MOVE_TO',
+        inProgress: true,
+        error: null,
+        mount: 'left',
+        slot: '3'
+      }
     })
   })
 
-  test('handles MOVE_TO_RESPONSE action', () => {
+  test('handles MOVE_TO response actions', () => {
     const state = {
       calibration: {
-        moveToRequest: {inProgress: true, error: null, slot: '5'},
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.MOVING_TO_SLOT}
+        calibrationRequest: {
+          type: 'MOVE_TO',
+          inProgress: true,
+          error: null,
+          mount: 'right',
+          slot: '5'
+        }
       }
     }
 
-    const success = {type: actionTypes.MOVE_TO_RESPONSE, error: false}
+    const success = {type: 'robot:MOVE_TO_SUCCESS', payload: {}}
     const failure = {
-      type: actionTypes.MOVE_TO_RESPONSE,
+      type: 'robot:MOVE_TO_FAILURE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      moveToRequest: {inProgress: false, error: null, slot: '5'},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT}
+      calibrationRequest: {
+        type: 'MOVE_TO',
+        inProgress: false,
+        error: null,
+        mount: 'right',
+        slot: '5'
+      }
     })
     expect(reducer(state, failure).calibration).toEqual({
-      moveToRequest: {inProgress: false, error: new Error('AH'), slot: '5'},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED}
+      calibrationRequest: {
+        type: 'MOVE_TO',
+        inProgress: false,
+        error: new Error('AH'),
+        mount: 'right',
+        slot: '5'
+      }
     })
   })
 
@@ -525,30 +522,61 @@ describe('robot reducer - calibration', () => {
   test('handles JOG action', () => {
     const state = {
       calibration: {
-        jogRequest: {inProgress: false, error: new Error()}
+        calibrationRequest: {
+          type: '',
+          inProgress: false,
+          error: new Error()
+        }
       }
     }
-    const action = {type: actionTypes.JOG}
+    const action = {type: 'robot:JOG', payload: {mount: 'right'}}
 
     expect(reducer(state, action).calibration).toEqual({
-      jogRequest: {inProgress: true, error: null}
+      calibrationRequest: {
+        type: 'JOG',
+        inProgress: true,
+        error: null,
+        mount: 'right'
+      }
     })
   })
 
-  test('handles JOG_RESPONSE action', () => {
-    const state = {calibration: {jogRequest: {inProgress: true, error: null}}}
-    const success = {type: actionTypes.JOG_RESPONSE, error: false}
+  test('handles JOG response actions', () => {
+    const state = {
+      calibration: {
+        calibrationRequest: {
+          type: 'JOG',
+          inProgress: true,
+          error: null,
+          mount: 'right'
+        }
+      }
+    }
+    const success = {
+      type: 'robot:JOG_SUCCESS',
+      payload: {}
+    }
     const failure = {
-      type: actionTypes.JOG_RESPONSE,
+      type: 'robot:JOG_FAILURE',
       error: true,
       payload: new Error('AH')
     }
 
     expect(reducer(state, success).calibration).toEqual({
-      jogRequest: {inProgress: false, error: null}
+      calibrationRequest: {
+        type: 'JOG',
+        inProgress: false,
+        error: null,
+        mount: 'right'
+      }
     })
     expect(reducer(state, failure).calibration).toEqual({
-      jogRequest: {inProgress: false, error: new Error('AH')}
+      calibrationRequest: {
+        type: 'JOG',
+        inProgress: false,
+        error: new Error('AH'),
+        mount: 'right'
+      }
     })
   })
 
@@ -559,8 +587,7 @@ describe('robot reducer - calibration', () => {
           type: '',
           inProgress: false,
           error: new Error()
-        },
-        labwareBySlot: {}
+        }
       }
     }
     const action = {
@@ -575,12 +602,11 @@ describe('robot reducer - calibration', () => {
         error: null,
         mount: 'right',
         slot: '5'
-      },
-      labwareBySlot: {5: constants.UPDATING}
+      }
     })
   })
 
-  test('handles UPDATE_OFFSET_RESPONSE action', () => {
+  test('handles UPDATE_OFFSET response actions', () => {
     const state = {
       calibration: {
         calibrationRequest: {
@@ -591,23 +617,20 @@ describe('robot reducer - calibration', () => {
           slot: '5'
         },
         tipOnByMount: {},
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATING},
         confirmedBySlot: {}
       }
     }
 
     const successNonTiprack = {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
-      error: false,
+      type: 'robot:UPDATE_OFFSET_SUCCESS',
       payload: {isTiprack: false}
     }
     const successTiprack = {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
-      error: false,
+      type: 'robot:UPDATE_OFFSET_SUCCESS',
       payload: {isTiprack: true}
     }
     const failure = {
-      type: 'robot:UPDATE_OFFSET_RESPONSE',
+      type: 'robot:UPDATE_OFFSET_FAILURE',
       error: true,
       payload: new Error('AH')
     }
@@ -621,7 +644,6 @@ describe('robot reducer - calibration', () => {
         slot: '5'
       },
       tipOnByMount: {},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
     expect(reducer(state, successTiprack).calibration).toEqual({
@@ -633,7 +655,6 @@ describe('robot reducer - calibration', () => {
         slot: '5'
       },
       tipOnByMount: {right: true},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UPDATED},
       confirmedBySlot: {}
     })
     expect(reducer(state, failure).calibration).toEqual({
@@ -645,22 +666,19 @@ describe('robot reducer - calibration', () => {
         slot: '5'
       },
       tipOnByMount: {},
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.UNCONFIRMED},
-      confirmedBySlot: {5: false}
+      confirmedBySlot: {}
     })
   })
 
   test('handles CONFIRM_LABWARE action', () => {
     const state = {
       calibration: {
-        labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.OVER_SLOT},
         confirmedBySlot: {}
       }
     }
     const action = {type: actionTypes.CONFIRM_LABWARE, payload: {labware: '5'}}
 
     expect(reducer(state, action).calibration).toEqual({
-      labwareBySlot: {3: constants.UNCONFIRMED, 5: constants.CONFIRMED},
       confirmedBySlot: {5: true}
     })
   })

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -491,7 +491,12 @@ describe('robot selectors', () => {
             left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
             right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
           },
-          calibrationRequest: {},
+          calibrationRequest: {
+            type: 'MOVE_TO',
+            inProgress: true,
+            slot: '1',
+            mount: 'left'
+          },
           probedByMount: {},
           tipOnByMount: {right: true}
         }
@@ -505,7 +510,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED,
+          isMoving: true,
+          calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'left'
         },
@@ -514,7 +520,8 @@ describe('robot selectors', () => {
           name: 'b2',
           type: 'b',
           isTiprack: false,
-          calibration: constants.OVER_SLOT,
+          isMoving: false,
+          calibration: 'unconfirmed',
           confirmed: true
         },
         {
@@ -522,7 +529,8 @@ describe('robot selectors', () => {
           name: 'c3',
           type: 'c',
           isTiprack: false,
-          calibration: constants.UNCONFIRMED,
+          isMoving: false,
+          calibration: 'unconfirmed',
           confirmed: false
         }
       ])
@@ -535,7 +543,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED,
+          isMoving: true,
+          calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'left'
         }
@@ -549,7 +558,8 @@ describe('robot selectors', () => {
           name: 'a1',
           type: 'a',
           isTiprack: true,
-          calibration: constants.UNCONFIRMED,
+          isMoving: true,
+          calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'left'
         },
@@ -558,7 +568,8 @@ describe('robot selectors', () => {
           name: 'c3',
           type: 'c',
           isTiprack: false,
-          calibration: constants.UNCONFIRMED,
+          isMoving: false,
+          calibration: 'unconfirmed',
           confirmed: false
         }
       ])
@@ -570,7 +581,8 @@ describe('robot selectors', () => {
         name: 'a1',
         type: 'a',
         isTiprack: true,
-        calibration: constants.UNCONFIRMED,
+        isMoving: true,
+        calibration: 'moving-to-slot',
         confirmed: false,
         calibratorMount: 'left'
       })
@@ -593,7 +605,8 @@ describe('robot selectors', () => {
         name: 'c3',
         type: 'c',
         isTiprack: false,
-        calibration: constants.UNCONFIRMED,
+        isMoving: false,
+        calibration: 'unconfirmed',
         confirmed: false
       })
     })

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -50,10 +50,7 @@ export type LabwareCalibrationStatus =
   | 'moving-to-slot'
   | 'over-slot'
   | 'picking-up'
-  | 'homing'
-  | 'homed'
-  | 'updating'
-  | 'updated'
+  | 'picked-up'
   | 'confirming'
   | 'confirmed'
 
@@ -103,5 +100,6 @@ export type StateLabware = {
 
 export type Labware = StateLabware & {
   calibration: LabwareCalibrationStatus,
-  confirmed: boolean
+  confirmed: boolean,
+  isMoving: boolean
 }


### PR DESCRIPTION
## overview

Upcoming labware calibration work requires some behavioral changes. Rather than try to lump the changes and state cleanup in one, I've split out a bunch of the state cleanup (without behavioral changes) into this PR.

## changelog

* Collapsed all remaining calibration request substates into the `calibrationRequest` substate
* Split calibration response actions into success and failure types to play correctly with flow
* Removed annoying labware calibration status substate (e.g. `moving-to-slot`, `over-slot`, etc.) in favor of generating the status in a selector based on `calibrationRequest`
    * We did this with great success with the tip probe status substate previously
    * Also added `labware` level `isMoving` prop to spinner logic!

## review requests

Standard review.

Please note: this PR breaks labware calibration revisitation temporarily. It will be restored in this week's upcoming calibration UI PRs
