### PR TITLE
feat(components): Add RefreshCard (Card for displaying refreshable data)

### DIFF
--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -27,7 +27,9 @@ exports[`LabeledValue renders LabeledValue correctly 1`] = `
     Label
     :
   </p>
-  <p>
+  <p
+    className="labeled_value_value"
+  >
     Value
   </p>
 </div>
@@ -85,6 +87,46 @@ exports[`PageTabs renders PageTabs correctly 1`] = `
     </h3>
   </span>
 </nav>
+`;
+
+exports[`RefreshCard renders correctly 1`] = `
+<section
+  className="card"
+>
+  <h3
+    className="card_title"
+  />
+  <div
+    className="card_content"
+  >
+    <button
+      className="button_flat button_icon refresh_card_icon"
+      disabled={true}
+      onClick={undefined}
+      title={undefined}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="button_only_icon spin"
+        fill="currentColor"
+        height={undefined}
+        style={undefined}
+        version="1.1"
+        viewBox="0 0 512 512"
+        width={undefined}
+        x={undefined}
+        y={undefined}
+      >
+        <path
+          d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </button>
+    child1 child2 child3
+  </div>
+</section>
 `;
 
 exports[`SidePanel renders SidePanel correctly 1`] = `

--- a/components/src/__tests__/structure.test.js
+++ b/components/src/__tests__/structure.test.js
@@ -3,7 +3,17 @@ import React from 'react'
 import {MemoryRouter} from 'react-router'
 import Renderer from 'react-test-renderer'
 
-import {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel, FILE, Card, LabeledValue} from '..'
+import {
+  PageTabs,
+  TitleBar,
+  VerticalNavBar,
+  NavButton,
+  SidePanel,
+  FILE,
+  Card,
+  RefreshCard,
+  LabeledValue
+} from '..'
 
 describe('TitleBar', () => {
   test('adds an h1 with the title', () => {
@@ -218,11 +228,50 @@ describe('SidePanel', () => {
 describe('Card', () => {
   test('renders Card correctly', () => {
     const tree = Renderer.create(
-      <Card title={'title'} >
+      <Card title={'title'}>
         children
         children
         children
       </Card>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('RefreshCard', () => {
+  test('calls refresh on mount', () => {
+    const refresh = jest.fn()
+    Renderer.create(
+      <RefreshCard id='foo' refresh={refresh} />
+    )
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('calls refresh on id change', () => {
+    const refresh = jest.fn()
+    const renderer = Renderer.create(
+      <RefreshCard watch='foo' refresh={refresh} />
+    )
+
+    refresh.mockClear()
+    renderer.update(<RefreshCard watch='bar' refresh={refresh} />)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    // test refresh is not called on a different props change
+    refresh.mockClear()
+    renderer.update(<RefreshCard watch='bar' refresh={refresh} refreshing />)
+    expect(refresh).toHaveBeenCalledTimes(0)
+  })
+
+  test('renders correctly', () => {
+    const tree = Renderer.create(
+      <RefreshCard watch='foo' refresh={() => {}} refreshing>
+        child1
+        child2
+        child3
+      </RefreshCard>
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/structure/LabeledValue.js
+++ b/components/src/structure/LabeledValue.js
@@ -21,8 +21,12 @@ export default function LabeledValue (props: Props) {
 
   return (
     <div className={className}>
-      <p className={styles.labeled_value_label}>{label}:</p>
-      <p>{value}</p>
+      <p className={styles.labeled_value_label}>
+        {label}:
+      </p>
+      <p className={styles.labeled_value_value}>
+        {value}
+      </p>
     </div>
   )
 }

--- a/components/src/structure/RefreshCard.js
+++ b/components/src/structure/RefreshCard.js
@@ -1,0 +1,50 @@
+// @flow
+// refreshable card component
+import * as React from 'react'
+
+import {IconButton} from '../buttons'
+import Card from './Card'
+import styles from './structure.css'
+
+type Props = React.ElementProps<typeof Card> & {
+  /** a change in the watch prop will trigger a refresh */
+  watch: string,
+  /** refreshing flag */
+  refreshing: boolean,
+  /** refresh function */
+  refresh: () => mixed,
+}
+
+/**
+ * Card variant for displaying refreshable data. `props.refresh` will be called
+ * on mount, on an update with a change in `props.watch`, or if the user clicks
+ * the refresh button. Takes all `Card` props as well as the ones listed here.
+ */
+export default class RefreshCard extends React.Component<Props> {
+  render () {
+    const {refresh, refreshing, children} = this.props
+
+    return (
+      <Card {...this.props}>
+        <IconButton
+          name={refreshing ? 'spinner' : 'refresh'}
+          className={styles.refresh_card_icon}
+          spin={refreshing}
+          disabled={refreshing}
+          onClick={refresh}
+        />
+        {children}
+      </Card>
+    )
+  }
+
+  componentDidMount () {
+    this.props.refresh()
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    if (prevProps.watch !== this.props.watch) {
+      this.props.refresh()
+    }
+  }
+}

--- a/components/src/structure/RefreshCard.md
+++ b/components/src/structure/RefreshCard.md
@@ -1,0 +1,31 @@
+Refreshable info Card with RefreshCard:
+
+```js
+initialState = {name: 'foo', when: Date.now(), refreshing: false}
+
+function refresh () {
+  setState({...state, refreshing: true})
+  setTimeout(() => setState({
+    ...state,
+    when: Date.now(),
+    refreshing: false
+  }), 2000)
+}
+
+;<div style={{width: '32rem'}}>
+  <RefreshCard
+    watch={state.name}
+    refreshing={state.refreshing}
+    refresh={refresh}
+    title={`Name: ${state.name}`}
+  >
+    <LabeledValue label={'Refreshed at'} value={state.when} />
+    <FlatButton onClick={() => setState({...state, name: 'foo'})}>
+      Name -> "foo"
+    </FlatButton>
+    <FlatButton onClick={() => setState({...state, name: 'bar'})}>
+      Name -> "bar"
+    </FlatButton>
+  </RefreshCard>
+</div>
+```

--- a/components/src/structure/index.js
+++ b/components/src/structure/index.js
@@ -6,9 +6,19 @@ import VerticalNavBar from './VerticalNavBar'
 import NavButton from './NavButton'
 import SidePanel from './SidePanel'
 import Card from './Card'
+import RefreshCard from './RefreshCard'
 import LabeledValue from './LabeledValue'
 
 // types
 export type {PageTabProps} from './PageTabs'
 
-export {PageTabs, TitleBar, VerticalNavBar, NavButton, SidePanel, Card, LabeledValue}
+export {
+  PageTabs,
+  TitleBar,
+  VerticalNavBar,
+  NavButton,
+  SidePanel,
+  Card,
+  RefreshCard,
+  LabeledValue
+}

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -86,6 +86,7 @@
 
 /* Card and card content styles */
 .card {
+  position: relative;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33);
   padding: 1rem;
 }
@@ -93,6 +94,7 @@
 .card_title {
   @apply --font-header-dark;
 
+  margin-top: 0;
   margin-bottom: 0.5rem;
   font-weight: --fw-regular;
 }
@@ -105,6 +107,14 @@
 
 .card_column {
   flex-direction: column;
+}
+
+.refresh_card_icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2.25rem;
+  color: var(--c-font-dark);
 }
 
 .disabled {
@@ -126,5 +136,10 @@
 
 .labeled_value_label {
   font-weight: var(--fw-semibold);
+}
+
+.labeled_value_label,
+.labeled_value_value {
+  margin-top: 0;
   margin-bottom: 0.25rem;
 }


### PR DESCRIPTION
## overview

Little PR to add a `RefreshCard` component. It's a `Card` with a refresh button in the corner that turns into a spinner when the card is refreshing. Also handles auto-refresh on mount or specific props change.

[Components Library - `RefreshCard`](https://s3-us-west-2.amazonaws.com/opentrons-components/complib_refresh-icon/index.html#refreshcard)

To be used in #698, #810, and anywhere else a `Card` is displaying data that needs to be fetched from somewhere.

## changelog

- Feature: Added `RefreshCard` to display refreshable data

## review requests

Standard review
