### PR TITLE
Api: Speaker-test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apk add --update \
       py3-zmq \
       py3-urwid \
       py3-numpy \
+      alsa-utils \
       && rm -rf /var/cache/apk/*
 
 # Resin's python base container compiles python from scratch and doesn't have


### PR DESCRIPTION
## overview

Adds `alsa-utils` to the Dockerfile. This gives us control over audio output, as well as a tool for QC'ing machines' speakers.

To test speaker from Resin Terminal or when ssh'ed into machine:
```
$ speaker-test
```
That will play pink-noise from speaker until quit using `Ctrl-C`