### PR TITLE
Update robot position after robot.reset()

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -273,6 +273,12 @@ class Robot(object):
 
         self.clear_commands()
 
+        # update the position of each Mover
+        self._driver.update_position()
+        for mount in self._actuators.values():
+            for mover in mount.values():
+                self.poses = mover.update_pose_from_driver(self.poses)
+
         return self
 
     def turn_on_button_light(self):


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Fixes #818 

Update each mover within  `robot._actuators` within `robot.reset()`, so that if `robot.reset()` is called in a protocol, the machines does not lose position.