### PR TITLE
Comp inverted buttons

### DIFF
--- a/app/src/components/ReviewDeckModal/Prompt.js
+++ b/app/src/components/ReviewDeckModal/Prompt.js
@@ -21,7 +21,7 @@ export default function Prompt (props: Props) {
         To calibrate deck, position full tipracks and empty labware in their
         designated slots as illustrated below
       </p>
-      <OutlineButton className={styles.prompt_button} onClick={onClick} light>
+      <OutlineButton className={styles.prompt_button} onClick={onClick} inverted>
         {`Continue moving to ${labwareType}`}
       </OutlineButton>
       <p className={styles.prompt_details}>

--- a/app/src/components/ReviewDeckModal/Prompt.js
+++ b/app/src/components/ReviewDeckModal/Prompt.js
@@ -21,7 +21,7 @@ export default function Prompt (props: Props) {
         To calibrate deck, position full tipracks and empty labware in their
         designated slots as illustrated below
       </p>
-      <OutlineButton className={styles.prompt_button} onClick={onClick}>
+      <OutlineButton className={styles.prompt_button} onClick={onClick} light>
         {`Continue moving to ${labwareType}`}
       </OutlineButton>
       <p className={styles.prompt_details}>

--- a/components/src/__tests__/__snapshots__/buttons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/buttons.test.js.snap
@@ -102,9 +102,20 @@ exports[`buttons IconButton renders correctly 1`] = `
 </button>
 `;
 
+exports[`buttons Inverted OutlineButton renders correctly 1`] = `
+<button
+  className="button_outline c inverted"
+  disabled={undefined}
+  onClick={[Function]}
+  title="t"
+>
+  children
+</button>
+`;
+
 exports[`buttons OutlineButton renders correctly 1`] = `
 <button
-  className="button_primary button_outline c"
+  className="button_outline c"
   disabled={undefined}
   onClick={[Function]}
   title="t"
@@ -115,7 +126,7 @@ exports[`buttons OutlineButton renders correctly 1`] = `
 
 exports[`buttons OutlineButton with iconName renders correctly 1`] = `
 <button
-  className="button_primary button_outline c"
+  className="button_outline c"
   disabled={undefined}
   onClick={[Function]}
   title="t"

--- a/components/src/__tests__/buttons.test.js
+++ b/components/src/__tests__/buttons.test.js
@@ -107,6 +107,16 @@ describe('buttons', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('Inverted OutlineButton renders correctly', () => {
+    const tree = Renderer.create(
+      <OutlineButton onClick={onClick} title='t' className='c' inverted>
+        children
+      </OutlineButton>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
   test('OutlineButton with iconName renders correctly', () => {
     const tree = Renderer.create(
       <OutlineButton onClick={onClick} title='t' className='c' iconName={FLASK}>

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -16,6 +16,8 @@ export type ButtonProps = {
   iconName?: IconName,
   /** classes to apply */
   className?: string,
+  /** inverts the default color/background/border of default button style */
+  inverted?: boolean,
   /** contents of the button */
   children?: React.Node,
   /** custom element or component to use instead of `<button>` */

--- a/components/src/buttons/FlatButton.js
+++ b/components/src/buttons/FlatButton.js
@@ -9,7 +9,7 @@ import styles from './buttons.css'
  * Flat-styled button with a default width of `9rem` and no background fill
  */
 export default function FlatButton (props: ButtonProps) {
-  const className = classnames(styles.button_flat, props.className)
+  const className = classnames(styles.button_flat, props.className, {[styles.inverted]: props.inverted})
 
   return (
     <Button {...props} className={className}>

--- a/components/src/buttons/FlatButton.md
+++ b/components/src/buttons/FlatButton.md
@@ -1,25 +1,50 @@
 Basic usage:
 
 ```js
-<FlatButton onClick={() => alert('you clicked me')}>
-  {'Click me!'}
-</FlatButton>
+  <FlatButton onClick={() => alert('you clicked me')}>
+    {'Click me!'}
+  </FlatButton>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <FlatButton onClick={() => alert('you clicked me')} inverted>
+    {'Click me!'}
+  </FlatButton>
+</div>
 ```
 
 Disabled:
 
 ```js
-<FlatButton onClick={() => alert("can't click me")} disabled>
-  {"Can't click"}
-</FlatButton>
+  <div>
+  <FlatButton onClick={() => alert("can't click me")} disabled>
+    {"Can't click"}
+  </FlatButton>
+</div>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <FlatButton onClick={() => alert("can't click me")} disabled inverted>
+    {"Can't click"}
+  </FlatButton>
+</div>
 ```
 
 With icon:
 
 ```js
-<FlatButton onClick={() => alert('you clicked me')} iconName='flask'>
-  {'Click me!'}
-</FlatButton>
+  <div>
+  <FlatButton onClick={() => alert('you clicked me')} iconName='flask'>
+    {'Click me!'}
+  </FlatButton>
+</div>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <FlatButton onClick={() => alert('you clicked me')} iconName='flask' inverted>
+    {'Click me!'}
+  </FlatButton>
+</div>
 ```
 
 Sometimes you need `<FlatButton>` that isn't a native `<button>`. To do this, pass a string or React component to the `Component` prop. If you pass `Component`, any extra props will get passed to your custom component.
@@ -35,4 +60,17 @@ Use the inspector on this example to see that the "button" is a `<div>` with the
 >
   {"I'm a div!"}
 </FlatButton>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <FlatButton
+    Component='div'
+    role='button'
+    iconName={'flask'}
+    onClick={() => alert('click!')}
+    inverted
+  >
+    {"I'm a div!"}
+  </FlatButton>
+</div>
 ```

--- a/components/src/buttons/FlatButton.md
+++ b/components/src/buttons/FlatButton.md
@@ -1,12 +1,12 @@
 Basic usage:
 
 ```js
-  <FlatButton onClick={() => alert('you clicked me')}>
-    {'Click me!'}
-  </FlatButton>
+<FlatButton onClick={() => alert('you clicked me')}>
+  {'Click me!'}
+</FlatButton>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <FlatButton onClick={() => alert('you clicked me')} inverted>
     {'Click me!'}
   </FlatButton>
@@ -23,7 +23,7 @@ Disabled:
 </div>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <FlatButton onClick={() => alert("can't click me")} disabled inverted>
     {"Can't click"}
   </FlatButton>
@@ -33,14 +33,14 @@ Disabled:
 With icon:
 
 ```js
-  <div>
+<div>
   <FlatButton onClick={() => alert('you clicked me')} iconName='flask'>
     {'Click me!'}
   </FlatButton>
 </div>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <FlatButton onClick={() => alert('you clicked me')} iconName='flask' inverted>
     {'Click me!'}
   </FlatButton>
@@ -62,7 +62,7 @@ Use the inspector on this example to see that the "button" is a `<div>` with the
 </FlatButton>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <FlatButton
     Component='div'
     role='button'

--- a/components/src/buttons/IconButton.js
+++ b/components/src/buttons/IconButton.js
@@ -17,7 +17,7 @@ type Props =
  * both Button _and_ Icon. Use `name` to specify icon name.
  */
 export default function IconButton (props: Props) {
-  const className = cx(styles.button_icon, props.className)
+  const className = cx(styles.button_icon, props.className, {[styles.inverted]: props.inverted})
 
   return (
     <FlatButton {...props} className={className} iconName={undefined}>

--- a/components/src/buttons/IconButton.md
+++ b/components/src/buttons/IconButton.md
@@ -23,7 +23,7 @@
 ```
 
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <IconButton
     onClick={() => alert('you clicked me')}
     title='left'

--- a/components/src/buttons/IconButton.md
+++ b/components/src/buttons/IconButton.md
@@ -21,3 +21,24 @@
   />
 </div>
 ```
+
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <IconButton
+    onClick={() => alert('you clicked me')}
+    title='left'
+    name='chevron left'
+    className='height-3-rem'
+    inverted
+  />
+  <IconButton
+    onClick={() => alert("can't click")}
+    title='in progress'
+    name='spinner'
+    className='width-3-rem'
+    disabled
+    spin
+    inverted
+  />
+</div>
+```

--- a/components/src/buttons/OutlineButton.js
+++ b/components/src/buttons/OutlineButton.js
@@ -3,18 +3,19 @@ import * as React from 'react'
 import cx from 'classnames'
 
 import type {ButtonProps} from './Button'
-import PrimaryButton from './PrimaryButton'
+import Button from './Button'
 import styles from './buttons.css'
 
 /**
- * `<PrimaryButton>` variant with no background fill and a light border
+ * Button with no background fill and a dark border.
+ Use inverted prop for buttons on dark backgrounds.
  */
 export default function OutlineButton (props: ButtonProps) {
-  const className = cx(styles.button_outline, props.className)
+  const className = cx(styles.button_outline, props.className, {[styles.inverted]: props.inverted})
 
   return (
-    <PrimaryButton {...props} className={className}>
+    <Button {...props} className={className}>
       {props.children}
-    </PrimaryButton>
+    </Button>
   )
 }

--- a/components/src/buttons/OutlineButton.md
+++ b/components/src/buttons/OutlineButton.md
@@ -1,9 +1,18 @@
 You can use an `<OutlineButton>` in exactly the same manner as a `<PrimaryButton>`
 
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.5)'}}>
+<div>
   <div style={{padding: '2rem', width: '20rem'}}>
     <OutlineButton onClick={() => alert('you clicked me')}>
+      {'Click for alert'}
+    </OutlineButton>
+  </div>
+</div>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <div style={{padding: '2rem', width: '20rem'}}>
+    <OutlineButton onClick={() => alert('you clicked me')} inverted>
       {'Click for alert'}
     </OutlineButton>
   </div>
@@ -13,9 +22,18 @@ You can use an `<OutlineButton>` in exactly the same manner as a `<PrimaryButton
 Disabled:
 
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.5)'}}>
+<div>
   <div style={{padding: '2rem', width: '20rem'}}>
     <OutlineButton onClick={() => alert("can't click")} disabled>
+      {'Disabled'}
+    </OutlineButton>
+  </div>
+</div>
+```
+```js
+<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+  <div style={{padding: '2rem', width: '20rem'}}>
+    <OutlineButton onClick={() => alert("can't click")} disabled inverted>
       {'Disabled'}
     </OutlineButton>
   </div>

--- a/components/src/buttons/OutlineButton.md
+++ b/components/src/buttons/OutlineButton.md
@@ -10,7 +10,7 @@ You can use an `<OutlineButton>` in exactly the same manner as a `<PrimaryButton
 </div>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <div style={{padding: '2rem', width: '20rem'}}>
     <OutlineButton onClick={() => alert('you clicked me')} inverted>
       {'Click for alert'}
@@ -31,7 +31,7 @@ Disabled:
 </div>
 ```
 ```js
-<div style={{backgroundColor: 'rgba(0,0,0,0.9)'}}>
+<div className='dark_background'>
   <div style={{padding: '2rem', width: '20rem'}}>
     <OutlineButton onClick={() => alert("can't click")} disabled inverted>
       {'Disabled'}

--- a/components/src/buttons/PrimaryButton.js
+++ b/components/src/buttons/PrimaryButton.js
@@ -10,7 +10,7 @@ import styles from './buttons.css'
  * background with white text
  */
 export default function PrimaryButton (props: ButtonProps) {
-  const className = cx(styles.button_primary, props.className)
+  const className = cx(styles.button_primary, props.className, {[styles.inverted]: props.inverted})
 
   return (
     <Button {...props} className={className}>

--- a/components/src/buttons/PrimaryButton.md
+++ b/components/src/buttons/PrimaryButton.md
@@ -7,6 +7,13 @@ Basic usage:
   </PrimaryButton>
 </div>
 ```
+```js
+<div style={{width: '16rem'}}>
+  <PrimaryButton onClick={() => alert('you clicked me')} inverted>
+    {'Click for alert'}
+  </PrimaryButton>
+</div>
+```
 
 Disabled:
 

--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -11,6 +11,7 @@
     color: var(--c-font-disabled);
     fill: var(--c-font-disabled);
     cursor: default;
+    pointer-events: none;
   }
 
   --button-default: {
@@ -25,6 +26,7 @@
     cursor: pointer;
     color: var(--c-font-dark);
     background: transparent;
+    border-radius: 2px;
 
     &:hover {
       background-color: color(var(--c-bg-light) shade(5%));
@@ -67,7 +69,6 @@
   @apply --button-default;
 
   width: 100%;
-  border-radius: 2px;
   color: var(--c-font-light);
   background-color: var(--c-bg-dark);
 
@@ -104,9 +105,9 @@
   }
 
   &:disabled,
-  &.disabled,
-  &:disabled:hover,
-  &.disabled:hover {
+  &.disabled {
+    @apply --button-disabled;
+
     background-color: color(var(--c-bg-dark) tint(70%));
     box-shadow: none;
     color: var(--c-font-disabled);
@@ -152,7 +153,7 @@
 
     &:disabled,
     &.disabled {
-      background-color: initial;
+      @apply --button-disabled;
     }
   }
 }

--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -2,33 +2,70 @@
 @import '..';
 
 :root {
-  --c-font-disabled: color(var(--c-font-light) shade(50%));
   --button-pad: 0.5rem;
+
+  --button-disabled : {
+    background-color: transparent;
+    font-weight: normal;
+    border-color: var(--c-font-disabled);
+    color: var(--c-font-disabled);
+    fill: var(--c-font-disabled);
+    cursor: default;
+  }
+
+  --button-default: {
+    position: relative;
+    line-height: 1.4;
+    border: none;
+    padding: var(--button-pad);
+    font-size: var(--fs-body-2);
+    font-weight: var(--fw-semibold);
+    text-align: center;
+    text-transform: uppercase;
+    cursor: pointer;
+    color: var(--c-font-dark);
+    background: transparent;
+
+    &:hover {
+      background-color: color(var(--c-bg-light) shade(5%));
+    }
+
+    &:active {
+      font-weight: var(--fw-regular);
+      background-color: color(var(--c-bg-light) shade(10%));
+    }
+
+    &:disabled,
+    &.disabled {
+      @apply --button-disabled;
+    }
+  }
+
+  --button-inverted: {
+    color: var(--c-font-light);
+    border-color: var(--c-font-light);
+
+    &:hover {
+      background-color: color(var(--c-bg-dark) tint(5%));
+    }
+
+    &:active {
+      font-weight: var(--fw-regular);
+      background-color: color(var(--c-bg-dark) tint(10%));
+    }
+
+    &:disabled,
+    &.disabled {
+      @apply --button-disabled;
+    }
+  }
 }
 
-.button_flat,
+/* TODO(ka, 2017-2-14): standardize primary button vars */
+
 .button_primary {
-  position: relative;
-  line-height: 1.4;
-  border: none;
-  padding: var(--button-pad);
-  font-size: var(--fs-body-2);
-  font-weight: var(--fw-semibold);
-  text-align: center;
-  text-transform: uppercase;
-  cursor: pointer;
-}
+  @apply --button-default;
 
-.button_primary[disabled],
-.button_primary.disabled,
-.button_flat[disabled],
-.button_flat.disabled {
-  font-weight: normal;
-  color: var(--c-font-disabled);
-  cursor: default;
-}
-
-.button_primary {
   width: 100%;
   border-radius: 2px;
   color: var(--c-font-light);
@@ -53,55 +90,52 @@
       0 8px 8px rgba(0, 0, 0, 0.24);
   }
 
+  &.inverted {
+    background-color: var(--c-bg-light);
+    color: var(--c-font-dark);
+
+    &:hover {
+      background-color: color(var(--c-bg-light) shade(5%));
+    }
+
+    &:active {
+      background-color: color(var(--c-bg-light) shade(10%));
+    }
+  }
+
   &:disabled,
-  &.disabled {
+  &.disabled,
+  &:disabled:hover,
+  &.disabled:hover {
     background-color: color(var(--c-bg-dark) tint(70%));
     box-shadow: none;
+    color: var(--c-font-disabled);
   }
 }
 
 .button_flat {
+  @apply --button-default;
+
   width: 9rem;
-  color: var(--c-font-dark);
-  background-color: transparent;
 
-  &:hover {
-    background-color: color(var(--c-bg-light) shade(5%));
-  }
-
-  &:active {
-    font-weight: var(--fw-regular);
-    background-color: color(var(--c-bg-light) shade(10%));
-  }
-
-  &:disabled,
-  &.disabled {
-    background-color: initial;
+  &.inverted {
+    @apply --button-inverted;
   }
 }
 
 .button_outline {
-  background-color: transparent;
-  box-shadow: none;
-  border: 1px solid var(--c-font-light);
+  @apply --button-default;
 
-  &:hover,
-  &:active {
-    color: color(var(--c-font-light) shade(10%));
-    border-color: color(var(--c-font-light) shade(10%));
-    background-color: transparent;
-    box-shadow: none;
-  }
+  width: 9rem;
+  border: 1px solid var(--c-font-dark);
 
-  &:disabled,
-  &.disabled {
-    color: color(var(--c-font-light) shade(20%));
-    border-color: color(var(--c-font-light) shade(20%));
-    background-color: initial;
+  &.inverted {
+    @apply --button-inverted;
   }
 }
 
 /* style for IconButton */
+
 .button_icon {
   width: auto;
 
@@ -109,6 +143,17 @@
     display: block;
     height: 100%;
     width: 100%;
+  }
+
+  &.inverted {
+    color: white;
+    fill: white;
+    stroke: white;
+
+    &:disabled,
+    &.disabled {
+      background-color: initial;
+    }
   }
 }
 

--- a/components/src/lists/ListItem.js
+++ b/components/src/lists/ListItem.js
@@ -12,8 +12,10 @@ type ListItemProps = {
   onClick?: (event: SyntheticEvent<>) => void,
   /** if URL is specified, ListItem is wrapped in a React Router NavLink */
   url?: string,
-  className?: string,
+  /** if URL is specified NavLink can receive an active class name */
   activeClassName?: string,
+  /** Additional class name */
+  className?: string,
   /** if disabled, the onClick handler / NavLink will be disabled */
   isDisabled: boolean,
   /** name constant of the icon to display */

--- a/components/src/lists/ListItem.js
+++ b/components/src/lists/ListItem.js
@@ -13,6 +13,7 @@ type ListItemProps = {
   /** if URL is specified, ListItem is wrapped in a React Router NavLink */
   url?: string,
   className?: string,
+  activeClassName?: string,
   /** if disabled, the onClick handler / NavLink will be disabled */
   isDisabled: boolean,
   /** name constant of the icon to display */
@@ -25,7 +26,7 @@ type ListItemProps = {
  *
  */
 export default function ListItem (props: ListItemProps) {
-  const {url, isDisabled, iconName} = props
+  const {url, isDisabled, iconName, activeClassName} = props
   const onClick = props.onClick && !isDisabled
     ? props.onClick
     : undefined
@@ -54,7 +55,7 @@ export default function ListItem (props: ListItemProps) {
           onClick={onClick}
           disabled={isDisabled}
           className={className}
-          activeClassName={styles.active}
+          activeClassName={activeClassName}
         >
           {itemIcon}
           {children}

--- a/components/styleguide.config.js
+++ b/components/styleguide.config.js
@@ -80,6 +80,9 @@ module.exports = {
       },
       '@global .height-3-rem': {
         height: '3rem !important'
+      },
+      '@global .dark_background': {
+        backgroundColor: 'rgba(0, 0, 0, 0.9)'
       }
     }
   }


### PR DESCRIPTION
## overview

This PR addresses #807. (new instance of outline button in the designs)
All comp lib buttons can now receive an `inverted` boolean which will change the button style to work on a dark background. You can see this in use in the app on the review deckmap page. 

## changelog

- adds inverted boolean to button components
- standardizes inverted and default classes for flat and outline buttons
- update styleguide and tests
- TODO: clean up primary button styles, I think they could be cleaner but punting for now.
- add activeClassName prop to ListItem (when url is present)

## review requests
Standard review. 
https://s3-us-west-2.amazonaws.com/opentrons-components/comp_inverted-buttons/index.html#buttons