### PR TITLE
refactor(api): Refactor /wifi/configure to respond with JSON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY ./compute/avahi_tools /tmp/avahi_tools
 # When adding more python packages make sure to use setuptools to keep
 # packaging consistent across environments
 ENV PIPENV_VENV_IN_PROJECT=true
-RUN pip install pipenv && \
+RUN pip install pipenv==9.0.3 && \
     pipenv install /tmp/api --system && \
     pip install /tmp/avahi_tools && \
     rm -rf /tmp/api && \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PROTOCOL_DESIGNER_DIR := protocol-designer
 #   https://github.com/electron-userland/electron-builder/issues/2222
 .PHONY: install
 install:
-	pip install pipenv
+	pip install pipenv==9.0.3
 	$(MAKE) -C $(API_DIR) install
 	yarn
 	$(MAKE) -C $(APP_SHELL_DIR) install

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -18,10 +18,10 @@ async def test_wifi_list(virtual_smoothie_env, loop, test_client):
     cli = await loop.create_task(test_client(app))
 
     expected = json.dumps({
-        "list": [
-            {"ssid": "a", "signal": 42, "active": True},
-            {"ssid": "b", "signal": 43, "active": False},
-            {"ssid": "c", "signal": None, "active": False}
+        'list': [
+            {'ssid': 'a', 'signal': 42, 'active': True},
+            {'ssid': 'b', 'signal': 43, 'active': False},
+            {'ssid': 'c', 'signal': None, 'active': False}
         ]
     })
     resp = await cli.get('/wifi/list')
@@ -34,7 +34,10 @@ async def test_wifi_configure(virtual_smoothie_env, loop, test_client):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    expected = "Configuration successful. SSID: this, PSK: that"
+    expected = json.dumps({
+        'ssid': 'this',
+        'message': "Configuration successful. PSK: 'that'"
+    })
     resp = await cli.post('/wifi/configure',
                           json={'ssid': 'this', 'psk': 'that'})
     text = await resp.text()


### PR DESCRIPTION
## overview

The `/wifi/configure` endpoint of the API took a JSON request and returned a text response. This PR updates the endpoint to return JSON for consistency and adds the SSID to the response body to help the client accurately process the response.

## changelog

- Refactored /wifi/configure to return JSON
- Locked pipenv install to 9.0.3 because the 9.1.0 release from a few hours ago seems to break Docker

BREAKING CHANGE: /wifi/configure response is a completely different format now. Ok because there are no clients as of yet

## review requests

Standard API review. Robot testing ongoing with `wandering-dream`

I am a little worried about this endpoint not working if the user is calling it over WiFi, but given that our primary use-case is calling the endpoint via ethernet (and we're hopefully only allowing /wifi/configure over that interface), I think this is fine to merge as is.