### PR TITLE
Recover from depressed limit switch during non-home commands

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -578,10 +578,6 @@ class Robot(object):
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)
 
-    # DEPRECATED
-    def move_plunger(self, *args, **kwargs):
-        self._driver.move_plunger(*args, **kwargs)
-
     def head_speed(
             self, combined_speed=None,
             x=None, y=None, z=None, a=None, b=None, c=None):


### PR DESCRIPTION
## overview

When a limit switch is hit during move, home the axis that caused the alarm to ensure that switches don't stay depressed. Fixes #939 

Also removed a deprecated method on robot that was not backed (this is not a _new_ breaking change, as calling that method would have raised an exception)

## changelog

- (feature/fix) Add recovery home after a limit switch is hit during move

## review requests

- tested on 🌔 🌔 
- unit tests are contract tests, not functional
