### PR TITLE
chore(api): Update Makefile to be more Windows friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,15 @@ Individual projects may have additional instructions, so be sure to check out th
 
 Your computer will need the following tools installed to be able to develop with the Opentrons platform:
 
-*   macOS 10.11+, Linux, or Windows 10 with Cygwin
-*   Python 3.5.3  - [pyenv](https://github.com/pyenv/pyenv) is optional, but recommended
+*   macOS 10.11+, Linux, or Windows 10
+*   Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux)
 
     ``` shell
     # pyenv on macOS: install with shared framework option
-    env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.5.3
+    env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.6.4
 
     # pyenv on Linux: install with shared library option
-    env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.5.3
+    env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.4
     ```
 
 *   Node v8 LTS (Carbon) - [nvm][] is optional, but recommended
@@ -117,6 +117,8 @@ Your computer will need the following tools installed to be able to develop with
 *   [yarn][yarn-install] - JavaScript package manager
 
 *   GNU Make - we use [Makefiles][] to manage our builds
+
+*   cURL - used to push development updates to robots
 
 Once you're set up, clone the repository and install all project dependencies:
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -2,6 +2,15 @@
 
 SHELL := /bin/bash
 
+# add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
+PATH := $(shell cd .. && yarn bin):$(PATH)
+
+# make push host
+host ?= \[fd00:0:cafe:fefe::1\]
+# make push wheel file (= rather than := to expand at every use)
+wheel = $(wildcard dist/*.whl)
+
+# python and pipenv config
 python := pipenv run python
 pipenv_opts := --dev
 pipenv_opts += $(and $(CI),--ignore-pipfile)
@@ -9,6 +18,17 @@ pipenv_opts += $(and $(CI),--ignore-pipfile)
 .PHONY: install
 install:
 	pipenv install $(pipenv_opts)
+
+.PHONY: clean
+clean:
+	shx rm -rf \
+		build \
+		dist \
+		.coverage \
+		coverage.xml \
+		'*.egg-info' \
+		'**/__pycache__' \
+		'**/*.pyc'
 
 .PHONY: test
 test:
@@ -35,28 +55,18 @@ dev:
 	$(python) opentrons/server/main.py -P 31950 opentrons.server.main:init
 
 .PHONY: wheel
-wheel:
+wheel: clean
 	$(python) setup.py bdist_wheel && \
-	ls dist
+	shx ls dist
 
 .PHONY: push
 push: wheel
 	curl -X POST \
 		-H "Content-Type: multipart/form-data" \
-		-F 'whl=@dist/`ls dist | grep whl`' \
-		http://\[fd00:0:cafe:fefe::1\]/server/update
+		-F "whl=@$(wheel)" \
+		http://$(host)/server/update
 
+# TODO(mc, 2018-03-14): use $(host) var
 .PHONY: term
 term:
 	ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@fd00:0:cafe:fefe::1
-
-.PHONY: clean
-clean:
-	rm -rf \
-		__pycache__ \
-		*.egg-info \
-		build \
-		dist \
-		calibrations \
-		.coverage
-	find . -name "*.pyc" -delete && find . -type d -name __pycache__ -delete


### PR DESCRIPTION
## overview

Little API PR to ensure that Windows machines (and AppVeyor, specifically) can succesfully run `make wheel`

## changelog

- Update api Makefile to use `shx` for cross-platform POSIX happiness

## review requests

Please make sure `make wheel` and `make push` continue to work on your machines. I also added a `host` var to `make push`, so you can try it out with different hosts:

```shell
make push host=localhost:31950
```

Something to note: regular `curl` is not yet available in Windows (there is a version available in PowerShell, but it didn't seem to me to act like regular `curl`; ymmv), so I needed to `choco install curl`. You may need to, too. The good news, though, is that [eventually they will be available in cmd.exe in mainline Windows](https://blogs.technet.microsoft.com/virtualization/2017/12/19/tar-and-curl-come-to-windows/)
