### PR TITLE
Add tentative update app modal

### DIFF
--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -11,7 +11,7 @@ const TITLE = 'Information'
 const VERSION_LABEL = 'Software Version'
 const VERSION_VALUE = version
 
-export default function StatusCard () {
+export default function AppInfoCard () {
   return (
     <Card title={TITLE}>
       <LabeledValue

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -11,7 +11,7 @@ import {AlertModal} from '@opentrons/components'
 
 const HEADING = 'App Update Available'
 
-const UPDATE_MESSAGE = 'We reccomend updating to the latest software version'
+const UPDATE_MESSAGE = 'We recommend updating to the latest software version'
 
 export default function AppUpdateModal () {
   const onUpdateClick = () => console.log('update')

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -1,0 +1,32 @@
+// @flow
+// AlertModal for updating to newest app version
+import * as React from 'react'
+
+import {AlertModal} from '@opentrons/components'
+
+// type Props = {
+//   onUpdateClick: () => *,
+//   onCloseClick: () => *
+// }
+
+const HEADING = 'App Update Available'
+
+const UPDATE_MESSAGE = 'We reccomend updating to the latest software version'
+
+export default function AppUpdateModal () {
+  const onUpdateClick = () => console.log('update')
+  const onCloseClick = () => console.log('close')
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      onCloseClick={onCloseClick}
+      buttons={[
+        {onClick: onCloseClick, children: 'not now'},
+        {onClick: onUpdateClick, children: 'update'}
+      ]}
+    >
+      {UPDATE_MESSAGE}
+    </AlertModal>
+  )
+}

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -2,12 +2,16 @@
 // app status panel with connect button
 import * as React from 'react'
 import AppInfoCard from './AppInfoCard'
+import AppUpdateModal from './AppUpdateModal'
+
 import styles from './styles.css'
 
-export default function AppSettings () {
+export default function AppInfo () {
   return (
     <div className={styles.app_settings}>
       <AppInfoCard />
     </div>
   )
 }
+
+export {AppUpdateModal}

--- a/app/src/pages/AppSettings.js
+++ b/app/src/pages/AppSettings.js
@@ -2,12 +2,13 @@
 // view info about the app and update
 import React from 'react'
 import Page from '../components/Page'
-import AppSettings from '../components/AppSettings'
+import AppInfo/*, {AppUpdateModal} */ from '../components/AppSettings'
 
 export default function AppSettingsPage () {
   return (
     <Page>
-      <AppSettings />
+      <AppInfo />
+      {/* <AppUpdateModal /> */}
     </Page>
   )
 }


### PR DESCRIPTION
## overview

Addresses #810 UI, adds the modal for app update but nothing more for now.

## changelog

- Add `AppUpdateModal` to `AppSettings` with dummy actions for now

## review requests
Uncomment lines 5 and 11 in app/src/pages/AppSettings.js to view modal. 