### PR TITLE
Assert that parsed axis values include all 6 axis

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -72,6 +72,9 @@ GCODE_ROUNDING_PRECISION = 3
 def _parse_axis_values(raw_axis_values):
     parsed_values = raw_axis_values.strip().split(' ')
     parsed_values = parsed_values[2:]
+    if len(parsed_values) != 6:
+        raise ParseError('Unexpected response from Smoothieware: {}'.format(
+            raw_axis_values))
     return {
         s.split(':')[0].upper(): round(
             float(s.split(':')[1]),
@@ -93,6 +96,10 @@ def _parse_switch_values(raw_switch_values):
 
 
 class SmoothieError(Exception):
+    pass
+
+
+class ParseError(Exception):
     pass
 
 
@@ -137,7 +144,7 @@ class SmoothieDriver_3_0_0:
                 updated_position = \
                     _parse_axis_values(position_response)
                 # TODO jmg 10/27: log warning rather than an exception
-            except TypeError as e:
+            except (TypeError, ParseError) as e:
                 if is_retry:
                     raise e
                 else:

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -1,10 +1,29 @@
 from threading import Thread
+import pytest
 
 from tests.opentrons.conftest import fuzzy_assert
 
 
 def position(x, y, z, a, b, c):
     return {axis: value for axis, value in zip('XYZABC', [x, y, z, a, b, c])}
+
+
+def test_parse_axis_values(smoothie):
+    from opentrons.drivers.smoothie_drivers import driver_3_0 as drv
+    good_data = 'ok M114.2 X:10 Y:20: Z:30 A:40 B:50 C:60'
+    bad_data = 'ok M114.2 X:10 Y:20: Z:30A:40 B:50 C:60'
+    res = drv._parse_axis_values(good_data)
+    expected = {
+        'X': 10,
+        'Y': 20,
+        'Z': 30,
+        'A': 40,
+        'B': 50,
+        'C': 60,
+    }
+    assert res == expected
+    with pytest.raises(drv.ParseError):
+        drv._parse_axis_values(bad_data)
 
 
 def test_plunger_commands(smoothie, monkeypatch):


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This PR raises an exception if when retrieving current position from Smoothieware we don't get all 6 axes. If `driver._parse_axis_values()` gets bad data, we want to raise an exception so `driver.update_position()` can try again.