### PR TITLE
feat(api): Add robot name to GET /health

### DIFF
--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -9,9 +9,15 @@ from opentrons import robot, __version__
 log = logging.getLogger(__name__)
 ENABLE_NMCLI = os.environ.get('ENABLE_NETWORKING_ENDPOINTS', '')
 
+# TODO(mc, 2018-02-22): this naming logic is copied instead of shared
+#   from compute/scripts/anounce_mdns.py
+NAME = 'opentrons-{}'.format(
+    os.environ.get('RESIN_DEVICE_NAME_AT_INIT', 'dev'))
+
 
 async def health(request):
     res = {
+        'name': NAME,
         'api_version': __version__,
         'fw_version': robot.fw_version
     }

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -1,0 +1,18 @@
+import json
+from opentrons import __version__
+from opentrons.server.main import init
+
+
+async def test_health(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    expected = json.dumps({
+        'name': 'opentrons-dev',
+        'api_version': __version__,
+        'fw_version': 'Virtual Smoothie'
+    })
+    resp = await cli.get('/health')
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected

--- a/app/src/http-api-client/__tests__/health.test.js
+++ b/app/src/http-api-client/__tests__/health.test.js
@@ -10,7 +10,9 @@ jest.mock('../client')
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
-const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+const name = 'opentrons-dev'
+const robot = {name, ip: '1.2.3.4', port: '1234'}
+const health = {name, api_version: '1.2.3', fw_version: '4.5.6'}
 
 describe('health', () => {
   beforeEach(() => client.__clearMock())
@@ -19,10 +21,10 @@ describe('health', () => {
     const state = {
       api: {
         health: {
-          opentrons: {
+          [name]: {
             inProgress: true,
             error: null,
-            response: {api_version: '1.2.3', fw_version: '4.5.6'}
+            response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
           }
         }
       }
@@ -32,8 +34,6 @@ describe('health', () => {
   })
 
   test('fetchHealth calls GET /health', () => {
-    const health = {api_version: '1.2.3', fw_version: '4.5.6'}
-
     client.__setMockResponse(health)
 
     return fetchHealth(robot)(() => {})
@@ -41,7 +41,6 @@ describe('health', () => {
   })
 
   test('fetchHealth dispatches HEALTH_REQUEST and HEALTH_SUCCESS', () => {
-    const health = {api_version: '1.2.3', fw_version: '4.5.6'}
     const store = mockStore({})
     const expectedActions = [
       {type: 'api:HEALTH_REQUEST', payload: {robot}},
@@ -71,42 +70,42 @@ describe('health', () => {
   test('reducer handles HEALTH_REQUEST', () => {
     const state = {
       health: {
-        opentrons: {
+        [name]: {
           inProgress: false,
           error: new Error('AH'),
-          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
         }
       }
     }
     const action = {type: 'api:HEALTH_REQUEST', payload: {robot}}
 
     expect(reducer(state, action).health).toEqual({
-      opentrons: {
+      [name]: {
         inProgress: true,
         error: null,
-        response: {api_version: '1.2.3', fw_version: '4.5.6'}
+        response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
       }
     })
   })
 
   test('reducer handles HEALTH_SUCCESS', () => {
-    const health = {api_version: '4.5.6', fw_version: '7.8.9'}
+    const health = {name, api_version: '4.5.6', fw_version: '7.8.9'}
     const state = {
       health: {
-        opentrons: {
+        [name]: {
           inProgress: true,
           error: null,
-          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
         }
       }
     }
     const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
 
     expect(reducer(state, action).health).toEqual({
-      opentrons: {
+      [name]: {
         inProgress: false,
         error: null,
-        response: {api_version: '4.5.6', fw_version: '7.8.9'}
+        response: {name, api_version: '4.5.6', fw_version: '7.8.9'}
       }
     })
   })
@@ -115,20 +114,20 @@ describe('health', () => {
     const error = new Error('AH')
     const state = {
       health: {
-        opentrons: {
+        [name]: {
           inProgress: true,
           error: null,
-          response: {api_version: '1.2.3', fw_version: '4.5.6'}
+          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
         }
       }
     }
     const action = {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
 
     expect(reducer(state, action).health).toEqual({
-      opentrons: {
+      [name]: {
         inProgress: false,
         error,
-        response: {api_version: '1.2.3', fw_version: '4.5.6'}
+        response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
       }
     })
   })

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -7,6 +7,7 @@ import type {ApiCall} from './types'
 import client, {type ClientResponseError} from './client'
 
 type HealthInfo = {
+  name: string,
   api_version: string,
   fw_version: string,
 }


### PR DESCRIPTION
## overview

This PR is to support #698 by updating the /health endpoint with the robot name. This will allow the app to display the correct name when updating the WiFi network. Without it, it's very hard for the user to know which robot they're operating on when they're plugged in via ethernet.

## changelog

- Feature (API): Added robot name to /health endpoint
- Tests (Run App, API): Updated/added tests accordingly

## review requests

Standard review. Let me know if the health endpoint test is at all worth having