### PR TITLE
fix(app): Make calibrator optional to support no-pipette protocols

### DIFF
--- a/app/src/components/CalibrateDeck/ConnectedLabwareItem.js
+++ b/app/src/components/CalibrateDeck/ConnectedLabwareItem.js
@@ -15,7 +15,7 @@ import LabwareItem, {type LabwareItemProps} from './LabwareItem'
 type OwnProps = LabwareComponentProps & ContextRouter
 
 type StateProps = {
-  _calibrator?: Mount,
+  _calibrator?: ?Mount,
   _labware?: $PropertyType<LabwareItemProps, 'labware'>
 }
 

--- a/app/src/components/LabwareCalibration/ConfirmModalContents.js
+++ b/app/src/components/LabwareCalibration/ConfirmModalContents.js
@@ -16,7 +16,7 @@ import InProgressContents from './InProgressContents'
 type OwnProps = Labware
 
 type StateProps = {
-  calibrator: Instrument
+  calibrator: ?Instrument
 }
 
 type Props = OwnProps & StateProps
@@ -24,6 +24,8 @@ type Props = OwnProps & StateProps
 export default connect(mapStateToProps)(ConfirmModalContents)
 
 function ConfirmModalContents (props: Props) {
+  if (!props.calibrator) return null
+
   switch (props.calibration) {
     case 'unconfirmed':
     case 'over-slot':

--- a/app/src/components/ReviewDeckModal/index.js
+++ b/app/src/components/ReviewDeckModal/index.js
@@ -21,7 +21,7 @@ type Props = Labware & {
 
 type StateProps = {
   currentLabware: Labware,
-  _calibrator: Mount | ''
+  _calibrator: ?Mount
 }
 
 type DispatchProps = {
@@ -68,15 +68,12 @@ function mergeProps (
   const {currentLabware, _calibrator} = stateProps
   const {dispatch} = dispatchProps
 
-  // TODO(mc, 2018-02-05): refactor so this check isn't necessary
-  if (!_calibrator) {
-    throw new Error('no calibrator available; this is a bug')
-  }
-
   return {
     ...currentLabware,
     onClick: () => {
-      dispatch(robotActions.moveTo(_calibrator, currentLabware.slot))
+      if (_calibrator) {
+        dispatch(robotActions.moveTo(_calibrator, currentLabware.slot))
+      }
     }
   }
 }

--- a/app/src/components/setup-panel/RunPanel.js
+++ b/app/src/components/setup-panel/RunPanel.js
@@ -37,7 +37,7 @@ function RunPanel (props: RunPanelProps) {
 
   return (
     <div>
-      {runMessage}
+      {readyToRun && runMessage}
       <RunButton onClick={run} disabled={isDisabled} />
     </div>
   )

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -260,7 +260,7 @@ export const getInstruments = createSelector(
 // TODO(mc, 2018-02-07): be smarter about the backup case
 export const getCalibrator = createSelector(
   getInstruments,
-  (instruments): Instrument => {
+  (instruments): ?Instrument => {
     const tipOn = instruments.find((i) => i.probed && i.tipOn)
 
     return tipOn || instruments[0]
@@ -268,13 +268,20 @@ export const getCalibrator = createSelector(
 )
 
 // TODO(mc, 2018-02-07): remove this selector in favor of the one above
-export function getCalibratorMount (state: State): Mount {
-  return getCalibrator(state).mount
+export function getCalibratorMount (state: State): ?Mount {
+  const calibrator = getCalibrator(state)
+
+  if (!calibrator) return null
+
+  return calibrator.mount
 }
 
 export const getInstrumentsCalibrated = createSelector(
   getInstruments,
-  (instruments): boolean => instruments.every((i) => !i.name || i.probed)
+  (instruments): boolean => (
+    instruments.length !== 0 &&
+    instruments.every((i) => i.probed)
+  )
 )
 
 export function getLabwareBySlot (state: State) {


### PR DESCRIPTION
## overview

Fixes #831

## changelog

- Fix: made `calibrator` and `calbratorMount` optional and updated containers to adjust accordingly

## review requests

Try it out with the protocol of 831
