### PR TITLE
feat(app,api): Refactor /wifi/list to provide signal and active flag

### DIFF
--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -17,7 +17,13 @@ async def test_wifi_list(virtual_smoothie_env, loop, test_client):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    expected = json.dumps(['a', 'b', 'c'])
+    expected = json.dumps({
+        "list": [
+            {"ssid": "a", "signal": 42, "active": True},
+            {"ssid": "b", "signal": 43, "active": False},
+            {"ssid": "c", "signal": None, "active": False}
+        ]
+    })
     resp = await cli.get('/wifi/list')
     text = await resp.text()
     assert resp.status == 200

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -28,10 +28,14 @@ describe('wifi', () => {
   })
 
   describe('fetchWifiList action creator', () => {
-    const list = ['ssid-1', 'ssid-2', 'ssid-3']
+    const list = [
+      {ssid: 'ssid-1', signal: 42, active: true},
+      {ssid: 'ssid-2', signa: 43, active: false},
+      {ssid: 'ssid-3', signal: null, active: false}
+    ]
 
     test('calls GET /wifi/list', () => {
-      client.__setMockResponse(list)
+      client.__setMockResponse({list})
 
       return fetchWifiList(robot)(() => {})
         .then(() => {
@@ -46,7 +50,7 @@ describe('wifi', () => {
         {type: 'api:WIFI_SUCCESS', payload: {robot, list, path: 'list'}}
       ]
 
-      client.__setMockResponse(list)
+      client.__setMockResponse({list})
 
       return store.dispatch(fetchWifiList(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -40,7 +40,7 @@ export default function client (
   method: Method,
   path: string,
   body?: {}
-): Promise<{}> {
+): Promise<any> {
   const url = `http://${robot.ip}:${robot.port}/${path}`
   const options = {
     method,
@@ -53,7 +53,7 @@ export default function client (
   return fetch(url, options).then(jsonFromResponse, fetchErrorFromError)
 }
 
-function jsonFromResponse (response: Response): Promise<{}> {
+function jsonFromResponse (response: Response): Promise<*> {
   if (!response.ok) {
     return Promise.reject(ResponseError(response))
   }
@@ -61,6 +61,6 @@ function jsonFromResponse (response: Response): Promise<{}> {
   return response.json().catch(fetchErrorFromError)
 }
 
-function fetchErrorFromError (error: Error): Promise<{}> {
+function fetchErrorFromError (error: Error): Promise<*> {
   return Promise.reject(FetchError(error))
 }


### PR DESCRIPTION
## overview

This PR is part of #698 and adds additional network information to the /wifi/list response.

## changelog

- Feature (BREAKING CHANGE): added signal and active flag to /wifi/list reponse
    - Previous format: `Array<string>`
    - New format: `{list: Array<{ssid: string, signal: ?number, active: boolean}>}`
- Refactor: removed all bespoke response validation from the client
    - It's not the client's job to ensure that the response formats are correct
    - The extra logic just makes the client harder to read and more brittle

## review requests

This PR touches both API (@btmorr + @Laura-Danielle) and Run App (@Kadee80 + @IanLondon). I'm also pushing it to `son-of-moon-moon` for testing.

--- 

Update: pushed to `son-of-moon-moon` and appears to be behaving properly
