### PR TITLE
feat(complib): Add generic AlertModal component

### DIFF
--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -1,23 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modals ContinueModal renders correctly 1`] = `
+exports[`modals AlertModal renders correctly 1`] = `
 <div
-  className="modal"
+  className="modal style"
 >
   <div
-    className="overlay"
+    className="overlay clickable"
     onClick={[Function]}
   />
   <div
     className="modal_contents"
   >
     <div
-      className="continue_modal_contents"
+      className="alert_modal_contents"
+    >
+      <div
+        className="alert_modal_heading"
+      >
+        heading
+      </div>
+      children
+    </div>
+    <div
+      className="alert_modal_buttons"
+    >
+      <button
+        className="button_flat"
+        disabled={undefined}
+        onClick={[Function]}
+        title={undefined}
+      >
+        a
+      </button>
+      <button
+        className="button_flat"
+        disabled={undefined}
+        onClick={[Function]}
+        title={undefined}
+      >
+        b
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`modals ContinueModal renders correctly 1`] = `
+<div
+  className="modal"
+>
+  <div
+    className="overlay clickable"
+    onClick={[Function]}
+  />
+  <div
+    className="modal_contents"
+  >
+    <div
+      className="alert_modal_contents"
     >
       children
     </div>
     <div
-      className="continue_modal_buttons"
+      className="alert_modal_buttons"
     >
       <button
         className="button_flat"
@@ -45,7 +90,7 @@ exports[`modals Modal renders correctly 1`] = `
   className="modal foo"
 >
   <div
-    className="overlay"
+    className="overlay clickable"
     onClick={[Function]}
   />
   <div
@@ -58,7 +103,7 @@ exports[`modals Modal renders correctly 1`] = `
 
 exports[`modals Overlay renders correctly 1`] = `
 <div
-  className="overlay"
+  className="overlay clickable"
   onClick={[Function]}
 />
 `;

--- a/components/src/__tests__/modals.test.js
+++ b/components/src/__tests__/modals.test.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Renderer from 'react-test-renderer'
 
-import {Modal, ContinueModal, Overlay} from '..'
+import {Modal, AlertModal, ContinueModal, Overlay} from '..'
 
 describe('modals', () => {
   test('Modal has a clickable overlay', () => {
@@ -13,7 +13,7 @@ describe('modals', () => {
       </Modal>
     ).root
 
-    const overlay = root.findByProps({className: 'overlay'})
+    const overlay = root.findByProps({className: 'overlay clickable'})
     overlay.props.onClick()
 
     expect(onCloseClick).toHaveBeenCalled()
@@ -53,7 +53,7 @@ describe('modals', () => {
       </ContinueModal>
     ).root
 
-    const overlay = root.findByProps({className: 'overlay'})
+    const overlay = root.findByProps({className: 'overlay clickable'})
 
     overlay.props.onClick()
     expect(onCancelClick).toHaveBeenCalled()
@@ -64,6 +64,24 @@ describe('modals', () => {
       <Modal onCloseClick={() => {}} className='foo'>
         children
       </Modal>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('AlertModal renders correctly', () => {
+    const tree = Renderer.create(
+      <AlertModal
+        heading={'heading'}
+        className={'style'}
+        onCloseClick={() => {}}
+        buttons={[
+          {onClick: () => {}, children: 'a'},
+          {onClick: () => {}, children: 'b'}
+        ]}
+      >
+        children
+      </AlertModal>
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -1,0 +1,46 @@
+// @flow
+import * as React from 'react'
+
+import {FlatButton, type ButtonProps} from '../buttons'
+import Modal from './Modal'
+import styles from './modals.css'
+
+type Props = {
+  /** optional handler for overlay click */
+  onCloseClick?: () => void,
+  /** optional modal heading */
+  heading?: React.Node,
+  /** optional array of `ButtonProps` for `FlatButton`s at bottom of modal */
+  buttons?: Array<ButtonProps>,
+  /** modal contents */
+  children: React.Node,
+  /** optional classes to apply */
+  className?: string
+}
+
+/**
+ * Generic alert modal with a heading and a set of buttons at the bottom
+ */
+export default function AlertModal (props: Props) {
+  const {heading, buttons, className, onCloseClick} = props
+
+  return (
+    <Modal className={className} onCloseClick={onCloseClick}>
+      <div className={styles.alert_modal_contents}>
+        {heading && (
+          <div className={styles.alert_modal_heading}>
+            {heading}
+          </div>
+        )}
+        {props.children}
+      </div>
+      {buttons && (
+        <div className={styles.alert_modal_buttons}>
+          {buttons.map((button, index) => (
+            <FlatButton key={index} {...button} />
+          ))}
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/components/src/modals/AlertModal.md
+++ b/components/src/modals/AlertModal.md
@@ -1,0 +1,29 @@
+AlertModal example:
+
+```js
+initialState = {alert: 'foo'}
+
+const alertContents = {
+  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+}
+
+;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>
+    Alert foo
+  </FlatButton>
+  {state.alert && (
+    <AlertModal
+      heading={state.alert}
+      onCloseClick={() => setState({alert: ''})}
+      buttons={[
+        {children: 'foo', onClick: () => setState({alert: 'foo'})},
+        {children: 'bar', onClick: () => setState({alert: 'bar'})},
+        {children: 'close', onClick: () => setState({alert: ''})}
+      ]}
+    >
+      {alertContents[state.alert]}
+    </AlertModal>
+  )}
+</div>
+```

--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -1,38 +1,33 @@
 // @flow
 import * as React from 'react'
 
-import {FlatButton} from '../buttons'
-import Modal from './Modal'
-import styles from './modals.css'
+import AlertModal from './AlertModal'
 
 type ContinueModalProps = {
   /** cancellation handler (also passed to `Modal`'s `onCloseClick`) */
-  onCancelClick: (event: SyntheticEvent<>) => void,
+  onCancelClick: () => void,
   /** continuation handler */
-  onContinueClick: (event: SyntheticEvent<>) => void,
+  onContinueClick: () => void,
   /** modal contents */
-  children: React.Node
+  children: React.Node,
 }
 
+const CANCEL = 'Cancel'
+const CONTINUE = 'Continue'
+
 /**
- * Modal to prompt the user to "Cancel" or "Continue" a given action
+ * AlertModal variant to prompt user to "Cancel" or "Continue" a given action
  */
 export default function ContinueModal (props: ContinueModalProps) {
   const {onCancelClick, onContinueClick} = props
+  const buttons = [
+    {title: CANCEL, children: CANCEL, onClick: onCancelClick},
+    {title: CONTINUE, children: CONTINUE, onClick: onContinueClick}
+  ]
 
   return (
-    <Modal onCloseClick={onCancelClick}>
-      <div className={styles.continue_modal_contents}>
-        {props.children}
-      </div>
-      <div className={styles.continue_modal_buttons}>
-        <FlatButton title='Cancel' onClick={onCancelClick}>
-          Cancel
-        </FlatButton>
-        <FlatButton title='Continue' onClick={onContinueClick}>
-          Continue
-        </FlatButton>
-      </div>
-    </Modal>
+    <AlertModal buttons={buttons} onCloseClick={onCancelClick}>
+      {props.children}
+    </AlertModal>
   )
 }

--- a/components/src/modals/ContinueModal.md
+++ b/components/src/modals/ContinueModal.md
@@ -3,7 +3,7 @@ Basic usage:
 ```js
 initialState = {continue: null}
 
-;<div style={{position: 'relative', width: '48em', height: '16rem'}}>
+;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
   {state.continue == null && (
     <ContinueModal
       onCancelClick={() => setState({continue: 'cancel'})}

--- a/components/src/modals/Modal.js
+++ b/components/src/modals/Modal.js
@@ -6,7 +6,7 @@ import styles from './modals.css'
 
 type ModalProps = {
   /** handler to close the modal (attached to `Overlay` onClick) */
-  onCloseClick: (event: SyntheticEvent<>) => void,
+  onCloseClick?: (event: SyntheticEvent<>) => void,
   /** modal contents */
   children: React.Node,
   /** classes to apply */

--- a/components/src/modals/Overlay.js
+++ b/components/src/modals/Overlay.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 
 import styles from './modals.css'
 
@@ -14,7 +15,11 @@ type OverlayProps = {
  * just want to use `<Modal>`
  */
 export default function Overlay (props: OverlayProps) {
+  const className = cx(styles.overlay, {
+    [styles.clickable]: props.onClick
+  })
+
   return (
-    <div className={styles.overlay} onClick={props.onClick} />
+    <div className={className} onClick={props.onClick} />
   )
 }

--- a/components/src/modals/index.js
+++ b/components/src/modals/index.js
@@ -2,7 +2,8 @@
 // modal components
 
 import Modal from './Modal'
+import AlertModal from './AlertModal'
 import ContinueModal from './ContinueModal'
 import Overlay from './Overlay'
 
-export {Modal, ContinueModal, Overlay}
+export {Modal, AlertModal, ContinueModal, Overlay}

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -13,16 +13,29 @@
   background-color: rgba(0, 0, 0, 0.8);
 }
 
+.clickable {
+  @apply --clickable;
+}
+
 .modal_contents {
   z-index: 1;
   padding: 1rem;
   background-color: white;
 }
 
-.continue_modal_contents {
-  padding: 1.5rem;
+.alert_modal_contents {
+  @apply --font-body-2-dark;
+
+  padding: 0.5rem 1rem;
 }
 
-.continue_modal_buttons {
+.alert_modal_heading {
+  @apply --font-header-dark;
+
+  margin-bottom: 0.5rem;
+}
+
+.alert_modal_buttons {
   float: right;
+  margin-top: 1rem;
 }


### PR DESCRIPTION
## overview

This PR is for #694, #695, #826 (and whatever other tickets require an alert modal of some sort to pop up. It adds an `AlertModal` component and refactors the `ContinueModal` to use `AlertModal` as its base.

<img width="830" alt="screenshot 2018-02-16 15 09 18" src="https://user-images.githubusercontent.com/2963448/36327074-5fde1458-132b-11e8-8c55-aedc9e03f911.png">

## changelog

- Feature: Added `AlertModal` and use it to drive `ContinueModal`
- Feature: Added `display: pointer` to `Overlay` when `onClick` is present

## review requests

Components library preview: <https://s3-us-west-2.amazonaws.com/opentrons-components/complib_alert-modal/index.html#alertmodal>
