### PR TITLE
feat(app): Add InformationCard with name + server version to robot page

### DIFF
--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -1,0 +1,81 @@
+// @flow
+// RobotSettings card for robot status
+import * as React from 'react'
+import {connect} from 'react-redux'
+
+import type {Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+import {fetchHealth} from '../../http-api-client'
+
+import {
+  Card,
+  LabeledValue,
+  OutlineButton,
+  Icon,
+  SPINNER
+} from '@opentrons/components'
+
+type OwnProps = Robot
+
+type DispatchProps = {
+  fetchHealth: () => *
+}
+
+type Props = OwnProps & DispatchProps
+
+const TITLE = 'Information'
+const NAME_LABEL = 'Robot Name'
+const SERVER_VERSION_LABEL = 'Server version'
+
+class InformationCard extends React.Component<Props> {
+  render () {
+    const {name} = this.props
+
+    return (
+      <Card title={TITLE}>
+        <LabeledValue
+          label={NAME_LABEL}
+          value={name}
+        />
+        <LabeledValue
+          label={SERVER_VERSION_LABEL}
+          value={this.getServerVersion()}
+        />
+        <OutlineButton disabled>
+          Updated
+        </OutlineButton>
+      </Card>
+    )
+  }
+
+  getServerVersion (): React.Node {
+    const {health} = this.props
+
+    if (!health) return null
+    if (health.inProgress) return (<Icon name={SPINNER} spin />)
+    if (health.error) return 'Error fetching version'
+
+    return health.response && health.response.api_version
+  }
+
+  componentDidMount () {
+    this.props.fetchHealth()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.name !== this.props.name) {
+      this.props.fetchHealth()
+    }
+  }
+}
+
+export default connect(null, mapDispatchToProps)(InformationCard)
+
+function mapDispatchToProps (
+  dispatch: Dispatch,
+  ownProps: OwnProps
+): DispatchProps {
+  return {
+    fetchHealth: () => dispatch(fetchHealth(ownProps))
+  }
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
+import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
 import styles from './styles.css'
 
@@ -15,6 +16,9 @@ export default function RobotSettings (props: Props) {
     <div className={styles.robot_settings}>
       <div className={styles.row}>
         <StatusCard {...props} />
+      </div>
+      <div className={styles.row}>
+        <InformationCard {...props} />
       </div>
       <div className={styles.row}>
         <div className={styles.column_50}>


### PR DESCRIPTION
## overview

This PR closes #812 by adding a basic information card to the robot settings page

![2018-02-20 17 29 21](https://user-images.githubusercontent.com/2963448/36452758-adfca3c6-1663-11e8-813f-609a7c8036de.gif)

## changelog

- Added basic InformationCard container component to the robot settings page

## review requests

Standard review

Similar to #883, the `InformationCard` container has fetch requests attached to `componentDidMount` and `componentDidUpdate`. We probably want a refresh button and/or periodic updates, too, but that's a future us problem.
