### PR TITLE
refactor(app): Refactor calibrate urls to reflect actual nav flow

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -7,8 +7,7 @@ import SidePanel from '../pages/SidePanel'
 import Robots from '../pages/Robots'
 import AppSettingsPage from '../pages/AppSettings'
 import Upload from '../pages/Upload'
-import SetupInstruments from '../pages/SetupInstruments'
-import SetupDeck from '../pages/SetupDeck'
+import Calibrate from '../pages/Calibrate'
 import Run from '../pages/Run'
 
 import './App.global.css'
@@ -24,8 +23,7 @@ export default function App () {
         <Route path='/robots/:name?' component={Robots} />
         <Route exact path='/menu/app' component={AppSettingsPage} />
         <Route path='/upload' component={Upload} />
-        <Route path='/setup-instruments/:mount' component={SetupInstruments} />
-        <Route path='/setup-deck/:slot' component={SetupDeck} />
+        <Route path='/calibrate' component={Calibrate} />
         <Route path='/run' component={Run} />
       </Switch>
     </div>

--- a/app/src/components/CalibrateDeck/ConnectedLabwareItem.js
+++ b/app/src/components/CalibrateDeck/ConnectedLabwareItem.js
@@ -48,7 +48,7 @@ function mapStateToProps (state, ownProps: OwnProps): StateProps {
       showName: highlighted || confirmed,
       showUnconfirmed: true,
       showSpinner: highlighted && labware.calibration === 'moving-to-slot',
-      url: `/setup-deck/${slot}`
+      url: `/calibrate/labware/${slot}`
     }
   }
 }

--- a/app/src/components/LabwareCalibration/InfoBox.js
+++ b/app/src/components/LabwareCalibration/InfoBox.js
@@ -130,7 +130,7 @@ function mergeProps (
       onClick: () => {
         if (_calibratorMount) {
           dispatch(robotActions.moveTo(_calibratorMount, _buttonTarget.slot))
-          dispatch(push(`/setup-deck/${_buttonTarget.slot}`))
+          dispatch(push(`/calibrate/labware/${_buttonTarget.slot}`))
         }
       },
       text: 'foobar'

--- a/app/src/components/LostConnectionAlert/ModalCopy.js
+++ b/app/src/components/LostConnectionAlert/ModalCopy.js
@@ -15,11 +15,8 @@ export default function DefaultCopy () {
           <Route path='/upload' render={() => (
             "If you've uploaded a protocol to your robot, it should re-open when you reconnect."
           )} />
-          <Route path='/setup-instruments' render={() => (
-            'Pipette calibration progress has been lost, so please redo it after you reconnect.'
-          )} />
-          <Route path='/setup-deck' render={() => (
-            'Pipette and deck calibration progress has been lost, so please redo it after you reconnect.'
+          <Route path='/calibrate' render={() => (
+            'Calibration progress has been lost, so please redo it after you reconnect.'
           )} />
           <Route path='/run' render={() => (
             'If your robot is still running, it will complete the protocol, and you may track its progress once you reconnect.'

--- a/app/src/components/SetupPanel/InstrumentListItem.js
+++ b/app/src/components/SetupPanel/InstrumentListItem.js
@@ -23,7 +23,7 @@ export default function InstrumentListItem (props: Props) {
   const confirmed = instrument && instrument.probed
   const isDisabled = !instrument || isRunning
   const url = !isDisabled
-    ? `/setup-instruments/${mount}`
+    ? `/calibrate/instruments/${mount}`
     : '#'
 
   const iconName: IconName = confirmed

--- a/app/src/components/SetupPanel/LabwareListItem.js
+++ b/app/src/components/SetupPanel/LabwareListItem.js
@@ -24,7 +24,7 @@ export default function LabwareListItem (props: Props) {
     onClick
   } = props
 
-  const url = `/setup-deck/${slot}`
+  const url = `/calibrate/labware/${slot}`
   const iconName = confirmed
     ? CHECKED
     : UNCHECKED

--- a/app/src/components/TipProbe/ContinuePanel.js
+++ b/app/src/components/TipProbe/ContinuePanel.js
@@ -65,12 +65,12 @@ function mapStateToProps (state): StateProps {
 
   if (nextInstrument) {
     _button = {
-      href: `/setup-instruments/${nextInstrument.mount}`,
+      href: `/calibrate/instruments/${nextInstrument.mount}`,
       text: 'Continue to Next Pipette'
     }
   } else if (nextLabware) {
     _button = {
-      href: `/setup-deck/${nextLabware.slot}`,
+      href: `/calibrate/labware/${nextLabware.slot}`,
       text: 'Continue to Labware setup'
     }
   }

--- a/app/src/components/Upload.js
+++ b/app/src/components/Upload.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import {Link} from 'react-router-dom'
 
 import {Icon, ALERT, CHECKED, SPINNER, Splash} from '@opentrons/components'
 
@@ -63,8 +64,9 @@ function UploadResults (props) {
     // instructions for a successful upload
     instructions = (
       <p className={styles.details}>
-        Continue to the Calibrate page to set up your pipettes and labware for
-        the run
+        <span>{'Continue to '}</span>
+        <Link to='/calibrate'>Calibrate</Link>
+        <span>{' to set up your pipettes and labware for the run'}</span>
       </p>
     )
   }

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -25,10 +25,10 @@ function mapStateToProps (state, ownProps) {
   let calibrateUrl
   if (isSessionLoaded & isTipsProbed) {
     calibrateUrl = nextLabware
-     ? `/setup-deck/${nextLabware.slot}`
-     : `/setup-deck/${labware[0].slot}`
+     ? `/calibrate/labware/${nextLabware.slot}`
+     : `/calibrate/labware/${labware[0].slot}`
   } else if (isSessionLoaded) {
-    calibrateUrl = `/setup-instruments/${nextInstrument.mount}`
+    calibrateUrl = `/calibrate/instruments/${nextInstrument.mount}`
   } else {
     calibrateUrl = '#'
   }

--- a/app/src/components/setup-instruments/InstrumentTabs.js
+++ b/app/src/components/setup-instruments/InstrumentTabs.js
@@ -21,7 +21,7 @@ function mapStateToProps (state, ownProps: OwnProps): PageTabProps {
 
   const pages = robotConstants.INSTRUMENT_MOUNTS.map((mount) => ({
     title: mount,
-    href: `/setup-instruments/${mount}`,
+    href: `/calibrate/instruments/${mount}`,
     isActive: mount === ownProps.mount,
     isDisabled: !instruments.some((inst) => inst.mount === mount)
   }))

--- a/app/src/pages/Calibrate.js
+++ b/app/src/pages/Calibrate.js
@@ -1,0 +1,18 @@
+// @flow
+// calibrate page routes
+import * as React from 'react'
+import {Switch, Route, type ContextRouter} from 'react-router'
+
+import SetupInstruments from '../pages/SetupInstruments'
+import SetupDeck from '../pages/SetupDeck'
+
+export default function Calibrate (props: ContextRouter) {
+  const {match: {path}} = props
+
+  return (
+    <Switch>
+      <Route path={`${path}/instruments/:mount`} component={SetupInstruments} />
+      <Route path={`${path}/labware/:slot`} component={SetupDeck} />
+    </Switch>
+  )
+}

--- a/app/src/pages/SidePanel.js
+++ b/app/src/pages/SidePanel.js
@@ -15,8 +15,7 @@ export default function NavPanel () {
       <Route path='/robots' component={ConnectPanel} />
       <Route path='/menu' component={MenuPanel} />
       <Route path='/upload' component={UploadPanel} />
-      <Route path='/setup-instruments' component={SetupPanel} />
-      <Route path='/setup-deck' component={SetupPanel} />
+      <Route path='/calibrate' component={SetupPanel} />
       <Route path='/run' component={RunPanel} />
     </Switch>
   )

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -202,7 +202,7 @@ export default function client (dispatch) {
     remote.calibration_manager.move_to(instrument, labware)
       .then(() => {
         dispatch(actions.moveToResponse())
-        dispatch(push(`/setup-deck/${slot}/confirm`))
+        dispatch(push(`/calibrate/labware/${slot}/confirm`))
       })
       .catch((error) => dispatch(actions.moveToResponse(error)))
   }


### PR DESCRIPTION
## overview

This PR refactors the internal URLs used for the calibration page to better reflect the actual nav flow and to prepare for continuing cleanup work in the calibration UI state.

These URLs are not user facing.

## changelog

- `/setup-intruments` -> `/calibrate/instruments`
- `/setup-deck` -> `/calibrate/labware`

## review requests

Calibration flow should still work

### known issues

This PR does not address wonky highlighting in the nav bar and the calibration side panel lists
