### PR TITLE
Add jupyter server to robot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY ./compute/avahi_tools /tmp/avahi_tools
 # When adding more python packages make sure to use setuptools to keep
 # packaging consistent across environments
 ENV PIPENV_VENV_IN_PROJECT=true
-RUN pip install pipenv && \
+RUN pip install pipenv jupyter && \
     pipenv install /tmp/api --system && \
     pip install /tmp/avahi_tools && \
     rm -rf /tmp/api && \

--- a/compute/conf/nginx.conf
+++ b/compute/conf/nginx.conf
@@ -47,5 +47,9 @@ http {
             client_body_buffer_size        128K;
             client_max_body_size           50M;
         }
+
+        location /notebook {
+            proxy_pass                      http://127.0.0.1:18888;
+        }
     }
 }

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -7,6 +7,9 @@ radvd --logmethod=stderr_syslog --pidfile=/run/radvd.pid
 # mdns announcement
 announce_mdns.py &
 
+# Start jupyter notebook server
+jupyter notebook --port 18888 &
+
 # serve static pages and proxy HTTP services
 nginx
 


### PR DESCRIPTION
## overview

Add a jupyter notebook server to the robot to make it easier to control for developers who wish to control the robot directly with Python instead of using the run app. (not ticketed--discussed amongst the team at a few points)

## changelog

- (container) Add jupyter install to Dockerfile, a jupyter notebook server to the start script and register the notebook server port through nginx
