### PR TITLE
Session parses list of placeables

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -5,7 +5,7 @@ from time import time
 from functools import reduce
 
 from opentrons.broker import publish, subscribe
-from opentrons.containers import get_container
+from opentrons.containers import get_container, location_to_list
 from opentrons.commands import tree, types
 from opentrons import robot
 
@@ -275,8 +275,9 @@ def _get_labware(command):
         containers.append(get_container(location))
 
     if locations:
+        list_of_locations = location_to_list(locations)
         containers.extend(
-            [get_container(location) for location in locations])
+            [get_container(location) for location in list_of_locations])
 
     containers = [c for c in containers if c is not None]
 

--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -90,11 +90,14 @@ def consolidate(instrument, volume, source, dest):
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
+    # incase either source or dest is list of tuple location
+    # strip both down to simply lists of Placeables
+    locations = [] + location_to_list(source) + location_to_list(dest)
     return make_command(
         name=types.CONSOLIDATE,
         payload={
             'instrument': instrument,
-            'locations': [source, dest],
+            'locations': locations,
             'volume': volume,
             'source': source,
             'dest': dest,
@@ -109,11 +112,14 @@ def distribute(instrument, volume, source, dest):
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
+    # incase either source or dest is list of tuple location
+    # strip both down to simply lists of Placeables
+    locations = [] + location_to_list(source) + location_to_list(dest)
     return make_command(
         name=types.DISTRIBUTE,
         payload={
             'instrument': instrument,
-            'locations': [source, dest],
+            'locations': locations,
             'volume': volume,
             'source': source,
             'dest': dest,
@@ -128,11 +134,14 @@ def transfer(instrument, volume, source, dest):
         source=stringify_location(source),
         dest=stringify_location(dest)
     )
+    # incase either source or dest is list of tuple location
+    # strip both down to simply lists of Placeables
+    locations = [] + location_to_list(source) + location_to_list(dest)
     return make_command(
         name=types.TRANSFER,
         payload={
             'instrument': instrument,
-            'locations': [source, dest],
+            'locations': locations,
             'volume': volume,
             'source': source,
             'dest': dest,

--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -2,8 +2,7 @@ from . import types
 from ..broker import broker
 import functools
 import inspect
-from opentrons.containers import Well, Container, Slot, WellSeries,\
-    unpack_location, location_to_list
+from opentrons.containers import Well, Container, Slot, location_to_list
 
 
 def stringify_location(location):

--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -3,7 +3,7 @@ from ..broker import broker
 import functools
 import inspect
 from opentrons.containers import Well, Container, Slot, WellSeries,\
-    unpack_location
+    unpack_location, location_to_list
 
 
 def stringify_location(location):
@@ -23,7 +23,7 @@ def stringify_location(location):
     if location is None:
         return '?'
 
-    location = _location_to_list(location)
+    location = location_to_list(location)
     multiple = len(location) > 1
 
     return '{object_text}{suffix} {first}{last} in "{slot_text}"'.format(
@@ -33,32 +33,6 @@ def stringify_location(location):
             last='...'+location[-1].get_name() if multiple else '',
             slot_text=get_slot(location[0]).get_name()
         )
-
-
-def _location_to_list(loc):
-    # might be a location tuple, or list of location tuples
-    # like what's returned from well.top()
-    if isinstance(loc, tuple):
-        loc = unpack_location(loc)[0]
-    elif isinstance(loc, list):
-        loc = [
-            unpack_location(l)[0]
-            for l in loc
-        ]
-
-    if isinstance(loc, WellSeries):
-        # TODO(artyom, 20171107): this is to handle a case when
-        # container.rows('1', '2') returns a WellSeries of WellSeries
-        # the data structure should be fixed when WellSeries is phased out
-        if isinstance(loc[0], WellSeries):
-            loc = [well for series in loc for well in series]
-        else:
-            loc = list(loc)
-
-    # ensure it returns either list or tuple
-    if not (isinstance(loc, list) or isinstance(loc, tuple)):
-        loc = [loc]
-    return loc
 
 
 def make_command(name, payload):

--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -11,6 +11,7 @@ from opentrons.containers.placeable import (
     Well,
     WellSeries,
     unpack_location,
+    location_to_list,
     get_container
 )
 from opentrons.containers.calibrator import apply_calibration
@@ -24,6 +25,7 @@ __all__ = [
     Well,
     WellSeries,
     unpack_location,
+    location_to_list,
     apply_calibration,
     get_container]
 

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -34,11 +34,14 @@ def location_to_list(loc):
     # like what's returned from well.top()
     if isinstance(loc, tuple):
         loc = unpack_location(loc)[0]
-    elif isinstance(loc, list):
-        loc = [
-            unpack_location(l)[0]
-            for l in loc
-        ]
+    if isinstance(loc, list):
+        if isinstance(loc[0], (WellSeries, list)):
+            loc = [well for series in loc for well in series]
+        else:
+            loc = [
+                unpack_location(l)[0]
+                for l in loc
+            ]
 
     if isinstance(loc, WellSeries):
         # TODO(artyom, 20171107): this is to handle a case when

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -29,6 +29,32 @@ def unpack_location(location):
     return (placeable, Vector(coordinates))
 
 
+def location_to_list(loc):
+    # might be a location tuple, or list of location tuples
+    # like what's returned from well.top()
+    if isinstance(loc, tuple):
+        loc = unpack_location(loc)[0]
+    elif isinstance(loc, list):
+        loc = [
+            unpack_location(l)[0]
+            for l in loc
+        ]
+
+    if isinstance(loc, WellSeries):
+        # TODO(artyom, 20171107): this is to handle a case when
+        # container.rows('1', '2') returns a WellSeries of WellSeries
+        # the data structure should be fixed when WellSeries is phased out
+        if isinstance(loc[0], WellSeries):
+            loc = [well for series in loc for well in series]
+        else:
+            loc = list(loc)
+
+    # ensure it returns either list or tuple
+    if not (isinstance(loc, list) or isinstance(loc, tuple)):
+        loc = [loc]
+    return loc
+
+
 def get_container(location):
     obj, _ = unpack_location(location)
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

This PR moves `location_to_list()` to `placeable.py`, and then session manager uses this method to parse command arguments that include lists of locations.

Just like an earlier PR, arguments to `pipette.transfer()` are being parsed by `session.py` and `commands.py`, and given the many different types of arguments accepted by `pipette.transfer()`, so then session and command must be prepared to parse those different types of location arguments.