### PR TITLE
fix(app): Disconnect old rpcClient if it exists on new connect

### DIFF
--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -55,7 +55,12 @@ export default function client (dispatch) {
   }
 
   function connect (state, action) {
-    if (rpcClient) return dispatch(actions.connectResponse())
+    if (rpcClient) {
+      isDisconnecting = true
+      rpcClient.removeAllListeners()
+      rpcClient.close()
+      handleClientDisconnect()
+    }
 
     const name = action.payload.name
     const target = state[constants._NAME].connection.discoveredByName[name]

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -106,21 +106,6 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
     })
 
-    test('dispatch CONNECT_RESPONSE success if already connected', () => {
-      const expectedResponse = actions.connectResponse()
-
-      return sendConnect()
-        .then(() => {
-          RpcClient.mockClear()
-          dispatch.mockClear()
-          return sendConnect()
-        })
-        .then(() => {
-          expect(dispatch).toHaveBeenCalledWith(expectedResponse)
-          expect(RpcClient).toHaveBeenCalledTimes(0)
-        })
-    })
-
     test('dispatch DISCONNECT_RESPONSE if already disconnected', () => {
       const expected = actions.disconnectResponse()
 


### PR DESCRIPTION
## overview

Fixes #881

This PR updates the robot client (RPC, not HTTP) to close any existing connection if it receives a connect command. Previous behavior was to noop upon new connect so this should be a drastic improvement.

## changelog

- Fix: disconnect old client on new connect command rather than nooping

## review requests

Works on my machine, so please double check that this works on yours!
