### PR TITLE
Add API client actions for /server/update and /server/restart

### DIFF
--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -1,15 +1,59 @@
+// @flow
+// TODO(mc, 2018-03-15): use babel with flow preset instead of comments
 // api updater
 'use strict'
 
 const fs = require('fs')
 const path = require('path')
+const {promisify} = require('util')
+const semver = require('semver')
 
-const updateDirectory = path.join(__dirname, '../../api/dist')
+const {version: LATEST_VERSION} = require('../package.json')
 
-module.exports = function initializeApiUpdate () {
-  // TODO(mc, 2018-03-14): proof-of-concept; remove
-  fs.readdir(updateDirectory, (error, files) => {
-    if (error) return console.error('error reading update dir:', error)
-    console.log('api update files:', files)
-  })
+const readDir = promisify(fs.readdir)
+const readFile = promisify(fs.readFile)
+
+/*::
+import type {RobotService} from '../../app/src/robot'
+import type {RobotHealth} from '../../app/src/http-api-client'
+*/
+
+const UPDATE_EXT = '.whl'
+const UPDATE_DIR = path.join(__dirname, '../../api/dist')
+let updateFile
+
+module.exports = {
+  initialize,
+  getUpdateAvailable,
+  getUpdateFile
+}
+
+function initialize () /*: Promise<void> */ {
+  return readDir(UPDATE_DIR)
+    .then((files) => {
+      const wheels = files.filter((file) => file.endsWith(UPDATE_EXT))
+
+      if (wheels.length !== 1) {
+        return Promise.reject(new Error(
+          `Expected 1 wheel, got ${wheels.length} of ${files.length} files`
+        ))
+      }
+
+      updateFile = wheels[0]
+    })
+}
+
+function getUpdateAvailable (robotHealth /*: RobotHealth */) /*: boolean */ {
+  if (robotHealth.response && robotHealth.response.api_version) {
+    return semver.gt(LATEST_VERSION, robotHealth.response.api_version)
+  }
+
+  return false
+}
+
+function getUpdateFile () /*: Promise<string> */ {
+  if (!updateFile) return Promise.reject(new Error('No update file available'))
+
+  return readFile(path.join(UPDATE_DIR, updateFile))
+    .then((contents) => ({name: updateFile, contents}))
 }

--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -7,7 +7,7 @@ const {app, dialog, Menu, BrowserWindow} = require('electron')
 const log = require('electron-log')
 
 const initializeMenu = require('./menu')
-const initializeApiUpdate = require('./api-update')
+const {initialize: initializeApiUpdate} = require('./api-update')
 
 // TODO(mc, 2018-01-06): replace dev and debug vars with feature vars
 const DEV_MODE = process.env.NODE_ENV === 'development'
@@ -33,6 +33,8 @@ function startUp () {
   createWindow()
   initializeMenu()
   initializeApiUpdate()
+    .catch((e) => console.error('Initialze API update module error', e))
+
   load()
 
   if (DEV_MODE || DEBUG_MODE) {

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -24,13 +24,14 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "devDependencies": {
     "cross-env": "^5.0.1",
-    "electron": "1.6.11",
+    "electron": "1.8.3",
     "electron-builder": "19.52.1",
     "shx": "^0.2.2"
   },
   "dependencies": {
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.2.0",
-    "electron-log": "^2.2.9"
+    "electron-log": "^2.2.9",
+    "semver": "^5.5.0"
   }
 }

--- a/app-shell/yarn.lock
+++ b/app-shell/yarn.lock
@@ -30,9 +30,9 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
 
-"@types/node@^7.0.18":
-  version "7.0.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.55.tgz#7bb6215ff9425a1d714106be9f0d3e0e28829288"
+"@types/node@^8.0.24":
+  version "8.9.5"
+  resolved "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
 
 ajv-keywords@^2.1.1:
   version "2.1.1"
@@ -580,11 +580,11 @@ electron-publish@19.52.0:
     fs-extra-p "^4.5.0"
     mime "^2.1.0"
 
-electron@1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.11.tgz#be79c0ebdcefedb5bf28117409800fa53baceffa"
+electron@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.3.tgz#001416ea3a25ce594e317cb5531bc41eadd22f7f"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 

--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -1,0 +1,8 @@
+// mock electron module
+'use strict'
+
+module.exports = {
+  remote: {
+    require: () => ({})
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -86,6 +86,7 @@
     "@opentrons/components": "3.0.0-beta.0",
     "bonjour": "^3.5.0",
     "classnames": "^2.2.5",
+    "electron": "1.8.3",
     "history": "^4.7.2",
     "lodash": "^4.17.4",
     "moment": "^2.19.1",

--- a/app/src/http-api-client/__tests__/client.test.js
+++ b/app/src/http-api-client/__tests__/client.test.js
@@ -43,7 +43,8 @@ describe('http api client', () => {
         'http://1.2.3.4:8080/foo',
         {
           method: 'GET',
-          headers: {'Content-Type': 'application/json'}
+          headers: {},
+          body: undefined
         }
       ))
   })

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -1,0 +1,69 @@
+// server api tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {
+  restartRobotServer
+} from '..'
+
+jest.mock('electron')
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+
+describe('server API client', () => {
+  beforeEach(() => client.__clearMock())
+
+  // TODO(mc, 2018-03-16): write tests for this action creator; skipping
+  //   because mocking electron, FormData, and Blob would be more work
+  describe.skip('updateRobotServer action creator')
+
+  describe('restartRobotServer action creator', () => {
+    test('calls POST /server/restart', () => {
+      client.__setMockResponse({message: 'restarting'})
+
+      return restartRobotServer(robot)(() => {})
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'POST', 'server/restart')
+        )
+    })
+
+    test('dispatches SERVER_REQUEST and SERVER_SUCCESS', () => {
+      const response = {message: 'restarting'}
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:SERVER_REQUEST', payload: {robot, path: 'restart'}},
+        {
+          type: 'api:SERVER_SUCCESS',
+          payload: {robot, response, path: 'restart'}
+        }
+      ]
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(restartRobotServer(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches SERVER_REQUEST and SERVER_FAILURE', () => {
+      const error = {name: 'ResponseError', status: '400'}
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'api:SERVER_REQUEST', payload: {robot, path: 'restart'}},
+        {
+          type: 'api:SERVER_FAILURE',
+          payload: {robot, error, path: 'restart'}
+        }
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(restartRobotServer(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+})

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -31,13 +31,11 @@ function ResponseError (
 }
 
 // not a real Error so it can be copied across worker boundries
-function FetchError (error: Error): ApiRequestError {
+export function FetchError (error: Error): ApiRequestError {
   return {name: error.name, message: error.message}
 }
 
-const HEADERS = {
-  'Content-Type': 'application/json'
-}
+const JSON_CONTENT_TYPE = 'application/json'
 
 export default function client<T, U> (
   robot: RobotService,
@@ -48,10 +46,16 @@ export default function client<T, U> (
   const url = `http://${robot.ip}:${robot.port}/${path}`
   const options = {
     method,
-    headers: HEADERS,
-    body: (body && method !== 'GET')
-      ? JSON.stringify(body)
-      : undefined
+    headers: {},
+    // to make flow happy...
+    body: undefined
+  }
+
+  if (body instanceof FormData) {
+    options.body = body
+  } else if (body) {
+    options.body = JSON.stringify(body)
+    options.headers['Content-Type'] = JSON_CONTENT_TYPE
   }
 
   return fetch(url, options).then(jsonFromResponse, fetchErrorFromError)

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -2,12 +2,14 @@
 // robot HTTP API client module
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
-import {wifiReducer, type WifiAction} from './wifi'
 import {healthCheckReducer, type HealthCheckAction} from './health-check'
+import {serverReducer, type ServerAction} from './server'
+import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
   health: healthReducer,
   healthCheck: healthCheckReducer,
+  server: serverReducer,
   wifi: wifiReducer
 })
 
@@ -35,6 +37,7 @@ export type State = $Call<typeof reducer>
 export type Action =
   | HealthAction
   | HealthCheckAction
+  | ServerAction
   | WifiAction
 
 export {
@@ -51,6 +54,11 @@ export {
   healthCheckMiddleware,
   makeGetHealthCheckOk
 } from './health-check'
+
+export {
+  updateRobotServer,
+  restartRobotServer
+} from './server'
 
 export {
   fetchWifiList,

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -1,0 +1,154 @@
+// @flow
+// server endpoints http api module
+import {remote} from 'electron'
+
+import type {ThunkPromiseAction, Action} from '../types'
+import type {RobotService} from '../robot'
+
+import type {ApiCall} from './types'
+import client, {FetchError, type ApiRequestError} from './client'
+
+// remote module paths relative to app-shell/lib/main.js
+const {getUpdateFile} = remote.require('./api-update')
+
+type RequestPath = 'update' | 'restart'
+
+export type ServerUpdateResponse = {
+  filename: string,
+  message: string,
+}
+
+export type ServerRestartResponse = {
+  message: 'restarting',
+}
+
+type ServerResponse =
+  | ServerUpdateResponse
+  | ServerRestartResponse
+
+export type ServerRequestAction = {|
+  type: 'api:SERVER_REQUEST',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+  |}
+|}
+
+export type ServerSuccessAction = {|
+  type: 'api:SERVER_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    response: ServerResponse,
+  |}
+|}
+
+export type ServerFailureAction = {|
+  type: 'api:SERVER_FAILURE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    error: ApiRequestError,
+  |}
+|}
+
+export type ServerAction =
+  | ServerRequestAction
+  | ServerSuccessAction
+  | ServerFailureAction
+
+export type RobotServerUpdate = ApiCall<void, ServerUpdateResponse>
+export type RobotServerRestart = ApiCall<void, ServerRestartResponse>
+
+type RobotServerState = {
+  update?: ?RobotServerUpdate,
+  restart?: ?RobotServerRestart,
+  updateAvailable?: boolean
+}
+
+type ServerState = {
+  [robotName: string]: ?RobotServerState
+}
+
+const UPDATE: RequestPath = 'update'
+const RESTART: RequestPath = 'restart'
+
+// TODO(mc, 2018-03-16): remove debug code when UI is hooked up
+// global.updateRobotServer = updateRobotServer
+
+export function updateRobotServer (
+  robot: RobotService
+): ThunkPromiseAction {
+  return (dispatch) => {
+    dispatch(serverRequest(robot, UPDATE))
+
+    return makeUpdateRequestBody()
+      .then((body) => client(robot, 'POST', 'server/update', body))
+      .then(
+        (response: ServerUpdateResponse) =>
+          dispatch(serverSuccess(robot, UPDATE, response)),
+        (error: ApiRequestError) =>
+          dispatch(serverFailure(robot, UPDATE, error))
+      )
+  }
+}
+
+export function restartRobotServer (
+  robot: RobotService
+): ThunkPromiseAction {
+  return (dispatch) => {
+    dispatch(serverRequest(robot, RESTART))
+
+    return client(robot, 'POST', 'server/restart')
+      .then(
+        (response: ServerRestartResponse) =>
+          dispatch(serverSuccess(robot, RESTART, response)),
+        (error: ApiRequestError) =>
+          dispatch(serverFailure(robot, RESTART, error))
+      )
+  }
+}
+
+export function serverReducer (
+  state: ?ServerState,
+  action: Action
+): ServerState {
+  if (state == null) return {}
+  return state
+}
+
+function makeUpdateRequestBody () {
+  return getUpdateFile()
+    .then((file) => {
+      const formData = new FormData()
+      formData.append('whl', new Blob([file.contents]), file.name)
+      return formData
+    })
+    .catch((error) => Promise.reject(FetchError(error)))
+}
+
+function serverRequest (
+  robot: RobotService,
+  path: RequestPath
+): ServerRequestAction {
+  return {type: 'api:SERVER_REQUEST', payload: {robot, path}}
+}
+
+function serverSuccess (
+  robot: RobotService,
+  path: RequestPath,
+  response: ServerResponse
+): ServerSuccessAction {
+  return {
+    type: 'api:SERVER_SUCCESS',
+    payload: {robot, path, response}
+  }
+}
+
+function serverFailure (
+  robot: RobotService,
+  path: RequestPath,
+  error: ApiRequestError
+): ServerFailureAction {
+  return {type: 'api:SERVER_FAILURE', payload: {robot, path, error}}
+}

--- a/app/src/robot/api-client/discovery.js
+++ b/app/src/robot/api-client/discovery.js
@@ -3,7 +3,9 @@ import os from 'os'
 import net from 'net'
 import Bonjour from 'bonjour'
 
-import {fetchHealth} from '../../http-api-client'
+// import directly from health to avoid importing other parts
+// of the api client (most importantly, the electron remote)
+import {fetchHealth} from '../../http-api-client/health'
 
 import {actions} from '../actions'
 import {getIsScanning} from '../selectors'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.19.1.tgz#8bdf8ed0e759eea1c7010d22fb9789e462ec0a9b"
 
+"@types/node@^8.0.24":
+  version "8.9.5"
+  resolved "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1797,7 +1801,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2158,7 +2162,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2454,6 +2458,20 @@ ejs@^2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
+electron-download@^3.0.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-3.3.0.tgz#2cfd54d6966c019c4d49ad65fbe65cc9cdef68c8"
+  dependencies:
+    debug "^2.2.0"
+    fs-extra "^0.30.0"
+    home-path "^1.0.1"
+    minimist "^1.2.0"
+    nugget "^2.0.0"
+    path-exists "^2.1.0"
+    rc "^1.1.2"
+    semver "^5.3.0"
+    sumchecker "^1.2.0"
+
 electron-releases@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
@@ -2463,6 +2481,14 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
   dependencies:
     electron-releases "^2.1.0"
+
+electron@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.3.tgz#001416ea3a25ce594e317cb5531bc41eadd22f7f"
+  dependencies:
+    "@types/node" "^8.0.24"
+    electron-download "^3.0.1"
+    extract-zip "^1.0.3"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2578,6 +2604,10 @@ es6-map@^0.1.3:
 es6-object-assign@^1.0.3, es6-object-assign@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+
+es6-promise@^4.0.5:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
 
 es6-promise@^4.1.1:
   version "4.2.2"
@@ -2960,6 +2990,15 @@ extract-text-webpack-plugin@^3.0.2:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
+extract-zip@^1.0.3:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.6.9"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -3235,6 +3274,16 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
+
 fs-extra@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -3502,7 +3551,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3720,6 +3769,10 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+home-path@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -4748,6 +4801,12 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -4838,6 +4897,12 @@ kind-of@^5.0.0, kind-of@^5.0.2:
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  optionalDependencies:
+    graceful-fs "^4.1.9"
 
 known-css-properties@^0.5.0:
   version "0.5.0"
@@ -5155,7 +5220,7 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0:
+meow@^3.1.0, meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -5310,7 +5375,7 @@ minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5343,6 +5408,12 @@ mixin-deep@^1.2.0:
 mkdirp@0.5, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
   dependencies:
     minimist "0.0.8"
 
@@ -5566,6 +5637,18 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
+nugget@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
+  dependencies:
+    debug "^2.1.3"
+    minimist "^1.1.0"
+    pretty-bytes "^1.0.2"
+    progress-stream "^1.1.0"
+    request "^2.45.0"
+    single-line-log "^1.1.2"
+    throttleit "0.0.2"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -5597,6 +5680,10 @@ object-copy@^0.1.0:
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5864,7 +5951,7 @@ path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
-path-exists@^2.0.0:
+path-exists@^2.0.0, path-exists@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
@@ -6578,6 +6665,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+pretty-bytes@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
+  dependencies:
+    get-stdin "^4.0.1"
+    meow "^3.1.0"
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -6607,6 +6701,13 @@ process@^0.11.10:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
+progress-stream@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-1.2.0.tgz#2cd3cfea33ba3a89c9c121ec3347abe9ab125f77"
+  dependencies:
+    speedometer "~0.1.2"
+    through2 "~0.2.3"
 
 progress@^1.1.8:
   version "1.1.8"
@@ -6774,6 +6875,15 @@ raw-body@2.3.2:
     http-errors "1.6.2"
     iconv-lite "0.4.19"
     unpipe "1.0.0"
+
+rc@^1.1.2:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
+  dependencies:
+    deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 rc@^1.1.7:
   version "1.2.3"
@@ -7074,6 +7184,15 @@ readable-stream@1.0, readable-stream@~1.0.0, readable-stream@~1.0.31:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -7366,6 +7485,33 @@ request@2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.45.0:
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 request@^2.78.0, request@^2.79.0, request@^2.81.0:
   version "2.83.0"
@@ -7746,6 +7892,12 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+single-line-log@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/single-line-log/-/single-line-log-1.1.2.tgz#c2f83f273a3e1a16edb0995661da0ed5ef033364"
+  dependencies:
+    string-width "^1.0.1"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -7929,6 +8081,10 @@ spdy@^3.4.1:
 specificity@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
+
+speedometer@~0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -8195,6 +8351,13 @@ sugarss@^1.0.0:
   dependencies:
     postcss "^6.0.14"
 
+sumchecker@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-1.3.1.tgz#79bb3b4456dd04f18ebdbc0d703a1d1daec5105d"
+  dependencies:
+    debug "^2.2.0"
+    es6-promise "^4.0.5"
+
 superagent@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
@@ -8325,12 +8488,23 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
+throttleit@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
+
+through2@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
+  dependencies:
+    readable-stream "~1.1.9"
+    xtend "~2.1.1"
 
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
@@ -9129,6 +9303,12 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  dependencies:
+    object-keys "~0.4.0"
+
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
@@ -9243,6 +9423,12 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yauzl@^2.8.0:
   version "2.9.1"


### PR DESCRIPTION
## overview

Part of #813 

This PR adds action creators to call `/server/update` and `/server/restart`.

### dependents

This PR blocks:

- #1055 
- #1056
- #1057 (**Use this PR for e2e testing**)
- #1058 (**Also good for e2e testing**)

## changelog

- Updated `electron` to latest
- Added method to app-shell's `api-update` method to read `whl` blob
- Created `http-api-client/server` module with action creators for `update` and `restart`
- Modified `http-api-client/client` to handle `multipart/form-data` bodies

## review requests

This one is kinda hard to test at the moment (because no UI) and there's a lot of follow-up to do. Given timing I may ask to punt on some stuff.

That being said, any sort of sanity checks are good (e.g. "does the app still launch on my machine?"; "does this code look reasonable?"), and from my testing the `/server/update` call looks proper and successful.

P.S. massive diff stats are for lockfiles I promise
