### PR TITLE
(pd) added splitLiquid & mergeLiquid fns with tests

### DIFF
--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {repeatArray, reduceCommandCreators} from '../utils'
+import {repeatArray, reduceCommandCreators, splitLiquid} from '../utils'
 
 describe('repeatArray', () => {
   test('repeat array of objects', () => {
@@ -42,5 +42,131 @@ describe('reduceCommandCreators', () => {
       'command: add 1',
       'command: multiply by 2'
     ])
+  })
+})
+
+describe('splitLiquid', () => {
+  const singleIngred = {
+    ingred1: {volume: 100}
+  }
+
+  const twoIngred = {
+    ingred1: {volume: 100},
+    ingred2: {volume: 300}
+  }
+
+  test('simple split with 1 ingredient in source', () => {
+    expect(splitLiquid(
+      60,
+      singleIngred
+    )).toEqual({
+      source: {ingred1: {volume: 40}},
+      dest: {ingred1: {volume: 60}}
+    })
+  })
+
+  test('get 0 volume in source when you split it all', () => {
+    expect(splitLiquid(
+      100,
+      singleIngred
+    )).toEqual({
+      source: {ingred1: {volume: 0}},
+      dest: {ingred1: {volume: 100}}
+    })
+  })
+
+  test('split with 2 ingredients in source', () => {
+    expect(splitLiquid(
+      20,
+      twoIngred
+    )).toEqual({
+      source: {
+        ingred1: {volume: 95},
+        ingred2: {volume: 285}
+      },
+      dest: {
+        ingred1: {volume: 5},
+        ingred2: {volume: 15}
+      }
+    })
+  })
+
+  test('split all with 2 ingredients', () => {
+    expect(splitLiquid(
+      400,
+      twoIngred
+    )).toEqual({
+      source: {
+        ingred1: {volume: 0},
+        ingred2: {volume: 0}
+      },
+      dest: twoIngred
+    })
+  })
+
+  test('taking out 0 volume results in same source, empty dest', () => {
+    expect(splitLiquid(
+      0,
+      twoIngred
+    )).toEqual({
+      source: twoIngred,
+      dest: {
+        ingred1: {volume: 0},
+        ingred2: {volume: 0}
+      }
+    })
+  })
+
+  test('split with 2 ingreds, one has 0 vol', () => {
+    expect(splitLiquid(
+      50,
+      {
+        ingred1: {volume: 200},
+        ingred2: {volume: 0}
+      }
+    )).toEqual({
+      source: {
+        ingred1: {volume: 150},
+        ingred2: {volume: 0}
+      },
+      dest: {
+        ingred1: {volume: 50},
+        ingred2: {volume: 0}
+      }
+    })
+  })
+
+  test('split with 2 ingredients, floating-point volume', () => {
+    expect(splitLiquid(
+      1000 / 3, // ~333.33
+      twoIngred
+    )).toEqual({
+      source: {
+        ingred1: {volume: 100 - (0.25 * 1000 / 3)},
+        ingred2: {volume: 50}
+      },
+      dest: {
+        ingred1: {volume: 0.25 * 1000 / 3},
+        ingred2: {volume: 250}
+      }
+    })
+  })
+
+  test('splitting with no ingredients in source raises error', () => {
+    expect(
+      () => splitLiquid(100, {})
+    ).toThrowError(/no volume in source/)
+  })
+
+  test('splitting with 0 volume in source raises error', () => {
+    expect(
+      () => splitLiquid(100, {ingred1: {volume: 0}})
+    ).toThrowError(/no volume in source/)
+  })
+
+  test('splitting with excessive volume raises error', () => {
+    expect(
+      () => splitLiquid(999, {ingred1: {volume: 10}})
+    ).toThrowError(/exceeds source volume/)
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {repeatArray, reduceCommandCreators, splitLiquid} from '../utils'
+import {repeatArray, reduceCommandCreators, splitLiquid, mergeLiquid} from '../utils'
 
 describe('repeatArray', () => {
   test('repeat array of objects', () => {
@@ -168,5 +168,40 @@ describe('splitLiquid', () => {
     expect(
       () => splitLiquid(999, {ingred1: {volume: 10}})
     ).toThrowError(/exceeds source volume/)
+  })
+})
+
+describe('mergeLiquid', () => {
+  test('merge ingreds 1 2 with 2 3 to get 1 2 3', () => {
+    expect(mergeLiquid(
+      {
+        ingred1: {volume: 30},
+        ingred2: {volume: 40}
+      },
+      {
+        ingred2: {volume: 15},
+        ingred3: {volume: 25}
+      }
+    )).toEqual({
+      ingred1: {volume: 30},
+      ingred2: {volume: 55},
+      ingred3: {volume: 25}
+    })
+  })
+
+  test('merge ingreds 3 with 1 2 to get 1 2 3', () => {
+    expect(mergeLiquid(
+      {
+        ingred3: {volume: 25}
+      },
+      {
+        ingred1: {volume: 30},
+        ingred2: {volume: 40}
+      }
+    )).toEqual({
+      ingred1: {volume: 30},
+      ingred2: {volume: 40},
+      ingred3: {volume: 25}
+    })
   })
 })

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -2,6 +2,7 @@
 import cloneDeep from 'lodash/cloneDeep'
 import flatMap from 'lodash/flatMap'
 import range from 'lodash/range'
+import reduce from 'lodash/reduce'
 import type {CommandCreator, RobotState} from './types'
 
 export function repeatArray<T> (array: Array<T>, repeats: number): Array<T> {
@@ -28,3 +29,48 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
       // Should I avoid cloning in the CommandCreators themselves and just do it pre-emptively in here?
     )
   )
+
+type Vol = {volume: number}
+type LiquidVolumeState = {[ingredGroup: string]: Vol}
+
+/** Breaks a liquid volume state into 2 parts. Assumes all liquids are evenly mixed. */
+export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeState): {
+  source: LiquidVolumeState,
+  dest: LiquidVolumeState
+} {
+  const totalSourceVolume = reduce(
+    sourceLiquidState,
+    (acc: number, ingredState: Vol) => acc + ingredState.volume,
+    0
+  )
+
+  if (totalSourceVolume === 0) {
+    throw new Error('Cannot split liquid: no volume in source')
+  }
+
+  if (volume > totalSourceVolume) {
+    throw new Error(`Cannot split liquid: volume ${volume} exceeds source volume ${totalSourceVolume}`)
+  }
+
+  const ratios: {[ingredId: string]: number} = reduce(
+    sourceLiquidState,
+    (acc: {[ingredId: string]: number}, ingredState: Vol, ingredId: string) => ({
+      ...acc,
+      [ingredId]: ingredState.volume / totalSourceVolume
+    })
+  , {})
+
+  return Object.keys(sourceLiquidState).reduce((acc, ingredId) => {
+    const destVol = ratios[ingredId] * volume
+    return {
+      source: {
+        ...acc.source,
+        [ingredId]: {volume: sourceLiquidState[ingredId].volume - destVol}
+      },
+      dest: {
+        ...acc.dest,
+        [ingredId]: {volume: destVol}
+      }
+    }
+  }, {source: {}, dest: {}})
+}

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -74,3 +74,27 @@ export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeStat
     }
   }, {source: {}, dest: {}})
 }
+
+/** The converse of splitLiquid. Adds all of one liquid to the other.
+  * The args are called 'source' and 'dest', but here they're interchangable.
+  */
+export function mergeLiquid (source: LiquidVolumeState, dest: LiquidVolumeState): LiquidVolumeState {
+  return {
+    // include all ingreds exclusive to 'dest'
+    ...dest,
+
+    ...reduce(source, (acc: LiquidVolumeState, ingredState: Vol, ingredId: string) => {
+      const isCommonIngred = ingredId in dest
+      const ingredVolume = isCommonIngred
+        // sum volumes of ingredients common to 'source' and 'dest'
+        ? ingredState.volume + dest[ingredId].volume
+        // include all ingreds exclusive to 'source'
+        : ingredState.volume
+
+      return {
+        ...acc,
+        [ingredId]: {volume: ingredVolume}
+      }
+    }, {})
+  }
+}


### PR DESCRIPTION
## overview

Pre-req for #957 -- `splitLiquid` utility function handles splitting out a given volume of liquid from a source to a dest. Takes equal parts of all ingredients in the source, assuming they're evenly mixed.

Also: `mergeLiquid` does the converse: add 2 liquids together entirely.

## review requests

* Sanity check: this is how liquid splitting + merging works, right? (Aside from phase separation, which we cannot presently handle in PD liquid tracking)

* Tests cover all useful cases?

Note: `splitLiquid` might return an error object instead of throwing the error later - not sure yet