### PR TITLE
Disable jest parallelism: add --runInBand option to all jest calls

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -54,6 +54,7 @@ dev:
 .PHONY: test
 test:
 	$(env)=test jest \
+		--runInBand \
 		--coverage=$(cover) \
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)

--- a/labware-definitions/Makefile
+++ b/labware-definitions/Makefile
@@ -35,6 +35,7 @@ build:
 .PHONY: test
 test:
 	$(env)=test jest \
+		--runInBand \
 		--coverage=$(cover) \
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -55,6 +55,7 @@ dev:
 .PHONY: test
 test:
 	$(env)=test jest \
+		--runInBand \
 		--coverage=$(cover) \
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)


### PR DESCRIPTION
We are getting failed builds sporadically in Travis that can always be fixed by just restarting the build.

I think it is this open issue in Jest: "Flaky failure mode" https://github.com/facebook/jest/issues/1874

Since it's a nondeterministic error, it's hard to reproduce. So this PR disables jest's parallelism with the `--runInBand` arg, and we can watch our builds to see if that fixes the error.

These errors look like:

```
make -C components test
make[1]: Entering directory `/home/travis/build/Opentrons/opentrons/components'
cross-env NODE_ENV=test jest \
        --coverage=true \
        --watch=false \
        --updateSnapshot=false
 FAIL  src/__tests__/structure.test.js
  ● Test suite failed to run
    /home/travis/build/Opentrons/opentrons/components/src/structure/TitleBar.js:24
    }});
    ^
    
    SyntaxError: Unexpected token }
      
      at ScriptTransformer._transformAndBuildScript (../node_modules/jest-runtime/build/ScriptTransformer.js:289:17)
      at Object.<anonymous> (src/structure/index.js:4:43)
      at Object.<anonymous> (src/index.js:22:297)
```

## review requests

good idea? bad idea?

~Does this make build time longer?~ There's a good +-5min variance in Travis and Appveyor build times, but this change doesn't significantly increase the build time