### PR TITLE
(complib) update Plate label styles

### DIFF
--- a/components/.babelrc
+++ b/components/.babelrc
@@ -7,7 +7,8 @@
     }
   },
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ],
   "presets": [
     "react",

--- a/components/interfaces/default-containers.json.js
+++ b/components/interfaces/default-containers.json.js
@@ -1,3 +1,5 @@
+import type {LabwareLocations} from '../src/labware-types'
+
 declare module './src/default-containers.json' {
   declare var containers: {
     [containerType: string]: {
@@ -5,16 +7,7 @@ declare module './src/default-containers.json' {
         x: number,
         y: number
       },
-      locations: {
-        [wellName: string]: {
-          x: number,
-          y: number,
-          z: number,
-          depth: number,
-          diameter: number,
-          'total-liquid-volume': number
-        }
-      }
+      locations: LabwareLocations
     }
   }
 }

--- a/components/src/deck/Plate.css
+++ b/components/src/deck/Plate.css
@@ -1,12 +1,13 @@
-@import '..';
+@import '@opentrons/components';
 
 .plate_label {
   pointer-events: none;
-  font-size: var(--fs-caption);
+  font-size: 0.325rem;
   text-anchor: middle;
 }
 
 .tiny_labels {
+  /* For 384 plate */
   font-size: 0.2rem;
 }
 

--- a/components/src/deck/Plate.css
+++ b/components/src/deck/Plate.css
@@ -2,13 +2,13 @@
 
 .plate_label {
   pointer-events: none;
-  font-size: 0.325rem;
+  font-size: var(--fs-tiny);
   text-anchor: middle;
 }
 
 .tiny_labels {
   /* For 384 plate */
-  font-size: 0.2rem;
+  font-size: var(--fs-micro);
 }
 
 .tiny_labels:nth-child(odd) {

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -10,6 +10,7 @@ import { SLOT_WIDTH, SLOT_HEIGHT } from './constants.js'
 
 import styles from './Plate.css'
 import Well from './Well'
+import type {LabwareLocations} from '../labware-types'
 
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
@@ -52,22 +53,15 @@ function FallbackPlate () {
   )
 }
 
-export default class Plate extends React.Component<PlateProps> {
-  constructor (props: PlateProps) {
-    super(props)
-    // TODO Ian 2017-12-12 A prettier way to bind `this` w/ flow still happy? https://github.com/facebook/flow/issues/1517
-    const self: any = this
-    self.createLabels = this.createLabels.bind(this)
-    self.createWell = this.createWell.bind(this)
-    self.getContainerData = this.getContainerData.bind(this)
-  }
+type LabwareData = {
+  originOffset: {x: number, y: number},
+  firstWell: wellDims,
+  containerLocations: LabwareLocations,
+  allWellNames: Array<string>
+}
 
-  getContainerData (): {
-    originOffset: {x: number, y: number},
-    firstWell: wellDims,
-    containerLocations: any,
-    allWellNames: Array<string>
-  } {
+export default class Plate extends React.Component<PlateProps> {
+  getContainerData = (): LabwareData => {
     const { containerType } = this.props
 
     if (!(containerType in defaultContainers.containers)) {
@@ -84,7 +78,7 @@ export default class Plate extends React.Component<PlateProps> {
     return { originOffset, firstWell, containerLocations, allWellNames }
   }
 
-  createWell (wellName: string) {
+  createWell = (wellName: string) => {
     const { selectable, wellContents } = this.props
     const { originOffset, firstWell, containerLocations } = this.getContainerData()
     const singleWellContents: singleWell = wellContents[wellName]
@@ -118,7 +112,7 @@ export default class Plate extends React.Component<PlateProps> {
     } />
   }
 
-  createLabels () {
+  createLabels = () => {
     const { originOffset, containerLocations, allWellNames } = this.getContainerData()
 
     const allWellsSplit = allWellNames.map(wellNameSplit)

--- a/components/src/labware-types.js
+++ b/components/src/labware-types.js
@@ -1,0 +1,17 @@
+// @flow
+export type LabwareLocations = {
+  [wellName: string]: {
+    x: number,
+    y: number,
+    z: number,
+
+    depth: number,
+
+    diameter?: number,
+
+    length?: number,
+    width?: number,
+
+    'total-liquid-volume': number
+  }
+}

--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -7,6 +7,8 @@
   --fs-body-2: 0.875rem;
   --fs-body-1: 0.75rem;
   --fs-caption: 0.625rem;
+  --fs-tiny: 0.325rem;
+  --fs-micro: 0.2rem;
   --fw-bold: 800;
   --fw-semibold: 600;
   --fw-regular: 400;


### PR DESCRIPTION
## overview

Plate labels became way too big with some style breakage a while back. This brings them back (and refactors types a bit)

![image](https://user-images.githubusercontent.com/11590381/36569350-7d975d72-17fb-11e8-9970-da9f193248dc.png)

Tiny wells for 384

![image](https://user-images.githubusercontent.com/11590381/36569363-89e17a72-17fb-11e8-9fd6-1956632df825.png)


## changelog

* Plate label font size fixed (both normal plates, and 384-format tiny labels)
* Add 'transform-class-properties' to `.babelrc` and refactor `Plate` to use this style instead of binding to `this` in constructor, which flow hates
* New `labware-types.js`, which will be moved into labware-definitions later?

## review requests
