### PR TITLE
feat(app): Add MVP robot update modal

### DIFF
--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -24,7 +24,7 @@ let updateFile
 
 module.exports = {
   initialize,
-  getUpdateAvailable,
+  getAvailableUpdate,
   getUpdateFile
 }
 
@@ -43,8 +43,10 @@ function initialize () /*: Promise<void> */ {
     })
 }
 
-function getUpdateAvailable (robotVersion /*: string */) /*: boolean */ {
+function getAvailableUpdate (robotVersion /*: string */) /*: ?string */ {
   return semver.gt(LATEST_VERSION, robotVersion)
+    ? LATEST_VERSION
+    : null
 }
 
 function getUpdateFile () /*: Promise<string> */ {

--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -1,0 +1,75 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+import {
+  updateRobotServer,
+  restartRobotServer,
+  makeGetAvailableRobotUpdate
+} from '../../http-api-client'
+
+import {AlertModal} from '@opentrons/components'
+
+type OwnProps = Robot
+
+type StateProps = {
+  availableUpdate: string
+}
+
+type DispatchProps = {
+  close: () => *,
+  update: () => *,
+  restart: () => *
+}
+
+type Props = StateProps & DispatchProps
+
+export default connect(makeMapStateToProps, mapDispatchToProps)(UpdateModal)
+
+function UpdateModal (props: Props) {
+  const {availableUpdate, close, update, restart} = props
+
+  // TODO(mc, 2018-03-18): switch based on request state (why `let` vs `const`)
+  let message = "We recommend updating your robot's software to the latest version"
+  let buttonText = 'update'
+  let buttonAction = update
+
+  return (
+    <AlertModal
+      onCloseClick={close}
+      heading={`Version ${availableUpdate} Available`}
+      buttons={[
+        {onClick: close, children: 'not now'},
+        {onClick: buttonAction, children: buttonText},
+        // TODO (mc, 2018-03-18): remove restart and make buttonAction dynamic
+        {onClick: restart, children: 'restart'}
+      ]}
+    >
+      {message}
+    </AlertModal>
+  )
+}
+
+function makeMapStateToProps () {
+  const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
+
+  return (state: State, ownProps: OwnProps): StateProps => ({
+    availableUpdate: getAvailableRobotUpdate(state, ownProps)
+  })
+}
+
+function mapDispatchToProps (
+  dispatch: Dispatch,
+  ownProps: OwnProps
+): DispatchProps {
+  const close = () => dispatch(push(`/robots/${ownProps.name}`))
+
+  return {
+    close,
+    update: () => dispatch(updateRobotServer(ownProps)),
+    restart: () => dispatch(restartRobotServer(ownProps)).then(close)
+  }
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -1,7 +1,7 @@
 // @flow
 // robot status panel with connect button
 import * as React from 'react'
-
+import {Route} from 'react-router'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
@@ -10,11 +10,14 @@ import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
 import CalibrationCard from './CalibrationCard'
 import ConnectAlertModal from './ConnectAlertModal'
+import UpdateModal from './UpdateModal'
 import styles from './styles.css'
 
 type Props = Robot
 
 export default function RobotSettings (props: Props) {
+  const updateUrl = `/robots/${props.name}/update`
+
   return (
     <div className={styles.robot_settings}>
       <div className={styles.row}>
@@ -24,7 +27,7 @@ export default function RobotSettings (props: Props) {
       <AttachedInstrumentsCard {...props} />
       </div> */}
       <div className={styles.row}>
-        <InformationCard {...props} />
+        <InformationCard {...props} updateUrl={updateUrl} />
       </div>
       <div className={styles.row}>
         <div className={styles.column_50}>
@@ -34,6 +37,9 @@ export default function RobotSettings (props: Props) {
           <CalibrationCard {...props} />
         </div>
       </div>
+      <Route path={updateUrl} render={() => (
+        <UpdateModal {...props} />
+      )} />
     </div>
   )
 }

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -26,6 +26,7 @@
 }
 
 .configure_form {
+  width: 100%;
   margin-top: 1rem;
 }
 

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -5,7 +5,7 @@ import electron from 'electron'
 
 import client from '../client'
 import {
-  makeGetRobotUpdateAvailable,
+  makeGetAvailableRobotUpdate,
   restartRobotServer,
   reducer
 } from '..'
@@ -37,19 +37,19 @@ describe('server API client', () => {
       state = {
         api: {
           server: {
-            opentrons: {
-              updateAvailable: true
+            [robot.name]: {
+              availableUpdate: '42.0.0'
             }
           }
         }
       }
     })
 
-    test('makeGetRobotUpdateAvailable', () => {
-      const getUpdateAvailable = makeGetRobotUpdateAvailable()
+    test('makeGetRobotAvailableUpdate', () => {
+      const getAvailableUpdate = makeGetAvailableRobotUpdate()
 
-      expect(getUpdateAvailable(state, robot)).toEqual(true)
-      expect(getUpdateAvailable(state, {name: 'foo'})).toEqual(false)
+      expect(getAvailableUpdate(state, robot)).toEqual('42.0.0')
+      expect(getAvailableUpdate(state, {name: 'foo'})).toEqual(null)
     })
   })
 
@@ -111,29 +111,29 @@ describe('server API client', () => {
       }
     }))
 
-    test('sets updateAvailable on HEALTH_SUCCESS', () => {
+    test('sets availableUpdate on HEALTH_SUCCESS', () => {
       const health = {name, api_version: '4.5.6', fw_version: '7.8.9'}
       const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
 
       // test update available
-      state.server[robot.name].updateAvailable = false
-      mockApiUpdate.getUpdateAvailable.mockReturnValueOnce(true)
+      state.server[robot.name].availableUpdate = null
+      mockApiUpdate.getAvailableUpdate.mockReturnValueOnce('42.0.0')
 
       expect(reducer(state, action).server).toEqual({
-        [robot.name]: {updateAvailable: true}
+        [robot.name]: {availableUpdate: '42.0.0'}
       })
-      expect(mockApiUpdate.getUpdateAvailable)
+      expect(mockApiUpdate.getAvailableUpdate)
         .toHaveBeenCalledWith(health.api_version)
 
       // test no update available
       electron.__clearMock()
-      state.server[robot.name].updateAvailable = true
-      mockApiUpdate.getUpdateAvailable.mockReturnValueOnce(true)
+      state.server[robot.name].availableUpdate = '42.0.0'
+      mockApiUpdate.getAvailableUpdate.mockReturnValueOnce(null)
 
       expect(reducer(state, action).server).toEqual({
-        [robot.name]: {updateAvailable: true}
+        [robot.name]: {availableUpdate: null}
       })
-      expect(mockApiUpdate.getUpdateAvailable)
+      expect(mockApiUpdate.getAvailableUpdate)
         .toHaveBeenCalledWith(health.api_version)
     })
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -58,7 +58,7 @@ export {
 export {
   updateRobotServer,
   restartRobotServer,
-  makeGetRobotUpdateAvailable
+  makeGetAvailableRobotUpdate
 } from './server'
 
 export {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -10,7 +10,7 @@ import type {ApiCall} from './types'
 import client, {FetchError, type ApiRequestError} from './client'
 
 // remote module paths relative to app-shell/lib/main.js
-const {getUpdateAvailable, getUpdateFile} = remote.require('./api-update')
+const {getAvailableUpdate, getUpdateFile} = remote.require('./api-update')
 
 type RequestPath = 'update' | 'restart'
 
@@ -64,7 +64,7 @@ export type RobotServerRestart = ApiCall<void, ServerRestartResponse>
 type RobotServerState = {
   update?: ?RobotServerUpdate,
   restart?: ?RobotServerRestart,
-  updateAvailable?: boolean
+  availableUpdate?: ?string
 }
 
 type ServerState = {
@@ -167,7 +167,7 @@ export function serverReducer (
         ...state,
         [name]: {
           ...state[name],
-          updateAvailable: getUpdateAvailable(
+          availableUpdate: getAvailableUpdate(
             action.payload.health.api_version
           )
         }
@@ -177,9 +177,11 @@ export function serverReducer (
   return state
 }
 
-export const makeGetRobotUpdateAvailable = () => createSelector(
+export const makeGetAvailableRobotUpdate = () => createSelector(
   selectRobotServerState,
-  (state: ?RobotServerState): boolean => !!(state && state.updateAvailable)
+  (state: ?RobotServerState): ?string => (
+    state && state.availableUpdate
+  ) || null
 )
 
 function selectRobotServerState (state: State, props: RobotService) {

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import omit from 'lodash/omit'
 
 import {Icon, type IconName} from '../icons'
@@ -47,7 +48,11 @@ export default function Button (props: ButtonProps) {
   // pass all props if using a custom component
   const buttonProps = !props.Component
     ? {type, title, disabled, onClick, className}
-    : {...omit(props, STRIP_PROPS), onClick}
+    : {
+      ...omit(props, STRIP_PROPS),
+      className: cx(className, {[styles.disabled]: disabled}),
+      onClick
+    }
 
   return (
     <Component {...buttonProps}>

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -108,6 +108,7 @@
 .card_content {
   display: flex;
   flex-direction: row;
+  align-items: center;
   justify-content: space-between;
 
   & > button {
@@ -117,6 +118,7 @@
 
 .card_column {
   flex-direction: column;
+  align-items: flex-start;
 }
 
 .refresh_card_icon {


### PR DESCRIPTION
## overview

Part of #813 

This PR adds an MVP robot update modal in place. It does not react to state (besides showing when you click the "Update" botton in the `InformationCard`), but it does have buttons wired up for both `/server/update` and `/server/restart` so you can test the client work in #1051 end-to-end.

### dependencies

_Base branch of this PR to be switched to `edge` when unblocked_

- [x] #1051
- [x] #1055 
- [x] #1056 

### dependents

This PR blocks:

- #1058

## changelog

- feat(app): Add MVP robot update modal 

## review requests

This is a good PR for actually testing the plumbing work for the blocking PRs.

**Question**: is the app supposed to try to only allow updates via ethernet (USB)?
    - Ping @umbhau @btmorr @pantslakz @howisthisnamenottakenyet  

### testing

This will work with `make -C api ENABLE_VIRTUAL_SMOOTHIE=true`, but after you're done testing you'll need to run `make -C api install` to undo the effects of the update process.

To see the app send requests, use the "Network" tab of the devtools. To check out the state, use the "Redux" tab.

0. `make -C api wheel` to ensure you have a wheel generated
1. `make -C app dev` and find a robot to test (can be WiFi or ethernet)
2. Open robot settings page for the device-under-test
    - [ ] Button in Information Card is disabled and reads "Updated"
    - [ ] App records latest version in `state.api.server[robot.name].availableUpdate`
4. Close app, make edit to `app-shell/package.json` as described below
5. `make -C app dev`
6. Open robot settings page for the device-under-test
    - [ ] Button in Information Card is enabled and reads "Update"
    - [ ] App records latest version in `state.api.server[robot.name].availableUpdate`
    - [ ] Clicking button opens update modal
    - [ ] Clicking overlay background closes modal
    - [ ] Clicking "Not Now" closes modal
7. Click "Update"
    - [ ] App sends proper `POST /server/update` with `opentrons-3.0.0-py2.py3-none-any.whl`
        - Also watch the robot logs for this
    - [ ] App records in progress state in `state.api.server[robot.name].update`
    - [ ] App records response in `state.api.server[robot.name].update`
8. Once update finishes, click "Restart"
    - [ ] App sends proper `POST /server/update`
    - [ ] App records in progress in `state.api.server[robot.name].restart`
    - [ ] App records response in `state.api.server[robot.name].restart`
    - [ ] Modal closes after request completes

#### mock available update

To mock an update being available, jump into `app-shell/package.json` and bump the version before running `make -C app dev`. This value is the "latest version" the app compares to a robot's version.

**Important**: if the robot you're testing with is pre-#1043, the robot will be at version `3.0.0` and your "latest version" test value will need to be `3.0.1` or later (rather than, say, `3.0.0-beta.1` because `3.0.0 > 3.0.0-beta.X`). Otherwise anything `3.0.0-beta.1` or higher will work.
