### PR TITLE
fix(complib): Do not allow flexbox to shrink the side panel

### DIFF
--- a/components/src/structure/SidePanel.css
+++ b/components/src/structure/SidePanel.css
@@ -5,7 +5,7 @@
 }
 
 .panel {
-  box-sizing: border-box;
+  flex-shrink: 0;
   overflow: hidden;
   border-right: var(--bd-light);
   background-color: var(--c-bg-light);


### PR DESCRIPTION
## overview

This PR closes #886 by preventing `display: flex` from shrinking the side panel.

## changelog

- Fix: Added `flex-shrink: 0` to the SidePanel CSS rules

## review requests

Should be a simple review. As an aside, I'm not sure why the Run App uses `display: flex` for the whole page in the first place, so we should investigate that.
