### PR TITLE
(pd) File page form

### DIFF
--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -13,7 +13,7 @@ export type DropdownOption = {
 // TODO(mc, 2018-02-22): disabled prop
 type Props = {
   /** change handler */
-  onChange: (event: SyntheticInputEvent<*>) => void,
+  onChange: (event: SyntheticInputEvent<*>) => mixed,
   /** value that is selected */
   value?: ?string,
   /** Array of {name, value} data */

--- a/components/src/forms/RadioGroup.js
+++ b/components/src/forms/RadioGroup.js
@@ -7,7 +7,7 @@ import styles from './forms.css'
 
 type Props = {
   /** change handler */
-  onChange: (event: SyntheticEvent<>) => void,
+  onChange: (event: SyntheticInputEvent<>) => mixed,
   /** value that is checked */
   value?: string,
   /** Array of {name, value} data */

--- a/protocol-designer/src/components/FilePage.css
+++ b/protocol-designer/src/components/FilePage.css
@@ -1,0 +1,9 @@
+@import '@opentrons/components';
+
+.file_page h1 {
+  @apply var(--font-header-dark);
+}
+
+.file_page section {
+  margin: 0 2.5rem;
+}

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,16 +1,18 @@
 // @flow
 import React from 'react'
 import {FormGroup, InputField} from '@opentrons/components'
-import type {FilePageFields, FieldConnector} from '../file-data'
+import type {FilePageFields} from '../file-data'
+import type {FormConnector} from '../utils'
 
 import styles from './FilePage.css'
 import formStyles from '../components/Form.css'
 
 type Props = {
-  fieldConnector: FieldConnector<FilePageFields>
+  formConnector: FormConnector<FilePageFields>
 }
 
 export default function FilePage (props: Props) {
+  const {formConnector} = props
   return (
     <div className={styles.file_page}>
       <section>
@@ -20,16 +22,16 @@ export default function FilePage (props: Props) {
 
         <div className={formStyles.row_wrapper}>
           <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
-            <InputField placeholder='Untitled' {...props.fieldConnector('name')} />
+            <InputField placeholder='Untitled' {...formConnector('name')} />
           </FormGroup>
 
           <FormGroup label='Organization/Author:' className={formStyles.column_1_2}>
-            <InputField {...props.fieldConnector('author')} />
+            <InputField {...formConnector('author')} />
           </FormGroup>
         </div>
 
         <FormGroup label='Description:'>
-          <InputField {...props.fieldConnector('description')}/>
+          <InputField {...formConnector('description')}/>
         </FormGroup>
       </section>
 

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,0 +1,43 @@
+// @flow
+import React from 'react'
+import {FormGroup, InputField} from '@opentrons/components'
+import type {FilePageFields, FieldConnector} from '../file-data'
+
+import styles from './FilePage.css'
+import formStyles from '../components/Form.css'
+
+type Props = {
+  fieldConnector: FieldConnector<FilePageFields>
+}
+
+export default function FilePage (props: Props) {
+  return (
+    <div className={styles.file_page}>
+      <section>
+        <h1>
+          Information
+        </h1>
+
+        <div className={formStyles.row_wrapper}>
+          <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
+            <InputField placeholder='Untitled' {...props.fieldConnector('name')} />
+          </FormGroup>
+
+          <FormGroup label='Organization/Author:' className={formStyles.column_1_2}>
+            <InputField {...props.fieldConnector('author')} />
+          </FormGroup>
+        </div>
+
+        <FormGroup label='Description:'>
+          <InputField {...props.fieldConnector('description')}/>
+        </FormGroup>
+      </section>
+
+      <section>
+        <h1>
+          Pipettes
+        </h1>
+      </section>
+    </div>
+  )
+}

--- a/protocol-designer/src/components/FormSection.js
+++ b/protocol-designer/src/components/FormSection.js
@@ -10,7 +10,7 @@ type Props = {
   children?: React.Node,
   className?: string,
   /** if defined, carat shows */
-  onCollapseToggle?: (event: SyntheticEvent<>) => void,
+  onCollapseToggle?: (event: SyntheticEvent<>) => mixed,
   collapsed?: boolean
 }
 

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -1,12 +1,12 @@
 // @flow
 import * as React from 'react'
 
-import ConnectedDeckSetup from '../containers/ConnectedDeckSetup'
 import ConnectedMoreOptionsModal from '../containers/ConnectedMoreOptionsModal'
 import ConnectedNav from '../containers/ConnectedNav'
 import ConnectedStepEditForm from '../containers/ConnectedStepEditForm'
 import ConnectedSidebar from '../containers/ConnectedSidebar'
 import ConnectedTitleBar from '../containers/ConnectedTitleBar'
+import ConnectedMainPanel from '../containers/ConnectedMainPanel'
 
 import styles from './ProtocolEditor.css'
 
@@ -28,7 +28,8 @@ export default function ProtocolEditor () {
           <div className={styles.main_page_content}>
             <ConnectedMoreOptionsModal />
             <ConnectedStepEditForm />
-            <ConnectedDeckSetup />
+
+            <ConnectedMainPanel />
           </div>
         </div>
       </div>

--- a/protocol-designer/src/components/StepEditForm.js
+++ b/protocol-designer/src/components/StepEditForm.js
@@ -24,10 +24,10 @@ export type Props = {
   pipetteOptions: Options,
   labwareOptions: Options,
   formSectionCollapse: FormSectionState,
-  onCancel: (event: SyntheticEvent<>) => void,
-  onSave: (event: SyntheticEvent<>) => void,
-  onClickMoreOptions: (event: SyntheticEvent<>) => void,
-  onToggleFormSection: (section: FormSectionNames) => mixed => void,
+  onCancel: (event: SyntheticEvent<>) => mixed,
+  onSave: (event: SyntheticEvent<>) => mixed,
+  onClickMoreOptions: (event: SyntheticEvent<>) => mixed,
+  onToggleFormSection: (section: FormSectionNames) => mixed => mixed, // ???
   handleChange: (accessor: string) => (event: SyntheticEvent<HTMLInputElement> | SyntheticEvent<HTMLSelectElement>) => void,
   formData: FormData, // TODO: make sure flow will give clear warning if you put transfer field in pause form, etc
   canSave: boolean

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -4,12 +4,15 @@ import thunk from 'redux-thunk'
 import labwareIngredRootReducer from './labware-ingred/reducers'
 import steplistRootReducer from './steplist/reducers'
 import {rootReducer as navigationRootReducer} from './navigation'
+import {rootReducer as fileDataRootReducer} from './file-data'
 
 // TODO: Ian 2018-01-15 how to make this more DRY with hot reloading?
 function getRootReducer () {
   return combineReducers({
     labwareIngred: require('./labware-ingred/reducers'),
-    steplist: require('./steplist/reducers')
+    steplist: require('./steplist/reducers'),
+    navigation: require('./navigation').rootReducer,
+    fileData: require('./file-data').rootReducer
   })
 }
 
@@ -17,7 +20,8 @@ export default function configureStore () {
   const reducer = combineReducers({
     labwareIngred: labwareIngredRootReducer,
     steplist: steplistRootReducer,
-    navigation: navigationRootReducer
+    navigation: navigationRootReducer,
+    fileData: fileDataRootReducer
   })
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
@@ -36,6 +40,8 @@ export default function configureStore () {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('./labware-ingred/reducers', replaceReducers)
     module.hot.accept('./steplist/reducers', replaceReducers)
+    module.hot.accept('./navigation/reducers', replaceReducers)
+    module.hot.accept('./file-data/reducers', replaceReducers)
   }
 
   return store

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react'
+import type {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+import type {BaseState} from '../types'
+
+import FilePage from '../components/FilePage'
+
+import {actions, selectors} from '../file-data'
+import type {FilePageFields, FieldConnector} from '../file-data'
+
+export default connect(mapStateToProps, null, mergeProps)(FilePage)
+
+function mapStateToProps (state: BaseState): FilePageFields {
+  return selectors.fileFormValues(state)
+}
+
+function mergeProps (
+  stateProps: FilePageFields,
+  dispatchProps: {dispatch: Dispatch<*>}
+): React.ElementProps<typeof FilePage> {
+  const values = stateProps
+  const {dispatch} = dispatchProps
+
+  const fieldConnector: FieldConnector<FilePageFields> = (accessor) => {
+    return {
+      onChange: (e: SyntheticInputEvent<*>) =>
+        dispatch(actions.updateFileField(accessor, e.currentTarget.value)),
+      value: values[accessor]
+    }
+  }
+
+  return {
+    fieldConnector
+  }
+}

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -7,8 +7,8 @@ import type {BaseState} from '../types'
 import FilePage from '../components/FilePage'
 
 import {actions, selectors} from '../file-data'
-import type {FilePageFields, FieldConnector} from '../file-data'
-
+import type {FilePageFields} from '../file-data'
+import {formConnectorFactory, type FormConnector} from '../utils'
 export default connect(mapStateToProps, null, mergeProps)(FilePage)
 
 function mapStateToProps (state: BaseState): FilePageFields {
@@ -22,15 +22,17 @@ function mergeProps (
   const values = stateProps
   const {dispatch} = dispatchProps
 
-  const fieldConnector: FieldConnector<FilePageFields> = (accessor) => {
-    return {
-      onChange: (e: SyntheticInputEvent<*>) =>
-        dispatch(actions.updateFileField(accessor, e.currentTarget.value)),
-      value: values[accessor]
+  const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
+    if (accessor === 'name' || accessor === 'description' || accessor === 'author') {
+      dispatch(actions.updateFileField(accessor, e.currentTarget.value))
+    } else {
+      console.warn('Invalid accessor in ConnectedFilePage:', accessor)
     }
   }
 
+  const formConnector: FormConnector<FilePageFields> = formConnectorFactory(onChange, values)
+
   return {
-    fieldConnector
+    formConnector
   }
 }

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react'
+import {connect} from 'react-redux'
+
+import ConnectedDeckSetup from '../containers/ConnectedDeckSetup'
+import ConnectedFilePage from '../containers/ConnectedFilePage'
+
+import type {BaseState} from '../types'
+import {selectors, type Page} from '../navigation'
+
+export default connect(mapStateToProps)(MainPanel)
+
+type Props = {page: Page}
+
+function MainPanel (props: Props) {
+  const {page} = props
+  if (page === 'file') {
+    return <ConnectedFilePage />
+  }
+  // all other pages show the deck setup
+  return <ConnectedDeckSetup />
+}
+
+function mapStateToProps (state: BaseState): Props {
+  return {
+    page: selectors.currentPage(state)
+  }
+}

--- a/protocol-designer/src/file-data/actions.js
+++ b/protocol-designer/src/file-data/actions.js
@@ -1,0 +1,10 @@
+// @flow
+import type {FilePageFieldAccessors} from './types'
+
+export const updateFileField = (accessor: FilePageFieldAccessors, value: string) => ({
+  type: 'UPDATE_FILE_FIELD',
+  payload: {
+    accessor,
+    value
+  }
+})

--- a/protocol-designer/src/file-data/index.js
+++ b/protocol-designer/src/file-data/index.js
@@ -1,0 +1,15 @@
+// @flow
+import * as actions from './actions'
+import {rootReducer, selectors, type RootState} from './reducers'
+
+export * from './types'
+
+export {
+  actions,
+  rootReducer,
+  selectors
+}
+
+export type {
+  RootState
+}

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -1,0 +1,44 @@
+// @flow
+import {combineReducers} from 'redux'
+import {handleActions, type ActionType} from 'redux-actions'
+import {createSelector} from 'reselect'
+import {updateFileField} from '../actions'
+
+import type {FilePageFields} from '../types'
+import type {BaseState} from '../../types'
+
+const defaultFields = {
+  name: '',
+  author: '',
+  description: ''
+}
+
+const metadataFields = handleActions({
+  UPDATE_FILE_FIELD: (state, action: ActionType<typeof updateFileField>) => ({
+    ...state,
+    [action.payload.accessor]: action.payload.value
+  })
+}, defaultFields)
+
+export type RootState = {
+  metadataFields: FilePageFields
+}
+
+const _allReducers = {
+  metadataFields
+}
+
+export const rootReducer = combineReducers(_allReducers)
+
+// ===== SELECTORS =====
+
+const rootSelector = (state: BaseState): RootState => state.fileData
+
+const fileFormValues = createSelector(
+  rootSelector,
+  state => state.metadataFields
+)
+
+export const selectors = {
+  fileFormValues
+}

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -7,8 +7,3 @@ export type FilePageFields = {|
 |}
 
 export type FilePageFieldAccessors = $Keys<FilePageFields>
-
-export type FieldConnector<P> = (accessor: $Keys<P>) => ({
-  onChange: (e: SyntheticInputEvent<*>) => mixed,
-  value: $Values<P>
-})

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,0 +1,14 @@
+// @flow
+export type FilePageFields = {|
+  name: string,
+  author: string,
+  description: string
+  // TODO Ian 2018-02-26 add pipettes to form
+|}
+
+export type FilePageFieldAccessors = $Keys<FilePageFields>
+
+export type FieldConnector<P> = (accessor: $Keys<P>) => ({
+  onChange: (e: SyntheticInputEvent<*>) => mixed,
+  value: $Values<P>
+})

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -3,9 +3,9 @@ import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import type { ActionType } from 'redux-actions'
 
-import type {BaseState} from '../types'
-import {navigateToPage} from './actions'
-import type {Page} from './types'
+import type {BaseState} from '../../types'
+import {navigateToPage} from '../actions'
+import type {Page} from '../types'
 
 const page = handleActions({
   NAVIGATE_TO_PAGE: (state, action: ActionType<typeof navigateToPage>) => action.payload

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -2,11 +2,13 @@
 import type {RootState as StepList} from './steplist/reducers'
 import type {RootState as Navigation} from './navigation'
 import type {RootState as LabwareIngred} from './labware-ingred/reducers'
+import type {RootState as FileData} from './file-data'
 
 export type BaseState = {
   steplist: StepList,
   navigation: Navigation,
-  labwareIngred: LabwareIngred
+  labwareIngred: LabwareIngred,
+  fileData: FileData
 }
 
 export type GetState = () => BaseState

--- a/protocol-designer/src/utils.js
+++ b/protocol-designer/src/utils.js
@@ -3,10 +3,18 @@ import * as componentLibrary from '@opentrons/components'
 
 export const { humanize, wellNameSplit } = componentLibrary
 
+export type FormConnectorFactory<F> = (
+  handleChange: (accessor: F) => (e: SyntheticInputEvent<*>) => mixed,
+  formData: F
+) => FormConnector<F>
+
+export type FormConnector<F> = (accessor: $Keys<F>) =>
+  {onChange: (e: SyntheticInputEvent<*>) => mixed, value: $Values<F>}
+
 export const formConnectorFactory = (
-  handleChange: (string) => (e: SyntheticEvent<*>) => void,
-  formData: {}
-) => (accessor: string): {| onChange: any, value: any |} => ({
+  handleChange: (accessor: string) => (e: SyntheticInputEvent<*>) => mixed,
+  formData: Object
+): FormConnector<*> => (accessor: string) => ({
   // Uses single accessor string to pass onChange & value into form fields
   // TODO Ian 2018-02-07 type error when accessor not valid ('string' is too general)
   onChange: handleChange(accessor),


### PR DESCRIPTION
## overview

Closes #739 

## changelog

* New 'file-data' atom to handle new form fields in File Page
* Clicking nav icons Page/Gear navigates to file page / design page (via ConnectedMainPanel)

* Changed Component Library input components to use `=> mixed` not `=> void` for onChange onClick etc handlers.

## Not in this PR

The pipette stuff is not in this PR - I have to factor out `InstrumentInfo` from app, it's identical in PD on the File Page.

NOTE: step forms do NOT disappear when you go back to file page. Later the page navigation action should cause that form to be canceled, since you're exiting that form when you navigate away

## flow notes :surfing_man: 

I tried to make Flow validate my form stuff as much as possible. The typing for this form gets applied in one place: `Props = {formConnector: FormConnector<FilePageFields>}` in `FilePage.js`

I reused the `formConnector` utility I made for the `StepEditForm.js`. In `FilePage.js`, Flow will give you a "property not found" error if you give a form field a nonexistent accessor (eg if you misspell `description` or something). (NOTE: this doesn't work in StepEditForm, since its form type is one big union of all the different step forms -- to get more helpful type checking, StepEditForm needs to be handle all that, which is far off from this PR).

## review

You can fill out the fields in the file page and they update the state immediately as you type.

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_file-page-form/index.html