### PR TITLE
Relative gcodes during y-homing retract

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -347,7 +347,7 @@ class SmoothieDriver_3_0_0:
         self.set_axis_max_speed({'Y': Y_RETRACT_SPEED})
 
         # retract, then home, then retract again
-        relative_retract_command = '{0} {1}{2} {3}'.format(
+        relative_retract_command = '{0} {1}Y{2} {3}'.format(
             GCODES['RELATIVE_COORDS'],  # set to relative coordinate system
             GCODES['MOVE'],  # move 3 millimeters away from switch
             str(-Y_RETRACT_DISTANCE),

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -57,6 +57,7 @@ GCODES = {'HOME': 'G28.2',
           'LIMIT_SWITCH_STATUS': 'M119',
           'PROBE': 'G38.2',
           'ABSOLUTE_COORDS': 'G90',
+          'RELATIVE_COORDS': 'G91',
           'RESET_FROM_ERROR': 'M999',
           'PUSH_SPEED': 'M120',
           'POP_SPEED': 'M121',
@@ -340,17 +341,22 @@ class SmoothieDriver_3_0_0:
     def _home_y(self):
         # home the Y at normal speed (fast)
         self._send_command(GCODES['HOME'] + 'Y')
-        self.update_position(default={'Y': HOMED_POSITION.get('Y')})
+
         # slow the maximum allowed speed on Y axis
         self.push_axis_max_speed()
         self.set_axis_max_speed({'Y': Y_RETRACT_SPEED})
-        # move away from the switch
-        self.move({'Y': self.position['Y'] - Y_RETRACT_DISTANCE})
-        # home again, but slower now
+
+        # retract, then home, then retract again
+        relative_retract_command = '{0} {1}{2} {3}'.format(
+            GCODES['RELATIVE_COORDS'],  # set to relative coordinate system
+            GCODES['MOVE'],  # move 3 millimeters away from switch
+            str(-Y_RETRACT_DISTANCE),
+            GCODES['ABSOLUTE_COORDS']  # set back to absolute coordinate system
+        )
+        self._send_command(relative_retract_command)
         self._send_command(GCODES['HOME'] + 'Y')
-        self.update_position()
-        # move away from the switch again
-        self.move({'Y': self.position['Y'] - Y_RETRACT_DISTANCE})
+        self._send_command(relative_retract_command)
+
         # bring max speeds back to normal
         self.pop_axis_max_speed()
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -59,12 +59,10 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['G0F24000 M400'],                      # set back to default speed
         ['G28.2X M400'],                       # home X
         ['G28.2Y M400'],                        # home Y
-        ['M114.2 M400'],                       # Get position
         ['M203.1 Y8 M400'],                     # lower speed on Y for retract
-        ['G0.+ M400'],                          # retract Y
+        ['G91 G0-3 G90'],                          # retract Y
         ['G28.2Y M400'],                        # home Y
-        ['M114.2 M400'],                       # Get position
-        ['G0.+ M400'],                          # retract Y
+        ['G91 G0-3 G90'],                          # retract Y
         ['M203.1 A100 B70 C70 X600 Y400 Z100 M400'],  # return to norm current
         ['M114.2 M400']                       # Get position
     ]

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -60,9 +60,9 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['G28.2X M400'],                       # home X
         ['G28.2Y M400'],                        # home Y
         ['M203.1 Y8 M400'],                     # lower speed on Y for retract
-        ['G91 G0-3 G90'],                          # retract Y
+        ['G91 G0Y-3 G90'],                          # retract Y
         ['G28.2Y M400'],                        # home Y
-        ['G91 G0-3 G90'],                          # retract Y
+        ['G91 G0Y-3 G90'],                          # retract Y
         ['M203.1 A100 B70 C70 X600 Y400 Z100 M400'],  # return to norm current
         ['M114.2 M400']                       # Get position
     ]


### PR DESCRIPTION


<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Use relative gcode command (`G91`) to retract the Y axis while homing, to avoid bug with retrieving current coordinate during Y homing.
