### PR TITLE
Pipette at safe(r) height when moving between labwares

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -138,7 +138,6 @@ class CalibrationManager:
             instrument=inst,
             save=True
         )
-        inst.robot.max_deck_height.cache_clear()
 
     # TODO (artyom, 20171003): along with session, consider extracting this
     # into abstract base class or find any other way to keep notifications

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -64,31 +64,15 @@ class Mover:
         return update(pose_tree, self, Point(*defaults(dst_x, dst_y, dst_z)))
 
     def home(self, pose_tree):
-        position = self._driver.home(axis=''.join(self._axis_mapping.values()))
-        # map from driver axis names to xyz and expand position
-        # into point object
-        point = Point(
-            x=position.get(self._axis_mapping.get('x', ''), 0.0),
-            y=position.get(self._axis_mapping.get('y', ''), 0.0),
-            z=position.get(self._axis_mapping.get('z', ''), 0.0)
-        )
-
-        return update(pose_tree, self, point)
+        self._driver.home(axis=''.join(self._axis_mapping.values()))
+        return self.update_pose_from_driver(pose_tree)
 
     def fast_home(self, pose_tree, safety_margin):
-        position = self._driver.fast_home(
+        self._driver.fast_home(
             axis=''.join(self._axis_mapping.values()),
             safety_margin=safety_margin
         )
-        # map from driver axis names to xyz and expand position
-        # into point object
-        point = Point(
-            x=position.get(self._axis_mapping.get('x', ''), 0.0),
-            y=position.get(self._axis_mapping.get('y', ''), 0.0),
-            z=position.get(self._axis_mapping.get('z', ''), 0.0)
-        )
-
-        return update(pose_tree, self, point)
+        return self.update_pose_from_driver(pose_tree)
 
     def set_speed(self, value):
         self._driver.set_speed(value)
@@ -115,16 +99,19 @@ class Mover:
         assert axis in self._axis_mapping, "mapping is not set for " + axis
 
         if axis in self._axis_mapping:
-            position = self._driver.probe_axis(
-                self._axis_mapping[axis],
-                movement)
-            point = Point(
-                x=position.get(self._axis_mapping.get('x', ''), 0.0),
-                y=position.get(self._axis_mapping.get('y', ''), 0.0),
-                z=position.get(self._axis_mapping.get('z', ''), 0.0)
-            )
-
-            return update(pose_tree, self, point)
+            self._driver.probe_axis(self._axis_mapping[axis], movement)
+            return self.update_pose_from_driver(pose_tree)
 
     def delay(self, seconds):
         self._driver.delay(seconds)
+
+    def update_pose_from_driver(self, pose_tree):
+        # map from driver axis names to xyz and expand position
+        # into point object
+        point = Point(
+            x=self._driver.position.get(self._axis_mapping.get('x', ''), 0.0),
+            y=self._driver.position.get(self._axis_mapping.get('y', ''), 0.0),
+            z=self._driver.position.get(self._axis_mapping.get('z', ''), 0.0)
+        )
+
+        return update(pose_tree, self, point)

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -8,18 +8,22 @@ class Mover:
         self._dst = dst
         self._src = src
 
-    def jog(self, pose_tree, axis, distance):
-        assert axis in 'xyz', "axis value should be x, y or z"
-        assert axis in self._axis_mapping, "mapping is not set for " + axis
-
+    def position(self, pose_tree):
         x, y, z = change_base(pose_tree, src=self)
 
-        target = {
+        pos = {
             'x': x if 'x' in self._axis_mapping else None,
             'y': y if 'y' in self._axis_mapping else None,
             'z': z if 'z' in self._axis_mapping else None,
         }
 
+        return pos
+
+    def jog(self, pose_tree, axis, distance):
+        assert axis in 'xyz', "axis value should be x, y or z"
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
+
+        target = self.position(pose_tree)
         target[axis] += distance
 
         return self.move(pose_tree, **target)

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -8,22 +8,18 @@ class Mover:
         self._dst = dst
         self._src = src
 
-    def position(self, pose_tree):
+    def jog(self, pose_tree, axis, distance):
+        assert axis in 'xyz', "axis value should be x, y or z"
+        assert axis in self._axis_mapping, "mapping is not set for " + axis
+
         x, y, z = change_base(pose_tree, src=self)
 
-        pos = {
+        target = {
             'x': x if 'x' in self._axis_mapping else None,
             'y': y if 'y' in self._axis_mapping else None,
             'z': z if 'z' in self._axis_mapping else None,
         }
 
-        return pos
-
-    def jog(self, pose_tree, axis, distance):
-        assert axis in 'xyz', "axis value should be x, y or z"
-        assert axis in self._axis_mapping, "mapping is not set for " + axis
-
-        target = self.position(pose_tree)
         target[axis] += distance
 
         return self.move(pose_tree, **target)

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -628,6 +628,8 @@ class Robot(object):
                 # Z arc height will be used for the new pipette
                 self._prev_container = None
 
+        self._previous_instrument = instrument
+
         if strategy == 'arc':
             arc_coords = self._create_arc(target, placeable)
             for coord in arc_coords:
@@ -669,6 +671,7 @@ class Robot(object):
         # TODO (andy): there is no check here for if this height will hit
         # the limit switches, so if a tall labware is used, we risk collision
         arc_top += self.arc_height
+        arc_top = max(arc_top, destination[2])
 
         strategy = [
             {'z': arc_top},

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -679,6 +679,8 @@ class Robot(object):
         current_height = current_pos.get('z', 0)
         arc_top = max(arc_top, current_height)
 
+        print(arc_top)
+
         strategy = [
             {'z': arc_top},
             {'x': destination[0], 'y': destination[1]},
@@ -989,6 +991,8 @@ class Robot(object):
             container,
             *delta, save
         )
+
+        self.max_deck_height.cache_clear()
 
     @lru_cache()
     def max_deck_height(self):

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -15,8 +15,8 @@ from opentrons.util.log import get_logger
 
 log = get_logger(__name__)
 
-TIP_CLEARANCE_DECK = 20   # clearance when moving between different labware
-TIP_CLEARANCE_LABWARE = 5 # clearance when staying within a single labware
+TIP_CLEARANCE_DECK = 20    # clearance when moving between different labware
+TIP_CLEARANCE_LABWARE = 5  # clearance when staying within a single labware
 
 
 class InstrumentMosfet(object):
@@ -189,8 +189,6 @@ class Robot(object):
         self.fw_version = self._driver.get_fw_version()
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
-
-        self.arc_height = TIP_CLEARANCE_DECK
 
         # TODO (artyom, 09182017): once protocol development experience
         # in the light of Session concept is fully fleshed out, we need
@@ -524,6 +522,11 @@ class Robot(object):
         self.poses = self._actuators['left']['plunger'].home(self.poses)
         self.poses = self._actuators['right']['plunger'].home(self.poses)
 
+        # next move should not use any previously used instrument or labware
+        # to prevent robot.move_to() from using risky path optimization
+        self._previous_instrument = None
+        self._prev_container = None
+
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)
 
@@ -663,7 +666,7 @@ class Robot(object):
         # can be relative to just that one container's height
         if this_container and self._prev_container == this_container:
             arc_top = self.max_placeable_height_on_deck(this_container)
-            arc_top += TIP_CLEARANCE_DECK
+            arc_top += TIP_CLEARANCE_LABWARE
 
         self._prev_container = this_container
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -632,7 +632,7 @@ class Robot(object):
         self._previous_instrument = instrument
 
         if strategy == 'arc':
-            arc_coords = self._create_arc(target, placeable)
+            arc_coords = self._create_arc(instrument, target, placeable)
             for coord in arc_coords:
                 self.poses = instrument._move(
                     self.poses,
@@ -647,7 +647,7 @@ class Robot(object):
             raise RuntimeError(
                 'Unknown move strategy: {}'.format(strategy))
 
-    def _create_arc(self, destination, placeable=None):
+    def _create_arc(self, inst, destination, placeable=None):
         """
         Returns a list of coordinates to arrive to the destination coordinate
         """
@@ -673,6 +673,11 @@ class Robot(object):
         # TODO (andy): there is no check here for if this height will hit
         # the limit switches, so if a tall labware is used, we risk collision
         arc_top = max(arc_top, destination[2])
+
+        # if instrument is currently taller than arc_top, no need to move down
+        current_pos = inst.instrument_mover.position(self.poses)
+        current_height = current_pos.get('z', 0)
+        arc_top = max(arc_top, current_height)
 
         strategy = [
             {'z': arc_top},

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -675,11 +675,8 @@ class Robot(object):
         arc_top = max(arc_top, destination[2])
 
         # if instrument is currently taller than arc_top, no need to move down
-        current_pos = inst.instrument_mover.position(self.poses)
-        current_height = current_pos.get('z', 0)
-        arc_top = max(arc_top, current_height)
-
-        print(arc_top)
+        _, _, pip_z = pose_tracker.absolute(self.poses, inst)
+        arc_top = max(arc_top, pip_z)
 
         strategy = [
             {'z': arc_top},

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -163,12 +163,13 @@ def update_instrument_config(instrument, measured_center) -> (Point, float):
 
 def move_instrument_for_probing_prep(instrument, robot):
     # TODO(artyom, ben 20171026): calculate from robot dimensions
-    robot.poses = instrument._move(
-        robot.poses,
-        x=191.5,
-        y=75.0,
-        z=128
-    )
+    # robot.poses = instrument._move(
+    #     robot.poses,
+    #     x=191.5,
+    #     y=75.0,
+    #     z=128
+    # )
+    instrument.move_to(robot.deck['5'].top(150))
 
 
 def jog_instrument(instrument, axis, robot, distance):

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -162,13 +162,6 @@ def update_instrument_config(instrument, measured_center) -> (Point, float):
 
 
 def move_instrument_for_probing_prep(instrument, robot):
-    # TODO(artyom, ben 20171026): calculate from robot dimensions
-    # robot.poses = instrument._move(
-    #     robot.poses,
-    #     x=191.5,
-    #     y=75.0,
-    #     z=128
-    # )
     instrument.move_to(robot.deck['5'].top(150))
 
 

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -130,10 +130,6 @@ def test_create_arc(robot):
     robot.poses = p200._move(robot.poses, x=10, y=10, z=new_labware_height)
     robot.calibrate_container_with_instrument(plate2, p200, save=False)
 
-    print(robot.max_placeable_height_on_deck(plate2))
-    print(robot.max_deck_height())
-    print(robot)
-    print(robot.max_placeable_height_on_deck(robot.deck['2'].get_children_list()[0]))
     assert robot.max_deck_height() == new_labware_height
 
     res = robot._create_arc(p200, (0, 0, 0), plate2[0])

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -93,7 +93,7 @@ def test_comment(robot):
 
 
 def test_create_arc(robot):
-    from opentrons.robot.robot import TIP_CLEARANCE
+    from opentrons.robot.robot import TIP_CLEARANCE_DECK, TIP_CLEARANCE_LABWARE
 
     p200 = pipette.Pipette(
         robot, mount='left', name='my-fancy-pancy-pipette'
@@ -104,10 +104,18 @@ def test_create_arc(robot):
     robot.calibrate_container_with_instrument(plate, p200, save=False)
 
     res = robot._create_arc((0, 0, 0), plate[0])
-    # TODO(artyom 20171030): confirm expected values are correct after merging
-    # calibration work
+    arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
     expected = [
-        {'z': robot.max_deck_height() + TIP_CLEARANCE},
+        {'z': arc_top},
+        {'x': 0, 'y': 0},
+        {'z': 0}
+    ]
+    assert res == expected
+
+    res = robot._create_arc((0, 0, 0), plate[1])
+    arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
+    expected = [
+        {'z': arc_top},
         {'x': 0, 'y': 0},
         {'z': 0}
     ]
@@ -118,11 +126,9 @@ def test_create_arc(robot):
         plate2, p200, save=False
     )
     res = robot._create_arc((0, 0, 0), plate2[0])
-
-    # TODO(artyom 20171030): confirm expected values are correct after merging
-    # calibration work
+    arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
     expected = [
-        {'z': robot.max_deck_height() + TIP_CLEARANCE},
+        {'z': arc_top},
         {'x': 0, 'y': 0},
         {'z': 0}
     ]

--- a/api/tests/opentrons/protocol/test_robot.py
+++ b/api/tests/opentrons/protocol/test_robot.py
@@ -100,10 +100,15 @@ def test_create_arc(robot):
     )
     plate = containers_load(robot, '96-flat', '1')
     plate2 = containers_load(robot, '96-flat', '2')
-    robot.poses = p200._move(robot.poses, x=10, y=10, z=10)
+
+    new_labware_height = 10
+    robot.poses = p200._move(robot.poses, x=10, y=10, z=new_labware_height)
     robot.calibrate_container_with_instrument(plate, p200, save=False)
 
-    res = robot._create_arc((0, 0, 0), plate[0])
+    trash_height = robot.max_placeable_height_on_deck(robot.fixed_trash)
+    assert robot.max_deck_height() == trash_height
+
+    res = robot._create_arc(p200, (0, 0, 0), plate[0])
     arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
     expected = [
         {'z': arc_top},
@@ -112,7 +117,7 @@ def test_create_arc(robot):
     ]
     assert res == expected
 
-    res = robot._create_arc((0, 0, 0), plate[1])
+    res = robot._create_arc(p200, (0, 0, 0), plate[1])
     arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
     expected = [
         {'z': arc_top},
@@ -121,11 +126,17 @@ def test_create_arc(robot):
     ]
     assert res == expected
 
-    robot.poses = p200._move(robot.poses, x=10, y=10, z=100)
-    robot.calibrate_container_with_instrument(
-        plate2, p200, save=False
-    )
-    res = robot._create_arc((0, 0, 0), plate2[0])
+    new_labware_height = 200
+    robot.poses = p200._move(robot.poses, x=10, y=10, z=new_labware_height)
+    robot.calibrate_container_with_instrument(plate2, p200, save=False)
+
+    print(robot.max_placeable_height_on_deck(plate2))
+    print(robot.max_deck_height())
+    print(robot)
+    print(robot.max_placeable_height_on_deck(robot.deck['2'].get_children_list()[0]))
+    assert robot.max_deck_height() == new_labware_height
+
+    res = robot._create_arc(p200, (0, 0, 0), plate2[0])
     arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
     expected = [
         {'z': arc_top},


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Fixes #790 

- Robot uses two separate tip-clearances when creating arced movements, one for moving between different labware (20mm), another for moving between wells in the same labware (5mm)
- Robot no longer unnecessarily lowers it's Z height before moving horizontally

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
