### PR TITLE
Api direct movements within well

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -915,6 +915,7 @@ class Pipette:
             self._add_tip(
                 length=self.robot.config.tip_length[self.mount][self.type]
             )
+            self.previous_placeable = None  # no longer inside a placeable
             self.robot.poses = self.instrument_mover.fast_home(
                 self.robot.poses, abs(plunge_depth))
 
@@ -1047,6 +1048,7 @@ class Pipette:
             self.robot.poses = self.instrument_actuator.home(
                 self.robot.poses)
             self.robot.poses = self.instrument_mover.home(self.robot.poses)
+            self.previous_placeable = None  # no longer inside a placeable
 
         _home(self.mount)
         return self

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -256,7 +256,7 @@ class Pipette:
         if not self.placeables or (placeable != self.placeables[-1]):
             self.placeables.append(placeable)
 
-    def move_to(self, location, strategy='arc'):
+    def move_to(self, location, strategy=None):
         """
         Move this :any:`Pipette` to a :any:`Placeable` on the :any:`Deck`
 
@@ -285,7 +285,16 @@ class Pipette:
         if not location:
             return self
 
-        self._associate_placeable(location)
+        placeable, _ = unpack_location(location)
+
+        if strategy is None:
+            # if no strategy is specified, default to type 'arc'
+            strategy = 'arc'
+            # unless we are still within the same Well, then move directly
+            if placeable == self.previous_placeable:
+                strategy = 'direct'
+
+        self._associate_placeable(placeable)
         self.robot.move_to(
             location,
             instrument=self,
@@ -498,7 +507,7 @@ class Pipette:
         # first go to the destination
         if location:
             placeable, _ = unpack_location(location)
-            self.move_to(placeable.top(), strategy='arc')
+            self.move_to(placeable.top())
 
         # setup the plunger above the liquid
         if self.current_volume == 0:
@@ -522,7 +531,7 @@ class Pipette:
         # first go to the destination
         if location:
             placeable, _ = unpack_location(location)
-            self.move_to(placeable.top(), strategy='arc')
+            self.move_to(placeable.top())
 
         # then go inside the location
         if location:
@@ -646,7 +655,7 @@ class Pipette:
         """
         assert self.tip_attached
 
-        self.move_to(location, strategy='arc')
+        self.move_to(location)
         self.robot.poses = self.instrument_actuator.move(
             self.robot.poses,
             x=self._get_plunger_position('blow_out')
@@ -707,7 +716,7 @@ class Pipette:
         # if no location specified, use the previously
         # associated placeable to get Well dimensions
         if location:
-            self.move_to(location, strategy='arc')
+            self.move_to(location)
         else:
             location = self.previous_placeable
 
@@ -886,7 +895,7 @@ class Pipette:
                 x=self._get_plunger_position('bottom')
             )
             self.current_volume = 0
-            self.move_to(self.current_tip().top(0), strategy='arc')
+            self.move_to(self.current_tip().top(0))
 
             for i in range(int(presses)):
                 # move nozzle down into the tip
@@ -976,7 +985,7 @@ class Pipette:
         @commands.publish.both(command=commands.drop_tip)
         def _drop_tip(location, instrument=self):
             if location:
-                self.move_to(location, strategy='arc')
+                self.move_to(location)
 
             pos_bottom = self._get_plunger_position('bottom')
             pos_drop_tip = self._get_plunger_position('drop_tip')

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -504,10 +504,17 @@ class Pipette:
         """
         assert self.tip_attached
 
-        # first go to the destination
+        placeable = None
         if location:
             placeable, _ = unpack_location(location)
+
+        # go to top of source, if not already there
+        if (placeable and placeable != self.previous_placeable):
             self.move_to(placeable.top())
+        # else, go to top of previous well, if currently empty
+        elif self.current_volume == 0 and self.previous_placeable:
+            # placeable is either None, or we're in the same well as before
+            self.move_to(self.previous_placeable.top())
 
         # setup the plunger above the liquid
         if self.current_volume == 0:
@@ -528,16 +535,10 @@ class Pipette:
         """
         assert self.tip_attached
 
-        # first go to the destination
-        if location:
-            placeable, _ = unpack_location(location)
-            self.move_to(placeable.top())
-
-        # then go inside the location
         if location:
             if isinstance(location, Placeable):
                 location = location.bottom(min(location.z_size(), 1))
-            self.move_to(location, strategy='direct')
+            self.move_to(location)
 
     def retract(self, safety_margin=10):
         '''

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1389,6 +1389,7 @@ class PipetteTest(unittest.TestCase):
             mock.call(self.plate[0],
                       instrument=self.p200,
                       strategy='arc'),
+
             mock.call(
                 (self.plate[0], (6.40, 3.20, 10.50)),
                 instrument=self.p200,
@@ -1683,10 +1684,36 @@ class PipetteTest(unittest.TestCase):
 
         self.assertEqual(self.p200.drop_tip.mock_calls, expected)
 
+    def test_direct_movement_within_well(self):
+        self.robot.move_to = mock.Mock()
+        self.p200.move_to(self.plate[0])
+        self.p200.move_to(self.plate[0].top())
+        self.p200.move_to(self.plate[0].bottom())
+        self.p200.move_to(self.plate[1])
+        self.p200.move_to(self.plate[2])
+        self.p200.move_to(self.plate[2].bottom())
+
+        expected = [
+            mock.call(
+                self.plate[0], self.p200, strategy='arc', low_current_z=False),
+            mock.call(
+                self.plate[0].top(), self.p200, strategy='direct', low_current_z=False),
+            mock.call(
+                self.plate[0].bottom(), self.p200, strategy='direct', low_current_z=False),
+            mock.call(
+                self.plate[1], self.p200, strategy='arc', low_current_z=False),
+            mock.call(
+                self.plate[2], self.p200, strategy='arc', low_current_z=False),
+            mock.call(
+                self.plate[3], self.p200, strategy='direct', low_current_z=False)
+        ]
+
+        self.assertEqual(self.robot.move_to.mock_calls, expected)
+
     def build_pick_up_tip(self, well):
         plunge = -10
         return [
-            mock.call(well.top(), strategy='arc'),
+            mock.call(well.top()),
             mock.call(well.top(plunge), strategy='direct'),
             mock.call(well.top(), strategy='direct'),
             mock.call(well.top(plunge), strategy='direct'),

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1695,18 +1695,19 @@ class PipetteTest(unittest.TestCase):
 
         expected = [
             mock.call(
-                self.plate[0], self.p200, strategy='arc', low_current_z=False),
+                self.plate[0], instrument=self.p200, low_current_z=False, strategy='arc'),
             mock.call(
-                self.plate[0].top(), self.p200, strategy='direct', low_current_z=False),
+                self.plate[0].top(), instrument=self.p200, low_current_z=False, strategy='direct'),
             mock.call(
-                self.plate[0].bottom(), self.p200, strategy='direct', low_current_z=False),
+                self.plate[0].bottom(), instrument=self.p200, low_current_z=False, strategy='direct'),
             mock.call(
-                self.plate[1], self.p200, strategy='arc', low_current_z=False),
+                self.plate[1], instrument=self.p200, low_current_z=False, strategy='arc'),
             mock.call(
-                self.plate[2], self.p200, strategy='arc', low_current_z=False),
+                self.plate[2], instrument=self.p200, low_current_z=False, strategy='arc'),
             mock.call(
-                self.plate[3], self.p200, strategy='direct', low_current_z=False)
+                self.plate[2].bottom(), instrument=self.p200, low_current_z=False, strategy='direct')
         ]
+        self.assertEqual(self.robot.move_to.mock_calls, expected)
 
         self.assertEqual(self.robot.move_to.mock_calls, expected)
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1499,6 +1499,8 @@ class PipetteTest(unittest.TestCase):
         self.p200.dispense = mock.Mock()
         self.p200.mix(volume=50, repetitions=2)
 
+        print(self.p200.tip_racks)
+
         self.assertEqual(
             self.p200.dispense.mock_calls,
             [
@@ -1510,7 +1512,7 @@ class PipetteTest(unittest.TestCase):
             self.p200.aspirate.mock_calls,
             [
                 mock.call.aspirate(volume=50,
-                                   location=self.p200.tip_racks[0][0],
+                                   location=None,
                                    rate=1.0),
                 mock.call.aspirate(50, rate=1.0)
             ]

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1697,20 +1697,20 @@ class PipetteTest(unittest.TestCase):
 
         expected = [
             mock.call(
-                self.plate[0], instrument=self.p200, low_current_z=False, strategy='arc'),
+                self.plate[0], instrument=self.p200, strategy='arc'),
             mock.call(
-                self.plate[0].top(), instrument=self.p200, low_current_z=False, strategy='direct'),
+                self.plate[0].top(), instrument=self.p200, strategy='direct'),
             mock.call(
-                self.plate[0].bottom(), instrument=self.p200, low_current_z=False, strategy='direct'),
+                self.plate[0].bottom(), instrument=self.p200, strategy='direct'),
             mock.call(
-                self.plate[1], instrument=self.p200, low_current_z=False, strategy='arc'),
+                self.plate[1], instrument=self.p200, strategy='arc'),
             mock.call(
-                self.plate[2], instrument=self.p200, low_current_z=False, strategy='arc'),
+                self.plate[2], instrument=self.p200, strategy='arc'),
             mock.call(
-                self.plate[2].bottom(), instrument=self.p200, low_current_z=False, strategy='direct')
+                self.plate[2].bottom(), instrument=self.p200, strategy='direct')
         ]
-        self.assertEqual(self.robot.move_to.mock_calls, expected)
-
+        from pprint import pprint
+        pprint(self.robot.move_to.mock_calls)
         self.assertEqual(self.robot.move_to.mock_calls, expected)
 
     def build_pick_up_tip(self, well):


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

When a `pipette.move_to()` is called on the same well as before, it will run a `'direct'` path instead of an `'arc'` path, so that there are no pointless up-and-down motions when performing multiple commands within the same well.