### PR TITLE
feat(app, api): Handle WiFi join failure

### DIFF
--- a/api/opentrons/server/endpoints.py
+++ b/api/opentrons/server/endpoints.py
@@ -44,13 +44,21 @@ async def wifi_list(request):
             proc = subprocess.run(["nmcli", "--terse",
                                    "--fields", "ssid,signal,active",
                                    "device", "wifi", "list"],
-                                  stdout=subprocess.PIPE)
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             res = "CalledProcessError: {}".format(e.stdout)
         except FileNotFoundError as e:
             res = "FileNotFoundError: {}".format(e)
         else:
-            lines = proc.stdout.decode().split("\n")
+            out = proc.stdout.decode().strip()
+            err = proc.stderr.decode().strip()
+
+            log.debug("'nmcli device wifi list' stdout: {}".format(out))
+            if len(err) > 0:
+                log.error("'nmcli device wifi list' stderr: {}".format(err))
+
+            lines = out.split("\n")
             networks = [x.split(":") for x in lines]
             res["list"] = [
                 {
@@ -83,33 +91,49 @@ async def wifi_configure(request):
     will not be set during development on a laptop, or while running the server
     during test on CI.
     """
+    status = None
     result = {}
+    message = ''
+
     try:
         body = await request.text()
         jbody = json.loads(body)
-        ssid = jbody['ssid']
-        psk = jbody['psk']
-    except Exception as e:
-        result = "Error: {}, type: {}".format(e, type(e))
-        log.warning(result)
-    else:
-        message = ''
-        if ENABLE_NMCLI:
+        ssid = jbody.get('ssid')
+        psk = jbody.get('psk')
+
+        if ssid is None or psk is None:
+            status = 400
+            message = 'Error: "ssid": string, "psk": string are required'
+        elif ENABLE_NMCLI:
             cmd = 'nmcli device wifi connect {} password "{}"'.format(
                 ssid, psk)
-            proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
-            # TODO(mc, 2019-02-20): check this string for success or failure
-            #   nmcli success: "Device 'wlan0' successfully activated..."
+            # some nmcli errors go to stdout (e.g. bad psk), while others go to
+            # stderr (e.g. bad ssid), so we pipe both outputs together
+            proc = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
             message = proc.stdout.decode().strip().split("\r")[-1]
+            log.debug("nmcli device wifi connect -> {}".format(message))
+
+            status = 201 if not message.startswith('Error:') else 401
+            result['ssid'] = ssid
         else:
-            message = "Configuration successful. PSK: '{}'".format(psk)
+            status = 200
+            message = 'Configuration unchanged'
+            result['ssid'] = 'a'
 
-        result = {'ssid': ssid, 'message': message}
+    except json.JSONDecodeError as e:
+        log.debug("Error: JSONDecodeError in /wifi/configure: {}".format(e))
+        status = 400
+        message = e.msg
 
-    log.info("Wifi configure result: {}".format(result))
+    except Exception as e:
+        log.warning("Error: {} in /wifi/configure': {}".format(type(e), e))
+        status = 500
+        message = 'An unexpected error occurred.'
 
-    # TODO(mc, 2019-02-20): return error status code if error
-    return web.json_response(result)
+    result['message'] = message
+    log.debug("Wifi configure result: {}".format(result))
+    return web.json_response(data=result, status=status)
 
 
 async def wifi_status(request):

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -35,8 +35,8 @@ async def test_wifi_configure(virtual_smoothie_env, loop, test_client):
     cli = await loop.create_task(test_client(app))
 
     expected = json.dumps({
-        'ssid': 'this',
-        'message': "Configuration successful. PSK: 'that'"
+        'ssid': 'a',
+        'message': 'Configuration unchanged'
     })
     resp = await cli.post('/wifi/configure',
                           json={'ssid': 'this', 'psk': 'that'})

--- a/app/src/components/RobotSettings/WifiConnectForm.js
+++ b/app/src/components/RobotSettings/WifiConnectForm.js
@@ -27,7 +27,7 @@ export default function ConfigureWifiForm (props: Props) {
   } = props
 
   const inputDisabled = props.disabled
-  const formDisabled = inputDisabled || !ssid || !psk || (ssid === activeSsid)
+  const formDisabled = inputDisabled || !ssid || (ssid === activeSsid)
 
   return (
     <Form

--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -4,34 +4,34 @@ import * as React from 'react'
 
 import type {
   WifiConfigureResponse,
-  ClientResponseError
+  ApiRequestError
 } from '../../http-api-client'
 
 import {AlertModal} from '@opentrons/components'
 
 type Props = {
   onClose: () => *,
-  error: ?ClientResponseError,
+  error: ?ApiRequestError,
   response: ?WifiConfigureResponse
 }
 
 const SUCCESS_TITLE = 'Succsesfully connected to '
 const FAILURE_TITLE = 'Could not join network'
 
-const SUCCESS_MESSAGE = 'Your robot has successfully connected to WiFi and should appear in the robot list shortly. If it does not, try refreshing the list manually or rebooting the robot'
-const FAILURE_MESSAGE = 'Please double check your network credentials. If this problem persists, try rebooting the robot or contacting our support team'
+const SUCCESS_MESSAGE = 'Your robot has successfully connected to WiFi and should appear in the robot list shortly. If not, try refreshing the list manually or rebooting the robot.'
+const FAILURE_MESSAGE = 'Please double check your network credentials. If this problem persists, try rebooting the robot or contacting our support team.'
 
 export default function WifiConnectModal (props: Props) {
   const {onClose} = props
   let title
   let message
 
-  if (props.error) {
-    title = FAILURE_TITLE
-    message = FAILURE_MESSAGE
-  } else if (props.response) {
+  if (props.response) {
     title = `${SUCCESS_TITLE} ${props.response.ssid}`
     message = SUCCESS_MESSAGE
+  } else {
+    title = FAILURE_TITLE
+    message = FAILURE_MESSAGE
   }
 
   return (

--- a/app/src/http-api-client/__tests__/client.test.js
+++ b/app/src/http-api-client/__tests__/client.test.js
@@ -56,13 +56,16 @@ describe('http api client', () => {
 
     global.fetch = mockResolve({
       ok: false,
-      status: '400',
-      statusText: 'Bad Request'
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({message: 'You tried'})
     })
 
     return expect(client(robot, 'GET', 'foo')).rejects
       .toEqual(expect.objectContaining({
-        message: '400 Bad Request'
+        status: 400,
+        statusText: 'Bad Request',
+        message: 'You tried'
       }))
   })
 
@@ -111,13 +114,16 @@ describe('http api client', () => {
 
     global.fetch = mockResolve({
       ok: false,
-      status: '400',
-      statusText: 'Bad Request'
+      status: 400,
+      statusText: 'Bad Request',
+      json: () => Promise.resolve({message: 'You tried'})
     })
 
     return expect(client(robot, 'POST', 'foo', {bar: 'baz'})).rejects
       .toEqual(expect.objectContaining({
-        message: '400 Bad Request'
+        status: 400,
+        statusText: 'Bad Request',
+        message: 'You tried'
       }))
   })
 

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -5,21 +5,25 @@ import type {RobotService} from '../robot'
 
 type Method = 'GET' | 'POST'
 
-export type ClientResponseError = {
+export type ApiRequestError = {
   name: string,
   message: string,
   url?: string,
   status?: number,
-  statusText?: string
+  statusText?: string,
 }
 
 // not a real Error or Response so it can be copied across worker boundries
-function ResponseError (response: Response): ClientResponseError {
+function ResponseError (
+  response: Response,
+  body: ?{message: ?string}
+): ApiRequestError {
   const {status, statusText, url} = response
+  const message = (body && body.message) || `${status} ${statusText}`
 
   return {
     name: 'ResponseError',
-    message: `${status} ${statusText}`,
+    message,
     status,
     statusText,
     url
@@ -27,7 +31,7 @@ function ResponseError (response: Response): ClientResponseError {
 }
 
 // not a real Error so it can be copied across worker boundries
-function FetchError (error: Error): ClientResponseError {
+function FetchError (error: Error): ApiRequestError {
   return {name: error.name, message: error.message}
 }
 
@@ -35,12 +39,12 @@ const HEADERS = {
   'Content-Type': 'application/json'
 }
 
-export default function client (
+export default function client<T, U> (
   robot: RobotService,
   method: Method,
   path: string,
-  body?: {}
-): Promise<any> {
+  body?: T
+): Promise<U> {
   const url = `http://${robot.ip}:${robot.port}/${path}`
   const options = {
     method,
@@ -53,12 +57,14 @@ export default function client (
   return fetch(url, options).then(jsonFromResponse, fetchErrorFromError)
 }
 
-function jsonFromResponse (response: Response): Promise<*> {
-  if (!response.ok) {
-    return Promise.reject(ResponseError(response))
-  }
-
-  return response.json().catch(fetchErrorFromError)
+function jsonFromResponse<T> (response: Response): Promise<T> {
+  return response.json()
+    .then(
+      (body) => response.ok
+        ? (body: T)
+        : Promise.reject(ResponseError(response, (body: ?{message: ?string}))),
+      fetchErrorFromError
+    )
 }
 
 function fetchErrorFromError (error: Error): Promise<*> {

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -6,7 +6,7 @@ import type {State, ThunkAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
 import type {ApiCall} from './types'
-import client, {type ClientResponseError} from './client'
+import client, {type ApiRequestError} from './client'
 
 type HealthResponse = {
   name: string,
@@ -33,7 +33,7 @@ export type HealthFailureAction = {|
   type: 'api:HEALTH_FAILURE',
   payload: {|
     robot: RobotService,
-    error: ClientResponseError,
+    error: ApiRequestError,
   |}
 |}
 
@@ -123,7 +123,7 @@ function healthSuccess (
 
 function healthFailure (
   robot: RobotService,
-  error: ClientResponseError
+  error: ApiRequestError
 ): HealthFailureAction {
   return {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
 }

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -10,7 +10,7 @@ export const reducer = combineReducers({
 })
 
 export type {
-  ClientResponseError
+  ApiRequestError
 } from './client'
 
 export type {

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -1,13 +1,13 @@
 // @flow
 // http api client types
 
-import type {ClientResponseError} from './client'
+import type {ApiRequestError} from './client'
 
 export type ApiCall<T, U> = {
   /** request in progress flag */
   inProgress: boolean,
   /** possible error response */
-  error: ?ClientResponseError,
+  error: ?ApiRequestError,
   /** possible request body */
   request?: ?T,
   /** possible success response body */


### PR DESCRIPTION
## overview

~Currently blocked by #914. Will rebase the branch and the PR when it's merged.~

This PR closes #694 by adding join failure logic to the API and updating the Run App as necessary to handle the failure cases.

## changelog

- Feature (API): Added error handling and statuses to /wifi/configure
- Refactor (Run App): Cleaned up HTTP response and error handling / types 

## review requests

@btmorr and @Laura-Danielle please check out the Python side of things. My robot testing is still ongoing to be completed on Monday.

Otherwise, front-end stuff in this PR is fairly light, so standard review.
