### PR TITLE
PD: ingredients have instances with volume, not an overall group volume

### DIFF
--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -21,7 +21,7 @@ type singleWell = {|
   selected: boolean,
   wellName: string,
   maxVolume: number,
-  groupId?: string
+  groupId: string | null
 |}
 
 type wellDims = { // TODO similar to type in Well.js. DRY it up

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -15,14 +15,14 @@ import type {LabwareLocations} from '../labware-types'
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
-type singleWell = {
+type singleWell = {|
   highlighted: boolean,
   preselected: boolean,
   selected: boolean,
   wellName: string,
   maxVolume: number,
   groupId?: string
-}
+|}
 
 type wellDims = { // TODO similar to type in Well.js. DRY it up
   x: number,

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -9,7 +9,7 @@ import { SELECTABLE_WELL_CLASS, swatchColors } from '../constants.js'
 
 type Props = {
   wellName: string,
-  groupId: string, // TODO Ian 2017-12-13 groupId represents an Ingredient Group ID, should be handled outside of this component.
+  groupId: string | null, // TODO Ian 2017-12-13 groupId represents an Ingredient Group ID, should be handled outside of this component.
   selectable: boolean,
   selected: boolean,
   preselected: boolean,

--- a/protocol-designer/src/collision-types.js
+++ b/protocol-designer/src/collision-types.js
@@ -1,0 +1,33 @@
+// @flow
+
+export type DragRect = {
+  xStart: number,
+  yStart: number,
+  xDynamic: number,
+  yDynamic: number
+}
+
+export type GenericRect = {
+  x0: number,
+  x1: number,
+  y0: number,
+  y1: number
+}
+
+export type BoundingRect = {
+  x: number,
+  y: number,
+  width: number,
+  height: number
+}
+
+export type ClientRect = { // from flow's dom.js
+  left: number,
+  width: number,
+  right: number,
+  top: number,
+  bottom: number,
+  height: number
+}
+
+export type RectEvent = (MouseEvent, GenericRect) => mixed

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -80,13 +80,6 @@ type Props = {
   numWellsSelected: number,
   selectedWellsMaxVolume: number,
 
-  // selectedIngredientProperties: {
-  //   name: string,
-  //   volume: number,
-  //   description: string,
-  //   groupId: string
-  // },
-
   allIngredientGroupFields: ?AllIngredGroupFields,
   allIngredientNamesIds: Array<{ingredientId: string, name: ?string}>,
   editingIngredGroupId: string | null,

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -166,7 +166,10 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
   }
 
   selectExistingIngred = (ingredGroupId: string) => {
-    this.resetInputState(ingredGroupId, undefined, () => this.setState({...this.state, copyGroupId: ingredGroupId}))
+    this.resetInputState(ingredGroupId, undefined, () => this.setState({
+      ...this.state,
+      copyGroupId: ingredGroupId
+    }))
   }
 
   handleDelete = (e: SyntheticEvent<*>) => {
@@ -202,7 +205,6 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     const Field = this.Field // ensures we don't lose focus on input re-render during typing
 
     if (!editMode && !addMode) {
-      console.log({editMode, addMode, selectedIngredientFields, editingIngredGroupId, allIngredientGroupFields})
       // Don't show anything, we're not editing or adding
       return null
     }
@@ -258,7 +260,10 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
 
         <div className={styles.button_row}>
           <FlatButton /* disabled={TODO: validate input here} */
-            onClick={() => onSave({...this.state.input, copyGroupId: this.state.copyGroupId})}
+            onClick={() => onSave({
+              ...this.state.input,
+              groupId: editingIngredGroupId,
+              copyGroupId: this.state.copyGroupId})}
           >
             Save
           </FlatButton>

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -12,31 +12,13 @@ import {
 import styles from './IngredientPropertiesForm.css'
 import formStyles from './Form.css'
 
+import type {
+  IngredInputs,
+  IngredGroupAccessor as Accessor,
+  AllIngredGroupFields
+} from '../labware-ingred/types'
+
 type SetStateCallback = (...args: Array<*>) => *
-
-type IngredInputs = {
-  groupId?: string,
-
-  name: string | null,
-  volume: number | null,
-  description: string | null,
-  concentration: string | null,
-  individualize: boolean,
-  serializeName: string | null
-}
-
-// type Accessor = $Keys<IngredInputs>
-type Accessor =
-  | 'name'
-  | 'volume'
-  | 'description'
-  | 'concentration'
-  | 'individualize'
-  | 'serializeName'
-
-type AllIngredGroupFields = {
-  [ingredGroupId: string]: IngredInputs
-}
 
 type SetSubstate = (accessor: string, value: string | boolean | number) => mixed
 type GetSubstate = (accessor: Accessor) => string | boolean | number | null

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -210,7 +210,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
       selectedWellsMaxVolume
     } = this.props
 
-    const selectedIngredientFields = allIngredientGroupFields && !isNil(editingIngredGroupId) && allIngredientGroupFields[editingIngredGroupId.toString()]
+    const selectedIngredientFields = allIngredientGroupFields && !isNil(editingIngredGroupId) && allIngredientGroupFields[editingIngredGroupId]
     const { volume, individualize } = this.state.input
 
     const editMode = selectedIngredientFields

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -9,8 +9,8 @@ import type {AllWellContents} from '../labware-ingred/types'
 export type Props = {
   wellContents: AllWellContents,
   containerType: string,
-  onSelectionMove: *,
-  onSelectionDone: *,
+  onSelectionMove: () => mixed, // TODO Ian 2018-03-08 type these 2 fns
+  onSelectionDone: () => mixed,
   containerId: string,
   selectable: boolean
 }

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -5,12 +5,13 @@ import { Plate } from '@opentrons/components'
 
 import SelectionRect from '../components/SelectionRect.js'
 import type {AllWellContents} from '../labware-ingred/types'
+import type {RectEvent} from '../collision-types'
 
 export type Props = {
   wellContents: AllWellContents,
   containerType: string,
-  onSelectionMove: () => mixed, // TODO Ian 2018-03-08 type these 2 fns
-  onSelectionDone: () => mixed,
+  onSelectionMove: RectEvent,
+  onSelectionDone: RectEvent,
   containerId: string,
   selectable: boolean
 }

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -13,7 +13,7 @@ export type Props = {
   onSelectionMove: RectEvent,
   onSelectionDone: RectEvent,
   containerId: string,
-  selectable: boolean
+  selectable?: boolean
 }
 
 export default function SelectablePlate (props: Props) {
@@ -31,6 +31,7 @@ export default function SelectablePlate (props: Props) {
     wellContents={wellContents}
     containerType={containerType}
     containerId={containerId}
+    showLabels={selectable}
   />
 
   if (!selectable) return plate // don't wrap plate with SelectionRect

--- a/protocol-designer/src/components/SelectionRect.js
+++ b/protocol-designer/src/components/SelectionRect.js
@@ -2,20 +2,7 @@
 import * as React from 'react'
 
 import styles from './SelectionRect.css'
-
-type DragRect = {
-  xStart: number,
-  yStart: number,
-  xDynamic: number,
-  yDynamic: number
-}
-
-type GenericRect = {
-  x0: number,
-  x1: number,
-  y0: number,
-  y1: number
-}
+import type {DragRect, GenericRect} from '../collision-types'
 
 type Props = {
   onSelectionMove?: (e: MouseEvent, GenericRect) => mixed,

--- a/protocol-designer/src/components/SelectionRect.js
+++ b/protocol-designer/src/components/SelectionRect.js
@@ -18,8 +18,8 @@ type GenericRect = {
 }
 
 type Props = {
-  onSelectionMove?: (e: MouseEvent, GenericRect) => void,
-  onSelectionDone?: (e: MouseEvent, GenericRect) => void,
+  onSelectionMove?: (e: MouseEvent, GenericRect) => mixed,
+  onSelectionDone?: (e: MouseEvent, GenericRect) => mixed,
   svg?: boolean, // set true if this is an embedded SVG
   children?: React.Node
 }

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -46,7 +46,7 @@ function OccupiedDeckSlotOverlay ({
       {/* TODO Ian 2018-02-16 Move labware, not copy labware. */}
 
       <ClickableText onClick={() =>
-          window.confirm(`Are you sure you want to permanently delete ${containerName} in slot ${slot}?`) &&
+          window.confirm(`Are you sure you want to permanently delete ${containerName || containerType} in slot ${slot}?`) &&
           deleteContainer({containerId, slot, containerType})
       }
         iconName='close' y='75%' text='Delete Labware' />
@@ -77,14 +77,14 @@ type LabwareOnDeckProps = {
 
   containerId: string,
   containerType: string,
-  containerName: string,
+  containerName: ?string,
 
   // canAdd: boolean,
 
   activeModals: {
     ingredientSelection: ?{
-      containerName: string,
-      slot: string
+      containerName: ?string,
+      slot: ?string
     },
     labwareSelection: boolean
   },
@@ -98,11 +98,11 @@ type LabwareOnDeckProps = {
   // closeLabwareSelector: ({slot: string}) => mixed,
 
   setCopyLabwareMode: (containerId: string) => void,
-  labwareToCopy: string, // ?
+  labwareToCopy: string | false,
   copyLabware: (slot: string) => void,
 
-  height: number,
-  width: number,
+  height?: number,
+  width?: number,
   highlighted: boolean,
 
   deckSetupMode: boolean

--- a/protocol-designer/src/containers/IngredientPropertiesForm.js
+++ b/protocol-designer/src/containers/IngredientPropertiesForm.js
@@ -10,7 +10,6 @@ export default connect(
     numWellsSelected: selectors.numWellsSelected(state),
     selectedWellsMaxVolume: selectors.selectedWellsMaxVolume(state),
     allIngredientNamesIds: selectors.allIngredientNamesIds(state),
-    editingIngredGroupId: selectors.selectedIngredientGroupId(state), // TODO should this be renamed? inconsistent prop vs selector
     allIngredientGroupFields: selectors.allIngredientGroupFields(state)
   }),
   {

--- a/protocol-designer/src/containers/IngredientPropertiesForm.js
+++ b/protocol-designer/src/containers/IngredientPropertiesForm.js
@@ -1,17 +1,36 @@
 // @flow
+import * as React from 'react'
 import { connect } from 'react-redux'
 import { editIngredient, editModeIngredientGroup, deleteIngredient } from '../labware-ingred/actions'
 import { selectors } from '../labware-ingred/reducers'
 import IngredientPropertiesForm from '../components/IngredientPropertiesForm.js'
 import type {BaseState} from '../types'
 
-export default connect(
-  (state: BaseState) => ({
+type Props = React.ElementProps<typeof IngredientPropertiesForm>
+
+type DispatchProps = {
+  onSave: *,
+  onCancel: *,
+  onDelete: *
+}
+
+type StateProps = $Diff<Props, DispatchProps>
+
+function mapStateToProps (state: BaseState): StateProps {
+  const selectedIngredGroup = selectors.selectedIngredientGroup(state)
+  return {
+    editingIngredGroupId: selectedIngredGroup && selectedIngredGroup.groupId,
     numWellsSelected: selectors.numWellsSelected(state),
     selectedWellsMaxVolume: selectors.selectedWellsMaxVolume(state),
     allIngredientNamesIds: selectors.allIngredientNamesIds(state),
     allIngredientGroupFields: selectors.allIngredientGroupFields(state)
-  }),
+  }
+}
+
+// TODO Ian 2018-03-08 also type mapDispatchToProps
+
+export default connect(
+  mapStateToProps,
   {
     onSave: editIngredient,
     onCancel: () => editModeIngredientGroup(null), // call with no args

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -16,13 +16,13 @@ type PropsWithoutActions = {
 function mapStateToProps (state: BaseState): PropsWithoutActions {
   // TODO Ian 2018-02-21 put these selectors in Header
   // const activeModals = selectors.activeModals(state)
-  // const container = selectors.selectedContainer(state)
+  const container = selectors.selectedContainer(state)
   const selectedIngredientGroup = selectors.selectedIngredientGroup(state)
   return {
     // slot: activeModals.ingredientSelection.slot || '1',
     // containerName: container ? container.name : 'No Name',
     // containerType: container ? container.type : 'No type',
-    ingredients: selectors.ingredientsForContainer(state),
+    ingredients: container ? selectors.ingredientsByLabware(state)[container.containerId] : {},
     selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,
     selected: false
   }

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -17,13 +17,13 @@ function mapStateToProps (state: BaseState): PropsWithoutActions {
   // TODO Ian 2018-02-21 put these selectors in Header
   // const activeModals = selectors.activeModals(state)
   // const container = selectors.selectedContainer(state)
-
+  const selectedIngredientGroup = selectors.selectedIngredientGroup(state)
   return {
     // slot: activeModals.ingredientSelection.slot || '1',
     // containerName: container ? container.name : 'No Name',
     // containerType: container ? container.type : 'No type',
     ingredients: selectors.ingredientsForContainer(state),
-    selectedIngredientGroupId: selectors.selectedIngredientGroupId(state),
+    selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,
     selected: false
   }
 }

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -19,9 +19,6 @@ function mapStateToProps (state: BaseState): PropsWithoutActions {
   const container = selectors.selectedContainer(state)
   const selectedIngredientGroup = selectors.selectedIngredientGroup(state)
   return {
-    // slot: activeModals.ingredientSelection.slot || '1',
-    // containerName: container ? container.name : 'No Name',
-    // containerType: container ? container.type : 'No type',
     ingredients: container ? selectors.ingredientsByLabware(state)[container.containerId] : {},
     selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,
     selected: false

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from 'react'
 import {connect} from 'react-redux'
 
 import {selectors} from '../labware-ingred/reducers'
@@ -25,13 +26,32 @@ type OwnProps = {
   slot: DeckSlot
 }
 
-function mapStateToProps (state: BaseState, ownProps: OwnProps) {
+type Props = React.ElementProps<typeof LabwareOnDeck>
+
+type DispatchProps = {
+  createContainer: mixed,
+  deleteContainer: mixed,
+  modifyContainer: mixed,
+
+  openIngredientSelector: mixed,
+  openLabwareSelector: mixed,
+
+  closeLabwareSelector: mixed,
+
+  setCopyLabwareMode: mixed,
+  copyLabware: mixed
+}
+
+type StateProps = $Diff<Props, DispatchProps>
+
+function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   const container = selectors.containersBySlot(state)[ownProps.slot]
   const containerInfo = (container)
     ? { containerType: container.type, containerId: container.containerId, containerName: container.name }
     : {}
   return {
     ...containerInfo,
+    slot: ownProps.slot,
     canAdd: selectors.canAdd(state),
     activeModals: selectors.activeModals(state),
     labwareToCopy: selectors.labwareToCopy(state),

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -1,12 +1,10 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-
+import type {Dispatch} from 'redux'
 import SelectablePlate from '../components/SelectablePlate.js'
 import { selectors } from '../labware-ingred/reducers'
 import { preselectWells, selectWells } from '../labware-ingred/actions'
-import { SELECTABLE_WELL_CLASS } from '../constants.js'
-import { getCollidingWells } from '../utils.js'
 import type {BaseState} from '../types'
 
 type OwnProps = {
@@ -17,9 +15,8 @@ type OwnProps = {
 type Props = React.ElementProps<typeof SelectablePlate>
 
 type DispatchProps = {
-  // TODO Ian 2018-03-08 type these functions
-  onSelectionMove: (e: mixed, rect: mixed) => mixed,
-  onSelectionDone: (e: mixed, rect: mixed) => mixed
+  onSelectionMove: $PropertyType<Props, 'onSelectionMove'>,
+  onSelectionDone: $PropertyType<Props, 'onSelectionDone'>
 }
 
 type StateProps = $Diff<Props, DispatchProps>
@@ -43,16 +40,11 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   }
 }
 
-const mapDispatchToProps = {
-  // HACK-Y action mapping
-  onSelectionMove: (e, rect) => preselectWells({
-    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
-    append: e.shiftKey
-  }),
-  onSelectionDone: (e, rect) => selectWells({
-    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
-    append: e.shiftKey
-  })
+function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
+  return {
+    onSelectionMove: (e, rect) => dispatch(preselectWells(e, rect)),
+    onSelectionDone: (e, rect) => dispatch(selectWells(e, rect))
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SelectablePlate)

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -30,7 +30,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps) {
   return {
     wellContents: isSelectedContainer
       ? selectors.wellContentsSelectedContainer(state)
-      : selectors.allWellMatricesById(state)[containerId],
+      : selectors.ingredientsByLabware(state)[containerId],
     containerType: containerById && containerById.type
   }
 }

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from 'react'
 import {connect} from 'react-redux'
 
 import SelectablePlate from '../components/SelectablePlate.js'
@@ -13,25 +14,32 @@ type OwnProps = {
   cssFillParent?: boolean
 }
 
-function mapStateToProps (state: BaseState, ownProps: OwnProps) {
+type Props = React.ElementProps<typeof SelectablePlate>
+
+type DispatchProps = {
+  // TODO Ian 2018-03-08 type these functions
+  onSelectionMove: (e: mixed, rect: mixed) => mixed,
+  onSelectionDone: (e: mixed, rect: mixed) => mixed
+}
+
+type StateProps = $Diff<Props, DispatchProps>
+
+function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   const selectedContainer = selectors.selectedContainer(state)
   const selectedContainerId = selectedContainer && selectedContainer.containerId
   const containerId = ownProps.containerId || selectedContainerId
 
-  const isSelectedContainer = containerId === selectedContainerId
-
   if (containerId === null) {
-    console.warn('SelectablePlate: No container is selected, and no containerId was given to Connected SelectablePlate')
-    return {}
+    throw new Error('SelectablePlate: No container is selected, and no containerId was given to Connected SelectablePlate')
   }
 
-  const containerById = selectors.containerById(containerId)(state)
+  const labware = selectors.getLabware(state)[containerId]
 
   return {
-    wellContents: isSelectedContainer
-      ? selectors.wellContentsSelectedContainer(state)
-      : selectors.ingredientsByLabware(state)[containerId],
-    containerType: containerById && containerById.type
+    containerId,
+    wellContents: selectors.wellContentsAllLabware(state)[containerId],
+    containerType: labware.type,
+    selectable: selectedContainerId === containerId
   }
 }
 

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -9,6 +9,7 @@ import type {BaseState} from '../types'
 
 type OwnProps = {
   containerId?: string,
+  selectable?: boolean,
   cssFillParent?: boolean
 }
 
@@ -36,7 +37,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     containerId,
     wellContents: selectors.wellContentsAllLabware(state)[containerId],
     containerType: labware.type,
-    selectable: selectedContainerId === containerId
+    selectable: ownProps.selectable
   }
 }
 

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -33,19 +33,25 @@ describe('DELETE_INGREDIENT action', () => {
     }
 
     const prevLocationsState = {
-      '2': { container1Id: [
-        {well: 'A1', volume: 123},
-        {well: 'A2', volume: 123}
-      ] },
-      '3': { container1Id: [
-        {well: 'A1', volume: 111},
-        {well: 'B1', volume: 111},
-        {well: 'C1', volume: 111}
-      ] },
-      '4': { container1Id: [
-        {well: 'C1', volume: 100},
-        {well: 'C2', volume: 100}
-      ] }
+      '2': {
+        container1Id: {
+          A1: {volume: 123},
+          A2: {volume: 123}
+        }
+      },
+      '3': {
+        container1Id: {
+          A1: {volume: 111},
+          B1: {volume: 112},
+          C1: {volume: 113}
+        }
+      },
+      '4': {
+        container1Id: {
+          C1: {volume: 100},
+          C2: {volume: 100}
+        }
+      }
     }
 
     expect(ingredients(
@@ -60,15 +66,19 @@ describe('DELETE_INGREDIENT action', () => {
       prevLocationsState,
       deleteGroup3
     )).toEqual({
-      '2': { container1Id: [
-        {well: 'A1', volume: 123},
-        {well: 'A2', volume: 123}
-      ] },
+      '2': {
+        container1Id: {
+          A1: {volume: 123},
+          A2: {volume: 123}
+        }
+      },
       // 3 is deleted
-      '4': { container1Id: [
-        {well: 'C1', volume: 100},
-        {well: 'C2', volume: 100}
-      ] }
+      '4': {
+        container1Id: {
+          C1: {volume: 100},
+          C2: {volume: 100}
+        }
+      }
     })
   })
 })
@@ -99,21 +109,21 @@ describe('COPY_LABWARE action', () => {
 
     const prevLocationsState = {
       '3': {
-        myTrough: [
-          {well: 'A1', volume: 101},
-          {well: 'B1', volume: 102},
-          {well: 'C1', volume: 103}
-        ],
-        otherContainer: [
-          {well: 'D4', volume: 201},
-          {well: 'E4', volume: 202}
-        ]
+        myTrough: {
+          A1: {volume: 101},
+          A2: {volume: 102},
+          A3: {volume: 103}
+        },
+        otherContainer: {
+          D4: {volume: 201},
+          E4: {volume: 202}
+        }
       },
       '4': {
-        otherContainer: [
-          {well: 'A4', volume: 301},
-          {well: 'B4', volume: 302}
-        ]
+        otherContainer: {
+          A4: {volume: 301},
+          B4: {volume: 302}
+        }
       }
     }
 
@@ -127,26 +137,26 @@ describe('COPY_LABWARE action', () => {
       copyLabwareAction
     )).toEqual({
       '3': {
-        myTrough: [
-          {well: 'A1', volume: 101},
-          {well: 'B1', volume: 102},
-          {well: 'C1', volume: 103}
-        ],
-        newContainer: [ // this is newly copied
-          {well: 'A1', volume: 101},
-          {well: 'B1', volume: 102},
-          {well: 'C1', volume: 103}
-        ],
-        otherContainer: [
-          {well: 'D4', volume: 201},
-          {well: 'E4', volume: 202}
-        ]
+        myTrough: {
+          A1: {volume: 101},
+          A2: {volume: 102},
+          A3: {volume: 103}
+        },
+        newContainer: { // this is newly copied
+          A1: {volume: 101},
+          A2: {volume: 102},
+          A3: {volume: 103}
+        },
+        otherContainer: {
+          D4: {volume: 201},
+          E4: {volume: 202}
+        }
       },
       '4': {
-        otherContainer: [
-          {well: 'A4', volume: 301},
-          {well: 'B4', volume: 302}
-        ]
+        otherContainer: {
+          A4: {volume: 301},
+          B4: {volume: 302}
+        }
       }
     })
   })
@@ -186,11 +196,11 @@ describe('EDIT_INGREDIENT action', () => {
       newIngredAction
     )).toEqual({
       '0': {
-        container1Id: [
-          {well: 'A1', volume: 250},
-          {well: 'A2', volume: 250},
-          {well: 'A3', volume: 250}
-        ]
+        container1Id: {
+          A1: {volume: 250},
+          A2: {volume: 250},
+          A3: {volume: 250}
+        }
       }
     })
   })
@@ -225,11 +235,11 @@ describe('EDIT_INGREDIENT action', () => {
 
     const prevLocationsState = {
       0: {
-        container1Id: [
-          {well: 'A1', volume: 250},
-          {well: 'A2', volume: 250},
-          {well: 'A3', volume: 250}
-        ]
+        container1Id: {
+          A1: {volume: 250},
+          A2: {volume: 250},
+          A3: {volume: 250}
+        }
       }
     }
 
@@ -238,13 +248,13 @@ describe('EDIT_INGREDIENT action', () => {
       copyIngredAction
     )).toEqual({
       0: {
-        container1Id: [
-          {well: 'A1', volume: 250},
-          {well: 'A2', volume: 250},
-          {well: 'A3', volume: 250},
-          {well: 'B1', volume: 250},
-          {well: 'B2', volume: 250}
-        ]
+        container1Id: {
+          A1: {volume: 250},
+          A2: {volume: 250},
+          A3: {volume: 250},
+          B1: {volume: 250},
+          B2: {volume: 250}
+        }
       }
     })
   })

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -1,6 +1,5 @@
 import {ingredients, ingredLocations} from '../reducers'
-
-const ingredientsInitialState = {}
+import omit from 'lodash/omit'
 
 describe('DELETE_INGREDIENT action', () => {
   const deleteGroup3 = {
@@ -10,12 +9,12 @@ describe('DELETE_INGREDIENT action', () => {
 
   test('delete ingredient by ingredient group id, when group id does NOT exist', () => {
     expect(ingredients(
-      ingredientsInitialState,
+      {},
       deleteGroup3
     )).toEqual({})
 
     expect(ingredLocations(
-      ingredientsInitialState,
+      {},
       deleteGroup3
     )).toEqual({})
   })
@@ -26,7 +25,6 @@ describe('DELETE_INGREDIENT action', () => {
       '3': {
         name: 'Buffer',
         wellDetailsByLocation: null,
-        volume: 100,
         concentration: '50 mol/ng',
         description: '',
         individualize: false
@@ -35,9 +33,19 @@ describe('DELETE_INGREDIENT action', () => {
     }
 
     const prevLocationsState = {
-      '2': { container1Id: ['A1', 'A2'] },
-      '3': { container1Id: ['A1', 'B1', 'C1'] },
-      '4': { container1Id: ['C1', 'C2'] }
+      '2': { container1Id: [
+        {well: 'A1', volume: 123},
+        {well: 'A2', volume: 123}
+      ] },
+      '3': { container1Id: [
+        {well: 'A1', volume: 111},
+        {well: 'B1', volume: 111},
+        {well: 'C1', volume: 111}
+      ] },
+      '4': { container1Id: [
+        {well: 'C1', volume: 100},
+        {well: 'C2', volume: 100}
+      ] }
     }
 
     expect(ingredients(
@@ -52,8 +60,15 @@ describe('DELETE_INGREDIENT action', () => {
       prevLocationsState,
       deleteGroup3
     )).toEqual({
-      '2': { container1Id: ['A1', 'A2'] },
-      '4': { container1Id: ['C1', 'C2'] }
+      '2': { container1Id: [
+        {well: 'A1', volume: 123},
+        {well: 'A2', volume: 123}
+      ] },
+      // 3 is deleted
+      '4': { container1Id: [
+        {well: 'C1', volume: 100},
+        {well: 'C2', volume: 100}
+      ] }
     })
   })
 })
@@ -69,7 +84,6 @@ describe('COPY_LABWARE action', () => {
       '3': {
         name: 'Buffer',
         wellDetailsByLocation: null,
-        volume: 100,
         concentration: '50 mol/ng',
         description: '',
         individualize: false
@@ -77,7 +91,6 @@ describe('COPY_LABWARE action', () => {
       '4': {
         name: 'Other Ingred',
         wellDetailsByLocation: null,
-        volume: 10,
         concentration: '100%',
         description: '',
         individualize: false
@@ -86,11 +99,21 @@ describe('COPY_LABWARE action', () => {
 
     const prevLocationsState = {
       '3': {
-        myTrough: ['A1', 'B1', 'C1'],
-        otherContainer: ['D4', 'E4']
+        myTrough: [
+          {well: 'A1', volume: 101},
+          {well: 'B1', volume: 102},
+          {well: 'C1', volume: 103}
+        ],
+        otherContainer: [
+          {well: 'D4', volume: 201},
+          {well: 'E4', volume: 202}
+        ]
       },
       '4': {
-        otherContainer: ['A4', 'B4']
+        otherContainer: [
+          {well: 'A4', volume: 301},
+          {well: 'B4', volume: 302}
+        ]
       }
     }
 
@@ -104,12 +127,26 @@ describe('COPY_LABWARE action', () => {
       copyLabwareAction
     )).toEqual({
       '3': {
-        myTrough: ['A1', 'B1', 'C1'],
-        newContainer: ['A1', 'B1', 'C1'], // <-- new
-        otherContainer: ['D4', 'E4']
+        myTrough: [
+          {well: 'A1', volume: 101},
+          {well: 'B1', volume: 102},
+          {well: 'C1', volume: 103}
+        ],
+        newContainer: [ // this is newly copied
+          {well: 'A1', volume: 101},
+          {well: 'B1', volume: 102},
+          {well: 'C1', volume: 103}
+        ],
+        otherContainer: [
+          {well: 'D4', volume: 201},
+          {well: 'E4', volume: 202}
+        ]
       },
       '4': {
-        otherContainer: ['A4', 'B4']
+        otherContainer: [
+          {well: 'A4', volume: 301},
+          {well: 'B4', volume: 302}
+        ]
       }
     })
   })
@@ -123,6 +160,8 @@ describe('EDIT_INGREDIENT action', () => {
     description: 'far out!',
     individualize: false
   }
+
+  const resultingIngred = omit(ingredFields, ['volume'])
 
   test('new ingredient', () => {
     const newIngredAction = {
@@ -139,7 +178,7 @@ describe('EDIT_INGREDIENT action', () => {
       {},
       newIngredAction)
     ).toEqual({
-      '0': {...ingredFields}
+      '0': {...resultingIngred}
     })
 
     expect(ingredLocations(
@@ -147,7 +186,11 @@ describe('EDIT_INGREDIENT action', () => {
       newIngredAction
     )).toEqual({
       '0': {
-        container1Id: ['A1', 'A2', 'A3']
+        container1Id: [
+          {well: 'A1', volume: 250},
+          {well: 'A2', volume: 250},
+          {well: 'A3', volume: 250}
+        ]
       }
     })
   })
@@ -170,19 +213,23 @@ describe('EDIT_INGREDIENT action', () => {
     }
 
     const prevIngredState = {
-      0: {...ingredFields}
+      0: {...resultingIngred}
     }
 
     expect(ingredients(
       prevIngredState,
       copyIngredAction
     )).toEqual({
-      0: {...ingredFields} // no new ingredient group created
+      0: {...resultingIngred} // no new ingredient group created
     })
 
     const prevLocationsState = {
       0: {
-        container1Id: ['A1', 'A2', 'A3']
+        container1Id: [
+          {well: 'A1', volume: 250},
+          {well: 'A2', volume: 250},
+          {well: 'A3', volume: 250}
+        ]
       }
     }
 
@@ -191,7 +238,13 @@ describe('EDIT_INGREDIENT action', () => {
       copyIngredAction
     )).toEqual({
       0: {
-        container1Id: ['A1', 'A2', 'A3', 'B1', 'B2']
+        container1Id: [
+          {well: 'A1', volume: 250},
+          {well: 'A2', volume: 250},
+          {well: 'A3', volume: 250},
+          {well: 'B1', volume: 250},
+          {well: 'B2', volume: 250}
+        ]
       }
     })
   })

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -20,7 +20,6 @@ const baseIngredFields2 = {
 
 const containerState = {
   'default-trash': {
-    id: 'default-trash',
     type: 'trash-box',
     name: 'Trash',
     slot: '12'
@@ -112,6 +111,69 @@ const allIngredientsXXSingleIngred = {
   }
 }
 
+const ingredsByLabwareXXSingleIngred = {
+  'container1Id': {
+    '0': {
+      ...baseIngredFields,
+      wells: {
+        A1: {volume: 100},
+        B1: {volume: 150}
+      }
+    }
+  },
+  'container2Id': {},
+  'container3Id': {},
+  'default-trash': {}
+}
+
+const ingredsByLabwareXXTwoIngred = {
+  container1Id: {
+    '0': {
+      ...baseIngredFields,
+      wells: {
+        A1: {volume: 100},
+        B1: {volume: 150}
+      }
+    }
+  },
+  container2Id: {
+    '0': {
+      ...baseIngredFields,
+      wells: {
+        A2: {volume: 105},
+        B2: {volume: 155}
+      }
+    },
+    '1': {
+      ...baseIngredFields2,
+      wells: {
+        H1: {volume: 111}
+      }
+    }
+  },
+  container3Id: {
+    '1': {
+      ...baseIngredFields2,
+      wells: {
+        H2: {volume: 222}
+      }
+    }
+  },
+  'default-trash': {}
+}
+
+const defaultWellContents = {
+  highlighted: false,
+  hovered: false,
+  preselected: false,
+  selected: false,
+  groupId: null
+}
+
+const container1MaxVolume = 400
+
+// ==============================
+
 describe('allIngredientNamesIds selector', () => {
   test('selects names & ids from allIngredients selector result', () => {
     expect(
@@ -149,20 +211,7 @@ describe('ingredientsByLabware', () => {
         baseStateXXSingleIngred.ingredients,
         baseStateXXSingleIngred.ingredLocations
       )
-    ).toEqual({
-      'container1Id': {
-        '0': {
-          ...baseIngredFields,
-          wells: {
-            A1: {volume: 100},
-            B1: {volume: 150}
-          }
-        }
-      },
-      'container2Id': {},
-      'container3Id': {},
-      'default-trash': {}
-    })
+    ).toEqual(ingredsByLabwareXXSingleIngred)
   })
 
   test('selects ingredients by labware: two ingred case', () => {
@@ -172,40 +221,68 @@ describe('ingredientsByLabware', () => {
         baseStateXXTwoIngred.ingredients,
         baseStateXXTwoIngred.ingredLocations
       )
-    ).toEqual({
-      container1Id: {
-        '0': {
-          ...baseIngredFields,
-          wells: {
-            A1: {volume: 100},
-            B1: {volume: 150}
-          }
-        }
+    ).toEqual(ingredsByLabwareXXTwoIngred)
+  })
+})
+
+describe('wellContentsAllLabware', () => {
+  const singleIngredResult = selectors.wellContentsAllLabware.resultFunc(
+    containerState, // all labware
+    ingredsByLabwareXXSingleIngred,
+    {containerId: 'container1Id'}, // selected labware
+    {preselected: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
+    {A3: 'A3'} // highlighted (TODO: is this used?)
+  )
+
+  // TODO: 2nd test case
+  // const twoIngredResult = selectors.wellContentsAllLabware.resultFunc(
+  //   containerState, // all labware
+  //   ingredsByLabwareXXTwoIngred,
+  //   containerState.container2Id, // selected labware
+  //   {preselected: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
+  //   {A3: 'A3'} // highlighted (TODO: is this used?)
+  // )
+
+  test('container has expected number of wells', () => {
+    expect(Object.keys(singleIngredResult.container1Id).length).toEqual(96)
+  })
+
+  test('selects well contents of all labware (for Plate props)', () => {
+    expect(
+      singleIngredResult
+    ).toMatchObject({
+      'default-trash': {
+        A1: defaultWellContents
       },
       container2Id: {
-        '0': {
-          ...baseIngredFields,
-          wells: {
-            A2: {volume: 105},
-            B2: {volume: 155}
-          }
-        },
-        '1': {
-          ...baseIngredFields2,
-          wells: {
-            H1: {volume: 111}
-          }
-        }
+        A1: defaultWellContents
       },
       container3Id: {
-        '1': {
-          ...baseIngredFields2,
-          wells: {
-            H2: {volume: 222}
-          }
-        }
+        A1: defaultWellContents
       },
-      'default-trash': {}
+
+      container1Id: {
+        A1: {
+          ...defaultWellContents,
+          selected: true,
+          groupId: '0',
+          maxVolume: container1MaxVolume
+        },
+        A2: {
+          ...defaultWellContents,
+          maxVolume: container1MaxVolume
+        },
+        B1: {
+          ...defaultWellContents,
+          selected: true,
+          groupId: '0',
+          maxVolume: container1MaxVolume
+        },
+        B2: {
+          ...defaultWellContents,
+          maxVolume: container1MaxVolume
+        }
+      }
     })
   })
 })

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -1,0 +1,159 @@
+import {selectors} from '../reducers'
+
+// FIXTURES
+
+const baseIngredFields = {
+  groupId: '0',
+  name: 'Some Ingred',
+  serializeName: null,
+  // concentration: null,
+  description: null,
+  individualize: false
+}
+
+const containersStateXXSingleIngred = {
+  'default-trash': {
+    id: 'default-trash',
+    type: 'trash-box',
+    name: 'Trash',
+    slot: '12'
+  },
+  container1Id: {
+    slot: '10',
+    type: '96-flat',
+    name: 'Labware 1'
+  }
+}
+
+const labwareIngredStateXXSingleIngred = {
+  ingredients: {
+    '0': {
+      ...baseIngredFields
+    }
+  },
+  ingredLocations: {
+    '0': {
+      'container1Id': {
+        A1: {
+          volume: 100
+        },
+        B1: {
+          volume: 150
+        }
+      }
+    }
+  }
+}
+
+const allIngredientsXXSingleIngred = {
+  '0': {
+    ...baseIngredFields,
+
+    instances: {
+      'container1Id': {
+        A1: {
+          volume: 100
+        },
+        B1: {
+          volume: 150
+        }
+      }
+    }
+  }
+}
+
+describe('allIngredients selector', () => {
+  test('combines ingredients and ingredLocations', () => {
+    expect(
+      selectors.allIngredients.resultFunc(labwareIngredStateXXSingleIngred)
+    ).toEqual(allIngredientsXXSingleIngred)
+  })
+})
+
+describe('allIngredientNamesIds selector', () => {
+  test('selects names & ids from allIngredients selector result', () => {
+    expect(
+      selectors.allIngredientNamesIds.resultFunc(allIngredientsXXSingleIngred)
+    ).toEqual([{
+      ingredientId: '0',
+      name: 'Some Ingred'
+    }])
+  })
+})
+
+describe('ingredientsForContainer selector', () => {
+  test('returns {} with no labware selected', () => {
+    expect(
+      selectors.ingredientsForContainer.resultFunc(
+        allIngredientsXXSingleIngred,
+        null
+      )
+    ).toEqual({})
+  })
+
+  test('returns {} when selected labware contains no ingreds', () => {
+    expect(
+      selectors.ingredientsForContainer.resultFunc(
+        allIngredientsXXSingleIngred,
+        {containerId: 'someEmptyContainerId'}
+      )
+    ).toEqual({})
+  })
+
+  test('gets all ingredient groups, for the currently selected labware', () => {
+    expect(
+      selectors.ingredientsForContainer.resultFunc(
+        allIngredientsXXSingleIngred, // from allIngredients selector
+        {containerId: 'container1Id'} // selected labware obj
+      )
+    ).toEqual({
+      '0': {
+        ...baseIngredFields,
+        wells: {
+          A1: {
+            volume: 100
+          },
+          B1: {
+            volume: 150
+          }
+        }
+      }
+    })
+  })
+})
+
+describe('allWellMatricesById selector', () => {
+  const result = selectors.allWellMatricesById.resultFunc(
+    allIngredientsXXSingleIngred,
+    containersStateXXSingleIngred
+  )
+
+  const baseWellData = {
+    highlighted: false,
+    preselected: false,
+    selected: false,
+    maxVolume: 400
+  }
+
+  test('A1 & B1 should have groupId 0', () => {
+    expect(result.container1Id.A1).toEqual({
+      ...baseWellData,
+      wellName: 'A1',
+      groupId: '0'
+    })
+
+    expect(result.container1Id.B1).toEqual({
+      ...baseWellData,
+      wellName: 'B1',
+      groupId: '0'
+    })
+  })
+
+  test('H12 should have no groupId', () => {
+    // empty well
+    expect(result.container1Id.H12).toEqual({
+      ...baseWellData,
+      wellName: 'H12'
+    })
+  })
+})

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -112,14 +112,6 @@ const allIngredientsXXSingleIngred = {
   }
 }
 
-describe('allIngredients selector', () => {
-  test('combines ingredients and ingredLocations', () => {
-    expect(
-      selectors.allIngredients.resultFunc(baseStateXXSingleIngred)
-    ).toEqual(allIngredientsXXSingleIngred)
-  })
-})
-
 describe('allIngredientNamesIds selector', () => {
   test('selects names & ids from allIngredients selector result', () => {
     expect(

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -188,16 +188,20 @@ export type EditIngredient = {
 export const editIngredient = (payload: {|copyGroupId: string, ...IngredInputFields|}) => (dispatch: Dispatch<EditIngredient>, getState: GetState) => {
   const state = getState()
   const container = selectors.selectedContainer(state)
-  const allIngredients = selectors.allIngredients(state)
+  const allIngredients = selectors.getIngredientGroups(state)
 
   const isUnchangedClone = allIngredients[payload.copyGroupId] &&
     editableIngredFields.every(field =>
       allIngredients[payload.copyGroupId][field] === payload[field]
     )
 
+  if (!isUnchangedClone) {
+    console.log('not clone', allIngredients[payload.copyGroupId])
+  }
+
   // TODO Ian 2018-02-19 make selector, or factor out as util.
   const nextGroupId = (max(Object.keys(allIngredients).map(id => parseInt(id))) + 1) || 0
-  console.log(Object.keys(allIngredients), {nextGroupId})
+  console.log('ingred ID assignment', Object.keys(allIngredients), {nextGroupId}) // TODO IMMEDIATELY remove this log
 
   const groupId = (isUnchangedClone)
     ? payload.copyGroupId

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -3,14 +3,15 @@ import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 import max from 'lodash/max'
 
-import {uuid} from '../utils'
+import { SELECTABLE_WELL_CLASS } from '../constants'
+import {uuid, getCollidingWells} from '../utils'
 import {selectors} from './reducers'
 
+import type {GetState} from '../types'
 import {editableIngredFields} from './types'
 import type {IngredInputFields, Wells} from './types'
 import type {DeckSlot} from '@opentrons/components'
-
-import type {GetState} from '../types'
+import type {GenericRect} from '../collision-types'
 
 // Payload mappers
 const xyToSingleWellObj = (x: string, y: string): Wells => ({ [(x + ',' + y)]: [x, y] })
@@ -86,19 +87,25 @@ export const modifyContainer = createAction(
 
 // ===== Preselect / select wells in plate
 
-type WellSelectionArgs = {|
+type WellSelectionPayload = {|
   wells: Wells,
   append: boolean // true if user is holding shift key
 |}
 
 export const preselectWells = createAction(
   'PRESELECT_WELLS',
-  (args: WellSelectionArgs) => args
+  (e: MouseEvent, rect: GenericRect): WellSelectionPayload => ({
+    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
+    append: e.shiftKey
+  })
 )
 
 export const selectWells = createAction(
   'SELECT_WELLS',
-  (args: WellSelectionArgs) => args
+  (e: MouseEvent, rect: GenericRect): WellSelectionPayload => ({
+    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
+    append: e.shiftKey
+  })
 )
 
 // ===== well hovering =====

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -425,7 +425,7 @@ const ingredientsByLabware: Selector<IngredsForAllLabware> = createSelector(
   getLabware,
   getIngredientGroups,
   getIngredientLocations,
-  (_labware, _ingredientGroups, _ingredLocations) => { // TODO IMMEDIATELY Ian 2018-03-08 fix this weird typing error
+  (_labware: ContainersState, _ingredientGroups: IngredientsState, _ingredLocations: LocationsState) => {
     const allLabwareIds = Object.keys(_labware)
     const allIngredIds = Object.keys(_ingredientGroups)
 
@@ -522,7 +522,7 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
   getSelectedContainer,
   getSelectedWells,
   getHighlightedWells, // TODO Ian 2018-03-08: is 'highlighted' used?
-  (_labware, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
+  (_labware: ContainersState, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
     const allLabwareIds = Object.keys(_labware)
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: AllWellContents | null}, labwareId: string) => {

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -15,7 +15,7 @@ import {getMaxVolumes, defaultContainers, sortedSlotnames} from '../../constants
 import {uuid} from '../../utils.js'
 
 import type {DeckSlot} from '@opentrons/components'
-import {editableIngredFields} from '../types'
+import {persistedIngredFields} from '../types'
 import type {
   IngredInputFields,
   Labware,
@@ -69,8 +69,8 @@ type SelectedIngredientGroupState = {|
 const selectedIngredientGroup = handleActions({
   // selected ingredient group to edit
   // TODO: SelectedIngredientGroupState is type of payload, type the action though
-  EDIT_MODE_INGREDIENT_GROUP: (state, action: ActionType<typeof actions.editModeIngredientGroup>) => action.payload,
-
+  EDIT_MODE_INGREDIENT_GROUP: (state, action: ActionType<typeof actions.editModeIngredientGroup>) =>
+    action.payload,
   OPEN_INGREDIENT_SELECTOR: () => null,
   EDIT_INGREDIENT: () => null, // unselect ingredient group when edited.
   DELETE_INGREDIENT: () => null, // unselect ingredient group when deleted.
@@ -154,7 +154,7 @@ export const ingredients = handleActions({
       // is a new ingredient
       return {
         ...state,
-        [groupId]: pick(action.payload, editableIngredFields)
+        [groupId]: pick(action.payload, persistedIngredFields)
       }
     }
 
@@ -167,7 +167,7 @@ export const ingredients = handleActions({
     return {
       ...state,
       [groupId]: {
-        ...pick(action.payload, editableIngredFields)
+        ...pick(action.payload, persistedIngredFields)
       }
     }
   },
@@ -192,6 +192,13 @@ export const ingredLocations = handleActions({
   EDIT_INGREDIENT: (state: LocationsState, action: EditIngredient) => {
     const { groupId, containerId, isUnchangedClone } = action.payload
 
+    function mapWellWithVol (well) {
+      return {
+        well,
+        volume: action.payload.volume
+      }
+    }
+
     if (isUnchangedClone) {
       // for an unchanged clone, just add the new wells.
       return {
@@ -200,7 +207,7 @@ export const ingredLocations = handleActions({
           ...state[groupId],
           [containerId]: uniq([
             ...(state[groupId][containerId] || []),
-            ...action.payload.wells
+            ...action.payload.wells.map(mapWellWithVol)
           ])
         }
       }
@@ -209,7 +216,7 @@ export const ingredLocations = handleActions({
     return {
       ...state,
       [groupId]: {
-        [containerId]: action.payload.wells
+        [containerId]: action.payload.wells.map(mapWellWithVol)
       }
     }
   },

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -72,3 +72,11 @@ export const editableIngredFields = [
   'description',
   'individualize'
 ]
+
+export const persistedIngredFields = [
+  'name',
+  'serializeName',
+  'concentration',
+  'description',
+  'individualize'
+]

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -19,20 +19,18 @@ type IngredInstance = {|
   volume: number
 |}
 
-export type WellContents = { // non-ingredient well state
+export type WellContents = {| // non-ingredient well state
   preselected: boolean,
   selected: boolean,
   highlighted: boolean,
   maxVolume: number,
   wellName: string, // eg 'A1', 'A2' etc
   groupId?: string // TODO Ian 2018-03-07 this should be color, not groupId.
-}
+|}
 
 export type AllWellContents = {
   [wellName: string]: WellContents
 }
-
-export type WellMatrices = {[containerId: string]: Array<Array<string>>}
 
 // ==== INGREDIENTS ====
 
@@ -46,11 +44,11 @@ export type IngredInputFields = {|
 
 export type IngredientGroup = {|
   groupId: string,
-  name?: string,
-  volume?: number, // TODO Ian 2018-03-07 this is the 'default' volume, only used to determine exact clone for EDIT_INGREDIENT. Revisit this.
-  description?: string,
-  serializeName?: string,
-  individualize?: boolean,
+  name: ?string,
+  volume: ?number, // TODO Ian 2018-03-07 this is the 'default' volume, only used to determine exact clone for EDIT_INGREDIENT. Revisit this.
+  description: ?string,
+  serializeName: ?string,
+  individualize: ?boolean,
   instances: {
     [labwareId: string]: {
       [wellName: string]: IngredInstance
@@ -64,6 +62,7 @@ export type AllIngredGroups = {
 
 export type IngredGroupForLabware = {
   ...IngredientGroup,
+  groupId: string,
   wells: {
     [wellName: string]: IngredInstance
   }
@@ -73,15 +72,6 @@ export type IngredGroupForLabware = {
 export type IngredsForLabware = {
   [groupId: string]: IngredGroupForLabware
 }
-
-export const singleWellFields = [
-  'highlighted',
-  'preselected',
-  'selected',
-  'wellName',
-  'maxVolume',
-  'groupId'
-]
 
 export const editableIngredFields = [
   'name',

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -25,7 +25,7 @@ export type WellContents = {| // non-ingredient well state
   highlighted: boolean,
   maxVolume: number,
   wellName: string, // eg 'A1', 'A2' etc
-  groupId?: string // TODO Ian 2018-03-07 this should be color, not groupId.
+  groupId: string | null // TODO Ian 2018-03-07 this should be color, not groupId.
 |}
 
 export type AllWellContents = {
@@ -92,8 +92,6 @@ export const persistedIngredFields = [
 ]
 
 export type IngredInputs = {
-  groupId?: string,
-
   name: string | null,
   volume: number | null,
   description: string | null,

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -12,33 +12,20 @@ export type Wells = {
   [wellName: string]: string // eg A1: 'A1'.
 }
 
-type WellDatum = {|
-  name: string,
-  volume: number,
-  concentration: string
+type IngredInstance = {|
+  labwareId: string,
+  groupId: string,
+  well: string,
+  volume: number
 |}
 
-export type WellDetails = {|
-  [wellName: string]: WellDatum
-|}
-
-type WellDetailsByLocation = {|
-  [containerId: string]: WellDetails
-|}
-
-type WellJawn = {|
-  wells: Wells | Array<string>, // TODO standardize what type of wells: obj or array?
-  wellDetails: WellDetails,
-  wellDetailsByLocation: WellDetailsByLocation | null
-|}
-
-export type WellContents = {
+export type WellContents = { // non-ingredient well state
   preselected: boolean,
   selected: boolean,
   highlighted: boolean,
   maxVolume: number,
   wellName: string, // eg 'A1', 'A2' etc
-  groupId?: string
+  groupId?: string // TODO Ian 2018-03-07 this should be color, not groupId.
 }
 
 export type AllWellContents = {
@@ -53,22 +40,53 @@ export type IngredInputFields = {|
   name: ?string,
   volume: ?string,
   description: ?string,
-  concentration: ?string,
   individualize: boolean,
   serializeName: ?string
 |}
 
-export type Ingredient = {
-    ...IngredInputFields, // TODO IMMEDIATELY is this a part of it?
-    ...WellJawn,
-    groupId: string
+export type IngredientGroup = {|
+  groupId: string,
+  name?: string,
+  volume?: number, // TODO Ian 2018-03-07 this is the 'default' volume, only used to determine exact clone for EDIT_INGREDIENT. Revisit this.
+  description?: string,
+  serializeName?: string,
+  individualize?: boolean,
+  instances: {
+    [labwareId: string]: {
+      [wellName: string]: IngredInstance
+    }
+  }
+|}
+
+export type AllIngredGroups = {
+  [groupId: string]: IngredientGroup
 }
+
+export type IngredGroupForLabware = {
+  ...IngredientGroup,
+  wells: {
+    [wellName: string]: IngredInstance
+  }
+}
+
+// Like AllIngredGroups, but no labwareId key. Here, labwareId has already been given
+export type IngredsForLabware = {
+  [groupId: string]: IngredGroupForLabware
+}
+
+export const singleWellFields = [
+  'highlighted',
+  'preselected',
+  'selected',
+  'wellName',
+  'maxVolume',
+  'groupId'
+]
 
 export const editableIngredFields = [
   'name',
   'serializeName',
   'volume',
-  'concentration',
   'description',
   'individualize'
 ]
@@ -76,7 +94,6 @@ export const editableIngredFields = [
 export const persistedIngredFields = [
   'name',
   'serializeName',
-  'concentration',
   'description',
   'individualize'
 ]

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -44,11 +44,11 @@ export type IngredInputFields = {|
 
 export type IngredientGroup = {|
   groupId: string,
-  name: ?string,
-  volume: ?number, // TODO Ian 2018-03-07 this is the 'default' volume, only used to determine exact clone for EDIT_INGREDIENT. Revisit this.
-  description: ?string,
-  serializeName: ?string,
-  individualize: ?boolean,
+  name: string,
+  volume: number, // TODO Ian 2018-03-07 this is the 'default' volume, only used to determine exact clone for EDIT_INGREDIENT. Revisit this.
+  description: string,
+  individualize: boolean,
+  serializeName: string,
   instances: {
     [labwareId: string]: {
       [wellName: string]: IngredInstance
@@ -61,16 +61,19 @@ export type AllIngredGroups = {
 }
 
 export type IngredGroupForLabware = {
-  ...IngredientGroup,
+  ...IngredInputFields,
   groupId: string,
   wells: {
     [wellName: string]: IngredInstance
   }
 }
 
-// Like AllIngredGroups, but no labwareId key. Here, labwareId has already been given
 export type IngredsForLabware = {
   [groupId: string]: IngredGroupForLabware
+}
+
+export type IngredsForAllLabware = {
+  [labwareId: string]: IngredsForLabware
 }
 
 export const editableIngredFields = [
@@ -87,3 +90,26 @@ export const persistedIngredFields = [
   'description',
   'individualize'
 ]
+
+export type IngredInputs = {
+  groupId?: string,
+
+  name: string | null,
+  volume: number | null,
+  description: string | null,
+  concentration: string | null,
+  individualize: boolean,
+  serializeName: string | null
+}
+
+export type IngredGroupAccessor =
+  | 'name'
+  | 'volume'
+  | 'description'
+  | 'concentration'
+  | 'individualize'
+  | 'serializeName'
+
+export type AllIngredGroupFields = {
+  [ingredGroupId: string]: IngredInputs
+}

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -79,7 +79,7 @@ export type IngredsForAllLabware = {
 export const editableIngredFields = [
   'name',
   'serializeName',
-  'volume',
+  // 'volume',
   'description',
   'individualize'
 ]
@@ -97,7 +97,6 @@ export type IngredInputs = {
   name: string | null,
   volume: number | null,
   description: string | null,
-  concentration: string | null,
   individualize: boolean,
   serializeName: string | null
 }
@@ -106,7 +105,6 @@ export type IngredGroupAccessor =
   | 'name'
   | 'volume'
   | 'description'
-  | 'concentration'
   | 'individualize'
   | 'serializeName'
 

--- a/protocol-designer/src/navigation/selectors.js
+++ b/protocol-designer/src/navigation/selectors.js
@@ -1,5 +1,4 @@
 // @flow
-import isEmpty from 'lodash/isEmpty'
 import type {BaseState, Selector} from '../types'
 // import {createSelector} from 'reselect'
 
@@ -11,10 +10,10 @@ import type {Page} from './types'
 
 export const currentPage: Selector<Page> = (state: BaseState) => {
   // If we're in ingredient detail mode, override the nav button page state
-  const ingredients = labwareIngredSelectors.ingredientsForContainer(state)
+  const selectedContainer = labwareIngredSelectors.selectedContainer(state)
   const page = navigationRootSelector(state).page
 
-  return !isEmpty(ingredients) ? 'ingredient-detail' : page
+  return selectedContainer ? 'ingredient-detail' : page
 }
 
 export const newProtocolModal = (state: BaseState) =>

--- a/protocol-designer/src/navigation/selectors.js
+++ b/protocol-designer/src/navigation/selectors.js
@@ -1,4 +1,5 @@
 // @flow
+import isEmpty from 'lodash/isEmpty'
 import type {BaseState, Selector} from '../types'
 // import {createSelector} from 'reselect'
 
@@ -13,7 +14,7 @@ export const currentPage: Selector<Page> = (state: BaseState) => {
   const ingredients = labwareIngredSelectors.ingredientsForContainer(state)
   const page = navigationRootSelector(state).page
 
-  return ingredients ? 'ingredient-detail' : page
+  return !isEmpty(ingredients) ? 'ingredient-detail' : page
 }
 
 export const newProtocolModal = (state: BaseState) =>


### PR DESCRIPTION
## overview

In preparation for implementing liquid tracking (the RobotState timeline will soon also include `liquid` state that is updated by the command generator reducers just like tip tracking state), this PR refactors the `labware-ingred/` atom's state to maintain ingredient instances (a volume, in a well, in a labware) separately from ingredient groups (name, description, id, etc).

Also, `labware-ingred/` was written before we were using flow so this is part of the ongoing process to standardize and correctly type the state/data getting passed around in `labware-ingred/` -- here, I cleaned up and tested a good chunk of the selectors.

## changelog

* stuff discussed above
* Slight modifications to Plate and Well prop types in component library
* By virtue of refactoring it, I fixed ingredient deletion (both deleting from a single well by clicking the X, and deleting a whole group with the DELETE button)
* Cleaned up rectangle types used by collision detection, switched non-experimental ClientRect properties, removed an `any`

## review requests

Make sure selecting/adding/editing/deleting ingredients still works for you

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_ingred-location-has-volume/index.html