### PR TITLE
Add about page

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -22,7 +22,6 @@ export default function App () {
       <NavPanel />
       <Switch>
         <Route exact path='/' component={Home} />
-        <Route exact path='/menu' component={Home} />
         <Route exact path='/menu/app' component={AppSettingsPage} />
         <Route path='/robots/:name?' component={Robots} />
         <Route path='/upload' component={Upload} />

--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -6,6 +6,7 @@ import NavBar from './nav-bar'
 
 import Home from '../pages/Home'
 import Robots from '../pages/Robots'
+import AppSettingsPage from '../pages/AppSettings'
 import Upload from '../pages/Upload'
 import SetupInstruments from '../pages/SetupInstruments'
 import SetupDeck from '../pages/SetupDeck'
@@ -21,6 +22,8 @@ export default function App () {
       <NavPanel />
       <Switch>
         <Route exact path='/' component={Home} />
+        <Route exact path='/menu' component={Home} />
+        <Route exact path='/menu/app' component={AppSettingsPage} />
         <Route path='/robots/:name?' component={Robots} />
         <Route path='/upload' component={Upload} />
         <Route path='/setup-instruments/:mount' component={SetupInstruments} />

--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -1,0 +1,26 @@
+// @flow
+// App info card with version and updated
+// TODO (ka 2018-2-22): make this a container once app info and update action are in place.
+import * as React from 'react'
+
+import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
+
+import {version} from '../../../../package.json'
+
+const TITLE = 'Information'
+const VERSION_LABEL = 'Software Version'
+const VERSION_VALUE = version
+
+export default function StatusCard () {
+  return (
+    <Card title={TITLE}>
+      <LabeledValue
+        label={VERSION_LABEL}
+        value={VERSION_VALUE}
+      />
+      <OutlineButton disabled>
+        updated
+      </OutlineButton>
+    </Card>
+  )
+}

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -1,0 +1,13 @@
+// @flow
+// app status panel with connect button
+import * as React from 'react'
+import AppInfoCard from './AppInfoCard'
+import styles from './styles.css'
+
+export default function AppSettings () {
+  return (
+    <div className={styles.app_settings}>
+      <AppInfoCard />
+    </div>
+  )
+}

--- a/app/src/components/AppSettings/styles.css
+++ b/app/src/components/AppSettings/styles.css
@@ -1,0 +1,6 @@
+/* stylesheet for AppSettings components */
+@import '@opentrons/components';
+
+.app_settings {
+  padding: 1.5rem;
+}

--- a/app/src/components/menu-panel/index.js
+++ b/app/src/components/menu-panel/index.js
@@ -1,0 +1,19 @@
+// @flow
+import * as React from 'react'
+
+import {ListItem, Icon, CHEVRON_RIGHT} from '@opentrons/components'
+
+import styles from './styles.css'
+
+export default function MenuPanel () {
+  return (
+    <div className={styles.menu_panel}>
+      <ol>
+        <ListItem className={styles.menu_item} url={'/menu/app'} activeClassName={styles.active}>
+          <span>App</span>
+          <Icon name={CHEVRON_RIGHT} className={styles.menu_icon}/>
+        </ListItem>
+      </ol>
+    </div>
+  )
+}

--- a/app/src/components/menu-panel/styles.css
+++ b/app/src/components/menu-panel/styles.css
@@ -1,0 +1,32 @@
+@import '@opentrons/components';
+
+.menu_panel {
+  & > * {
+    margin: 0.5rem 0 1.5rem;
+  }
+}
+
+.menu_list {
+  list-style: none;
+  margin-left: 0;
+}
+
+.menu_item {
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  font-size: var(--fs-body-2);
+
+  & > span {
+    width: 100%;
+  }
+}
+
+.menu_icon {
+  width: 1.5rem;
+}
+
+.active {
+  color: #0ec9eb;
+  fill: #0ec9eb;
+  background-color: #f0f3ff;
+}

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -11,7 +11,7 @@ import {
   constants as robotConstants
 } from '../../robot'
 
-import {NavButton, FILE, COG, CONNECT} from '@opentrons/components'
+import {NavButton, FILE, COG, CONNECT, MORE} from '@opentrons/components'
 
 export default connect(mapStateToProps, null, mergeProps)(NavButton)
 
@@ -35,6 +35,9 @@ function mapStateToProps (state, ownProps) {
     iconName = COG
   } else if (name === 'connect') {
     iconName = CONNECT
+  } else if (name === 'more') {
+    iconName = MORE
+    isBottom = true
   }
 
   return {

--- a/app/src/components/side-panel/index.js
+++ b/app/src/components/side-panel/index.js
@@ -15,6 +15,7 @@ import {SidePanel} from '@opentrons/components'
 import ConnectPanel from '../connect-panel'
 import UploadPanel from '../upload-panel'
 import SetupPanel from '../setup-panel'
+import MenuPanel from '../menu-panel'
 
 export default withRouter(
   connect(mapStateToProps, mapDispatchToProps)(NavPanel)
@@ -23,7 +24,8 @@ export default withRouter(
 const PANELS_BY_NAME = {
   connect: ConnectPanel,
   upload: UploadPanel,
-  setup: SetupPanel
+  setup: SetupPanel,
+  more: MenuPanel
 }
 
 NavPanel.propTypes = {

--- a/app/src/interface/index.js
+++ b/app/src/interface/index.js
@@ -8,11 +8,12 @@ import {actionTypes as robotActionTypes} from '../robot/actions'
 export const NAME = 'interface'
 const META_ALERT = `${NAME}:alert`
 
-export const PANEL_NAMES = ['connect', 'upload', 'setup']
+export const PANEL_NAMES = ['connect', 'upload', 'setup', 'more']
 export const PANEL_PROPS_BY_NAME = {
   upload: {title: 'Open Protocol'},
   setup: {title: 'Prepare for Run'},
-  connect: {title: 'Robots'}
+  connect: {title: 'Robots'},
+  more: {title: 'Menu'}
 }
 const DEFAULT_PANEL = 'connect'
 

--- a/app/src/pages/AppSettings.js
+++ b/app/src/pages/AppSettings.js
@@ -1,0 +1,13 @@
+// @flow
+// view info about the app and update
+import React from 'react'
+import Page from '../components/Page'
+import AppSettings from '../components/AppSettings'
+
+export default function AppSettingsPage () {
+  return (
+    <Page>
+      <AppSettings />
+    </Page>
+  )
+}

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -35,6 +35,7 @@ export const MENU_DOWN = 'menu down'
 export const MOVE = 'move'
 export const PLUS = 'plus'
 export const COPY = 'copy'
+export const MORE = 'more'
 
 // icon data
 const ICON_DATA_BY_NAME = {
@@ -169,6 +170,10 @@ const ICON_DATA_BY_NAME = {
   [COPY]: {
     viewBox: '0 0 24 24',
     path: 'M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z'
+  },
+  [MORE]: {
+    viewBox: '0 0 24 24',
+    path: 'M5.5 10A2.5 2.5 0 1 1 3 12.5 2.5 2.5 0 0 1 5.5 10zm7 0a2.5 2.5 0 1 1-2.5 2.5 2.5 2.5 0 0 1 2.5-2.5zm7 0a2.5 2.5 0 1 1-2.5 2.5 2.5 2.5 0 0 1 2.5-2.5z'
   }
 }
 

--- a/components/src/lists/ListItem.js
+++ b/components/src/lists/ListItem.js
@@ -17,7 +17,7 @@ type ListItemProps = {
   /** Additional class name */
   className?: string,
   /** if disabled, the onClick handler / NavLink will be disabled */
-  isDisabled: boolean,
+  isDisabled?: boolean,
   /** name constant of the icon to display */
   iconName?: IconName,
   children: React.Node


### PR DESCRIPTION
## overview
closes #808, addresses #809.

This PR adds 'more' button to the bottom of the `NavBar`, adds a `MenuPanel` to `Sidebar` with its first menu item for App page. App page for now renders a card with a placeholder version from `package.json` and renders disabled update button with the text 'updated'.

<img width="800" alt="about page" src="https://user-images.githubusercontent.com/3430313/36556243-8a74f398-17d2-11e8-98b4-4a70f0edb7fa.png">

## changelog

- Add more icon to complib
- Make disabled optional param for list-item
- Update navbar to have more tab on bottom
- Add MenuPanel to sidebar
- Add App list item to MenuPanel
- Create AppSettingsPage with AppInfoCard with placeholder version and disabled update button
  - Hitting route '/menu' defaults to splash page
  - Hitting route '/menu/app' loads AppSettingsPage

## review requests
Standard review, I tried to follow the same patterns as RobotSettings page.
