### PR TITLE
build(make): Fix concurrently color messing with yarn bin output

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -48,10 +48,10 @@ dist:
 
 .PHONY: dev
 dev:
-	concurrently \
+	concurrently --no-color --kill-others --names "server,mdns,shell"\
 		"$(MAKE) dev-server" \
 		"$(MAKE) dev-mdns" \
-		"wait-on http-get://localhost:$(port) && $(MAKE) -C $(shell_dir) dev port=$(port)"
+		"$(MAKE) dev-shell"
 
 .PHONY: dev-server
 dev-server:
@@ -61,6 +61,11 @@ dev-server:
 .PHONY: dev-mdns
 dev-mdns:
 	$(env)=development node scripts/advertise-local-api.js
+
+.PHONY: dev-shell
+dev-shell:
+	wait-on http-get://localhost:$(port) && \
+	$(MAKE) -C $(shell_dir) dev port=$(port)
 
 # checks
 #####################################################################


### PR DESCRIPTION
## overview

This is dumb and my fault for not testing #805 more extensively. Turns out I broke `make -C app` on (my) mac, and maybe on *nix in general.

1. `make -C app dev` uses an npm package called [concurrently](https://github.com/kimmobrunfeldt/concurrently) to spawn several tasks concurrently
    * webpack dev server
    * local mdns reporter
    * electron
2. The electron task is a call to `make -C ../app-shell dev`
3. `concurrently` enables color logging by default
    - On my machine, this resulted in color codes prepended to the output of `yarn bin`
4. The Makefiles now call `yarn bin` to add to the `PATH`

End result: the extraneous color codes completely borked `PATH` and thereby rendered the `electron` executable in `app-shell/node_modules/.bin` unfindable by Make.

This PR adds the `--no-color` flag (and some other sane options) to the `concurrently` call to make sure everything behaves again.

## changelog

- Disabled colors on concurrently call in `app/Makefile` to fix `dev` task

## review requests

Sorry everyone. Please double check this works on your machine.
