### PR TITLE
increases p10 pick_up_tip current to 0.1 amps

### DIFF
--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -28,7 +28,7 @@ p10_single = pipette_config(
         'blow_out': 0,
         'drop_tip': -6
     },
-    pick_up_current=0.05,
+    pick_up_current=0.1,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
     ul_per_mm=0.617,


### PR DESCRIPTION
## overview

This PR increases the `P10_Single` pipette's default Z current while creating a seal with a new tip, to avoid Z motor now having enough force and stalling.