### PR TITLE
retracts slowly away from Y endstop when homing

### DIFF
--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -25,14 +25,6 @@ def test_plunger_commands(smoothie, monkeypatch):
     monkeypatch.setattr(driver_3_0, '_parse_axis_values', _parse_axis_values)
 
     smoothie.home()
-    smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
-    smoothie.move({
-        'X': 10.987654321,
-        'Y': 1.12345678,
-        'Z': 2,
-        'A': 3,
-        'B': 4,
-        'C': 5})
     expected = [
         ['M907 B0.5 C0.5 M400'],               # Set plunger current high
         ['G4P0.05 M400'],                      # Dwell
@@ -47,9 +39,38 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['G4P0.05 M400'],                      # delay for current
         ['G0F24000 M400'],                      # set back to default speed
         ['G28.2X M400'],                       # home X
-        ['G28.2Y M400'],                       # home Y
+        ['G28.2Y M400'],                        # home Y
         ['M114.2 M400'],                       # Get position
-        ['G0.+ M400'],                         # Move (non-plunger)
+        ['M203.1 Y8 M400'],                     # lower speed on Y for retract
+        ['G0.+ M400'],                          # retract Y
+        ['G28.2Y M400'],                        # home Y
+        ['M114.2 M400'],                       # Get position
+        ['G0.+ M400'],                          # retract Y
+        ['M203.1 A100 B70 C70 X600 Y400 Z100 M400'],  # return to norm current
+        ['M114.2 M400']                       # Get position
+    ]
+    # from pprint import pprint
+    # pprint(command_log)
+    fuzzy_assert(result=command_log, expected=expected)
+    command_log = []
+
+    smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
+    expected = [
+        ['G0.+ M400']                         # Move (non-plunger)
+    ]
+    # from pprint import pprint
+    # pprint(command_log)
+    fuzzy_assert(result=command_log, expected=expected)
+    command_log = []
+
+    smoothie.move({
+        'X': 10.987654321,
+        'Y': 1.12345678,
+        'Z': 2,
+        'A': 3,
+        'B': 4,
+        'C': 5})
+    expected = [
         ['M907 B0.5 C0.5 M400'],               # Set plunger current high
         ['G4P0.05 M400'],                      # Dwell
         ['G0.+[BC].+ M400'],                   # Move (including BC)


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Fixes #788 

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
