### PR TITLE
fix(complib): Use default offset of (0,0) if missing from container

### DIFF
--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -75,7 +75,7 @@ export default class Plate extends React.Component<PlateProps> {
     }
 
     const infoForContainerType = defaultContainers.containers[containerType]
-    const originOffset = infoForContainerType['origin-offset']
+    const originOffset = infoForContainerType['origin-offset'] || {x: 0, y: 0}
     const containerLocations = infoForContainerType.locations
     const firstWell: wellDims = containerLocations['A1']
 


### PR DESCRIPTION
## overview

Fixes #890. The protocol attached to that ticket blew up the deck map in the app because it uses the `point` container type, which has no `origin-offset` in `default-containers.json`. @IanLondon I'm not sure how "correct" this fix is, but it does stop everything from exploding.

## changelog

- Fix: added a default `originOffset` of `{x: 0, y: 0}` to the `Plate` component if it can't find one in the labware definition file

## review requests

@IanLondon could you verify this doesn't cause problems with PD?
