### PR TITLE
Jog and position functionalities broke CLITool

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -29,7 +29,6 @@ def position(pipette):
 
 def jog(axis, direction, step):
 
-    print('Moving Robot')
     robot._driver.move(
         {axis: robot._driver.position[axis] + direction * step})
 

--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -11,14 +11,15 @@ dots = 'dots'
 holes = 'holes'
 
 
-def position(axis):
+def position(pipette):
     """
     Read position from driver into a tuple and map 3-rd value
     to the axis of a pipette currently used
     """
     try:
+
         p = robot._driver.position
-        res = (p['X'], p['Y'], p[axis.upper()])
+        res = (p['X'], p['Y'], p[pipette.upper()])
     except KeyError:
         # for some reason we are sometimes getting
         # key error in dict returned from driver
@@ -28,6 +29,7 @@ def position(axis):
 
 def jog(axis, direction, step):
 
+    print('Moving Robot')
     robot._driver.move(
         {axis: robot._driver.position[axis] + direction * step})
 

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -102,7 +102,6 @@ class SessionManager:
         given by the user.
         """
         if self.current_mount:
-            print('In Jog')
             res = jog(
                 data['axis'],
                 float(data['direction']),

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -102,6 +102,7 @@ class SessionManager:
         given by the user.
         """
         if self.current_mount:
+            print('In Jog')
             res = jog(
                 data['axis'],
                 float(data['direction']),


### PR DESCRIPTION
## overview

Adds first iteration of endpoints for factory calibration within the UI. Also changes code syntax so that the CLITool still functions as expected.

## changelog
Begins work on issue #744

- Re-names factory calibration folder to 'deck_calibration'
- Pulls out 'position' and 'jog' functions from dc_main.py and application constants
- Adds 'start' and 'dispatch' endpoints
- 'Dispatch' function currently supports initializing pipette, selecting pipette and jogging current pipette

## review requests