### PR TITLE
build(make): Add flow-typed install to make install task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # opentrons platform makefile
 # https://github.com/OpenTrons/opentrons
 
+SHELL := /bin/bash
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
-
-SHELL := /bin/bash
 
 API_DIR := api
 COMPONENTS_DIR := components
@@ -23,6 +23,13 @@ install:
 	$(MAKE) -C $(API_DIR) install
 	yarn
 	$(MAKE) -C $(APP_SHELL_DIR) install
+	$(MAKE) install-types
+
+.PHONY: install-types
+install-types:
+	$(MAKE) -C $(COMPONENTS_DIR) install-types
+	$(MAKE) -C $(APP_DIR) install-types
+	$(MAKE) -C $(PROTOCOL_DESIGNER_DIR) install-types
 
 # all tests
 .PHONY: test

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -1,5 +1,7 @@
 # opentrons app desktop shell makefile
 
+SHELL := /bin/bash
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,5 +1,7 @@
 # opentrons app makefile
 
+SHELL := /bin/bash
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
 

--- a/components/Makefile
+++ b/components/Makefile
@@ -1,5 +1,7 @@
 # opentrons component library makefile
 
+SHELL := /bin/bash
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
 

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -1,5 +1,7 @@
 # opentrons protocol designer makefile
 
+SHELL := /bin/bash
+
 # add node_modules/.bin to PATH
 PATH := $(shell yarn bin):$(PATH)
 
@@ -59,4 +61,4 @@ test:
 
 .PHONY: install-types
 install-types:
-	flow-typed install --ignoreDeps=dev --packageDir=..
+	flow-typed install --packageDir=..


### PR DESCRIPTION
## overview

Hotfix PR for our build process

## changelog

- Added call to `flow-typed install` to `make install` so CI `flow` doesn't choke on `jest` for new tests in PD that use jest (#825)
- Reverted removal of  `SHELL=/bin/bash` in Makefiles because apparently `zsh` chokes on the `PATH` setting

## review requests

Please double check your local build env