### PR TITLE
Remove save parameter on containers.create

### DIFF
--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -77,7 +77,7 @@ def list():
     return database.list_all_containers()
 
 
-def create(name, grid, spacing, diameter, depth, volume=0, save=False):
+def create(name, grid, spacing, diameter, depth, volume=0):
     columns, rows = grid
     col_spacing, row_spacing = spacing
     custom_container = Container()
@@ -94,8 +94,7 @@ def create(name, grid, spacing, diameter, depth, volume=0, save=False):
             well_name = chr(c + ord('A')) + str(1 + r)
             coordinates = (c * col_spacing, r * row_spacing, 0)
             custom_container.add(well, well_name, coordinates)
-    if save:
-        database.save_new_container(custom_container, name)
+    database.save_new_container(custom_container, name)
     return custom_container
 
 

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -24,8 +24,7 @@ def test_containers_create(robot):
         spacing=(9, 9),
         diameter=4,
         depth=8,
-        volume=1000,
-        save=True)
+        volume=1000)
 
     p = containers_load(robot, container_name, '1')
     assert len(p) == 96
@@ -41,16 +40,6 @@ def test_containers_create(robot):
 
     database.delete_container(container_name)
     assert container_name not in containers_list()
-
-    container_name = 'other_plate_for_testing_containers_create'
-    p = containers_create(
-        name=container_name,
-        grid=(8, 12),
-        spacing=(9, 9),
-        diameter=4,
-        depth=8,
-        save=False)
-    assert p['C3'].max_volume() == 0
 
 
 class ContainerTestCase(unittest.TestCase):


### PR DESCRIPTION
## overview

`containers.create` should always save the definition, because otherwise it is not possible to use the created definition in a protocol, so `save=False` is a non-sense option. Fixes #915 

## changelog

- (bugfix) Remove `save` parameter from `containers.create`, restoring expected functionality

