### PR TITLE
Make pick_up_tip press incrementally further

### DIFF
--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -1719,8 +1719,8 @@ class PipetteTest(unittest.TestCase):
             mock.call(well.top()),
             mock.call(well.top(plunge), strategy='direct'),
             mock.call(well.top(), strategy='direct'),
-            mock.call(well.top(plunge), strategy='direct'),
+            mock.call(well.top(plunge - 1), strategy='direct'),
             mock.call(well.top(), strategy='direct'),
-            mock.call(well.top(plunge), strategy='direct'),
+            mock.call(well.top(plunge - 2), strategy='direct'),
             mock.call(well.top(), strategy='direct')
         ]


### PR DESCRIPTION
## overview

Add a parameter to `Pipette.pick_up_tip` for incremental distance during presses. This will cause the pipette to press by an additional N mm on each press (where N is a float value of the parameter), which will make it possible to experiment on the correct number of presses and press distance without requiring a code push for each iteration, and allow these to be specified in protocols if desired.

## changelog

- (feature) Add `increment` parameter to `Pipette.pick_up_tip`
