### PR TITLE
feat(app): Add update available state and wire to robot info card

### DIFF
--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -43,12 +43,8 @@ function initialize () /*: Promise<void> */ {
     })
 }
 
-function getUpdateAvailable (robotHealth /*: RobotHealth */) /*: boolean */ {
-  if (robotHealth.response && robotHealth.response.api_version) {
-    return semver.gt(LATEST_VERSION, robotHealth.response.api_version)
-  }
-
-  return false
+function getUpdateAvailable (robotVersion /*: string */) /*: boolean */ {
+  return semver.gt(LATEST_VERSION, robotVersion)
 }
 
 function getUpdateFile () /*: Promise<string> */ {

--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -1,8 +1,34 @@
 // mock electron module
 'use strict'
 
+const path = require('path')
+
+const __mockRemotes = {}
+
+const __clearMock = () => {
+  Object.keys(__mockRemotes).forEach((remoteName) => {
+    const remote = __mockRemotes[remoteName]
+
+    Object.keys(remote).forEach((methodName) => {
+      remote[methodName].mockClear()
+    })
+  })
+}
+
 module.exports = {
+  __mockRemotes,
+  __clearMock,
+  // return jest mocked versions of remote modules
   remote: {
-    require: () => ({})
+    require: jest.fn((name) => {
+      if (__mockRemotes[name]) return __mockRemotes[name]
+
+      const remote = jest.genMockFromModule(
+        path.join(__dirname, '../../app-shell/lib', name)
+      )
+
+      __mockRemotes[name] = remote
+      return remote
+    })
   }
 }

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -8,6 +8,7 @@ import type {Robot} from '../../robot'
 import {
   fetchHealth,
   makeGetRobotHealth,
+  makeGetRobotUpdateAvailable,
   type RobotHealth
 } from '../../http-api-client'
 
@@ -16,7 +17,8 @@ import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
 type OwnProps = Robot
 
 type StateProps = {
-  healthRequest: RobotHealth
+  healthRequest: RobotHealth,
+  updateAvailable: boolean
 }
 
 type DispatchProps = {
@@ -31,9 +33,17 @@ const SERVER_VERSION_LABEL = 'Server version'
 
 class InformationCard extends React.Component<Props> {
   render () {
-    const {name, healthRequest: {response: health}} = this.props
+    const {
+      name,
+      updateAvailable,
+      healthRequest: {response: health}
+    } = this.props
+
     const realName = (health && health.name) || name
     const version = (health && health.api_version) || 'Unknown'
+    const updateText = updateAvailable
+      ? 'Update'
+      : 'Updated'
 
     return (
       <Card title={TITLE}>
@@ -46,7 +56,7 @@ class InformationCard extends React.Component<Props> {
           value={version}
         />
         <OutlineButton disabled>
-          Updated
+          {updateText}
         </OutlineButton>
       </Card>
     )
@@ -67,9 +77,11 @@ export default connect(makeMapStateToProps, mapDispatchToProps)(InformationCard)
 
 function makeMapStateToProps () {
   const getRobotHealth = makeGetRobotHealth()
+  const getRobotUpdateAvailable = makeGetRobotUpdateAvailable()
 
   return (state: State, ownProps: OwnProps): StateProps => ({
-    healthRequest: getRobotHealth(state, ownProps)
+    healthRequest: getRobotHealth(state, ownProps),
+    updateAvailable: getRobotUpdateAvailable(state, ownProps)
   })
 }
 

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -1,10 +1,13 @@
 // server api tests
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
+import electron from 'electron'
 
 import client from '../client'
 import {
-  restartRobotServer
+  makeGetRobotUpdateAvailable,
+  restartRobotServer,
+  reducer
 } from '..'
 
 jest.mock('electron')
@@ -14,9 +17,36 @@ const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
 const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
+const mockApiUpdate = electron.__mockRemotes['./api-update']
 
 describe('server API client', () => {
-  beforeEach(() => client.__clearMock())
+  beforeEach(() => {
+    client.__clearMock()
+    electron.__clearMock()
+  })
+
+  describe('selectors', () => {
+    let state
+
+    beforeEach(() => {
+      state = {
+        api: {
+          server: {
+            opentrons: {
+              updateAvailable: true
+            }
+          }
+        }
+      }
+    })
+
+    test('makeGetRobotUpdateAvailable', () => {
+      const getUpdateAvailable = makeGetRobotUpdateAvailable()
+
+      expect(getUpdateAvailable(state, robot)).toEqual(true)
+      expect(getUpdateAvailable(state, {name: 'foo'})).toEqual(false)
+    })
+  })
 
   // TODO(mc, 2018-03-16): write tests for this action creator; skipping
   //   because mocking electron, FormData, and Blob would be more work
@@ -64,6 +94,36 @@ describe('server API client', () => {
 
       return store.dispatch(restartRobotServer(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('reducer', () => {
+    test('sets updateAvailable on HEALTH_SUCCESS', () => {
+      let state = {
+        server: {
+          opentrons: {
+            updateAvailable: false
+          }
+        }
+      }
+      const health = {name, api_version: '4.5.6', fw_version: '7.8.9'}
+      const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+
+      mockApiUpdate.getUpdateAvailable.mockReturnValueOnce(true)
+      expect(reducer(state, action).server).toEqual({
+        opentrons: {updateAvailable: true}
+      })
+      expect(mockApiUpdate.getUpdateAvailable)
+        .toHaveBeenCalledWith(health.api_version)
+
+      state.server.opentrons.updateAvailable = true
+      electron.__clearMock()
+      mockApiUpdate.getUpdateAvailable.mockReturnValueOnce(true)
+      expect(reducer(state, action).server).toEqual({
+        opentrons: {updateAvailable: true}
+      })
+      expect(mockApiUpdate.getUpdateAvailable)
+        .toHaveBeenCalledWith(health.api_version)
     })
   })
 })

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -41,7 +41,9 @@ describe('wifi', () => {
     test('makeGetRobotWifiStatus', () => {
       const getStatus = makeGetRobotWifiStatus()
 
-      expect(getStatus(state, robot)).toEqual(state.api.wifi.opentrons.status)
+      expect(getStatus(state, robot))
+        .toEqual(state.api.wifi.opentrons.status)
+
       expect(getStatus(state, {name: 'foo'})).toEqual({
         inProgress: false,
         error: null,

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -57,7 +57,8 @@ export {
 
 export {
   updateRobotServer,
-  restartRobotServer
+  restartRobotServer,
+  makeGetRobotUpdateAvailable
 } from './server'
 
 export {


### PR DESCRIPTION
## overview

Part of #813

This PR adds update availability tracking to the robot state and wires the robot info card in the robot page to that state.

Update available is calculated on every successful health check, which means it'll be checked every time the robot page is opened (and the info card is refreshed) and constantly while connected (due to the periodic health check).

### dependencies

~_Base branch of this PR to be swapped to `edge`on when unblocked_~ Unblocked

- [x] #1051

### dependents

This PR blocks:

- #1056
- #1057 (**Use this PR for e2e testing**)
- #1058 (**Also good for e2e testing**)

## changelog

- feat(app): Add update available state and wire to robot info card 

## review requests

Standard review. You can check view this logic in action by bumping the `version` field in `app-shell/package.json`, connecting to the API dev server, and observing that the update button in the robot page will now say "Update" instead of "Updated"