### PR TITLE
PD: Deck setup step, deck setup mode

### DIFF
--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import noop from 'lodash/noop'
 
 import {Icon, TitledList} from '@opentrons/components'
 import StepDescription from './StepDescription'
@@ -48,7 +47,7 @@ export default function StepItem (props: StepItemProps) {
     <TitledList
       className={styles.step_item}
       description={Description}
-      {...{iconName, title, selected, onClick, onCollapseToggle: onCollapseToggle || noop, collapsed}}
+      {...{iconName, title, selected, onClick, onCollapseToggle: onCollapseToggle, collapsed}}
     >
       {showLabwareHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <span>{sourceLabwareName}</span>

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -19,8 +19,8 @@ type StepListProps = {
 }
 
 function generateSubsteps (substeps) {
-  if (substeps === null) {
-    // no substeps, form is probably not finished
+  if (!substeps) {
+    // no substeps, form is probably not finished (or it's "deck-setup" stepType)
     return null
   }
 
@@ -58,7 +58,11 @@ export default function StepList (props: StepListProps) {
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
-          onCollapseToggle={props.handleStepItemCollapseToggleById && props.handleStepItemCollapseToggleById(step.id)}
+          onCollapseToggle={
+            (step.stepType === 'deck-setup' || !props.handleStepItemCollapseToggleById)
+              ? null // Deck Setup steps are not collapsible
+              : props.handleStepItemCollapseToggleById(step.id)
+          }
           selected={!isNil(props.selectedStepId) && step.id === props.selectedStepId}
           {...pick(step, [
             'title',

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -2,14 +2,14 @@
 import * as React from 'react'
 import isNil from 'lodash/isNil'
 import pick from 'lodash/pick'
-import {SidePanel, TitledList} from '@opentrons/components'
+import {SidePanel} from '@opentrons/components'
 
 import type {StepItemData, StepSubItemData} from '../steplist/types'
 import StepItem from '../components/StepItem'
 import TransferishSubstep from '../components/TransferishSubstep'
 import StepCreationButton from '../containers/StepCreationButton'
 
-import styles from '../components/StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
+// import styles from '../components/StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
 
 type StepListProps = {
   selectedStepId?: number,
@@ -53,7 +53,7 @@ export default function StepList (props: StepListProps) {
     <SidePanel title='Protocol Step List'>
 
       {/* TODO: Ian 2018-01-16 figure out if 'Deck Setup' is a Step or something else... */}
-      <TitledList className={styles.step_item} iconName='flask' title='Deck Setup' />
+      {/* <TitledList className={styles.step_item} iconName='flask' title='Deck Setup' /> */}
 
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -111,10 +111,6 @@ export const selectStep = (stepId: StepIdType): ThunkAction<*> =>
     if (stepType === 'deck-setup') {
       // Cancel open step form, if any
       dispatch(cancelStepForm())
-      dispatch({
-        type: 'ENTER_DECK_SETUP',
-        payload: 'TODO IMMEDIATELY' // TODO IMMEDIATELY Ian 2018-02-14: make this action real, make it do something
-      })
     } else {
       dispatch({
         type: 'POPULATE_FORM',

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -97,17 +97,30 @@ export type SelectStepAction = {
   payload: StepIdType
 }
 
-export const selectStep = (payload: StepIdType): ThunkAction<*> =>
+export const selectStep = (stepId: StepIdType): ThunkAction<*> =>
   (dispatch: Dispatch<*>, getState: GetState) => {
-    dispatch({
-      type: 'SELECT_STEP',
-      payload: payload
-    })
+    const stepData = selectors.allSteps(getState())[stepId]
+    const stepType = stepData && stepData.stepType
 
     dispatch({
-      type: 'POPULATE_FORM',
-      payload: selectors.selectedStepFormData(getState())
+      type: 'SELECT_STEP',
+      payload: stepId
     })
+
+    // 'deck-setup' steps don't use a Step Form, all others do
+    if (stepType === 'deck-setup') {
+      // Cancel open step form, if any
+      dispatch(cancelStepForm())
+      dispatch({
+        type: 'ENTER_DECK_SETUP',
+        payload: 'TODO IMMEDIATELY' // TODO IMMEDIATELY Ian 2018-02-14: make this action real, make it do something
+      })
+    } else {
+      dispatch({
+        type: 'POPULATE_FORM',
+        payload: selectors.selectedStepFormData(getState())
+      })
+    }
   }
 
 export type SaveStepFormAction = {
@@ -129,10 +142,12 @@ export const saveStepForm = () =>
     }
   }
 
-export const cancelStepForm = () => ({
-  type: 'CANCEL_STEP_FORM',
-  payload: null
-})
+export function cancelStepForm () {
+  return {
+    type: 'CANCEL_STEP_FORM',
+    payload: null
+  }
+}
 
 export type CollapseFormSectionAction = {type: 'COLLAPSE_FORM_SECTION', payload: FormSectionNames}
 export function collapseFormSection (payload: FormSectionNames): CollapseFormSectionAction {

--- a/protocol-designer/src/steplist/constants.js
+++ b/protocol-designer/src/steplist/constants.js
@@ -1,0 +1,2 @@
+// @flow
+export const INITIAL_DECK_SETUP_ID = 0

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -182,6 +182,7 @@ export function generateCommands (data: ProcessedFormData): Array<Command> {
       }
     ])
   }
+  // TODO IMMEDIATELY Ian 2018-02-14 why does this keep getting undefined stepType?
   console.warn('generateCommands only supports transfer, got: ' + data.stepType)
   return [] // TODO
 }

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -26,7 +26,7 @@ export const generateNewForm = (stepId: StepIdType, stepType: StepType) => {
     }
   }
   if (stepType !== 'pause') {
-    console.warn('generateNewForm: Only transfer, consolidate, & pause forms are supported now. TODO.')
+    console.warn('generateNewForm: Only transfer, consolidate, & pause forms are supported now. TODO. Got ' + stepType)
   }
   return baseForm
 }
@@ -124,14 +124,7 @@ export function validateAndProcessForm (formData: FormData): ValidFormAndErrors 
 
     return {
       errors,
-      validatedForm: (
-        !formHasErrors({errors}) &&
-        // extra explicit for flow
-        totalSeconds &&
-        hours &&
-        minutes &&
-        seconds
-      )
+      validatedForm: formHasErrors({errors})
         ? null
         : {
           stepType: formData.stepType,
@@ -183,7 +176,7 @@ export function generateCommands (data: ProcessedFormData): Array<Command> {
     ])
   }
   // TODO IMMEDIATELY Ian 2018-02-14 why does this keep getting undefined stepType?
-  console.warn('generateCommands only supports transfer, got: ' + data.stepType)
+  console.warn('generateCommands only supports transfer, got: ' + data.stepType, data)
   return [] // TODO
 }
 

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -10,6 +10,7 @@ import mapValues from 'lodash/mapValues'
 import omit from 'lodash/omit'
 import range from 'lodash/range'
 
+import {INITIAL_DECK_SETUP_ID} from './constants'
 import type {BaseState} from '../types'
 import type {
   Command,
@@ -103,13 +104,21 @@ const unsavedFormModal = handleActions({
 
 type StepsState = {[StepIdType]: StepItemData}
 
+const initialStepState = {
+  [INITIAL_DECK_SETUP_ID]: {
+    id: INITIAL_DECK_SETUP_ID,
+    title: 'Deck Setup',
+    stepType: 'deck-setup'
+  }
+}
+
 const steps = handleActions({
   ADD_STEP: (state, action: AddStepAction) => ({
     ...state,
     [action.payload.id]: createDefaultStep(action)
   }),
   DELETE_STEP: (state, action: DeleteStepAction) => omit(state, action.payload.toString())
-}, {})
+}, initialStepState)
 
 type SavedStepFormState = {
   [StepIdType]: FormData
@@ -146,7 +155,7 @@ const orderedSteps = handleActions({
     [...state, action.payload.id],
   DELETE_STEP: (state: OrderedStepsState, action: DeleteStepAction) =>
     state.filter(stepId => stepId !== action.payload)
-}, [])
+}, [INITIAL_DECK_SETUP_ID])
 
 type SelectedStepState = null | StepIdType
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -20,7 +20,8 @@ export const stepIconsByType = {
   'distribute': 'distribute',
   'consolidate': 'consolidate',
   'mix': 'mix',
-  'pause': 'pause'
+  'pause': 'pause',
+  'deck-setup': 'flask'
 }
 
 export type StepType = $Keys<typeof stepIconsByType>


### PR DESCRIPTION
## overview

Closes #759 

## changelog

* Initial Deck Setup step exists in default state instead of being hard-coded in step list
* Selecting "Deck Setup" steps doesn't dispatch
`POPULATE_FORM` action, and doesn't cause a new blank form to be generated - unlike all other Step types, "Deck Setup" step doesn't open a form upon selection.
* `deckSetupMode` selector indicates if we're in Deck Setup Mode (as opposed to Step Form Edit Mode for Transfer/Mix/etc step types)
* StepItem for "Deck Setup" has no collapse carat
* validatedForms selector supports deck-setup step (kinda, hard-coded data)

And:
* Fix bug with Pause form validation where it would be invalidated when it should have been valid

## review requests

Using the selector debugger in dev mode, confirm `deckSetupMode` selector is `true` only when a "Deck Setup" step is selected in the step list.

Creating transfer and pause steps should work as before, and creating deck setup steps should make a new step in the step list that you can select (but doesn't do anything else except trigger `deckSetupMode` selector to `true`).