### PR TITLE
feat(app): Add HTTP API client and health state to robots

### DIFF
--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -76,7 +76,10 @@ function createWindow () {
       devTools: DEV_MODE || DEBUG_MODE,
       experimentalFeatures: true,
       // node integration needed for mdns robot discovery
-      nodeIntegrationInWorker: true
+      nodeIntegrationInWorker: true,
+      // TODO(mc, 2018-02-12): this works around CORS restrictions
+      //   while in dev mode; evaluate whether this is acceptable
+      webSecurity: !DEV_MODE
     }
   })
 

--- a/app/package.json
+++ b/app/package.json
@@ -69,6 +69,7 @@
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.10",
+    "redux-mock-store": "^1.5.1",
     "script-ext-html-webpack-plugin": "^1.8.5",
     "style-loader": "^0.18.2",
     "superagent": "^3.8.1",

--- a/app/src/http-api-client/__mocks__/client.js
+++ b/app/src/http-api-client/__mocks__/client.js
@@ -1,9 +1,10 @@
 // mock http api client
+'use strict'
 
 let _mockResponse = null
 let _mockError = null
 
-const client = jest.fn(() => {
+const client = module.exports = jest.fn(() => {
   if (_mockResponse) {
     return new Promise((resolve) => process.nextTick(() => {
       resolve(_mockResponse)
@@ -28,5 +29,3 @@ client.__setMockError = function setMockError (error) {
 client.__clearMock = function clearMockResponses () {
   client.mockClear()
 }
-
-export default client

--- a/app/src/http-api-client/__mocks__/client.js
+++ b/app/src/http-api-client/__mocks__/client.js
@@ -1,0 +1,32 @@
+// mock http api client
+
+let _mockResponse = null
+let _mockError = null
+
+const client = jest.fn(() => {
+  if (_mockResponse) {
+    return new Promise((resolve) => process.nextTick(() => {
+      resolve(_mockResponse)
+    }))
+  }
+
+  return new Promise((resolve, reject) => process.nextTick(() => {
+    reject(_mockError || new Error('Mock values not seeded'))
+  }))
+})
+
+client.__setMockResponse = function setMockResponse (response) {
+  _mockError = null
+  _mockResponse = response
+}
+
+client.__setMockError = function setMockError (error) {
+  _mockResponse = null
+  _mockError = error
+}
+
+client.__clearMock = function clearMockResponses () {
+  client.mockClear()
+}
+
+export default client

--- a/app/src/http-api-client/__mocks__/health.js
+++ b/app/src/http-api-client/__mocks__/health.js
@@ -1,0 +1,7 @@
+// mock health module
+'use strict'
+
+const health = module.exports = jest.genMockFromModule('../health')
+
+health.__mockThunk = jest.fn()
+health.fetchHealth = jest.fn(() => health.__mockThunk)

--- a/app/src/http-api-client/__tests__/client.test.js
+++ b/app/src/http-api-client/__tests__/client.test.js
@@ -1,0 +1,82 @@
+// http api client tests
+import client from '../client'
+
+const mockResolve = (value) => jest.fn(() => new Promise((resolve) => {
+  process.nextTick(() => resolve(value))
+}))
+
+const mockReject = (error) => jest.fn(() => new Promise((resolve, reject) => {
+  process.nextTick(() => reject(error))
+}))
+
+describe('http api client', () => {
+  let _oldFetch
+
+  beforeAll(() => {
+    // mock fetch
+    _oldFetch = global.fetch
+    global.fetch = mockResolve({ok: false})
+  })
+
+  afterAll(() => {
+    global.fetch = _oldFetch
+  })
+
+  beforeEach(() => {
+    global.fetch.mockClear()
+  })
+
+  test('GET request', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockResolve({
+      ok: true,
+      json: () => Promise.resolve({foo: 'bar'})
+    })
+
+    return expect(client(robot, 'GET', 'foo')).resolves
+      .toEqual({foo: 'bar'})
+      .then(() => expect(global.fetch).toHaveBeenCalledWith(
+        'http://1.2.3.4:8080/foo',
+        {
+          method: 'GET',
+          headers: {'Content-Type': 'application/json'}
+        }
+      ))
+  })
+
+  test('GET request failure', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockResolve({
+      ok: false,
+      status: '400',
+      statusText: 'Bad Request'
+    })
+
+    return expect(client(robot, 'GET', 'foo')).rejects
+      .toEqual(expect.objectContaining({
+        message: '400 Bad Request'
+      }))
+  })
+
+  test('GET request error', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockReject(new Error('AH'))
+
+    return expect(client(robot, 'GET', 'foo')).rejects
+      .toEqual(expect.objectContaining({
+        message: 'AH'
+      }))
+  })
+})

--- a/app/src/http-api-client/__tests__/health.test.js
+++ b/app/src/http-api-client/__tests__/health.test.js
@@ -1,0 +1,129 @@
+// health api tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {fetchHealth, reducer, selectHealth} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('health', () => {
+  afterEach(() => client.__clearMock())
+
+  test('fetchHealth dispatches HEALTH_REQUEST and HEALTH_SUCCESS', () => {
+    const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+    const health = {api_version: '1.2.3', fw_version: '4.5.6'}
+    const store = mockStore({})
+    const expectedActions = [
+      {type: 'api:HEALTH_REQUEST', payload: {robot}},
+      {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+    ]
+
+    client.__setMockResponse(health)
+
+    return store.dispatch(fetchHealth(robot))
+      .then(() => expect(store.getActions()).toEqual(expectedActions))
+  })
+
+  test('fetchHealth dispatches HEALTH_REQUEST and HEALTH_FAILURE', () => {
+    const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+    const error = new Error('AH')
+    const store = mockStore({})
+    const expectedActions = [
+      {type: 'api:HEALTH_REQUEST', payload: {robot}},
+      {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
+    ]
+
+    client.__setMockError(error)
+
+    return store.dispatch(fetchHealth(robot))
+      .then(() => expect(store.getActions()).toEqual(expectedActions))
+  })
+
+  test('reducer handles HEALTH_REQUEST', () => {
+    const robot = {name: 'opentrons-1', ip: '1.2.3.4', port: '1234'}
+    const state = {
+      health: {
+        'opentrons-1': {
+          inProgress: false,
+          error: new Error('AH'),
+          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+        }
+      }
+    }
+    const action = {type: 'api:HEALTH_REQUEST', payload: {robot}}
+
+    expect(reducer(state, action).health).toEqual({
+      'opentrons-1': {
+        inProgress: true,
+        error: null,
+        response: {api_version: '1.2.3', fw_version: '4.5.6'}
+      }
+    })
+  })
+
+  test('reducer handles HEALTH_SUCCESS', () => {
+    const robot = {name: 'opentrons-1', ip: '1.2.3.4', port: '1234'}
+    const health = {api_version: '4.5.6', fw_version: '7.8.9'}
+    const state = {
+      health: {
+        'opentrons-1': {
+          inProgress: true,
+          error: null,
+          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+        }
+      }
+    }
+    const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+
+    expect(reducer(state, action).health).toEqual({
+      'opentrons-1': {
+        inProgress: false,
+        error: null,
+        response: {api_version: '4.5.6', fw_version: '7.8.9'}
+      }
+    })
+  })
+
+  test('reducer handles HEALTH_FAILURE', () => {
+    const robot = {name: 'opentrons-1', ip: '1.2.3.4', port: '1234'}
+    const error = new Error('AH')
+    const state = {
+      health: {
+        'opentrons-1': {
+          inProgress: true,
+          error: null,
+          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+        }
+      }
+    }
+    const action = {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
+
+    expect(reducer(state, action).health).toEqual({
+      'opentrons-1': {
+        inProgress: false,
+        error,
+        response: {api_version: '1.2.3', fw_version: '4.5.6'}
+      }
+    })
+  })
+
+  test('selectHealth returns health substate', () => {
+    const state = {
+      api: {
+        health: {
+          'opentrons-1': {
+            inProgress: true,
+            error: null,
+            response: {api_version: '1.2.3', fw_version: '4.5.6'}
+          }
+        }
+      }
+    }
+
+    expect(selectHealth(state)).toBe(state.api.health)
+  })
+})

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -1,0 +1,61 @@
+// @flow
+// robot HTTP API client
+
+import type {RobotService} from '../robot'
+
+type Method = 'GET'
+
+export type ClientResponseError = {
+  name: string,
+  message: string,
+  url?: string,
+  status?: number,
+  statusText?: string
+}
+
+// not a real Error or Response so it can be copied across worker boundries
+function ResponseError (response: Response): ClientResponseError {
+  const {status, statusText, url} = response
+
+  return {
+    name: 'ResponseError',
+    message: `${status} ${statusText}`,
+    status,
+    statusText,
+    url
+  }
+}
+
+// not a real Error so it can be copied across worker boundries
+function FetchError (error: Error): ClientResponseError {
+  return {name: error.name, message: error.message}
+}
+
+const HEADERS = {
+  'Content-Type': 'application/json'
+}
+
+export default function client (
+  robot: RobotService,
+  method: Method,
+  path: string,
+  body?: {}
+): Promise<any> {
+  const url = `http://${robot.ip}:${robot.port}/${path}`
+  const options = {
+    method,
+    headers: HEADERS,
+    body: (body && method !== 'GET')
+      ? JSON.stringify(body)
+      : undefined
+  }
+
+  return fetch(url, options)
+    .then(
+      (response) => (response.ok
+        ? response.json()
+        : Promise.reject(ResponseError(response))
+      ),
+      (error) => Promise.reject(FetchError(error))
+    )
+}

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -1,0 +1,137 @@
+// @flow
+// http api actions and action types
+import type {State, ThunkAction, Action} from '../types'
+import type {RobotService} from '../robot'
+
+import client, {type ClientResponseError} from './client'
+
+export type HealthResponse = {
+  api_version: string,
+  fw_version: string,
+}
+
+export type HealthRequestAction = {|
+  type: 'api:HEALTH_REQUEST',
+  payload: {
+    robot: RobotService
+  }
+|}
+
+export type HealthSuccessAction = {|
+  type: 'api:HEALTH_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    health: HealthResponse
+  |}
+|}
+
+export type HealthFailureAction = {|
+  type: 'api:HEALTH_FAILURE',
+  payload: {|
+    robot: RobotService,
+    error: ClientResponseError
+  |}
+|}
+
+export type HealthAction =
+ | HealthRequestAction
+ | HealthSuccessAction
+ | HealthFailureAction
+
+export type HealthState = {
+  /** robot name */
+  [string]: {
+    /** request in progress flag */
+    inProgress: boolean,
+    /** possible error response */
+    error: ?ClientResponseError,
+    /** possible success response */
+    response: ?HealthResponse
+  }
+}
+
+export function fetchHealth (robot: RobotService): ThunkAction {
+  return (dispatch) => {
+    dispatch(healthRequest(robot))
+
+    return client(robot, 'GET', 'health')
+      .then((maybeHealth) => dispatch(healthResponse(null, robot, maybeHealth)))
+      .catch((error) => dispatch(healthResponse(error, robot)))
+  }
+}
+
+function healthRequest (robot: RobotService): HealthRequestAction {
+  return {type: 'api:HEALTH_REQUEST', payload: {robot}}
+}
+
+function healthResponse (
+  error: ?Error,
+  robot: RobotService,
+  maybeHealth?: any
+): HealthSuccessAction | HealthFailureAction {
+  if (error || typeof maybeHealth !== 'object') {
+    return {
+      type: 'api:HEALTH_FAILURE',
+      payload: {
+        robot,
+        error: error || {name: 'Error', message: 'malformed /health response'}
+      }
+    }
+  }
+
+  return {
+    type: 'api:HEALTH_SUCCESS',
+    payload: {
+      robot,
+      health: {
+        api_version: maybeHealth.api_version,
+        fw_version: maybeHealth.fw_version
+      }
+    }
+  }
+}
+
+export function healthReducer (
+  state: ?HealthState,
+  action: Action
+): HealthState {
+  if (state == null) return {}
+
+  switch (action.type) {
+    case 'api:HEALTH_REQUEST':
+      return {
+        ...state,
+        [action.payload.robot.name]: {
+          ...state[action.payload.robot.name],
+          inProgress: true,
+          error: null
+        }
+      }
+
+    case 'api:HEALTH_SUCCESS':
+      return {
+        ...state,
+        [action.payload.robot.name]: {
+          ...state[action.payload.robot.name],
+          inProgress: false,
+          response: action.payload.health
+        }
+      }
+
+    case 'api:HEALTH_FAILURE':
+      return {
+        ...state,
+        [action.payload.robot.name]: {
+          ...state[action.payload.robot.name],
+          inProgress: false,
+          error: action.payload.error
+        }
+      }
+  }
+
+  return state
+}
+
+export function selectHealth (state: State) {
+  return state.api.health
+}

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -38,16 +38,18 @@ export type HealthAction =
  | HealthSuccessAction
  | HealthFailureAction
 
+export type RobotHealth = {
+  /** request in progress flag */
+  inProgress: boolean,
+  /** possible error response */
+  error: ?ClientResponseError,
+  /** possible success response */
+  response: ?HealthResponse
+}
+
 export type HealthState = {
   /** robot name */
-  [string]: {
-    /** request in progress flag */
-    inProgress: boolean,
-    /** possible error response */
-    error: ?ClientResponseError,
-    /** possible success response */
-    response: ?HealthResponse
-  }
+  [string]: RobotHealth
 }
 
 export function fetchHealth (robot: RobotService): ThunkAction {

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -3,14 +3,19 @@
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
 
-export type {HealthSuccessAction, HealthFailureAction} from './health'
-export {fetchHealth, selectHealth} from './health'
-
-export type Action =
-  | HealthAction
-
 export const reducer = combineReducers({
   health: healthReducer
 })
+
+export {fetchHealth, selectHealth} from './health'
+
+export type {
+  RobotHealth,
+  HealthSuccessAction,
+  HealthFailureAction
+} from './health'
+
+export type Action =
+  | HealthAction
 
 export type State = $Call<typeof reducer>

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -1,0 +1,16 @@
+// @flow
+// robot HTTP API client module
+import {combineReducers} from 'redux'
+import {healthReducer, type HealthAction} from './health'
+
+export type {HealthSuccessAction, HealthFailureAction} from './health'
+export {fetchHealth, selectHealth} from './health'
+
+export type Action =
+  | HealthAction
+
+export const reducer = combineReducers({
+  health: healthReducer
+})
+
+export type State = $Call<typeof reducer>

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -3,35 +3,16 @@ import React from 'react'
 import ReactDom from 'react-dom'
 import {Provider} from 'react-redux'
 import {AppContainer} from 'react-hot-loader'
-import {createStore, combineReducers, applyMiddleware} from 'redux'
+import {createStore, applyMiddleware} from 'redux'
 import {createLogger} from 'redux-logger'
+import thunk from 'redux-thunk'
 import createHistory from 'history/createBrowserHistory'
-import {
-  ConnectedRouter,
-  routerReducer,
-  routerMiddleware
-} from 'react-router-redux'
+import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
-// interface state
-import {
-  NAME as INTERFACE_NAME,
-  reducer as interfaceReducer,
-  alertMiddleware
-} from './interface'
-
-// robot state
-import {
-  NAME as ROBOT_NAME,
-  reducer as robotReducer,
-  apiClientMiddleware as robotApiMiddleware
-} from './robot'
-
-// analytics state
-import {
-  NAME as ANALYTICS_NAME,
-  reducer as analyticsReducer,
-  middleware as analyticsMiddleware
-} from './analytics'
+import {alertMiddleware} from './interface'
+import {apiClientMiddleware as robotApiMiddleware} from './robot'
+import {middleware as analyticsMiddleware} from './analytics'
+import reducer from './reducer'
 
 // analytics events map
 // in a separate file for separation of concerns / DI / cicular dep prevention
@@ -40,16 +21,10 @@ import analyticsEventsMap from './analytics/events-map'
 // components
 import App from './components/App'
 
-const reducer = combineReducers({
-  [INTERFACE_NAME]: interfaceReducer,
-  [ROBOT_NAME]: robotReducer,
-  [ANALYTICS_NAME]: analyticsReducer,
-  router: routerReducer
-})
-
 const history = createHistory()
 
 const middleware = applyMiddleware(
+  thunk,
   robotApiMiddleware(),
   analyticsMiddleware(analyticsEventsMap),
   alertMiddleware(window),

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -1,0 +1,24 @@
+// @flow
+// interface state
+import {combineReducers} from 'redux'
+import {routerReducer} from 'react-router-redux'
+
+// ui state
+import {NAME as INTERFACE_NAME, reducer as interfaceReducer} from './interface'
+
+// robot state
+import {NAME as ROBOT_NAME, reducer as robotReducer} from './robot'
+
+// api state
+import {reducer as httpApiReducer} from './http-api-client'
+
+// analytics state
+import {NAME as ANALYTICS_NAME, reducer as analyticsReducer} from './analytics'
+
+export default combineReducers({
+  [INTERFACE_NAME]: interfaceReducer,
+  [ROBOT_NAME]: robotReducer,
+  [ANALYTICS_NAME]: analyticsReducer,
+  api: httpApiReducer,
+  router: routerReducer
+})

--- a/app/src/robot/api-client/worker.js
+++ b/app/src/robot/api-client/worker.js
@@ -17,13 +17,14 @@ self.onmessage = function handleIncoming (event) {
 function dispatchFromWorker (action) {
   // webworkers cannot post Error objects, so convert them to plain objects
   if (action.error === true) {
-    const {payload} = action
-
-    action.payload = Object.assign(
-      {name: payload.name, message: payload.message},
-      payload
-    )
+    action.payload = errorToPlainObject(action.payload)
   }
 
   self.postMessage(action)
+}
+
+function errorToPlainObject (error) {
+  return Object.assign({
+    name: error.name, message: error.message
+  }, error)
 }

--- a/app/src/robot/index.js
+++ b/app/src/robot/index.js
@@ -6,6 +6,8 @@ import * as selectors from './selectors'
 import * as constants from './constants'
 import apiClientMiddleware from './api-client'
 
+export type {Action} from './actions'
+
 export * from './types'
 export {_NAME as NAME} from './constants'
 export {actions, actionTypes} from './actions'

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -3,18 +3,22 @@
 import omit from 'lodash/omit'
 import without from 'lodash/without'
 
+import type {Action} from '../../types'
+
+import type {
+  HealthSuccessAction,
+  HealthFailureAction
+} from '../../http-api-client'
+
+import type {RobotService} from '../types'
+
 import {actionTypes} from '../actions'
 
-export type State = {
+type State = {
   isScanning: boolean,
   discovered: string[],
   discoveredByName: {
-    [string]: {
-      name: String,
-      ip: String,
-      host: String,
-      port: number
-    }
+    [string]: RobotService
   },
   connectedTo: string,
   connectRequest: {
@@ -29,13 +33,6 @@ export type State = {
 }
 
 // TODO(mc, 2018-01-11): import union of discrete action types from actions
-type Action = {
-  type: string,
-  payload?: any,
-  error?: boolean,
-  meta?: {}
-}
-
 const {
   DISCOVER,
   DISCOVER_FINISH,
@@ -57,38 +54,43 @@ const INITIAL_STATE: State = {
 }
 
 export default function connectionReducer (
-  state: State = INITIAL_STATE,
+  state?: State,
   action: Action
 ): State {
+  if (state == null) return INITIAL_STATE
+
   switch (action.type) {
-    case DISCOVER: return handleDiscover(state, action)
-    case DISCOVER_FINISH: return handleDiscoverFinish(state, action)
+    case DISCOVER: return handleDiscover(state)
+    case DISCOVER_FINISH: return handleDiscoverFinish(state)
     case ADD_DISCOVERED: return handleAddDiscovered(state, action)
     case REMOVE_DISCOVERED: return handleRemoveDiscovered(state, action)
     case CONNECT: return handleConnect(state, action)
     case CONNECT_RESPONSE: return handleConnectResponse(state, action)
     case DISCONNECT: return handleDisconnect(state, action)
     case DISCONNECT_RESPONSE: return handleDisconnectResponse(state, action)
+
+    case 'api:HEALTH_SUCCESS': return maybeDiscoverWired(state, action)
+    case 'api:HEALTH_FAILURE': return maybeRemoveWired(state, action)
   }
 
   return state
 }
 
-function handleDiscover (state, action) {
+function handleDiscover (state: State): State {
   return {
     ...state,
     isScanning: true
   }
 }
 
-function handleDiscoverFinish (state, action) {
+function handleDiscoverFinish (state: State): State {
   return {
     ...state,
     isScanning: false
   }
 }
 
-function handleAddDiscovered (state, action) {
+function handleAddDiscovered (state: State, action: any): State {
   if (!action.payload) return state
 
   const {payload} = action
@@ -110,7 +112,7 @@ function handleAddDiscovered (state, action) {
   return {...state, discovered, discoveredByName}
 }
 
-function handleRemoveDiscovered (state, action) {
+function handleRemoveDiscovered (state: State, action: any): State {
   if (!action.payload || state.connectedTo === action.payload.name) {
     return state
   }
@@ -124,7 +126,7 @@ function handleRemoveDiscovered (state, action) {
   }
 }
 
-function handleConnect (state, action) {
+function handleConnect (state: State, action: any): State {
   if (!action.payload) return state
 
   const {payload: {name}} = action
@@ -132,7 +134,7 @@ function handleConnect (state, action) {
   return {...state, connectRequest: {inProgress: true, error: null, name}}
 }
 
-function handleConnectResponse (state, action) {
+function handleConnectResponse (state: State, action: any): State {
   const {error: didError} = action
   let connectedTo = state.connectRequest.name
   let error = null
@@ -151,11 +153,11 @@ function handleConnectResponse (state, action) {
   }
 }
 
-function handleDisconnect (state, action) {
+function handleDisconnect (state: State, action: any): State {
   return {...state, disconnectRequest: {inProgress: true, error: null}}
 }
 
-function handleDisconnectResponse (state, action) {
+function handleDisconnectResponse (state, action: any) {
   const {error: didError} = action
   let connectedTo = ''
   let error = null
@@ -166,4 +168,20 @@ function handleDisconnectResponse (state, action) {
   }
 
   return {...state, connectedTo, disconnectRequest: {error, inProgress: false}}
+}
+
+function maybeDiscoverWired (state: State, action: HealthSuccessAction): State {
+  const robot = action.payload.robot
+
+  if (!robot.wired) return state
+
+  return handleAddDiscovered(state, {payload: robot})
+}
+
+function maybeRemoveWired (state: State, action: HealthFailureAction): State {
+  const robot = action.payload.robot
+
+  if (!robot.wired) return state
+
+  return handleRemoveDiscovered(state, {payload: robot})
 }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -4,6 +4,8 @@ import padStart from 'lodash/padStart'
 import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
 
+import type {State} from '../types'
+
 import type {
   Mount,
   Instrument,
@@ -13,10 +15,6 @@ import type {
   LabwareType
 } from './types'
 
-import type {State as CalibrationState} from './reducer/calibration'
-import type {State as ConnectionState} from './reducer/connection'
-import type {State as SessionState} from './reducer/session'
-
 import {
   type ConnectionStatus,
   type SessionStatus,
@@ -25,19 +23,9 @@ import {
   DECK_SLOTS
 } from './constants'
 
-type State = {
-  robot: {
-    calibration: CalibrationState,
-    connection: ConnectionState,
-    session: SessionState
-  }
-}
-
-const calibration = (state: State): CalibrationState => state[_NAME].calibration
-
-const connection = (state: State): ConnectionState => state[_NAME].connection
-
-const session = (state: State): SessionState => state[_NAME].session
+const calibration = (state: State) => state[_NAME].calibration
+const connection = (state: State) => state[_NAME].connection
+const session = (state: State) => state[_NAME].session
 const sessionRequest = (state: State) => session(state).sessionRequest
 const sessionStatus = (state: State) => session(state).state
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -5,6 +5,7 @@ import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
 
 import type {State} from '../types'
+import {selectHealth} from '../http-api-client'
 
 import type {
   Mount,
@@ -12,7 +13,8 @@ import type {
   InstrumentCalibrationStatus,
   Labware,
   LabwareCalibrationStatus,
-  LabwareType
+  LabwareType,
+  Robot
 } from './types'
 
 import {
@@ -51,17 +53,20 @@ export const getDiscovered = createSelector(
   (state: State) => connection(state).discovered,
   (state: State) => connection(state).discoveredByName,
   (state: State) => connection(state).connectedTo,
-  (discovered, discoveredByName, connectedTo) => sortBy(
-    discovered.map((name) => ({
+  selectHealth,
+  (discovered, discoveredByName, connectedTo, healthByName): Robot[] => {
+    const robots = discovered.map((name) => ({
       ...discoveredByName[name],
-      isConnected: connectedTo === name
-    })),
-    [
+      isConnected: connectedTo === name,
+      health: healthByName[name]
+    }))
+
+    return sortBy(robots, [
       (robot) => !robot.isConnected,
       (robot) => !robot.wired,
       'name'
-    ]
-  )
+    ])
+  }
 )
 
 export const getConnectionStatus = createSelector(

--- a/app/src/robot/test/api-client-discovery.test.js
+++ b/app/src/robot/test/api-client-discovery.test.js
@@ -3,10 +3,13 @@ import Bonjour from 'bonjour'
 import EventEmitter from 'events'
 
 import {delay as _delay} from '../../util'
+import {fetchHealth, __mockThunk} from '../../http-api-client/health'
 import client from '../api-client/client'
 import {actions} from '../'
 
 jest.mock('bonjour')
+jest.mock('../../http-api-client/health')
+
 jest.useFakeTimers()
 
 const EXPECTED_DISCOVERY_MS = 30000
@@ -32,17 +35,6 @@ describe('api client - discovery', () => {
   let browser
   let dispatch
   let sendToClient
-  let _oldFetch
-
-  beforeAll(() => {
-    // mock fetch
-    _oldFetch = global.fetch
-    global.fetch = jest.fn(() => Promise.resolve({ok: false}))
-  })
-
-  afterAll(() => {
-    global.fetch = _oldFetch
-  })
 
   beforeEach(() => {
     // mock mdns browser
@@ -52,7 +44,8 @@ describe('api client - discovery', () => {
     bonjour = {find: jest.fn(() => browser)}
     Bonjour.mockReturnValue(bonjour)
 
-    global.fetch.mockClear()
+    fetchHealth.mockClear()
+    __mockThunk.mockClear()
 
     dispatch = jest.fn()
     const _receive = client(dispatch)
@@ -97,6 +90,22 @@ describe('api client - discovery', () => {
       .then(() => services.forEach((s) => {
         const robot = Object.assign({}, s, {ip: s.addresses[0]})
         expect(dispatch).toHaveBeenCalledWith(actions.addDiscovered(robot))
+      }))
+  })
+
+  test('dispatches fetchHealth on new services', () => {
+    const services = [
+      {name: 'opentrons-1', port: '31950', addresses: ['192.168.1.1']},
+      {name: 'opentrons-2', port: '31950', addresses: ['192.168.1.2']},
+      {name: 'opentrons-3', port: '31950', addresses: ['192.168.1.3']}
+    ]
+
+    return sendToClient(notScanningState, actions.discover())
+      .then(() => services.forEach((s) => browser.emit('up', s)))
+      .then(() => services.forEach((s) => {
+        const robot = Object.assign({}, s, {ip: s.addresses[0]})
+        expect(fetchHealth).toHaveBeenCalledWith(robot)
+        expect(__mockThunk).toHaveBeenCalledWith(dispatch)
       }))
   })
 
@@ -161,46 +170,22 @@ describe('api client - discovery', () => {
       ))
   })
 
-  test('polls directly connected host every second and adds it', () => {
-    const expectedEndpoint = 'http://[fd00:0:cafe:fefe::1]:31950/health'
-    const expectedDispatch = actions.addDiscovered({
+  test('dispatches fetchHealth for wired host every second', () => {
+    const expectedRobot = {
       name: 'Opentrons USB',
       ip: '[fd00:0:cafe:fefe::1]',
       port: 31950,
       wired: true
-    })
-
-    global.fetch.mockReturnValue(Promise.resolve({ok: true}))
+    }
 
     return sendToClient(notScanningState, actions.discover())
       .then(() => delay(EXPECTED_DISCOVERY_MS))
       .then(() => {
-        expect(global.fetch).toHaveBeenCalledTimes(30)
-        expect(global.fetch).toHaveBeenCalledWith(expectedEndpoint)
+        expect(fetchHealth).toHaveBeenCalledTimes(30)
+        expect(fetchHealth).toHaveBeenCalledWith(expectedRobot)
+        expect(__mockThunk).toHaveBeenCalledTimes(30)
+        expect(__mockThunk).toHaveBeenCalledWith(dispatch)
       })
-      .then(() => expect(dispatch).toHaveBeenCalledWith(expectedDispatch))
-  })
-
-  test('does not add a direct service if fetch fails', () => {
-    const unexpected = actions.addDiscovered(expect.anything())
-
-    global.fetch.mockReturnValue(Promise.resolve({ok: false}))
-
-    return sendToClient(notScanningState, actions.discover())
-      .then(() => delay(1000))
-      .then(() => expect(global.fetch).toHaveBeenCalled())
-      .then(() => expect(dispatch).not.toHaveBeenCalledWith(unexpected))
-  })
-
-  test('does not add a direct service if fetch errors', () => {
-    const unexpected = actions.addDiscovered(expect.anything())
-
-    global.fetch.mockReturnValue(Promise.reject(new Error('network error')))
-
-    return sendToClient(notScanningState, actions.discover())
-      .then(() => delay(1000))
-      .then(() => expect(global.fetch).toHaveBeenCalled())
-      .then(() => expect(dispatch).not.toHaveBeenCalledWith(unexpected))
   })
 
   test('does not start new discovery if already in progress', () => {
@@ -209,6 +194,6 @@ describe('api client - discovery', () => {
     return sendToClient(state, actions.discover())
       .then(() => delay(EXPECTED_DISCOVERY_MS))
       .then(() => expect(bonjour.find).not.toHaveBeenCalled())
-      .then(() => expect(global.fetch).not.toHaveBeenCalled())
+      .then(() => expect(fetchHealth).not.toHaveBeenCalled())
   })
 })

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -227,4 +227,56 @@ describe('robot reducer - connection', () => {
       }
     })
   })
+
+  test('adds wired robot to discovered on HEALTH_SUCCESS', () => {
+    const state = {
+      connection: {
+        discovered: ['foo'],
+        discoveredByName: {
+          foo: {name: 'foo', host: 'abcdef.local'}
+        }
+      }
+    }
+
+    const action = {
+      type: 'api:HEALTH_SUCCESS',
+      payload: {
+        robot: {name: 'bar', host: 'ghijkl.local', wired: true}
+      }
+    }
+
+    expect(getState(reducer(state, action))).toEqual({
+      discovered: ['foo', 'bar'],
+      discoveredByName: {
+        foo: {name: 'foo', host: 'abcdef.local'},
+        bar: {name: 'bar', host: 'ghijkl.local', wired: true}
+      }
+    })
+  })
+
+  test('removes wired robot from discovered on HEALTH_FAILURE', () => {
+    const state = {
+      connection: {
+        discovered: ['foo', 'bar'],
+        discoveredByName: {
+          foo: {name: 'foo', host: 'abcdef.local'},
+          bar: {name: 'bar', host: 'ghijkl.local', wired: true}
+        }
+      }
+    }
+
+    const action = {
+      type: 'api:HEALTH_FAILURE',
+      payload: {
+        robot: {name: 'bar', host: 'ghijkl.local', wired: true}
+      }
+    }
+
+    expect(getState(reducer(state, action))).toEqual({
+      discovered: ['foo'],
+      discoveredByName: {
+        foo: {name: 'foo', host: 'abcdef.local'}
+      }
+    })
+  })
 })

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -40,21 +40,40 @@ describe('robot selectors', () => {
 
   test('getDiscovered', () => {
     const state = {
-      connection: {
-        connectedTo: 'bar',
-        discovered: ['foo', 'bar', 'baz', 'qux'],
-        discoveredByName: {
-          foo: {host: 'abcdef.local', name: 'foo'},
-          bar: {host: '123456.local', name: 'bar'},
-          baz: {host: 'qwerty.local', name: 'baz'},
-          qux: {host: 'dvorak.local', name: 'qux', wired: true}
+      api: {
+        health: {
+          bar: {response: {api_version: '1.2.3', fw_version: '4.5.6'}},
+          qux: {response: {api_version: '1.2.3', fw_version: '4.5.6'}}
+        }
+      },
+      robot: {
+        connection: {
+          connectedTo: 'bar',
+          discovered: ['foo', 'bar', 'baz', 'qux'],
+          discoveredByName: {
+            foo: {host: 'abcdef.local', name: 'foo'},
+            bar: {host: '123456.local', name: 'bar'},
+            baz: {host: 'qwerty.local', name: 'baz'},
+            qux: {host: 'dvorak.local', name: 'qux', wired: true}
+          }
         }
       }
     }
 
-    expect(getDiscovered(makeState(state))).toEqual([
-      {name: 'bar', host: '123456.local', isConnected: true},
-      {name: 'qux', host: 'dvorak.local', isConnected: false, wired: true},
+    expect(getDiscovered(state)).toEqual([
+      {
+        name: 'bar',
+        host: '123456.local',
+        isConnected: true,
+        health: state.api.health.bar
+      },
+      {
+        name: 'qux',
+        host: 'dvorak.local',
+        isConnected: false,
+        wired: true,
+        health: state.api.health.qux
+      },
       {name: 'baz', host: 'qwerty.local', isConnected: false},
       {name: 'foo', host: 'abcdef.local', isConnected: false}
     ])

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,6 +1,10 @@
 // @flow
 // common robot types
 
+import typeof reducer from './reducer'
+
+export type State = $Call<reducer>
+
 export type Channels = 1 | 8
 
 export type Mount = 'left' | 'right'
@@ -34,6 +38,7 @@ export type RobotService = {
   name: string,
   host: string,
   ip: string,
+  port: number,
   wired?: boolean,
 }
 

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,6 +1,7 @@
 // @flow
 // common robot types
 
+import type {RobotHealth} from '../http-api-client'
 import typeof reducer from './reducer'
 
 export type State = $Call<reducer>
@@ -40,6 +41,12 @@ export type RobotService = {
   ip: string,
   port: number,
   wired?: boolean,
+}
+
+// robot from getDiscovered selector
+export type Robot = RobotService & {
+  isConnected: boolean,
+  health: RobotHealth
 }
 
 // protocol file (browser File object)

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -1,0 +1,21 @@
+// @flow
+// application types
+
+import typeof reducer from './reducer'
+import type {Action as RobotAction} from './robot'
+import type {Action as HttpApiAction} from './http-api-client'
+
+export type State = $Call<reducer>
+
+export type Action =
+  | RobotAction
+  | HttpApiAction
+
+// TODO(mc, 2018-02-12): remove this eslint-disable
+//   https://github.com/babel/babel-eslint/issues/485
+/* eslint-disable no-use-before-define */
+
+export type Dispatch = (action: Action | ThunkAction) => any
+export type ThunkAction = (dispatch: Dispatch, getState: () => State) => any
+
+/* eslint-enable no-use-before-define */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,6 +5194,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -7424,6 +7428,12 @@ redux-logger@^3.0.6:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
   dependencies:
     deep-diff "^0.3.5"
+
+redux-mock-store@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## overview

This PR is part of #807 and #812.

## changelog

- Added a simple HTTP API client
    - Will use this client to retrieve robot settings
- Added a redux module to track responses from the HTTP API
    - Currently includes /health, where we get API version information
- Added health data to `getDiscovered` selector 
- Refactors robot discovery to use new HTTP API client for wired robot discovery

## review requests

This looks big, but the size is mostly from tests, mocks, and flow type additions. I apologize regardless