### PR TITLE
feat(app): Add ConnectAlertModal for failed robot connection attempts

### DIFF
--- a/app/src/components/RobotSettings/ConnectAlertModal.js
+++ b/app/src/components/RobotSettings/ConnectAlertModal.js
@@ -1,0 +1,34 @@
+// @flow
+// AlertModal for failed connection to robot
+import * as React from 'react'
+
+import {AlertModal} from '@opentrons/components'
+
+type Props = {
+  onCloseClick: () => *
+}
+
+const HEADING = 'Could not connect to robot'
+
+const TRY_AGAIN_MESSAGE = 'If this problem persists, we recommend restarting your robot and waiting 30 seconds before trying again. '
+
+const CONTACT_SUPPORT_MESSAGE = "If you're still unable to connect, please contact our support team"
+
+export default function ConnectAlertModal (props: Props) {
+  const {onCloseClick} = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      onCloseClick={onCloseClick}
+      buttons={[
+        {onClick: onCloseClick, children: 'close'}
+      ]}
+    >
+      <p>
+        {TRY_AGAIN_MESSAGE}
+        {CONTACT_SUPPORT_MESSAGE}
+      </p>
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -6,6 +6,7 @@ import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
 import ConnectivityCard from './ConnectivityCard'
+import ConnectAlertModal from './ConnectAlertModal'
 import styles from './styles.css'
 
 type Props = Robot
@@ -24,3 +25,5 @@ export default function RobotSettings (props: Props) {
     </div>
   )
 }
+
+export {ConnectAlertModal}

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -19,6 +19,10 @@ const tagForRobotApi = (action) => ({...action, meta: {robotCommand: true}})
 
 type Error = {message: string}
 
+export type ClearConnectResponseAction = {|
+  type: 'robot:CLEAR_CONNECT_RESPONSE'
+|}
+
 export type ConfirmProbedAction = {|
   type: 'robot:CONFIRM_PROBED',
   payload: Mount
@@ -129,6 +133,7 @@ export const actionTypes = {
 
 // TODO(mc, 2018-01-23): NEW ACTION TYPES GO HERE
 export type Action =
+  | ClearConnectResponseAction
   | ConfirmProbedAction
   | PipetteCalibrationAction
   | LabwareCalibrationAction
@@ -155,6 +160,10 @@ export const actions = {
     if (didError) return {...action, payload: error}
 
     return tagForAnalytics(action)
+  },
+
+  clearConnectResponse (): ClearConnectResponseAction {
+    return {type: 'robot:CLEAR_CONNECT_RESPONSE'}
   },
 
   disconnect () {

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -12,7 +12,7 @@ import type {
 
 import type {RobotService} from '../types'
 
-import {actionTypes} from '../actions'
+import {actionTypes, type ClearConnectResponseAction} from '../actions'
 
 type State = {
   isScanning: boolean,
@@ -69,8 +69,14 @@ export default function connectionReducer (
     case DISCONNECT: return handleDisconnect(state, action)
     case DISCONNECT_RESPONSE: return handleDisconnectResponse(state, action)
 
-    case 'api:HEALTH_SUCCESS': return maybeDiscoverWired(state, action)
-    case 'api:HEALTH_FAILURE': return maybeRemoveWired(state, action)
+    case 'robot:CLEAR_CONNECT_RESPONSE':
+      return handleClearConnectResponse(state, action)
+
+    case 'api:HEALTH_SUCCESS':
+      return maybeDiscoverWired(state, action)
+
+    case 'api:HEALTH_FAILURE':
+      return maybeRemoveWired(state, action)
   }
 
   return state
@@ -168,6 +174,13 @@ function handleDisconnectResponse (state, action: any) {
   }
 
   return {...state, connectedTo, disconnectRequest: {error, inProgress: false}}
+}
+
+function handleClearConnectResponse (
+  state: State,
+  action: ClearConnectResponseAction
+): State {
+  return {...state, connectRequest: INITIAL_STATE.connectRequest}
 }
 
 function maybeDiscoverWired (state: State, action: HealthSuccessAction): State {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -76,9 +76,13 @@ export const getDiscovered = createSelector(
   }
 )
 
+export function getConnectRequest (state: State) {
+  return connection(state).connectRequest
+}
+
 export const getConnectionStatus = createSelector(
   (state: State) => connection(state).connectedTo,
-  (state: State) => connection(state).connectRequest.inProgress,
+  (state: State) => getConnectRequest(state).inProgress,
   (state: State) => connection(state).disconnectRequest.inProgress,
   (connectedTo, isConnecting, isDisconnecting): ConnectionStatus => {
     if (!connectedTo && isConnecting) return 'connecting'

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -66,6 +66,12 @@ describe('robot actions', () => {
     expect(actions.connectResponse(new Error('AH'))).toEqual(failure)
   })
 
+  test('CLEAR_CONNECT_RESPONSE action', () => {
+    const expected = {type: 'robot:CLEAR_CONNECT_RESPONSE'}
+
+    expect(actions.clearConnectResponse()).toEqual(expected)
+  })
+
   test('DISCONNECT action', () => {
     const expected = {
       type: actionTypes.DISCONNECT,

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -80,6 +80,26 @@ describe('robot reducer - connection', () => {
     })
   })
 
+  test('handles CLEAR_CONNECT_RESPONSE action', () => {
+    const state = {
+      connection: {
+        connectedTo: '',
+        connectRequest: {
+          inProgress: false,
+          error: new Error('AH'),
+          name: 'ot'
+        }
+      }
+    }
+
+    const action = {type: 'robot:CLEAR_CONNECT_RESPONSE', error: false}
+
+    expect(getState(reducer(state, action))).toEqual({
+      connectedTo: '',
+      connectRequest: {inProgress: false, error: null, name: ''}
+    })
+  })
+
   test('handles CONNECT_RESPONSE failure', () => {
     const state = {
       connection: {


### PR DESCRIPTION
## overview

This PR closes #826 by adding an AlertModal to the RobotSettings component that will display if a connect attempt fails.

![2018-02-20 18 50 01](https://user-images.githubusercontent.com/2963448/36455612-e581233e-166e-11e8-92f7-94eb9c0397b1.gif)

## changelog

- Feature: Added ConnectAlertModal to display a message if a robot connection fails

## review requests

Standard review
