### PR TITLE
Update robot list item design

### DIFF
--- a/app/src/components/connect-panel/RobotItem.js
+++ b/app/src/components/connect-panel/RobotItem.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {ListItem, Icon, USB, UNCHECKED_RADIO, CHECKED_RADIO} from '@opentrons/components'
+import {ListItem, IconButton, TOGGLED_OFF, TOGGLED_ON} from '@opentrons/components'
 
 import styles from './connect-panel.css'
 
@@ -18,22 +18,28 @@ export default function RobotItem (props) {
   const onClick = isConnected
     ? onDisconnectClick
     : onConnectClick
-  const className = cx({
+  const className = cx(styles.robot_item, {
     [styles.connected]: isConnected,
     [styles.disconnected]: !isConnected
   })
-  // TODO (ka 2018-2-6):this is a temp workaround for pending connection toggle button
+  /* TODO (ka 2018-2-7): No onClick passed to IconButton for now because parent
+    ListItem receives the onClick temporarily. double toggle = no toggle.
+    Once routes in place for connection pages this will be resolved by replacing
+    onClick in ListItem with url */
   const toggleIcon = isConnected
-    ? CHECKED_RADIO
-    : UNCHECKED_RADIO
+    ? TOGGLED_ON
+    : TOGGLED_OFF
   return (
     <ListItem
       onClick={onClick}
-      iconName={USB}
+      iconName={'usb'}
       className={className}
     >
       <p className={styles.robot_name}>{name}</p>
-      <Icon name={toggleIcon} className={styles.connection_toggle} />
+      <IconButton
+        name={toggleIcon}
+        className={styles.connection_toggle}
+      />
     </ListItem>
   )
 }

--- a/app/src/components/connect-panel/RobotItem.js
+++ b/app/src/components/connect-panel/RobotItem.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {ListItem, IconButton, TOGGLED_OFF, TOGGLED_ON} from '@opentrons/components'
+import {ListItem, IconButton, USB, TOGGLED_OFF, TOGGLED_ON} from '@opentrons/components'
 
 import styles from './connect-panel.css'
 
@@ -32,7 +32,7 @@ export default function RobotItem (props) {
   return (
     <ListItem
       onClick={onClick}
-      iconName={'usb'}
+      iconName={USB}
       className={className}
     >
       <p className={styles.robot_name}>{name}</p>

--- a/app/src/components/connect-panel/connect-panel.css
+++ b/app/src/components/connect-panel/connect-panel.css
@@ -5,6 +5,15 @@
   margin-left: 0;
 }
 
+.robot_item {
+  text-transform: uppercase;
+}
+
+/* this is needed for usb icon to override default icon height  render it at proper size */
+.robot_item svg:first-child {
+  height: 1.5rem;
+}
+
 .item_icon {
   height: 2rem;
 }
@@ -26,7 +35,8 @@
 }
 
 .connection_toggle {
-  height: calc(2 * var(--fs-body-1));
+  width: 2rem;
+  padding: 0;
 }
 
 .disconnected {
@@ -34,9 +44,11 @@
   fill: var(--c-dark-gray);
 }
 
-.connected {
-  color: blue;
-  fill: blue;
+.connected,
+.connected button {
+  color: #0ec9eb;
+  fill: #0ec9eb;
+  background-color: #f0f3ff;
 }
 
 .scan_status {

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -47,15 +47,16 @@ function mapStateToProps (state, ownProps) {
 
 function mergeProps (stateProps, dispatchProps, ownProps) {
   const {dispatch} = dispatchProps
-  const {isCurrent} = stateProps
   const {name} = ownProps
+  /* TODO (ka 2018-2-8): leaving this commented out in the event we need to
+  bring back the collapsible panel.
   const clickAction = isCurrent
     ? interfaceActions.closePanel()
-    : interfaceActions.setCurrentPanel(name)
+    : interfaceActions.setCurrentPanel(name) */
 
   return {
     ...ownProps,
     ...stateProps,
-    onClick: () => dispatch(clickAction)
+    onClick: () => dispatch(interfaceActions.setCurrentPanel(name))
   }
 }

--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -418,6 +418,44 @@ exports[`icons SPINNER icon renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons TOGGLED_OFF icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  height={undefined}
+  version="1.1"
+  viewBox="0 0 24 24"
+  width={undefined}
+  x={undefined}
+  y={undefined}
+>
+  <path
+    d="M19.2 7.8h-7.61a6.3 6.3 0 1 0 0 8.4h7.61a4.2 4.2 0 0 0 0-8.4zM6.9 17.3a5.3 5.3 0 1 1 5.3-5.3 5.31 5.31 0 0 1-5.3 5.3z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons TOGGLED_ON icon renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  height={undefined}
+  version="1.1"
+  viewBox="0 0 24 24"
+  width={undefined}
+  x={undefined}
+  y={undefined}
+>
+  <path
+    d="M17.1,5.7a6.28,6.28,0,0,0-4.69,2.1H4.8a4.2,4.2,0,1,0,0,8.4h7.61A6.3,6.3,0,1,0,17.1,5.7Zm-5.42,9.5H4.8a3.2,3.2,0,1,1,0-6.4h6.88a6.26,6.26,0,0,0,0,6.4Z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons UNCHECKED icon renders correctly 1`] = `
 <svg
   aria-hidden="true"

--- a/components/src/__tests__/icons.test.js
+++ b/components/src/__tests__/icons.test.js
@@ -18,6 +18,8 @@ import {
   UNCHECKED_RADIO,
   CHECKED_BOX,
   UNCHECKED_BOX,
+  TOGGLED_OFF,
+  TOGGLED_ON,
   CHEVRON_UP,
   CHEVRON_DOWN,
   CHEVRON_LEFT,
@@ -149,6 +151,22 @@ describe('icons', () => {
   test('UNCHECKED_BOX icon renders correctly', () => {
     const tree = Renderer.create(
       <Icon name={UNCHECKED_BOX} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('TOGGLED_OFF icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={TOGGLED_OFF} className='foo' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('TOGGLED_ON icon renders correctly', () => {
+    const tree = Renderer.create(
+      <Icon name={TOGGLED_ON} className='foo' />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/icons/Icon.md
+++ b/components/src/icons/Icon.md
@@ -4,9 +4,9 @@ All available icons:
 // import {ALERT, BACK, REFRESH, etc.} from @opentrons/components
 const {
   ALERT, BACK, CLOSE, REFRESH, SPINNER, USB, WIFI, FLASK, CHECKED, UNCHECKED,
-  CHECKED_RADIO, UNCHECKED_RADIO, CHECKED_BOX, UNCHECKED_BOX,
-  CHEVRON_UP, CHEVRON_DOWN, CHEVRON_LEFT, CHEVRON_RIGHT, FILE, COG, CONNECT,
-  CONSOLIDATE, DISTRIBUTE, MIX, PAUSE, ARROW_RIGHT, MENU_DOWN
+  CHECKED_RADIO, UNCHECKED_RADIO, CHECKED_BOX, UNCHECKED_BOX, TOGGLED_OFF,
+  TOGGLED_ON, CHEVRON_UP, CHEVRON_DOWN, CHEVRON_LEFT, CHEVRON_RIGHT, FILE, COG,
+  CONNECT, CONSOLIDATE, DISTRIBUTE, MIX, PAUSE, ARROW_RIGHT, MENU_DOWN
 } = require('./icon-data')
 
 ;<div>
@@ -24,6 +24,8 @@ const {
   <Icon width='64px' name={UNCHECKED_RADIO} />
   <Icon width='64px' name={CHECKED_BOX} />
   <Icon width='64px' name={UNCHECKED_BOX} />
+  <Icon width='64px' name={TOGGLED_OFF} />
+  <Icon width='64px' name={TOGGLED_ON} />
   <Icon width='64px' name={CHEVRON_UP} />
   <Icon width='64px' name={CHEVRON_DOWN} />
   <Icon width='64px' name={CHEVRON_LEFT} />

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -16,6 +16,8 @@ export const CHECKED_RADIO = 'checked radio'
 export const UNCHECKED_RADIO = 'unchecked radio'
 export const CHECKED_BOX = 'checked box'
 export const UNCHECKED_BOX = 'unchecked box'
+export const TOGGLED_OFF = 'toggled off'
+export const TOGGLED_ON = 'toggled on'
 export const CHEVRON_UP = 'chevron up'
 export const CHEVRON_DOWN = 'chevron down'
 export const CHEVRON_LEFT = 'chevron left'
@@ -87,6 +89,14 @@ const ICON_DATA_BY_NAME = {
   [UNCHECKED_BOX]: {
     viewBox: '0 0 24 24',
     path: 'M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2m0 2v14H5V5h14z'
+  },
+  [TOGGLED_OFF]: {
+    viewBox: '0 0 24 24',
+    path: 'M19.2 7.8h-7.61a6.3 6.3 0 1 0 0 8.4h7.61a4.2 4.2 0 0 0 0-8.4zM6.9 17.3a5.3 5.3 0 1 1 5.3-5.3 5.31 5.31 0 0 1-5.3 5.3z'
+  },
+  [TOGGLED_ON]: {
+    viewBox: '0 0 24 24',
+    path: 'M17.1,5.7a6.28,6.28,0,0,0-4.69,2.1H4.8a4.2,4.2,0,1,0,0,8.4h7.61A6.3,6.3,0,1,0,17.1,5.7Zm-5.42,9.5H4.8a3.2,3.2,0,1,1,0-6.4h6.88a6.26,6.26,0,0,0,0,6.4Z'
   },
   [CHEVRON_UP]: {
     viewBox: '0 0 24 24',


### PR DESCRIPTION
## overview

This PR closes #770. Matches RobotItem designs. Introduces TOGGLED_ON and TOGGLED_OFF icons to comp lib and implements then in an `IconButton` in robot item. This button does not toggle connectivity yet since we don't have ConnectPage implemented yet. Entire RobotItem dispatched connect or disconnect actions until next PR. 

p.s. I took out the open/close side panel action from the nav bar buttons since i removed the close button in SidePanel in the last PR. SidePanel is officially fixed and open for now. I commented out the logic rather than deleting in incase we have to revert.

### available robot item
<img width="600" alt="available robot item" src="https://user-images.githubusercontent.com/3430313/35985470-ba55d26c-0cc4-11e8-9b89-8632ae2bb46a.png">

### connected robot item
<img width="600" alt="connected robot item" src="https://user-images.githubusercontent.com/3430313/35985523-d107185e-0cc4-11e8-84fe-3f60c79946e7.png">

## change log

- Adds `Toggled_On` and `Toggled_Off` icons to complib
- Adds `IconButton` with toggle icons to `RobotItem`,
  - This button is tested with onClick connect disconnect,
  but since the entire RobotItem is handling the onClick right now,
  button is disabled to avoid double toggle connectivity calls. This will be
  fixed in subsequent PRs where RobotItem becomes NavLink and IconButton handles onCLick
- Updates styling to closer match designs, fixes that wonky USB icon alignment
- Disables open/close panel action for NavBarButtons, previous PR fixed SidePanel as open

## review requests
standard review.
Meanwhile in CSS town, we have a few new colors, at some point we should make sync to make sure PD and app aren't diverging visually. That being said, the new blues are lovely and come directly form component library designs.