### PR TITLE
Add and use feature flag switch for new labware definitions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV RUNNING_ON_PI=1
 # connecting to Host OS services
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 # Add persisted data directory where new python packages are being installed
-ENV PYTHONPATH=$PYTHONPATH:/data/packages/usr/local/lib/python3.6/site-packages
+ENV PYTHONPATH=$PYTHONPATH/data/packages/usr/local/lib/python3.6/site-packages
 ENV PATH=$PATH:/data/packages/usr/local/bin
 # Port name for connecting to smoothie over serial, i.e. /dev/ttyAMA0
 ENV OT_SMOOTHIE_ID=AMA
@@ -60,7 +60,8 @@ RUN pip install pipenv==9.0.3 jupyter
 # Copy server files and data into the container. Note: any directories that
 # you wish to copy into the container must be excluded from the .dockerignore
 # file, or you will encounter a copy error
-ENV LABWARE_DEF=/etc/labware
+ENV LABWARE_DEF /etc/labware
+ENV USER_DEFN_ROOT /data/user_storage/opentrons_data/labware
 COPY ./compute/conf/jupyter_notebook_config.py /root/.jupyter/
 COPY ./labware-definitions/definitions /etc/labware
 COPY ./api /tmp/api

--- a/api/opentrons/config/feature_flags.py
+++ b/api/opentrons/config/feature_flags.py
@@ -1,8 +1,19 @@
 import os
 
 
+def _get_feature_flag(name: str) -> bool:
+    return bool(os.environ.get(name))
+
+
 # short_fixed_trash
 # - True ('55.0'): Old (55mm tall) fixed trash
-# - False: 77mm tall fixed trash
+# - False:         77mm tall fixed trash
 # - EOL: when all short fixed trash containers have been replaced
-def short_fixed_trash(): return os.environ.get('OT2_PROBE_HEIGHT', False)
+def short_fixed_trash(): return _get_feature_flag('OT2_PROBE_HEIGHT')
+
+
+# split_labware_definitions
+# - True:  Use new labware definitions (See: labware_definitions.py and
+#          serializers.py)
+# - False: Use sqlite db
+def split_labware_definitions(): return _get_feature_flag('SPLIT_LABWARE_DEF')

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -498,6 +498,7 @@ class Container(Placeable):
         super(Container, self).__init__(*args, **kwargs)
         self.grid = None
         self.grid_transposed = None
+        self.ordering = None
 
     def invalidate_grid(self):
         """

--- a/api/opentrons/data_storage/labware_definitions.py
+++ b/api/opentrons/data_storage/labware_definitions.py
@@ -107,14 +107,20 @@ Notes:
 # on the robot, and fall back to paths relative to this file within the source
 # repository for development purposes
 FILE_DIR = os.path.abspath(os.path.dirname(__file__))
-DEFAULT_DEFN_DIR = os.environ.get(
-    'LABWARE_DEF',
-    os.path.abspath(os.path.join(
-        FILE_DIR, '..', '..', '..', 'labware-definitions', 'definitions')))
-USER_DEFN_ROOT = os.environ.get(
-    'USER_DEFN_ROOT',
-    os.path.abspath(os.path.join(
-        FILE_DIR, '..', '..', '..', 'labware-definitions', 'user')))
+
+
+def default_definition_dir():
+    return os.environ.get(
+        'LABWARE_DEF',
+        os.path.abspath(os.path.join(
+            FILE_DIR, '..', '..', '..', 'labware-definitions', 'definitions')))
+
+
+def user_defn_root():
+    return os.environ.get(
+        'USER_DEFN_ROOT',
+        os.path.abspath(os.path.join(
+            FILE_DIR, '..', '..', '..', 'labware-definitions', 'user')))
 
 
 def _load_definition(path: str, labware_name: str) -> dict:
@@ -186,7 +192,7 @@ def _load(default_defn_dir: str,
 
 
 def load_json(labware_name: str) -> dict:
-    return _load(DEFAULT_DEFN_DIR, USER_DEFN_ROOT, labware_name)
+    return _load(default_definition_dir(), user_defn_root(), labware_name)
 
 
 def _list_labware(path: str) -> List[str]:
@@ -198,8 +204,10 @@ def _list_labware(path: str) -> List[str]:
 
 
 def list_all_labware() -> List[str]:
-    user_list = [] + _list_labware(os.path.join(USER_DEFN_ROOT, 'definitions'))
-    default_list = [] + _list_labware(DEFAULT_DEFN_DIR)
+    user_list = [] + _list_labware(
+        os.path.join(user_defn_root(), 'definitions'))
+    default_list = [] + _list_labware(
+        default_definition_dir())
     return sorted(list(set(user_list + default_list)))
 
 
@@ -227,8 +235,10 @@ def save_user_definition(defn: dict) -> bool:
         `opentrons.data_storage.serializers.labware_to_json`
     :return: success code
     """
-    return _save_user_definition(
-        os.path.join(USER_DEFN_ROOT, 'definitions'), defn)
+    defn_dir = os.path.join(user_defn_root(), 'definitions')
+    if not os.path.exists(defn_dir):
+        os.makedirs(defn_dir, exist_ok=True)
+    return _save_user_definition(defn_dir, defn)
 
 
 def save_labware_offset(name: str, offset: dict) -> bool:
@@ -240,5 +250,7 @@ def save_labware_offset(name: str, offset: dict) -> bool:
         definition file, as determined by calibration
     :return: success code
     """
-    return _save_offset(
-        os.path.join(USER_DEFN_ROOT, 'offsets'), name, offset)
+    offset_dir = os.path.join(user_defn_root(), 'offsets')
+    if not os.path.exists(offset_dir):
+        os.makedirs(offset_dir, exist_ok=True)
+    return _save_offset(offset_dir, name, offset)

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -127,7 +127,8 @@ async def test_jog(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
-async def test_update_container_offset(main_router, model):
+async def test_update_container_offset(
+        user_definition_dirs, main_router, model):
     with mock.patch.object(
             model.robot,
             'calibrate_container_with_instrument') as call:
@@ -142,7 +143,8 @@ async def test_update_container_offset(main_router, model):
         )
 
 
-async def test_jog_calibrate(dummy_db, main_router, model):
+async def test_jog_calibrate(
+        dummy_db, user_definition_dirs, main_router, model):
     from numpy import array, isclose
     from opentrons.trackers import pose_tracker
 
@@ -160,6 +162,7 @@ async def test_jog_calibrate(dummy_db, main_router, model):
     main_router.calibration_manager.jog(model.instrument, 2, 'y')
     main_router.calibration_manager.jog(model.instrument, 3, 'z')
 
+    # Todo: make tests use a tmp dir instead of a real one
     main_router.calibration_manager.update_container_offset(
         model.container,
         model.instrument

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import re
 import shutil
+import tempfile
 from collections import namedtuple
 from functools import partial
 from uuid import uuid4 as uuid
@@ -110,7 +111,7 @@ def robot(dummy_db):
 def protocol(request):
     try:
         root = request.getfuncargvalue('protocol_file')
-    except Exception as e:
+    except Exception:
         root = request.param
 
     filename = os.path.join(os.path.dirname(__file__), 'data', root)
@@ -139,7 +140,7 @@ def session(loop, test_client, request, main_router):
             root = main_router
         # Assume test fixture has init to attach test loop
         root.init(loop)
-    except Exception as e:
+    except Exception:
         pass
 
     server = rpc.Server(loop=loop, root=root)
@@ -191,6 +192,16 @@ def virtual_smoothie_env(monkeypatch):
     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
     yield
     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+
+
+@pytest.fixture
+def user_definition_dirs(monkeypatch):
+    tmp_usr_root = tempfile.mkdtemp()
+    os.mkdir(os.path.join(tmp_usr_root, 'definitions'))
+    os.mkdir(os.path.join(tmp_usr_root, 'offsets'))
+    monkeypatch.setenv("USER_DEFN_ROOT", tmp_usr_root)
+    yield
+    monkeypatch.setenv("USER_DEFN_ROOT", '')
 
 
 @pytest.fixture

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -16,7 +16,7 @@ from opentrons.containers.placeable import (
     Slot)
 
 
-def test_containers_create(robot):
+def test_containers_create(user_definition_dirs, robot):
     container_name = 'plate_for_testing_containers_create'
     containers_create(
         name=container_name,


### PR DESCRIPTION
## overview

Add new labware definition behind feature flags. This PR is actually more about the feature flags than about the labware definition code (which is partially working, but can be refined incrementally). See `opentrons.config.feature_flags` for examples. Related to #764, but acting as a ticket for the feature flag model.

## changelog

- (feature) Add feature flags module
- (feature) Use new labware definitions (unstable--only enable this feature for further developement) 

## review requests

Tested on `moon-moon` with the feature flag both enabled and disabled, to ensure that new unstable code is not used when disabled.