### PR TITLE
faster homing

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -18,6 +18,9 @@ from opentrons.drivers.rpi_drivers import gpio
 
 log = logging.getLogger(__name__)
 
+ERROR_KEYWORD = 'error'
+ALARM_KEYWORD = 'ALARM'
+
 # TODO (artyom, ben 20171026): move to config
 HOMED_POSITION = {
     'X': 418,
@@ -86,6 +89,10 @@ def _parse_switch_values(raw_switch_values):
         for s in parsed_values
         if any([n in s for n in ['max', 'Probe']])
     }
+
+
+class SmoothieError(Exception):
+    pass
 
 
 class SmoothieDriver_3_0_0:
@@ -274,13 +281,19 @@ class SmoothieDriver_3_0_0:
             ret_code = serial_communication.write_and_return(
                 command_line, self._connection, timeout)
 
-            if ret_code and 'alarm' in ret_code.lower():
+            # Smoothieware returns error state if a switch was hit while moving
+            smoothie_error = False
+            if ERROR_KEYWORD in ret_code or ALARM_KEYWORD in ret_code:
                 self._reset_from_error()
-                raise RuntimeError('Smoothieware Error: {}'.format(ret_code))
+                smoothie_error = True
 
             if moving_plunger:
                 self.set_current({axis: self._config.plunger_current_low
                                   for axis in 'BC'})
+
+            # ensure we lower plunger currents before raising an exception
+            if smoothie_error:
+                raise SmoothieError(ret_code)
 
             return ret_code
 
@@ -419,7 +432,13 @@ class SmoothieDriver_3_0_0:
             ax: HOMED_POSITION.get(ax) - abs(safety_margin)
             for ax in axis.upper()
         }
-        self.move(destination)
+
+        # there is a chance the axis will hit it's home switch too soon
+        # if this happens, catch the error and continue with homing afterwards
+        try:
+            self.move(destination)
+        except SmoothieError:
+            pass
 
         # then home once we're closer to the endstop(s)
         disabled = ''.join([ax for ax in AXES if ax not in axis.upper()])

--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -10,9 +10,6 @@ RECOVERY_TIMEOUT = 10
 DEFAULT_SERIAL_TIMEOUT = 5
 DEFAULT_WRITE_TIMEOUT = 30
 
-ERROR_KEYWORD = b'error'
-ALARM_KEYWORD = b'ALARM'
-
 
 def get_ports_by_name(device_name):
     '''Returns all serial devices with a given name'''
@@ -42,9 +39,6 @@ def serial_with_temp_timeout(serial_connection, timeout):
 
 
 def _parse_smoothie_response(response):
-    if ERROR_KEYWORD in response or ALARM_KEYWORD in response:
-        print("[SMOOTHIE ISSUE]: ", response)
-
     if DRIVER_ACK in response:
         parsed_response = response.split(DRIVER_ACK)[0]
         return parsed_response

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -887,7 +887,8 @@ class Pipette:
             self._add_tip(
                 length=self.robot.config.tip_length[self.mount][self.type]
             )
-            self.robot.poses = self.instrument_mover.home(self.robot.poses)
+            self.robot.poses = self.instrument_mover.fast_home(
+                self.robot.poses, abs(plunge_depth))
 
             return self
 
@@ -968,8 +969,13 @@ class Pipette:
             )
 
             if home_after:
-                self.robot.poses = self.instrument_actuator.home(
-                    self.robot.poses)
+                # incase plunger motor stalled while dropping a tip, add a
+                # safety margin of the distance between `bottom` and `drop_tip`
+                b = self._get_plunger_position('bottom')
+                d = self._get_plunger_position('drop_tip')
+                safety_margin = abs(b - d)
+                self.robot.poses = self.instrument_actuator.fast_home(
+                    self.robot.poses, safety_margin)
                 self.robot.poses = self.instrument_actuator.move(
                     self.robot.poses,
                     x=self._get_plunger_position('bottom')

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -521,17 +521,13 @@ class Robot(object):
         >>> robot.home()
         """
 
-        # Home pipettes first to avoid colliding with labware
+        # Home gantry first to avoid colliding with labware
         # and to make sure tips are not in the liquid while
-        # homing plungers
-        self.poses = self._actuators['left']['carriage'].home(self.poses)
-        self.poses = self._actuators['right']['carriage'].home(self.poses)
+        # homing plungers. Z/A axis will automatically home before X/Y
+        self.poses = self.gantry.home(self.poses)
         # Then plungers
         self.poses = self._actuators['left']['plunger'].home(self.poses)
         self.poses = self._actuators['right']['plunger'].home(self.poses)
-        # Gantry goes last to avoid any further movement while
-        # close to XY switches so we are don't accidentally hit them
-        self.poses = self.gantry.home(self.poses)
 
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This PR reduces the amount of time spent homing all axes or an individual axis, which occur both by user-initiation, and also during pipette operations like `probe`, `drop_tip`, and `pick_up_tip`

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

`drop_tip()` and `pick_up_tip()` use the `fast_home()` method, which moves that axis near it's switch, then homes from there.

`fast_home()` will recover from hitting the home switch to soon, by catching that `SmoothieError` and proceeding with a normal home afterwards.

`robot.home()` was previously homing the `Z` and `A` axis multiple times. This PR removes those redundant homes by only calling `gantry.home()` to home the `XYZA` axes, following by the plunger motors `BC`.

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
