### PR TITLE
feat(app): Add configureWifi action creator to call /wifi/configure

### DIFF
--- a/app/src/http-api-client/__tests__/client.test.js
+++ b/app/src/http-api-client/__tests__/client.test.js
@@ -79,4 +79,59 @@ describe('http api client', () => {
         message: 'AH'
       }))
   })
+
+  test('POST request', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockResolve({
+      ok: true,
+      json: () => Promise.resolve({foo: 'bar'})
+    })
+
+    return expect(client(robot, 'POST', 'foo', {bar: 'baz'})).resolves
+      .toEqual({foo: 'bar'})
+      .then(() => expect(global.fetch).toHaveBeenCalledWith(
+        'http://1.2.3.4:8080/foo',
+        {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({bar: 'baz'})
+        }
+      ))
+  })
+
+  test('POST request failure', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockResolve({
+      ok: false,
+      status: '400',
+      statusText: 'Bad Request'
+    })
+
+    return expect(client(robot, 'POST', 'foo', {bar: 'baz'})).rejects
+      .toEqual(expect.objectContaining({
+        message: '400 Bad Request'
+      }))
+  })
+
+  test('POST request error', () => {
+    const robot = {
+      ip: '1.2.3.4',
+      port: 8080
+    }
+
+    global.fetch = mockReject(new Error('AH'))
+
+    return expect(client(robot, 'POST', 'foo', {bar: 'baz'})).rejects
+      .toEqual(expect.objectContaining({
+        message: 'AH'
+      }))
+  })
 })

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -3,7 +3,7 @@
 
 import type {RobotService} from '../robot'
 
-type Method = 'GET'
+type Method = 'GET' | 'POST'
 
 export type ClientResponseError = {
   name: string,

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -3,7 +3,7 @@
 import type {State, ThunkAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
-import type {ApiResponse} from './types'
+import type {ApiCall} from './types'
 import client, {type ClientResponseError} from './client'
 
 type HealthInfo = {
@@ -39,7 +39,7 @@ export type HealthAction =
  | HealthSuccessAction
  | HealthFailureAction
 
-export type RobotHealth = ApiResponse<HealthInfo>
+export type RobotHealth = ApiCall<void, HealthInfo>
 
 export type HealthState = {
   [robotName: string]: RobotHealth

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -10,7 +10,14 @@ export const reducer = combineReducers({
 })
 
 export {fetchHealth, selectHealth} from './health'
-export {fetchWifiList, fetchWifiStatus, selectWifi} from './wifi'
+
+export {
+  fetchWifiList,
+  fetchWifiStatus,
+  setConfigureWifiBody,
+  configureWifi,
+  selectWifi
+} from './wifi'
 
 export type {
   RobotHealth,

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -3,11 +3,13 @@
 
 import type {ClientResponseError} from './client'
 
-export type ApiResponse<T> = {
+export type ApiCall<T, U> = {
   /** request in progress flag */
   inProgress: boolean,
   /** possible error response */
   error: ?ClientResponseError,
-  /** possible success response */
-  response?: T
+  /** possible request body */
+  request?: T,
+  /** possible success response body */
+  response?: U,
 }


### PR DESCRIPTION
## overview

~Blocked by #880. Will rebase branch over / update PR base to `v3a` when 880 is merged. Ready to review, though.~ Rebased and merged

This PR is part of #698 and adds the plumbing necessary for the app to update the WiFi network.

## changelog

- Feature: added `configureWifi` action creator to call `/wifi/configure`

## review requests

Standard review. No UI yet so end-to-end robot testing will have to wait until then (unit tests in place, though)
