### PR TITLE
feat(app): Add failure/success modal after wifi connect response

### DIFF
--- a/app/src/components/RobotSettings/WifiConnectForm.js
+++ b/app/src/components/RobotSettings/WifiConnectForm.js
@@ -7,7 +7,7 @@ import {Form, Select, TextInput} from './inputs'
 import styles from './styles.css'
 
 type Props = {
-  wired: ?boolean,
+  disabled: boolean,
   ssid: ?string,
   psk: ?string,
   activeSsid: ?string,
@@ -18,7 +18,6 @@ type Props = {
 
 export default function ConfigureWifiForm (props: Props) {
   const {
-    wired,
     ssid,
     psk,
     activeSsid,
@@ -27,12 +26,13 @@ export default function ConfigureWifiForm (props: Props) {
     onSubmit
   } = props
 
-  const disabled = !wired || !ssid || !psk || (ssid === activeSsid)
+  const inputDisabled = props.disabled
+  const formDisabled = inputDisabled || !ssid || !psk || (ssid === activeSsid)
 
   return (
     <Form
       onSubmit={onSubmit}
-      disabled={disabled}
+      disabled={formDisabled}
       className={styles.configure_form}
     >
       <label className={styles.configure_label}>
@@ -41,7 +41,7 @@ export default function ConfigureWifiForm (props: Props) {
           name='ssid'
           value={ssid || activeSsid}
           options={networks}
-          disabled={!wired}
+          disabled={inputDisabled}
           onChange={onChange}
           className={styles.configure_input}
         />
@@ -52,14 +52,14 @@ export default function ConfigureWifiForm (props: Props) {
           type='password'
           name='psk'
           value={psk}
-          disabled={!wired}
+          disabled={inputDisabled}
           onChange={onChange}
           className={styles.configure_input}
         />
       </label>
       <OutlineButton
         type='submit'
-        disabled={disabled}
+        disabled={formDisabled}
         className={styles.configure_button}
       >
         Join

--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -1,0 +1,48 @@
+// @flow
+// wifi connect response (or error) alert modal
+import * as React from 'react'
+
+import type {
+  WifiConfigureResponse,
+  ClientResponseError
+} from '../../http-api-client'
+
+import {AlertModal} from '@opentrons/components'
+
+type Props = {
+  onClose: () => *,
+  error: ?ClientResponseError,
+  response: ?WifiConfigureResponse
+}
+
+const SUCCESS_TITLE = 'Succsesfully connected to '
+const FAILURE_TITLE = 'Could not join network'
+
+const SUCCESS_MESSAGE = 'Your robot has successfully connected to WiFi and should appear in the robot list shortly. If it does not, try refreshing the list manually or rebooting the robot'
+const FAILURE_MESSAGE = 'Please double check your network credentials. If this problem persists, try rebooting the robot or contacting our support team'
+
+export default function WifiConnectModal (props: Props) {
+  const {onClose} = props
+  let title
+  let message
+
+  if (props.error) {
+    title = FAILURE_TITLE
+    message = FAILURE_MESSAGE
+  } else if (props.response) {
+    title = `${SUCCESS_TITLE} ${props.response.ssid}`
+    message = SUCCESS_MESSAGE
+  }
+
+  return (
+    <AlertModal
+      heading={title}
+      onCloseClick={onClose}
+      buttons={[
+        {onClick: onClose, children: 'close'}
+      ]}
+    >
+      {message}
+    </AlertModal>
+  )
+}

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -7,6 +7,7 @@ import {
   fetchWifiList,
   fetchWifiStatus,
   setConfigureWifiBody,
+  clearConfigureWifiResponse,
   configureWifi,
   reducer,
   makeGetRobotWifiStatus,
@@ -209,6 +210,15 @@ describe('wifi', () => {
     })
   })
 
+  test('clearConfigureWifiResponse action creator', () => {
+    const expected = {
+      type: 'api:CLEAR_CONFIGURE_WIFI_RESPONSE',
+      payload: {robot}
+    }
+
+    expect(clearConfigureWifiResponse(robot)).toEqual(expected)
+  })
+
   describe('configureWifi action creator', () => {
     const ssid = 'some-ssid'
     const psk = 'some-psk'
@@ -225,7 +235,7 @@ describe('wifi', () => {
       }
     }
 
-    test('configureWifi calls POST /wifi/configure, GET /wifi/list', () => {
+    test('calls POST /wifi/configure, GET /wifi/list', () => {
       const store = mockStore(initialState)
 
       client.__setMockResponse(response)
@@ -239,7 +249,7 @@ describe('wifi', () => {
         ))
     })
 
-    test('configureWifi dispatches WIFI_REQUEST and WIFI_SUCCESS', () => {
+    test('dispatches WIFI_REQUEST and WIFI_SUCCESS', () => {
       const store = mockStore(initialState)
       const expectedActions = [
         {type: 'api:WIFI_REQUEST', payload: {robot, path: 'configure'}},
@@ -255,7 +265,7 @@ describe('wifi', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('configureWifi dispatches WIFI_REQUEST and WIFI_FAILURE', () => {
+    test('dispatches WIFI_REQUEST and WIFI_FAILURE', () => {
       const error = {name: 'ResponseError', status: '400'}
       const store = mockStore(initialState)
       const expectedActions = [
@@ -486,6 +496,37 @@ describe('wifi', () => {
       })
     })
 
+    test('handles CLEAR_CONFIGURE_WIFI_RESPONSE', () => {
+      const state = {
+        wifi: {
+          opentrons: {
+            configure: {
+              request: {ssid: 'baz', psk: ''},
+              inProgress: false,
+              error: new Error('AH'),
+              response: {ssid: 'foo', message: 'bar'}
+            }
+          }
+        }
+      }
+
+      const action = {
+        type: 'api:CLEAR_CONFIGURE_WIFI_RESPONSE',
+        payload: {robot}
+      }
+
+      expect(reducer(state, action).wifi).toEqual({
+        opentrons: {
+          configure: {
+            request: {ssid: 'baz', psk: ''},
+            inProgress: false,
+            error: null,
+            response: null
+          }
+        }
+      })
+    })
+
     test('handles WIFI_REQUEST', () => {
       const state = {
         wifi: {
@@ -534,7 +575,7 @@ describe('wifi', () => {
       expect(reducer(state, action).wifi).toEqual({
         opentrons: {
           configure: {
-            request: null,
+            request: {ssid: 'baz', psk: ''},
             inProgress: false,
             error: null,
             response: {ssid: 'baz', message: 'qux'}
@@ -548,6 +589,7 @@ describe('wifi', () => {
         wifi: {
           opentrons: {
             configure: {
+              request: {ssid: 'baz', psk: 'qux'},
               inProgress: true,
               error: null,
               response: {ssid: 'foo', message: 'bar'}
@@ -563,7 +605,7 @@ describe('wifi', () => {
       expect(reducer(state, action).wifi).toEqual({
         opentrons: {
           configure: {
-            request: null,
+            request: {ssid: 'baz', psk: 'qux'},
             inProgress: false,
             error: {name: 'ResponseError'},
             response: {ssid: 'foo', message: 'bar'}

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -9,17 +9,9 @@ export const reducer = combineReducers({
   wifi: wifiReducer
 })
 
-export {fetchHealth, makeGetRobotHealth} from './health'
-
-export {
-  fetchWifiList,
-  fetchWifiStatus,
-  setConfigureWifiBody,
-  configureWifi,
-  makeGetRobotWifiStatus,
-  makeGetRobotWifiList,
-  makeGetRobotWifiConfigure
-} from './wifi'
+export type {
+  ClientResponseError
+} from './client'
 
 export type {
   RobotHealth,
@@ -28,13 +20,29 @@ export type {
 } from './health'
 
 export type {
+  WifiListResponse,
+  WifiStatusResponse,
+  WifiConfigureResponse,
   RobotWifiList,
   RobotWifiStatus,
   RobotWifiConfigure
 } from './wifi'
 
+export type State = $Call<typeof reducer>
+
 export type Action =
   | HealthAction
   | WifiAction
 
-export type State = $Call<typeof reducer>
+export {fetchHealth, makeGetRobotHealth} from './health'
+
+export {
+  fetchWifiList,
+  fetchWifiStatus,
+  setConfigureWifiBody,
+  clearConfigureWifiResponse,
+  configureWifi,
+  makeGetRobotWifiStatus,
+  makeGetRobotWifiList,
+  makeGetRobotWifiConfigure
+} from './wifi'

--- a/app/src/robot/api-client/discovery.js
+++ b/app/src/robot/api-client/discovery.js
@@ -86,7 +86,11 @@ function withIp (service) {
 
   // API doesn't listen on all interfaces when running locally
   // this hostname check is only for handling that situation
-  if (service.host === os.hostname()) ip = 'localhost'
+  if (service.host === os.hostname()) {
+    ip = 'localhost'
+    // emulate a wired robot when running locally
+    service = {...service, wired: true}
+  }
 
   return Object.assign({ip}, service)
 }


### PR DESCRIPTION
## overview

This PR is (excluding polish) the last front-end PR for #698.

![2018-02-23 18 26 26](https://user-images.githubusercontent.com/2963448/36621674-39742d74-18c7-11e8-907e-9bd3fb5f27f4.gif)

## changelog

- Feature: added WifiConnectModal that shows up when `/wifi/configure` responds
- Refactor: renamed ConfigureWifiForm to WifiConnectForm for consistency
- Dev: defaulted local dev API to appear as a wired robot

## review requests

Try it out! Otherwise standard review