### PR TITLE
ci(flow): Upgrade flow, lock flow-typed defs to v0.61, re-enable flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ lint: lint-py lint-js lint-css
 lint-py:
 	$(MAKE) -C $(API_DIR) lint
 
-# TODO(mc, 2018-02-05): bring flow back
 .PHONY: lint-js
 lint-js:
 	eslint '**/*.js'
+	flow
 
 .PHONY: lint-css
 lint-css:

--- a/app/Makefile
+++ b/app/Makefile
@@ -76,4 +76,4 @@ test:
 
 .PHONY: install-types
 install-types:
-	flow-typed install --ignoreDeps=dev --packageDir=..
+	flow-typed install --ignoreDeps=dev --packageDir=.. --flowVersion=0.61.0

--- a/components/Makefile
+++ b/components/Makefile
@@ -60,4 +60,4 @@ test:
 
 .PHONY: install-types
 install-types:
-	flow-typed install --ignoreDeps=dev --packageDir=..
+	flow-typed install --ignoreDeps=dev --packageDir=.. --flowVersion=0.61.0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.6.1",
     "eslint-plugin-standard": "^3.0.1",
-    "flow-bin": "^0.63.0",
+    "flow-bin": "^0.66.0",
     "flow-typed": "^2.2.3",
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^18.0.0"

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -61,4 +61,4 @@ test:
 
 .PHONY: install-types
 install-types:
-	flow-typed install --packageDir=..
+	flow-typed install --packageDir=.. --flowVersion=0.61.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,9 +3136,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.63.0:
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.63.1.tgz#ab00067c197169a5fb5b4996c8f6927b06694828"
+flow-bin@^0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
 
 flow-typed@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
## overview

Re-enable flow after #983. This is still looking pretty brittle so we may want to consider avoiding typing redux connected components until we can run this to ground a little farther.

## changelog

- Upgrade flow to v0.66 (nicer messages)
- Lock flow-typed defs to flow@0.61.0 (gets us the old react-redux types that our code passes with)
- Re-enable flow in CI (reverts #983)

## review requests

Run `make install` and make sure that `make lint` passes on your machine