### PR TITLE
PD: factor out ingred locations

### DIFF
--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -10,8 +10,6 @@ export default connect(
     const activeModals = selectors.activeModals(state)
     const container = selectors.selectedContainer(state)
 
-    console.log('selectedContainer', container)
-
     return {
       slot: activeModals.ingredientSelection.slot,
       containerName: container.name,

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -1,26 +1,30 @@
-import { ingredients } from '../reducers'
+import {ingredients, ingredLocations} from '../reducers'
 
 const ingredientsInitialState = {}
 
 describe('DELETE_INGREDIENT action', () => {
-  test('delete ingredient by ingredient group id, when id does not exist', () => {
+  const deleteGroup3 = {
+    type: 'DELETE_INGREDIENT',
+    payload: {groupId: 3}
+  }
+
+  test('delete ingredient by ingredient group id, when group id does NOT exist', () => {
     expect(ingredients(
       ingredientsInitialState,
-      {
-        type: 'DELETE_INGREDIENT',
-        payload: {groupId: 3}
-      }
+      deleteGroup3
+    )).toEqual({})
+
+    expect(ingredLocations(
+      ingredientsInitialState,
+      deleteGroup3
     )).toEqual({})
   })
 
   test('delete ingredient by ingredient group id, when id does exist', () => {
-    const prevState = {
+    const prevIngredState = {
       '2': 'blaah',
       '3': {
         name: 'Buffer',
-        locations: {
-          'A1': ['H1', 'H2', 'H3', 'H4']
-        },
         wellDetailsByLocation: null,
         volume: 100,
         concentration: '50 mol/ng',
@@ -30,27 +34,40 @@ describe('DELETE_INGREDIENT action', () => {
       '4': 'blah'
     }
 
+    const prevLocationsState = {
+      '2': { container1Id: ['A1', 'A2'] },
+      '3': { container1Id: ['A1', 'B1', 'C1'] },
+      '4': { container1Id: ['C1', 'C2'] }
+    }
+
     expect(ingredients(
-      prevState,
-      {
-        type: 'DELETE_INGREDIENT',
-        payload: {groupId: '3'}
-      }
+      prevIngredState,
+      deleteGroup3
     )).toEqual({
       '2': 'blaah',
       '4': 'blah'
+    })
+
+    expect(ingredLocations(
+      prevLocationsState,
+      deleteGroup3
+    )).toEqual({
+      '2': { container1Id: ['A1', 'A2'] },
+      '4': { container1Id: ['C1', 'C2'] }
     })
   })
 })
 
 describe('COPY_LABWARE action', () => {
-  test('copy single ingredient, and no more', () => {
-    const prevState = {
+  test('copy ingredient locations from cloned container', () => {
+    const copyLabwareAction = {
+      type: 'COPY_LABWARE',
+      payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: 'A3'}
+    }
+
+    const prevIngredState = {
       '3': {
         name: 'Buffer',
-        locations: {
-          'myTrough': ['H1', 'H2', 'H3', 'H4']
-        },
         wellDetailsByLocation: null,
         volume: 100,
         concentration: '50 mol/ng',
@@ -59,9 +76,6 @@ describe('COPY_LABWARE action', () => {
       },
       '4': {
         name: 'Other Ingred',
-        locations: {
-          'otherContainer': ['A1', 'A2', 'B3', 'B4']
-        },
         wellDetailsByLocation: null,
         volume: 10,
         concentration: '100%',
@@ -70,37 +84,119 @@ describe('COPY_LABWARE action', () => {
       }
     }
 
-    expect(ingredients(
-      prevState,
-      {
-        type: 'COPY_LABWARE',
-        payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: 'A3'}
-      }
-    )).toEqual({
+    const prevLocationsState = {
       '3': {
-        name: 'Buffer',
-        locations: {
-          'myTrough': ['H1', 'H2', 'H3', 'H4'],
-          // Clone locations
-          'newContainer': ['H1', 'H2', 'H3', 'H4']
-        },
-        wellDetailsByLocation: null,
-        volume: 100,
-        concentration: '50 mol/ng',
-        description: '',
-        individualize: false
+        myTrough: ['A1', 'B1', 'C1'],
+        otherContainer: ['D4', 'E4']
       },
       '4': {
-        name: 'Other Ingred',
-        locations: {
-          'otherContainer': ['A1', 'A2', 'B3', 'B4']
-        },
-        wellDetailsByLocation: null,
-        volume: 10,
-        concentration: '100%',
-        description: '',
-        individualize: false
+        otherContainer: ['A4', 'B4']
+      }
+    }
+
+    expect(ingredients(
+      prevIngredState,
+      copyLabwareAction
+    )).toEqual(prevIngredState)
+
+    expect(ingredLocations(
+      prevLocationsState,
+      copyLabwareAction
+    )).toEqual({
+      '3': {
+        myTrough: ['A1', 'B1', 'C1'],
+        newContainer: ['A1', 'B1', 'C1'], // <-- new
+        otherContainer: ['D4', 'E4']
+      },
+      '4': {
+        otherContainer: ['A4', 'B4']
       }
     })
+  })
+})
+
+describe('EDIT_INGREDIENT action', () => {
+  const ingredFields = {
+    name: 'Cool Ingredient',
+    serializeName: null,
+    volume: 250,
+    description: 'far out!',
+    individualize: false
+  }
+
+  test('new ingredient', () => {
+    const newIngredAction = {
+      type: 'EDIT_INGREDIENT',
+      payload: {
+        ...ingredFields,
+        groupId: '0',
+        containerId: 'container1Id',
+        wells: ['A1', 'A2', 'A3']
+      }
+    }
+
+    expect(ingredients(
+      {},
+      newIngredAction)
+    ).toEqual({
+      '0': {...ingredFields}
+    })
+
+    expect(ingredLocations(
+      {},
+      newIngredAction
+    )).toEqual({
+      '0': {
+        container1Id: ['A1', 'A2', 'A3']
+      }
+    })
+  })
+
+  test.skip('edit ingredient', () => {
+    // TODO
+  })
+
+  test('copy ingredient without any changes', () => {
+    const copyIngredAction = {
+      type: 'EDIT_INGREDIENT',
+      payload: {
+        ...ingredFields,
+        containerId: 'container1Id',
+        groupId: 0,
+        copyGroupId: 0,
+        isUnchangedClone: true,
+        wells: ['B1', 'B2'] // new wells
+      }
+    }
+
+    const prevIngredState = {
+      0: {...ingredFields}
+    }
+
+    expect(ingredients(
+      prevIngredState,
+      copyIngredAction
+    )).toEqual({
+      0: {...ingredFields} // no new ingredient group created
+    })
+
+    const prevLocationsState = {
+      0: {
+        container1Id: ['A1', 'A2', 'A3']
+      }
+    }
+
+    expect(ingredLocations(
+      prevLocationsState,
+      copyIngredAction
+    )).toEqual({
+      0: {
+        container1Id: ['A1', 'A2', 'A3', 'B1', 'B2']
+      }
+    })
+  })
+
+  test.skip('copy ingredient with changes', () => {
+    // TODO
   })
 })

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -23,3 +23,12 @@ export type IngredInputFields = {|
   individualize: boolean,
   serializeName: ?string
 |}
+
+export const editableIngredFields = [
+  'name',
+  'serializeName',
+  'volume',
+  'concentration',
+  'description',
+  'individualize'
+]


### PR DESCRIPTION
## overview

Still cleaning up ingred selection in PD. Previously, `ingredients` reducer contained `locations`. Since it was all in one reducer, the reducer itself could assign IDs to new ingredients, and differentiate between copying an ingredient with changes, copying an ingredient with no changes, creating a new ingred, or editing an existing ingred -- this is all under the `EDIT_INGREDIENT` action.

This PR factors out `ingredients[ingredGroupId].locations` to its own reducer and adds some tests for it.

## changelog

* 'ingredients' broken out into 'ingredientLocations'
* No more ID assignment inside 'ingredients' - now 'editIngredients' thunk creates ID of new ingredients
* tests & selectors updated
* Added more type checking to `labware-ingred/` stuff

## review requests

In PD ingredient selection modal, you should be able to create and copy ingredients. Deletion is broken, and was broken earlier.