### PR TITLE
Improve redux flow types in the app and enable flow linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,9 +2,9 @@ module.exports = {
   parser: 'babel-eslint',
 
   extends: [
-    'standard'
+    'standard',
     // TODO(mc, 2018-02-10): plugin:react/recommended
-    // TODO(mc, 2018-02-10): plugin:flowtype/recommended
+    'plugin:flowtype/recommended'
   ],
 
   plugins: [
@@ -17,17 +17,7 @@ module.exports = {
     'react/jsx-uses-vars': 'error'
   },
 
-  globals: {
-    SyntheticEvent: true,
-    SyntheticMouseEvent: true,
-    SyntheticInputEvent: true,
-    $Keys: true,
-    $Values: true,
-    $Call: true,
-    $Diff: true,
-    $PropertyType: true,
-    Class: true
-  },
+  globals: {},
 
   env: {
     node: true,

--- a/app/src/analytics/index.js
+++ b/app/src/analytics/index.js
@@ -42,7 +42,7 @@ export const middleware = (store) => (next) => (action) => {
     }
   }
 
-  next(action)
+  return next(action)
 }
 
 // maps a payload object to an analytics label string

--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -10,7 +10,7 @@ import type {
 import {AlertModal} from '@opentrons/components'
 
 type Props = {
-  onClose: () => *,
+  onClose: () => mixed,
   error: ?ApiRequestError,
   response: ?WifiConfigureResponse
 }

--- a/app/src/components/TipProbe/UnprobedPanel.js
+++ b/app/src/components/TipProbe/UnprobedPanel.js
@@ -28,7 +28,7 @@ type DispatchProps = {
 }
 
 type Props = {
-  probed: bool,
+  probed: boolean,
   onPrepareClick: () => void
 }
 

--- a/app/src/components/setup-panel/InstrumentList.js
+++ b/app/src/components/setup-panel/InstrumentList.js
@@ -14,7 +14,7 @@ import InstrumentListItem from './InstrumentListItem'
 
 type Props = {
   instruments: Instrument[],
-  isRunning: bool,
+  isRunning: boolean,
 }
 
 const TITLE = 'Pipette Calibration'

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -2,7 +2,7 @@
 // health http api module
 import {createSelector} from 'reselect'
 
-import type {State, ThunkAction, Action} from '../types'
+import type {State, ThunkPromiseAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
 import type {ApiCall} from './types'
@@ -48,7 +48,7 @@ type HealthState = {
   [robotName: string]: ?RobotHealth
 }
 
-export function fetchHealth (robot: RobotService): ThunkAction {
+export function fetchHealth (robot: RobotService): ThunkPromiseAction {
   return (dispatch) => {
     dispatch(healthRequest(robot))
 

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -2,7 +2,7 @@
 // wifi http api module
 import {createSelector} from 'reselect'
 
-import type {State, ThunkAction, Action} from '../types'
+import type {State, ThunkPromiseAction, Action} from '../types'
 import type {RobotService} from '../robot'
 
 import type {ApiCall} from './types'
@@ -100,10 +100,8 @@ export type WifiAction =
 
 export type RobotWifiList = ApiCall<void, WifiListResponse>
 export type RobotWifiStatus = ApiCall<void, WifiStatusResponse>
-export type RobotWifiConfigure = ApiCall<
-  ConfigureRequest,
-  WifiConfigureResponse
->
+export type RobotWifiConfigure =
+  ApiCall<ConfigureRequest, WifiConfigureResponse>
 
 type RobotWifiState = {
   list?: RobotWifiList,
@@ -119,7 +117,7 @@ const LIST: RequestPath = 'list'
 const STATUS: RequestPath = 'status'
 const CONFIGURE: RequestPath = 'configure'
 
-export function fetchWifiList (robot: RobotService): ThunkAction {
+export function fetchWifiList (robot: RobotService): ThunkPromiseAction {
   return (dispatch) => {
     dispatch(wifiRequest(robot, LIST))
 
@@ -130,7 +128,7 @@ export function fetchWifiList (robot: RobotService): ThunkAction {
   }
 }
 
-export function fetchWifiStatus (robot: RobotService): ThunkAction {
+export function fetchWifiStatus (robot: RobotService): ThunkPromiseAction {
   return (dispatch) => {
     dispatch(wifiRequest(robot, STATUS))
 
@@ -154,14 +152,15 @@ export function clearConfigureWifiResponse (
   return {type: 'api:CLEAR_CONFIGURE_WIFI_RESPONSE', payload: {robot}}
 }
 
-export function configureWifi (robot: RobotService): ThunkAction {
+export function configureWifi (robot: RobotService): ThunkPromiseAction {
   return (dispatch, getState) => {
     const robotWifiState = selectRobotWifiState(getState(), robot) || {}
     const configureState = robotWifiState.configure || {}
     const body = configureState.request
 
     if (!body) {
-      return console.warn('configureWifi called without setConfigureWifiBody')
+      console.warn('configureWifi called without setConfigureWifiBody')
+      return Promise.resolve()
     }
 
     dispatch(wifiRequest(robot, CONFIGURE))

--- a/app/src/interface/index.js
+++ b/app/src/interface/index.js
@@ -82,6 +82,6 @@ export function alertMiddleware (root) {
       root.alert(message)
     }
 
-    next(action)
+    return next(action)
   }
 }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -83,9 +83,9 @@ export type ConfirmProbedAction = {|
 |}
 
 export type PipetteCalibrationAction = {|
-  type:
+  type: (
     | 'robot:JOG'
-  ,
+  ),
   payload: {|
     mount: Mount,
     axis?: Axis,
@@ -97,13 +97,13 @@ export type PipetteCalibrationAction = {|
 |}
 
 export type LabwareCalibrationAction = {|
-  type:
+  type: (
     | 'robot:MOVE_TO'
     | 'robot:PICKUP_AND_HOME'
     | 'robot:DROP_TIP_AND_HOME'
     | 'robot:CONFIRM_TIPRACK'
     | 'robot:UPDATE_OFFSET'
-  ,
+  ),
   payload: {|
     mount: Mount,
     slot: Slot
@@ -114,14 +114,14 @@ export type LabwareCalibrationAction = {|
 |}
 
 export type CalibrationSuccessAction = {
-  type:
+  type: (
     | 'robot:MOVE_TO_SUCCESS'
     | 'robot:JOG_SUCCESS'
     | 'robot:PICKUP_AND_HOME_SUCCESS'
     | 'robot:DROP_TIP_AND_HOME_SUCCESS'
     | 'robot:CONFIRM_TIPRACK_SUCCESS'
     | 'robot:UPDATE_OFFSET_SUCCESS'
-  ,
+  ),
   payload: {
     isTiprack?: boolean,
     tipOn?: boolean
@@ -129,14 +129,14 @@ export type CalibrationSuccessAction = {
 }
 
 export type CalibrationFailureAction = {|
-  type:
+  type: (
     | 'robot:MOVE_TO_FAILURE'
     | 'robot:JOG_FAILURE'
     | 'robot:PICKUP_AND_HOME_FAILURE'
     | 'robot:DROP_TIP_AND_HOME_FAILURE'
     | 'robot:CONFIRM_TIPRACK_FAILURE'
     | 'robot:UPDATE_OFFSET_FAILURE'
-  ,
+  ),
   error: true,
   payload: Error
 |}

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -1,5 +1,10 @@
+/* eslint-disable no-use-before-define */
 // @flow
 // application types
+import type {
+  Store as ReduxStore,
+  Dispatch as ReduxDispatch
+} from 'redux'
 
 import typeof reducer from './reducer'
 import type {Action as RobotAction} from './robot'
@@ -11,11 +16,19 @@ export type Action =
   | RobotAction
   | HttpApiAction
 
-// TODO(mc, 2018-02-12): remove this eslint-disable
-//   https://github.com/babel/babel-eslint/issues/485
-/* eslint-disable no-use-before-define */
+export type ThunkAction = (Dispatch, GetState) => ?Action
 
-export type Dispatch = (action: Action | ThunkAction) => any
-export type ThunkAction = (dispatch: Dispatch, getState: () => State) => any
+export type ThunkPromiseAction = (Dispatch, GetState) => Promise<?Action>
 
-/* eslint-enable no-use-before-define */
+export type Store = ReduxStore<State, Action>
+
+export type GetState = () => State
+
+export type ThunkDispatch<A> = (thunk: ThunkAction) => ?A
+
+export type ThunkPromiseDispatch<A> = (thunk: ThunkPromiseAction) => Promise<?A>
+
+export type Dispatch =
+  & ReduxDispatch<Action>
+  & ThunkDispatch<Action>
+  & ThunkPromiseDispatch<Action>

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -11,7 +11,7 @@ export type ButtonProps = {
   /** title attribute */
   title?: string,
   /** disabled attribute (setting disabled removes onClick) */
-  disabled?: bool,
+  disabled?: boolean,
   /** optional Icon name */
   iconName?: IconName,
   /** classes to apply */

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -21,7 +21,7 @@ type singleWell = {
   selected: boolean,
   wellName: string,
   maxVolume: number,
-  groupId? : string
+  groupId?: string
 }
 
 type wellDims = { // TODO similar to type in Well.js. DRY it up

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -7,7 +7,7 @@ import styles from './modals.css'
 
 type Props = {
   /** optional handler for overlay click */
-  onCloseClick?: () => void,
+  onCloseClick?: () => mixed,
   /** optional modal heading */
   heading?: React.Node,
   /** optional array of `ButtonProps` for `FlatButton`s at bottom of modal */

--- a/components/src/modals/Modal.js
+++ b/components/src/modals/Modal.js
@@ -6,7 +6,7 @@ import styles from './modals.css'
 
 type ModalProps = {
   /** handler to close the modal (attached to `Overlay` onClick) */
-  onCloseClick?: (event: SyntheticEvent<>) => void,
+  onCloseClick?: (event: SyntheticEvent<>) => mixed,
   /** modal contents */
   children: React.Node,
   /** classes to apply */

--- a/components/src/modals/Overlay.js
+++ b/components/src/modals/Overlay.js
@@ -6,7 +6,7 @@ import styles from './modals.css'
 
 type OverlayProps = {
   /** optional onClick handler */
-  onClick?: (event: SyntheticEvent<>) => void
+  onClick?: (event: SyntheticEvent<>) => mixed
 }
 
 /**

--- a/components/src/structure/PageTabs.js
+++ b/components/src/structure/PageTabs.js
@@ -10,8 +10,8 @@ import styles from './structure.css'
 type TabProps = {
   title: string,
   href: string,
-  isActive: bool,
-  isDisabled: bool
+  isActive: boolean,
+  isDisabled: boolean
 }
 
 export type PageTabProps = {

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -99,7 +99,7 @@ type LabwareOnDeckProps = {
 
   setCopyLabwareMode: (containerId: string) => void,
   labwareToCopy: string, // ?
-  copyLabware : (slot: string) => void,
+  copyLabware: (slot: string) => void,
 
   height: number,
   width: number,

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -49,10 +49,10 @@ export const closeIngredientSelector = createAction(
 
 export const editModeIngredientGroup = createAction(
   'EDIT_MODE_INGREDIENT_GROUP',
-  (args:
+  (args: (
     | null // null here means "deselect ingredient group"
     | {| wellName: string, groupId: string |}
-  ) => args
+  )) => args
 )
 
 // ==== Create/delete/modify labware =====

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -89,7 +89,7 @@ export type RobotState = {|
       }
     },
     pipettes: {
-      [pipetteId: string] : boolean // true if tip is on pipette
+      [pipetteId: string]: boolean // true if tip is on pipette
     }
   }
 |}


### PR DESCRIPTION
## overview

I was trying to work on health check and ran right into a flow wall. Rather than try to fix everything up in that feature branch, I gave [this article](https://blog.callstack.io/type-checking-react-and-redux-thunk-with-flow-part-2-206ce5f6e705) a read and made some flow tweaks and improvements as its own PR.

## changelog

- Refactor: improved run app base redux types and enabled flow linting

## review requests

Make sure linting still passes on your machine. It does on mine
