### PR TITLE
 feat(app): Add basic robot settings page

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -5,6 +5,7 @@ import NavPanel from './side-panel'
 import NavBar from './nav-bar'
 
 import Home from '../pages/Home'
+import Robots from '../pages/Robots'
 import Upload from '../pages/Upload'
 import SetupInstruments from '../pages/SetupInstruments'
 import SetupDeck from '../pages/SetupDeck'
@@ -20,6 +21,7 @@ export default function App () {
       <NavPanel />
       <Switch>
         <Route exact path='/' component={Home} />
+        <Route path='/robots/:name?' component={Robots} />
         <Route path='/upload' component={Upload} />
         <Route path='/setup-instruments/:mount' component={SetupInstruments} />
         <Route path='/setup-deck/:slot' component={SetupDeck} />

--- a/app/src/components/RobotSettings/StatusCard.js
+++ b/app/src/components/RobotSettings/StatusCard.js
@@ -1,0 +1,78 @@
+// @flow
+// RobotSettings card for robot status
+import * as React from 'react'
+import {connect} from 'react-redux'
+import capitalize from 'lodash/capitalize'
+
+import type {State, Dispatch} from '../../types'
+import {
+  selectors as robotSelectors,
+  actions as robotActions,
+  type Robot
+} from '../../robot'
+
+import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
+
+type OwnProps = Robot
+
+type StateProps = {
+  status: string,
+  connectButtonText: string
+}
+
+type DispatchProps = {
+  onClick: () => *
+}
+
+type Props = OwnProps & StateProps & DispatchProps
+
+const TITLE = 'Status'
+const STATUS_LABEL = 'This robot is currently'
+const STATUS_VALUE_DISCONNECTED = 'Unknown - connect to view status'
+const STATUS_VALUE_DEFAULT = 'Idle'
+
+export default connect(mapStateToProps, mapDispatchToProps)(StatusCard)
+
+function StatusCard (props: Props) {
+  const {status, connectButtonText, onClick} = props
+
+  return (
+    <Card title={TITLE}>
+      <LabeledValue
+        label={STATUS_LABEL}
+        value={status}
+      />
+      <OutlineButton onClick={onClick}>
+        {connectButtonText}
+      </OutlineButton>
+    </Card>
+  )
+}
+
+function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
+  const {isConnected} = ownProps
+  const sessionStatus = robotSelectors.getSessionStatus(state)
+  const status = isConnected
+    ? (sessionStatus && capitalize(sessionStatus)) || STATUS_VALUE_DEFAULT
+    : STATUS_VALUE_DISCONNECTED
+
+  const connectButtonText = isConnected
+    ? 'disconnect'
+    : 'connect'
+
+  return {status, connectButtonText}
+}
+
+function mapDispatchToProps (
+  dispatch: Dispatch,
+  ownProps: OwnProps
+): DispatchProps {
+  const {name, isConnected} = ownProps
+  const onClickAction = isConnected
+    ? robotActions.disconnect()
+    : robotActions.connect(name)
+
+  return {
+    onClick: () => dispatch(onClickAction)
+  }
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -1,0 +1,18 @@
+// @flow
+// robot status panel with connect button
+import * as React from 'react'
+
+import type {Robot} from '../../robot'
+
+import StatusCard from './StatusCard'
+import styles from './styles.css'
+
+type Props = Robot
+
+export default function RobotSettings (props: Props) {
+  return (
+    <div className={styles.robot_settings}>
+      <StatusCard {...props} />
+    </div>
+  )
+}

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -1,0 +1,6 @@
+/* stylesheet for RobotSettings components */
+@import '@opentrons/components';
+
+.robot_settings {
+  padding: 1.5rem;
+}

--- a/app/src/components/connect-panel/RobotItem.js
+++ b/app/src/components/connect-panel/RobotItem.js
@@ -27,15 +27,15 @@ export default function RobotItem (props) {
     ? onDisconnectClick
     : onConnectClick
 
-  const className = cx(styles.robot_item, {
+  const className = cx(styles.connection_toggle, {
     [styles.connected]: isConnected,
     [styles.disconnected]: !isConnected
   })
 
-  /* TODO (ka 2018-2-7): No onClick passed to IconButton for now because parent
-    ListItem receives the onClick temporarily. double toggle = no toggle.
-    Once routes in place for connection pages this will be resolved by replacing
-    onClick in ListItem with url */
+  /* TODO (ka 2018-2-13):
+  Toggle Button Class based on connectivity,
+  NavLink gets ActiveClassName in ListItem
+  */
   const toggleIcon = isConnected
     ? TOGGLED_ON
     : TOGGLED_OFF
@@ -46,14 +46,16 @@ export default function RobotItem (props) {
 
   return (
     <ListItem
-      onClick={onClick}
+      url={`/robots/${name}`}
       iconName={iconName}
-      className={className}
+      className={styles.robot_item}
+      activeClassName={styles.active}
     >
       <p className={styles.robot_name}>{name}</p>
       <IconButton
         name={toggleIcon}
-        className={styles.connection_toggle}
+        className={className}
+        onClick={onClick}
       />
     </ListItem>
   )

--- a/app/src/components/connect-panel/RobotList.js
+++ b/app/src/components/connect-panel/RobotList.js
@@ -1,6 +1,5 @@
 // list of robots
 import React from 'react'
-
 import styles from './connect-panel.css'
 
 export default function RobotList (props) {

--- a/app/src/components/connect-panel/connect-panel.css
+++ b/app/src/components/connect-panel/connect-panel.css
@@ -40,15 +40,17 @@
 }
 
 .disconnected {
-  color: var(--c-dark-gray);
   fill: var(--c-dark-gray);
 }
 
-.connected,
-.connected button {
+.active {
   color: #0ec9eb;
-  fill: #0ec9eb;
   background-color: #f0f3ff;
+}
+
+.connected {
+  fill: #0ec9eb;
+  color: #0ec9eb;
 }
 
 .scan_status {

--- a/app/src/components/connect-panel/index.js
+++ b/app/src/components/connect-panel/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {withRouter} from 'react-router'
 import {connect} from 'react-redux'
 
 import {
@@ -10,7 +11,9 @@ import RobotList from './RobotList'
 import RobotItem from './RobotItem'
 import ScanStatus from './ScanStatus'
 
-export default connect(mapStateToProps, null, mergeProps)(ConnectPanel)
+export default withRouter(
+  connect(mapStateToProps, null, mergeProps)(ConnectPanel)
+)
 
 function ConnectPanel (props) {
   return (

--- a/app/src/components/upload-panel/upload-panel.css
+++ b/app/src/components/upload-panel/upload-panel.css
@@ -38,7 +38,7 @@
 }
 
 .upload_warning_title {
-  @apply --font-heading-dark;
+  @apply --font-header-dark;
 
   margin-bottom: 0.5rem;
 }

--- a/app/src/pages/Robots.js
+++ b/app/src/pages/Robots.js
@@ -1,0 +1,47 @@
+// @flow
+// connect and configure robots page
+import React from 'react'
+import {connect} from 'react-redux'
+import {withRouter, Redirect, type ContextRouter} from 'react-router'
+
+import type {State} from '../types'
+import {selectors as robotSelectors, type Robot} from '../robot'
+
+import {TitleBar} from '@opentrons/components'
+import Page from '../components/Page'
+import RobotStatus from '../components/RobotSettings'
+import Splash from '../components/Splash'
+
+type StateProps = {
+  robot: ?Robot
+}
+
+type Props = StateProps & ContextRouter
+
+export default withRouter(connect(mapStateToProps)(RobotSettingsPage))
+
+function RobotSettingsPage (props: Props) {
+  const {robot, match: {url, params: {name}}} = props
+
+  if (name && !robot) {
+    console.warn(`Robot ${name} does not exist; redirecting`)
+    return (<Redirect to={url.replace(`/${name}`, '')} />)
+  }
+
+  return (
+    <Page>
+      {!robot && (<Splash />)}
+      {robot && (<TitleBar title={robot.name} />)}
+      {robot && (<RobotStatus {...robot} />)}
+    </Page>
+  )
+}
+
+function mapStateToProps (state: State, ownProps: ContextRouter): StateProps {
+  const {match: {params: {name}}} = ownProps
+  const robots = robotSelectors.getDiscovered(state)
+
+  return {
+    robot: robots.find((r) => r.name === name)
+  }
+}

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -108,7 +108,6 @@ export default function client (dispatch) {
     remote = null
     isDisconnecting = false
 
-    dispatch(push('/'))
     dispatch(response)
   }
 

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -23,14 +23,6 @@ export type ConnectionStatus =
 export const RUNNING = 'running'
 export const PAUSED = 'paused'
 export const FINISHED = 'finished'
-export type SessionStatus =
-  | ''
-  | 'loaded'
-  | 'running'
-  | 'paused'
-  | 'error'
-  | 'finished'
-  | 'stopped'
 
 // tip probe calibration states
 // TODO(mc, 2018-01-22): remove constant exports in favor of flowtype

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -1,7 +1,14 @@
 // @flow
 // robot session (protocol) state and reducer
-import type {Command, StateInstrument, StateLabware, Mount, Slot} from '../types'
-import type {SessionStatus} from '../constants'
+import type {
+  Command,
+  StateInstrument,
+  StateLabware,
+  Mount,
+  Slot,
+  SessionStatus
+} from '../types'
+
 import {actionTypes} from '../actions'
 
 type Request = {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -14,12 +14,12 @@ import type {
   Labware,
   LabwareCalibrationStatus,
   LabwareType,
-  Robot
+  Robot,
+  SessionStatus
 } from './types'
 
 import {
   type ConnectionStatus,
-  type SessionStatus,
   _NAME,
   INSTRUMENT_MOUNTS,
   DECK_SLOTS
@@ -29,7 +29,6 @@ const calibration = (state: State) => state[_NAME].calibration
 const connection = (state: State) => state[_NAME].connection
 const session = (state: State) => state[_NAME].session
 const sessionRequest = (state: State) => session(state).sessionRequest
-const sessionStatus = (state: State) => session(state).state
 
 export function isMount (target: ?string): boolean {
   return INSTRUMENT_MOUNTS.indexOf(target) > -1
@@ -94,16 +93,20 @@ export function getSessionName (state: State): string {
   return session(state).name
 }
 
+export function getSessionStatus (state: State): SessionStatus {
+  return session(state).state
+}
+
 export function getSessionIsLoaded (state: State): boolean {
-  return sessionStatus(state) !== ('': SessionStatus)
+  return getSessionStatus(state) !== ('': SessionStatus)
 }
 
 export function getIsReadyToRun (state: State): boolean {
-  return sessionStatus(state) === ('loaded': SessionStatus)
+  return getSessionStatus(state) === ('loaded': SessionStatus)
 }
 
 export function getIsRunning (state: State): boolean {
-  const status = sessionStatus(state)
+  const status = getSessionStatus(state)
 
   return (
     status === ('running': SessionStatus) ||
@@ -112,11 +115,11 @@ export function getIsRunning (state: State): boolean {
 }
 
 export function getIsPaused (state: State): boolean {
-  return sessionStatus(state) === ('paused': SessionStatus)
+  return getSessionStatus(state) === ('paused': SessionStatus)
 }
 
 export function getIsDone (state: State): boolean {
-  const status = sessionStatus(state)
+  const status = getSessionStatus(state)
 
   return (
     status === ('error': SessionStatus) ||

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -133,3 +133,12 @@ export type Labware = StateLabware & {
 }
 
 export type LabwareType = 'tiprack' | 'labware'
+
+export type SessionStatus =
+  | ''
+  | 'loaded'
+  | 'running'
+  | 'paused'
+  | 'error'
+  | 'finished'
+  | 'stopped'

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Card renders Card correctly 1`] = `
+<section
+  className="card"
+>
+  <h3
+    className="card_title"
+  >
+    title
+  </h3>
+  <div
+    className="card_content"
+  >
+    children children children
+  </div>
+</section>
+`;
+
+exports[`LabeledValue renders LabeledValue correctly 1`] = `
+<div
+  className="labeled_value"
+>
+  <p>
+    Label
+    :
+  </p>
+  <p>
+    Value
+  </p>
+</div>
+`;
+
 exports[`NavButton renders nav button with icon correctly 1`] = `
 <button
   className="button"

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -21,7 +21,9 @@ exports[`LabeledValue renders LabeledValue correctly 1`] = `
 <div
   className="labeled_value"
 >
-  <p>
+  <p
+    className="labeled_value_label"
+  >
     Label
     :
   </p>

--- a/components/src/__tests__/structure.test.js
+++ b/components/src/__tests__/structure.test.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {MemoryRouter} from 'react-router'
 import Renderer from 'react-test-renderer'
 
-import {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel, FILE} from '..'
+import {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel, FILE, Card, LabeledValue} from '..'
 
 describe('TitleBar', () => {
   test('adds an h1 with the title', () => {
@@ -209,6 +209,30 @@ describe('SidePanel', () => {
       <SidePanel title={'title'} onCloseClick={onClick} isClosed='true'>
         children
       </SidePanel>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('Card', () => {
+  test('renders Card correctly', () => {
+    const tree = Renderer.create(
+      <Card title={'title'} >
+        children
+        children
+        children
+      </Card>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('LabeledValue', () => {
+  test('renders LabeledValue correctly', () => {
+    const tree = Renderer.create(
+      <LabeledValue label={'Label'} value={'Value'} />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -1,0 +1,33 @@
+// @flow
+// Card component with drop shadow
+
+import * as React from 'react'
+import cx from 'classnames'
+
+import styles from './structure.css'
+
+type Props = {
+  /** Title for card */
+  title: React.Node,
+  /** Card content, displays in a flex-row by default */
+  children: React.Node,
+  /** Displays card content in a flex-column */
+  column?: boolean,
+  /** If card can not be used, gray it out and remove pointer events */
+  disabled?: boolean,
+  /** Additional class names */
+  className?: string
+}
+
+export default function Card (props: Props) {
+  const {title, column, children} = props
+  const style = cx(styles.card, props.className, {[styles.disabled]: props.disabled})
+  return (
+    <section className={style}>
+      <h3 className={styles.card_title}>{title}</h3>
+      <div className={cx(styles.card_content, {[styles.card_column]: column})}>
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -21,11 +21,18 @@ type Props = {
 
 export default function Card (props: Props) {
   const {title, column, children} = props
-  const style = cx(styles.card, props.className, {[styles.disabled]: props.disabled})
+
+  const style = cx(styles.card, props.className, {
+    [styles.disabled]: props.disabled
+  })
+  const childrenStyle = cx(styles.card_content, {
+    [styles.card_column]: column
+  })
+
   return (
     <section className={style}>
       <h3 className={styles.card_title}>{title}</h3>
-      <div className={cx(styles.card_content, {[styles.card_column]: column})}>
+      <div className={childrenStyle}>
         {children}
       </div>
     </section>

--- a/components/src/structure/Card.md
+++ b/components/src/structure/Card.md
@@ -1,0 +1,27 @@
+Basic usage:
+
+```js
+<Card title='Hello Title Card'>
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+</Card>
+```
+
+Display content in a flex-column:
+```js
+<Card title='Hello Title Card' column>
+  <LabeledValue label={'Label'} value={'Value'} />
+  <span>Some child content</span>
+  <span>Some more child content</span>  
+</Card>
+```
+
+Disable the card:
+```js
+<Card title='Hello Title Card' disabled>
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+</Card>
+```

--- a/components/src/structure/LabeledValue.js
+++ b/components/src/structure/LabeledValue.js
@@ -1,0 +1,27 @@
+// @flow
+// Card component with drop shadow
+
+import * as React from 'react'
+import cx from 'classnames'
+
+import styles from './structure.css'
+
+type Props = {
+  /** Label */
+  label: React.Node,
+  /** Value */
+  value: React.Node,
+  /** Additional className */
+  className?: string
+}
+
+export default function LabeledValue (props: Props) {
+  const {label, value} = props
+  const className = cx(styles.labeled_value, props.className)
+  return (
+    <div className={className}>
+      <p>{label}:</p>
+      <p>{value}</p>
+    </div>
+  )
+}

--- a/components/src/structure/LabeledValue.js
+++ b/components/src/structure/LabeledValue.js
@@ -18,9 +18,10 @@ type Props = {
 export default function LabeledValue (props: Props) {
   const {label, value} = props
   const className = cx(styles.labeled_value, props.className)
+
   return (
     <div className={className}>
-      <p>{label}:</p>
+      <p className={styles.labeled_value_label}>{label}:</p>
       <p>{value}</p>
     </div>
   )

--- a/components/src/structure/LabeledValue.md
+++ b/components/src/structure/LabeledValue.md
@@ -1,0 +1,5 @@
+Basic Usage:
+
+```js
+<LabeledValue label={'Some label'} value={'Some value that needs a label'} />
+```

--- a/components/src/structure/SidePanel.css
+++ b/components/src/structure/SidePanel.css
@@ -26,18 +26,16 @@
 }
 
 .title {
-  margin: 0 auto;
-  font-size: var(fs-header);
-  font-weight: normal;
-  color: var(--c-dark-gray);
-  line-height: 2;
+  @apply --font-header-dark;
+
+  margin: 1rem auto;
 }
 
 .panel_contents {
   width: var(--sidebar-width);
   height: calc(100vh - 2.625rem);
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 /*

--- a/components/src/structure/index.js
+++ b/components/src/structure/index.js
@@ -5,8 +5,10 @@ import TitleBar from './TitleBar'
 import VerticalNavBar from './VerticalNavBar'
 import NavButton from './NavButton'
 import SidePanel from './SidePanel'
+import Card from './Card'
+import LabeledValue from './LabeledValue'
 
 // types
 export type {PageTabProps} from './PageTabs'
 
-export {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel}
+export {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel, Card, LabeledValue}

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -1,6 +1,14 @@
 /* TitleBar styles */
 @import '..';
 
+:root {
+  --card-disabled: {
+    color: var(--c-font-disabled);
+    fill: var(--c-font-disabled);
+    background-color: transparent;
+  }
+}
+
 .title_bar {
   display: flex;
   align-items: center;
@@ -74,4 +82,39 @@
 
 .active_tab_link .tab_title {
   font-weight: var(--fw-bold);
+}
+
+/* Card and card content styles */
+.card {
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.33);
+  padding: 1rem;
+}
+
+.card_title {
+  @apply --font-header-dark;
+
+  font-weight: 400;
+}
+
+.card_content {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.card_column {
+  flex-direction: column;
+}
+
+.disabled {
+  pointer-events: none;
+  background-color: transparent;
+
+  & * {
+    @apply --card-disabled;
+  }
+}
+
+.labeled_value {
+  @apply --font-body-1-dark;
 }

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -86,14 +86,15 @@
 
 /* Card and card content styles */
 .card {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.33);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33);
   padding: 1rem;
 }
 
 .card_title {
   @apply --font-header-dark;
 
-  font-weight: 400;
+  margin-bottom: 0.5rem;
+  font-weight: --fw-regular;
 }
 
 .card_content {
@@ -116,5 +117,10 @@
 }
 
 .labeled_value {
-  @apply --font-body-1-dark;
+  @apply --font-body-2-dark;
+}
+
+.labeled_value_label {
+  font-weight: var(--fw-semibold);
+  margin-bottom: 0.25rem;
 }


### PR DESCRIPTION
## overview

This PR closes #807 by adding a basic robot settings page. Props to @Kadee80 who did most of this work and then got super sick (please feel better soon).

![2018-02-19 15 14 11](https://user-images.githubusercontent.com/2963448/36395540-9e39ff60-1587-11e8-86cc-5cb92d4e103f.gif)

## changelog

- Feature: Added Card and LabeledValue components to the component library `structure` group
- Feature: Added basic robot settings page to Run App

## review requests

Standard review!

Build links:
- Windows: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-win-2018-02-19_20-09-app_robot-settings-page-58ade2b.exe
- Debian: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-linux-amd64-2018-02-19_20-12-app_robot-settings-page-58ade2b.deb
- Mac: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-mac-2018-02-19_20-12-app_robot-settings-page-58ade2b.zip

**Note:**

The robot status strings are coming straight from `session.py` in the API. They're a little awkward as user facing messages, and they only apply to the protocol (i.e. not calibration). UX + engineering should hash out what we actually want to display