### PR TITLE
refactor(app): Simplify getInstruments to only return Array<Instrument>

### DIFF
--- a/app/src/components/setup-instruments/InstrumentGroup.js
+++ b/app/src/components/setup-instruments/InstrumentGroup.js
@@ -11,6 +11,7 @@ type Props = {
 
 export default function InstrumentGroup (props: Props) {
   const {instruments} = props
+
   return (
     <section className={styles.pipette_group}>
       {instruments.map((instrument) => {

--- a/app/src/components/setup-instruments/InstrumentTabs.js
+++ b/app/src/components/setup-instruments/InstrumentTabs.js
@@ -4,7 +4,11 @@
 
 import {connect} from 'react-redux'
 import {PageTabs, type PageTabProps} from '@opentrons/components'
-import {selectors as robotSelectors, type Mount} from '../../robot'
+import {
+  constants as robotConstants,
+  selectors as robotSelectors,
+  type Mount
+} from '../../robot'
 
 export default connect(mapStateToProps)(PageTabs)
 
@@ -13,11 +17,13 @@ type OwnProps = {
 }
 
 function mapStateToProps (state, ownProps: OwnProps): PageTabProps {
-  const pages = robotSelectors.getInstruments(state).map((inst) => ({
-    title: inst.mount,
-    href: `/setup-instruments/${inst.mount}`,
-    isActive: inst.mount === ownProps.mount,
-    isDisabled: !('name' in inst)
+  const instruments = robotSelectors.getInstruments(state)
+
+  const pages = robotConstants.INSTRUMENT_MOUNTS.map((mount) => ({
+    title: mount,
+    href: `/setup-instruments/${mount}`,
+    isActive: mount === ownProps.mount,
+    isDisabled: !instruments.some((inst) => inst.mount === mount)
   }))
 
   return {pages}

--- a/app/src/components/setup-panel/InstrumentList.js
+++ b/app/src/components/setup-panel/InstrumentList.js
@@ -1,28 +1,23 @@
 // @flow
 import React from 'react'
 import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 import {
+  constants as robotConstants,
   selectors as robotSelectors,
-  type Mount,
-  type Channels
+  type Instrument
 } from '../../robot'
 
 import {TitledList} from '@opentrons/components'
 import InstrumentListItem from './InstrumentListItem'
 
 type Props = {
-  instruments: {
-    mount: Mount,
-    name?: string,
-    volume?: number,
-    channels?: Channels,
-    probed?: boolean,
-  }[],
+  instruments: Instrument[],
   isRunning: bool,
 }
 
-export default connect(mapStateToProps)(InstrumentList)
+export default withRouter(connect(mapStateToProps)(InstrumentList))
 
 const TITLE = 'Pipette Setup'
 
@@ -31,13 +26,17 @@ function InstrumentList (props: Props) {
 
   return (
     <TitledList title={TITLE}>
-      {instruments.map((inst) => (
-        <InstrumentListItem
-          key={inst.mount}
-          isRunning={isRunning}
-          {...inst}
-        />
-      ))}
+      {robotConstants.INSTRUMENT_MOUNTS.map((mount) => {
+        const inst = instruments.find((i) => i.mount === mount) || {mount}
+
+        return (
+          <InstrumentListItem
+            key={inst.mount}
+            isRunning={isRunning}
+            {...inst}
+          />
+        )
+      })}
     </TitledList>
   )
 }

--- a/app/src/components/setup-panel/LabwareList.js
+++ b/app/src/components/setup-panel/LabwareList.js
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 import {TitledList} from '@opentrons/components'
 import LabwareListItem from './LabwareListItem'
@@ -9,11 +10,9 @@ import {
   actions as robotActions
 } from '../../robot'
 
-export default connect(
-  mapStateToProps,
-  null,
-  mergeProps
-)(LabwareList)
+export default withRouter(
+  connect(mapStateToProps, null, mergeProps)(LabwareList)
+)
 
 function LabwareList (props) {
   const {labware, disabled} = props

--- a/app/src/components/setup-panel/TipRackList.js
+++ b/app/src/components/setup-panel/TipRackList.js
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 import {TitledList} from '@opentrons/components'
 import LabwareListItem from './LabwareListItem'
@@ -9,7 +10,9 @@ import {
   actions as robotActions
 } from '../../robot'
 
-export default connect(mapStateToProps, null, mergeProps)(TipRackList)
+export default withRouter(
+  connect(mapStateToProps, null, mergeProps)(TipRackList)
+)
 
 function TipRackList (props) {
   const {tipracks, disabled} = props

--- a/app/src/robot/README.md
+++ b/app/src/robot/README.md
@@ -54,7 +54,7 @@ const {
   STOPPED,
 
   // deck layout
-  INSTRUMENT_AXES,
+  INSTRUMENT_MOUNTS,
   DECK_SLOTS,
 
   // pipette channels names

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -67,7 +67,7 @@ export const LABWARE_CONFIRMATION_TYPE = PropTypes.oneOf([
 ])
 
 // deck layout
-export const INSTRUMENT_AXES: Mount[] = ['left', 'right']
+export const INSTRUMENT_MOUNTS: Mount[] = ['left', 'right']
 export const DECK_SLOTS: Slot[] = [
   '1',
   '2',

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -82,6 +82,12 @@ export type StateInstrument = {
   volume: number,
 }
 
+export type Instrument = StateInstrument & {
+  calibration: InstrumentCalibrationStatus,
+  probed: boolean,
+  tipOn: boolean
+}
+
 // labware as stored in redux state
 export type StateLabware = {
   // resource ID


### PR DESCRIPTION
## overview

Little PR to clean up `getInstruments`. Previously, it could return an `Instrument` _or_ an object `{mount: Mount}`. This made for some convoluted logic in some components. Now, `getInstruments` always returns an array of `Instrument` objects.

This helps with #677 because the jog confirmation screens need to identify which instrument is being used to confirm the position.

## changelog

- Added `Instrument` type that represents the instrument object from `getInstruments`
- Refactored `getInstruments` to only return used instruments
- Fixed instrument and labware highlighting in `SetupPanel`

## review requests

Standard review