### PR TITLE
refactor(app): Implement visual UX feedback for calibration flow

### DIFF
--- a/app/src/components/CalibrateDeck/LabwareItem.js
+++ b/app/src/components/CalibrateDeck/LabwareItem.js
@@ -4,15 +4,13 @@ import cx from 'classnames'
 import {Link} from 'react-router-dom'
 
 import {
-  type LabwareComponentProps,
   ContainerNameOverlay,
   EmptyDeckSlot,
   Icon,
-  SlotOverlay,
   LabwareContainer,
   Plate,
   SPINNER,
-  ALERT
+  type LabwareComponentProps
 } from '@opentrons/components'
 
 import type {Labware} from '../../robot'
@@ -23,8 +21,6 @@ export type LabwareItemProps = LabwareComponentProps & {
   labware?: Labware & {
     highlighted?: boolean,
     disabled?: boolean,
-    showName?: boolean,
-    showUnconfirmed?: boolean,
     showSpinner?: boolean,
     onClick?: () => void,
     url?: string
@@ -45,11 +41,8 @@ export default function LabwareItem (props: LabwareItemProps) {
   const {
     name,
     type,
-    confirmed,
     highlighted,
     disabled,
-    showName,
-    showUnconfirmed,
     showSpinner,
     onClick,
     url
@@ -62,12 +55,8 @@ export default function LabwareItem (props: LabwareItemProps) {
       <g className={plateClass}>
         <Plate containerType={type} wellContents={{}} />
 
-        {!showSpinner && showName && (
+        {!showSpinner && (
           <ContainerNameOverlay containerName={name} containerType={type} />
-        )}
-
-        {!showSpinner && showUnconfirmed && !confirmed && (
-          <SlotOverlay text='Position Unconfirmed' icon={ALERT} />
         )}
 
         {showSpinner && (

--- a/app/src/components/LabwareCalibration/ConfirmModal.js
+++ b/app/src/components/LabwareCalibration/ConfirmModal.js
@@ -29,8 +29,8 @@ export default function ConfirmModal (props: Props) {
       <Overlay />
       <TitleBar
         className={styles.title_bar}
-        title='Setup Deck'
-        subtitle={labware.name}
+        title='Calibrate Deck'
+        subtitle={labware.type}
         onBackClick={onBackClick}
         backClickDisabled={backClickDisabled}
       />

--- a/app/src/components/LabwareCalibration/ConfirmPositionDiagram.js
+++ b/app/src/components/LabwareCalibration/ConfirmPositionDiagram.js
@@ -19,17 +19,11 @@ type Props = Labware & {
 }
 
 export default function ConfirmPositionDiagram (props: Props) {
-  const {
-    slot,
-    name,
-    type,
-    isTiprack,
-    buttonText,
-    calibrator: {mount, channels}
-  } = props
+  const {type, isTiprack, calibrator: {mount, channels}} = props
   const multi = channels === 8
   const calibrator = `${mount} ${multi ? 'multi' : 'single'}-channel pipette`
-  const target = isTiprack ? 'tiprack' : 'labware'
+  const targetLocation = multi ? 'column 1' : 'A1'
+  const target = (isTiprack ? 'tip' : 'well') + (multi ? 's' : '')
   const tipOrNozzle = isTiprack ? 'nozzle' : 'tip'
   const calibrationDescription = `${tipOrNozzle}${multi ? 's are ' : ' is '}`
 
@@ -55,13 +49,14 @@ export default function ConfirmPositionDiagram (props: Props) {
   return (
     <div className={styles.position_diagram}>
       <h3 className={styles.diagram_title}>
-        Calibrate {target} {name} in slot {slot}
+        Calibrate pipette to {type}
       </h3>
       <img className={styles.diagram_image} src={diagramSrc} />
       <p className={styles.diagram_instructions}>
-        If necesary, jog the {calibrator} until the {calibrationDescription}
-        aligned over the {target} in slot {slot} as illustrated. Once aligned,
-        click [{buttonText.toUpperCase()}].
+        Jog the {calibrator} until the {calibrationDescription} centered
+        above and flush with the top of the {targetLocation} {target} as
+        illustrated above.
+        {isTiprack && ` Then try picking up the ${target}.`}
       </p>
     </div>
   )

--- a/app/src/components/LabwareCalibration/InfoBox.js
+++ b/app/src/components/LabwareCalibration/InfoBox.js
@@ -56,7 +56,7 @@ function InfoBox (props: Props) {
   if (labware) {
     const labwareType = robotSelectors.labwareType(labware)
 
-    title = labware.name
+    title = labware.type
     confirmed = labware.confirmed
     description = confirmed
       ? `${capitalize(labwareType)} is calibrated`

--- a/app/src/components/LabwareCalibration/styles.css
+++ b/app/src/components/LabwareCalibration/styles.css
@@ -35,15 +35,7 @@
 .diagram_title {
   @apply --font-header-dark;
 
-  margin: 0 auto 0.5rem;
-  text-align: center;
-}
-
-.diagram_subtitle {
-  @apply --font-body-2-dark;
-
-  margin: 0 auto 1rem;
-  text-align: center;
+  margin: 0 1rem 0.5rem;
 }
 
 .diagram_instructions {

--- a/app/src/components/ReviewDeckModal/LabwareComponent.js
+++ b/app/src/components/ReviewDeckModal/LabwareComponent.js
@@ -30,10 +30,5 @@ function mapStateToProps (state, ownProps: OwnProps): StateProps {
 
   if (!labware) return {}
 
-  return {
-    labware: {
-      ...labware,
-      showName: true
-    }
-  }
+  return {labware: {...labware}}
 }

--- a/app/src/components/ReviewDeckModal/Prompt.js
+++ b/app/src/components/ReviewDeckModal/Prompt.js
@@ -2,7 +2,7 @@
 // prompt for ReviewDeckModal of labware calibration page
 import * as React from 'react'
 
-import type {Labware} from '../../robot'
+import {selectors as robotSelectors, type Labware} from '../../robot'
 import {OutlineButton} from '@opentrons/components'
 
 import styles from './styles.css'
@@ -12,16 +12,21 @@ type Props = Labware & {
 }
 
 export default function Prompt (props: Props) {
-  const {name, type, slot, onClick} = props
+  const {type, slot, onClick} = props
+  const labwareType = robotSelectors.labwareType(props)
 
   return (
     <div className={styles.prompt}>
       <p className={styles.prompt_text}>
-        To calibrate labware on the deck, position full tipracks and empty labware in their designated slots as illustrated below
+        To calibrate deck, position full tipracks and empty labware in their
+        designated slots as illustrated below
       </p>
       <OutlineButton className={styles.prompt_button} onClick={onClick}>
-        {`Calibrate ${name} (${type}) in slot ${slot}`}
+        {`Continue moving to ${labwareType}`}
       </OutlineButton>
+      <p className={styles.prompt_details}>
+        {`Pipette will move to ${type} in slot ${slot}`}
+      </p>
     </div>
   )
 }

--- a/app/src/components/ReviewDeckModal/styles.css
+++ b/app/src/components/ReviewDeckModal/styles.css
@@ -13,22 +13,29 @@
 
 .prompt {
   max-width: 32rem;
-  margin-bottom: 1.5rem;
+  margin: 0 0 0.5rem;
 }
 
 .prompt_text {
   @apply --font-header-light;
 
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
   text-align: center;
 }
 
 .prompt_button {
   display: block;
   width: auto;
-  margin: 0 auto;
+  margin: 1rem auto;
   padding-left: 3rem;
   padding-right: 3rem;
+}
+
+.prompt_details {
+  @apply --font-body-2-light;
+
+  margin: 1rem 0 0;
+  text-align: center;
 }
 
 .deck {

--- a/app/src/components/TipProbe/ContinuePanel.js
+++ b/app/src/components/TipProbe/ContinuePanel.js
@@ -10,6 +10,7 @@ import CalibrationInfoContent from '../CalibrationInfoContent'
 import {selectors as robotSelectors} from '../../robot'
 
 type StateProps = {
+  done: boolean,
   _button: ?{
     href: string,
     text: string
@@ -21,6 +22,7 @@ type DispatchProps = {
 }
 
 type RemoveTipProps = {
+  done: boolean,
   button: ?{
     text: string,
     onClick: () => void
@@ -30,38 +32,34 @@ type RemoveTipProps = {
 export default connect(mapStateToProps, null, mergeProps)(RemoveTipPanel)
 
 function RemoveTipPanel (props: RemoveTipProps) {
-  const {button} = props
-
-  // TODO(mc, 2018-01-22): needed to quickly work around the case of
-  //   no-next-labware; rethink this display after talking to UX
-  const leftChildren = (
-    <div>
-      <p>Pipette tip has been calibrated.</p>
-      {button && (
-        <PrimaryButton onClick={button.onClick}>
-          {button.text}
-        </PrimaryButton>
-      )}
-      {!button && (
-        <p>
-          Your protocol is ready to run!
-        </p>
-      )}
-    </div>
-  )
+  const {done, button} = props
 
   return (
-    <CalibrationInfoContent
-      leftChildren={leftChildren}
-    />
+    <CalibrationInfoContent leftChildren={(
+      <div>
+        <p>Pipette tip has been calibrated.</p>
+        {done && (
+          <p>Replace trash bin on top of tip probe before continuing</p>
+        )}
+        {button && (
+          <PrimaryButton onClick={button.onClick}>
+            {button.text}
+          </PrimaryButton>
+        )}
+        {!button && (
+          <p>
+            Your protocol is ready to run!
+          </p>
+        )}
+      </div>
+    )} />
   )
 }
 
 function mapStateToProps (state): StateProps {
   const instruments = robotSelectors.getInstruments(state)
   const nextLabware = robotSelectors.getNextLabware(state)
-  const nextInstrument = instruments
-    .find((inst) => inst.name && !inst.probed)
+  const nextInstrument = instruments.find((inst) => !inst.probed)
 
   let _button = null
 
@@ -77,17 +75,18 @@ function mapStateToProps (state): StateProps {
     }
   }
 
-  return {_button}
+  return {_button, done: nextInstrument == null}
 }
 
 function mergeProps (
   stateProps: StateProps,
   dispatchProps: DispatchProps
 ): RemoveTipProps {
-  const {_button} = stateProps
+  const {done, _button} = stateProps
   const {dispatch} = dispatchProps
 
   return {
+    done,
     button: _button && {
       text: _button.text,
       onClick: () => dispatch(push(_button.href))

--- a/app/src/components/TipProbe/index.js
+++ b/app/src/components/TipProbe/index.js
@@ -60,7 +60,7 @@ function mapStateToProps (state, ownProps: OwnProps): StateProps {
 
 function TipProbe (props: TipProbeProps) {
   const {mount, probed, calibration} = props
-  const title = `${mount} pipette setup`
+  const title = `${mount} pipette calibration`
 
   const Panel = PANEL_BY_CALIBRATION[calibration]
 

--- a/app/src/components/setup-panel/DeckCalibrationGroup.js
+++ b/app/src/components/setup-panel/DeckCalibrationGroup.js
@@ -1,26 +1,29 @@
 // @flow
 import {connect} from 'react-redux'
-import {SidePanelGroup, type IconName} from '@opentrons/components'
+import {SidePanelGroup, type IconName, FLASK} from '@opentrons/components'
 
 import {
   selectors as robotSelectors
 } from '../../robot'
 
-type Props = {
+const TITLE = 'Deck Calibration'
+
+type StateProps = {
+  title: string,
+  iconName: IconName,
   disabled: boolean,
-  title?: string,
-  iconName?: IconName
 }
 
 export default connect(mapStateToProps)(SidePanelGroup)
 
-function mapStateToProps (state): Props {
+function mapStateToProps (state): StateProps {
   const instrumentsCalibrated = robotSelectors.getInstrumentsCalibrated(state)
   const isRunning = robotSelectors.getIsRunning(state)
   const disabled = isRunning || !instrumentsCalibrated
+
   return {
-    disabled,
-    title: 'Deck Calibration',
-    iconName: 'flask'
+    title: TITLE,
+    iconName: FLASK,
+    disabled
   }
 }

--- a/app/src/components/setup-panel/InstrumentList.js
+++ b/app/src/components/setup-panel/InstrumentList.js
@@ -17,26 +17,23 @@ type Props = {
   isRunning: bool,
 }
 
-export default withRouter(connect(mapStateToProps)(InstrumentList))
+const TITLE = 'Pipette Calibration'
 
-const TITLE = 'Pipette Setup'
+export default withRouter(connect(mapStateToProps)(InstrumentList))
 
 function InstrumentList (props: Props) {
   const {instruments, isRunning} = props
 
   return (
     <TitledList title={TITLE}>
-      {robotConstants.INSTRUMENT_MOUNTS.map((mount) => {
-        const inst = instruments.find((i) => i.mount === mount) || {mount}
-
-        return (
-          <InstrumentListItem
-            key={inst.mount}
-            isRunning={isRunning}
-            {...inst}
-          />
-        )
-      })}
+      {robotConstants.INSTRUMENT_MOUNTS.map((mount) => (
+        <InstrumentListItem
+          key={mount}
+          mount={mount}
+          isRunning={isRunning}
+          instrument={instruments.find((i) => i.mount === mount)}
+        />
+      ))}
     </TitledList>
   )
 }

--- a/app/src/components/setup-panel/InstrumentListItem.js
+++ b/app/src/components/setup-panel/InstrumentListItem.js
@@ -10,52 +10,33 @@ import {
   IconName
 } from '@opentrons/components'
 
-import type {Mount, Channels} from '../../robot'
+import type {Mount, Instrument} from '../../robot'
 
 type Props = {
   isRunning: boolean,
   mount: Mount,
-  name: ?string,
-  volume: ?number,
-  channels: ?Channels,
-  probed: ?boolean,
+  instrument: ?Instrument
 }
 
 export default function InstrumentListItem (props: Props) {
-  const {
-    isRunning,
-    name,
-    mount,
-    volume,
-    channels,
-    probed
-  } = props
-
-  const isUsed = name != null
-  const isDisabled = !isUsed || isRunning
-
+  const {isRunning, mount, instrument} = props
+  const confirmed = instrument && instrument.probed
+  const isDisabled = !instrument || isRunning
   const url = !isDisabled
     ? `/setup-instruments/${mount}`
     : '#'
-
-  // TODO (ka 2018-1-17): Move this up to container mergeProps in upcoming update setup panel ticket
-  const confirmed = probed
 
   const iconName: IconName = confirmed
     ? CHECKED
     : UNCHECKED
 
-  const pipetteType = channels === 8
-    ? 'multi'
-    : 'single'
-
-  const description = isUsed
-    ? `${capitalize(pipetteType)}-channel`
+  const description = instrument
+    ? `${capitalize(instrument.channels === 8 ? 'multi' : 'single')}-channel`
     : 'N/A'
 
-  const units = !isDisabled
-    ? 'ul'
-    : null
+  const name = instrument
+    ? instrument.name
+    : 'N/A'
 
   return (
     <ListItem
@@ -66,7 +47,7 @@ export default function InstrumentListItem (props: Props) {
     >
       <span>{capitalize(mount)}</span>
       <span>{description}</span>
-      <span>{volume} {units}</span>
+      <span>{name}</span>
     </ListItem>
   )
 }

--- a/app/src/components/setup-panel/LabwareListItem.js
+++ b/app/src/components/setup-panel/LabwareListItem.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
+
+import type {Labware} from '../../robot'
+
 import {ListItem, CHECKED, UNCHECKED} from '@opentrons/components'
-import capitalize from 'lodash/capitalize'
-import {
-  type Labware
-} from '../../robot'
+import styles from './styles.css'
 
 type LabwareItemProps = {
   isDisabled: boolean,
@@ -15,7 +15,7 @@ type Props = Labware & LabwareItemProps
 
 export default function LabwareListItem (props: Props) {
   const {
-    name,
+    type,
     slot,
     calibratorMount,
     isTiprack,
@@ -25,10 +25,6 @@ export default function LabwareListItem (props: Props) {
   } = props
 
   const url = `/setup-deck/${slot}`
-  const label = capitalize(name.replace('-', ' '))
-  const mount = isTiprack && calibratorMount
-    ? capitalize(calibratorMount.charAt(0))
-    : ''
   const iconName = confirmed
     ? CHECKED
     : UNCHECKED
@@ -41,8 +37,17 @@ export default function LabwareListItem (props: Props) {
       iconName={iconName}
     >
       <span>Slot {slot}</span>
-      <span>{label}</span>
-      <span>{mount}</span>
+      {isTiprack && (
+        <span>
+          <span className={styles.tiprack_item_mount}>
+            {calibratorMount && calibratorMount.charAt(0).toUpperCase()}
+          </span>
+          Tiprack
+        </span>
+      )}
+      <span>
+        {type}
+      </span>
     </ListItem>
   )
 }

--- a/app/src/components/setup-panel/RunButton.js
+++ b/app/src/components/setup-panel/RunButton.js
@@ -1,7 +1,9 @@
 // @flow
 import * as React from 'react'
+
 import {PrimaryButton} from '@opentrons/components'
-import styles from './run-panel.css'
+
+import styles from './styles.css'
 
 type RunButtonProps = {
   onClick: () => void,

--- a/app/src/components/setup-panel/RunMessage.js
+++ b/app/src/components/setup-panel/RunMessage.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
 import InfoBox from '../InfoBox'
-import styles from './run-panel.css'
+
+import styles from './styles.css'
 
 export default function RunMessage () {
   return (

--- a/app/src/components/setup-panel/index.js
+++ b/app/src/components/setup-panel/index.js
@@ -1,13 +1,16 @@
-import React from 'react'
+// @flow
+import * as React from 'react'
+
 import InstrumentList from './InstrumentList'
 import DeckCalibrationGroup from './DeckCalibrationGroup'
 import TipRackList from './TipRackList'
 import LabwareList from './LabwareList'
 import RunPanel from './RunPanel'
+import styles from './styles.css'
 
-export default function SetupPanel (props) {
+export default function SetupPanel () {
   return (
-    <div>
+    <div className={styles.setup_panel}>
       <InstrumentList />
       <DeckCalibrationGroup>
         <TipRackList />

--- a/app/src/components/setup-panel/styles.css
+++ b/app/src/components/setup-panel/styles.css
@@ -1,3 +1,16 @@
+@import '@opentrons/components';
+
+.setup_panel {
+  & > * {
+    margin: 0.5rem 0 1.5rem;
+  }
+}
+
+.tiprack_item_mount {
+  font-weight: var(--fw-bold);
+  padding-right: 0.75rem;
+}
+
 .run_message {
   margin: 1rem;
   font-size: 0.75rem;

--- a/app/src/pages/SetupDeck.js
+++ b/app/src/pages/SetupDeck.js
@@ -23,7 +23,7 @@ function SetupDeckPage (props: Props) {
 
   return (
     <Page>
-      <SessionHeader subtitle='Setup Deck' />
+      <SessionHeader />
       <LabwareCalibration slot={slot} url={url} />
       {!deckPopulated && (
         <ReviewDeckModal slot={slot} />

--- a/app/src/pages/SetupInstruments.js
+++ b/app/src/pages/SetupInstruments.js
@@ -12,8 +12,6 @@ import {InstrumentTabs, Instruments} from '../components/setup-instruments'
 
 import SessionHeader from '../containers/SessionHeader'
 
-const PAGE_TITLE = 'Setup Instruments'
-
 type Props = {
   match: {
     url: string,
@@ -29,7 +27,7 @@ export default function SetupInstrumentsPage (props: Props) {
 
   return (
     <Page>
-      <SessionHeader subtitle={PAGE_TITLE} />
+      <SessionHeader />
       <InstrumentTabs mount={mount} />
       <Instruments mount={mount} />
       <TipProbe mount={mount} confirmTipProbeUrl={confirmTipProbeUrl} />

--- a/components/src/deck/LabwareContainer.css
+++ b/components/src/deck/LabwareContainer.css
@@ -92,7 +92,3 @@ NOTE: available defs are:
 .name_overlay .container_type {
   font-weight: var(--fw-bold);
 }
-
-.deck_slot:hover .name_overlay {
-  display: none;
-}


### PR DESCRIPTION
## overview

@pantslakz, @umbhau and I did an in-person review of the calibration flow as implemented, and came away with a set of changes to get the app closer to the designs.

https://docs.google.com/presentation/d/16QWNSxA1xqloF92yMbjGQmF5O_Zs5-6SiLBLQWjc_Dw/edit?usp=sharing

## changelog

- Refactor: Updated various visual elements and copy based on in-person comparison to UX screens

Still TODO in another PR:

- Swap alignment diagram assets to the new ones
- Deckmap opacity tweaks and MOVE TO overlay
- Return Tip button + setup panel run button removal

Longer term punts:

- Labware details (need to spec out what we want from the API rather than trying to parse labware types on the front-end)
- Tooltips (larger project also involving tutorial mode)

## review requests

Standard review. @pantslakz here are the links to the app build that implements these changes: 

- Windows: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-win-2018-02-09_23-19-app_calibration-feedback-ac902ee.exe
- Mac: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-mac-2018-02-09_23-18-app_calibration-feedback-ac902ee.zip
- Debian Linux: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-linux-amd64-2018-02-09_23-18-app_calibration-feedback-ac902ee.deb