### PR TITLE
(pd) NewFileModal comp; modal style cleanup

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -16,9 +16,9 @@ export default function FilePage (props: Props) {
   return (
     <div className={styles.file_page}>
       <section>
-        <h1>
+        <h2>
           Information
-        </h1>
+        </h2>
 
         <div className={formStyles.row_wrapper}>
           <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
@@ -36,9 +36,9 @@ export default function FilePage (props: Props) {
       </section>
 
       <section>
-        <h1>
+        <h2>
           Pipettes
-        </h1>
+        </h2>
       </section>
     </div>
   )

--- a/protocol-designer/src/components/ProtocolEditor.css
+++ b/protocol-designer/src/components/ProtocolEditor.css
@@ -1,19 +1,36 @@
+@import '@opentrons/components';
+
 .wrapper {
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  height: 100%;
   width: 100%;
+  height: 100vh;
 }
 
 .main_page_wrapper {
   /* Wraps TitleBar + page content */
-  display: block;
-  flex: 1;
-  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow-y: scroll;
+
+  & > :first-child {
+    flex: 0 0 auto;
+  }
 }
 
 .main_page_content {
+  flex: 1 1;
   position: relative;
-  height: 100%;
+
+  & h2 {
+    /** TODO Ian 2018-02-27 is there a better place for making h2's look like headers --
+     * without making TitleBar etc components headers wrong? */
+    @apply --font-header-dark;
+
+    line-height: 4rem;
+    padding: 0;
+    margin: 0;
+  }
 }

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -7,6 +7,7 @@ import ConnectedStepEditForm from '../containers/ConnectedStepEditForm'
 import ConnectedSidebar from '../containers/ConnectedSidebar'
 import ConnectedTitleBar from '../containers/ConnectedTitleBar'
 import ConnectedMainPanel from '../containers/ConnectedMainPanel'
+import NewFileModal from './modals/NewFileModal' // TODO replace with container
 
 import styles from './ProtocolEditor.css'
 
@@ -26,6 +27,8 @@ export default function ProtocolEditor () {
           <ConnectedTitleBar />
 
           <div className={styles.main_page_content}>
+            {/* TODO Ian 2018-02-27 connect this modal IRL */}
+            {false && <NewFileModal onSave={console.log} onCancel={() => console.log('cancel!')}/>}
             <ConnectedMoreOptionsModal />
             <ConnectedStepEditForm />
 

--- a/protocol-designer/src/components/modals/MoreOptionsModal.css
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.css
@@ -1,9 +1,5 @@
 @import './grid.css';
 
-.modal {
-  z-index: 100;
-}
-
 .big_text_box {
   height: 12rem;
 }

--- a/protocol-designer/src/components/modals/MoreOptionsModal.js
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.js
@@ -11,6 +11,7 @@ import {
 import type {FormModalFields} from '../../steplist/types'
 import {formConnectorFactory} from '../../utils'
 import styles from './MoreOptionsModal.css'
+import modalStyles from './modal.css'
 
 type Props = {
   onDelete: (event: SyntheticEvent<>) => void,
@@ -24,8 +25,8 @@ type Props = {
 export default function (props: Props) {
   const formConnector = formConnectorFactory(props.handleChange, props.formData)
   return (
-    !props.hideModal && <Modal onCloseClick={props.onCancel} className={styles.modal}>
-      <div>
+    !props.hideModal && <Modal onCloseClick={props.onCancel} className={modalStyles.modal}>
+      <div className={modalStyles.modal_contents}>
         <FormGroup label='Step Name' className={styles.column_1_2}>
           <InputField {...formConnector('step-name')} />
         </FormGroup>

--- a/protocol-designer/src/components/modals/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal.css
@@ -1,0 +1,21 @@
+@import '@opentrons/components';
+@import '../Form.css';
+
+.cancel_continue_button_row {
+  padding-top: 2rem;
+  lost-utility: clearfix;
+
+  & > *:first-child {
+    lost-offset: 2/4;
+  }
+
+  & button {
+    lost-column: 1/4;
+  }
+}
+
+.pipette_text {
+  @apply --font-body-1-dark;
+
+  padding: 2rem 0 1rem 0;
+}

--- a/protocol-designer/src/components/modals/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal.css
@@ -1,19 +1,6 @@
 @import '@opentrons/components';
 @import '../Form.css';
 
-.cancel_continue_button_row {
-  padding-top: 2rem;
-  lost-utility: clearfix;
-
-  & > *:first-child {
-    lost-offset: 2/4;
-  }
-
-  & button {
-    lost-column: 1/4;
-  }
-}
-
 .pipette_text {
   @apply --font-body-1-dark;
 

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -1,0 +1,96 @@
+// @flow
+import * as React from 'react'
+import {
+  OutlineButton,
+  FormGroup,
+  InputField,
+  DropdownField,
+  Modal
+} from '@opentrons/components'
+
+import styles from './NewFileModal.css'
+import modalStyles from './modal.css'
+
+type State = {
+  name?: string,
+  leftPipette?: string, // TODO: make this union of pipette option values
+  rightPipette?: string,
+}
+
+type Props = {
+  onCancel: () => mixed,
+  onSave: State => mixed
+}
+
+const pipetteOptions = [ // TODO: standardize pipette values
+  {name: 'None', value: ''},
+  {name: 'P10 Single-Channel', value: 'p10-single'},
+  {name: 'P10 8-Channel', value: 'p10-8channel'},
+  {name: 'P300 Single-Channel', value: 'p300-single'},
+  {name: 'P300 8-Channel', value: 'p300-8channel'}
+]
+
+// 'invalid' state is just a concern of these dropdowns, not selected pipette state in general
+const INVALID = 'INVALID'
+
+const pipetteOptionsWithInvalid = [{name: '', value: INVALID}, ...pipetteOptions]
+
+export default class NewFileModal extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      name: '',
+      leftPipette: INVALID,
+      rightPipette: INVALID
+    }
+  }
+
+  handleChange = (accessor: $Keys<State>) => (e: SyntheticInputEvent<*>) => {
+    const value: string = e.target.value
+    this.setState({
+      ...this.state,
+      [accessor]: value
+    })
+  }
+
+  handleSubmit = () => {
+    this.props.onSave(this.state)
+  }
+
+  render () {
+    const {name, leftPipette, rightPipette} = this.state
+    const canSubmit = (leftPipette !== INVALID && rightPipette !== INVALID) && // neither can be invalid
+      (leftPipette || rightPipette) // at least one must not be none (empty string)
+
+    // NOTE Ian 2018-02-27: This is similar to but not quite the same as ContinueModal in complib
+    return <Modal className={modalStyles.modal}>
+      <div className={modalStyles.modal_contents}>
+        <h2>Create New Protocol</h2>
+
+        <FormGroup label='Protocol Name:'>
+          <InputField placeholder='untitled' value={name} onChange={this.handleChange('name')} />
+        </FormGroup>
+
+        <div className={styles.pipette_text}>
+          Select the pipettes you will be using. This cannot be changed later.
+        </div>
+
+        <div className={styles.row_wrapper}>
+          <FormGroup label='Left pipette*:' className={styles.column_1_2}>
+            <DropdownField options={pipetteOptionsWithInvalid}
+              value={leftPipette} onChange={this.handleChange('leftPipette')} />
+          </FormGroup>
+          <FormGroup label='Right pipette*:' className={styles.column_1_2}>
+            <DropdownField options={pipetteOptionsWithInvalid}
+              value={rightPipette} onChange={this.handleChange('rightPipette')} />
+          </FormGroup>
+        </div>
+
+        <div className={styles.cancel_continue_button_row}>
+          <OutlineButton onClick={this.props.onCancel}>Cancel</OutlineButton>
+          <OutlineButton onClick={this.handleSubmit} disabled={!canSubmit}>Save</OutlineButton>
+        </div>
+      </div>
+    </Modal>
+  }
+}

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -1,11 +1,10 @@
 // @flow
 import * as React from 'react'
 import {
-  OutlineButton,
   FormGroup,
   InputField,
   DropdownField,
-  Modal
+  AlertModal
 } from '@opentrons/components'
 
 import styles from './NewFileModal.css'
@@ -62,9 +61,12 @@ export default class NewFileModal extends React.Component<Props, State> {
     const canSubmit = (leftPipette !== INVALID && rightPipette !== INVALID) && // neither can be invalid
       (leftPipette || rightPipette) // at least one must not be none (empty string)
 
-    // NOTE Ian 2018-02-27: This is similar to but not quite the same as ContinueModal in complib
-    return <Modal className={modalStyles.modal}>
-      <div className={modalStyles.modal_contents}>
+    return <AlertModal className={modalStyles.modal}
+      buttons={[
+        {onClick: this.props.onCancel, children: 'Cancel'},
+        {onClick: this.handleSubmit, disabled: !canSubmit, children: 'Save'}
+      ]}>
+      <form className={modalStyles.modal_contents}>
         <h2>Create New Protocol</h2>
 
         <FormGroup label='Protocol Name:'>
@@ -85,12 +87,7 @@ export default class NewFileModal extends React.Component<Props, State> {
               value={rightPipette} onChange={this.handleChange('rightPipette')} />
           </FormGroup>
         </div>
-
-        <div className={styles.cancel_continue_button_row}>
-          <OutlineButton onClick={this.props.onCancel}>Cancel</OutlineButton>
-          <OutlineButton onClick={this.handleSubmit} disabled={!canSubmit}>Save</OutlineButton>
-        </div>
-      </div>
-    </Modal>
+      </form>
+    </AlertModal>
   }
 }

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -1,0 +1,8 @@
+.modal {
+  z-index: 100;
+}
+
+.modal_contents {
+  /* HACK Ian 2018-02-27 -- there's not a nice way to give the modal a width! */
+  width: 60vw;
+}

--- a/protocol-designer/src/css/globals.css
+++ b/protocol-designer/src/css/globals.css
@@ -18,16 +18,6 @@ ul {
   list-style-type: none;
 }
 
-h1 {
-  font-size: fontSizeHuge;
-}
-
-h2 {
-  color: gray;
-  font-size: fontSizeHeader;
-  text-align: center;
-}
-
 label {
   display: inline-block;
 }


### PR DESCRIPTION
## overview

Closes #904 

## changelog

* `NewFileModal` - stateful form to populate brand new protocol file
* Fixed weird height issues with PD's high level layout (Navbar + Sidebar + (Header & Panel) -- before it would always scroll the height of the Panel + height of Header, and Navbar / Sidebar didn't ever reach the bottom
* Consolidated PD's modal styles -- `.modal` in `modals.css` gives 80% width

## review requests

Must be run locally -- get rid of `false` in `ProtocolEditor.js`'s `{false && <NewFileModal onSave={console.log} onCancel={() => console.log('cancel!')}/>}` to see NewFileModal (it doesn't do anything but console.log on save in this PR).

Check out CSS - cleanup suggestions appreciated!