### PR TITLE
feat(app): Wire request states to robot update modal

### DIFF
--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -5,18 +5,23 @@ import {push} from 'react-router-redux'
 
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
+import type {RobotServerUpdate, RobotServerRestart} from '../../http-api-client'
 import {
   updateRobotServer,
   restartRobotServer,
-  makeGetAvailableRobotUpdate
+  makeGetAvailableRobotUpdate,
+  makeGetRobotUpdateRequest,
+  makeGetRobotRestartRequest
 } from '../../http-api-client'
 
-import {AlertModal} from '@opentrons/components'
+import {AlertModal, Icon, SPINNER} from '@opentrons/components'
 
 type OwnProps = Robot
 
 type StateProps = {
-  availableUpdate: string
+  availableUpdate: ?string,
+  updateRequest: RobotServerUpdate,
+  restartRequest: RobotServerRestart
 }
 
 type DispatchProps = {
@@ -27,25 +32,46 @@ type DispatchProps = {
 
 type Props = StateProps & DispatchProps
 
+const UPDATE_MSG = "We recommend updating your robot's software to the latest version"
+const RESTART_MSG = 'Restart your robot to finish the update. It may take several minutes for your robot to restart.'
+const DONE_MSG = 'Your robot has been updated. Please wait for your robot to fully restart, which may take several minutes.'
+
+// TODO(mc, 2018-03-19): prop or component for text-height icons
+const Spinner = () => (<Icon name={SPINNER} height='1em' spin />)
+
 export default connect(makeMapStateToProps, mapDispatchToProps)(UpdateModal)
 
 function UpdateModal (props: Props) {
-  const {availableUpdate, close, update, restart} = props
+  const {close, update, restart, updateRequest, restartRequest} = props
+  const availableUpdate = props.availableUpdate || ''
+  const inProgress = updateRequest.inProgress || restartRequest.inProgress
+  let closeButtonText = 'not now'
+  let message
+  let button
 
-  // TODO(mc, 2018-03-18): switch based on request state (why `let` vs `const`)
-  let message = "We recommend updating your robot's software to the latest version"
-  let buttonText = 'update'
-  let buttonAction = update
+  if (!updateRequest.response) {
+    message = UPDATE_MSG
+    button = inProgress
+      ? {disabled: true, children: (<Spinner />)}
+      : {onClick: update, children: 'update'}
+  } else if (!restartRequest.response) {
+    message = RESTART_MSG
+    button = inProgress
+      ? {disabled: true, children: (<Spinner />)}
+      : {onClick: restart, children: 'restart'}
+  } else {
+    message = DONE_MSG
+    button = null
+    closeButtonText = 'close'
+  }
 
   return (
     <AlertModal
       onCloseClick={close}
-      heading={`Version ${availableUpdate} Available`}
+      heading={`Version ${availableUpdate || ''} Available`}
       buttons={[
-        {onClick: close, children: 'not now'},
-        {onClick: buttonAction, children: buttonText},
-        // TODO (mc, 2018-03-18): remove restart and make buttonAction dynamic
-        {onClick: restart, children: 'restart'}
+        {onClick: close, children: closeButtonText},
+        button
       ]}
     >
       {message}
@@ -55,9 +81,13 @@ function UpdateModal (props: Props) {
 
 function makeMapStateToProps () {
   const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
+  const getRobotUpdateRequest = makeGetRobotUpdateRequest()
+  const getRobotRestartRequest = makeGetRobotRestartRequest()
 
   return (state: State, ownProps: OwnProps): StateProps => ({
-    availableUpdate: getAvailableRobotUpdate(state, ownProps)
+    availableUpdate: getAvailableRobotUpdate(state, ownProps),
+    updateRequest: getRobotUpdateRequest(state, ownProps),
+    restartRequest: getRobotRestartRequest(state, ownProps)
   })
 }
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -24,6 +24,11 @@ export type {
 } from './health'
 
 export type {
+  RobotServerUpdate,
+  RobotServerRestart
+} from './server'
+
+export type {
   WifiListResponse,
   WifiStatusResponse,
   WifiConfigureResponse,
@@ -58,7 +63,9 @@ export {
 export {
   updateRobotServer,
   restartRobotServer,
-  makeGetAvailableRobotUpdate
+  makeGetAvailableRobotUpdate,
+  makeGetRobotUpdateRequest,
+  makeGetRobotRestartRequest
 } from './server'
 
 export {

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -11,7 +11,7 @@ type Props = {
   /** optional modal heading */
   heading?: React.Node,
   /** optional array of `ButtonProps` for `FlatButton`s at bottom of modal */
-  buttons?: Array<ButtonProps>,
+  buttons?: Array<?ButtonProps>,
   /** modal contents */
   children: React.Node,
   /** optional classes to apply */
@@ -36,7 +36,7 @@ export default function AlertModal (props: Props) {
       </div>
       {buttons && (
         <div className={styles.alert_modal_buttons}>
-          {buttons.map((button, index) => (
+          {buttons.filter(Boolean).map((button, index) => (
             <FlatButton key={index} {...button} />
           ))}
         </div>


### PR DESCRIPTION
## overview

Last PR of #813 

This PR wires up `/server/:path` request state to the robot update modal to determine what message to display and what the buttons do. Along with #1057, you can use this branch to verify robot update end-to-end.

### dependencies

_Base branch of this PR to be switched to `edge` when unblocked_

- [x] #1051
- [x] #1055 
- [x] #1056 
- [x] #1057

## changelog

- feat(app): Wire request states to robot update modal

## review requests

This is another good PR for actually testing the plumbing work for the blocking PRs

### testing

This test process is very similar to (and adapted from) the test checklist from #1057 

This will work with `make -C api ENABLE_VIRTUAL_SMOOTHIE=true`, but after you're done testing you'll need to run `make -C api install` to undo the effects of the update process.

To see the app send requests, use the "Network" tab of the devtools. To check out the state, use the "Redux" tab.

To begin, go through steps 0 - 2 in the #1057 checklist

0. Mock out versions as described below
1. `make -C api wheel` to build the "updated" wheel
    - **Important**: If you're testing with a real robot, be sure to push a non-mock update to the robot to avoid confusing people later with a bogus version mismatch
2. `make -C app dev` and find a robot to test (can be WiFi or ethernet)
6. Open robot settings page for the device-under-test
    - [ ] Button in Information Card is enabled and reads "Update"
    - [ ] Clicking button opens update modal
    - [ ] Clicking overlay background closes modal
    - [ ] Clicking "Not Now" closes modal
7. Click "Update"
    - [ ] App sends proper `POST /server/update` with `opentrons-3.0.0-py2.py3-none-any.whl`
    - [ ] Update button changes to spinner
8. Once update finishes
    - [ ] Message changes to restart robot message
    - [ ] Update button changes to "Restart"
    - [ ] "Not now" and overlay clicks still close modal
    - [ ] Re-opening modal still displays restart message
9. Click "Restart"
    - [ ] App sends proper `POST /server/restart`
    - [ ] Refresh button changes to spinner (may be hard to see, not super important either)
10. Restart response returns (robot will not reboot for another 3 seconds)
    - [ ] Modal closes
    - [ ] Clicking on "Update" opens a modal with a "Please wait for restart" message and a Close button
    - [ ] "Close" and overlay clicks close the modal
11. After robot finishes rebooting, click Information Card refresh button
    - (Reboot means manually ctrl-c and relaunch if using virtual robot)
    - [ ] "Update" button changes to disabled "Updated" button
    - [ ] `update` and `restart` substates in `state.api.server[robot.name]` cleared to `null`

#### mock available update

To mock an update being available, first pick an obviously bogus value like `42.0.0-mock`, then:

1. Replace the version `app-shell/package.json`
2. Replace the version in `api/version`
3. `make -C api install`

**Important**: If the robot you're testing with is pre-#1043, the robot will start at version `3.0.0` and your "latest version" test value will need to be `3.0.1` or later (rather than, say, `3.0.0-beta.1` because `3.0.0 > 3.0.0-beta.X`). Otherwise anything `3.0.0-beta.1` or higher will work.

**EXTRA IMPORTANT**: Do not leave any of these mock update files on a robot. They will be very confusing to everyone involved
