### PR TITLE
low arc height within same container

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -637,6 +637,9 @@ class Robot(object):
             safe_height = self.max_deck_height() + TIP_CLEARANCE
             if z < safe_height:
                 self.poses = other._move(self.poses, z=safe_height)
+                # because we're switching pipettes, this ensures a large (safe)
+                # Z arc height will be used for the new pipette
+                self._prev_container = None
 
         if strategy == 'arc':
             arc_coords = self._create_arc(target, placeable)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -678,8 +678,8 @@ class Robot(object):
 
         self._prev_container = this_container
 
-        # TODO (andy): need some way of avoiding collision with top ZA switches
-        # for when using tall labware
+        # TODO (andy): there is no check here for if this height will hit
+        # the limit switches, so if a tall labware is used, we risk collision
         arc_top += self.arc_height
 
         strategy = [

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -17,9 +17,8 @@ log = get_logger(__name__)
 
 # TODO (andy) this is the height the tip will travel above the deck's tallest
 # container. This should not be a single value, but should be optimized given
-# the movements context (ie sterility vs speed). This is being set to 20mm
-# to allow containers >150mm to be usable on the deck for the tiem being.
-TIP_CLEARANCE = 20
+# the movements context (ie sterility vs speed)
+TIP_CLEARANCE = 5
 
 
 class InstrumentMosfet(object):
@@ -191,10 +190,6 @@ class Robot(object):
         self.modules = []
         self.fw_version = self._driver.get_fw_version()
 
-        # TODO (andy) should come from a config file
-        # TODO (andy) height 200 is arbitrary, should calc per pipette/tip?
-        self.dimensions = (393, 357.5, 200)
-
         self.INSTRUMENT_DRIVERS_CACHE = {}
 
         self.arc_height = TIP_CLEARANCE
@@ -271,6 +266,8 @@ class Robot(object):
         self.setup_deck()
         self.setup_gantry()
         self._instruments = {}
+
+        self._prev_container = None
 
         # TODO: Move homing info to driver
         self.axis_homed = {
@@ -671,18 +668,24 @@ class Robot(object):
         elif isinstance(placeable, containers.Container):
             this_container = placeable
 
-        travel_height = self.max_deck_height() + self.arc_height
+        arc_top = self.max_deck_height()
 
-        _, _, robot_max_z = self.dimensions  # TODO: Check what this does
-        arc_top = min(travel_height, robot_max_z)
-        arrival_z = min(destination[2], robot_max_z)
+        # movements that stay within the same container do not need to avoid
+        # other containers on the deck, so the travel height of arced movements
+        # can be relative to just that one container's height
+        if this_container and self._prev_container == this_container:
+            arc_top = self.max_placeable_height_on_deck(this_container)
 
-        self._previous_container = this_container
+        self._prev_container = this_container
+
+        # TODO (andy): need some way of avoiding collision with top ZA switches
+        # for when using tall labware
+        arc_top += self.arc_height
 
         strategy = [
             {'z': arc_top},
             {'x': destination[0], 'y': destination[1]},
-            {'z': arrival_z}
+            {'z': destination[2]}
         ]
 
         return strategy


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

In this PR, if moving from one well to another within the same labware, it will only move high enough to avoid collision with that single labware.

If moving from one labware to another, however, it will move up to it's a safe height above all labware.

```python
p300.move_to(plate[0])  # safe height is above ALL labware
p300.move_to(plate[1])  # safe height is above just the plate
p300.move_to(plate[95])  # safe height is above just the plate
p300.move_to(trough[0])  # safe height is above ALL labware
p10.move_to(trough[1])  # different pipette, safe height is above ALL labware
```

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

`robot._create_arc()` keeps track of the most previously moved-to labware, and if the current container is the same as prior, the arc's `Z` height is determined using that container's calibrated height with the method `max_placeable_height_on_deck(labware)`

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
