### PR TITLE
feat(app): Add health check to http api module

### DIFF
--- a/app/src/http-api-client/__mocks__/health.js
+++ b/app/src/http-api-client/__mocks__/health.js
@@ -1,6 +1,5 @@
 // mock health module
 'use strict'
-
 const health = module.exports = jest.genMockFromModule('../health')
 
 health.__mockThunk = jest.fn(() => new Promise((resolve) => {
@@ -8,3 +7,5 @@ health.__mockThunk = jest.fn(() => new Promise((resolve) => {
 }))
 
 health.fetchHealth = jest.fn(() => health.__mockThunk)
+
+health.healthReducer.mockReturnValue({})

--- a/app/src/http-api-client/__tests__/health-check.test.js
+++ b/app/src/http-api-client/__tests__/health-check.test.js
@@ -1,0 +1,269 @@
+// health check tests
+import {actions as robotActions} from '../../robot'
+import {__mockThunk, fetchHealth} from '../health'
+import {
+  reducer,
+  startHealthCheck,
+  stopHealthCheck,
+  setHealthCheckId,
+  clearHealthCheckId,
+  resetHealthCheck,
+  healthCheckMiddleware,
+  makeGetHealthCheckOk
+} from '..'
+
+jest.mock('../health')
+
+const name = 'opentrons-dev'
+const robot = {name, ip: '1.2.3.4', port: '1234'}
+
+describe('health check', () => {
+  let state
+
+  beforeEach(() => {
+    state = {
+      robot: {
+        connection: {
+          connectedTo: name,
+          connectRequest: {name},
+          discoveredByName: {[name]: robot}}
+      },
+      api: {
+        healthCheck: {
+          alreadyRunning: {id: 1, missed: 0},
+          alreadyMissed: {id: 2, missed: 2},
+          [name]: {id: null, missed: 1}
+        }
+      }
+    }
+  })
+
+  describe('actions', () => {
+    test('START_HEALTH_CHECK', () => {
+      expect(startHealthCheck(robot)).toEqual({
+        type: 'api:START_HEALTH_CHECK',
+        payload: {robot}
+      })
+    })
+
+    test('STOP_HEALTH_CHECK', () => {
+      expect(stopHealthCheck(robot)).toEqual({
+        type: 'api:STOP_HEALTH_CHECK',
+        payload: {robot}
+      })
+    })
+
+    test('SET_HEALTH_CHECK_ID', () => {
+      expect(setHealthCheckId(robot, 1234)).toEqual({
+        type: 'api:SET_HEALTH_CHECK_ID',
+        payload: {robot, id: 1234}
+      })
+    })
+
+    test('CLEAR_HEALTH_CHECK_ID', () => {
+      expect(clearHealthCheckId(robot)).toEqual({
+        type: 'api:CLEAR_HEALTH_CHECK_ID',
+        payload: {robot}
+      })
+    })
+
+    test('RESET_HEALTH_CHECK', () => {
+      expect(resetHealthCheck(robot)).toEqual({
+        type: 'api:RESET_HEALTH_CHECK',
+        payload: {robot}
+      })
+    })
+  })
+
+  describe('middleware', () => {
+    let store
+    let next
+    let invoke
+
+    beforeEach(() => {
+      store = {getState: jest.fn(() => state), dispatch: jest.fn()}
+      next = jest.fn()
+      invoke = (action) => healthCheckMiddleware(store)(next)(action)
+    })
+
+    afterEach(() => {
+      jest.clearAllTimers()
+      jest.useRealTimers()
+    })
+
+    test('returns next(action)', () => {
+      const connectResponse = robotActions.connectResponse()
+      const expected = {foo: 'bar'}
+
+      next.mockReturnValueOnce(expected)
+
+      const result = invoke(connectResponse)
+      expect(next).toHaveBeenCalledWith(connectResponse)
+      expect(result).toBe(expected)
+    })
+
+    test('START_HEALTH_CHECK starts an interval and saves it', () => {
+      const id = 1234
+      jest.useFakeTimers()
+      setInterval.mockReturnValueOnce(id)
+      invoke(startHealthCheck(robot))
+
+      expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 3000)
+      expect(store.dispatch).toHaveBeenCalledWith(setHealthCheckId(robot, id))
+    })
+
+    test('START_HEALTH_CHECK dispatches fetchHealth on interval', () => {
+      jest.useFakeTimers()
+      invoke(startHealthCheck(robot))
+
+      const intervalFn = setInterval.mock.calls[0][0]
+      expect(store.dispatch).not.toHaveBeenCalledWith(__mockThunk)
+      intervalFn()
+      expect(fetchHealth).toHaveBeenCalledWith(robot)
+      expect(store.dispatch).toHaveBeenCalledWith(__mockThunk)
+    })
+
+    test('STOP_HEALTH_CHECK clears interval and saves it', () => {
+      const robot = {name: 'alreadyRunning'}
+      jest.useFakeTimers()
+      invoke(stopHealthCheck(robot))
+
+      expect(clearInterval).toHaveBeenCalledWith(1)
+      expect(store.dispatch).toHaveBeenCalledWith(clearHealthCheckId(robot))
+    })
+
+    test('START_HEALTH_CHECK noops if health check is already running', () => {
+      jest.useFakeTimers()
+      invoke(startHealthCheck({name: 'alreadyRunning'}))
+      expect(setInterval).toHaveBeenCalledTimes(0)
+      expect(store.dispatch).toHaveBeenCalledTimes(0)
+    })
+
+    test('STOP_HEALTH_CHECK noops if health check is not running', () => {
+      jest.useFakeTimers()
+      invoke(stopHealthCheck({name}))
+      expect(setInterval).toHaveBeenCalledTimes(0)
+      expect(store.dispatch).toHaveBeenCalledTimes(0)
+    })
+
+    test('CONNECT_RESPONSE success dispatches START_HEALTH_CHECK', () => {
+      state.robot.connection.connectedTo = ''
+      invoke(robotActions.connectResponse())
+      // middleware should pull `robot` from the connection request state
+      expect(store.dispatch).toHaveBeenCalledWith(startHealthCheck(robot))
+    })
+
+    test('CONNECT_RESPONSE failure noops', () => {
+      invoke(robotActions.connectResponse(new Error('AH')))
+      expect(store.dispatch).toHaveBeenCalledTimes(0)
+    })
+
+    test('DISCONNECT_RESPONSE dispatches (STOP|RESET)_HEALTH_CHECK', () => {
+      const expectedRobot = expect.objectContaining({name})
+      invoke(robotActions.disconnectResponse())
+      // middleware should pull `robot` from the connection state
+      expect(store.dispatch)
+        .toHaveBeenCalledWith(stopHealthCheck(expectedRobot))
+      expect(store.dispatch)
+        .toHaveBeenCalledWith(resetHealthCheck(expectedRobot))
+    })
+
+    test('HEALTH_FAILURE sends STOP_HEALTH_CHECK if over threshold', () => {
+      const robot = {name: 'alreadyMissed'}
+      invoke({type: 'api:HEALTH_FAILURE', payload: {robot}})
+      expect(store.dispatch).toHaveBeenCalledWith(stopHealthCheck(robot))
+    })
+
+    test('HEALTH_FAILURE noops if under threshold', () => {
+      const robot = {name: 'alreadyRunning'}
+      invoke({type: 'api:HEALTH_FAILURE', payload: {robot}})
+      expect(store.dispatch).not.toHaveBeenCalledWith(stopHealthCheck(robot))
+    })
+
+    test('HEALTH_FAILURE noops if not running', () => {
+      state.api.healthCheck[name].missed = 2
+      invoke({type: 'api:HEALTH_FAILURE', payload: {robot}})
+      expect(store.dispatch).not.toHaveBeenCalledWith(stopHealthCheck(robot))
+    })
+  })
+
+  describe('reducer', () => {
+    const reduce = (action) => reducer(state.api, action).healthCheck
+
+    test('RESET_HEALTH_CHECK resets interval ID and count', () => {
+      const action = resetHealthCheck({name: 'alreadyMissed'})
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 0},
+        alreadyMissed: {id: null, missed: 0},
+        [name]: {id: null, missed: 1}
+      })
+    })
+
+    test('SET_HEALTH_CHECK_ID sets interval ID and resets count', () => {
+      const action = setHealthCheckId(robot, 1234)
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 0},
+        alreadyMissed: {id: 2, missed: 2},
+        [name]: {id: 1234, missed: 0}
+      })
+    })
+
+    test('CLEAR_HEALTH_CHECK_ID clears interval ID', () => {
+      const action = clearHealthCheckId({name: 'alreadyRunning'})
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: null, missed: 0},
+        alreadyMissed: {id: 2, missed: 2},
+        [name]: {id: null, missed: 1}
+      })
+    })
+
+    test('HEALTH_SUCCESS resets missed to 0', () => {
+      const robot = {name: 'alreadyMissed'}
+      const action = {type: 'api:HEALTH_SUCCESS', payload: {robot}}
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 0},
+        alreadyMissed: {id: 2, missed: 0},
+        [name]: {id: null, missed: 1}
+      })
+    })
+
+    test('HEALTH_SUCCESS noops if not running', () => {
+      const action = {type: 'api:HEALTH_SUCCESS', payload: {robot}}
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 0},
+        alreadyMissed: {id: 2, missed: 2},
+        [name]: {id: null, missed: 1}
+      })
+    })
+
+    test('HEALTH_FAILURE increases missed by 1', () => {
+      const robot = {name: 'alreadyRunning'}
+      const action = {type: 'api:HEALTH_FAILURE', payload: {robot}}
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 1},
+        alreadyMissed: {id: 2, missed: 2},
+        [name]: {id: null, missed: 1}
+      })
+    })
+
+    test('HEALTH_FAILURE noops if not running', () => {
+      const action = {type: 'api:HEALTH_FAILURE', payload: {robot}}
+      expect(reduce(action)).toEqual({
+        alreadyRunning: {id: 1, missed: 0},
+        alreadyMissed: {id: 2, missed: 2},
+        [name]: {id: null, missed: 1}
+      })
+    })
+  })
+
+  describe('selectors', () => {
+    test('makeGetHealthCheckOk', () => {
+      const getHealthCheckOk = makeGetHealthCheckOk()
+
+      expect(getHealthCheckOk(state, robot)).toEqual(true)
+      expect(getHealthCheckOk(state, {name: 'alreadyRunning'})).toEqual(true)
+      expect(getHealthCheckOk(state, {name: 'alreadyMissed'})).toEqual(false)
+      expect(getHealthCheckOk(state, {name: 'foobar'})).toEqual(null)
+    })
+  })
+})

--- a/app/src/http-api-client/health-check.js
+++ b/app/src/http-api-client/health-check.js
@@ -1,0 +1,227 @@
+// @flow
+// health check module for keeping tabs on connected robots
+import {createSelector} from 'reselect'
+
+import type {Middleware, State, Action} from '../types'
+import type {BaseRobot, RobotService} from '../robot'
+
+// TODO(mc, 2018-02-26): figure out this circular dependency
+import {
+  getDiscoveredByName,
+  getConnectRequest,
+  getConnectedRobotName
+} from '../robot/selectors'
+
+import {fetchHealth} from './health'
+
+// since middleware triggers before actions are reduced, health check failure
+// is triggered after CHECK_THRESHOLD + 1 missed polls
+const CHECK_INTERVAL_MS = 3000
+const CHECK_THRESHOLD = 2
+
+const INITIAL_STATE_BY_NAME = {id: null, missed: 0}
+
+export type StartHealthCheckAction = {|
+  type: 'api:START_HEALTH_CHECK',
+  payload: {|
+    robot: RobotService,
+  |}
+|}
+
+export type StopHealthCheckAction = {|
+  type: 'api:STOP_HEALTH_CHECK',
+  payload: {|
+    robot: BaseRobot,
+  |}
+|}
+
+export type SetHealthCheckIdAction = {|
+  type: 'api:SET_HEALTH_CHECK_ID',
+  payload: {|
+    robot: BaseRobot,
+    id: IntervalID,
+  |},
+|}
+
+export type ClearHealthCheckIdAction = {|
+  type: 'api:CLEAR_HEALTH_CHECK_ID',
+  payload: {|
+    robot: BaseRobot,
+  |},
+|}
+
+export type ResetHealthCheckAction = {|
+  type: 'api:RESET_HEALTH_CHECK',
+  payload: {|
+    robot: BaseRobot
+  |}
+|}
+
+type RobotHealthCheck = {
+  missed: number,
+  id: ?IntervalID,
+}
+
+type HealthCheckState = {
+  [robotName: string]: ?RobotHealthCheck
+}
+
+export type HealthCheckAction =
+  | StartHealthCheckAction
+  | StopHealthCheckAction
+  | ResetHealthCheckAction
+  | SetHealthCheckIdAction
+  | ClearHealthCheckIdAction
+
+export function startHealthCheck (robot: RobotService): StartHealthCheckAction {
+  return {
+    type: 'api:START_HEALTH_CHECK',
+    payload: {robot}
+  }
+}
+
+export function stopHealthCheck (robot: BaseRobot): StopHealthCheckAction {
+  return {
+    type: 'api:STOP_HEALTH_CHECK',
+    payload: {robot}
+  }
+}
+
+export function setHealthCheckId (
+  robot: BaseRobot,
+  id: IntervalID
+): SetHealthCheckIdAction {
+  return {type: 'api:SET_HEALTH_CHECK_ID', payload: {robot, id}}
+}
+
+export function clearHealthCheckId (
+  robot: BaseRobot
+): ClearHealthCheckIdAction {
+  return {type: 'api:CLEAR_HEALTH_CHECK_ID', payload: {robot}}
+}
+
+export function resetHealthCheck (robot: BaseRobot): ResetHealthCheckAction {
+  return {type: 'api:RESET_HEALTH_CHECK', payload: {robot}}
+}
+
+export const healthCheckMiddleware: Middleware =
+  (store) => (next) => (action) => {
+    switch (action.type) {
+      case 'api:START_HEALTH_CHECK':
+        startChecking(store, action.payload.robot)
+        break
+
+      case 'api:STOP_HEALTH_CHECK':
+        stopChecking(store, action.payload.robot)
+        break
+
+      case 'api:HEALTH_FAILURE':
+        handleHealthFailure(store, action.payload.robot)
+        break
+
+      case 'robot:CONNECT_RESPONSE':
+        if (!action.payload.error) {
+          const state = store.getState()
+          const name = getConnectRequest(state).name
+          const robot = getDiscoveredByName(state)[name]
+          if (robot) store.dispatch(startHealthCheck(robot))
+        }
+        break
+
+      case 'robot:DISCONNECT_RESPONSE':
+        const robot = {name: getConnectedRobotName(store.getState())}
+        store.dispatch(stopHealthCheck(robot))
+        store.dispatch(resetHealthCheck(robot))
+    }
+
+    return next(action)
+  }
+
+export function healthCheckReducer (
+  state: ?HealthCheckState,
+  action: Action
+): HealthCheckState {
+  if (!state) return {}
+
+  let name
+  let stateByName
+
+  switch (action.type) {
+    case 'api:RESET_HEALTH_CHECK':
+      name = action.payload.robot.name
+      return {...state, [name]: INITIAL_STATE_BY_NAME}
+
+    case 'api:SET_HEALTH_CHECK_ID':
+      name = action.payload.robot.name
+      return {...state, [name]: {id: action.payload.id, missed: 0}}
+
+    case 'api:CLEAR_HEALTH_CHECK_ID':
+      name = action.payload.robot.name
+      stateByName = state[name]
+      return {...state, [name]: {...stateByName, id: null}}
+
+    case 'api:HEALTH_SUCCESS':
+      name = action.payload.robot.name
+      stateByName = state[name]
+      return stateByName && stateByName.id
+        ? {...state, [name]: {...stateByName, missed: 0}}
+        : state
+
+    case 'api:HEALTH_FAILURE':
+      name = action.payload.robot.name
+      stateByName = state[name]
+      return stateByName && stateByName.id
+        ? {...state, [name]: {...stateByName, missed: stateByName.missed + 1}}
+        : state
+  }
+
+  return state
+}
+
+export const makeGetHealthCheckOk = () => createSelector(
+  selectRobotHealthCheck,
+  (state: ?RobotHealthCheck): ?boolean => {
+    if (!state) return null
+
+    return state.missed < CHECK_THRESHOLD
+  }
+)
+
+function startChecking (store, robot: RobotService): void {
+  if (!shouldCheck(store, robot)) return
+
+  const action = fetchHealth(robot)
+  const id = setInterval(() => store.dispatch(action), CHECK_INTERVAL_MS)
+
+  store.dispatch(setHealthCheckId(robot, id))
+}
+
+function stopChecking (store, robot: BaseRobot): void {
+  const state = selectRobotHealthCheck(store.getState(), robot)
+
+  if (state && state.id) {
+    clearInterval(state.id)
+    store.dispatch(clearHealthCheckId(robot))
+  }
+}
+
+function handleHealthFailure (store, robot: BaseRobot): void {
+  const state = selectRobotHealthCheck(store.getState(), robot)
+
+  if (state && state.id && state.missed >= CHECK_THRESHOLD) {
+    store.dispatch(stopHealthCheck(robot))
+  }
+}
+
+function shouldCheck (store, robot: RobotService): boolean {
+  const state = selectRobotHealthCheck(store.getState(), robot)
+
+  return !state || state.id == null
+}
+
+function selectRobotHealthCheck (
+  state: State,
+  props: BaseRobot
+): ?RobotHealthCheck {
+  return state.api.healthCheck[props.name]
+}

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -3,9 +3,11 @@
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
 import {wifiReducer, type WifiAction} from './wifi'
+import {healthCheckReducer, type HealthCheckAction} from './health-check'
 
 export const reducer = combineReducers({
   health: healthReducer,
+  healthCheck: healthCheckReducer,
   wifi: wifiReducer
 })
 
@@ -32,9 +34,23 @@ export type State = $Call<typeof reducer>
 
 export type Action =
   | HealthAction
+  | HealthCheckAction
   | WifiAction
 
-export {fetchHealth, makeGetRobotHealth} from './health'
+export {
+  fetchHealth,
+  makeGetRobotHealth
+} from './health'
+
+export {
+  startHealthCheck,
+  stopHealthCheck,
+  setHealthCheckId,
+  clearHealthCheckId,
+  resetHealthCheck,
+  healthCheckMiddleware,
+  makeGetHealthCheckOk
+} from './health-check'
 
 export {
   fetchWifiList,

--- a/app/src/http-api-client/wifi.js
+++ b/app/src/http-api-client/wifi.js
@@ -49,10 +49,10 @@ type RequestPath = 'list' | 'status' | 'configure'
 
 export type WifiRequestAction = {|
   type: 'api:WIFI_REQUEST',
-  payload: {
+  payload: {|
     robot: RobotService,
     path: RequestPath,
-  }
+  |}
 |}
 
 export type WifiSuccessAction = {|

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -9,6 +9,7 @@ import createHistory from 'history/createBrowserHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
 import {alertMiddleware} from './interface'
+import {healthCheckMiddleware} from './http-api-client'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {middleware as analyticsMiddleware} from './analytics'
 import reducer from './reducer'
@@ -21,6 +22,7 @@ const history = createHistory()
 const middleware = applyMiddleware(
   thunk,
   robotApiMiddleware(),
+  healthCheckMiddleware,
   analyticsMiddleware,
   alertMiddleware(window),
   routerMiddleware(history)

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -8,6 +8,7 @@ import type {
   Slot,
   Axis,
   Direction,
+  BaseRobot,
   RobotService,
   ProtocolFile
 } from './types'
@@ -36,7 +37,7 @@ export type AddDiscoveredAction = {|
 
 export type RemoveDiscoveredAction = {|
   type: 'robot:REMOVE_DISCOVERED',
-  payload: RobotService,
+  payload: BaseRobot,
 |}
 
 export type ConnectAction = {|

--- a/app/src/robot/api-client/worker.js
+++ b/app/src/robot/api-client/worker.js
@@ -35,6 +35,8 @@ function dispatchFromWorker (action) {
   } catch (error) {
     console.error('Unable to dispatch action from worker', action, error)
   }
+
+  return action
 }
 
 function errorToPlainObject (error) {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -47,9 +47,13 @@ export function getIsScanning (state: State): boolean {
   return connection(state).isScanning
 }
 
+export function getDiscoveredByName (state: State) {
+  return connection(state).discoveredByName
+}
+
 export const getDiscovered = createSelector(
   (state: State) => connection(state).discovered,
-  (state: State) => connection(state).discoveredByName,
+  getDiscoveredByName,
   (state: State) => connection(state).connectedTo,
   (discovered, discoveredByName, connectedTo): Robot[] => {
     const robots = discovered.map((name) => ({
@@ -69,8 +73,12 @@ export function getConnectRequest (state: State) {
   return connection(state).connectRequest
 }
 
+export function getConnectedRobotName (state: State) {
+  return connection(state).connectedTo
+}
+
 export const getConnectionStatus = createSelector(
-  (state: State) => connection(state).connectedTo,
+  getConnectedRobotName,
   (state: State) => getConnectRequest(state).inProgress,
   (state: State) => connection(state).disconnectRequest.inProgress,
   (connectedTo, isConnecting, isDisconnecting): ConnectionStatus => {

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -33,9 +33,13 @@ export type JogButtonName =
   | 'up'
   | 'down'
 
+// minimum robot for actions/reducers/middleware to work
+export type BaseRobot = {
+  name: string
+}
+
 // robot MDNS service for connectivity
-export type RobotService = {
-  name: string,
+export type RobotService = BaseRobot & {
   host: string,
   ip: string,
   port: number,

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -12,9 +12,13 @@ import type {Action as HttpApiAction} from './http-api-client'
 
 export type State = $Call<reducer>
 
+export type GetState = () => State
+
 export type Action =
   | RobotAction
   | HttpApiAction
+
+export type ActionType = $PropertyType<Action, 'type'>
 
 export type ThunkAction = (Dispatch, GetState) => ?Action
 
@@ -22,13 +26,20 @@ export type ThunkPromiseAction = (Dispatch, GetState) => Promise<?Action>
 
 export type Store = ReduxStore<State, Action>
 
-export type GetState = () => State
-
-export type ThunkDispatch<A> = (thunk: ThunkAction) => ?A
-
-export type ThunkPromiseDispatch<A> = (thunk: ThunkPromiseAction) => Promise<?A>
-
 export type Dispatch =
-  & ReduxDispatch<Action>
-  & ThunkDispatch<Action>
-  & ThunkPromiseDispatch<Action>
+  & PlainDispatch
+  & ThunkDispatch
+  & ThunkPromiseDispatch
+
+export type Middleware = (s: MwStore) => (n: PlainDispatch) => PlainDispatch
+
+type MwStore = {
+  getState: GetState,
+  dispatch: Dispatch
+}
+
+type PlainDispatch = ReduxDispatch<Action>
+
+type ThunkDispatch = (thunk: ThunkAction) => ?Action
+
+type ThunkPromiseDispatch = (thunk: ThunkPromiseAction) => Promise<?Action>


### PR DESCRIPTION
## overview

Alrighty. This PR starts work on #695 by building out the necessary logic to poll connected robots `/health` endpoints to make sure they're still up. The next PR(s) will:

* Swap RPC connection drop logic to health check logic
* Wired health check state to connection dropped alert modal

For this one: I've added a `health-check` library to the `http-api-client` module. It consists of:

* Four actions
    * Two async ones: `api:START_HEALTH_CHECK` and `api:STOP_HEALTH_CHECK`
        * Inform the middleware to start or stop a health check polling interval
    * Three sync ones: `api:RESET_HEALTH_CHECK`, `api:SET_HEALTH_CHECK_ID`, and `api:CLEAR_HEALTH_CHECK_ID`
        * Reset all health check state for a robot, save the `setInterval` id for a robot, and clear it, respectively
* Middleware
    * Calls `setInterval`  + `api:SET_HEALTH_CHECK_ID` and `clearInterval` + `api:CLEAR_HEALTH_CHECK_ID` as needed
    * "Forwards" `robot:CONNECT_RESPONSE` to `api:START_HEALTH_CHECK`
    * "Forwards" `robot:DISCONNECT_RESPONSE` to `api:STOP_HEALTH_CHECK` and `api:RESET_HEALTH_CHECK`
* Reducer
    * Saves `setInterval` ID
    * Keeps track of missed polls based on `api:HEALTH_SUCCESS` and `api:HEALTH_FAILURE`
* Selector
    * `makeGetHealthCheckOk` selector factory
        * Returns `true` if health check is OK, `false` if too many missed checkins, and `null` if no data

I tried implementing the timers as both thunk actions and as middleware, and the middleware solution ended up being way easier to test and reason with. That being said, could take another crack at thunks if anyone wanted me to; the second time would hopefully go better than the first.

## changelog

- Feature (app): added health check module to poll the health of connected robots

## review requests

This doesn't implement any UI, so the best way to test this one is in the Redux devtools. Expected behavior is:

1. Connect to robot
2. Notice that `START_HEALTH_CHECK` was dispatched and a series of `HEALTH_REQUEST` actions start dispatching
3. Remove the connection somehow (e.g. yank USB cable)
4. Notice that, after three `HTTP_FAILURE` actions, a `STOP_HEALTH_CHECK` is dispatched
    - Depending on how the failure is induced, the RPC connection drop detection may kick in
    - To be addressed in future PR (deprecate connection drop in favor of health check)
    - For testing with virtual smoothie, run `SKIP_WIRED_POLL=1 make dev` to so the wired robot discovery routine doesn't crowd your log (or wait until discovery has finished before testing)

    - For testing a purposefully weird connection, I found temporarily commenting out [this line](https://github.com/Opentrons/opentrons/blob/17511217114fbf1b0743c6b6ff43df7aed2ef7ee/app/src/robot/api-client/client.js#L116) helped

I'm most paranoid about timer leak bugs, so if you can, please stress test and try to get a timer going even after a robot is gone.
