### PR TITLE
feat(app-shell): Bundle API update wheel in desktop app

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,6 +8,9 @@ PATH := $(shell yarn bin):$(PATH)
 # ui directory for production build
 ui_dir := ../app
 
+# api directory for robot API update bundled in production build
+api_dir := ../api
+
 # set NODE_ENV for a command with $(env)=environment
 env := cross-env NODE_ENV
 
@@ -15,7 +18,7 @@ env := cross-env NODE_ENV
 #####################################################################
 
 .PHONY: all
-all: clean package
+all: package
 
 .PHONY: install
 install:
@@ -36,27 +39,34 @@ clean:
 ui:
 	$(MAKE) -C $(ui_dir)
 
+.PHONY: api
+api:
+	$(MAKE) -C $(api_dir) wheel
+
+.PHONY: package-deps
+package-deps: clean ui api
+
 .PHONY: package
-package: ui
+package: package-deps
 	electron-builder --dir
 
 .PHONY: dist-posix
-dist-posix: clean ui
+dist-posix: package-deps
 	electron-builder --linux --mac --publish never
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-osx
-dist-osx: clean ui
+dist-osx: package-deps
 	electron-builder --mac --publish never
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-linux
-dist-linux: clean ui
+dist-linux: package-deps
 	electron-builder --linux --publish never
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-win
-dist-win: clean ui
+dist-win: package-deps
 	electron-builder --win --x64 --publish never
 	$(MAKE) _dist-collect-artifacts
 

--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -62,16 +62,18 @@ This section details production build instructions for the desktop application.
 *   `make dist-posix` - Create macOS and Linux apps simultaneously
 *   `make dist-win` - Create a Windows distributable of the app
 
+#### production builds
+
 All packages and/or distributables will be placed in `app-shell/dist`. After running `make package`, you can launch the production app with:
 
-*   macOS: `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons\ Run`
-*   Linux: `./dist/linux-unpacked/opentrons-run`
-*   Windows: `TODO`
+*   macOS: `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons`
+*   Linux: `./dist/linux-unpacked/ot-app-desktop`
+*   Windows: `./dist/win-unpacked/Opentrons.exe`
 
 To run the production app in debug mode, set the `DEBUG` environment variable. For example, on macOS:
 
 ```shell
-DEBUG=1 `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons\ Run`
+DEBUG=1 ./dist/mac/Opentrons.app/Contents/MacOS/Opentrons
 ```
 
 [style-guide]: https://standardjs.com

--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -10,6 +10,13 @@
       "filter": ["**/*"]
     }
   ],
+  "extraResources": [
+    {
+      "from": "../api/dist",
+      "to": "./api/dist",
+      "filter": ["**/*"]
+    }
+  ],
   "artifactName": "opentrons-v${version}-${os}-${arch}${env.OT_TIME_SUFFIX}${env.OT_BRANCH_SUFFIX}${env.OT_COMMIT_SUFFIX}.${ext}",
   "asar": true,
   "dmg": {

--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -1,0 +1,15 @@
+// api updater
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const updateDirectory = path.join(__dirname, '../../api/dist')
+
+module.exports = function initializeApiUpdate () {
+  // TODO(mc, 2018-03-14): proof-of-concept; remove
+  fs.readdir(updateDirectory, (error, files) => {
+    if (error) return console.error('error reading update dir:', error)
+    console.log('api update files:', files)
+  })
+}

--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -7,6 +7,7 @@ const {app, dialog, Menu, BrowserWindow} = require('electron')
 const log = require('electron-log')
 
 const initializeMenu = require('./menu')
+const initializeApiUpdate = require('./api-update')
 
 // TODO(mc, 2018-01-06): replace dev and debug vars with feature vars
 const DEV_MODE = process.env.NODE_ENV === 'development'
@@ -31,6 +32,7 @@ function startUp () {
 
   createWindow()
   initializeMenu()
+  initializeApiUpdate()
   load()
 
   if (DEV_MODE || DEBUG_MODE) {


### PR DESCRIPTION
## overview

This PR updates the `app-shell` Makefile and electron-builder config to build the API wheel file and bundle it in the app, respectively. It also adds a little proof-of-concept api updater module to ensure that the update file is accessible.

## changelog

- Bundle API update wheel in desktop app

## review requests

Standard review

### test plan

#### dev

1. `make -C app dev`
2. Observe `[shell] api update files: [ 'opentrons-3.0.0-py2.py3-none-any.whl' ]` in the terminal

#### prod

1. `make -C app-shell`
2. Launch production build
    *   macOS: `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons`
    *   Linux: `./dist/linux-unpacked/ot-app-desktop`
    *   Windows: `./dist/win-unpacked/Opentrons.exe`
3. Observe `api update files: [ 'opentrons-3.0.0-py2.py3-none-any.whl' ]` in the terminal