### PR TITLE
(complib, app, pd) Update InstrumentGroup to take left/right props

### DIFF
--- a/app/src/components/setup-instruments/Instruments.js
+++ b/app/src/components/setup-instruments/Instruments.js
@@ -40,7 +40,10 @@ export default function Instruments (props: Props) {
     }
   })
 
+  const left = instruments.find(i => i.mount === 'left')
+  const right = instruments.find(i => i.mount === 'right')
+
   return (
-    <InstrumentGroup instruments={instruments} />
+    <InstrumentGroup {...{left, right}} />
   )
 }

--- a/components/src/__tests__/instrument-diagram.test.js
+++ b/components/src/__tests__/instrument-diagram.test.js
@@ -24,23 +24,23 @@ describe('InstrumentDiagram', () => {
 describe('InstrumentGroup', () => {
   test('Renders correctly', () => {
     const tree = Renderer.create(
-      <InstrumentGroup instruments={[
-        {
+      <InstrumentGroup
+        left={{
           mount: 'left',
           description: 'p300 8-Channel',
           tipType: '150',
           channels: 8,
           className: 'foo'
-        },
-        {
+        }}
+        right={{
           mount: 'right',
           description: 'p10 Single',
           tipType: '10',
           channels: 1,
           isDisabled: true,
           className: 'blah'
-        }
-      ]}/>
+        }}
+      />
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/instrument-diagram/InstrumentGroup.js
+++ b/components/src/instrument-diagram/InstrumentGroup.js
@@ -6,7 +6,8 @@ import InstrumentInfo, {type InstrumentInfoProps} from './InstrumentInfo'
 import styles from './instrument.css'
 
 type Props = {
-  instruments: Array<InstrumentInfoProps>
+  left?: InstrumentInfoProps,
+  right?: InstrumentInfoProps
 }
 
 /**
@@ -14,15 +15,12 @@ type Props = {
  * Takes an array of `InstrumentInfo` props.
  */
 export default function InstrumentGroup (props: Props) {
-  const {instruments} = props
+  const {left, right} = props
 
   return (
     <section className={styles.pipette_group}>
-      {instruments.map((instrument) => {
-        return (
-          <InstrumentInfo key={instrument.mount} {...instrument} />
-        )
-      })}
+      {left && <InstrumentInfo {...left} />}
+      {right && <InstrumentInfo {...right} />}
     </section>
   )
 }

--- a/components/src/instrument-diagram/InstrumentGroup.md
+++ b/components/src/instrument-diagram/InstrumentGroup.md
@@ -1,6 +1,6 @@
 ```js
-<InstrumentGroup instruments={[
-  {mount: 'left', description: 'p300 8-Channel', tipType: '150', channels: 8},
-  {mount: 'right', description: 'p10 Single', tipType: '10', channels: 1, isDisabled: true}
-]}/>
+<InstrumentGroup
+  left={{mount: 'left', description: 'p300 8-Channel', tipType: '150', channels: 8}}
+  right={{mount: 'right', description: 'p10 Single', tipType: '10', channels: 1, isDisabled: true}}
+/>
 ```

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,6 +1,6 @@
 // @flow
-import React from 'react'
-import {FormGroup, InputField, InstrumentGroup, type InstrumentInfoProps} from '@opentrons/components'
+import * as React from 'react'
+import {FormGroup, InputField, InstrumentGroup} from '@opentrons/components'
 import type {FilePageFields} from '../file-data'
 import type {FormConnector} from '../utils'
 
@@ -9,7 +9,7 @@ import formStyles from '../components/Form.css'
 
 type Props = {
   formConnector: FormConnector<FilePageFields>,
-  instruments: Array<InstrumentInfoProps>
+  instruments: React.ElementProps<typeof InstrumentGroup>
 }
 
 export default function FilePage (props: Props) {
@@ -40,7 +40,7 @@ export default function FilePage (props: Props) {
         <h2>
           Pipettes
         </h2>
-        <InstrumentGroup instruments={instruments} />
+        <InstrumentGroup {...instruments} />
       </section>
     </div>
   )

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -24,7 +24,10 @@ function mapStateToProps (state: BaseState): StateProps {
 
   return {
     _values: formValues,
-    instruments: pipetteData
+    instruments: {
+      left: pipetteData.find(i => i.mount === 'left'),
+      right: pipetteData.find(i => i.mount === 'right')
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1000 

Different props, but snapshot is the same

# review requests

* Check out component library's `InstrumentGroup` example
* Think about whether this might break anything in the app
* If you want, check PD is the same as well