### PR TITLE
PD liquid tracking: Dispense

### DIFF
--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -105,7 +105,17 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
 
   return {
     commands,
-    robotState: prevRobotState // TODO LATER deep clone robotState and manipulate it for liquid tracking here?
+    robotState: {
+      ...prevRobotState,
+      liquidState: _updateLiquidState({
+        pipetteId: pipette,
+        pipetteData: prevRobotState.instruments[pipette],
+        labwareId: labware,
+        labwareType: prevRobotState.labware[labware].type,
+        volume,
+        well
+      }, prevRobotState.liquidState)
+    }
   }
 }
 

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -1,6 +1,42 @@
 // @flow
 // import cloneDeep from 'lodash/cloneDeep'
+import mapValues from 'lodash/mapValues'
+import {splitLiquid, mergeLiquid} from './utils'
 import type {RobotState, CommandCreator, AspirateDispenseArgs} from './'
+
+type LiquidState = $PropertyType<RobotState, 'liquidState'>
+export function _updateLiquidState (
+  args: AspirateDispenseArgs,
+  prevLiquidState: LiquidState
+): LiquidState {
+  const {pipette, volume, labware, well} = args
+  // remove liquid from pipette
+  console.log(prevLiquidState.pipettes)
+  // : {[ingredId: string]: {volume: number}}) TODO
+  const pipetteLiquidState = mapValues(
+    prevLiquidState.pipettes[pipette],
+    (prevTipLiquidState: {[ingredId: string]: {volume: number}}) =>
+      ({volume: 444})
+      // splitLiquid(
+      //   volume,
+      //   prevLiquidState
+      // ).source
+  )
+
+  // add liquid to well(s)
+  const labwareLiquidState = {}
+
+  return {
+    pipettes: {
+      ...prevLiquidState.pipettes,
+      [pipette]: pipetteLiquidState
+    },
+    labware: {
+      ...prevLiquidState.labware,
+      [labware]: labwareLiquidState
+    }
+  }
+}
 
 // TODO Ian 2018-02-12 dispense is almost identical to aspirate, what will change? Should they share code?
 const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -1,39 +1,87 @@
 // @flow
-// import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash/cloneDeep'
 import mapValues from 'lodash/mapValues'
+import reduce from 'lodash/reduce'
+import {computeWellAccess} from '@opentrons/labware-definitions'
 import {splitLiquid, mergeLiquid} from './utils'
-import type {RobotState, CommandCreator, AspirateDispenseArgs} from './'
+import type {RobotState, CommandCreator, AspirateDispenseArgs, PipetteData} from './'
 
 type LiquidState = $PropertyType<RobotState, 'liquidState'>
 export function _updateLiquidState (
-  args: AspirateDispenseArgs,
+  args: {
+    pipetteId: string,
+    pipetteData: PipetteData,
+    volume: number,
+    labwareId: string,
+    labwareType: string,
+    well: string
+  },
   prevLiquidState: LiquidState
 ): LiquidState {
-  const {pipette, volume, labware, well} = args
-  // remove liquid from pipette
-  console.log(prevLiquidState.pipettes)
-  // : {[ingredId: string]: {volume: number}}) TODO
-  const pipetteLiquidState = mapValues(
-    prevLiquidState.pipettes[pipette],
+  const {pipetteId, pipetteData, volume, labwareId, labwareType, well} = args
+  type Ingreds = {[ingredId: string]: {volume: number}} // TODO import a type
+  type SourceAndDest = {|source: Ingreds, dest: Ingreds|}
+
+  // remove liquid from pipette tips,
+  // create intermediate object where sources are updated tip liquid states
+  // and dests are "droplets" that need to be merged to dest well contents
+  const splitLiquidStates: {[tipId: string]: SourceAndDest} = mapValues(
+    prevLiquidState.pipettes[pipetteId],
     (prevTipLiquidState: {[ingredId: string]: {volume: number}}) =>
-      ({volume: 444})
-      // splitLiquid(
-      //   volume,
-      //   prevLiquidState
-      // ).source
+      splitLiquid(
+        volume,
+        prevTipLiquidState
+      )
   )
 
+  const wellsForTips = (pipetteData.channels === 1)
+    ? [well]
+    : computeWellAccess(labwareType, well)
+
+  // TODO Ian 2018-03-16: duplicated in aspirate.js
+  if (!wellsForTips) {
+    throw new Error(pipetteData.channels === 1
+      ? `Invalid well: ${well}`
+      : `Labware id "${labwareId}", type ${labwareType}, well ${well} is not accessible by 8-channel's 1st tip`
+    )
+  }
+  // TODO Also duplicated:
+  const allWellsShared = wellsForTips.every(w => w && w === wellsForTips[0])
+
   // add liquid to well(s)
-  const labwareLiquidState = {}
+  const labwareLiquidState = allWellsShared
+  // merge all liquid into the single well
+  ? {[well]: reduce(
+    splitLiquidStates,
+    (wellLiquidStateAcc, splitLiquidStateForTip: {|source: Ingreds, dest: Ingreds|}) =>
+    mergeLiquid(
+      wellLiquidStateAcc,
+      splitLiquidStateForTip.dest
+    ),
+    cloneDeep(prevLiquidState.labware[labwareId][well])
+  )}
+  // merge each tip's liquid into that tip's respective well
+  : wellsForTips.reduce((acc, wellForTip, tipIdx) => {
+    return {
+      ...acc,
+      [wellForTip]: mergeLiquid(
+        splitLiquidStates[`${tipIdx}`].dest,
+        prevLiquidState.labware[labwareId][wellForTip]
+      )
+    }
+  }, {})
 
   return {
     pipettes: {
       ...prevLiquidState.pipettes,
-      [pipette]: pipetteLiquidState
+      [pipetteId]: mapValues(splitLiquidStates, 'source')
     },
     labware: {
       ...prevLiquidState.labware,
-      [labware]: labwareLiquidState
+      [labwareId]: {
+        ...prevLiquidState.labware[labwareId],
+        ...labwareLiquidState
+      }
     }
   }
 }

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -1,55 +1,397 @@
 // @flow
-import {createRobotState} from './fixtures'
-import {dispense} from '../'
+import merge from 'lodash/merge'
+import {
+  createRobotState,
+  createEmptyLiquidState,
+  createTipLiquidState,
+  p300Single,
+  p300Multi
+} from './fixtures'
+import dispense, {_updateLiquidState} from '../dispense'
 
 describe('dispense', () => {
-  const initialRobotState = createRobotState({
-    sourcePlateType: 'trough-12row',
-    destPlateType: '96-flat',
-    fillTiprackTips: true,
-    fillPipetteTips: false,
-    tipracks: [200, 200]
-  })
+  describe('tip tracking & commands:', () => {
+    const initialRobotState = createRobotState({
+      sourcePlateType: 'trough-12row',
+      destPlateType: '96-flat',
+      fillTiprackTips: true,
+      fillPipetteTips: false,
+      tipracks: [200, 200]
+    })
 
-  const robotStateWithTip = {
-    ...initialRobotState,
-    tipState: {
-      ...initialRobotState.tipState,
-      pipettes: {
-        ...initialRobotState.tipState.pipettes,
-        p300SingleId: true
+    const robotStateWithTip = {
+      ...initialRobotState,
+      tipState: {
+        ...initialRobotState.tipState,
+        pipettes: {
+          ...initialRobotState.tipState.pipettes,
+          p300SingleId: true
+        }
       }
     }
-  }
 
-  test('dispense with tip', () => {
-    const result = dispense({
-      pipette: 'p300SingleId',
-      volume: 50,
-      labware: 'sourcePlateId',
-      well: 'A1'
-    })(robotStateWithTip)
+    test('dispense with tip', () => {
+      const result = dispense({
+        pipette: 'p300SingleId',
+        volume: 50,
+        labware: 'sourcePlateId',
+        well: 'A1'
+      })(robotStateWithTip)
 
-    expect(result.commands).toEqual([{
-      command: 'dispense',
-      pipette: 'p300SingleId',
-      volume: 50,
-      labware: 'sourcePlateId',
-      well: 'A1'
-    }])
+      expect(result.commands).toEqual([{
+        command: 'dispense',
+        pipette: 'p300SingleId',
+        volume: 50,
+        labware: 'sourcePlateId',
+        well: 'A1'
+      }])
+    })
+
+    test('dispensing without tip should throw error', () => {
+      expect(() => dispense({
+        pipette: 'p300SingleId',
+        volume: 50,
+        labware: 'sourcePlateId',
+        well: 'A1'
+      })(initialRobotState)).toThrow(/Attempted to dispense with no tip on pipette/)
+    })
+
+    // TODO Ian 2018-02-12... what is excessive volume?
+    // Is it OK to dispense vol > pipette max vol?
+    // LATER: shouldn't dispense > volume of liquid in pipette
+    test.skip('dispense with excessive volume should... ?')
   })
 
-  test('dispensing without tip should throw error', () => {
-    expect(() => dispense({
-      pipette: 'p300SingleId',
-      volume: 50,
-      labware: 'sourcePlateId',
-      well: 'A1'
-    })(initialRobotState)).toThrow(/Attempted to dispense with no tip on pipette/)
-  })
+  describe('liquid tracking: ', () => {
+    function getBlankLiquidState (sourcePlateType) {
+      return createEmptyLiquidState({
+        // leave sourcePlateType undefined for tests that don't care
+        // TODO: should this `pipettes` arg be createEmptyLiquidState default?
+        sourcePlateType: sourcePlateType || '96-flat',
+        pipettes: {
+          p300SingleId: p300Single,
+          p300MultiId: p300Multi
+        }
+      })
+    }
 
-  // TODO Ian 2018-02-12... what is excessive volume?
-  // Is it OK to dispense vol > pipette max vol?
-  // LATER: shouldn't dispense > volume of liquid in pipette
-  test.skip('dispense with excessive volume should throw error')
+    let dispenseSingleCh150ToA1Args
+
+    beforeEach(() => {
+      dispenseSingleCh150ToA1Args = {
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A1'
+      }
+    })
+
+    describe('...single-channel pipette', () => {
+      test('fully dispense single ingredient into empty well', () => {
+        const initialLiquidState = merge(
+          {},
+          getBlankLiquidState(),
+          {
+            pipettes: {
+              p300SingleId: {
+                '0': {
+                  ingred1: {volume: 150}
+                }
+              }
+            }
+          }
+        )
+
+        const result = _updateLiquidState(
+          dispenseSingleCh150ToA1Args,
+          initialLiquidState
+        )
+
+        expect(result).toMatchObject({
+          pipettes: {
+            p300SingleId: {
+              '0': {
+                ingred1: {volume: 0}
+              }
+            }
+          },
+          labware: {
+            sourcePlateId: {
+              A1: {ingred1: {volume: 150}},
+              A2: {},
+              B1: {}
+            }
+          }
+        })
+      })
+
+      test('dispense ingred 1 into well containing ingreds 1 & 2', () => {
+        const initialLiquidState = merge(
+          {},
+          getBlankLiquidState(),
+          {
+            pipettes: {
+              p300SingleId: {
+                '0': {
+                  ingred1: {volume: 150}
+                }
+              }
+            },
+            labware: {
+              sourcePlateId: {
+                A1: {
+                  ingred1: {volume: 30},
+                  ingred2: {volume: 50}
+                }
+              }
+            }
+          }
+        )
+
+        const result = _updateLiquidState(
+          dispenseSingleCh150ToA1Args,
+          initialLiquidState
+        )
+
+        expect(result).toMatchObject({
+          pipettes: {
+            p300SingleId: {
+              '0': {
+                ingred1: {volume: 0}
+              }
+            }
+          },
+          labware: {
+            sourcePlateId: {
+              A1: {
+                ingred1: {volume: 150 + 30},
+                ingred2: {volume: 50}
+              },
+              A2: {},
+              B1: {}
+            }
+          }
+        })
+      })
+
+      test('dispense ingred 1 & 2 into well containing 2 & 3', () => {
+        const initialLiquidState = merge(
+          {},
+          getBlankLiquidState(),
+          {
+            pipettes: {
+              p300SingleId: {
+                '0': {
+                  ingred1: {volume: 50},
+                  ingred2: {volume: 100}
+                }
+              }
+            },
+            labware: {
+              sourcePlateId: {
+                A1: {
+                  ingred2: {volume: 25},
+                  ingred3: {volume: 20}
+                }
+              }
+            }
+          }
+        )
+
+        const result = _updateLiquidState(
+          dispenseSingleCh150ToA1Args,
+          initialLiquidState
+        )
+
+        expect(result).toMatchObject({
+          pipettes: {
+            p300SingleId: {
+              '0': {
+                ingred1: {volume: 0},
+                ingred2: {volume: 0}
+              }
+            }
+          },
+          labware: {
+            sourcePlateId: {
+              A1: {
+                ingred1: {volume: 50},
+                ingred2: {volume: 100 + 25},
+                ingred3: {volume: 20}
+              },
+              A2: {},
+              B1: {}
+            }
+          }
+        })
+      })
+
+      test('partially dispense ingred 1 & 2 into well containing 2 & 3', () => {
+        const initialLiquidState = merge(
+          {},
+          getBlankLiquidState(),
+          {
+            pipettes: {
+              p300SingleId: {
+                '0': {
+                  ingred1: {volume: 50},
+                  ingred2: {volume: 200}
+                }
+              }
+            },
+            labware: {
+              sourcePlateId: {
+                A1: {
+                  ingred2: {volume: 25},
+                  ingred3: {volume: 20}
+                }
+              }
+            }
+          }
+        )
+
+        const result = _updateLiquidState(
+          dispenseSingleCh150ToA1Args,
+          initialLiquidState
+        )
+
+        expect(result).toMatchObject({
+          pipettes: {
+            p300SingleId: {
+              '0': {
+                ingred1: {volume: 10},
+                ingred2: {volume: 40}
+              }
+            }
+          },
+          labware: {
+            sourcePlateId: {
+              A1: {
+                ingred1: {volume: 40},
+                ingred2: {volume: 160 + 40},
+                ingred3: {volume: 20}
+              },
+              A2: {},
+              B1: {}
+            }
+          }
+        })
+      })
+
+      describe.skip('handle air in pipette tips', () => {
+        // TODO Ian 2018-03-16 deal with air (especially regarding air gap)
+      })
+    })
+
+    describe('...8-channel pipette', () => {
+      describe('dispense into empty column with different ingreds in each tip:', () => {
+        const tests = [
+          {
+            labwareType: '96-flat',
+            expectedLabwareMatch: {
+              sourcePlateId: {
+                A1: {
+                  ingred2: {volume: 25 + 150},
+                  ingred3: {volume: 20}
+                },
+                B1: {},
+                C1: {ingred1: {volume: 150}},
+                D1: {ingred1: {volume: 150}},
+                E1: {ingred1: {volume: 150}},
+                F1: {ingred1: {volume: 150}},
+                G1: {ingred1: {volume: 150}},
+                H1: {ingred1: {volume: 150}}
+              }
+            }
+          },
+          {
+            labwareType: 'trough-12row',
+            expectedLabwareMatch: {
+              sourcePlateId: {
+                A1: {
+                  ingred1: {volume: 40 + (6 * 150)},
+                  ingred2: {volume: 25 + 200},
+                  ingred3: {volume: 20}
+                },
+                B1: {}
+              }
+            }
+          },
+          {
+            labwareType: '384-plate',
+            expectedLabwareMatch: {
+              sourcePlateId: {
+                A1: {
+                  ingred2: {volume: 25 + 150},
+                  ingred3: {volume: 20}
+                },
+                C1: {},
+                E1: {ingred1: {volume: 150}},
+                G1: {ingred1: {volume: 150}},
+                I1: {ingred1: {volume: 150}},
+                K1: {ingred1: {volume: 150}},
+                M1: {ingred1: {volume: 150}},
+                O1: {ingred1: {volume: 150}},
+
+                // odd rows out
+                B1: {},
+                D1: {},
+                F1: {},
+                H1: {},
+                J1: {},
+                L1: {},
+                N1: {},
+                P1: {}
+              }
+            }
+          }
+        ]
+
+        tests.forEach(({labwareType, expectedLabwareMatch}) => test(labwareType, () => {
+          const initialLiquidState = merge(
+            {},
+            getBlankLiquidState(labwareType),
+            {
+              pipettes: {
+                p300MultiId: {
+                  // all tips have 150uL of ingred1, except tips 0 and 1
+                  ...createTipLiquidState(8, {ingred1: {volume: 150}}),
+                  '0': {
+                    ingred2: {volume: 200}
+                  },
+                  '1': {}
+                }
+              },
+              labware: {
+                sourcePlateId: {
+                  A1: {
+                    ingred2: {volume: 25},
+                    ingred3: {volume: 20}
+                  }
+                }
+              }
+            }
+          )
+
+          const result = _updateLiquidState(
+            dispenseSingleCh150ToA1Args,
+            initialLiquidState
+          )
+
+          expect(result).toMatchObject({
+            pipettes: {
+              p300MultiId: {
+                ...createTipLiquidState(8, {ingred1: {volume: 0}}),
+                '0': {
+                  ingred2: {volume: 50}
+                },
+                '1': {}
+              }
+            },
+            labware: expectedLabwareMatch
+          })
+        }))
+      })
+    })
+  })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -79,8 +79,10 @@ describe('dispense', () => {
 
     beforeEach(() => {
       dispenseSingleCh150ToA1Args = {
-        labware: 'sourcePlateId',
-        pipette: 'p300SingleId',
+        labwareId: 'sourcePlateId',
+        labwareType: '96-flat',
+        pipetteId: 'p300SingleId',
+        pipetteData: p300Single,
         volume: 150,
         well: 'A1'
       }
@@ -118,7 +120,7 @@ describe('dispense', () => {
           labware: {
             sourcePlateId: {
               A1: {ingred1: {volume: 150}},
-              A2: {},
+              A2: {}, // TODO IMMEDIATELY: look for all empty well checks, toMatchObject is too permissive?
               B1: {}
             }
           }
@@ -259,17 +261,17 @@ describe('dispense', () => {
           pipettes: {
             p300SingleId: {
               '0': {
-                ingred1: {volume: 10},
-                ingred2: {volume: 40}
+                ingred1: {volume: 20},
+                ingred2: {volume: 80}
               }
             }
           },
           labware: {
             sourcePlateId: {
               A1: {
-                ingred1: {volume: 40},
-                ingred2: {volume: 160 + 40},
-                ingred3: {volume: 20}
+                ingred1: {volume: 0 + (50 - 20)},
+                ingred2: {volume: 25 + (200 - 80)},
+                ingred3: {volume: 0 + 20}
               },
               A2: {},
               B1: {}
@@ -309,11 +311,11 @@ describe('dispense', () => {
             expectedLabwareMatch: {
               sourcePlateId: {
                 A1: {
-                  ingred1: {volume: 40 + (6 * 150)},
-                  ingred2: {volume: 25 + 200},
+                  ingred1: {volume: 6 * 150},
+                  ingred2: {volume: 25 + 150},
                   ingred3: {volume: 20}
                 },
-                B1: {}
+                A2: {}
               }
             }
           },
@@ -374,7 +376,14 @@ describe('dispense', () => {
           )
 
           const result = _updateLiquidState(
-            dispenseSingleCh150ToA1Args,
+            {
+              pipetteId: 'p300MultiId',
+              pipetteData: p300Multi,
+              volume: 150,
+              labwareId: 'sourcePlateId',
+              labwareType,
+              well: 'A1'
+            },
             initialLiquidState
           )
 

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -179,7 +179,8 @@ describe('splitLiquid', () => {
     })
   })
 
-  test('splitting with air in source should throw error', () => {
+  // TODO Ian 2018-03-19 figure out what to do with air warning reporting
+  test.skip('splitting with air in source should throw error', () => {
     expect(
       () => splitLiquid(50, {ingred1: {volume: 100}, [AIR]: {volume: 20}})
     ).toThrow(/source cannot contain air/)

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -34,9 +34,6 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
 type Vol = {volume: number}
 type LiquidVolumeState = {[ingredGroup: string]: Vol}
 
-// TODO Ian 2018-03-15 use Symbol, or other way to ensure no conflict with ingredGroupId keys?
-// However, Flow doesn't like Symbol keys.
-// (this conflict is unlikely, since ingredGroupIds are strings of numbers)
 export const AIR = '__air__'
 
 /** Breaks a liquid volume state into 2 parts. Assumes all liquids are evenly mixed. */
@@ -46,13 +43,19 @@ export function splitLiquid (volume: number, sourceLiquidState: LiquidVolumeStat
 } {
   const totalSourceVolume = reduce(
     sourceLiquidState,
-    (acc: number, ingredState: Vol) => acc + ingredState.volume,
+    (acc: number, ingredState: Vol, ingredId: string) => {
+      // air is not included in the total volume
+      return (ingredId === AIR)
+        ? acc
+        : acc + ingredState.volume
+    },
     0
   )
 
-  if (AIR in sourceLiquidState) {
-    throw new Error(`Invalid source liquid state: source cannot contain air (key '${AIR}' cannot exist in sourceLiquidState object)`)
-  }
+  // TODO Ian 2018-03-19 figure out what to do with air warning reporting
+  // if (AIR in sourceLiquidState) {
+  //   console.warn('Splitting liquid with air present', sourceLiquidState)
+  // }
 
   if (totalSourceVolume === 0) {
     // Splitting from empty source


### PR DESCRIPTION
Closes #1054 

## overview

Liquid tracking in PD supports `dispense`.

## changelog / notes

* Slight changes to fixture generator fns to be easier to use and hopefully more expressive (eg, if I don't care about `destPlateType`, I leave it out when making my fixture)
* Unlike aspirate which is all in one function, I wrote a private `_updateLiquidState` in `dispense.js`, which the main `dispense` fn calls. This makes testing a lot easier. I think I'm going to factor tip state, liquid state, and command creation all apart for these commands to make them more testable. I should have thought of that earlier!
* `mergeLiquids` no longer throws warning, just ignores `__air__` key in calculating its volume. Error/warning reporting for things like "you aspirated from a well that is supposed to be empty" or "you dispensed more liquid than was in the pipette (instead of blowout)" etc is all TBD.

## review requests

1. Read the tests, please lmk if you have ideas about how to make them more readable. Even with the fixture generator fns, several levels of nesting makes for a lot of lines for simply defining things like "tip 1 contains 20uL of ingredientId1". I tried `lodash/set` + merge, and mutating the objects, but I found both those methods less readable than `merge` and merge objects.

2. (Optional) Under the selector debugger yellow box, `robotStateTimeline` should contain the updated liquid states for each of your Consolidate steps (remember, only aspirate and dispense are implemented now, so don't change tips or do blowout b/c those do not currently update liquid state! Also, only Consolidate is implemented now). But yeah it's annoying to read in there but you should be able to see the liquid state correctly update as long as you stick with consolidate and reusing one tip -- will be a lot nicer once it's rendered in the deckmap instead of a huge JS object.
