### PR TITLE
PD: Liquid tracking for aspirate

### DIFF
--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -1,6 +1,9 @@
 // @flow
 // import cloneDeep from 'lodash/cloneDeep'
+import {computeWellAccess} from '@opentrons/labware-definitions'
+import range from 'lodash/range'
 import type {RobotState, CommandCreator, AspirateDispenseArgs} from './'
+import {splitLiquid} from './utils'
 
 const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
   /** Aspirate with given args. Requires tip. */
@@ -28,9 +31,56 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     well
   }]
 
+  const labwareType = prevRobotState.labware[labware].type
+
+  const wellsForTips = (pipetteData.channels === 1)
+    ? [well]
+    : computeWellAccess(labwareType, well)
+
+  if (!wellsForTips) {
+    throw new Error(pipetteData.channels === 1
+      ? `Invalid well: ${well}`
+      : `Labware id "${labware}", type ${labwareType}, well ${well} is not accessible by 8-channel's 1st tip`
+    )
+  }
+
+  // TODO unify this: for each tip, a well (except for trough :/ )
+  const pipetteLiquidState = range(pipetteData.channels).reduce((acc, tipIndex) => ({
+    ...acc,
+    [tipIndex]: splitLiquid(
+      volume / pipetteData.channels,
+      prevRobotState.liquidState.labware[labware][wellsForTips[tipIndex]]
+    ).dest
+  }), {})
+
+  const labwareLiquidState = {
+    ...prevRobotState.liquidState.labware[labware],
+    ...wellsForTips.reduce((acc, well) => ({
+      ...acc,
+      [well]: splitLiquid(
+        volume,
+        prevRobotState.liquidState.labware[labware][well]
+      ).source
+    }), {})
+  }
+
+  const robotState = {
+    ...prevRobotState,
+    liquidState: {
+      pipettes: {
+        ...prevRobotState.liquidState.pipettes,
+        [pipette]: pipetteLiquidState
+      },
+      labware: {
+        ...prevRobotState.liquidState.labware,
+        [labware]: labwareLiquidState
+      }
+    }
+  }
+
   return {
     commands,
-    robotState: prevRobotState // TODO LATER deep clone robotState and manipulate it for liquid tracking here?
+    robotState
   }
 }
 

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -49,7 +49,7 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
   const allWellsShared = wellsForTips.length > 1 && wellsForTips.every(w => w && w === wellsForTips[0])
 
   const pipetteLiquidState = range(pipetteData.channels).reduce((acc, tipIndex) => {
-    const prevTipLiquidState = prevRobotState.liquidState.pipettes[pipette][tipIndex]
+    const prevTipLiquidState = prevRobotState.liquidState.pipettes[pipette][tipIndex.toString()]
     const prevSourceLiquidState = prevRobotState.liquidState.labware[labware][wellsForTips[tipIndex]]
 
     const newLiquidFromWell = splitLiquid(

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -76,6 +76,10 @@ describe('aspirate', () => {
   })
 
   describe('liquid tracking:', () => {
+    // Unlike the above tests, these tests rely on the fixure labware types matching the following:
+    expect(robotStateWithTip.labware.destPlateId.type).toBe('96-flat')
+    expect(robotStateWithTip.labware.sourcePlateId.type).toBe('trough-12row')
+
     const initialRobotWithIngred = merge(
       {},
       robotStateWithTip,
@@ -115,15 +119,6 @@ describe('aspirate', () => {
 
     // TODO Ian 2018-03-14 also do tests for tips that contain air
     // (prereq: need to define behavior in liquid tracking for that)
-
-    // Assertion for fixture. Alternatively, could re-declare the fixtures for this set of tests
-    if (initialRobotWithIngred.labware.destPlateId.type !== '96-flat') {
-      throw new Error('This set of tests expects destPlateId to be "96-flat"')
-    }
-
-    if (initialRobotWithIngred.labware.sourcePlateId.type !== 'trough-12row') {
-      throw new Error('This set of tests expects sourcePlateId to be "trough-12row"')
-    }
 
     describe('...single-channel pipette', () => {
       describe('...fresh tip', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -1,4 +1,5 @@
 // @flow
+import omit from 'lodash/omit'
 import aspirate from '../aspirate'
 import {getBasicRobotState} from './fixtures' // all8ChTipIds
 const AIR = 'air' // TODO get from constants
@@ -17,6 +18,10 @@ describe('aspirate', () => {
     }
   }
 
+  // Fixtures without liquidState key, for use with `toMatchObject`
+  // const initialRobotStateNoLiquidState = omit(initialRobotState, ['liquidState'])
+  const robotStateWithTipNoLiquidState = omit(robotStateWithTip, ['liquidState'])
+
   test('aspirate with tip', () => {
     const result = aspirate({
       pipette: 'p300SingleId',
@@ -33,7 +38,7 @@ describe('aspirate', () => {
       well: 'A1'
     }])
 
-    expect(result.robotState).toEqual(robotStateWithTip)
+    expect(result.robotState).toMatchObject(robotStateWithTipNoLiquidState)
   })
 
   test('aspirate with volume > pipette max vol should throw error', () => {
@@ -189,7 +194,7 @@ describe('aspirate', () => {
             ...initialRobotWithIngred.liquidState.labware,
             destPlateId: {
               ...initialRobotWithIngred.liquidState.labware.destPlateId,
-              A6: {ingred1: {volume: 0}, ingred2: {volume: 0}}
+              B6: {ingred1: {volume: 0}, ingred2: {volume: 0}}
             }
           }
         })
@@ -260,7 +265,7 @@ describe('aspirate', () => {
       test('aspirate from single-ingredient common well (trough-12row)', () => {
         const result = aspirate({
           pipette: 'p300MultiId',
-          volume: 150,
+          volume: 100,
           labware: 'sourcePlateId',
           well: 'A1'
         })(initialRobotWithIngred)
@@ -271,7 +276,7 @@ describe('aspirate', () => {
             p300MultiId: {
               ...(Array.from('01234567').reduce((acc, tipId) => ({
                 ...acc,
-                [tipId]: {ingred1: {volume: 150 / 8}} // aspirate volume divided among the 8 tips
+                [tipId]: {ingred1: {volume: 100 / 8}} // aspirate volume divided among the 8 tips
               }), {}))
             }
           },
@@ -279,7 +284,7 @@ describe('aspirate', () => {
             ...initialRobotWithIngred.liquidState.labware,
             sourcePlateId: {
               ...initialRobotWithIngred.liquidState.labware.sourcePlateId,
-              A1: {ingred1: {volume: 150}}
+              A1: {ingred1: {volume: 200}}
             }
           }
         })

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -9,13 +9,15 @@ describe('aspirate', () => {
     sourcePlateType: 'trough-12row',
     destPlateType: '96-flat',
     fillPipetteTips: false,
-    fillTiprackTips: true
+    fillTiprackTips: true,
+    tipracks: [200, 200]
   })
   const robotStateWithTip = createRobotState({
     sourcePlateType: 'trough-12row',
     destPlateType: '96-flat',
     fillPipetteTips: true,
-    fillTiprackTips: true
+    fillTiprackTips: true,
+    tipracks: [200, 200]
   })
 
   // Fixtures without liquidState key, for use with `toMatchObject`
@@ -23,7 +25,8 @@ describe('aspirate', () => {
     sourcePlateType: 'trough-12row',
     destPlateType: '96-flat',
     fillPipetteTips: true,
-    fillTiprackTips: true
+    fillTiprackTips: true,
+    tipracks: [200, 200]
   })
 
   test('aspirate with tip', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -1,6 +1,7 @@
 // @flow
 import aspirate from '../aspirate'
-import {getBasicRobotState} from './fixtures'
+import {getBasicRobotState} from './fixtures' // all8ChTipIds
+const AIR = 'air' // TODO get from constants
 
 describe('aspirate', () => {
   const initialRobotState = getBasicRobotState()
@@ -10,7 +11,8 @@ describe('aspirate', () => {
       ...initialRobotState.tipState,
       pipettes: {
         ...initialRobotState.tipState.pipettes,
-        p300SingleId: true
+        p300SingleId: true,
+        p300MultiId: true
       }
     }
   }
@@ -59,5 +61,229 @@ describe('aspirate', () => {
       labware: 'sourcePlateId',
       well: 'A1'
     })(initialRobotState)).toThrow(/Attempted to aspirate with no tip on pipette/)
+  })
+
+  describe('liquid tracking:', () => {
+    // TODO IMMEDIATELY factor up to fixtures
+    const initialRobotWithIngred = {
+      ...robotStateWithTip,
+      liquidState: {
+        ...robotStateWithTip.liquidState,
+        labware: {
+          ...robotStateWithTip.liquidState.labware,
+          sourcePlateId: {
+            A1: {ingred1: {volume: 300}},
+            A2: {ingred1: {volume: 150}, ingred2: {volume: 150}}
+          },
+          destPlateId: {
+            A1: {ingred1: {volume: 200}},
+            B1: {ingred1: {volume: 150}},
+            A6: {ingred1: {volume: 200}, ingred2: {volume: 100}},
+            B6: {ingred1: {volume: 60}, ingred2: {volume: 70}}
+          }
+        }
+      }
+    }
+
+    // Assertion for fixture
+    if (initialRobotWithIngred.labware.destPlateId.type !== '96-flat') {
+      throw new Error('This set of tests expects destPlateId to be "96-flat"')
+    }
+
+    if (initialRobotWithIngred.labware.sourcePlateId.type !== 'trough-12row') {
+      throw new Error('This set of tests expects sourcePlateId to be "trough-12row"')
+    }
+
+    describe('...single-channel pipette', () => {
+      test('aspirate from single-ingredient well', () => {
+        const result = aspirate({
+          pipette: 'p300SingleId',
+          volume: 50,
+          labware: 'destPlateId',
+          well: 'A1'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300SingleId: {
+              '0': {ingred1: {volume: 50}}
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A1: {ingred1: {volume: 150}}
+            }
+          }
+        })
+      })
+
+      test('aspirate everything + air from a single-ingredient well', () => {
+        const result = aspirate({
+          pipette: 'p300SingleId',
+          volume: 300,
+          labware: 'destPlateId',
+          well: 'A1'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300SingleId: {
+              '0': {ingred1: {volume: 200}, [AIR]: {volume: 100}}
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A1: {ingred1: {volume: 0}}
+            }
+          }
+        })
+      })
+
+      test('aspirate from two-ingredient well', () => {
+        const result = aspirate({
+          pipette: 'p300SingleId',
+          volume: 60,
+          labware: 'destPlateId',
+          well: 'A6'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300SingleId: {
+              '0': {ingred1: {volume: 40}, ingred2: {volume: 20}}
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A6: {ingred1: {volume: 200 - 40}, ingred2: {volume: 100 - 20}}
+            }
+          }
+        })
+      })
+
+      test('aspirate everything + air from two-ingredient well', () => {
+        const result = aspirate({
+          pipette: 'p300SingleId',
+          volume: 150,
+          labware: 'destPlateId',
+          well: 'B6'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300SingleId: {
+              '0': {ingred1: {volume: 60}, ingred2: {volume: 70}, [AIR]: {volume: 20}}
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A6: {ingred1: {volume: 0}, ingred2: {volume: 0}}
+            }
+          }
+        })
+      })
+    })
+
+    describe('...8-channel pipette', () => {
+      test('aspirate from single-ingredient set of wells (96-flat)', () => {
+        const result = aspirate({
+          pipette: 'p300MultiId',
+          volume: 50,
+          labware: 'destPlateId',
+          well: 'A1'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300MultiId: {
+              '0': {ingred1: {volume: 50}},
+              '1': {ingred1: {volume: 50}},
+              ...(Array.from('234567').reduce((acc, tipId) =>
+                ({...acc, [tipId]: {[AIR]: {volume: 50}}}), {})
+              )
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A1: {ingred1: {volume: 150}},
+              B1: {ingred1: {volume: 100}}
+            }
+          }
+        })
+      })
+
+      test('aspirate everything + air from single-ingredient wells (96-flat)', () => {
+        const result = aspirate({
+          pipette: 'p300MultiId',
+          volume: 250,
+          labware: 'destPlateId',
+          well: 'A1'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300MultiId: {
+              ...(Array.from('234567').reduce((acc, tipId) =>
+                ({...acc, [tipId]: {[AIR]: {volume: 250}}}), {})
+              ),
+              '0': {ingred1: {volume: 200}, [AIR]: {volume: 50}},
+              '1': {ingred1: {volume: 150}, [AIR]: {volume: 100}}
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            destPlateId: {
+              ...initialRobotWithIngred.liquidState.labware.destPlateId,
+              A1: {ingred1: {volume: 0}},
+              B1: {ingred1: {volume: 0}}
+            }
+          }
+        })
+      })
+
+      test('aspirate from single-ingredient common well (trough-12row)', () => {
+        const result = aspirate({
+          pipette: 'p300MultiId',
+          volume: 150,
+          labware: 'sourcePlateId',
+          well: 'A1'
+        })(initialRobotWithIngred)
+
+        expect(result.robotState.liquidState).toEqual({
+          pipettes: {
+            ...initialRobotWithIngred.liquidState.pipettes,
+            p300MultiId: {
+              ...(Array.from('01234567').reduce((acc, tipId) => ({
+                ...acc,
+                [tipId]: {ingred1: {volume: 150 / 8}} // aspirate volume divided among the 8 tips
+              }), {}))
+            }
+          },
+          labware: {
+            ...initialRobotWithIngred.liquidState.labware,
+            sourcePlateId: {
+              ...initialRobotWithIngred.liquidState.labware.sourcePlateId,
+              A1: {ingred1: {volume: 150}}
+            }
+          }
+        })
+      })
+    })
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -1,9 +1,16 @@
 // @flow
 import blowout from '../blowout'
-import {getBasicRobotState} from './fixtures'
+import {createRobotState} from './fixtures'
 
 describe('blowout', () => {
-  const initialRobotState = getBasicRobotState()
+  const initialRobotState = createRobotState({
+    sourcePlateType: 'trough-12row',
+    destPlateType: '96-flat',
+    fillTiprackTips: true,
+    fillPipetteTips: false,
+    tipracks: [200, 200]
+  })
+
   const robotStateWithTip = {
     ...initialRobotState,
     tipState: {

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -1,39 +1,49 @@
 // @flow
+import merge from 'lodash/merge'
 import omit from 'lodash/omit'
-import {getBasicRobotState, filledTiprackWells} from './fixtures'
+import {createRobotState, getTipColumn, getTiprackTipstate} from './fixtures'
 import {consolidate} from '../'
 
-const robotInitialState = getBasicRobotState()
+const robotInitialState = createRobotState({
+  sourcePlateType: 'trough-12row',
+  destPlateType: '96-flat',
+  fillTiprackTips: true,
+  fillPipetteTips: false,
+  tipracks: [200, 200]
+})
 
-const robotStatePickedUpOneTip = {
-  ...robotInitialState,
-  tipState: {
-    tipracks: {
-      ...robotInitialState.tipState.tipracks,
-      tiprack1Id: {...filledTiprackWells, A1: false}
-    },
-    pipettes: {
-      ...robotInitialState.tipState.pipettes,
-      p300SingleId: true
+const robotStatePickedUpOneTip = merge(
+  {},
+  robotInitialState,
+  {
+    tipState: {
+      tipracks: {
+        tiprack1Id: {A1: false}
+      },
+      pipettes: {
+        p300SingleId: true
+      }
     }
   }
-}
+)
 
-const robotStatePickedUpMultiTips = {
-  ...robotInitialState,
-  tipState: {
-    tipracks: {
-      ...robotInitialState.tipState.tipracks,
-      tiprack1Id: {...filledTiprackWells, A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false}
-    },
-    pipettes: {
-      ...robotInitialState.tipState.pipettes,
-      p300MultiId: true
+const robotStatePickedUpMultiTips = merge(
+  {},
+  robotInitialState,
+  {
+    tipState: {
+      tipracks: {
+        tiprack1Id: getTipColumn(1, false)
+      },
+      pipettes: {
+        p300MultiId: true
+      }
     }
   }
-}
+)
 
 // fixtures without 'liquidState' key for use with `toMatchObject`
+// TODO IMMEDIATELY: use fixture generator fns
 const robotInitialStateNoLiquidState = omit(robotInitialState, ['liquidState'])
 const robotStatePickedUpOneTipNoLiquidState = omit(robotStatePickedUpOneTip, ['liquidState'])
 const robotStatePickedUpMultiTipsNoLiquidState = omit(robotStatePickedUpMultiTips, ['liquidState'])
@@ -245,7 +255,7 @@ describe('consolidate single-channel', () => {
       tipState: {
         tipracks: {
           ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {...filledTiprackWells, A1: false, B1: false}
+          tiprack1Id: {...getTiprackTipstate(true), A1: false, B1: false}
         },
         pipettes: {
           ...robotInitialState.tipState.pipettes,

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -1,10 +1,9 @@
 // @flow
 import merge from 'lodash/merge'
-import omit from 'lodash/omit'
-import {createRobotState, getTipColumn, getTiprackTipstate} from './fixtures'
+import {createRobotStateFixture, createEmptyLiquidState, getTipColumn, getTiprackTipstate} from './fixtures'
 import {consolidate} from '../'
 
-const robotInitialState = createRobotState({
+const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
   destPlateType: '96-flat',
   fillTiprackTips: true,
@@ -12,9 +11,15 @@ const robotInitialState = createRobotState({
   tipracks: [200, 200]
 })
 
-const robotStatePickedUpOneTip = merge(
+const emptyLiquidState = createEmptyLiquidState({
+  sourcePlateType: 'trough-12row',
+  destPlateType: '96-flat',
+  pipettes: robotInitialStateNoLiquidState.instruments
+})
+
+const robotStatePickedUpOneTipNoLiquidState = merge(
   {},
-  robotInitialState,
+  robotInitialStateNoLiquidState,
   {
     tipState: {
       tipracks: {
@@ -27,9 +32,9 @@ const robotStatePickedUpOneTip = merge(
   }
 )
 
-const robotStatePickedUpMultiTips = merge(
+const robotStatePickedUpMultiTipsNoLiquidState = merge(
   {},
-  robotInitialState,
+  robotInitialStateNoLiquidState,
   {
     tipState: {
       tipracks: {
@@ -42,11 +47,9 @@ const robotStatePickedUpMultiTips = merge(
   }
 )
 
-// fixtures without 'liquidState' key for use with `toMatchObject`
-// TODO IMMEDIATELY: use fixture generator fns
-const robotInitialStateNoLiquidState = omit(robotInitialState, ['liquidState'])
-const robotStatePickedUpOneTipNoLiquidState = omit(robotStatePickedUpOneTip, ['liquidState'])
-const robotStatePickedUpMultiTipsNoLiquidState = omit(robotStatePickedUpMultiTips, ['liquidState'])
+// Fixtures with empty liquidState
+const robotInitialState = {...robotInitialStateNoLiquidState, liquidState: emptyLiquidState}
+const robotStatePickedUpOneTip = {...robotStatePickedUpOneTipNoLiquidState, liquidState: emptyLiquidState}
 
 describe('consolidate single-channel', () => {
   const baseData = {

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -1,24 +1,44 @@
 // @flow
+import omit from 'lodash/omit'
 import {getBasicRobotState, filledTiprackWells} from './fixtures'
 import {consolidate} from '../'
 
-describe('consolidate single-channel', () => {
-  const robotInitialState = getBasicRobotState()
+const robotInitialState = getBasicRobotState()
 
-  const robotStatePickedUpOneTip = {
-    ...robotInitialState,
-    tipState: {
-      tipracks: {
-        ...robotInitialState.tipState.tipracks,
-        tiprack1Id: {...filledTiprackWells, A1: false}
-      },
-      pipettes: {
-        ...robotInitialState.tipState.pipettes,
-        p300SingleId: true
-      }
+const robotStatePickedUpOneTip = {
+  ...robotInitialState,
+  tipState: {
+    tipracks: {
+      ...robotInitialState.tipState.tipracks,
+      tiprack1Id: {...filledTiprackWells, A1: false}
+    },
+    pipettes: {
+      ...robotInitialState.tipState.pipettes,
+      p300SingleId: true
     }
   }
+}
 
+const robotStatePickedUpMultiTips = {
+  ...robotInitialState,
+  tipState: {
+    tipracks: {
+      ...robotInitialState.tipState.tipracks,
+      tiprack1Id: {...filledTiprackWells, A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false}
+    },
+    pipettes: {
+      ...robotInitialState.tipState.pipettes,
+      p300MultiId: true
+    }
+  }
+}
+
+// fixtures without 'liquidState' key for use with `toMatchObject`
+const robotInitialStateNoLiquidState = omit(robotInitialState, ['liquidState'])
+const robotStatePickedUpOneTipNoLiquidState = omit(robotStatePickedUpOneTip, ['liquidState'])
+const robotStatePickedUpMultiTipsNoLiquidState = omit(robotStatePickedUpMultiTips, ['liquidState'])
+
+describe('consolidate single-channel', () => {
   const baseData = {
     stepType: 'consolidate',
     name: 'Consolidate Test',
@@ -52,7 +72,8 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTip)
 
     expect(result.commands).toEqual([
       {
@@ -144,7 +165,7 @@ describe('consolidate single-channel', () => {
       }
     ])
 
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('Single-channel with exceeding pipette max: with changeTip="always"', () => {
@@ -219,8 +240,8 @@ describe('consolidate single-channel', () => {
       }
     ])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
+    expect(result.robotState).toMatchObject({
+      ...robotInitialStateNoLiquidState,
       tipState: {
         tipracks: {
           ...robotInitialState.tipState.tipracks,
@@ -294,7 +315,7 @@ describe('consolidate single-channel', () => {
       }
     ])
 
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('Single-channel with exceeding pipette max: with changeTip="never"', () => {
@@ -351,7 +372,7 @@ describe('consolidate single-channel', () => {
       }
     ])
 
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('disposal vol should be taken from first well', () => {
@@ -427,7 +448,7 @@ describe('consolidate single-channel', () => {
         well: 'A1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('mix on aspirate should mix before aspirate in first well of chunk only', () => {
@@ -577,7 +598,7 @@ describe('consolidate single-channel', () => {
         well: 'B1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('mix on aspirate with disposal vol', () => {
@@ -742,7 +763,7 @@ describe('consolidate single-channel', () => {
         well: 'A1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('mix after dispense', () => {
@@ -892,7 +913,7 @@ describe('consolidate single-channel', () => {
       }
       // done mix 2
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('mix after dispense with blowout to trash: first mix, then blowout', () => {
@@ -1055,7 +1076,7 @@ describe('consolidate single-channel', () => {
         well: 'A1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('mix after dispense with disposal volume: dispose, then mix (?)', () => {
@@ -1220,7 +1241,7 @@ describe('consolidate single-channel', () => {
         well: 'B1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('"pre-wet tip" should aspirate and dispense consolidate volume from first well of each chunk', () => {
@@ -1318,7 +1339,7 @@ describe('consolidate single-channel', () => {
         well: 'B1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('touch-tip after aspirate should touch tip after every aspirate command', () => {
@@ -1405,7 +1426,7 @@ describe('consolidate single-channel', () => {
         well: 'B1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 
   test('touch-tip after dispense should touch tip after dispense on destination well', () => {
@@ -1480,27 +1501,11 @@ describe('consolidate single-channel', () => {
         well: 'B1'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
 })
 
 describe('consolidate multi-channel', () => {
-  const robotInitialState = getBasicRobotState()
-
-  const robotStatePickedUpOneTip = {
-    ...robotInitialState,
-    tipState: {
-      tipracks: {
-        ...robotInitialState.tipState.tipracks,
-        tiprack1Id: {...filledTiprackWells, A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false}
-      },
-      pipettes: {
-        ...robotInitialState.tipState.pipettes,
-        p300MultiId: true
-      }
-    }
-  }
-
   const baseData = {
     stepType: 'consolidate',
     name: 'Consolidate Test',
@@ -1583,10 +1588,10 @@ describe('consolidate multi-channel', () => {
         well: 'A12'
       }
     ])
-    expect(result.robotState).toEqual(robotStatePickedUpOneTip)
+    expect(result.robotState).toMatchObject(robotStatePickedUpMultiTipsNoLiquidState)
   })
 
-  // TODO later: address different multi-channel layouts of plates?
+  // TODO Ian 2018-03-14: address different multi-channel layouts of plates
   test.skip('multi-channel 384 plate: cols A1 B1 A2 B2 to 96-plate col A12')
 
   test.skip('multi-channel trough A1 A2 A3 A4 to 96-plate A12')

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -1,9 +1,16 @@
 // @flow
-import {getBasicRobotState} from './fixtures'
+import {createRobotState} from './fixtures'
 import {dispense} from '../'
 
 describe('dispense', () => {
-  const initialRobotState = getBasicRobotState()
+  const initialRobotState = createRobotState({
+    sourcePlateType: 'trough-12row',
+    destPlateType: '96-flat',
+    fillTiprackTips: true,
+    fillPipetteTips: false,
+    tipracks: [200, 200]
+  })
+
   const robotStateWithTip = {
     ...initialRobotState,
     tipState: {

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -16,8 +16,8 @@ function makeRobotState (args: {singleHasTips: boolean, multiHasTips: boolean}) 
     {
       tipState: {
         pipettes: {
-          p300Single: args.singleHasTips,
-          p300Multi: args.multiHasTips
+          p300SingleId: args.singleHasTips,
+          p300MultiId: args.multiHasTips
         }
       }
     }
@@ -26,10 +26,10 @@ function makeRobotState (args: {singleHasTips: boolean, multiHasTips: boolean}) 
 
 describe('replaceTip: single channel', () => {
   test('drop tip if there is a tip', () => {
-    const result = dropTip('p300Single')(makeRobotState({singleHasTips: true, multiHasTips: true}))
+    const result = dropTip('p300SingleId')(makeRobotState({singleHasTips: true, multiHasTips: true}))
     expect(result.commands).toEqual([{
       command: 'drop-tip',
-      pipette: 'p300Single',
+      pipette: 'p300SingleId',
       labware: 'trashId',
       well: 'A1'
     }])
@@ -38,7 +38,7 @@ describe('replaceTip: single channel', () => {
 
   test('no tip on pipette, ignore dropTip', () => {
     const initialRobotState = makeRobotState({singleHasTips: false, multiHasTips: true})
-    const result = dropTip('p300Single')(initialRobotState)
+    const result = dropTip('p300SingleId')(initialRobotState)
     expect(result.commands).toEqual([])
     expect(result.robotState).toEqual(initialRobotState)
   })
@@ -46,10 +46,10 @@ describe('replaceTip: single channel', () => {
 
 describe('Multi-channel dropTip', () => {
   test('drop tip if there is a tip', () => {
-    const result = dropTip('p300Multi')(makeRobotState({singleHasTips: true, multiHasTips: true}))
+    const result = dropTip('p300MultiId')(makeRobotState({singleHasTips: true, multiHasTips: true}))
     expect(result.commands).toEqual([{
       command: 'drop-tip',
-      pipette: 'p300Multi',
+      pipette: 'p300MultiId',
       labware: 'trashId',
       well: 'A1'
     }])
@@ -58,7 +58,7 @@ describe('Multi-channel dropTip', () => {
 
   test('no tip on pipette, ignore dropTip', () => {
     const initialRobotState = makeRobotState({singleHasTips: true, multiHasTips: false})
-    const result = dropTip('p300Multi')(initialRobotState)
+    const result = dropTip('p300MultiId')(initialRobotState)
     expect(result.commands).toEqual([])
     expect(result.robotState).toEqual(initialRobotState)
   })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -1,0 +1,91 @@
+// @flow
+import {createRobotState, createEmptyLiquidState, filledTiprackWells, emptyTiprackWells} from './fixtures'
+
+describe('createEmptyLiquidState fixture generator', () => {
+  test('labware', () => {
+    const result = createEmptyLiquidState({
+      sourcePlateType: '96-flat',
+      destPlateType: 'trough-12row',
+      pipettes: {}
+    })
+
+    expect(Object.keys(result.labware)).toHaveLength(3) // 3 labwares: source, dest, trash
+
+    expect(result.labware.sourcePlateId).toMatchObject({
+      A1: {},
+      B1: {},
+      A2: {}
+    })
+
+    expect(Object.keys(result.labware.sourcePlateId)).toHaveLength(96)
+
+    expect(result.labware.destPlateId).toEqual({
+      A1: {},
+      A2: {},
+      A3: {},
+      A4: {},
+      A5: {},
+      A6: {},
+      A7: {},
+      A8: {},
+      A9: {},
+      A10: {},
+      A11: {},
+      A12: {}
+    })
+
+    expect(result.labware.trashId).toEqual({A1: {}})
+  })
+})
+
+// TODO IMMEDIATELY: update to use refactored createRobotStateFixture fn
+describe.skip('createRobotState fixture generator', () => {
+  describe('tip filling', () => {
+    const tipFillingOptions = ['full', 'empty']
+
+    tipFillingOptions.forEach(fillTiprackTips => {
+      test('tiprack tips: ' + fillTiprackTips, () => {
+        const result = createRobotState({
+          labware: {tiprack1: {type: 'tiprack-200ul', slot: '1', name: ''}},
+          pipetteTips: 'empty',
+          tiprackTips: fillTiprackTips
+        })
+
+        expect(result).toHaveProperty('tipState.tipracks.tiprack1')
+        expect(result.tipState.tipracks['tiprack1']).toEqual(fillTiprackTips === 'full'
+          ? filledTiprackWells
+          : emptyTiprackWells
+        )
+      })
+    })
+
+    tipFillingOptions.forEach(fillPipetteTips => {
+      test('tiprack tips ' + fillPipetteTips, () => {
+        const result = createRobotState({
+          labware: {},
+          leftPipette: 'p300Single',
+          rightPipette: 'p10Multi',
+          pipetteTips: fillPipetteTips,
+          tiprackTips: 'empty'
+        })
+
+        const tipIsFull = fillPipetteTips === 'full'
+
+        expect(result).toHaveProperty('tipState.pipettes.left')
+        expect(result.tipState.pipettes.left).toEqual({'0': tipIsFull})
+
+        expect(result).toHaveProperty('tipState.pipettes.right')
+        expect(result.tipState.pipettes.right).toEqual({
+          '0': tipIsFull,
+          '1': tipIsFull,
+          '2': tipIsFull,
+          '3': tipIsFull,
+          '4': tipIsFull,
+          '5': tipIsFull,
+          '6': tipIsFull,
+          '7': tipIsFull
+        })
+      })
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -38,7 +38,6 @@ describe('createEmptyLiquidState fixture generator', () => {
   })
 })
 
-// TODO IMMEDIATELY: update to use refactored createRobotStateFixture fn
 describe('createRobotState fixture generator', () => {
   describe('tip filling', () => {
     const tipFillingOptions = [true, false]

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {createRobotState, createEmptyLiquidState, filledTiprackWells, emptyTiprackWells} from './fixtures'
+import {createRobotState, createEmptyLiquidState, getTiprackTipstate} from './fixtures'
 
 describe('createEmptyLiquidState fixture generator', () => {
   test('labware', () => {
@@ -39,51 +39,45 @@ describe('createEmptyLiquidState fixture generator', () => {
 })
 
 // TODO IMMEDIATELY: update to use refactored createRobotStateFixture fn
-describe.skip('createRobotState fixture generator', () => {
+describe('createRobotState fixture generator', () => {
   describe('tip filling', () => {
-    const tipFillingOptions = ['full', 'empty']
+    const tipFillingOptions = [true, false]
 
     tipFillingOptions.forEach(fillTiprackTips => {
-      test('tiprack tips: ' + fillTiprackTips, () => {
+      test('tiprack tips: ' + (fillTiprackTips ? 'full' : 'empty'), () => {
         const result = createRobotState({
-          labware: {tiprack1: {type: 'tiprack-200ul', slot: '1', name: ''}},
-          pipetteTips: 'empty',
-          tiprackTips: fillTiprackTips
+          sourcePlateType: 'trough-12row',
+          destPlateType: '96-flat',
+          fillPipetteTips: false,
+          fillTiprackTips,
+          tipracks: [200, 200]
         })
 
-        expect(result).toHaveProperty('tipState.tipracks.tiprack1')
-        expect(result.tipState.tipracks['tiprack1']).toEqual(fillTiprackTips === 'full'
-          ? filledTiprackWells
-          : emptyTiprackWells
-        )
+        const tiprackIds = ['tiprack1Id', 'tiprack2Id']
+        tiprackIds.forEach(tiprackId => {
+          expect(result).toHaveProperty(`tipState.tipracks.${tiprackId}`)
+
+          expect(result.tipState.tipracks[tiprackId]).toEqual(
+            getTiprackTipstate(fillTiprackTips)
+          )
+        })
       })
     })
 
     tipFillingOptions.forEach(fillPipetteTips => {
-      test('tiprack tips ' + fillPipetteTips, () => {
+      test('tiprack tips ' + (fillPipetteTips ? 'full' : 'empty'), () => {
         const result = createRobotState({
-          labware: {},
-          leftPipette: 'p300Single',
-          rightPipette: 'p10Multi',
-          pipetteTips: fillPipetteTips,
-          tiprackTips: 'empty'
+          sourcePlateType: 'trough-12row',
+          destPlateType: '96-flat',
+          fillPipetteTips,
+          fillTiprackTips: true,
+          tipracks: [200, 200]
         })
 
-        const tipIsFull = fillPipetteTips === 'full'
-
-        expect(result).toHaveProperty('tipState.pipettes.left')
-        expect(result.tipState.pipettes.left).toEqual({'0': tipIsFull})
-
-        expect(result).toHaveProperty('tipState.pipettes.right')
-        expect(result.tipState.pipettes.right).toEqual({
-          '0': tipIsFull,
-          '1': tipIsFull,
-          '2': tipIsFull,
-          '3': tipIsFull,
-          '4': tipIsFull,
-          '5': tipIsFull,
-          '6': tipIsFull,
-          '7': tipIsFull
+        const pipetteIds = ['p300SingleId', 'p300MultiId']
+        pipetteIds.forEach(pipetteId => {
+          expect(result).toHaveProperty(`tipState.pipettes.${pipetteId}`)
+          expect(result.tipState.pipettes[pipetteId]).toEqual(fillPipetteTips)
         })
       })
     })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -32,10 +32,12 @@ export const p300Multi = {
   channels: 8
 }
 
+export const all8ChTipIds = ['0', '1', '2', '3', '4', '5', '6', '7']
+
 export const basicLiquidState = {
   pipettes: {
     p300SingleId: { '0': {} },
-    p300MultiId: { '0': {}, '1': {}, '2': {}, '3': {}, '4': {}, '5': {}, '6': {}, '7': {} }
+    p300MultiId: all8ChTipIds.reduce((acc, tipId) => ({...acc, [tipId]: {}}), {})
   },
   labware: {
     sourcePlateId: {

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -1,6 +1,10 @@
 // @flow
+import {getLabware} from '@opentrons/labware-definitions'
+import mapValues from 'lodash/mapValues'
+import range from 'lodash/range'
+import reduce from 'lodash/reduce'
 import {tiprackWellNamesFlat} from '../'
-import type {RobotState} from '../'
+import type {RobotState, PipetteData} from '../'
 
 // export const wellNames96 = flatMap(
 //   'ABCDEFGH'.split(''),
@@ -17,7 +21,8 @@ export const emptyTiprackWells = tiprackWellNamesFlat.reduce(
   (acc, wellName) => ({...acc, [wellName]: false}),
   {}
 )
-
+// TODO Ian 2018-03-14: these pipette fixtures should use file-data/pipetteData.js,
+// which should in turn be lifted out to a general pipette data project?
 export const p300Single = {
   id: 'p300SingleId',
   mount: 'right',
@@ -32,75 +37,206 @@ export const p300Multi = {
   channels: 8
 }
 
-export const all8ChTipIds = ['0', '1', '2', '3', '4', '5', '6', '7']
+export const all8ChTipIds = range(8)
 
-export const basicLiquidState = {
-  pipettes: {
-    p300SingleId: { '0': {} },
-    p300MultiId: all8ChTipIds.reduce((acc, tipId) => ({...acc, [tipId]: {}}), {})
-  },
-  labware: {
-    sourcePlateId: {
-      A1: {},
-      A2: {},
-      A3: {},
-      A4: {},
-      A5: {},
-      A6: {},
-      A7: {},
-      A8: {},
-      A9: {},
-      A10: {},
-      A11: {},
-      A12: {}
-    },
-    destPlateId: tiprackWellNamesFlat.reduce((acc, well) => ({
-      // Eg {A1: {}, B1: {}, ...etc}
-      [well]: {}
-    }), {}),
-    trashId: {
-      A1: {}
+// export const basicLiquidState = {
+//   pipettes: {
+//     p300SingleId: { '0': {} },
+//     p300MultiId: all8ChTipIds.reduce((acc, tipId) => ({...acc, [tipId]: {}}), {})
+//   },
+//   labware: {
+//     sourcePlateId: {
+//       A1: {},
+//       A2: {},
+//       A3: {},
+//       A4: {},
+//       A5: {},
+//       A6: {},
+//       A7: {},
+//       A8: {},
+//       A9: {},
+//       A10: {},
+//       A11: {},
+//       A12: {}
+//     },
+//     destPlateId: tiprackWellNamesFlat.reduce((acc, well) => ({
+//       // Eg {A1: {}, B1: {}, ...etc}
+//       [well]: {}
+//     }), {}),
+//     trashId: {
+//       A1: {}
+//     }
+//   }
+// }
+
+export function getWellsForLabware (labwareType: string) {
+  const labware = getLabware(labwareType)
+  if (!labware) {
+    throw new Error(`Labware "${labwareType}" not found.`)
+  }
+  if (!labware.wells) {
+    throw new Error(`Labware "${labwareType} has no wells!"`)
+  }
+  return labware.wells
+}
+
+export function createEmptyLiquidState (args: {
+  sourcePlateType: string,
+  destPlateType: string,
+  pipettes: $PropertyType<RobotState, 'instruments'>
+}) {
+  const {sourcePlateType, destPlateType, pipettes} = args
+  return {
+    pipettes: reduce(
+      pipettes,
+      (acc, pipetteData: PipetteData, pipetteId: string) => ({
+        ...acc,
+        [pipetteId]: range(pipetteData.channels).reduce((tipIdAcc, tipId) => ({ // TODO: replace with helper fn
+          ...tipIdAcc,
+          [tipId]: {}
+        }), {})
+      }), {}),
+    labware: {
+      sourcePlateId: mapValues(getWellsForLabware(sourcePlateType), () => ({})),
+      destPlateId: mapValues(getWellsForLabware(destPlateType), () => ({})),
+      trashId: {A1: {}}
     }
   }
 }
 
-export const getBasicRobotState = (): RobotState => ({
-  instruments: {
+type SubtractLiquidState = {liquidState: *}
+type RobotStateNoLiquidState = $Diff<RobotState, SubtractLiquidState>
+
+/** RobotState with empty liquid state */
+export function createRobotState (args: {
+  sourcePlateType: string,
+  destPlateType: string,
+  fillPipetteTips?: boolean,
+  fillTiprackTips?: boolean
+}): RobotState {
+  const {labware, instruments, tipState} = createRobotStateFixture(args)
+
+  return {
+    labware,
+    instruments,
+    tipState,
+    liquidState: createEmptyLiquidState({
+      ...args,
+      pipettes: {p300SingleId: p300Single, p300MultiId: p300Multi}
+    })
+  }
+}
+
+/** RobotState without liquidState key, for use with jest's `toMatchObject` */
+export function createRobotStateFixture (args: {
+  sourcePlateType: string,
+  destPlateType: string,
+  fillPipetteTips?: boolean,
+  fillTiprackTips?: boolean
+}): RobotStateNoLiquidState {
+  const instruments = {
     p300SingleId: p300Single,
     p300MultiId: p300Multi
-  },
-  labware: {
-    tiprack1Id: {
-      slot: '7',
-      type: 'tiprack-200uL',
-      name: 'Tip rack'
-    },
-    sourcePlateId: {
-      slot: '10',
-      type: 'trough-12row',
-      name: 'Source (Buffer)'
-    },
-    destPlateId: {
-      slot: '11',
-      type: '96-flat',
-      name: 'Destination Plate'
-    },
-    trashId: {
-      slot: '12',
-      type: 'fixed-trash',
-      name: 'Trash'
-    }
-  },
+  }
 
-  tipState: {
-    tipracks: {
-      tiprack1Id: {...filledTiprackWells}
+  return {
+    instruments,
+    labware: {
+      tiprack1Id: {
+        slot: '7',
+        type: 'tiprack-200uL',
+        name: 'Tip rack'
+      },
+      sourcePlateId: {
+        slot: '10',
+        type: args.sourcePlateType, // WAS: 'trough-12row'. TODO IMMEDIATELY: remove this comment
+        name: 'Source (Buffer)'
+      },
+      destPlateId: {
+        slot: '11',
+        type: args.destPlateType, // WAS: '96-flat'. TODO IMMEDIATELY: remove this comment
+        name: 'Destination Plate'
+      },
+      trashId: {
+        slot: '12',
+        type: 'fixed-trash',
+        name: 'Trash'
+      }
     },
-    pipettes: {
-      p300SingleId: false,
-      p300MultiId: false
-    }
-  },
 
-  liquidState: basicLiquidState
-})
+    tipState: {
+      tipracks: {
+        tiprack1Id: args.fillTiprackTips ? filledTiprackWells : emptyTiprackWells
+      },
+      pipettes: {
+        p300SingleId: !!args.fillPipetteTips,
+        p300MultiId: !!args.fillPipetteTips
+      }
+    }
+  }
+}
+
+// type SubtractMount = {mount: *}
+//
+// type PipetteNoMount = $Diff<PipetteData, SubtractMount>
+//
+// const _pipetteShortcuts: {[string]: PipetteNoMount} = {
+//   'p300Single': {maxVolume: 300, channels: 1, id: 'p300Single'},
+//   'p300Multi': {maxVolume: 300, channels: 8, id: 'p300Multi'},
+//   'p10Single': {maxVolume: 10, channels: 1, id: 'p10Single'},
+//   'p10Multi': {maxVolume: 10, channels: 8, id: 'p10Multi'}
+// }
+//
+// export function createRobotState (args: { // TODO remove
+//   labware: $PropertyType<RobotState, 'labware'>,
+//   leftPipette?: $Keys<typeof _pipetteShortcuts>,
+//   rightPipette?: $Keys<typeof _pipetteShortcuts>,
+//   tiprackTips: 'full' | 'empty',
+//   pipetteTips: 'full' | 'empty'
+// }): RobotStateNoLiquidState {
+//   const {labware, leftPipette, rightPipette, tiprackTips, pipetteTips} = args
+//   // Construct instruments
+//   let instruments = {}
+//
+//   if (leftPipette) {
+//     instruments.left = {
+//       ..._pipetteShortcuts[leftPipette],
+//       mount: 'left'
+//     }
+//   }
+//
+//   if (rightPipette) {
+//     instruments.right = {
+//       ..._pipetteShortcuts[rightPipette],
+//       mount: 'right'
+//     }
+//   }
+//
+//   // construct tipstate
+//   const tipState = {
+//     tipracks: reduce(
+//       Object.keys(labware).filter(labwareName => labware[labwareName].type.startsWith('tiprack')),
+//       (acc, tiprackId) => ({
+//         ...acc,
+//         [tiprackId]: tiprackTips === 'full'
+//           ? {...filledTiprackWells}
+//           : {...emptyTiprackWells}
+//       }),
+//       {}),
+//     pipettes: reduce(
+//       instruments,
+//       (acc, pipette: PipetteNoMount, pipetteId) => ({
+//         ...acc,
+//         [pipetteId]: range(pipette.channels).reduce((tipAcc, tipIndex) => ({
+//           ...tipAcc,
+//           [tipIndex]: pipetteTips === 'full'
+//         }), {})
+//       }), {})
+//   }
+//
+//   return {
+//     labware,
+//     instruments,
+//     tipState
+//   }
+// }

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -155,12 +155,12 @@ export function createRobotStateFixture (args: CreateRobotArgs): RobotStateNoLiq
   const baseLabware = {
     sourcePlateId: {
       slot: '10',
-      type: args.sourcePlateType, // WAS: 'trough-12row'. TODO IMMEDIATELY: remove this comment
+      type: args.sourcePlateType,
       name: 'Source Plate'
     },
     destPlateId: {
       slot: '11',
-      type: args.destPlateType, // WAS: '96-flat'. TODO IMMEDIATELY: remove this comment
+      type: args.destPlateType,
       name: 'Destination Plate'
     },
     trashId: {

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -7,11 +7,6 @@ import reduce from 'lodash/reduce'
 import {tiprackWellNamesFlat} from '../'
 import type {RobotState, PipetteData, LabwareData} from '../'
 
-// export const wellNames96 = flatMap(
-//   'ABCDEFGH'.split(''),
-//   (letter): Array<string> => range(12).map(number => letter + (number + 1))
-// )
-
 // Eg {A1: true, B1: true, ...}
 type WellTipState = {[wellName: string]: boolean}
 export function getTiprackTipstate (filled: ?boolean): WellTipState {
@@ -26,6 +21,15 @@ export function getTipColumn<T> (index: number, filled: T): {[well: string]: T} 
   return Array.from('ABCDEFGH').map(wellLetter => `${wellLetter}${index}`).reduce((acc, well) => ({
     ...acc,
     [well]: filled
+  }), {})
+}
+
+export const all8ChTipIds = range(8)
+
+export function createTipLiquidState<T> (channels: number, contents: T): {[tipId: string]: T} {
+  return range(channels).reduce((tipIdAcc, tipId) => ({
+    ...tipIdAcc,
+    [tipId]: contents
   }), {})
 }
 
@@ -44,38 +48,6 @@ export const p300Multi = {
   maxVolume: 300,
   channels: 8
 }
-
-export const all8ChTipIds = range(8)
-
-// export const basicLiquidState = {
-//   pipettes: {
-//     p300SingleId: { '0': {} },
-//     p300MultiId: all8ChTipIds.reduce((acc, tipId) => ({...acc, [tipId]: {}}), {})
-//   },
-//   labware: {
-//     sourcePlateId: {
-//       A1: {},
-//       A2: {},
-//       A3: {},
-//       A4: {},
-//       A5: {},
-//       A6: {},
-//       A7: {},
-//       A8: {},
-//       A9: {},
-//       A10: {},
-//       A11: {},
-//       A12: {}
-//     },
-//     destPlateId: tiprackWellNamesFlat.reduce((acc, well) => ({
-//       // Eg {A1: {}, B1: {}, ...etc}
-//       [well]: {}
-//     }), {}),
-//     trashId: {
-//       A1: {}
-//     }
-//   }
-// }
 
 export function getWellsForLabware (labwareType: string) {
   const labware = getLabware(labwareType)
@@ -99,10 +71,7 @@ export function createEmptyLiquidState (args: {
       pipettes,
       (acc, pipetteData: PipetteData, pipetteId: string) => ({
         ...acc,
-        [pipetteId]: range(pipetteData.channels).reduce((tipIdAcc, tipId) => ({ // TODO: replace with helper fn
-          ...tipIdAcc,
-          [tipId]: {}
-        }), {})
+        [pipetteId]: createTipLiquidState(pipetteData.channels, {})
       }), {}),
     labware: {
       sourcePlateId: mapValues(getWellsForLabware(sourcePlateType), () => ({})),
@@ -201,68 +170,3 @@ export function createRobotStateFixture (args: CreateRobotArgs): RobotStateNoLiq
     }
   }
 }
-
-// type SubtractMount = {mount: *}
-//
-// type PipetteNoMount = $Diff<PipetteData, SubtractMount>
-//
-// const _pipetteShortcuts: {[string]: PipetteNoMount} = {
-//   'p300Single': {maxVolume: 300, channels: 1, id: 'p300Single'},
-//   'p300Multi': {maxVolume: 300, channels: 8, id: 'p300Multi'},
-//   'p10Single': {maxVolume: 10, channels: 1, id: 'p10Single'},
-//   'p10Multi': {maxVolume: 10, channels: 8, id: 'p10Multi'}
-// }
-//
-// export function createRobotState (args: { // TODO remove
-//   labware: $PropertyType<RobotState, 'labware'>,
-//   leftPipette?: $Keys<typeof _pipetteShortcuts>,
-//   rightPipette?: $Keys<typeof _pipetteShortcuts>,
-//   tiprackTips: 'full' | 'empty',
-//   pipetteTips: 'full' | 'empty'
-// }): RobotStateNoLiquidState {
-//   const {labware, leftPipette, rightPipette, tiprackTips, pipetteTips} = args
-//   // Construct instruments
-//   let instruments = {}
-//
-//   if (leftPipette) {
-//     instruments.left = {
-//       ..._pipetteShortcuts[leftPipette],
-//       mount: 'left'
-//     }
-//   }
-//
-//   if (rightPipette) {
-//     instruments.right = {
-//       ..._pipetteShortcuts[rightPipette],
-//       mount: 'right'
-//     }
-//   }
-//
-//   // construct tipstate
-//   const tipState = {
-//     tipracks: reduce(
-//       Object.keys(labware).filter(labwareName => labware[labwareName].type.startsWith('tiprack')),
-//       (acc, tiprackId) => ({
-//         ...acc,
-//         [tiprackId]: tiprackTips === 'full'
-//           ? {...filledTiprackWells}
-//           : {...emptyTiprackWells}
-//       }),
-//       {}),
-//     pipettes: reduce(
-//       instruments,
-//       (acc, pipette: PipetteNoMount, pipetteId) => ({
-//         ...acc,
-//         [pipetteId]: range(pipette.channels).reduce((tipAcc, tipIndex) => ({
-//           ...tipAcc,
-//           [tipIndex]: pipetteTips === 'full'
-//         }), {})
-//       }), {})
-//   }
-//
-//   return {
-//     labware,
-//     instruments,
-//     tipState
-//   }
-// }

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -1,193 +1,168 @@
 // @flow
-import {filledTiprackWells, emptyTiprackWells, p300Single, p300Multi, basicLiquidState} from './fixtures'
+import merge from 'lodash/merge'
+import {createRobotState, getTiprackTipstate} from './fixtures'
 import {replaceTip} from '../'
 
 // TODO use a fixture, standardize
-describe('replaceTip: single channel', () => {
-  const robotInitialState = {
-    instruments: {
-      p300SingleId: p300Single
-    },
-    labware: {
-      tiprack1Id: {
-        slot: '1',
-        type: 'tiprack-200uL',
-        name: 'Tip rack'
-      },
-      tiprack10Id: {
-        slot: '10',
-        type: 'tiprack-200uL',
-        name: 'Tip rack'
-      },
-      sourcePlateId: {
-        slot: '11',
-        type: 'trough-12row',
-        name: 'Source (Buffer)'
-      },
-      destPlateId: {
-        slot: '8',
-        type: '96-flat',
-        name: 'Destination Plate'
-      },
-      trashId: {
-        slot: '12',
-        type: 'fixed-trash',
-        name: 'Trash'
-      }
-    },
-    tipState: {
-      tipracks: {
-        tiprack1Id: {...filledTiprackWells},
-        tiprack10Id: {...filledTiprackWells}
-      },
-      pipettes: {
-        p300SingleId: false
-      }
-    },
-    liquidState: basicLiquidState
-  }
+const tiprack1Id = 'tiprack1Id'
+const tiprack2Id = 'tiprack2Id'
 
+const labwareTypes1 = {
+  sourcePlateType: 'trough-12row',
+  destPlateType: '96-flat'
+}
+
+const robotInitialState = createRobotState({
+  ...labwareTypes1,
+  fillTiprackTips: true,
+  fillPipetteTips: false,
+  tipracks: [200, 200]
+})
+
+describe('replaceTip: single channel', () => {
   test('Single-channel: first tip', () => {
     const result = replaceTip('p300SingleId')(robotInitialState)
 
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300SingleId',
-      labware: 'tiprack1Id',
+      labware: tiprack1Id,
       well: 'A1'
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false
+    expect(result.robotState).toEqual(merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false
+            }
+          },
+          pipettes: {
+            p300SingleId: true
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    ))
   })
 
   test('Single-channel: second tip B1', () => {
-    const result = replaceTip('p300SingleId')({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false
+    const result = replaceTip('p300SingleId')(merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false
+            }
+          },
+          pipettes: {
+            p300SingleId: false
           }
-        },
-        pipettes: {
-          p300SingleId: false
         }
       }
-    })
+    ))
 
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300SingleId',
-      labware: 'tiprack1Id',
+      labware: tiprack1Id,
       well: 'B1'
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false,
-            B1: false
+    expect(result.robotState).toEqual(merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false,
+              B1: false
+            }
+          },
+          pipettes: {
+            p300SingleId: true
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    ))
   })
 
   test('Single-channel: ninth tip (next column)', () => {
-    const result = replaceTip('p300SingleId')({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false,
-            B1: false,
-            C1: false,
-            D1: false,
-            E1: false,
-            F1: false,
-            G1: false,
-            H1: false
+    const initialTestRobotState = merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false,
+              B1: false,
+              C1: false,
+              D1: false,
+              E1: false,
+              F1: false,
+              G1: false,
+              H1: false
+            }
+          },
+          pipettes: {
+            p300SingleId: false
           }
-        },
-        pipettes: {
-          p300SingleId: false
         }
       }
-    })
+    )
+
+    const result = replaceTip('p300SingleId')(initialTestRobotState)
 
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300SingleId',
-      labware: 'tiprack1Id',
+      labware: tiprack1Id,
       well: 'A2'
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false,
-            B1: false,
-            C1: false,
-            D1: false,
-            E1: false,
-            F1: false,
-            G1: false,
-            H1: false,
-            A2: false
+    expect(result.robotState).toEqual(merge(
+      {},
+      initialTestRobotState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A2: false
+            }
+          },
+          pipettes: {
+            p300SingleId: true
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    ))
   })
 
   test('Single-channel: pipette already has tip, so tip will be replaced.', () => {
-    const result = replaceTip('p300SingleId')({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false
+    const initialTestRobotState = merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false
+            }
+          },
+          pipettes: {
+            p300SingleId: true
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    )
+
+    const result = replaceTip('p300SingleId')(initialTestRobotState)
 
     expect(result.commands).toEqual([
       {
@@ -199,138 +174,95 @@ describe('replaceTip: single channel', () => {
       {
         command: 'pick-up-tip',
         pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
+        labware: tiprack1Id,
         well: 'B1'
       }
     ])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false,
-            B1: false
+    expect(result.robotState).toEqual(merge(
+      {},
+      initialTestRobotState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              B1: false
+            }
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    ))
   })
 
   test('Single-channel: used all tips in first rack, move to second rack', () => {
-    const result = replaceTip('p300SingleId')({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {...emptyTiprackWells}
-        },
-        pipettes: {
-          p300SingleId: false
+    const initialTestRobotState = merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: getTiprackTipstate(false)
+          },
+          pipettes: {
+            p300SingleId: false
+          }
         }
       }
-    })
+    )
+
+    const result = replaceTip('p300SingleId')(initialTestRobotState)
 
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300SingleId',
-      labware: 'tiprack10Id',
+      labware: tiprack2Id,
       well: 'A1'
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          ...robotInitialState.tipState.tipracks,
-          tiprack1Id: {
-            ...emptyTiprackWells
+    expect(result.robotState).toEqual(merge(
+      {},
+      initialTestRobotState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack2Id]: {
+              A1: false
+            }
           },
-          tiprack10Id: {
-            ...filledTiprackWells,
-            A1: false
+          pipettes: {
+            p300SingleId: true
           }
-        },
-        pipettes: {
-          p300SingleId: true
         }
       }
-    })
+    ))
   })
 })
 
 describe('replaceTip: multi-channel', () => {
-  // TODO use a fixture, standardize
-  const robotInitialState = {
-    instruments: {
-      p300MultiId: p300Multi
-    },
-    labware: {
-      tiprack1Id: {
-        slot: '1',
-        type: 'tiprack-200uL',
-        name: 'Tip rack'
-      },
-      tiprack10Id: {
-        slot: '10',
-        type: 'tiprack-200uL',
-        name: 'Tip rack'
-      },
-      sourcePlateId: {
-        slot: '11',
-        type: 'trough-12row',
-        name: 'Source (Buffer)'
-      },
-      destPlateId: {
-        slot: '8',
-        type: '96-flat',
-        name: 'Destination Plate'
-      },
-      trashId: {
-        slot: '12',
-        type: 'fixed-trash',
-        name: 'Trash'
-      }
-    },
-    tipState: {
-      tipracks: {
-        tiprack1Id: {...filledTiprackWells},
-        tiprack10Id: {...filledTiprackWells}
-      },
-      pipettes: {
-        p300MultiId: false
-      }
-    },
-    liquidState: basicLiquidState
-  }
-
   test('multi-channel, all tipracks have tips', () => {
     const result = replaceTip('p300MultiId')(robotInitialState)
 
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300MultiId',
-      labware: 'tiprack1Id',
+      labware: tiprack1Id,
       well: 'A1'
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotInitialState,
-      tipState: {
-        tipracks: {
-          tiprack1Id: {...filledTiprackWells, A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
-          tiprack10Id: {...filledTiprackWells}
-        },
-        pipettes: {
-          p300MultiId: true
+    expect(result.robotState).toEqual(merge(
+      {},
+      robotInitialState,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
+          },
+          pipettes: {
+            p300MultiId: true
+          }
         }
       }
-    })
+    ))
   })
 
   test('multi-channel, missing tip in first row', () => {
@@ -339,8 +271,8 @@ describe('replaceTip: multi-channel', () => {
       tipState: {
         ...robotInitialState.tipState,
         tipracks: {
-          tiprack1Id: {...filledTiprackWells, A1: false},
-          tiprack10Id: {...filledTiprackWells}
+          [tiprack1Id]: {...getTiprackTipstate(true), A1: false},
+          [tiprack2Id]: getTiprackTipstate(true)
         }
       }
     }
@@ -349,35 +281,35 @@ describe('replaceTip: multi-channel', () => {
     expect(result.commands).toEqual([{
       command: 'pick-up-tip',
       pipette: 'p300MultiId',
-      labware: 'tiprack1Id',
+      labware: tiprack1Id,
       well: 'A2' // get from next row
     }])
 
-    expect(result.robotState).toEqual({
-      ...robotStateWithTipA1Missing,
-      tipState: {
-        ...robotStateWithTipA1Missing.tipState,
-        tipracks: {
-          tiprack1Id: {
-            ...filledTiprackWells,
-            A1: false,
-            // Column 2 now empty
-            A2: false,
-            B2: false,
-            C2: false,
-            D2: false,
-            E2: false,
-            F2: false,
-            G2: false,
-            H2: false
+    expect(result.robotState).toEqual(merge(
+      {},
+      robotStateWithTipA1Missing,
+      {
+        tipState: {
+
+          tipracks: {
+            [tiprack1Id]: {
+              // Column 2 now empty
+              A2: false,
+              B2: false,
+              C2: false,
+              D2: false,
+              E2: false,
+              F2: false,
+              G2: false,
+              H2: false
+            }
           },
-          tiprack10Id: {...filledTiprackWells}
-        },
-        pipettes: {
-          p300MultiId: true
+          pipettes: {
+            p300MultiId: true
+          }
         }
       }
-    })
+    ))
   })
 
   test('Multi-channel: pipette already has tip, so tip will be replaced.', () => {
@@ -401,22 +333,25 @@ describe('replaceTip: multi-channel', () => {
       {
         command: 'pick-up-tip',
         pipette: 'p300MultiId',
-        labware: 'tiprack1Id',
+        labware: tiprack1Id,
         well: 'A1' // get from next row
       }
     ])
 
-    expect(result.robotState).toEqual({
-      ...robotStateWithTipsOnMulti,
-      tipState: {
-        tipracks: {
-          tiprack1Id: {...filledTiprackWells, A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
-          tiprack10Id: {...filledTiprackWells}
-        },
-        pipettes: {
-          p300MultiId: true
+    expect(result.robotState).toEqual(merge(
+      {},
+      robotStateWithTipsOnMulti,
+      {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {...getTiprackTipstate(true), A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
+            [tiprack2Id]: {...getTiprackTipstate(true)}
+          },
+          pipettes: {
+            p300MultiId: true
+          }
         }
       }
-    })
+    ))
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -1,6 +1,6 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotState, getTiprackTipstate} from './fixtures'
+import {createRobotState, getTiprackTipstate, getTipColumn} from './fixtures'
 import {replaceTip} from '../'
 
 // TODO use a fixture, standardize
@@ -99,16 +99,7 @@ describe('replaceTip: single channel', () => {
       {
         tipState: {
           tipracks: {
-            [tiprack1Id]: {
-              A1: false,
-              B1: false,
-              C1: false,
-              D1: false,
-              E1: false,
-              F1: false,
-              G1: false,
-              H1: false
-            }
+            [tiprack1Id]: getTipColumn(1, false)
           },
           pipettes: {
             p300SingleId: false
@@ -255,7 +246,7 @@ describe('replaceTip: multi-channel', () => {
       {
         tipState: {
           tipracks: {
-            [tiprack1Id]: {A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
+            [tiprack1Id]: getTipColumn(1, false)
           },
           pipettes: {
             p300MultiId: true
@@ -344,8 +335,11 @@ describe('replaceTip: multi-channel', () => {
       {
         tipState: {
           tipracks: {
-            [tiprack1Id]: {...getTiprackTipstate(true), A1: false, B1: false, C1: false, D1: false, E1: false, F1: false, G1: false, H1: false},
-            [tiprack2Id]: {...getTiprackTipstate(true)}
+            [tiprack1Id]: {
+              ...getTiprackTipstate(true),
+              ...getTipColumn(1, false)
+            },
+            [tiprack2Id]: getTiprackTipstate(true)
           },
           pipettes: {
             p300MultiId: true

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -1,19 +1,17 @@
 // @flow
 import touchTip from '../touchTip'
-import {getBasicRobotState} from './fixtures'
+import {createRobotState} from './fixtures'
 
 describe('touchTip', () => {
-  const initialRobotState = getBasicRobotState()
-  const robotStateWithTip = {
-    ...initialRobotState,
-    tipState: {
-      ...initialRobotState.tipState,
-      pipettes: {
-        ...initialRobotState.tipState.pipettes,
-        p300SingleId: true
-      }
-    }
+  const _robotFixtureArgs = {
+    sourcePlateType: 'trough-12row',
+    destPlateType: '96-flat',
+    fillTiprackTips: true,
+    fillPipetteTips: false,
+    tipracks: [200, 200]
   }
+  const initialRobotState = createRobotState(_robotFixtureArgs)
+  const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: true})
 
   test('touchTip with tip', () => {
     const result = touchTip({

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {repeatArray, reduceCommandCreators, splitLiquid, mergeLiquid} from '../utils'
+import {repeatArray, reduceCommandCreators, splitLiquid, mergeLiquid, AIR} from '../utils'
 
 describe('repeatArray', () => {
   test('repeat array of objects', () => {
@@ -152,22 +152,37 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('splitting with no ingredients in source raises error', () => {
+  test('splitting with no ingredients in source just splits "air"', () => {
     expect(
-      () => splitLiquid(100, {})
-    ).toThrowError(/no volume in source/)
+      splitLiquid(100, {})
+    ).toEqual({
+      source: {},
+      dest: {[AIR]: {volume: 100}}
+    })
   })
 
-  test('splitting with 0 volume in source raises error', () => {
+  test('splitting with 0 volume in source just splits "air"', () => {
     expect(
-      () => splitLiquid(100, {ingred1: {volume: 0}})
-    ).toThrowError(/no volume in source/)
+      splitLiquid(100, {ingred1: {volume: 0}})
+    ).toEqual({
+      source: {ingred1: {volume: 0}},
+      dest: {[AIR]: {volume: 100}}
+    })
   })
 
-  test('splitting with excessive volume raises error', () => {
+  test('splitting with excessive volume leaves "air" in dest', () => {
     expect(
-      () => splitLiquid(999, {ingred1: {volume: 10}})
-    ).toThrowError(/exceeds source volume/)
+      splitLiquid(100, {ingred1: {volume: 50}, ingred2: {volume: 20}})
+    ).toEqual({
+      source: {ingred1: {volume: 0}, ingred2: {volume: 0}},
+      dest: {ingred1: {volume: 50}, ingred2: {volume: 20}, [AIR]: {volume: 30}}
+    })
+  })
+
+  test('splitting with air in source should throw error', () => {
+    expect(
+      () => splitLiquid(50, {ingred1: {volume: 100}, [AIR]: {volume: 20}})
+    ).toThrow(/source cannot contain air/)
   })
 })
 

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -70,7 +70,10 @@ export type LabwareData = {
   slot: DeckSlot
 }
 
-type TipId = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7'
+/** tips are numbered 0-7. 0 is the furthest to the back of the robot.
+  * For an 8-channel, on a 96-flat, Tip 0 is in row A, Tip 7 is in row H.
+  */
+type TipId = string
 
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -1,6 +1,7 @@
 // @flow
 import cloneDeep from 'lodash/cloneDeep'
 import flatMap from 'lodash/flatMap'
+import mapValues from 'lodash/mapValues'
 import range from 'lodash/range'
 import reduce from 'lodash/reduce'
 import type {CommandCreator, RobotState} from './types'
@@ -33,7 +34,10 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
 type Vol = {volume: number}
 type LiquidVolumeState = {[ingredGroup: string]: Vol}
 
-export const AIR = 'air' // TODO use Symbol?
+// TODO Ian 2018-03-15 use Symbol, or other way to ensure no conflict with ingredGroupId keys?
+// However, Flow doesn't like Symbol keys.
+// (this conflict is unlikely, since ingredGroupIds are strings of numbers)
+export const AIR = 'air'
 
 /** Breaks a liquid volume state into 2 parts. Assumes all liquids are evenly mixed. */
 export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeState): {
@@ -61,10 +65,7 @@ export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeStat
   if (volume > totalSourceVolume) {
     // Take all of source, plus air
     return {
-      source: Object.keys(sourceLiquidState).reduce((acc, ingredId) => ({ // TODO mapvalues?
-        ...acc,
-        [ingredId]: {volume: 0}
-      }), {}),
+      source: mapValues(sourceLiquidState, () => ({volume: 0})),
       dest: {
         ...sourceLiquidState,
         [AIR]: {volume: volume - totalSourceVolume}

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -37,7 +37,7 @@ type LiquidVolumeState = {[ingredGroup: string]: Vol}
 // TODO Ian 2018-03-15 use Symbol, or other way to ensure no conflict with ingredGroupId keys?
 // However, Flow doesn't like Symbol keys.
 // (this conflict is unlikely, since ingredGroupIds are strings of numbers)
-export const AIR = 'air'
+export const AIR = '__air__'
 
 /** Breaks a liquid volume state into 2 parts. Assumes all liquids are evenly mixed. */
 export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeState): {


### PR DESCRIPTION
## overview

Closes #957 

* Single and 8-channel support
* Multiple ingredients supported - assumed to be uniformly mixed
* Well liquid state, and tip liquid state is updated on aspirate
* Track air being aspirated from a source with less volume than the aspirate volume

## changelog/notes

### Big fixture cleanup

In writing new liquid state tests I started tripping over all my verbose copy-and-paste fixtures so I cleaned some things up:

* started heavily using `lodash/merge` to make small variations of test fixtures (eg, same as initial state, except tip A1 is `false` under `tipState.tipracks.tiprack1Id`). This fn mutates the obj in its first argument, so I need to be careful to always do give a new obj as its first arg `merge({}, baseFixture, updateObj)`
* had a problem with hard-to-find mutation of `filledTiprackWells` and `emptyTiprackWells` causes otherwise valid tests to fail, so I'm trying to use more fixture generator functions that create a fresh fixture instance. Another advantage of these fns is that as fns they can take args that make it more convenient to obtain different fixtures
* fixture generators to create real RobotState, and a RobotState with no `liquidState` key to use with jest matcher `.toMatchObj(robotStateWithNoLiquidState)`. Later on, I may also make a fn like
`function matchObjsIgnoringKeys (a: {}, b: {}, keysToIgnore: Array<string>): {} {...}` that calls `expect` itself (probably just using `lodash/omit` to drop the key) instead of maintaining 2 versions of the fixtures - but either way, it's often necessary to be able to construct empty liquid states separately of the rest of robot state, and pop them in.
* also wrote some unit tests for fixture generator fns, I'm paranoid about fixture generators behaving unexpectedly because it will cause false negatives and false positives in the tests where those fixtures are used and it will be cumbersome to trace back to bad fixture generators.

### Liquid state updates for aspirate

The  `aspirate` command generator fn will update liquid state for single and multi-channel pipettes, for any labware. See the tests in `aspirate.test.js` -- outline view is helpful to jump around in these long tests.

To improve test readability, I'm still searching for a way to make the fixtures obvious without being verbose - for example, `robotWithLiquidInTipsNoAir` fixture contains a few liquids in different labware, different wells, different volumes. When I scroll down to a test at the bottom, I have to recall what is in which well. I don't want to copy & paste those, that causes its own problems. Right now the best way to read the tests is to use split screen, with the fixture data in one screen and the test in the other. Maybe that's the right way to do these data-heavy tests.

I also introduced the concept of "air" to liquid tracking -- when a pipette aspirates more than the volume of its source, it will draw the difference of the volumes as "air". For new, air is treated as its own ingredient group. It won't do anything special right now, but it's available to display to users if we decide we should have warnings etc later.

I'm planning that for the first version of liquid tracking, `dispense` will ignore air, and `blowout` will remove it.

FYI: liquid tracking is purely for display for the first version of PD (and potentially for many later versions, TBD). Liquid tracking doesn't affect aspirate/dispense commands sent to the robot; it doesn't affect plunger movements.

The problem with air is that if you are drawing air into the tip on purpose, you're probably working with a low-viscosity liquid like ethanol, which moves down the tip, gradually displacing that air gap you created. For the air gap to mean anything, PD would have to know about the viscosity of the liquid, which isn't part of the app now.

## review requests

Mostly check out the aspirate liquid tracking tests and think of cases that aren't covered or aren't covered correctly.