### PR TITLE
Sort connected/wired robots first and change icon based on wired/wireless

### DIFF
--- a/app/src/components/connect-panel/RobotItem.js
+++ b/app/src/components/connect-panel/RobotItem.js
@@ -2,7 +2,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import {ListItem, IconButton, USB, TOGGLED_OFF, TOGGLED_ON} from '@opentrons/components'
+
+import {
+  ListItem,
+  IconButton,
+  USB,
+  WIFI,
+  TOGGLED_OFF,
+  TOGGLED_ON
+} from '@opentrons/components'
 
 import styles from './connect-panel.css'
 
@@ -14,14 +22,16 @@ RobotItem.propTypes = {
 }
 
 export default function RobotItem (props) {
-  const {name, isConnected, onConnectClick, onDisconnectClick} = props
+  const {name, wired, isConnected, onConnectClick, onDisconnectClick} = props
   const onClick = isConnected
     ? onDisconnectClick
     : onConnectClick
+
   const className = cx(styles.robot_item, {
     [styles.connected]: isConnected,
     [styles.disconnected]: !isConnected
   })
+
   /* TODO (ka 2018-2-7): No onClick passed to IconButton for now because parent
     ListItem receives the onClick temporarily. double toggle = no toggle.
     Once routes in place for connection pages this will be resolved by replacing
@@ -29,10 +39,15 @@ export default function RobotItem (props) {
   const toggleIcon = isConnected
     ? TOGGLED_ON
     : TOGGLED_OFF
+
+  const iconName = wired
+    ? USB
+    : WIFI
+
   return (
     <ListItem
       onClick={onClick}
-      iconName={USB}
+      iconName={iconName}
       className={className}
     >
       <p className={styles.robot_name}>{name}</p>

--- a/app/src/components/setup-panel/run-panel.css
+++ b/app/src/components/setup-panel/run-panel.css
@@ -16,5 +16,7 @@
   margin: 1rem;
   width: calc(100% - 2rem);
   position: absolute;
+  left: 0;
+  right: 0;
   bottom: 0;
 }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -177,8 +177,8 @@ export const actions = {
     return {type: actionTypes.ADD_DISCOVERED, payload: service}
   },
 
-  removeDiscovered (name: string) {
-    return {type: actionTypes.REMOVE_DISCOVERED, payload: {name}}
+  removeDiscovered (service: RobotService) {
+    return {type: actionTypes.REMOVE_DISCOVERED, payload: service}
   },
 
   // make new session with protocol file

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -111,7 +111,9 @@ function handleAddDiscovered (state, action) {
 }
 
 function handleRemoveDiscovered (state, action) {
-  if (!action.payload) return state
+  if (!action.payload || state.connectedTo === action.payload.name) {
+    return state
+  }
 
   const {payload: {name}} = action
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -1,6 +1,7 @@
 // @flow
 // robot selectors
 import padStart from 'lodash/padStart'
+import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
 
 import type {
@@ -55,10 +56,17 @@ export const getDiscovered = createSelector(
   (state: State) => connection(state).discovered,
   (state: State) => connection(state).discoveredByName,
   (state: State) => connection(state).connectedTo,
-  (discovered, discoveredByName, connectedTo) => discovered.map((name) => ({
-    ...discoveredByName[name],
-    isConnected: connectedTo === name
-  }))
+  (discovered, discoveredByName, connectedTo) => sortBy(
+    discovered.map((name) => ({
+      ...discoveredByName[name],
+      isConnected: connectedTo === name
+    })),
+    [
+      (robot) => !robot.isConnected,
+      (robot) => !robot.wired,
+      'name'
+    ]
+  )
 )
 
 export const getConnectionStatus = createSelector(

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -32,13 +32,13 @@ describe('robot actions', () => {
   })
 
   test('REMOVE_DISCOVERED action', () => {
-    const name = 'ot'
+    const service = {name: 'ot'}
     const expected = {
       type: actionTypes.REMOVE_DISCOVERED,
-      payload: {name}
+      payload: service
     }
 
-    expect(actions.removeDiscovered(name)).toEqual(expected)
+    expect(actions.removeDiscovered(service)).toEqual(expected)
   })
 
   test('CONNECT action', () => {

--- a/app/src/robot/test/api-client-discovery.test.js
+++ b/app/src/robot/test/api-client-discovery.test.js
@@ -111,7 +111,7 @@ describe('api client - discovery', () => {
       .then(() => services.forEach((s) => browser.emit('down', s)))
       .then(() => services.forEach((s) => {
         expect(dispatch)
-          .toHaveBeenCalledWith(actions.removeDiscovered(s.name))
+          .toHaveBeenCalledWith(actions.removeDiscovered(s))
       }))
   })
 
@@ -153,11 +153,11 @@ describe('api client - discovery', () => {
     return sendToClient(notScanningState, actions.discover())
       .then(() => services.forEach((s) => browser.emit('up', s)))
       .then(() => expect(dispatch).not.toHaveBeenCalledWith(
-        actions.addDiscovered({host: 'nope.local'})
+        actions.addDiscovered(services[1])
       ))
       .then(() => services.forEach((s) => browser.emit('down', s)))
       .then(() => expect(dispatch).not.toHaveBeenCalledWith(
-        actions.removeDiscovered('nope.local')
+        actions.removeDiscovered(services[1])
       ))
   })
 
@@ -166,7 +166,8 @@ describe('api client - discovery', () => {
     const expectedDispatch = actions.addDiscovered({
       name: 'Opentrons USB',
       ip: '[fd00:0:cafe:fefe::1]',
-      port: 31950
+      port: 31950,
+      wired: true
     })
 
     global.fetch.mockReturnValue(Promise.resolve({ok: true}))

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -41,18 +41,22 @@ describe('robot selectors', () => {
   test('getDiscovered', () => {
     const state = {
       connection: {
-        connectedTo: 'foo',
-        discovered: ['foo', 'bar'],
+        connectedTo: 'bar',
+        discovered: ['foo', 'bar', 'baz', 'qux'],
         discoveredByName: {
           foo: {host: 'abcdef.local', name: 'foo'},
-          bar: {host: '123456.local', name: 'bar'}
+          bar: {host: '123456.local', name: 'bar'},
+          baz: {host: 'qwerty.local', name: 'baz'},
+          qux: {host: 'dvorak.local', name: 'qux', wired: true}
         }
       }
     }
 
     expect(getDiscovered(makeState(state))).toEqual([
-      {name: 'foo', host: 'abcdef.local', isConnected: true},
-      {name: 'bar', host: '123456.local', isConnected: false}
+      {name: 'bar', host: '123456.local', isConnected: true},
+      {name: 'qux', host: 'dvorak.local', isConnected: false, wired: true},
+      {name: 'baz', host: 'qwerty.local', isConnected: false},
+      {name: 'foo', host: 'abcdef.local', isConnected: false}
     ])
   })
 

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -34,6 +34,7 @@ export type RobotService = {
   name: string,
   host: string,
   ip: string,
+  wired?: boolean,
 }
 
 // protocol file (browser File object)


### PR DESCRIPTION
## overview

This PR doesn't have a ticket, which is a weird oversight on my part. It is a little PR to improve the usability of the robot list now that it's all pretty and stuff

## changelog

* Feature: added sorting to the robot list by:
    1. Connected vs disconnected
    2. Wired vs wireless
    3. Alphabetically
* Feature: added wifi icon to the robot in the list if it's not a wired connection
* Feature: added removal detection of wired bot in discovery
    * Side note: removal detection while connected is a weird edge case
    * Until we can think through error detection and communication, to prevent anything strange, the app will _not_ remove the currently connected robot from the list

## review requests

Standard review
