### PR TITLE
Add factory calibration card

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -1,0 +1,26 @@
+// @flow
+// Card for displaying/initiating factory calibration
+import * as React from 'react'
+import type {Robot} from '../../robot'
+import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
+
+type Props = Robot
+
+const TITLE = 'Initial robot calibration'
+const LAST_RUN_LABEL = 'Last Run:'
+const CALIBRATION_MESSAGE = 'Calibrate your robot to initial factory settings to ensure accuracy.'
+
+export default function CalibrationCard (props: Props) {
+  const lastCalibrated = 'never'
+  return (
+    <Card title={TITLE} description={CALIBRATION_MESSAGE}>
+    <LabeledValue
+      label={LAST_RUN_LABEL}
+      value={lastCalibrated}
+    />
+    <OutlineButton disabled>
+      Calibrate
+    </OutlineButton>
+    </Card>
+  )
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -7,6 +7,7 @@ import type {Robot} from '../../robot'
 import StatusCard from './StatusCard'
 import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
+import CalibrationCard from './CalibrationCard'
 import ConnectAlertModal from './ConnectAlertModal'
 import styles from './styles.css'
 
@@ -24,6 +25,9 @@ export default function RobotSettings (props: Props) {
       <div className={styles.row}>
         <div className={styles.column_50}>
           <ConnectivityCard {...props} />
+        </div>
+        <div className={styles.column_50}>
+          <CalibrationCard {...props} />
         </div>
       </div>
     </div>

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -17,6 +17,7 @@
 
 .column_50 {
   display: inline-block;
+  vertical-align: top;
   width: calc(50% - (0.5 * var(--robot_settings_card_spacing)));
 
   &:not(:last-child) {

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -10,7 +10,7 @@ type Props = {
   /** Title for card */
   title: React.Node,
   /** Optional description or message for card */
-  description: string,
+  description?: string,
   /** Card content, displays in a flex-row by default */
   children: React.Node,
   /** Displays card content in a flex-column */

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -9,6 +9,8 @@ import styles from './structure.css'
 type Props = {
   /** Title for card */
   title: React.Node,
+  /** Optional description or message for card */
+  description: string,
   /** Card content, displays in a flex-row by default */
   children: React.Node,
   /** Displays card content in a flex-column */
@@ -32,6 +34,13 @@ export default function Card (props: Props) {
   return (
     <section className={style}>
       <h3 className={styles.card_title}>{title}</h3>
+      {props.description &&
+        (<p
+          className={styles.card_description}
+          >
+          {props.description}
+        </p>)
+      }
       <div className={childrenStyle}>
         {children}
       </div>

--- a/components/src/structure/Card.md
+++ b/components/src/structure/Card.md
@@ -8,6 +8,15 @@ Basic usage:
 </Card>
 ```
 
+Optional description or message to display under title:
+```js
+<Card title='Hello Title Card' description={'some sort of description about the buttons and values below'}>
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+  <LabeledValue label={'Label'} value={'Value'} />
+</Card>
+```
+
 Display content in a flex-column:
 ```js
 <Card title='Hello Title Card' column>

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -99,6 +99,12 @@
   font-weight: --fw-regular;
 }
 
+.card_description {
+  @apply --font-body-2-dark;
+
+  margin: 1rem 0;
+}
+
 .card_content {
   display: flex;
   flex-direction: row;

--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -12,6 +12,7 @@
   --fw-bold: 800;
   --fw-semibold: 600;
   --fw-regular: 400;
+  --fw-light: 300;
 
   --font-huge-dark: {
     font-size: var(--fs-huge);


### PR DESCRIPTION
## overview

This PR closes #937. Adds a non functioning factory calibration card to RobotSettings to later be wired up. 

<img width="800" alt="calibration card" src="https://user-images.githubusercontent.com/3430313/37354302-b49a426a-26b7-11e8-9af2-32954c8f8c4d.png">

## changelog

- update card component to display optional description
- add factory calibration card to RobotSettings

## review requests
standard review.