### PR TITLE
Pd liquid state in robot state

### DIFF
--- a/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
+++ b/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
@@ -1,0 +1,93 @@
+// @flow
+import {getLabwareLiquidState} from '../selectors'
+
+// TODO Ian 2018-03-09 copied from labware-ingred selectors,
+// you should export fixures for each labwareState & ingredLocs
+// then import here instead of copy-paste
+const labwareState = {
+  'default-trash': {
+    type: 'trash-box',
+    name: 'Trash',
+    slot: '12'
+  },
+  container1Id: {
+    slot: '10',
+    type: '96-flat',
+    name: 'Labware 1'
+  },
+  container2Id: {
+    slot: '8',
+    type: '96-deep-well',
+    name: 'Labware 2'
+  },
+  container3Id: {
+    slot: '9',
+    type: 'tube-rack-2ml',
+    name: 'Labware 3'
+  }
+}
+
+const ingredLocs = {
+  '0': {
+    container1Id: {
+      A1: {volume: 100},
+      B1: {volume: 150}
+    },
+    container2Id: {
+      A2: {volume: 105},
+      B2: {volume: 155}
+    }
+  },
+  '1': {
+    container2Id: {
+      A2: {volume: 115}, // added this, no longer exactly matching copy
+      H1: {volume: 111}
+    },
+    container3Id: {
+      H2: {volume: 222}
+    }
+  }
+}
+
+describe('getLabwareLiquidState', () => {
+  test('no liquids', () => {
+    expect(getLabwareLiquidState.resultFunc(
+      {},
+      {}
+    )).toEqual({})
+  })
+
+  test('selects liquids with multiple ingredient groups & multiple labware', () => {
+    expect(getLabwareLiquidState.resultFunc(
+      labwareState,
+      ingredLocs
+    )).toEqual({
+      container1Id: {
+        A1: {
+          '0': {volume: 100}
+        },
+        B1: {
+          '0': {volume: 150}
+        }
+      },
+      container2Id: {
+        A2: {
+          '0': {volume: 105},
+          '1': {volume: 115}
+        },
+        B2: {
+          '0': {volume: 155}
+        },
+        H1: {
+          '1': {volume: 111}
+        }
+      },
+      container3Id: {
+        H2: {
+          '1': {volume: 222}
+        }
+      },
+      'default-trash': {}
+    })
+  })
+})

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -2,11 +2,12 @@
 import {createSelector} from 'reselect'
 import isEmpty from 'lodash/isEmpty'
 import reduce from 'lodash/reduce'
-import type {BaseState} from '../../types'
+import type {BaseState, Selector} from '../../types'
 import * as StepGeneration from '../../step-generation'
 import {selectors as steplistSelectors} from '../../steplist/reducers'
 import {equippedPipettes} from './pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import type {IngredInstance} from '../../labware-ingred/types'
 
 const all96Tips = reduce(
   StepGeneration.tiprackWellNamesFlat,
@@ -14,10 +15,49 @@ const all96Tips = reduce(
   {}
 )
 
+type LiquidState = { // TODO import
+  [labwareId: string]: {
+    [well: string]: {
+      [ingredGroup: string]: {
+        volume: number
+      }
+    }
+  }
+}
+const getLabwareLiquidState: Selector<LiquidState> = createSelector(
+  labwareIngredSelectors.getLabware,
+  labwareIngredSelectors.getIngredientLocations,
+  (labware, ingredLocs) => {
+    const allLabwareIds = Object.keys(labware)
+
+    type WellVolume = {volume: number}
+
+    function getAllIngredsForLabware (labwareId: string) {
+      return reduce(ingredLocs, (ingredAcc: {[wellName: string]: WellVolume}, ingredGroupData: IngredInstance, ingredGroupId: string) => {
+        return {
+          ...ingredAcc,
+          ...reduce(ingredGroupData[labwareId], (wellAcc, wellData: WellVolume, wellName: string) => ({
+            ...wellAcc,
+            [wellName]: {
+              ...ingredAcc[wellName],
+              [ingredGroupId]: wellData
+            }
+          }), {})
+        }
+      }, {})
+    }
+    return allLabwareIds.reduce((acc, labwareId) => ({
+      ...acc,
+      [labwareId]: getAllIngredsForLabware(labwareId)
+    }), {})
+  }
+)
+
 export const getInitialRobotState: BaseState => StepGeneration.RobotState = createSelector(
   equippedPipettes,
   labwareIngredSelectors.getLabware,
-  (pipettes, labware) => {
+  getLabwareLiquidState,
+  (pipettes, labware, labwareLiquidState) => {
     type TipState = $PropertyType<StepGeneration.RobotState, 'tipState'>
     type TiprackTipState = $PropertyType<TipState, 'tipracks'>
 
@@ -44,12 +84,26 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
         }),
       {})
 
+    const pipetteLiquidState = reduce(
+      pipettes,
+      (acc, pipetteData: StepGeneration.PipetteData, pipetteId: string) => ({
+        ...acc,
+        [pipetteId]: (pipetteData.channels > 1)
+          ? {'0': {}, '1': {}, '2': {}, '3': {}, '4': {}, '5': {}, '6': {}, '7': {}}
+          : {'0': {}}
+      }),
+    {})
+
     return {
       instruments: pipettes,
       labware,
       tipState: {
         tipracks,
         pipettes: pipetteTipState
+      },
+      liquidState: {
+        pipettes: pipetteLiquidState,
+        labware: labwareLiquidState
       }
     }
   }

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -15,16 +15,12 @@ const all96Tips = reduce(
   {}
 )
 
-type LiquidState = { // TODO import
-  [labwareId: string]: {
-    [well: string]: {
-      [ingredGroup: string]: {
-        volume: number
-      }
-    }
-  }
-}
-const getLabwareLiquidState: Selector<LiquidState> = createSelector(
+type LiquidState = $PropertyType<StepGeneration.RobotState, 'liquidState'>
+type LabwareLiquidState = $PropertyType<LiquidState, 'labware'>
+/** getLabwareLiquidState reshapes data from labwareIngreds.ingredLocations reducer
+  * to match RobotState.liquidState.labware's shape
+  */
+export const getLabwareLiquidState: Selector<LabwareLiquidState> = createSelector(
   labwareIngredSelectors.getLabware,
   labwareIngredSelectors.getIngredientLocations,
   (labware, ingredLocs) => {

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -70,9 +70,9 @@ export const createFile: BaseState => ?ProtocolFile = createSelector(
       instruments,
       labware,
 
-      commands: timeline.map(timelineItem => ({
+      commands: timeline.map((timelineItem, i) => ({
         annotation: {
-          name: 'TODO Name',
+          name: `TODO Name ${i}`,
           description: 'todo description'
         },
         commands: timelineItem.commands.reduce((acc, c) => [...acc, c], [])

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -24,13 +24,10 @@ import type {
   AllIngredGroupFields,
   Labware,
   Wells,
-  // WellContents,
   AllWellContents,
-  // IngredientGroup,
-  // AllIngredGroups,
   IngredsForLabware,
-  IngredsForAllLabware
-  // IngredGroupForLabware
+  IngredsForAllLabware,
+  IngredInstance
 } from '../types'
 import type {BaseState, Selector, JsonWellData, VolumeJson} from '../../types'
 import * as actions from '../actions'
@@ -189,12 +186,7 @@ export const ingredients = handleActions({
 }, {})
 
 type LocationsState = {
-  [ingredGroupId: string]: {
-    [containerId: string]: {
-      [wellName: string]: {
-        volume: number}
-    }
-  }
+  [ingredGroupId: string]: IngredInstance
 }
 
 export const ingredLocations = handleActions({
@@ -571,6 +563,7 @@ export const selectors = {
   rootSelector,
 
   getIngredientGroups,
+  getIngredientLocations,
   getLabware,
 
   activeModals,

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -12,7 +12,14 @@ export type Wells = {
   [wellName: string]: string // eg A1: 'A1'.
 }
 
-type IngredInstance = {|
+export type IngredInstance = {
+  [containerId: string]: {
+    [wellName: string]: {
+      volume: number}
+  }
+}
+
+type IngredInstanceFlat = {|
   labwareId: string,
   groupId: string,
   well: string,
@@ -51,7 +58,7 @@ export type IngredientGroup = {|
   serializeName: string,
   instances: {
     [labwareId: string]: {
-      [wellName: string]: IngredInstance
+      [wellName: string]: IngredInstanceFlat
     }
   }
 |}
@@ -64,7 +71,7 @@ export type IngredGroupForLabware = {
   ...IngredInputFields,
   groupId: string,
   wells: {
-    [wellName: string]: IngredInstance
+    [wellName: string]: IngredInstanceFlat
   }
 }
 

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -1,7 +1,8 @@
 // @flow
-import {filledTiprackWells, p300Single, p300Multi} from './fixtures'
+import {filledTiprackWells, p300Single, p300Multi, basicLiquidState} from './fixtures'
 import {dropTip, type RobotState} from '../'
 
+// TODO use a fixture, standardize
 const makeRobotState = ({singleHasTips, multiHasTips}: {singleHasTips: boolean, multiHasTips: boolean}): RobotState => ({
   instruments: {
     p300SingleId: p300Single,
@@ -43,7 +44,8 @@ const makeRobotState = ({singleHasTips, multiHasTips}: {singleHasTips: boolean, 
       p300SingleId: singleHasTips,
       p300MultiId: multiHasTips
     }
-  }
+  },
+  liquidState: basicLiquidState
 })
 
 describe('replaceTip: single channel', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -1,5 +1,6 @@
 // @flow
 import {tiprackWellNamesFlat} from '../'
+import type {RobotState} from '../'
 
 // export const wellNames96 = flatMap(
 //   'ABCDEFGH'.split(''),
@@ -31,7 +32,37 @@ export const p300Multi = {
   channels: 8
 }
 
-export const getBasicRobotState = () => ({
+export const basicLiquidState = {
+  pipettes: {
+    p300SingleId: { '0': {} },
+    p300MultiId: { '0': {}, '1': {}, '2': {}, '3': {}, '4': {}, '5': {}, '6': {}, '7': {} }
+  },
+  labware: {
+    sourcePlateId: {
+      A1: {},
+      A2: {},
+      A3: {},
+      A4: {},
+      A5: {},
+      A6: {},
+      A7: {},
+      A8: {},
+      A9: {},
+      A10: {},
+      A11: {},
+      A12: {}
+    },
+    destPlateId: tiprackWellNamesFlat.reduce((acc, well) => ({
+      // Eg {A1: {}, B1: {}, ...etc}
+      [well]: {}
+    }), {}),
+    trashId: {
+      A1: {}
+    }
+  }
+}
+
+export const getBasicRobotState = (): RobotState => ({
   instruments: {
     p300SingleId: p300Single,
     p300MultiId: p300Multi
@@ -58,6 +89,7 @@ export const getBasicRobotState = () => ({
       name: 'Trash'
     }
   },
+
   tipState: {
     tipracks: {
       tiprack1Id: {...filledTiprackWells}
@@ -66,5 +98,7 @@ export const getBasicRobotState = () => ({
       p300SingleId: false,
       p300MultiId: false
     }
-  }
+  },
+
+  liquidState: basicLiquidState
 })

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -1,7 +1,8 @@
 // @flow
-import {filledTiprackWells, emptyTiprackWells, p300Single, p300Multi} from './fixtures'
+import {filledTiprackWells, emptyTiprackWells, p300Single, p300Multi, basicLiquidState} from './fixtures'
 import {replaceTip} from '../'
 
+// TODO use a fixture, standardize
 describe('replaceTip: single channel', () => {
   const robotInitialState = {
     instruments: {
@@ -42,7 +43,8 @@ describe('replaceTip: single channel', () => {
       pipettes: {
         p300SingleId: false
       }
-    }
+    },
+    liquidState: basicLiquidState
   }
 
   test('Single-channel: first tip', () => {
@@ -263,6 +265,7 @@ describe('replaceTip: single channel', () => {
 })
 
 describe('replaceTip: multi-channel', () => {
+  // TODO use a fixture, standardize
   const robotInitialState = {
     instruments: {
       p300MultiId: p300Multi
@@ -302,7 +305,8 @@ describe('replaceTip: multi-channel', () => {
       pipettes: {
         p300MultiId: false
       }
-    }
+    },
+    liquidState: basicLiquidState
   }
 
   test('multi-channel, all tipracks have tips', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
@@ -1,9 +1,10 @@
 // @flow
-import {filledTiprackWells, emptyTiprackWells, p300Single} from './fixtures'
+import {filledTiprackWells, emptyTiprackWells, p300Single, basicLiquidState} from './fixtures'
 import {sortLabwareBySlot, getNextTiprack, _getNextTip} from '../'
 
 describe('sortLabwareBySlot', () => {
   test('sorts all labware by slot', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -37,7 +38,8 @@ describe('sortLabwareBySlot', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
     expect(sortLabwareBySlot(robotState)).toEqual(['one', 'two', 'six', 'eleven'])
   })
@@ -55,7 +57,8 @@ describe('sortLabwareBySlot', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
     expect(sortLabwareBySlot(robotState)).toEqual([])
   })
@@ -119,6 +122,7 @@ describe('_getNextTip', () => {
 
 describe('getNextTiprack - single-channel', () => {
   test('single tiprack, missing A1', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -155,7 +159,8 @@ describe('getNextTiprack - single-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(1, robotState)
@@ -165,6 +170,7 @@ describe('getNextTiprack - single-channel', () => {
   })
 
   test('single tiprack, empty, should return null', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -191,7 +197,8 @@ describe('getNextTiprack - single-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(1, robotState)
@@ -200,6 +207,7 @@ describe('getNextTiprack - single-channel', () => {
   })
 
   test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -243,7 +251,8 @@ describe('getNextTiprack - single-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(1, robotState)
@@ -253,6 +262,7 @@ describe('getNextTiprack - single-channel', () => {
   })
 
   test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -298,7 +308,8 @@ describe('getNextTiprack - single-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(1, robotState)
@@ -313,6 +324,7 @@ describe('getNextTiprack - single-channel', () => {
 
 describe('getNextTiprack - 8-channel', () => {
   test('single tiprack, totally full', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -346,7 +358,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -356,6 +369,7 @@ describe('getNextTiprack - 8-channel', () => {
   })
 
   test('single tiprack, partially full', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -394,7 +408,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -430,7 +445,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -439,6 +455,7 @@ describe('getNextTiprack - 8-channel', () => {
   })
 
   test('single tiprack, a well missing from each column, should return null', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -486,7 +503,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -495,6 +513,7 @@ describe('getNextTiprack - 8-channel', () => {
   })
 
   test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -546,7 +565,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -556,6 +576,7 @@ describe('getNextTiprack - 8-channel', () => {
   })
 
   test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -632,7 +653,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)
@@ -642,6 +664,7 @@ describe('getNextTiprack - 8-channel', () => {
   })
 
   test('multiple tipracks, all empty, should return null', () => {
+    // TODO use a fixture, standardize
     const robotState = {
       instruments: {
         p300SingleId: p300Single
@@ -729,7 +752,8 @@ describe('getNextTiprack - 8-channel', () => {
         pipettes: {
           p300SingleId: false
         }
-      }
+      },
+      liquidState: basicLiquidState
     }
 
     const result = getNextTiprack(8, robotState)

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -70,6 +70,8 @@ export type LabwareData = {
   slot: DeckSlot
 }
 
+type TipId = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7'
+
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
   instruments: {
@@ -86,6 +88,26 @@ export type RobotState = {|
     },
     pipettes: {
       [pipetteId: string]: boolean // true if tip is on pipette
+    }
+  },
+  liquidState: {
+    pipettes: {
+      [pipetteId: string]: {
+        [tipId: TipId]: {
+          [ingredGroup: string]: {
+            volume: number
+          }
+        }
+      }
+    },
+    labware: {
+      [labwareId: string]: {
+        [well: string]: {
+          [ingredGroup: string]: {
+            volume: number
+          }
+        }
+      }
     }
   }
 |}


### PR DESCRIPTION
## overview

Closes #956 

## changelog

* Add `liquidState` key to `RobotState` type

* `getLabwareLiquidState` selector reshapes data from the labwareIngreds.ingredLocations reducer to match RobotState.liquidState.labware's shape (access with labwareId.well.ingredGroupId.volume instead of ingredGroupId.labwareId.well.volume)

* Pipette tips also have a place to hold liquid state: pipetteId.tipId.ingredGroupId.volume where tipId is 0-indexed tip number cast to string (for single-channel, just '0'. For 8-channel, '0' is the tip that would go into A1 of a 96-well plate, and '7' would go into well H1. They aren't called 'A' 'B' 'C' because 384 plates skip letters, so I went with zero-indexed numbers to identify the tips of a pipette.

## review requests

PD should work the same.

If you look at the liquid state selector (Ctrl+F for `liquidState` when you have the yellow selector debugger box open), you should see all the liquids you placed in Deck Setup. Eg

```js
"1520628071023.0.48444833180157154:96-flat": {
            "A1": {
              "0": {
                "volume": 50
              },
            "A2": {
              "1": {
                "volume": 55
              },
```

means, in that 96-flat's well A1, there is 50uL of ingredient '0' (that '0' is called the ingredGroup in PD), and in same labware's well A2 there is 55uL of ingredient '1'.

Lastly you should see the pipette tip liquid state under `"liquidState"`, as discussed above.