### PR TITLE
feat(app): Add wifi configuration to ConnectivityCard

### DIFF
--- a/app/src/components/RobotSettings/ConfigureWifiForm.js
+++ b/app/src/components/RobotSettings/ConfigureWifiForm.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from 'react'
+
+import {OutlineButton, type DropdownOption} from '@opentrons/components'
+import type {FormProps, InputProps} from './inputs'
+import {Form, Select, TextInput} from './inputs'
+import styles from './styles.css'
+
+type Props = {
+  wired: ?boolean,
+  ssid: ?string,
+  psk: ?string,
+  activeSsid: ?string,
+  networks: Array<DropdownOption>,
+  onChange: $PropertyType<InputProps<*>, 'onChange'>,
+  onSubmit: $PropertyType<FormProps, 'onSubmit'>,
+}
+
+export default function ConfigureWifiForm (props: Props) {
+  const {
+    wired,
+    ssid,
+    psk,
+    activeSsid,
+    networks,
+    onChange,
+    onSubmit
+  } = props
+
+  const disabled = !wired || !ssid || !psk || (ssid === activeSsid)
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      disabled={disabled}
+      className={styles.configure_form}
+    >
+      <label className={styles.configure_label}>
+        {'WiFi network:'}
+        <Select
+          name='ssid'
+          value={ssid || activeSsid}
+          options={networks}
+          disabled={!wired}
+          onChange={onChange}
+          className={styles.configure_input}
+        />
+      </label>
+      <label className={styles.configure_label}>
+        {'Password:'}
+        <TextInput
+          type='password'
+          name='psk'
+          value={psk}
+          disabled={!wired}
+          onChange={onChange}
+          className={styles.configure_input}
+        />
+      </label>
+      <OutlineButton
+        type='submit'
+        disabled={disabled}
+        className={styles.configure_button}
+      >
+        Join
+      </OutlineButton>
+    </Form>
+  )
+}

--- a/app/src/components/RobotSettings/inputs.js
+++ b/app/src/components/RobotSettings/inputs.js
@@ -1,0 +1,101 @@
+// @flow
+// input component convenience wrappers
+// TODO(mc, 2018): hopefully merge some of this functionality into components
+//   library so this file isn't necessary
+import * as React from 'react'
+
+import {
+  InputField,
+  DropdownField,
+  type DropdownOption
+} from '@opentrons/components'
+
+export type FormProps = {
+  onSubmit: () => *,
+  disabled?: boolean,
+  children: React.Node,
+  className?: string,
+}
+
+export type InputProps<T> = {
+  name: T,
+  value: ?string,
+  disabled: ?boolean,
+  onChange: ({[name: T]: string}) => *,
+  className?: string,
+}
+
+type SelectProps<T> = InputProps<T> & {
+  options: Array<DropdownOption>
+}
+
+type TextInputProps<T> = InputProps<T> & {
+  type: 'text' | 'password'
+}
+
+export class Form extends React.Component<FormProps> {
+  onSubmit = (event: SyntheticEvent<>) => {
+    this.props.onSubmit()
+    event.preventDefault()
+  }
+
+  render () {
+    const onSubmit = !this.props.disabled
+      ? this.onSubmit
+      : undefined
+
+    return (
+      <form onSubmit={onSubmit} className={this.props.className}>
+        {this.props.children}
+      </form>
+    )
+  }
+}
+
+export class Select<T: string> extends React.Component<SelectProps<T>> {
+  onChange = (event: SyntheticInputEvent<>) => {
+    if (!this.props.disabled) {
+      this.props.onChange({
+        [this.props.name]: event.target.value
+      })
+    }
+  }
+
+  render () {
+    const {value, options, disabled, className} = this.props
+
+    return (
+      <DropdownField
+        value={value}
+        options={options}
+        disabled={disabled}
+        onChange={this.onChange}
+        className={className}
+      />
+    )
+  }
+}
+
+export class TextInput<T: string> extends React.Component<TextInputProps<T>> {
+  onChange = (event: SyntheticInputEvent<>) => {
+    if (!this.props.disabled) {
+      this.props.onChange({
+        [this.props.name]: event.target.value
+      })
+    }
+  }
+
+  render () {
+    const {type, value, disabled, className} = this.props
+
+    return (
+      <InputField
+        type={type}
+        value={value}
+        disabled={disabled}
+        onChange={this.onChange}
+        className={className}
+      />
+    )
+  }
+}

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -23,3 +23,29 @@
     margin-right: var(--robot_settings_card_spacing);
   }
 }
+
+.configure_form {
+  margin-top: 1rem;
+}
+
+.configure_label {
+  @apply --font-body-2-dark;
+
+  margin-bottom: 0.5rem;
+  font-weight: var(--fw-semibold);
+}
+
+.configure_input {
+  margin-top: 0.25rem;
+
+  /* TODO(mc, 2018-02-22): refactor so these nested styles aren't needed */
+  & input,
+  & select {
+    @apply --font-body-2-dark;
+  }
+}
+
+.configure_button {
+  float: right;
+  margin-top: 0.5rem;
+}

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -120,7 +120,30 @@ describe('wifi', () => {
     })
   })
 
-  describe('setConfigureWifiBody and configureWifi action creators', () => {
+  describe('setConfigureWifiBody action creator', () => {
+    const ssid = 'some-ssid'
+    const psk = 'some-psk'
+
+    test('works with ssid', () => {
+      const expected = {
+        type: 'api:SET_CONFIGURE_WIFI_BODY',
+        payload: {robot, update: {ssid}}
+      }
+
+      expect(setConfigureWifiBody(robot, {ssid})).toEqual(expected)
+    })
+
+    test('works with psk', () => {
+      const expected = {
+        type: 'api:SET_CONFIGURE_WIFI_BODY',
+        payload: {robot, update: {psk}}
+      }
+
+      expect(setConfigureWifiBody(robot, {psk})).toEqual(expected)
+    })
+  })
+
+  describe('configureWifi action creator', () => {
     const ssid = 'some-ssid'
     const psk = 'some-psk'
     const response = {ssid, message: 'Success!'}
@@ -136,16 +159,7 @@ describe('wifi', () => {
       }
     }
 
-    test('setConfigureWifiBody creator works', () => {
-      const expected = {
-        type: 'api:SET_CONFIGURE_WIFI_BODY',
-        payload: {robot, ssid, psk}
-      }
-
-      expect(setConfigureWifiBody(robot, ssid, psk)).toEqual(expected)
-    })
-
-    test('configureWifi calls POST /wifi/configure', () => {
+    test('configureWifi calls POST /wifi/configure, GET /wifi/list', () => {
       const store = mockStore(initialState)
 
       client.__setMockResponse(response)
@@ -154,7 +168,7 @@ describe('wifi', () => {
         .then(() => expect(client).toHaveBeenCalledWith(
           robot,
           'POST',
-          '/wifi/configure',
+          'wifi/configure',
           {ssid, psk}
         ))
     })
@@ -391,7 +405,7 @@ describe('wifi', () => {
 
       const action = {
         type: 'api:SET_CONFIGURE_WIFI_BODY',
-        payload: {robot, ssid: 'baz', psk: 'qux'}
+        payload: {robot, update: {ssid: 'baz', psk: 'qux'}}
       }
 
       expect(reducer(state, action).wifi).toEqual({

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -72,8 +72,10 @@ export type SetConfigureWifiBodyAction = {|
   type: 'api:SET_CONFIGURE_WIFI_BODY',
   payload: {|
     robot: RobotService,
-    ssid: Ssid,
-    psk: Psk,
+    update: {
+      ssid?: Ssid,
+      psk?: Psk
+    }
   |}
 |}
 
@@ -119,10 +121,9 @@ export function fetchWifiStatus (robot: RobotService): ThunkAction {
 
 export function setConfigureWifiBody (
   robot: RobotService,
-  ssid: Ssid,
-  psk: Psk
+  update: {ssid?: Ssid, psk?: Psk}
 ): SetConfigureWifiBodyAction {
-  return {type: 'api:SET_CONFIGURE_WIFI_BODY', payload: {robot, ssid, psk}}
+  return {type: 'api:SET_CONFIGURE_WIFI_BODY', payload: {robot, update}}
 }
 
 export function configureWifi (robot: RobotService): ThunkAction {
@@ -137,7 +138,7 @@ export function configureWifi (robot: RobotService): ThunkAction {
 
     dispatch(wifiRequest(robot, CONFIGURE_PATH))
 
-    return client(robot, 'POST', `/wifi/${CONFIGURE_PATH}`, body)
+    return client(robot, 'POST', `wifi/${CONFIGURE_PATH}`, body)
       .then((resp) => dispatch(wifiSuccess(robot, CONFIGURE_PATH, resp)))
       .catch((error) => dispatch(wifiFailure(robot, CONFIGURE_PATH, error)))
   }
@@ -247,15 +248,19 @@ function reduceSetConfigureWifiBody (
   state: WifiState,
   action: SetConfigureWifiBodyAction
 ): WifiState {
-  const {payload: {ssid, psk, robot: {name}}} = action
+  const {payload: {update, robot: {name}}} = action
   const stateByName = state[name] || {}
   const configureState = stateByName.configure || {}
+  const requestState = configureState.request || {}
 
   return {
     ...state,
     [name]: {
       ...stateByName,
-      configure: {...configureState, request: {ssid, psk}}
+      configure: {
+        ...configureState,
+        request: {...requestState, ...update}
+      }
     }
   }
 }

--- a/components/src/__tests__/__snapshots__/buttons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/buttons.test.js.snap
@@ -6,6 +6,7 @@ exports[`buttons Button renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   children
 </button>
@@ -17,6 +18,7 @@ exports[`buttons Button with iconName renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   <svg
     aria-hidden="true"
@@ -44,6 +46,7 @@ exports[`buttons FlatButton renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   children
 </button>
@@ -55,6 +58,7 @@ exports[`buttons FlatButton with iconName renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   <svg
     aria-hidden="true"
@@ -82,6 +86,7 @@ exports[`buttons IconButton renders correctly 1`] = `
   disabled={true}
   onClick={undefined}
   title="t"
+  type="button"
 >
   <svg
     aria-hidden="true"
@@ -108,6 +113,7 @@ exports[`buttons Inverted OutlineButton renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   children
 </button>
@@ -119,6 +125,7 @@ exports[`buttons OutlineButton renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   children
 </button>
@@ -130,6 +137,7 @@ exports[`buttons OutlineButton with iconName renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   <svg
     aria-hidden="true"
@@ -157,6 +165,7 @@ exports[`buttons PrimaryButton renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   children
 </button>
@@ -168,6 +177,7 @@ exports[`buttons PrimaryButton with iconName renders correctly 1`] = `
   disabled={undefined}
   onClick={[Function]}
   title="t"
+  type="button"
 >
   <svg
     aria-hidden="true"

--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -78,7 +78,7 @@ exports[`CheckboxField renders correctly when unchecked 1`] = `
 
 exports[`DropdownField renders correctly with a falsey value 1`] = `
 <div
-  className={undefined}
+  className="foo"
 >
   <div
     className="dropdown_field"
@@ -140,7 +140,7 @@ exports[`DropdownField renders correctly with a falsey value 1`] = `
 
 exports[`DropdownField renders correctly with a value 1`] = `
 <div
-  className={undefined}
+  className="foo"
 >
   <div
     className="dropdown_field"
@@ -222,7 +222,9 @@ exports[`InputField renders correctly 1`] = `
   >
     Input field
   </div>
-  <div>
+  <div
+    className="input_field_container"
+  >
     <div
       className="input_field"
     >

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -29,6 +29,7 @@ exports[`modals AlertModal renders correctly 1`] = `
         disabled={undefined}
         onClick={[Function]}
         title={undefined}
+        type="button"
       >
         a
       </button>
@@ -37,6 +38,7 @@ exports[`modals AlertModal renders correctly 1`] = `
         disabled={undefined}
         onClick={[Function]}
         title={undefined}
+        type="button"
       >
         b
       </button>
@@ -69,6 +71,7 @@ exports[`modals ContinueModal renders correctly 1`] = `
         disabled={undefined}
         onClick={[Function]}
         title="Cancel"
+        type="button"
       >
         Cancel
       </button>
@@ -77,6 +80,7 @@ exports[`modals ContinueModal renders correctly 1`] = `
         disabled={undefined}
         onClick={[Function]}
         title="Continue"
+        type="button"
       >
         Continue
       </button>

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -103,6 +103,7 @@ exports[`SidePanel renders SidePanel correctly 1`] = `
       disabled={undefined}
       onClick={[Function]}
       title="close panel"
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -139,6 +140,7 @@ exports[`TitleBar renders TitleBar with back button correctly 1`] = `
     disabled={undefined}
     onClick={[Function]}
     title="back"
+    type="button"
   >
     <svg
       aria-hidden="true"

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -20,9 +20,14 @@ export type ButtonProps = {
   inverted?: boolean,
   /** contents of the button */
   children?: React.Node,
+  /** type of button (default "button") */
+  type?: 'submit' | 'reset' | 'button',
   /** custom element or component to use instead of `<button>` */
-  Component?: React.ElementType
+  Component?: React.ElementType,
 }
+
+// props to strip if using a custom component
+const STRIP_PROPS = ['inverted', 'iconName', 'children', 'Component']
 
 /**
  * Basic, unstyled button. You probably want to use a styled button
@@ -37,11 +42,12 @@ export default function Button (props: ButtonProps) {
   const {title, disabled, className} = props
   const onClick = !disabled ? props.onClick : undefined
   const Component = props.Component || 'button'
+  const type = props.type || 'button'
 
   // pass all props if using a custom component
   const buttonProps = !props.Component
-    ? {title, disabled, onClick, className}
-    : {...omit(props, ['iconName', 'children', 'Component']), onClick}
+    ? {type, title, disabled, onClick, className}
+    : {...omit(props, STRIP_PROPS), onClick}
 
   return (
     <Component {...buttonProps}>

--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -1,18 +1,23 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
+
 import {Icon} from '..'
 import styles from './forms.css'
 
+export type DropdownOption = {
+  name: string,
+  value: string,
+}
+
+// TODO(mc, 2018-02-22): disabled prop
 type Props = {
   /** change handler */
-  onChange: (event: SyntheticEvent<>) => void,
+  onChange: (event: SyntheticInputEvent<*>) => void,
   /** value that is selected */
-  value?: string,
+  value?: ?string,
   /** Array of {name, value} data */
-  options: Array<{
-    name: string,
-    value: string
-  }>,
+  options: Array<DropdownOption>,
   /** classes to apply */
   className?: string,
   /** optional caption. hidden when `error` is given */
@@ -28,9 +33,10 @@ export default function DropdownField (props: Props) {
     : [{name: '', value: ''}, ...props.options]
 
   const error = props.error != null
+  const className = cx(props.className, {[styles.error]: error})
 
   return (
-    <div className={error ? styles.error : undefined}>
+    <div className={className}>
       <div className={styles.dropdown_field}>
         <select value={props.value || ''} onChange={props.onChange} className={styles.dropdown}>
           {options.map(opt =>

--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -5,9 +5,10 @@ import {Icon} from '../icons'
 // import globalStyles from '../styles/index.css'
 import styles from './forms.css'
 
+// TODO(mc, 2018-02-22): disabled prop
 type Props = {
   /** change handler */
-  onChange: (event: SyntheticEvent<>) => void,
+  onChange: (event: SyntheticInputEvent<*>) => void,
   /** classes to apply */
   className?: string,
   /** inline label text */
@@ -17,19 +18,33 @@ type Props = {
   /** optional units string, appears to the right of input text */
   units?: string,
   /** current value of text in box, defaults to '' */
-  value?: string,
+  value?: ?string,
   /** if included, InputField will use error style and display error instead of caption */
   error?: ?string,
   /** optional caption. hidden when `error` is given */
   caption?: string,
   /** appears to the right of the caption. Used for character limits, eg '0/45' */
-  secondaryCaption?: string
+  secondaryCaption?: string,
+  /** optional input type (default "text") */
+  type?: 'text' | 'password'
 }
 
 export default function InputField (props: Props) {
   const error = props.error != null
+  const labelClass = cx(styles.form_field, props.className, {
+    [styles.error]: error
+  })
+
+  if (!props.label) {
+    return (
+      <div className={labelClass}>
+        <Input {...props} />
+      </div>
+    )
+  }
+
   return (
-    <label className={cx(styles.form_field, props.className, {[styles.error]: error})}>
+    <label className={labelClass}>
       <div className={styles.label_text}>
         {props.label && error &&
           <div className={styles.error_icon}>
@@ -38,21 +53,30 @@ export default function InputField (props: Props) {
         }
         {props.label}
       </div>
-      <div>
-        <div className={styles.input_field}>
-          <input
-            type='text' /* TODO: support number ? */
-            value={props.value || ''}
-            placeholder={props.placeholder}
-            onChange={props.onChange}
-          />
-          {props.units && <div className={styles.suffix}>{props.units}</div>}
-        </div>
-        <div className={styles.input_caption}>
-          <span>{error ? props.error : props.caption}</span>
-          <span className={styles.right}>{props.secondaryCaption}</span>
-        </div>
-      </div>
+      <Input {...props} />
     </label>
+  )
+}
+
+// TODO(mc, 2018-02-21): maybe simplify further and split out?
+function Input (props: Props) {
+  const error = props.error != null
+
+  return (
+    <div className={styles.input_field_container}>
+      <div className={styles.input_field}>
+        <input
+          type={props.type || 'text'}
+          value={props.value || ''}
+          placeholder={props.placeholder}
+          onChange={props.onChange}
+        />
+        {props.units && <div className={styles.suffix}>{props.units}</div>}
+      </div>
+      <div className={styles.input_caption}>
+        <span>{error ? props.error : props.caption}</span>
+        <span className={styles.right}>{props.secondaryCaption}</span>
+      </div>
+    </div>
   )
 }

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -45,6 +45,10 @@
   }
 }
 
+.input_field_container {
+  width: 100%;
+}
+
 .input_field {
   display: flex;
   flex: 1 1;
@@ -58,6 +62,9 @@
     border: none;
     flex: 1 1 auto;
     color: var(--c-dark-gray);
+
+    /* add 1px padding that is present in chrome but not ff */
+    padding: 1px;
   }
 
   & input:focus {

--- a/components/src/forms/index.js
+++ b/components/src/forms/index.js
@@ -5,6 +5,8 @@ import FormGroup from './FormGroup'
 import InputField from './InputField'
 import RadioGroup from './RadioGroup'
 
+export * from './DropdownField'
+
 export {
   CheckboxField,
   DropdownField,

--- a/protocol-designer/src/components/StepEditForm.js
+++ b/protocol-designer/src/components/StepEditForm.js
@@ -7,7 +7,8 @@ import {
   DropdownField,
   CheckboxField,
   InputField,
-  RadioGroup
+  RadioGroup,
+  type DropdownOption
 } from '@opentrons/components'
 
 import FormSection from './FormSection'
@@ -16,10 +17,7 @@ import type {FormData, FormSectionNames, FormSectionState} from '../steplist/typ
 
 import {formConnectorFactory} from '../utils'
 
-type Options = Array<{
-  name: string,
-  value: string
-}>
+type Options = Array<DropdownOption>
 
 export type Props = {
   // ingredientOptions: Options,


### PR DESCRIPTION
## overview

This PR addresses checkbox 2 of #698 by adding a wifi configuration form to the ConnectivityCard

![2018-02-22 15 08 56](https://user-images.githubusercontent.com/2963448/36561692-80f2bff2-17e2-11e8-984d-7750c710f38b.gif)

## changelog

- Feature: added ConfigureWifiForm to ConnectifyCard to allow setting the WiFi network of a robot

## review requests

Standard review. A few things to note:

- @IanLondon this PR touches a few of the input components in complib pretty lightly
    - I gave PD a once over and everything seemed OK, but can you double check?
- The WiFi form is disabled if the robot is not wired
    - **It won't work with `make -C api dev`**
    - Still TODO: actually showing this disabled state in the UI with instruction on how to enable it
- Still TODO: indication of "request in progress"
    - Soft plan: spinner in the top right corner of the card and disable form