### PR TITLE
feat(app): Add request/response state for /server/[update,restart]

### DIFF
--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -116,15 +116,57 @@ export function serverReducer (
 ): ServerState {
   if (state == null) return {}
 
-  let robotName
+  let name
+  let path
   switch (action.type) {
-    case 'api:HEALTH_SUCCESS':
-      robotName = action.payload.robot.name
+    case 'api:SERVER_REQUEST':
+      ({path, robot: {name}} = action.payload)
 
       return {
         ...state,
-        [robotName]: {
-          ...state[robotName],
+        [name]: {
+          ...state[name],
+          [path]: {inProgress: true, response: null, error: null}
+        }
+      }
+
+    case 'api:SERVER_SUCCESS':
+      ({path, robot: {name}} = action.payload)
+
+      return {
+        ...state,
+        [name]: {
+          ...state[name],
+          [path]: {
+            response: action.payload.response,
+            inProgress: false,
+            error: null
+          }
+        }
+      }
+
+    case 'api:SERVER_FAILURE':
+      ({path, robot: {name}} = action.payload)
+
+      return {
+        ...state,
+        [name]: {
+          ...state[name],
+          [path]: {
+            error: action.payload.error,
+            inProgress: false,
+            response: null
+          }
+        }
+      }
+
+    case 'api:HEALTH_SUCCESS':
+      ({robot: {name}} = action.payload)
+
+      return {
+        ...state,
+        [name]: {
+          ...state[name],
           updateAvailable: getUpdateAvailable(
             action.payload.health.api_version
           )


### PR DESCRIPTION
## overview

Part of #813

This PR adds request/response state tracking for the two `/server` endpoints. This state will be used to drive the modal copy, button state, and spinners as (mostly) described by 813.

### dependencies

_Base branch of this PR to be switched to `edge` when unblocked_

- [x] #1051
- [x] #1055

### dependents

This PR blocks:

- #1057 (**Use this PR for e2e testing**)
- #1058 (**Also good for e2e testing**)

## changelog

- feat(app): Add request/response state for /server/[update,restart] 

## review requests

This one is another hard one to verify because the UI isn't in place yet. Next PR will add that, so for now a code sanity check would be good. I'm pretty satisfied with the unit tests on this one.