### PR TITLE
ci(js): Temporarily disable flow typechecking in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ lint: lint-py lint-js lint-css
 lint-py:
 	$(MAKE) -C $(API_DIR) lint
 
+# TODO(mc, 2018-02-05): bring flow back
 .PHONY: lint-js
 lint-js:
 	eslint '**/*.js'
-	flow
 
 .PHONY: lint-css
 lint-css:


### PR DESCRIPTION
## overview

[`flow-typed` updated its type definitions for redux](https://github.com/flowtype/flow-typed/pull/1731) and now _a bunch_ of our files are showing flow errors. This PR temporarily disables `flow` in CI until we can fix whatever flow is unhappy about and figure out how to avoid this in the future (probably by committing the `flow-typed` defs but maybe something else).

## changelog

- Disabled `flow` in `make lint-js` CI task

## review requests

Nothing special here
