### PR TITLE
feat(app): Add /wifi/list and /wifi/status to HTTP API client

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -27,11 +27,12 @@ make dev
 
 At this point, the Electron app will be running with [HMR][] and various Chrome devtools enabled. The app and dev server look for the following environment variables (defaults set in Makefile):
 
- variable   | default      | description
------------ | ------------ | -------------------------------------------------
- `NODE_ENV` | `production` | Run environment: production, development, or test
- `DEBUG`    | unset        | Runs the app in debug mode
- `PORT`     | `8090`       | Development server port
+ variable          | default      | description
+------------------ | ------------ | ----------------------------------------------
+ `NODE_ENV`        | `production` | Environment: production, development, or test
+ `DEBUG`           | unset        | Runs the app in debug mode
+ `PORT`            | `8090`       | Development server port
+ `SKIP_WIRED_POLL` | unset        | Turn off polling for directly connected wired robots
 
 **Note:** you may want to be running the Opentrons API in a different terminal while developing the app. Please see [the contributing guide][contributing-guide-running-the-api] for API specific instructions.
 
@@ -48,7 +49,9 @@ The UI stack is built using:
 Some important directories:
 
 *   `app/src` — Client-side React app run in Electron's [renderer process][electron-renderer]
-*   `app/src/rpc` - Opentrons API RPC client (see `api/opentrons/server`)
+*   API clients (see [`api/opentrons/server`][api-server-source])
+    *   `app/src/rpc` - RPC API client
+    *   `app/src/http-api-client` - HTTP API client
 *   `app/webpack` - Webpack configuration helpers
 
 ## testing
@@ -99,6 +102,7 @@ ANALYZER=true make
 [contributing-guide-setup]: ../CONTRIBUTING.md#development-setup
 [contributing-guide-running-the-api]: ../CONTRIBUTING.md#opentrons-api
 [app-shell-readme-build]: ../app-shell/README.md#building
+[api-server-source]: ../api/opentrons/server
 [electron]: https://electron.atom.io/
 [electron-renderer]: https://electronjs.org/docs/tutorial/quick-start#renderer-process
 [hmr]: https://webpack.js.org/concepts/hot-module-replacement/

--- a/app/src/http-api-client/__mocks__/client.js
+++ b/app/src/http-api-client/__mocks__/client.js
@@ -27,5 +27,7 @@ client.__setMockError = function setMockError (error) {
 }
 
 client.__clearMock = function clearMockResponses () {
+  _mockResponse = null
+  _mockError = null
   client.mockClear()
 }

--- a/app/src/http-api-client/__mocks__/health.js
+++ b/app/src/http-api-client/__mocks__/health.js
@@ -3,5 +3,8 @@
 
 const health = module.exports = jest.genMockFromModule('../health')
 
-health.__mockThunk = jest.fn()
+health.__mockThunk = jest.fn(() => new Promise((resolve) => {
+  process.nextTick(resolve)
+}))
+
 health.fetchHealth = jest.fn(() => health.__mockThunk)

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -1,0 +1,279 @@
+// health api tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {fetchWifiList, fetchWifiStatus, reducer, selectWifi} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+
+describe('wifi', () => {
+  beforeEach(() => client.__clearMock())
+
+  test('selectWifi returns wifi substate', () => {
+    const state = {
+      api: {
+        wifi: {
+          opentrons: {}
+        }
+      }
+    }
+
+    expect(selectWifi(state)).toBe(state.api.wifi)
+  })
+
+  describe('fetchWifiList action creator', () => {
+    const list = ['ssid-1', 'ssid-2', 'ssid-3']
+
+    test('calls GET /wifi/list', () => {
+      client.__setMockResponse(list)
+
+      return fetchWifiList(robot)(() => {})
+        .then(() => {
+          expect(client).toHaveBeenCalledWith(robot, 'GET', 'wifi/list')
+        })
+    })
+
+    test('dispatches WIFI_REQUEST and WIFI_SUCCESS', () => {
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:WIFI_REQUEST', payload: {robot, path: 'list'}},
+        {type: 'api:WIFI_SUCCESS', payload: {robot, list, path: 'list'}}
+      ]
+
+      client.__setMockResponse(list)
+
+      return store.dispatch(fetchWifiList(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches WIFI_REQUEST and WIFI_FAILURE', () => {
+      const error = {name: 'ResponseError', status: '400'}
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:WIFI_REQUEST', payload: {robot, path: 'list'}},
+        {type: 'api:WIFI_FAILURE', payload: {robot, error, path: 'list'}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(fetchWifiList(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('fetchWifiStatus action creator', () => {
+    const status = 'full'
+
+    test('calls GET /wifi/status', () => {
+      client.__setMockResponse({status})
+
+      return fetchWifiStatus(robot)(() => {})
+        .then(() => {
+          expect(client).toHaveBeenCalledWith(robot, 'GET', 'wifi/status')
+        })
+    })
+
+    test('dispatches WIFI_REQUEST and WIFI_SUCCESS', () => {
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:WIFI_REQUEST', payload: {robot, path: 'status'}},
+        {type: 'api:WIFI_SUCCESS', payload: {robot, status, path: 'status'}}
+      ]
+
+      client.__setMockResponse({status})
+
+      return store.dispatch(fetchWifiStatus(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches WIFI_REQUEST and WIFI_FAILURE', () => {
+      const error = {name: 'ResponseError', status: '400'}
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:WIFI_REQUEST', payload: {robot, path: 'status'}},
+        {type: 'api:WIFI_FAILURE', payload: {robot, error, path: 'status'}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(fetchWifiStatus(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('reducer with /wifi/list', () => {
+    const path = 'list'
+
+    test('handles WIFI_REQUEST', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            list: {
+              inProgress: false,
+              error: new Error('AH'),
+              response: ['ssid-1']
+            }
+          }
+        }
+      }
+      const action = {type: 'api:WIFI_REQUEST', payload: {path, robot}}
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          list: {
+            inProgress: true,
+            error: null,
+            response: ['ssid-1']
+          }
+        }
+      })
+    })
+
+    test('handles WIFI_SUCCESS', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            list: {
+              inProgress: true,
+              error: null,
+              response: ['ssid-1']
+            }
+          }
+        }
+      }
+      const action = {
+        type: 'api:WIFI_SUCCESS',
+        payload: {robot, path, list: ['ssid-1', 'ssid-2', 'ssid-3']}
+      }
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          list: {
+            inProgress: false,
+            error: null,
+            response: ['ssid-1', 'ssid-2', 'ssid-3']
+          }
+        }
+      })
+    })
+
+    test('handles WIFI_FAILURE', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            list: {
+              inProgress: true,
+              error: null,
+              response: ['ssid-1']
+            }
+          }
+        }
+      }
+      const action = {
+        type: 'api:WIFI_FAILURE',
+        payload: {robot, path, error: {name: 'ResponseError'}}
+      }
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          list: {
+            inProgress: false,
+            error: {name: 'ResponseError'},
+            response: ['ssid-1']
+          }
+        }
+      })
+    })
+  })
+
+  describe('reducer with /wifi/status', () => {
+    const path = 'status'
+
+    test('handles WIFI_REQUEST', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            status: {
+              inProgress: false,
+              error: new Error('AH'),
+              response: 'limited'
+            }
+          }
+        }
+      }
+      const action = {type: 'api:WIFI_REQUEST', payload: {robot, path}}
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          status: {
+            inProgress: true,
+            error: null,
+            response: 'limited'
+          }
+        }
+      })
+    })
+
+    test('handles WIFI_SUCCESS', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            status: {
+              inProgress: true,
+              error: null,
+              response: 'limited'
+            }
+          }
+        }
+      }
+      const action = {
+        type: 'api:WIFI_SUCCESS',
+        payload: {robot, path, status: 'full'}
+      }
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          status: {
+            inProgress: false,
+            error: null,
+            response: 'full'
+          }
+        }
+      })
+    })
+
+    test('handles WIFI_FAILURE', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            status: {
+              inProgress: true,
+              error: null,
+              response: 'limited'
+            }
+          }
+        }
+      }
+      const action = {
+        type: 'api:WIFI_FAILURE',
+        payload: {robot, path, error: {name: 'ResponseError'}}
+      }
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          status: {
+            inProgress: false,
+            error: {name: 'ResponseError'},
+            response: 'limited'
+          }
+        }
+      })
+    })
+  })
+})

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -40,7 +40,7 @@ export default function client (
   method: Method,
   path: string,
   body?: {}
-): Promise<any> {
+): Promise<{}> {
   const url = `http://${robot.ip}:${robot.port}/${path}`
   const options = {
     method,
@@ -50,12 +50,17 @@ export default function client (
       : undefined
   }
 
-  return fetch(url, options)
-    .then(
-      (response) => (response.ok
-        ? response.json()
-        : Promise.reject(ResponseError(response))
-      ),
-      (error) => Promise.reject(FetchError(error))
-    )
+  return fetch(url, options).then(jsonFromResponse, fetchErrorFromError)
+}
+
+function jsonFromResponse (response: Response): Promise<{}> {
+  if (!response.ok) {
+    return Promise.reject(ResponseError(response))
+  }
+
+  return response.json().catch(fetchErrorFromError)
+}
+
+function fetchErrorFromError (error: Error): Promise<{}> {
+  return Promise.reject(FetchError(error))
 }

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -1,11 +1,12 @@
 // @flow
-// http api actions and action types
+// health http api module
 import type {State, ThunkAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
+import type {ApiResponse} from './types'
 import client, {type ClientResponseError} from './client'
 
-export type HealthResponse = {
+type HealthResponse = {
   api_version: string,
   fw_version: string,
 }
@@ -38,18 +39,10 @@ export type HealthAction =
  | HealthSuccessAction
  | HealthFailureAction
 
-export type RobotHealth = {
-  /** request in progress flag */
-  inProgress: boolean,
-  /** possible error response */
-  error: ?ClientResponseError,
-  /** possible success response */
-  response: ?HealthResponse
-}
+export type RobotHealth = ApiResponse<HealthResponse>
 
 export type HealthState = {
-  /** robot name */
-  [string]: RobotHealth
+  [robotName: string]: RobotHealth
 }
 
 export function fetchHealth (robot: RobotService): ThunkAction {
@@ -67,7 +60,7 @@ function healthRequest (robot: RobotService): HealthRequestAction {
 }
 
 function healthResponse (
-  error: ?Error,
+  error: ?ClientResponseError,
   robot: RobotService,
   maybeHealth?: any
 ): HealthSuccessAction | HealthFailureAction {
@@ -134,6 +127,6 @@ export function healthReducer (
   return state
 }
 
-export function selectHealth (state: State) {
+export function selectHealth (state: State): HealthState {
   return state.api.health
 }

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -2,12 +2,15 @@
 // robot HTTP API client module
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
+import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
-  health: healthReducer
+  health: healthReducer,
+  wifi: wifiReducer
 })
 
 export {fetchHealth, selectHealth} from './health'
+export {fetchWifiList, fetchWifiStatus, selectWifi} from './wifi'
 
 export type {
   RobotHealth,
@@ -15,7 +18,12 @@ export type {
   HealthFailureAction
 } from './health'
 
+export type {
+  RobotWifi
+} from './wifi'
+
 export type Action =
   | HealthAction
+  | WifiAction
 
 export type State = $Call<typeof reducer>

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -1,0 +1,13 @@
+// @flow
+// http api client types
+
+import type {ClientResponseError} from './client'
+
+export type ApiResponse<T> = {
+  /** request in progress flag */
+  inProgress: boolean,
+  /** possible error response */
+  error: ?ClientResponseError,
+  /** possible success response */
+  response?: T
+}

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -1,0 +1,223 @@
+// @flow
+// wifi http api module
+import type {State, ThunkAction, Action} from '../types'
+import type {RobotService} from '../robot'
+
+import type {ApiResponse} from './types'
+import client, {type ClientResponseError} from './client'
+
+type SsidList = string[]
+
+type Status = 'none' | 'portal' | 'limited' | 'full' | 'unknown' | 'testing'
+
+type ListResponse = SsidList
+
+type StatusResponse = {
+  status: Status,
+}
+
+type ConfigureResponse = {}
+
+type RequestPath = 'list' | 'status'
+
+export type WifiRequestAction = {|
+  type: 'api:WIFI_REQUEST',
+  payload: {
+    robot: RobotService,
+    path: RequestPath,
+  }
+|}
+
+export type WifiSuccessAction = {|
+  type: 'api:WIFI_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    list?: SsidList,
+    status?: Status,
+  |}
+|}
+
+export type WifiFailureAction = {|
+  type: 'api:WIFI_FAILURE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    error: ClientResponseError,
+  |}
+|}
+
+export type WifiAction =
+  | WifiRequestAction
+  | WifiSuccessAction
+  | WifiFailureAction
+
+export type RobotWifi = {
+  list: ApiResponse<ListResponse>,
+  configure: ApiResponse<ConfigureResponse>,
+  status: ApiResponse<StatusResponse>,
+}
+
+export type WifiState = {
+  [robotName: string]: RobotWifi
+}
+
+const LIST_PATH: RequestPath = 'list'
+const STATUS_PATH: RequestPath = 'status'
+
+export function fetchWifiList (robot: RobotService): ThunkAction {
+  return (dispatch) => {
+    dispatch(wifiRequest(robot, LIST_PATH))
+
+    return client(robot, 'GET', `wifi/${LIST_PATH}`)
+      .then((response) => dispatch(wifiSuccess(robot, LIST_PATH, response)))
+      .catch((error) => dispatch(wifiFailure(robot, LIST_PATH, error)))
+  }
+}
+
+export function fetchWifiStatus (robot: RobotService): ThunkAction {
+  return (dispatch) => {
+    dispatch(wifiRequest(robot, STATUS_PATH))
+
+    return client(robot, 'GET', `wifi/${STATUS_PATH}`)
+      .then((response) => dispatch(wifiSuccess(robot, STATUS_PATH, response)))
+      .catch((error) => dispatch(wifiFailure(robot, STATUS_PATH, error)))
+  }
+}
+
+export function wifiReducer (state: ?WifiState, action: Action): WifiState {
+  if (state == null) return {}
+
+  switch (action.type) {
+    case 'api:WIFI_REQUEST': return reduceWifiRequest(state, action)
+    case 'api:WIFI_SUCCESS': return reduceWifiSuccess(state, action)
+    case 'api:WIFI_FAILURE': return reduceWifiFailure(state, action)
+  }
+
+  return state
+}
+
+export function selectWifi (state: State): WifiState {
+  return state.api.wifi
+}
+
+function wifiRequest (
+  robot: RobotService,
+  path: RequestPath
+): WifiRequestAction {
+  return {type: 'api:WIFI_REQUEST', payload: {robot, path}}
+}
+
+function wifiSuccess (
+  robot: RobotService,
+  path: RequestPath,
+  response: {}
+): WifiSuccessAction {
+  const action: WifiSuccessAction = {
+    type: 'api:WIFI_SUCCESS',
+    payload: {robot, path}
+  }
+
+  if (path === LIST_PATH) {
+    action.payload.list = listFromResponse(response)
+  } else if (path === STATUS_PATH) {
+    action.payload.status = statusFromResponse(response)
+  }
+
+  return action
+}
+
+function wifiFailure (
+  robot: RobotService,
+  path: RequestPath,
+  error: ClientResponseError
+): WifiFailureAction {
+  return {type: 'api:WIFI_FAILURE', payload: {robot, path, error}}
+}
+
+function listFromResponse (response: {}): SsidList {
+  return Array.isArray(response)
+    ? response.map((ssid) => `${ssid}`)
+    : []
+}
+
+function isStatus (maybeStatus: mixed): boolean %checks {
+  return (
+    maybeStatus === 'none' ||
+    maybeStatus === 'portal' ||
+    maybeStatus === 'limited' ||
+    maybeStatus === 'full' ||
+    maybeStatus === 'unknown' ||
+    maybeStatus === 'testing'
+  )
+}
+
+function statusFromResponse (response: {}): Status {
+  if (response && response.status && isStatus(response.status)) {
+    return response.status
+  }
+
+  return 'unknown'
+}
+
+function reduceWifiRequest (
+  state: WifiState,
+  action: WifiRequestAction
+): WifiState {
+  const {payload: {path, robot: {name}}} = action
+  const stateByName = state[name] || {}
+  const stateByNameByPath = stateByName[path] || {}
+
+  return {
+    ...state,
+    [name]: {
+      ...stateByName,
+      [path]: {
+        ...stateByNameByPath,
+        inProgress: true,
+        error: null
+      }
+    }
+  }
+}
+
+function reduceWifiSuccess (
+  state: WifiState,
+  action: WifiSuccessAction
+): WifiState {
+  const {payload: {path, robot: {name}}} = action
+  const stateByName = state[name] || {}
+
+  return {
+    ...state,
+    [name]: {
+      ...stateByName,
+      [path]: {
+        inProgress: false,
+        error: null,
+        response: action.payload[path]
+      }
+    }
+  }
+}
+
+function reduceWifiFailure (
+  state: WifiState,
+  action: WifiFailureAction
+): WifiState {
+  const {payload: {path, error, robot: {name}}} = action
+  const stateByName = state[name] || {}
+  const stateByNameByPath = stateByName[path] || {}
+
+  return {
+    ...state,
+    [name]: {
+      ...stateByName,
+      [path]: {
+        ...stateByNameByPath,
+        inProgress: false,
+        error
+      }
+    }
+  }
+}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -30,7 +30,12 @@ const middleware = applyMiddleware(
   routerMiddleware(history)
 )
 
-const composeEnhancers = global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+const composeEnhancers = (
+  (
+    global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ && global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({maxAge: 200})
+  ) ||
+  compose
+)
 
 const store = createStore(reducer, composeEnhancers(middleware))
 

--- a/app/src/robot/api-client/worker.js
+++ b/app/src/robot/api-client/worker.js
@@ -20,7 +20,11 @@ function dispatchFromWorker (action) {
     action.payload = errorToPlainObject(action.payload)
   }
 
-  self.postMessage(action)
+  try {
+    self.postMessage(action)
+  } catch (error) {
+    console.error('Unable to dispatch action from worker', action, error)
+  }
 }
 
 function errorToPlainObject (error) {


### PR DESCRIPTION
## overview

This PR is part of #698. It adds the ability to retrieve the current WiFi status of a robot (i.e. does the robot have internet access) and the available SSIDs.

## changelog

- Feature: added wifi module to http-api-client with support for `/wifi/list` and `/wifi/status`
- Feature: added `SKIP_WIRED_POLL` env var to disable polling for wired robot
    - Reduces failed `fetchHealth` Redux spam in development (ping @Kadee80)
    - `SKIP_WIRED_POLL=1 make -C app dev`

## review requests

Standard review
