### PR TITLE
Add endpoint for reading pipette model info and organize endpoint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pytest_cache
 
 # C extensions
 *.so

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -207,19 +207,20 @@ class SmoothieDriver_3_0_0:
         mount:
             String (str) with value 'left' or 'right'
         '''
-        return self._read_from_pipette(
-            GCODES['READ_INSTRUMENT_ID'], mount)
+        res = self._read_from_pipette(GCODES['READ_INSTRUMENT_ID'], mount)
+        if res:
+            return {'pipette_id': res}
 
     def read_pipette_model(self, mount):
         '''
         Reads an attached pipette's MODEL
         The MODEL is a unique string for this model of pipette
 
-        mount:
-            String (str) with value 'left' or 'right'
+        :return :dict with key 'model' and model string as value, or None
         '''
-        return self._read_from_pipette(
-            GCODES['READ_INSTRUMENT_MODEL'], mount)
+        res = self._read_from_pipette(GCODES['READ_INSTRUMENT_MODEL'], mount)
+        if res:
+            return {'model': res}
 
     def write_pipette_id(self, mount, data_string):
         '''

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -930,6 +930,18 @@ class Robot(object):
         self.reset()
         self.home()
 
+    def get_attached_pipettes(self):
+        """
+        Gets model names of attached pipettes
+
+        :return: :dict with keys 'left' and 'right' and a model string for each
+            mount, or 'uncommissioned' if no model string available
+        """
+        return {
+            'left': self._driver.read_pipette_model('left'),
+            'right': self._driver.read_pipette_model('right')
+        }
+
     def get_serial_ports_list(self):
         ports = []
         # TODO: Store these settings in config

--- a/api/opentrons/server/endpoints/__init__.py
+++ b/api/opentrons/server/endpoints/__init__.py
@@ -1,0 +1,23 @@
+import os
+import json
+import logging
+from aiohttp import web
+from opentrons import robot, __version__
+
+log = logging.getLogger(__name__)
+
+# TODO(mc, 2018-02-22): this naming logic is copied instead of shared
+#   from compute/scripts/anounce_mdns.py
+NAME = 'opentrons-{}'.format(
+    os.environ.get('RESIN_DEVICE_NAME_AT_INIT', 'dev'))
+
+
+async def health(request):
+    res = {
+        'name': NAME,
+        'api_version': __version__,
+        'fw_version': robot.fw_version
+    }
+    return web.json_response(
+        headers={'Access-Control-Allow-Origin': '*'},
+        body=json.dumps(res))

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -1,0 +1,61 @@
+import os
+import logging
+from time import sleep
+from aiohttp import web
+from threading import Thread
+from opentrons import robot
+
+log = logging.getLogger(__name__)
+
+
+async def get_attached_pipettes(request):
+    """
+    Query robot for model strings on 'left' and 'right' mounts, and return a
+    dict with the results keyed by mount
+
+    Example:
+
+    ```
+    {
+      'left': {
+        'model': 'p300_single'
+      },
+      'right': {
+        'model': 'p10_multi'
+      }
+    }
+    ```
+
+    If a pipette is "uncommissioned" (e.g.: does not have a model string
+    written to on-board memory), or if no pipette is present, the corresponding
+    mount will report `'model': 'uncommissioned'`
+    """
+    return web.json_response(robot.get_attached_pipettes())
+
+
+async def identify(request):
+    Thread(target=lambda: robot.identify(
+        int(request.query.get('seconds', '10')))).start()
+    return web.json_response({"message": "identifying"})
+
+
+async def turn_on_rail_lights(request):
+    robot.turn_on_rail_lights()
+    return web.json_response({"lights": "on"})
+
+
+async def turn_off_rail_lights(request):
+    robot.turn_off_rail_lights()
+    return web.json_response({"lights": "off"})
+
+
+async def restart(request):
+    """
+    Returns OK, then waits approximately 3 seconds and restarts container
+    """
+    def wait_and_restart():
+        log.info('Restarting server')
+        sleep(3)
+        os.system('kill 1')
+    Thread(target=wait_and_restart).start()
+    return web.json_response({"message": "restarting"})

--- a/api/opentrons/server/endpoints/update.py
+++ b/api/opentrons/server/endpoints/update.py
@@ -1,0 +1,55 @@
+import os
+import logging
+import asyncio
+from aiohttp import web
+
+log = logging.getLogger(__name__)
+
+
+async def _install(filename, loop):
+    proc = await asyncio.create_subprocess_shell(
+        'pip install --upgrade --force-reinstall --no-deps {}'.format(
+            filename),
+        stdout=asyncio.subprocess.PIPE,
+        loop=loop)
+
+    rd = await proc.stdout.read()
+    res = rd.decode().strip()
+    print(res)
+    await proc.wait()
+    return res
+
+
+async def install_api(request):
+    """
+    This handler accepts a POST request with Content-Type: multipart/form-data
+    and a file field in the body named "whl". The file should be a valid Python
+    wheel to be installed. The received file is install using pip, and then
+    deleted and a success code is returned.
+    """
+    log.debug('Update request received')
+    data = await request.post()
+    try:
+        filename = data['whl'].filename
+        log.info('Preparing to install: {}'.format(filename))
+        content = data['whl'].file.read()
+
+        with open(filename, 'wb') as wf:
+            wf.write(content)
+
+        msg = await _install(filename, request.loop)
+        log.debug('Install complete')
+        try:
+            os.remove(filename)
+        except OSError:
+            pass
+        log.debug("Result: {}".format(msg))
+        res = web.json_response({
+            'message': msg,
+            'filename': filename})
+    except Exception as e:
+        res = web.json_response(
+            {'error': 'Exception {} raised by update of {}. Trace: {}'.format(
+                type(e), data, e.__traceback__)},
+            status=500)
+    return res

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -7,6 +7,7 @@ from aiohttp import web
 from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
 from opentrons.server import endpoints as endp
+from opentrons.server.endpoints import (wifi, control, update)
 from opentrons.deck_calibration import endpoints as dc_endp
 from logging.config import dictConfig
 
@@ -19,11 +20,7 @@ def log_init():
     """
     Function that sets log levels and format strings. Checks for the
     OT_LOG_LEVEL environment variable otherwise defaults to DEBUG.
-    :return:
     """
-    # TODO(artyom): might as well use this:
-    # https://pypi.python.org/pypi/logging-color-formatter
-
     default_log_level = 'INFO'
     ot_log_level = os.environ.get('OT_LOG_LEVEL', default_log_level)
     if ot_log_level not in logging._nameToLevel:
@@ -78,16 +75,17 @@ def init(loop=None):
     """
     server = Server(MainRouter(), loop=loop)
     server.app.router.add_get('/health', endp.health)
-    server.app.router.add_get('/wifi/list', endp.wifi_list)
-    server.app.router.add_post('/wifi/configure', endp.wifi_configure)
-    server.app.router.add_get('/wifi/status', endp.wifi_status)
-    server.app.router.add_post('/identify', endp.identify)
-    server.app.router.add_post('/lights/on', endp.turn_on_rail_lights)
-    server.app.router.add_post('/lights/off', endp.turn_off_rail_lights)
-    server.app.router.add_post('/server/update', endp.update_api)
-    server.app.router.add_post('/server/restart', endp.restart)
+    server.app.router.add_get('/wifi/list', wifi.list_networks)
+    server.app.router.add_post('/wifi/configure', wifi.configure)
+    server.app.router.add_get('/wifi/status', wifi.status)
+    server.app.router.add_post('/identify', control.identify)
+    server.app.router.add_post('/lights/on', control.turn_on_rail_lights)
+    server.app.router.add_post('/lights/off', control.turn_off_rail_lights)
+    server.app.router.add_post('/server/update', update.install_api)
+    server.app.router.add_post('/server/restart', control.restart)
     server.app.router.add_get('/calibration/deck', dc_endp.start)
     server.app.router.add_post('/calibration/deck', dc_endp.dispatch)
+    server.app.router.add_get('/pipettes', control.get_attached_pipettes)
     return server.app
 
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -287,10 +287,11 @@ def test_read_and_write_pipettes(model):
     test_model = 'TestPipette'
     driver.write_pipette_id('left', test_id)
     read_id = driver.read_pipette_id('left')
-    assert read_id == test_id
+    assert read_id == {'pipette_id': test_id}
+
     driver.write_pipette_model('left', test_model)
     read_model = driver.read_pipette_model('left')
-    assert read_model == test_model
+    assert read_model == {'model': test_model}
 
     driver._send_command = types.MethodType(_old_send_command, driver)
 

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -1,0 +1,47 @@
+import json
+from opentrons.server.main import init
+from opentrons.drivers.smoothie_drivers import driver_3_0
+
+
+async def test_get_pipettes_uncommissioned(
+        virtual_smoothie_env, loop, test_client, monkeypatch):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    def mock_parse_fail(smoothie_response):
+        return ''
+
+    monkeypatch.setattr(driver_3_0, '_parse_instrument_data', mock_parse_fail)
+
+    expected = '{"left": null, "right": null}'
+    resp = await cli.get('/pipettes')
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected
+
+
+async def test_get_pipettes(
+        virtual_smoothie_env, loop, test_client, monkeypatch):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    dummy_by_mount = {
+        'left': {
+            'model': 'p10_multi'
+        },
+        'right': {
+            'model': 'p300_single'
+        }
+    }
+
+    def mock_parse_p300(self, gcode, mount):
+        return dummy_by_mount[mount]['model']
+
+    monkeypatch.setattr(
+        driver_3_0.SmoothieDriver_3_0_0, '_read_from_pipette', mock_parse_p300)
+
+    expected = json.dumps(dummy_by_mount)
+    resp = await cli.get('/pipettes')
+    text = await resp.text()
+    assert resp.status == 200
+    assert text == expected

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 from aiohttp import web
 from opentrons.server.main import init, log_init
-from opentrons.server import endpoints
+from opentrons.server.endpoints import (control, update)
 
 
 async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
@@ -11,7 +11,7 @@ async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
 
     async def mock_restart(request):
         return web.json_response(test_data)
-    monkeypatch.setattr(endpoints, 'restart', mock_restart)
+    monkeypatch.setattr(control, 'restart', mock_restart)
 
     app = init(loop)
     cli = await loop.create_task(test_client(app))
@@ -34,7 +34,7 @@ async def test_update(virtual_smoothie_env, monkeypatch, loop, test_client):
 
     async def mock_install(filename, loop):
         return msg
-    monkeypatch.setattr(endpoints, '_install', mock_install)
+    monkeypatch.setattr(update, '_install', mock_install)
 
     app = init(loop)
     cli = await loop.create_task(test_client(app))


### PR DESCRIPTION
## overview

Add endpoint to get model strings for attached pipettes (fixes #998)

Also reorganize endpoints into sub-modules to make it easier to find functions (no behavioral changes).

## changelog

- (feature) add endpoint to get model strings for attached pipettes
- (refactor) reorganize endpoint functions into sub-modules