### PR TITLE
chore(app): Enable redux devtools extension

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -98,7 +98,6 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.6",
     "redux": "^3.6.0",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",
     "winston": "^2.2.0"

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -3,8 +3,7 @@ import React from 'react'
 import ReactDom from 'react-dom'
 import {Provider} from 'react-redux'
 import {AppContainer} from 'react-hot-loader'
-import {createStore, applyMiddleware} from 'redux'
-import {createLogger} from 'redux-logger'
+import {createStore, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
 import createHistory from 'history/createBrowserHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
@@ -28,12 +27,12 @@ const middleware = applyMiddleware(
   robotApiMiddleware(),
   analyticsMiddleware(analyticsEventsMap),
   alertMiddleware(window),
-  routerMiddleware(history),
-  // TODO(mc): log to file instead of console in prod
-  createLogger()
+  routerMiddleware(history)
 )
 
-const store = createStore(reducer, middleware)
+const composeEnhancers = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+
+const store = createStore(reducer, composeEnhancers(middleware))
 
 const renderApp = () => ReactDom.render(
   (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,10 +2183,6 @@ decompress-response@^3.2.0:
   dependencies:
     mimic-response "^1.0.0"
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -7175,12 +7171,6 @@ redux-actions@^2.2.1:
     lodash "^4.13.1"
     lodash-es "^4.17.4"
     reduce-reducers "^0.1.0"
-
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux-mock-store@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
## overview

Little chore PR to replace the `redux-logger` middleware with the way more informative [redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) in the app. Fixes #625

## changelog

- Chore: enabled Redux devtools extension in the app ui

## review requests

This PR removes the `redux-logger` dep so you may want to run `yarn` before testing / after merge. Standard review otherwise.
