### PR TITLE
API: public driver methods for writing/reading pipette memory

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -74,8 +74,6 @@ GCODES = {'HOME': 'G28.2',
 # to Smoothie
 GCODE_ROUNDING_PRECISION = 3
 
-PIPETTE_DATA_LENGTH = 32
-
 
 def _parse_axis_values(raw_axis_values):
     parsed_values = raw_axis_values.strip().split(' ')
@@ -562,7 +560,6 @@ class SmoothieDriver_3_0_0:
             res = self._send_command(gcode + mount)
             res = _parse_instrument_data(res)
             assert mount in res
-            assert len(res[mount]) == PIPETTE_DATA_LENGTH
             # data is read/written as strings of HEX characters
             # to avoid firmware weirdness in how it parses GCode arguments
             return _byte_array_to_ascii_string(res[mount])

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -94,9 +94,13 @@ def _parse_axis_values(raw_axis_values):
 def _parse_instrument_data(smoothie_response):
     items = smoothie_response.split('\n')[0].strip().split(':')
     mount = items[0]
-    # data received from Smoothieware is stringified HEX values
-    # because of how Smoothieware handles GCODE messages
-    data = bytearray.fromhex(items[1])
+    try:
+        # data received from Smoothieware is stringified HEX values
+        # because of how Smoothieware handles GCODE messages
+        data = bytearray.fromhex(items[1])
+    except ValueError:
+        raise ParseError('Unexpected response from Smoothieware: {}'.format(
+            smoothie_response))
     return {mount: data}
 
 
@@ -197,38 +201,56 @@ class SmoothieDriver_3_0_0:
 
         self._update_position(updated_position)
 
-    def _read_from_pipette(self, gcode, mount):
-        res = self._send_command(gcode + mount)
-        try:
-            res = _parse_instrument_data(res)
-            assert mount in res
-            assert len(res[mount]) == PIPETTE_DATA_LENGTH
-            return _byte_array_to_ascii_string(res[mount])
-        except Exception as e:
-            return None
+    def read_pipette_id(self, mount):
+        '''
+        Reads in an attached pipette's UUID
+        The UUID is unique to this pipette, and is a string of unknown length
 
-    def _write_to_pipette(self, gcode, mount, data_string):
-        if not isinstance(data_string, str):
-            raise ValueError(
-                'Expected {0}, not {1}'.format(str, type(data_string)))
-        byte_string = _byte_array_to_hex_string(
-            bytearray(data_string.encode()))
-        command = gcode + mount + byte_string
-        self._send_command(command)
-
-    def _read_pipette_id(self, mount):
+        mount:
+            String (str) with value 'left' or 'right'
+        '''
         return self._read_from_pipette(
             GCODES['READ_INSTRUMENT_ID'], mount)
 
-    def _read_pipette_model(self, mount):
+    def read_pipette_model(self, mount):
+        '''
+        Reads an attached pipette's MODEL
+        The MODEL is a unique string for this model of pipette
+
+        mount:
+            String (str) with value 'left' or 'right'
+        '''
         return self._read_from_pipette(
             GCODES['READ_INSTRUMENT_MODEL'], mount)
 
-    def _write_pipette_id(self, mount, data_string):
+    def write_pipette_id(self, mount, data_string):
+        '''
+        Writes to an attached pipette's UUID memory location
+        The UUID is unique to this pipette, and is a string of unknown length
+
+        NOTE: To enable write-access to the pipette, it's button must be held
+
+        mount:
+            String (str) with value 'left' or 'right'
+        data_string:
+            String (str) that is of unknown length, and should be unique to
+            this one pipette
+        '''
         self._write_to_pipette(
             GCODES['WRITE_INSTRUMENT_ID'], mount, data_string)
 
-    def _write_pipette_model(self, mount, data_string):
+    def write_pipette_model(self, mount, data_string):
+        '''
+        Writes to an attached pipette's MODEL memory location
+        The MODEL is a unique string for this model of pipette
+
+        NOTE: To enable write-access to the pipette, it's button must be held
+
+        mount:
+            String (str) with value 'left' or 'right'
+        data_string:
+            String (str) that is unique to this model of pipette
+        '''
         self._write_to_pipette(
             GCODES['WRITE_INSTRUMENT_MODEL'], mount, data_string)
 
@@ -520,6 +542,62 @@ class SmoothieDriver_3_0_0:
         self.update_position(default=self.homed_position)
         self.pop_axis_max_speed()
         self.pop_speed()
+
+    def _read_from_pipette(self, gcode, mount):
+        '''
+        Read from an attached pipette's internal memory. The gcode used
+        determines which portion of memory is read and returned.
+
+        gcode:
+            String (str) containing a GCode
+            either 'READ_INSTRUMENT_ID' or 'READ_INSTRUMENT_MODEL'
+        mount:
+            String (str) with value 'left' or 'right'
+        '''
+        allowed_mounts = {'left': 'L', 'right': 'R'}
+        mount = allowed_mounts.get(mount)
+        if not mount:
+            raise ValueError('Unexpected mount: {}'.format(mount))
+        try:
+            res = self._send_command(gcode + mount)
+            res = _parse_instrument_data(res)
+            assert mount in res
+            assert len(res[mount]) == PIPETTE_DATA_LENGTH
+            # data is read/written as strings of HEX characters
+            # to avoid firmware weirdness in how it parses GCode arguments
+            return _byte_array_to_ascii_string(res[mount])
+        except (ParseError, AssertionError, SmoothieError):
+            pass
+
+    def _write_to_pipette(self, gcode, mount, data_string):
+        '''
+        Write to an attached pipette's internal memory. The gcode used
+        determines which portion of memory is written to.
+
+        NOTE: To enable write-access to the pipette, it's button must be held
+
+        gcode:
+            String (str) containing a GCode
+            either 'WRITE_INSTRUMENT_ID' or 'WRITE_INSTRUMENT_MODEL'
+        mount:
+            String (str) with value 'left' or 'right'
+        data_string:
+            String (str) that is of unkown length
+        '''
+        allowed_mounts = {'left': 'L', 'right': 'R'}
+        mount = allowed_mounts.get(mount)
+        if not mount:
+            raise ValueError('Unexpected mount: {}'.format(mount))
+        if not isinstance(data_string, str):
+            raise ValueError(
+                'Expected {0}, not {1}'.format(str, type(data_string)))
+        # data is read/written as strings of HEX characters
+        # to avoid firmware weirdness in how it parses GCode arguments
+        byte_string = _byte_array_to_hex_string(
+            bytearray(data_string.encode()))
+        command = gcode + mount + byte_string
+        self._send_command(command)
+
     # ----------- END Private functions ----------- #
 
     # ----------- Public interface ---------------- #

--- a/api/opentrons/tools/write_pipette_memory.py
+++ b/api/opentrons/tools/write_pipette_memory.py
@@ -16,9 +16,9 @@ def scan_instruments(robot):
     '''
     print()
     found_instruments = {}
-    for mount in 'LR':
-        read_id = robot._driver._read_pipette_id(mount)
-        read_model = robot._driver._read_pipette_model(mount)
+    for mount in ['left', 'right']:
+        read_id = robot._driver.read_pipette_id(mount)
+        read_model = robot._driver.read_pipette_model(mount)
         if read_id and read_model:
             found_instruments[mount] = {
                 'id': read_id,
@@ -39,11 +39,12 @@ def select_mount(found_instruments):
     User selects which mount to write the data to (L or R)
     '''
     print()
-    mount_msg = 'Select which side pipette to write to (L or R):  '
+    mount_msg = 'Select which side pipette to write to (enter "l" or "r"):  '
     res = input(mount_msg)
-    mount = res.strip().upper()[0]
+    mount = res.strip().upper()[0].upper()
     if mount not in 'LR':
         raise Exception('Unknown mount: {}'.format(res))
+    mount = {'L': 'left', 'R': 'right'}.get(mount)
     print('Writing to mount {}'.format(mount))
     if mount in found_instruments:
         confirm_msg = 'Pipette {} already has data. '.format(mount)
@@ -84,12 +85,12 @@ def write_identifiers(robot, mount, new_id, new_model):
     if 'Y' not in input('Ready to save the ID? (Y or N):  ').upper():
         raise Exception('Not writing ID to pipette, and exiting script')
 
-    robot._driver._write_pipette_id(mount, new_id)
-    read_id = robot._driver._read_pipette_id(mount)
+    robot._driver.write_pipette_id(mount, new_id)
+    read_id = robot._driver.read_pipette_id(mount)
     _assert_the_same(new_id, read_id)
 
-    robot._driver._write_pipette_model(mount, new_model)
-    read_model = robot._driver._read_pipette_model(mount)
+    robot._driver.write_pipette_model(mount, new_model)
+    read_model = robot._driver.read_pipette_model(mount)
     _assert_the_same(new_model, read_model)
 
 


### PR DESCRIPTION
## overview

Make pipette read/write methods public on the driver. Also adds docstring to each method, as well as changes the `mount` arg to `"left"` and `"right"` just like how the rest of the API refers to mounts.

Some small changes were also required to `opentrons.tools.write_pipette_memory` to get it working with new methods/args.

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
