### PR TITLE
(pd) component-only FileSidebar

### DIFF
--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -1,0 +1,28 @@
+@import '@opentrons/components';
+
+.download_button,
+.bottom_buttons {
+  & button {
+    margin: 1rem 0;
+  }
+}
+
+.download_button {
+  margin: 0 1rem;
+}
+
+.divider {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background-color: var(--c-light-gray);
+}
+
+.bottom_buttons {
+  margin: 1rem 2rem;
+
+  & button {
+    /* Unlike PrimaryButton, OutlineButton isn't 100% width */
+    width: 100%;
+  }
+}

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react'
+import {PrimaryButton, OutlineButton, SidePanel} from '@opentrons/components'
+import styles from './FileSidebar.css'
+
+type Props = {
+  onUploadClick?: () => mixed,
+  onDownloadClick?: () => mixed,
+  onCreateNew?: () => mixed
+}
+
+export default function FileSidebar (props: Props) {
+  return (
+    <SidePanel title='Protocol File' className={styles.file_sidebar}>
+      {props.onDownloadClick &&
+        <div>
+          <div className={styles.download_button}>
+            <PrimaryButton onClick={props.onDownloadClick}>Download</PrimaryButton>
+          </div>
+          <div className={styles.divider} />
+        </div>
+      }
+
+      <div className={styles.bottom_buttons}>
+        <OutlineButton onClick={props.onUploadClick}>Upload</OutlineButton>
+        <OutlineButton onClick={props.onCreateNew}>Create New</OutlineButton>
+      </div>
+    </SidePanel>
+  )
+}

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -5,6 +5,7 @@ import {selectors} from '../navigation'
 
 import ConnectedStepList from './ConnectedStepList'
 import IngredientsList from './IngredientsList'
+import FileSidebar from '../components/FileSidebar'
 
 import type {BaseState} from '../types'
 import type {Page} from '../navigation'
@@ -20,7 +21,7 @@ function Sidebar (props: Props) {
     case 'ingredient-detail':
       return <IngredientsList />
     case 'file':
-      return <div>TODO: File Sidebar</div>
+      return <FileSidebar />
   }
   return null
 }


### PR DESCRIPTION
## overview

Closes #903 

## changelog

FileSidebar component

No `onDownloadClick`: 
![image](https://user-images.githubusercontent.com/11590381/36701235-a4b64bca-1b20-11e8-9abb-829d779dce0a.png)

With `onDownloadClick`:

![image](https://user-images.githubusercontent.com/11590381/36701264-b735eb0c-1b20-11e8-8fa9-1c9184a11b74.png)

## review requests

Give a truthy onDownloadClick prop to show the download button

* Is it useful to factor out that horizontal divider to component library? Do we use it in Run App?