### PR TITLE
(pd) add all possible pipettes to setup; show pipette InstrumentGroup

### DIFF
--- a/components/src/instrument-diagram/InstrumentGroup.md
+++ b/components/src/instrument-diagram/InstrumentGroup.md
@@ -1,5 +1,5 @@
 ```js
-<InstrumentGroup  instruments={[
+<InstrumentGroup instruments={[
   {mount: 'left', description: 'p300 8-Channel', tipType: '150', channels: 8},
   {mount: 'right', description: 'p10 Single', tipType: '10', channels: 1, isDisabled: true}
 ]}/>

--- a/components/src/instrument-diagram/index.js
+++ b/components/src/instrument-diagram/index.js
@@ -2,6 +2,7 @@
 import InstrumentDiagram from './InstrumentDiagram'
 import InstrumentGroup from './InstrumentGroup'
 import InstrumentInfo from './InstrumentInfo'
+import type {InstrumentInfoProps} from './InstrumentInfo'
 import InfoItem from './InfoItem'
 
 export {
@@ -9,4 +10,8 @@ export {
   InstrumentGroup,
   InstrumentInfo,
   InfoItem
+}
+
+export type {
+  InstrumentInfoProps
 }

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {FormGroup, InputField} from '@opentrons/components'
+import {FormGroup, InputField, InstrumentGroup, type InstrumentInfoProps} from '@opentrons/components'
 import type {FilePageFields} from '../file-data'
 import type {FormConnector} from '../utils'
 
@@ -8,11 +8,12 @@ import styles from './FilePage.css'
 import formStyles from '../components/Form.css'
 
 type Props = {
-  formConnector: FormConnector<FilePageFields>
+  formConnector: FormConnector<FilePageFields>,
+  instruments: Array<InstrumentInfoProps>
 }
 
 export default function FilePage (props: Props) {
-  const {formConnector} = props
+  const {formConnector, instruments} = props
   return (
     <div className={styles.file_page}>
       <section>
@@ -39,6 +40,7 @@ export default function FilePage (props: Props) {
         <h2>
           Pipettes
         </h2>
+        <InstrumentGroup instruments={instruments} />
       </section>
     </div>
   )

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -37,9 +37,7 @@ function mergeProps (
 
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
     if (accessor === 'name' || accessor === 'description' || accessor === 'author') {
-      dispatch(actions.updateFileFields({
-        [accessor]: e.target.value
-      }))
+      dispatch(actions.updateFileFields({[accessor]: e.target.value}))
     } else {
       console.warn('Invalid accessor in ConnectedFilePage:', accessor)
     }

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -9,17 +9,30 @@ import FilePage from '../components/FilePage'
 import {actions, selectors} from '../file-data'
 import type {FilePageFields} from '../file-data'
 import {formConnectorFactory, type FormConnector} from '../utils'
+
 export default connect(mapStateToProps, null, mergeProps)(FilePage)
 
-function mapStateToProps (state: BaseState): FilePageFields {
-  return selectors.fileFormValues(state)
+type Props = React.ElementProps<typeof FilePage>
+type StateProps = {
+  instruments: $PropertyType<Props, 'instruments'>,
+  _values: {[string]: string}
+}
+
+function mapStateToProps (state: BaseState): StateProps {
+  const formValues = selectors.fileFormValues(state)
+  const pipetteData = selectors.pipettesForInstrumentGroup(state)
+
+  return {
+    _values: formValues,
+    instruments: pipetteData
+  }
 }
 
 function mergeProps (
-  stateProps: FilePageFields,
+  stateProps: StateProps,
   dispatchProps: {dispatch: Dispatch<*>}
-): React.ElementProps<typeof FilePage> {
-  const values = stateProps
+): Props {
+  const {instruments, _values} = stateProps
   const {dispatch} = dispatchProps
 
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
@@ -32,9 +45,10 @@ function mergeProps (
     }
   }
 
-  const formConnector: FormConnector<FilePageFields> = formConnectorFactory(onChange, values)
+  const formConnector: FormConnector<FilePageFields> = formConnectorFactory(onChange, _values)
 
   return {
-    formConnector
+    formConnector,
+    instruments
   }
 }

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -27,8 +27,17 @@ function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
     onSave: fields => {
-      dispatch(fileActions.updateFileFields(fields))
+      dispatch(fileActions.updateFileFields({
+        name: fields.name || ''
+      }))
+
+      dispatch(fileActions.updatePipettes({
+        left: fields.leftPipette,
+        right: fields.rightPipette
+      }))
+
       dispatch(navigationActions.toggleNewProtocolModal(false))
+
       dispatch(navigationActions.navigateToPage('file-detail'))
     }
   }

--- a/protocol-designer/src/file-data/actions.js
+++ b/protocol-designer/src/file-data/actions.js
@@ -1,7 +1,15 @@
 // @flow
 import type {FilePageFieldAccessors} from './types'
+import type {PipetteName} from './pipetteData'
 
+// NOTE: updateFileFields contains pipette name identifiers, though pipettes aren't file fields.
+// This is because both pipettes and file fields can get changed in the same place
 export const updateFileFields = (payload: {[accessor: FilePageFieldAccessors]: string}) => ({
   type: 'UPDATE_FILE_FIELDS',
-  payload: payload
+  payload
+})
+
+export const updatePipettes = (payload: {['left' | 'right']: ?PipetteName}) => ({
+  type: 'UPDATE_PIPETTES',
+  payload
 })

--- a/protocol-designer/src/file-data/pipetteData.js
+++ b/protocol-designer/src/file-data/pipetteData.js
@@ -10,6 +10,14 @@ export const pipetteDataByName: {[pipetteName: string]: {maxVolume: number, chan
     maxVolume: 10,
     channels: 8
   },
+  'P50 Single-Channel': {
+    maxVolume: 50,
+    channels: 1
+  },
+  'P50 8-Channel': {
+    maxVolume: 50,
+    channels: 8
+  },
   'P300 Single-Channel': {
     maxVolume: 300,
     channels: 1
@@ -17,14 +25,23 @@ export const pipetteDataByName: {[pipetteName: string]: {maxVolume: number, chan
   'P300 8-Channel': {
     maxVolume: 300,
     channels: 8
+  },
+  'P1000 Single-Channel': {
+    maxVolume: 1000,
+    channels: 1
   }
 }
 
 export type PipetteName = $Keys<typeof pipetteDataByName>
 
 export const pipetteOptions = [
-  {name: 'P10 Single-Channel', value: 'P10 Single-Channel'},
-  {name: 'P10 8-Channel', value: 'P10 8-Channel'},
-  {name: 'P300 Single-Channel', value: 'P300 Single-Channel'},
-  {name: 'P300 8-Channel', value: 'P300 8-Channel'}
-]
+  'P10 Single-Channel',
+  'P10 8-Channel',
+  'P50 Single-Channel',
+  'P50 8-Channel',
+  'P300 Single-Channel',
+  'P300 8-Channel',
+  'P1000 Single-Channel'
+].map(
+  (name: string) => ({name, value: name})
+)

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,7 +2,7 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
-import {updateFileFields} from '../actions'
+import {updateFileFields, updatePipettes} from '../actions'
 import {pipetteDataByName, type PipetteName} from '../pipetteData'
 
 import type {Mount} from '@opentrons/components'
@@ -12,9 +12,7 @@ import type {FilePageFields} from '../types'
 const defaultFields = {
   name: '',
   author: '',
-  description: '',
-  leftPipette: '',
-  rightPipette: ''
+  description: ''
 }
 
 const metadataFields = handleActions({
@@ -45,17 +43,16 @@ function createPipette (name: PipetteName, mount: Mount) {
 }
 
 const pipettes = handleActions({
-  UPDATE_FILE_FIELDS: (state: PipetteState, action: ActionType<typeof updateFileFields>) => {
-    const leftPipetteName = action.payload.leftPipette
-    const rightPipetteName = action.payload.rightPipette
+  UPDATE_PIPETTES: (state: PipetteState, action: ActionType<typeof updatePipettes>) => {
+    const {left, right} = action.payload // left and/or right pipette names, eg 'P10 Single-Channel'
 
     return {
-      left: leftPipetteName
-        ? createPipette(leftPipetteName, 'left')
-        : state.left,
-      right: rightPipetteName
-        ? createPipette(rightPipetteName, 'right')
-        : state.right
+      left: left
+        ? createPipette(left, 'left')
+        : null,
+      right: right
+        ? createPipette(right, 'right')
+        : null
     }
   }
 }, {left: null, right: null})

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -5,7 +5,7 @@ import reduce from 'lodash/reduce'
 import type {BaseState} from '../../types'
 import * as StepGeneration from '../../step-generation'
 import {selectors as steplistSelectors} from '../../steplist/reducers'
-import {equippedPipettes} from './'
+import {equippedPipettes} from './pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 
 const all96Tips = reduce(

--- a/protocol-designer/src/file-data/selectors/fileFields.js
+++ b/protocol-designer/src/file-data/selectors/fileFields.js
@@ -1,8 +1,5 @@
 // @flow
 import {createSelector} from 'reselect'
-import reduce from 'lodash/reduce'
-import type {DropdownOption} from '@opentrons/components'
-import type {PipetteData} from '../../step-generation'
 import type {BaseState} from '../../types'
 import type {RootState} from '../reducers'
 
@@ -11,28 +8,4 @@ export const rootSelector = (state: BaseState): RootState => state.fileData
 export const fileFormValues = createSelector(
   rootSelector,
   state => state.metadataFields
-)
-
-// TODO Ian 2018-03-01 develop out Pipette ID generation
-export const equippedPipetteOptions: BaseState => Array<DropdownOption> = createSelector(
-  rootSelector,
-  s => [
-    {name: s.metadataFields.leftPipette, value: 'left:' + s.metadataFields.leftPipette},
-    {name: s.metadataFields.rightPipette, value: 'right:' + s.metadataFields.rightPipette}
-  ].filter(option => option.name) // remove 'None' pipette
-)
-
-// TODO LATER factor out into own file
-// Shows pipettes by ID, not mount
-type PipettesById = {[pipetteId: string]: PipetteData}
-export const equippedPipettes = createSelector(
-  rootSelector,
-  s => reduce(s.pipettes, (acc: PipettesById, pipetteData: ?PipetteData): PipettesById => {
-    return (pipetteData)
-      ? {
-        ...acc,
-        [pipetteData.id]: pipetteData
-      }
-      : acc
-  }, {})
 )

--- a/protocol-designer/src/file-data/selectors/index.js
+++ b/protocol-designer/src/file-data/selectors/index.js
@@ -1,4 +1,5 @@
 // @flow
-export * from './fileFields'
-export * from './fileCreator'
 export * from './commands'
+export * from './fileCreator'
+export * from './fileFields'
+export * from './pipettes'

--- a/protocol-designer/src/file-data/selectors/pipettes.js
+++ b/protocol-designer/src/file-data/selectors/pipettes.js
@@ -1,0 +1,61 @@
+// @flow
+import {createSelector} from 'reselect'
+import type {BaseState} from '../../types'
+import reduce from 'lodash/reduce'
+import type {DropdownOption} from '@opentrons/components'
+import type {PipetteData} from '../../step-generation'
+import {rootSelector} from './fileFields'
+import {pipetteDataByName} from '../pipetteData'
+
+export const equippedPipetteOptions: BaseState => Array<DropdownOption> = createSelector(
+  rootSelector,
+  s => [
+    {name: s.metadataFields.leftPipette, value: 'left:' + s.metadataFields.leftPipette},
+    {name: s.metadataFields.rightPipette, value: 'right:' + s.metadataFields.rightPipette}
+  ].filter(option => option.name) // remove 'None' pipette
+)
+
+// TODO LATER factor out into own file
+// Shows pipettes by ID, not mount
+type PipettesById = {[pipetteId: string]: PipetteData}
+export const equippedPipettes = createSelector(
+  rootSelector,
+  s => reduce(s.pipettes, (acc: PipettesById, pipetteData: ?PipetteData): PipettesById => {
+    return (pipetteData)
+      ? {
+        ...acc,
+        [pipetteData.id]: pipetteData
+      }
+      : acc
+  }, {})
+)
+
+function _getPipetteName (pipetteData) {
+  const result = Object.keys(pipetteDataByName).find(pipetteName => {
+    const p = pipetteDataByName[pipetteName]
+    return (
+      p.channels === pipetteData.channels &&
+      p.maxVolume === pipetteData.maxVolume
+    )
+  })
+  if (!result) {
+    console.error('_getPipetteName: No name found for given pipette')
+    return '???'
+  }
+  return result
+}
+
+// Formats pipette data specifically for instrumentgroup
+export const pipettesForInstrumentGroup = createSelector(
+  rootSelector,
+  s => [s.pipettes.left, s.pipettes.right].reduce((acc, pipetteData) => pipetteData
+    ? [...acc, {
+      mount: pipetteData.mount,
+      channels: pipetteData.channels,
+      description: _getPipetteName(pipetteData),
+      isDisabled: false,
+      tipType: `${pipetteData.maxVolume} uL`
+    }]
+    : acc,
+    [])
+)

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -5,11 +5,7 @@ import type {Command} from '../step-generation/types'
 export type FilePageFields = {
   name: string,
   author: string,
-  description: string,
-
-  // pipettes are empty string '' if user selects 'None'
-  leftPipette: string,
-  rightPipette: string
+  description: string
 }
 
 export type FilePageFieldAccessors = $Keys<FilePageFields>


### PR DESCRIPTION
## overview

Closes #971 and #968 

## changelog

Refactor cleanup, setting pipettes was too closely tied to file fields.

* Factored out pipette selectors into `pipettes.js` from `fileFields.js`
* Took out pipette field setting from `updateFileFields` action, moved those fields to new `updatePipettes` action.

## review requests

* User can create new protocol with any combo of pipettes (to leave a mount blank, you still need to explicitly set that pipette to "None" in the New Protocol File modal's pipette dropdown)
* User can see those pipettes in the InstrumentGroup once they click "Save" in New Protocol File modal
