### PR TITLE
Pd new file modal -- submits

### DIFF
--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -7,7 +7,7 @@ import ConnectedStepEditForm from '../containers/ConnectedStepEditForm'
 import ConnectedSidebar from '../containers/ConnectedSidebar'
 import ConnectedTitleBar from '../containers/ConnectedTitleBar'
 import ConnectedMainPanel from '../containers/ConnectedMainPanel'
-import NewFileModal from './modals/NewFileModal' // TODO replace with container
+import ConnectedNewFileModal from '../containers/ConnectedNewFileModal'
 
 import styles from './ProtocolEditor.css'
 
@@ -28,7 +28,7 @@ export default function ProtocolEditor () {
 
           <div className={styles.main_page_content}>
             {/* TODO Ian 2018-02-27 connect this modal IRL */}
-            {false && <NewFileModal onSave={console.log} onCancel={() => console.log('cancel!')}/>}
+            <ConnectedNewFileModal />
             <ConnectedMoreOptionsModal />
             <ConnectedStepEditForm />
 

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -35,13 +35,22 @@ const INVALID = 'INVALID'
 
 const pipetteOptionsWithInvalid = [{name: '', value: INVALID}, ...pipetteOptions]
 
+const initialState = {
+  name: '',
+  leftPipette: INVALID,
+  rightPipette: INVALID
+}
+
 export default class NewFileModal extends React.Component<Props, State> {
   constructor (props: Props) {
     super(props)
-    this.state = {
-      name: '',
-      leftPipette: INVALID,
-      rightPipette: INVALID
+    this.state = initialState
+  }
+
+  componentWillReceiveProps (nextProps: Props) {
+    // reset form state when modal is hidden
+    if (!this.props.hideModal && nextProps.hideModal) {
+      this.setState(initialState)
     }
   }
 
@@ -75,7 +84,7 @@ export default class NewFileModal extends React.Component<Props, State> {
         <h2>Create New Protocol</h2>
 
         <FormGroup label='Protocol Name:'>
-          <InputField placeholder='untitled' value={name} onChange={this.handleChange('name')} />
+          <InputField placeholder='Untitled' value={name} onChange={this.handleChange('name')} />
         </FormGroup>
 
         <div className={styles.pipette_text}>

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -17,6 +17,7 @@ type State = {
 }
 
 type Props = {
+  hideModal: boolean,
   onCancel: () => mixed,
   onSave: State => mixed
 }
@@ -57,6 +58,10 @@ export default class NewFileModal extends React.Component<Props, State> {
   }
 
   render () {
+    if (this.props.hideModal) {
+      return null
+    }
+
     const {name, leftPipette, rightPipette} = this.state
     const canSubmit = (leftPipette !== INVALID && rightPipette !== INVALID) && // neither can be invalid
       (leftPipette || rightPipette) // at least one must not be none (empty string)

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -24,7 +24,9 @@ function mergeProps (
 
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
     if (accessor === 'name' || accessor === 'description' || accessor === 'author') {
-      dispatch(actions.updateFileField(accessor, e.currentTarget.value))
+      dispatch(actions.updateFileFields({
+        [accessor]: e.target.value
+      }))
     } else {
       console.warn('Invalid accessor in ConnectedFilePage:', accessor)
     }

--- a/protocol-designer/src/containers/ConnectedFileSidebar.js
+++ b/protocol-designer/src/containers/ConnectedFileSidebar.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+import type {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+import {actions, selectors} from '../navigation'
+import FileSidebar from '../components/FileSidebar'
+import type {BaseState} from '../types'
+
+type Props = React.ElementProps<typeof FileSidebar>
+
+export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
+
+function mapStateToProps (state: BaseState): * {
+  return {
+    // Ignore clicking 'CREATE NEW' button in these cases
+    _canCreateNew: !selectors.newProtocolModal(state)
+  }
+}
+
+function mergeProps (stateProps: *, dispatchProps: {dispatch: Dispatch<*>}): Props {
+  const {_canCreateNew} = stateProps
+  const {dispatch} = dispatchProps
+  return {
+    onCreateNew: _canCreateNew
+      ? () => dispatch(actions.toggleNewProtocolModal(true))
+      : undefined
+  }
+}

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -14,7 +14,7 @@ type Props = {page: Page}
 
 function MainPanel (props: Props) {
   const {page} = props
-  if (page === 'file') {
+  if (page === 'file-detail') {
     return <ConnectedFilePage />
   }
   // all other pages show the deck setup

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -14,6 +14,9 @@ type Props = {page: Page}
 
 function MainPanel (props: Props) {
   const {page} = props
+  if (page === 'file-splash') {
+    return <div>TODO: splash page</div>
+  }
   if (page === 'file-detail') {
     return <ConnectedFilePage />
   }

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -17,8 +17,8 @@ function Nav (props: Props) {
     <VerticalNavBar className={styles.nav_bar}>
       <NavButton
         iconName='file'
-        isCurrent={props.currentPage === 'file'}
-        onClick={props.handleClick('file')} />
+        isCurrent={props.currentPage === 'file-detail'}
+        onClick={props.handleClick('file-detail')} />
 
       <NavButton
         iconName='cog'

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -17,11 +17,13 @@ function Nav (props: Props) {
     <VerticalNavBar className={styles.nav_bar}>
       <NavButton
         iconName='file'
-        isCurrent={props.currentPage === 'file-detail'}
+        disabled={props.currentPage === 'file-splash'}
+        isCurrent={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
         onClick={props.handleClick('file-detail')} />
 
       <NavButton
         iconName='cog'
+        disabled={props.currentPage === 'file-splash'}
         isCurrent={props.currentPage === 'steplist' || props.currentPage === 'ingredient-detail'}
         onClick={props.handleClick('steplist')} />
     </VerticalNavBar>

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -26,6 +26,10 @@ function mapStateToProps (state: BaseState): StateProps {
 function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
-    onSave: fields => dispatch(fileActions.updateFileFields(fields))
+    onSave: fields => {
+      dispatch(fileActions.updateFileFields(fields))
+      dispatch(navigationActions.toggleNewProtocolModal(false))
+      dispatch(navigationActions.navigateToPage('file-detail'))
+    }
   }
 }

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import type {Dispatch} from 'redux'
+import type {BaseState} from '../types'
+import {selectors, actions as navigationActions} from '../navigation'
+import {actions as fileActions} from '../file-data'
+
+import NewFileModal from '../components/modals/NewFileModal'
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewFileModal)
+
+type Props = React.ElementProps<typeof NewFileModal>
+
+type StateProps = {
+  hideModal: $PropertyType<Props, 'hideModal'>
+}
+type DispatchProps = $Diff<Props, StateProps>
+
+function mapStateToProps (state: BaseState): StateProps {
+  return {
+    hideModal: !selectors.newProtocolModal(state)
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
+  return {
+    onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
+    onSave: fields => dispatch(fileActions.updateFileFields(fields))
+  }
+}

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -5,7 +5,7 @@ import {selectors} from '../navigation'
 
 import ConnectedStepList from './ConnectedStepList'
 import IngredientsList from './IngredientsList'
-import FileSidebar from '../components/FileSidebar'
+import ConnectedFileSidebar from './ConnectedFileSidebar'
 
 import type {BaseState} from '../types'
 import type {Page} from '../navigation'
@@ -20,8 +20,8 @@ function Sidebar (props: Props) {
       return <ConnectedStepList />
     case 'ingredient-detail':
       return <IngredientsList />
-    case 'file':
-      return <FileSidebar />
+    case 'file-detail':
+      return <ConnectedFileSidebar />
   }
   return null
 }

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -20,6 +20,8 @@ function Sidebar (props: Props) {
       return <ConnectedStepList />
     case 'ingredient-detail':
       return <IngredientsList />
+    case 'file-splash':
+      return <ConnectedFileSidebar />
     case 'file-detail':
       return <ConnectedFileSidebar />
   }

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -28,6 +28,13 @@ function mapStateToProps (state: BaseState): StateProps {
   const selectedStep = steplistSelectors.selectedStep(state)
   const stepName = selectedStep && selectedStep.title
 
+  if (_page === 'file-splash') {
+    return {
+      _page,
+      title: 'Opentrons Protocol Designer'
+    }
+  }
+
   if (_page === 'file-detail') {
     return {
       _page,

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -28,7 +28,7 @@ function mapStateToProps (state: BaseState): StateProps {
   const selectedStep = steplistSelectors.selectedStep(state)
   const stepName = selectedStep && selectedStep.title
 
-  if (_page === 'file') {
+  if (_page === 'file-detail') {
     return {
       _page,
       title: fileName,

--- a/protocol-designer/src/file-data/actions.js
+++ b/protocol-designer/src/file-data/actions.js
@@ -1,10 +1,7 @@
 // @flow
 import type {FilePageFieldAccessors} from './types'
 
-export const updateFileField = (accessor: FilePageFieldAccessors, value: string) => ({
-  type: 'UPDATE_FILE_FIELD',
-  payload: {
-    accessor,
-    value
-  }
+export const updateFileFields = (payload: {[accessor: FilePageFieldAccessors]: string}) => ({
+  type: 'UPDATE_FILE_FIELDS',
+  payload: payload
 })

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,7 +2,7 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 import {createSelector} from 'reselect'
-import {updateFileField} from '../actions'
+import {updateFileFields} from '../actions'
 
 import type {FilePageFields} from '../types'
 import type {BaseState} from '../../types'
@@ -10,13 +10,15 @@ import type {BaseState} from '../../types'
 const defaultFields = {
   name: '',
   author: '',
-  description: ''
+  description: '',
+  leftPipette: '',
+  rightPipette: ''
 }
 
 const metadataFields = handleActions({
-  UPDATE_FILE_FIELD: (state, action: ActionType<typeof updateFileField>) => ({
+  UPDATE_FILE_FIELDS: (state: FilePageFields, action: ActionType<typeof updateFileFields>) => ({
     ...state,
-    [action.payload.accessor]: action.payload.value
+    ...action.payload
   })
 }, defaultFields)
 

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,9 +1,12 @@
 // @flow
-export type FilePageFields = {|
+export type FilePageFields = {
   name: string,
   author: string,
-  description: string
-  // TODO Ian 2018-02-26 add pipettes to form
-|}
+  description: string,
+
+  // pipettes are empty string '' if user selects 'None'
+  leftPipette: string,
+  rightPipette: string
+}
 
 export type FilePageFieldAccessors = $Keys<FilePageFields>

--- a/protocol-designer/src/navigation/actions.js
+++ b/protocol-designer/src/navigation/actions.js
@@ -5,3 +5,8 @@ export const navigateToPage = (payload: Page) => ({
   type: 'NAVIGATE_TO_PAGE',
   payload
 })
+
+export const toggleNewProtocolModal = (payload: boolean) => ({
+  type: 'TOGGLE_NEW_PROTOCOL_MODAL',
+  payload
+})

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -9,13 +9,11 @@ import type {Page} from '../types'
 
 const page = handleActions({
   NAVIGATE_TO_PAGE: (state, action: ActionType<typeof navigateToPage>) => action.payload
-}, 'file-detail') // TODO Ian 2018-02-28 this will start on 'file-splash'
+}, 'file-splash')
 
 const newProtocolModal = handleActions({
   TOGGLE_NEW_PROTOCOL_MODAL: (state, action: ActionType<typeof toggleNewProtocolModal>) =>
-    action.payload,
-  /** Close modal on NewFileModal form submit */
-  UPDATE_FILE_FIELDS: () => false
+    action.payload
 }, false)
 
 export const _allReducers = {

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -4,18 +4,29 @@ import { handleActions } from 'redux-actions'
 import type { ActionType } from 'redux-actions'
 
 import type {BaseState} from '../../types'
-import {navigateToPage} from '../actions'
+import {navigateToPage, toggleNewProtocolModal} from '../actions'
 import type {Page} from '../types'
 
 const page = handleActions({
   NAVIGATE_TO_PAGE: (state, action: ActionType<typeof navigateToPage>) => action.payload
-}, 'file')
+}, 'file-detail') // TODO Ian 2018-02-28 this will start on 'file-splash'
+
+const newProtocolModal = handleActions({
+  TOGGLE_NEW_PROTOCOL_MODAL: (state, action: ActionType<typeof toggleNewProtocolModal>) =>
+    action.payload,
+  /** Close modal on NewFileModal form submit */
+  UPDATE_FILE_FIELDS: () => false
+}, false)
 
 export const _allReducers = {
-  page
+  page,
+  newProtocolModal
 }
 
-export type RootState = {page: Page}
+export type RootState = {
+  page: Page,
+  newProtocolModal: boolean
+}
 
 const rootReducer = combineReducers(_allReducers)
 

--- a/protocol-designer/src/navigation/selectors.js
+++ b/protocol-designer/src/navigation/selectors.js
@@ -15,3 +15,6 @@ export const currentPage: Selector<Page> = (state: BaseState) => {
 
   return ingredients ? 'ingredient-detail' : page
 }
+
+export const newProtocolModal = (state: BaseState) =>
+  navigationRootSelector(state).newProtocolModal

--- a/protocol-designer/src/navigation/types.js
+++ b/protocol-designer/src/navigation/types.js
@@ -1,2 +1,2 @@
 // @flow
-export type Page = 'file' | 'steplist' | 'ingredient-detail' | 'well-selection-modal'
+export type Page = 'file-splash' | 'file-detail' | 'steplist' | 'ingredient-detail' | 'well-selection-modal'


### PR DESCRIPTION
Closes #905 

## overview

* Placeholder splash page for PD
* On initial PD blank slate state, can click "Create New" in SideBar to open NewFileModal
* Can cancel modal
* Can save modal to state
* With protocol loaded, can click "Create New" in SideBar to open a blank NewFileModal and create a new file alltogether (later ticket: all state should be wiped out on new file / load file)

![2018-02-28 13-40 905](https://user-images.githubusercontent.com/11590381/36806157-257c181c-1c8d-11e8-9f9b-71886feadeb7.gif)

## changelog

* `updateFileField` -> `updateFileFields` to take object of keys instead of key, value (since now you can submit the whole form at once)
* Placeholder div and new string enum in `Pages` type for `'file-splash'` page
* ConnectedNav disabled until user creates a protocol (TBD: will it be disabled whenever NewFileModal is open, too?)

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_new-file-modal-submits/index.html