### PR TITLE
refactor(app): Refactor HTTP API selectors for usability

### DIFF
--- a/app/src/http-api-client/__tests__/health.test.js
+++ b/app/src/http-api-client/__tests__/health.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 
 import client from '../client'
-import {fetchHealth, reducer, selectHealth} from '..'
+import {fetchHealth, reducer, makeGetRobotHealth} from '..'
 
 jest.mock('../client')
 
@@ -17,7 +17,7 @@ const health = {name, api_version: '1.2.3', fw_version: '4.5.6'}
 describe('health', () => {
   beforeEach(() => client.__clearMock())
 
-  test('selectHealth returns health substate', () => {
+  test('makeGetRobotHealth returns health of existing robot', () => {
     const state = {
       api: {
         health: {
@@ -30,7 +30,29 @@ describe('health', () => {
       }
     }
 
-    expect(selectHealth(state)).toBe(state.api.health)
+    const getRobotHealth = makeGetRobotHealth()
+
+    expect(getRobotHealth(state, {name})).toEqual({
+      inProgress: true,
+      error: null,
+      response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+    })
+  })
+
+  test('makeGetRobotHealth returns health of non-robot', () => {
+    const state = {
+      api: {
+        health: {}
+      }
+    }
+
+    const getRobotHealth = makeGetRobotHealth()
+
+    expect(getRobotHealth(state, {name})).toEqual({
+      inProgress: false,
+      error: null,
+      response: null
+    })
   })
 
   test('fetchHealth calls GET /health', () => {

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -1,12 +1,14 @@
 // @flow
 // health http api module
+import {createSelector} from 'reselect'
+
 import type {State, ThunkAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
 import type {ApiCall} from './types'
 import client, {type ClientResponseError} from './client'
 
-type HealthInfo = {
+type HealthResponse = {
   name: string,
   api_version: string,
   fw_version: string,
@@ -23,7 +25,7 @@ export type HealthSuccessAction = {|
   type: 'api:HEALTH_SUCCESS',
   payload: {|
     robot: RobotService,
-    health: HealthInfo,
+    health: HealthResponse,
   |}
 |}
 
@@ -40,10 +42,10 @@ export type HealthAction =
  | HealthSuccessAction
  | HealthFailureAction
 
-export type RobotHealth = ?ApiCall<void, HealthInfo>
+export type RobotHealth = ApiCall<void, HealthResponse>
 
-export type HealthState = {
-  [robotName: string]: RobotHealth
+type HealthState = {
+  [robotName: string]: ?RobotHealth
 }
 
 export function fetchHealth (robot: RobotService): ThunkAction {
@@ -54,24 +56,6 @@ export function fetchHealth (robot: RobotService): ThunkAction {
       .then((health) => dispatch(healthSuccess(robot, health)))
       .catch((error) => dispatch(healthFailure(robot, error)))
   }
-}
-
-function healthRequest (robot: RobotService): HealthRequestAction {
-  return {type: 'api:HEALTH_REQUEST', payload: {robot}}
-}
-
-function healthSuccess (
-  robot: RobotService,
-  health: HealthInfo
-): HealthSuccessAction {
-  return {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
-}
-
-function healthFailure (
-  robot: RobotService,
-  error: ClientResponseError
-): HealthFailureAction {
-  return {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
 }
 
 export function healthReducer (
@@ -115,6 +99,31 @@ export function healthReducer (
   return state
 }
 
-export function selectHealth (state: State): HealthState {
-  return state.api.health
+export const makeGetRobotHealth = () => createSelector(
+  selectRobotHealthState,
+  (state: ?RobotHealth): RobotHealth => {
+    return state || {inProgress: false, error: null, response: null}
+  }
+)
+
+function selectRobotHealthState (state: State, props: RobotService) {
+  return state.api.health[props.name]
+}
+
+function healthRequest (robot: RobotService): HealthRequestAction {
+  return {type: 'api:HEALTH_REQUEST', payload: {robot}}
+}
+
+function healthSuccess (
+  robot: RobotService,
+  health: HealthResponse
+): HealthSuccessAction {
+  return {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+}
+
+function healthFailure (
+  robot: RobotService,
+  error: ClientResponseError
+): HealthFailureAction {
+  return {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
 }

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -9,14 +9,16 @@ export const reducer = combineReducers({
   wifi: wifiReducer
 })
 
-export {fetchHealth, selectHealth} from './health'
+export {fetchHealth, makeGetRobotHealth} from './health'
 
 export {
   fetchWifiList,
   fetchWifiStatus,
   setConfigureWifiBody,
   configureWifi,
-  selectWifi
+  makeGetRobotWifiStatus,
+  makeGetRobotWifiList,
+  makeGetRobotWifiConfigure
 } from './wifi'
 
 export type {
@@ -26,7 +28,9 @@ export type {
 } from './health'
 
 export type {
-  RobotWifi
+  RobotWifiList,
+  RobotWifiStatus,
+  RobotWifiConfigure
 } from './wifi'
 
 export type Action =

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -9,7 +9,7 @@ export type ApiCall<T, U> = {
   /** possible error response */
   error: ?ClientResponseError,
   /** possible request body */
-  request?: T,
+  request?: ?T,
   /** possible success response body */
-  response?: U,
+  response?: ?U,
 }

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -1,5 +1,7 @@
 // @flow
 // wifi http api module
+import {createSelector} from 'reselect'
+
 import type {State, ThunkAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
@@ -85,14 +87,18 @@ export type WifiAction =
   | WifiFailureAction
   | SetConfigureWifiBodyAction
 
-export type RobotWifi = ?{
-  list?: ApiCall<void, ListResponse>,
-  status?: ApiCall<void, StatusResponse>,
-  configure?: ApiCall<ConfigureRequest, ConfigureResponse>,
+export type RobotWifiList = ApiCall<void, ListResponse>
+export type RobotWifiStatus = ApiCall<void, StatusResponse>
+export type RobotWifiConfigure = ApiCall<ConfigureRequest, ConfigureResponse>
+
+type RobotWifiState = {
+  list?: RobotWifiList,
+  status?: RobotWifiStatus,
+  configure?: RobotWifiConfigure,
 }
 
-export type WifiState = {
-  [robotName: string]: RobotWifi
+type WifiState = {
+  [robotName: string]: ?RobotWifiState
 }
 
 const LIST_PATH: RequestPath = 'list'
@@ -128,7 +134,7 @@ export function setConfigureWifiBody (
 
 export function configureWifi (robot: RobotService): ThunkAction {
   return (dispatch, getState) => {
-    const robotWifiState = selectWifi(getState())[robot.name] || {}
+    const robotWifiState = selectRobotWifiState(getState(), robot) || {}
     const configureState = robotWifiState.configure || {}
     const body = configureState.request
 
@@ -164,8 +170,61 @@ export function wifiReducer (state: ?WifiState, action: Action): WifiState {
   return state
 }
 
-export function selectWifi (state: State): WifiState {
-  return state.api.wifi
+export const makeGetRobotWifiStatus = () => createSelector(
+  selectRobotWifiState,
+  (state: ?RobotWifiState): RobotWifiStatus => (
+    (state && state.status) ||
+    {inProgress: false, error: null, response: null}
+  )
+)
+
+export const makeGetRobotWifiList = () => createSelector(
+  selectRobotWifiState,
+  (state: ?RobotWifiState): RobotWifiList => {
+    const listState = (
+      (state && state.list) ||
+      {inProgress: false, error: null, response: null}
+    )
+
+    if (!listState.response) return listState
+
+    return {
+      ...listState,
+      response: {
+        ...listState.response,
+        list: dedupeNetworkList(listState.response.list)
+      }
+    }
+  }
+)
+
+export const makeGetRobotWifiConfigure = () => createSelector(
+  selectRobotWifiState,
+  (state: ?RobotWifiState): RobotWifiConfigure => (
+    (state && state.configure) ||
+    {inProgress: false, error: null, request: null, response: null}
+  )
+)
+
+function selectRobotWifiState (state: State, props: RobotService) {
+  return state.api.wifi[props.name]
+}
+
+function dedupeNetworkList (list: NetworkList): NetworkList {
+  const {ids, networksById} = list.reduce((result, network) => {
+    const {ssid, active} = network
+
+    if (!result.networksById[ssid]) {
+      result.ids.push(ssid)
+      result.networksById[ssid] = network
+    } else if (active) {
+      result.networksById[ssid].active = true
+    }
+
+    return result
+  }, {ids: [], networksById: {}})
+
+  return ids.map((ssid) => networksById[ssid])
 }
 
 function wifiRequest (

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -5,7 +5,6 @@ import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
 
 import type {State} from '../types'
-import {selectHealth, selectWifi} from '../http-api-client'
 
 import type {
   Mount,
@@ -52,20 +51,10 @@ export const getDiscovered = createSelector(
   (state: State) => connection(state).discovered,
   (state: State) => connection(state).discoveredByName,
   (state: State) => connection(state).connectedTo,
-  selectHealth,
-  selectWifi,
-  (
-    discovered,
-    discoveredByName,
-    connectedTo,
-    healthByName,
-    wifiByName
-  ): Robot[] => {
+  (discovered, discoveredByName, connectedTo): Robot[] => {
     const robots = discovered.map((name) => ({
       ...discoveredByName[name],
-      isConnected: connectedTo === name,
-      health: healthByName[name],
-      wifi: wifiByName[name]
+      isConnected: connectedTo === name
     }))
 
     return sortBy(robots, [

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -40,16 +40,6 @@ describe('robot selectors', () => {
 
   test('getDiscovered', () => {
     const state = {
-      api: {
-        health: {
-          bar: {response: {api_version: '1.2.3', fw_version: '4.5.6'}},
-          qux: {response: {api_version: '1.2.3', fw_version: '4.5.6'}}
-        },
-        wifi: {
-          bar: {list: null, status: null, configure: null},
-          qux: {list: null, status: null, configure: null}
-        }
-      },
       robot: {
         connection: {
           connectedTo: 'bar',
@@ -68,17 +58,13 @@ describe('robot selectors', () => {
       {
         name: 'bar',
         host: '123456.local',
-        isConnected: true,
-        health: state.api.health.bar,
-        wifi: state.api.wifi.bar
+        isConnected: true
       },
       {
         name: 'qux',
         host: 'dvorak.local',
         isConnected: false,
-        wired: true,
-        health: state.api.health.qux,
-        wifi: state.api.wifi.qux
+        wired: true
       },
       {name: 'baz', host: 'qwerty.local', isConnected: false},
       {name: 'foo', host: 'abcdef.local', isConnected: false}

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,7 +1,6 @@
 // @flow
 // common robot types
 
-import type {RobotHealth, RobotWifi} from '../http-api-client'
 import typeof reducer from './reducer'
 
 export type State = $Call<reducer>
@@ -45,9 +44,7 @@ export type RobotService = {
 
 // robot from getDiscovered selector
 export type Robot = RobotService & {
-  isConnected: boolean,
-  health: RobotHealth,
-  wifi: RobotWifi
+  isConnected: boolean
 }
 
 // protocol file (browser File object)


### PR DESCRIPTION
## overview

This PR addresses a few TODOs from #898 related to selectors. Basically, just jamming the HTTP API request/response state into the `robot` module's selectors was not scalable.

Instead, I've implemented [selectors that take props](https://github.com/reactjs/reselect#sharing-selectors-with-props-across-multiple-component-instances), where `props` is a discovered robot object. I'd recommend reading through the `reselect` docs, but the key details of using props in selectors are:

* Memoization will break if different components share a normal selector, because different components have different props
* If you export a selector factory instead of a selector, memoization is fine again because there are multiple instances of the selector
* However, if you have a selector factory, you now need a `mapStateToProps` factory so that your component can hang onto its selector instance

## changelog

- Refactor: move custom HTTP API logic to selectors in their respective modules

## review requests

Like I said, read the reselect docs first. Otherwise try this out on various wired and non-wired robots!