### PR TITLE
fix(app): Fix regressions introduced by #947 and #984

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -19,9 +19,10 @@ export default function App () {
       <NavBar />
       <SidePanel />
       <Switch>
+        <Redirect from='(.*)/index.html' to='/' />
         <Redirect exact from='/' to='/robots' />
         <Route path='/robots/:name?' component={Robots} />
-        <Route exact path='/menu/app' component={AppSettingsPage} />
+        <Route path='/menu/app' component={AppSettingsPage} />
         <Route path='/upload' component={Upload} />
         <Route path='/calibrate' component={Calibrate} />
         <Route path='/run' component={Run} />

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -1,17 +1,31 @@
+// @flow
 // nav button container
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
+
+import type {State} from '../../types'
 
 import {
   selectors as robotSelectors,
   constants as robotConstants
 } from '../../robot'
 
+import type {IconName} from '@opentrons/components'
 import {NavButton, FILE, CALIBRATE, CONNECT, RUN, MORE} from '@opentrons/components'
+
+type OwnProps = {
+  name: string
+}
+
+type StateProps = {
+  iconName: IconName,
+  title: string,
+  url: string
+}
 
 export default withRouter(connect(mapStateToProps)(NavButton))
 
-function mapStateToProps (state, ownProps) {
+function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
   const {name} = ownProps
   const isSessionLoaded = robotSelectors.getSessionIsLoaded(state)
   const nextInstrument = robotSelectors.getNextInstrument(state)
@@ -22,15 +36,19 @@ function mapStateToProps (state, ownProps) {
   const isConnected = (
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
   )
+
+  // TODO(mc, 2018-03-08): move this logic to the Calibrate page
   let calibrateUrl
-  if (isSessionLoaded & isTipsProbed) {
-    calibrateUrl = nextLabware
-     ? `/calibrate/labware/${nextLabware.slot}`
-     : `/calibrate/labware/${labware[0].slot}`
-  } else if (isSessionLoaded) {
-    calibrateUrl = `/calibrate/instruments/${nextInstrument.mount}`
-  } else {
-    calibrateUrl = '#'
+  if (isSessionLoaded) {
+    calibrateUrl = '/calibrate/instruments'
+
+    if (!isTipsProbed && nextInstrument) {
+      calibrateUrl = `/calibrate/instruments/${nextInstrument.mount}`
+    } else if (nextLabware) {
+      calibrateUrl = `/calibrate/labware/${nextLabware.slot}`
+    } else if (labware[0]) {
+      calibrateUrl = `/calibrate/labware/${labware[0].slot}`
+    }
   }
 
   const NAV_ITEM_BY_NAME = {


### PR DESCRIPTION
## overview

Bugfix PR to fix a couple routing based regressions in the app

## changelog

- Fixed crash on protocol upload with no pipettes (broken by #947)
- Fixed default redirect to /robots in prod build (broken by #984)

## review requests

Please make sure that:

* Clicking on the "Calibrate" nav button takes you where you expect
    * If you find bugs here I may ask to punt given the TODO item in this PR about moving that logic from the button to the page
* Uploading a protocol with no pipettes or no labware doesn't blow up the app

@umbhau I added you as a reviewer because you reported one of these bugs. Let me know if this clears things up: https://s3.amazonaws.com/ot-app-builds/ci-builds/opentrons-v3.0.0-mac-2018-03-08_15-54-app_fix-route-bugs-e99cd79.zip