### PR TITLE
feat(app): Show AlertModal with instructions after health check failure

### DIFF
--- a/app/src/components/LostConnectionAlert/ModalCopy.js
+++ b/app/src/components/LostConnectionAlert/ModalCopy.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import {Switch, Route} from 'react-router'
+
+import styles from './styles.css'
+
+export default function DefaultCopy () {
+  return (
+    <div className={styles.copy}>
+      <p>
+        {"We can't seem to communicate with your robot right now. Please double check your USB or WiFi connection, and then try to reconnect."}
+      </p>
+      <p>
+        <Switch>
+          <Route path='/upload' render={() => (
+            "If you've uploaded a protocol to your robot, it should re-open when you reconnect."
+          )} />
+          <Route path='/setup-instruments' render={() => (
+            'Pipette calibration progress has been lost, so please redo it after you reconnect.'
+          )} />
+          <Route path='/setup-deck' render={() => (
+            'Pipette and deck calibration progress has been lost, so please redo it after you reconnect.'
+          )} />
+          <Route path='/run' render={() => (
+            'If your robot is still running, it will complete the protocol, and you may track its progress once you reconnect.'
+          )} />
+          <Route render={() => (
+            "If you've just unplugged or turned off your robot on purpose, you may ignore this message."
+          )} />
+        </Switch>
+      </p>
+    </div>
+  )
+}

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -1,0 +1,66 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+
+import {
+  selectors as robotSelectors,
+  actions as robotActions
+} from '../../robot'
+
+import {makeGetHealthCheckOk} from '../../http-api-client'
+
+import {AlertModal} from '@opentrons/components'
+import ModalCopy from './ModalCopy'
+
+type StateProps = {
+  robot: ?Robot,
+  ok: ?boolean
+}
+
+type DispatchProps = {
+  disconnect: () => mixed
+}
+
+type Props = StateProps & DispatchProps
+
+export default withRouter(connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(LostConnectionAlert))
+
+function LostConnectionAlert (props: Props) {
+  const {ok, disconnect} = props
+
+  return ok === false && (
+    <AlertModal
+      onCloseClick={disconnect}
+      heading={'Connection to robot lost'}
+      buttons={[
+        {onClick: disconnect, children: 'close'}
+      ]}
+    >
+      <ModalCopy />
+    </AlertModal>
+  )
+}
+
+function makeMapStateToProps () {
+  const getHealthOk = makeGetHealthCheckOk()
+
+  return (state: State) => {
+    const robot = robotSelectors.getConnectedRobot(state)
+
+    return {
+      ok: robot && getHealthOk(state, robot)
+    }
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch) {
+  return {
+    disconnect: () => dispatch(robotActions.disconnect())
+  }
+}

--- a/app/src/components/LostConnectionAlert/styles.css
+++ b/app/src/components/LostConnectionAlert/styles.css
@@ -1,0 +1,3 @@
+.copy p {
+  margin-top: 1rem;
+}

--- a/app/src/components/Page.js
+++ b/app/src/components/Page.js
@@ -2,11 +2,13 @@
 import React from 'react'
 
 import styles from './Page.css'
+import LostConnectionAlert from '../components/LostConnectionAlert'
 
 export default function Page (props) {
   return (
     <main className={styles.task}>
       {props.children}
+      <LostConnectionAlert />
     </main>
   )
 }

--- a/app/src/http-api-client/__tests__/health-check.test.js
+++ b/app/src/http-api-client/__tests__/health-check.test.js
@@ -258,11 +258,13 @@ describe('health check', () => {
 
   describe('selectors', () => {
     test('makeGetHealthCheckOk', () => {
+      state.api.healthCheck[name].missed = 2
       const getHealthCheckOk = makeGetHealthCheckOk()
 
-      expect(getHealthCheckOk(state, robot)).toEqual(true)
+      // health check fails if id is cleared and missed threshold exceeded
+      expect(getHealthCheckOk(state, robot)).toEqual(false)
       expect(getHealthCheckOk(state, {name: 'alreadyRunning'})).toEqual(true)
-      expect(getHealthCheckOk(state, {name: 'alreadyMissed'})).toEqual(false)
+      expect(getHealthCheckOk(state, {name: 'alreadyMissed'})).toEqual(true)
       expect(getHealthCheckOk(state, {name: 'foobar'})).toEqual(null)
     })
   })

--- a/app/src/http-api-client/health-check.js
+++ b/app/src/http-api-client/health-check.js
@@ -183,7 +183,9 @@ export const makeGetHealthCheckOk = () => createSelector(
   (state: ?RobotHealthCheck): ?boolean => {
     if (!state) return null
 
-    return state.missed < CHECK_THRESHOLD
+    const failed = state.id == null && state.missed >= CHECK_THRESHOLD
+
+    return !failed
   }
 )
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -92,6 +92,8 @@ export default function client (dispatch) {
     rpcClient = null
     remote = null
 
+    // TODO(mc, 2018-03-02): refactor this away
+    dispatch(push('/robots'))
     dispatch(actions.disconnectResponse())
   }
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -77,6 +77,11 @@ export function getConnectedRobotName (state: State) {
   return connection(state).connectedTo
 }
 
+export const getConnectedRobot = createSelector(
+  getDiscovered,
+  (discovered) => discovered.find((r) => r.isConnected)
+)
+
 export const getConnectionStatus = createSelector(
   getConnectedRobotName,
   (state: State) => getConnectRequest(state).inProgress,


### PR DESCRIPTION
## overview

This PR adds a very simple AlertModal if and when health check (#940) fails. It does not handle any disabling of links outside the modal, as may be necessary during a "global" (i.e. can appear on any page) alert like this.

Part of #695

![2018-03-02 14 06 46](https://user-images.githubusercontent.com/2963448/36916943-6975b914-1e23-11e8-816b-9a2775aec830.gif)

## changelog

* feat(app): Show AlertModal with instructions after health check failure 

## review requests

Please keep an eye out for any times when clicking "Close" on the modal crashes the UI, or any times the modal doesn't pop up when it should.

Known issue: The alert modal doesn't play super nicely with our modal-like subpages. Will fix this up in a following PR.

Otherwise, @howisthisnamenottakenyet I kinda winged it on [the copy](https://github.com/Opentrons/opentrons/blob/app_disconnect-modal/app/src/components/LostConnectionAlert/ModalCopy.js) based on stuff in the screens. Feedback is much appreciated (and telling me to just replace it with exactly what's in the screens is perfectly valid feedback!).

* Default:
    <img width="546" alt="screenshot 2018-03-02 14 13 25" src="https://user-images.githubusercontent.com/2963448/36917100-e2a20342-1e23-11e8-98cf-98b473faf18b.png">

* While on upload page:
    <img width="532" alt="screenshot 2018-03-02 14 14 24" src="https://user-images.githubusercontent.com/2963448/36917142-05774e18-1e24-11e8-8158-5a5bc6b44d47.png">

* During tip probe:
    <img width="532" alt="screenshot 2018-03-02 14 15 03" src="https://user-images.githubusercontent.com/2963448/36917176-1d446fe4-1e24-11e8-8b0f-bbdd0d02431c.png">

* During labware calibration:
    <img width="514" alt="screenshot 2018-03-02 14 17 40" src="https://user-images.githubusercontent.com/2963448/36917369-971b9dc4-1e24-11e8-8e37-ee1996c7eb08.png">

* During run:
    <img width="537" alt="screenshot 2018-03-02 14 19 11" src="https://user-images.githubusercontent.com/2963448/36917397-b2416af2-1e24-11e8-8836-147c5fc63e58.png">




