### PR TITLE
App add attached pipettes card

### DIFF
--- a/app/src/components/Page.css
+++ b/app/src/components/Page.css
@@ -1,4 +1,5 @@
 .task {
   flex: 1 1;
   position: relative;
+  overflow-y: scroll;
 }

--- a/app/src/components/RobotSettings/AttachedInstrumentsCard.js
+++ b/app/src/components/RobotSettings/AttachedInstrumentsCard.js
@@ -1,17 +1,11 @@
-// @flow
 // RobotSettings card for wifi status
 import * as React from 'react'
-import {type StateInstrument} from '../../robot'
 import InstrumentInfo from './InstrumentInfo'
 import {Card} from '@opentrons/components'
 
-type Props = {
-  left: StateInstrument,
-  right: StateInstrument
-}
 const TITLE = 'Pipettes'
 
-export default function AttachedInstrumentsCard (props: Props) {
+export default function AttachedInstrumentsCard (props) {
   // TODO (ka 2018-3-14): not sure where this will be comining from in state so mocking it up for styling purposes
   // here I am assuming they key and  mount will always exist and some sort of presence of a pipette indicator will affect InstrumentInfo
   // delete channels and volume in either elft or right to view value and button message change

--- a/app/src/components/RobotSettings/AttachedInstrumentsCard.js
+++ b/app/src/components/RobotSettings/AttachedInstrumentsCard.js
@@ -1,0 +1,38 @@
+// @flow
+// RobotSettings card for wifi status
+import * as React from 'react'
+import {type StateInstrument} from '../../robot'
+import InstrumentInfo from './InstrumentInfo'
+import {Card} from '@opentrons/components'
+
+type Props = {
+  left: StateInstrument,
+  right: StateInstrument
+}
+const TITLE = 'Pipettes'
+
+export default function AttachedInstrumentsCard (props: Props) {
+  // TODO (ka 2018-3-14): not sure where this will be comining from in state so mocking it up for styling purposes
+  // here I am assuming they key and  mount will always exist and some sort of presence of a pipette indicator will affect InstrumentInfo
+  // delete channels and volume in either elft or right to view value and button message change
+  // apologies for the messy logic, hard to anticipate what is returned just yet
+  const attachedInstruments = {
+    left: {
+      mount: 'left',
+      channels: 8,
+      volume: 300
+    },
+    right: {
+      mount: 'right',
+      channels: 1,
+      volume: 10
+    }
+  }
+
+  return (
+    <Card title={TITLE} >
+      <InstrumentInfo {...attachedInstruments.left}/>
+      <InstrumentInfo {...attachedInstruments.right} />
+    </Card>
+  )
+}

--- a/app/src/components/RobotSettings/InstrumentInfo.js
+++ b/app/src/components/RobotSettings/InstrumentInfo.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import cx from 'classnames'
-import {LabeledValue, OutlineButton} from '@opentrons/components'
+import {LabeledValue, OutlineButton, InstrumentDiagram} from '@opentrons/components'
 import styles from './styles.css'
 
 const LEFT_LABEL = 'Left pipette'
@@ -30,7 +30,9 @@ export default function InstrumentInfo (props) {
       <OutlineButton disabled>
         {buttonText}
       </OutlineButton>
-      <div className={styles.image}></div>
+      <div className={styles.image}>
+        {props.channels && (<InstrumentDiagram channels={props.channels}/>)}
+      </div>
     </div>
   )
 }

--- a/app/src/components/RobotSettings/InstrumentInfo.js
+++ b/app/src/components/RobotSettings/InstrumentInfo.js
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import cx from 'classnames'
+import {LabeledValue, OutlineButton} from '@opentrons/components'
+import styles from './styles.css'
+
+const LEFT_LABEL = 'Left pipette'
+const RIGHT_LABEL = 'Right pipette'
+export default function InstrumentInfo (props) {
+  const label = props.mount === 'left'
+    ? LEFT_LABEL
+    : RIGHT_LABEL
+  const value = props.volume
+    ? `${props.channels}-channel p${props.volume}`
+    : 'no pipette attached'
+  const buttonText = props.volume
+    ? 'change'
+    : 'attach'
+  const className = cx(
+    styles.instrument_card, {
+      [styles.left]: props.mount === 'left',
+      [styles.right]: props.mount === 'right'
+    }
+  )
+  return (
+    <div className={className}>
+      <LabeledValue
+        label={label}
+        value={value}
+      />
+      <OutlineButton disabled>
+        {buttonText}
+      </OutlineButton>
+      <div className={styles.image}></div>
+    </div>
+  )
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -5,7 +5,7 @@ import * as React from 'react'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
-import AttachedInstrumentsCard from './AttachedInstrumentsCard'
+// import AttachedInstrumentsCard from './AttachedInstrumentsCard'
 import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
 import ConnectAlertModal from './ConnectAlertModal'
@@ -19,9 +19,9 @@ export default function RobotSettings (props: Props) {
       <div className={styles.row}>
         <StatusCard {...props} />
       </div>
-      <div className={styles.row}>
-        <AttachedInstrumentsCard {...props} />
-      </div>
+      {/* <div className={styles.row}>
+      <AttachedInstrumentsCard {...props} />
+      </div> */}
       <div className={styles.row}>
         <InformationCard {...props} />
       </div>

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
+import AttachedInstrumentsCard from './AttachedInstrumentsCard'
 import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
 import ConnectAlertModal from './ConnectAlertModal'
@@ -17,6 +18,9 @@ export default function RobotSettings (props: Props) {
     <div className={styles.robot_settings}>
       <div className={styles.row}>
         <StatusCard {...props} />
+      </div>
+      <div className={styles.row}>
+        <AttachedInstrumentsCard {...props} />
       </div>
       <div className={styles.row}>
         <InformationCard {...props} />

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -70,6 +70,14 @@
   position: relative;
   top: -4rem;
   border: 1px solid var(--c-light-gray);
+  overflow: hidden;
+}
+
+.image div img {
+  width: 100%;
+  height: auto;
+  position: absolute;
+  top: -40%;
 }
 
 .right {

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -49,3 +49,39 @@
   float: right;
   margin-top: 0.5rem;
 }
+
+.instrument_card {
+  display: flex;
+  position: relative;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 4rem;
+  padding-top: 1rem;
+  width: 49.5%;
+
+  & > button {
+    width: 8rem;
+  }
+}
+
+.image {
+  height: 8rem;
+  width: 1.75rem;
+  position: relative;
+  top: -4rem;
+  border: 1px solid var(--c-light-gray);
+}
+
+.right {
+  & > div {
+    order: 2;
+  }
+
+  & > .image {
+    order: 1;
+  }
+
+  & > button {
+    order: 3;
+  }
+}

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -103,6 +103,10 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
+  & > button {
+    height: 3rem;
+  }
 }
 
 .card_column {
@@ -127,7 +131,9 @@
 }
 
 .labeled_value {
-  @apply --font-body-2-dark;
+  @apply --font-body-1-dark;
+
+  line-height: 1.5;
 
   & svg {
     height: var(--fs-body-2);


### PR DESCRIPTION
## overview
 
This PR addresses #862 (UI only). Adds an `AttachedInstrumentCard` and `InstrumentInfo` to the robot setting app. The splitting of these components is necessary to account for some styling one-offs.

Both left and right pipettes detected. Also note the main page area is now scrollable (separate from overflow y scrollable in the sidebar)

<img width="800" alt="both pipettes attached" src="https://user-images.githubusercontent.com/3430313/37422061-f95459c0-2790-11e8-8672-e6256e3cf4fe.png">

Right pipette not detected, mount present in data, not volume or channels. Totally tentative for now.

<img width="800" alt="right pipette mount but no volume or channels present" src="https://user-images.githubusercontent.com/3430313/37422081-03b1ebda-2791-11e8-9201-6f3b688b08dd.png">

## changelog

- Implement styled AttachedInstrumentCard with mock data
  - Note this is all highly speculative data that assumes attachedInstruments
  always returns at least a left and right object with at least a mount
- Update page.css to allow for scrolling in main page area of app
- Update labeled value styles to use smaller font size for layout purposes,
lots of zany one-offs for styling in this card

## review requests
standard review, I feel like this ones a little speculative and zany so please be nit-picky if you have time.
in retrospect, after review i should comment out the card until its wired up with actually data in a subsequent PR