### PR TITLE
feat(app): Add Connectivity card WiFi network to robot settings page

### DIFF
--- a/app/src/components/RobotSettings/ConnectivityCard.js
+++ b/app/src/components/RobotSettings/ConnectivityCard.js
@@ -1,0 +1,81 @@
+// @flow
+// RobotSettings card for wifi status
+import * as React from 'react'
+import {connect} from 'react-redux'
+
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+
+import {fetchWifiList} from '../../http-api-client'
+
+import {
+  Card,
+  LabeledValue,
+  Icon,
+  SPINNER
+} from '@opentrons/components'
+
+type OwnProps = Robot
+
+type StateProps = {}
+
+type DispatchProps = {
+  fetchWifiList: () => *,
+}
+
+type Props = OwnProps & StateProps & DispatchProps
+
+const TITLE = 'Connectivity'
+const CONNECTED_TO_LABEL = 'Connected to'
+
+class ConnectivityCard extends React.Component<Props> {
+  render () {
+    return (
+      <Card title={TITLE} column>
+        <LabeledValue
+          label={CONNECTED_TO_LABEL}
+          value={this.getConnectedTo()}
+        />
+      </Card>
+    )
+  }
+
+  componentDidMount () {
+    this.props.fetchWifiList()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.name !== this.props.name) {
+      this.props.fetchWifiList()
+    }
+  }
+
+  getConnectedTo (): React.Node {
+    const {wired, wifi} = this.props
+
+    if (wired) return 'USB'
+    if (!wifi || !wifi.list) return ''
+    if (wifi.list.inProgress) return (<Icon name={SPINNER} spin />)
+    if (wifi.list.error) return 'Error retrieving network list'
+
+    const list = (wifi.list.response && wifi.list.response.list)
+    const current = list && list.find((network) => network.active)
+
+    return current && current.ssid
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConnectivityCard)
+
+function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
+  return {}
+}
+
+function mapDispatchToProps (
+  dispatch: Dispatch,
+  ownProps: OwnProps
+): DispatchProps {
+  return {
+    fetchWifiList: () => dispatch(fetchWifiList(ownProps))
+  }
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
+import ConnectivityCard from './ConnectivityCard'
 import styles from './styles.css'
 
 type Props = Robot
@@ -12,7 +13,14 @@ type Props = Robot
 export default function RobotSettings (props: Props) {
   return (
     <div className={styles.robot_settings}>
-      <StatusCard {...props} />
+      <div className={styles.row}>
+        <StatusCard {...props} />
+      </div>
+      <div className={styles.row}>
+        <div className={styles.column_50}>
+          <ConnectivityCard {...props} />
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -1,6 +1,25 @@
 /* stylesheet for RobotSettings components */
 @import '@opentrons/components';
 
+:root {
+  --robot_settings_card_spacing: 1.5rem;
+}
+
 .robot_settings {
-  padding: 1.5rem;
+  overflow-y: auto;
+  padding: var(--robot_settings_card_spacing);
+}
+
+.row {
+  width: 100%;
+  margin-bottom: var(--robot_settings_card_spacing);
+}
+
+.column_50 {
+  display: inline-block;
+  width: calc(50% - (0.5 * var(--robot_settings_card_spacing)));
+
+  &:not(:last-child) {
+    margin-right: var(--robot_settings_card_spacing);
+  }
 }

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -39,7 +39,7 @@ export type HealthAction =
  | HealthSuccessAction
  | HealthFailureAction
 
-export type RobotHealth = ApiCall<void, HealthInfo>
+export type RobotHealth = ?ApiCall<void, HealthInfo>
 
 export type HealthState = {
   [robotName: string]: RobotHealth

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -83,14 +83,14 @@ export type WifiAction =
   | WifiFailureAction
   | SetConfigureWifiBodyAction
 
-export type RobotWifi = {
+export type RobotWifi = ?{
   list?: ApiCall<void, ListResponse>,
   status?: ApiCall<void, StatusResponse>,
   configure?: ApiCall<ConfigureRequest, ConfigureResponse>,
 }
 
 export type WifiState = {
-  [robotName: string]: ?RobotWifi
+  [robotName: string]: RobotWifi
 }
 
 const LIST_PATH: RequestPath = 'list'

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
 
 import type {State} from '../types'
-import {selectHealth} from '../http-api-client'
+import {selectHealth, selectWifi} from '../http-api-client'
 
 import type {
   Mount,
@@ -53,11 +53,19 @@ export const getDiscovered = createSelector(
   (state: State) => connection(state).discoveredByName,
   (state: State) => connection(state).connectedTo,
   selectHealth,
-  (discovered, discoveredByName, connectedTo, healthByName): Robot[] => {
+  selectWifi,
+  (
+    discovered,
+    discoveredByName,
+    connectedTo,
+    healthByName,
+    wifiByName
+  ): Robot[] => {
     const robots = discovered.map((name) => ({
       ...discoveredByName[name],
       isConnected: connectedTo === name,
-      health: healthByName[name]
+      health: healthByName[name],
+      wifi: wifiByName[name]
     }))
 
     return sortBy(robots, [

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -44,6 +44,10 @@ describe('robot selectors', () => {
         health: {
           bar: {response: {api_version: '1.2.3', fw_version: '4.5.6'}},
           qux: {response: {api_version: '1.2.3', fw_version: '4.5.6'}}
+        },
+        wifi: {
+          bar: {list: null, status: null, configure: null},
+          qux: {list: null, status: null, configure: null}
         }
       },
       robot: {
@@ -65,14 +69,16 @@ describe('robot selectors', () => {
         name: 'bar',
         host: '123456.local',
         isConnected: true,
-        health: state.api.health.bar
+        health: state.api.health.bar,
+        wifi: state.api.wifi.bar
       },
       {
         name: 'qux',
         host: 'dvorak.local',
         isConnected: false,
         wired: true,
-        health: state.api.health.qux
+        health: state.api.health.qux,
+        wifi: state.api.wifi.qux
       },
       {name: 'baz', host: 'qwerty.local', isConnected: false},
       {name: 'foo', host: 'abcdef.local', isConnected: false}

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,7 +1,7 @@
 // @flow
 // common robot types
 
-import type {RobotHealth} from '../http-api-client'
+import type {RobotHealth, RobotWifi} from '../http-api-client'
 import typeof reducer from './reducer'
 
 export type State = $Call<reducer>
@@ -46,7 +46,8 @@ export type RobotService = {
 // robot from getDiscovered selector
 export type Robot = RobotService & {
   isConnected: boolean,
-  health: RobotHealth
+  health: RobotHealth,
+  wifi: RobotWifi
 }
 
 // protocol file (browser File object)

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -118,6 +118,10 @@
 
 .labeled_value {
   @apply --font-body-2-dark;
+
+  & svg {
+    height: var(--fs-body-2);
+  }
 }
 
 .labeled_value_label {


### PR DESCRIPTION
## overview

~Blocked by #882. Will rebase the branch and PR when 882 is merged.~ Unblocked

This PR is part of #698 and adds a card that displays the current WiFi network to the robot settings page.

![2018-02-20 16 17 08](https://user-images.githubusercontent.com/2963448/36449983-838f4b6a-165a-11e8-9bb1-7f7c53b46d0d.gif)

## changelog

- Added basic ConnectivityCard container component to display current WiFi network

## review requests

Standard review. Please prioritize reviewing #882 first.

The ConnectiviyCard container uses the `componentDidMount` and `componentDidUpdate` to trigger a call to `/wifi/list` on first render and on updates with a new robot, respectively. We'll probably need a refresh button, too, but for now this works I think.