### PR TITLE
chore(app): Avoid hostname collisions in dev mdns advertisement

### DIFF
--- a/app/scripts/advertise-local-api.js
+++ b/app/scripts/advertise-local-api.js
@@ -12,12 +12,20 @@ const LOCAL_API_HEALTH_URL = `http://localhost:${LOCAL_API_PORT}/health`
 const NAME = `Opentrons on ${LOCAL_API_HOST}`
 const SERVICE = {
   name: NAME,
-  host: LOCAL_API_HOST,
+  host: NAME,
   port: LOCAL_API_PORT,
   type: 'http'
 }
 
 startPolling()
+
+process.on('SIGINT', () => {
+  console.log('Unpublishing all dev MDNS services')
+  bonjour.unpublishAll(() => {
+    console.log('All MDNS services unpublished')
+    process.exit(0)
+  })
+})
 
 function startPolling () {
   setTimeout(pollAndPublish, LOCAL_API_POLL_INTERVAL_MS)

--- a/app/src/robot/api-client/discovery.js
+++ b/app/src/robot/api-client/discovery.js
@@ -86,7 +86,7 @@ function withIp (service) {
 
   // API doesn't listen on all interfaces when running locally
   // this hostname check is only for handling that situation
-  if (service.host === os.hostname()) {
+  if (service.host && service.host.endsWith(os.hostname())) {
     ip = 'localhost'
     // emulate a wired robot when running locally
     service = {...service, wired: true}


### PR DESCRIPTION
## overview

During the `make -C app dev` task, a little service is launched (`make -C app dev-mdns`) purely to check if you're also running `make -C api dev` and, if you are, advertise your API dev server via MDNS so the app can pick it up.

Changes made to the `dev-mdns` task in #551, while helpful for identification, seems like they were causing MDNS hostname collisions. On my mac, this resulted in a frequent automatic changes to my computer's hostname to try to avoid those collisions. That, in turn, broke the logic the app uses to detect if a given advertisement is coming from `localhost`.

This PR changes the advertised hostname (prepends `Opentrons at`) to avoid collisions and also ensures that advertisements are unpublished on `SIGINT`. This has cleared up the issues on my machine.

## changelog

- Chore: Changed advertised dev-only MDNS advertisement to avoid collisions with OS hostname

## review requests

Please make sure that `make dev` still works with virtual smoothie on your machine. @Laura-Danielle can you verify on Windows and @IanLondon could use your help with Debian. Will test on my own Windows and Ubuntu VMs as well

--- 

Update: I have tested on Windows 10 and Ubuntu 14.04 LTS and found everything to be working