### PR TITLE
(pd) download file with metadata; buttons.css resets for <a>

### DIFF
--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -15,6 +15,8 @@
   }
 
   --button-default: {
+    display: inline-block;
+    text-decoration: none;
     position: relative;
     line-height: 1.4;
     border: none;

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -1,21 +1,26 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {PrimaryButton, OutlineButton, SidePanel} from '@opentrons/components'
 import styles from './FileSidebar.css'
 
 type Props = {
   onUploadClick?: () => mixed,
-  onDownloadClick?: () => mixed,
-  onCreateNew?: () => mixed
+  onCreateNew?: () => mixed,
+  downloadData: ?{
+    fileContents: string,
+    fileName: string
+  }
 }
 
 export default function FileSidebar (props: Props) {
   return (
     <SidePanel title='Protocol File' className={styles.file_sidebar}>
-      {props.onDownloadClick &&
+      {props.downloadData &&
         <div>
           <div className={styles.download_button}>
-            <PrimaryButton onClick={props.onDownloadClick}>Download</PrimaryButton>
+            <PrimaryButton Component='a' download={props.downloadData.fileName}
+              href={'data:applicatin/json;charset=utf-8,' + encodeURIComponent(props.downloadData.fileContents)}
+            >Download</PrimaryButton>
           </div>
           <div className={styles.divider} />
         </div>

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -19,7 +19,7 @@ export default function FileSidebar (props: Props) {
         <div>
           <div className={styles.download_button}>
             <PrimaryButton Component='a' download={props.downloadData.fileName}
-              href={'data:applicatin/json;charset=utf-8,' + encodeURIComponent(props.downloadData.fileContents)}
+              href={'data:application/json;charset=utf-8,' + encodeURIComponent(props.downloadData.fileContents)}
             >Download</PrimaryButton>
           </div>
           <div className={styles.divider} />

--- a/protocol-designer/src/containers/ConnectedFileSidebar.js
+++ b/protocol-designer/src/containers/ConnectedFileSidebar.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {actions, selectors} from '../navigation'
+import {selectors as fileDataSelectors} from '../file-data'
 import FileSidebar from '../components/FileSidebar'
 import type {BaseState} from '../types'
 
@@ -11,16 +12,24 @@ type Props = React.ElementProps<typeof FileSidebar>
 export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
 
 function mapStateToProps (state: BaseState): * {
+  const protocolName = fileDataSelectors.fileFormValues(state).name || 'untitled'
+  const fileData = fileDataSelectors.createFile(state)
+
   return {
+    downloadData: fileData && {
+      fileContents: JSON.stringify(fileData, null, 4),
+      fileName: protocolName + '.json'
+    },
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.newProtocolModal(state)
   }
 }
 
 function mergeProps (stateProps: *, dispatchProps: {dispatch: Dispatch<*>}): Props {
-  const {_canCreateNew} = stateProps
+  const {_canCreateNew, downloadData} = stateProps
   const {dispatch} = dispatchProps
   return {
+    downloadData,
     onCreateNew: _canCreateNew
       ? () => dispatch(actions.toggleNewProtocolModal(true))
       : undefined

--- a/protocol-designer/src/file-data/index.js
+++ b/protocol-designer/src/file-data/index.js
@@ -1,6 +1,8 @@
 // @flow
+/** This is the big selector that generates a .json file to download */
 import * as actions from './actions'
-import {rootReducer, selectors, type RootState} from './reducers'
+import {rootReducer, type RootState} from './reducers'
+import * as selectors from './selectors'
 
 export * from './types'
 

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -1,11 +1,10 @@
 // @flow
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
-import {createSelector} from 'reselect'
+
 import {updateFileFields} from '../actions'
 
 import type {FilePageFields} from '../types'
-import type {BaseState} from '../../types'
 
 const defaultFields = {
   name: '',
@@ -31,16 +30,3 @@ const _allReducers = {
 }
 
 export const rootReducer = combineReducers(_allReducers)
-
-// ===== SELECTORS =====
-
-const rootSelector = (state: BaseState): RootState => state.fileData
-
-const fileFormValues = createSelector(
-  rootSelector,
-  state => state.metadataFields
-)
-
-export const selectors = {
-  fileFormValues
-}

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -26,7 +26,7 @@ export const createFile: BaseState => ?ProtocolFile = createSelector(
         'protocol-name': name,
         author,
         description,
-        created: new Date().toISOString(),
+        created: Date.now(),
         'last-modified': null,
         category: null,
         subcategory: null,

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -1,0 +1,59 @@
+// @flow
+import {createSelector} from 'reselect'
+import type {BaseState} from '../../types'
+import type {ProtocolFile} from '../types'
+import {fileFormValues} from './fileFields'
+
+// TODO LATER Ian 2018-02-28 deal with versioning
+const protocolSchemaVersion = '1.0.0'
+const applicationVersion = '1.0.0'
+
+export const createFile: BaseState => ?ProtocolFile = createSelector(
+  fileFormValues,
+  (fileFormValues) => {
+    const {author, description} = fileFormValues
+    const name = fileFormValues.name || 'untitled'
+    const isValidFile = true // TODO Ian 2018-02-28 this will be its own selector
+
+    if (!isValidFile) {
+      return null
+    }
+
+    return {
+      'protocol-schema': protocolSchemaVersion,
+
+      metadata: {
+        'protocol-name': name,
+        author,
+        description,
+        created: new Date().toISOString(),
+        'last-modified': null,
+        category: null,
+        subcategory: null,
+        tags: []
+      },
+
+      'designer-application': {
+        'application-name': 'opentrons/protocol-designer',
+        'application-version': applicationVersion,
+        data: {/* TODO */}
+      },
+
+      robot: {
+        model: 'OT-2 Standard'
+      },
+
+      instruments: {
+        // TODO
+      },
+
+      labware: {
+        // TODO
+      },
+
+      commands: [
+        // TODO
+      ]
+    }
+  }
+)

--- a/protocol-designer/src/file-data/selectors/fileFields.js
+++ b/protocol-designer/src/file-data/selectors/fileFields.js
@@ -1,0 +1,11 @@
+// @flow
+import {createSelector} from 'reselect'
+import type {BaseState} from '../../types'
+import type {RootState} from '../reducers'
+
+export const rootSelector = (state: BaseState): RootState => state.fileData
+
+export const fileFormValues = createSelector(
+  rootSelector,
+  state => state.metadataFields
+)

--- a/protocol-designer/src/file-data/selectors/index.js
+++ b/protocol-designer/src/file-data/selectors/index.js
@@ -1,0 +1,3 @@
+// @flow
+export * from './fileFields'
+export * from './fileCreator'

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -14,8 +14,8 @@ export type FilePageFields = {
 
 export type FilePageFieldAccessors = $Keys<FilePageFields>
 
-type ISODate = $Subtype<string> // TODO Ian 2018-02-28 ???
-type VersionString = $Subtype<string> // TODO Ian 2018-02-28 ???
+type MsSinceEpoch = number
+type VersionString = string // eg '1.0.0'
 
 // A JSON protocol
 export type ProtocolFile = {
@@ -25,8 +25,8 @@ export type ProtocolFile = {
     'protocol-name': string,
     author: string,
     description: string,
-    created: ISODate,
-    'last-modified': ISODate | null,
+    created: MsSinceEpoch,
+    'last-modified': MsSinceEpoch | null,
     // TODO LATER string enums for category/subcategory? Or just strings?
     category: string | null,
     subcategory: string | null,

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,4 +1,7 @@
 // @flow
+import type {DeckSlot, Mount, Channels} from '@opentrons/components'
+import type {Command} from '../step-generation/types'
+
 export type FilePageFields = {
   name: string,
   author: string,
@@ -10,3 +13,60 @@ export type FilePageFields = {
 }
 
 export type FilePageFieldAccessors = $Keys<FilePageFields>
+
+type ISODate = $Subtype<string> // TODO Ian 2018-02-28 ???
+type VersionString = $Subtype<string> // TODO Ian 2018-02-28 ???
+
+// A JSON protocol
+export type ProtocolFile = {
+  'protocol-schema': VersionString,
+
+  metadata: {
+    'protocol-name': string,
+    author: string,
+    description: string,
+    created: ISODate,
+    'last-modified': ISODate | null,
+    // TODO LATER string enums for category/subcategory? Or just strings?
+    category: string | null,
+    subcategory: string | null,
+    tags: Array<string>
+  },
+
+  'designer-application': {
+    'application-name': 'opentrons/protocol-designer',
+    'application-version': VersionString,
+    data: {
+      // TODO
+    }
+  },
+
+  robot: {
+    model: 'OT-2 Standard' // TODO LATER support additional models
+  },
+
+  instruments: {
+    [instrumentId: string]: {
+      type: 'pipette',
+      mount: Mount,
+      model: string, // Eg '10' for p10
+      channels: Channels
+    }
+  },
+
+  labware: {
+    [labwareId: string]: {
+      slot: DeckSlot,
+      type: string,
+      name: string
+    }
+  },
+
+  commands: Array<{
+    annotation: {
+      name: string,
+      description: string
+    },
+    commands: Array<Command>
+  }>
+}


### PR DESCRIPTION
Closes #854

## overview

"Download" button appears, and user can download a JSON file.
Right now it just has blank/placeholder data, and the download button doesn't only show when there is a file to download.

## changelog

* Added 2 lines to `buttons.css` in Components Library so that `<a>` buttons can render (I need <a> to trigger download)
* Factored out `file-data` selectors into their own dir with an `index.js`

## review requests

Are changes to `buttons.css` ok?

You should be able to download a JSON file, and if you enter a protocol name / author / description it should show up in the file. The file name should match the name you entered.

## Discussion question

Right now, this `createFile` selector is going to run every time any of its inputs change. Ideally this should happen lazily, and only actually run when the user clicks the download button - maybe some less expensive selector could toggle the download button visibility. However, I can't think of a nice way to make the `a`'s `href` prop update only when the user clicks - maybe I can stick something into the onclick before the download is triggered, or I can have the <a> go to a route that then triggers a download somehow? I'm OK trying to optimize this lazy file generation thing later, but if you have any thoughts I'd like to hear them.

Maybe something like https://github.com/kennethjiang/js-file-download -- it appends a hidden `a` with a blob URL, clicks it, removes it, then deletes the blob... this lets you lazily call `createFile` by making the download button's onClick handler look like `onClick={() => fileDownload(props.createFile(), 'filename.json', 'application/json')}`. If that works, then I don't need to use an `a`, can just use a normal `button`.