### PR TITLE
Add position info and move endpoints

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -56,7 +56,8 @@ dev:
 
 .PHONY: wheel
 wheel: clean
-	$(python) setup.py bdist_wheel && \
+	$(python) setup.py bdist_wheel
+	shx rm -rf build
 	shx ls dist
 
 .PHONY: push
@@ -64,7 +65,12 @@ push: wheel
 	curl -X POST \
 		-H "Content-Type: multipart/form-data" \
 		-F "whl=@$(wheel)" \
-		http://$(host)/server/update
+		http://$(host):31950/server/update
+
+.PHONY: restart
+restart:
+	curl -X POST http://$(host):31950/server/restart
+
 
 # TODO(mc, 2018-03-14): use $(host) var
 .PHONY: term

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -228,9 +228,8 @@ class SmoothieDriver_3_0_0:
 
         :return :dict with key 'model' and model string as value, or None
         '''
-        res = self._read_from_pipette(GCODES['READ_INSTRUMENT_MODEL'], mount)
-        if res:
-            return {'model': res}
+        return {'model': self._read_from_pipette(
+            GCODES['READ_INSTRUMENT_MODEL'], mount)}
 
     def write_pipette_id(self, mount, data_string):
         '''

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -43,7 +43,7 @@ class Mover:
             src=self._src,
             dst=self._dst,
             point=Point(*defaults(x, y, z)))
-
+        # print("Arguments: {}".format((x, y, z)))
         driver_target = {}
 
         if 'x' in self._axis_mapping:
@@ -57,7 +57,7 @@ class Mover:
         if 'z' in self._axis_mapping:
             assert z is not None, "Value must be set for each axis mapped"
             driver_target[self._axis_mapping['z']] = dst_z
-
+        # print("Driver target: {}".format(driver_target))
         self._driver.move(driver_target)
 
         # Update pose with the new value. Since stepper motors are open loop

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -43,7 +43,6 @@ class Mover:
             src=self._src,
             dst=self._dst,
             point=Point(*defaults(x, y, z)))
-        # print("Arguments: {}".format((x, y, z)))
         driver_target = {}
 
         if 'x' in self._axis_mapping:
@@ -57,7 +56,6 @@ class Mover:
         if 'z' in self._axis_mapping:
             assert z is not None, "Value must be set for each axis mapped"
             driver_target[self._axis_mapping['z']] = dst_z
-        # print("Driver target: {}".format(driver_target))
         self._driver.move(driver_target)
 
         # Update pose with the new value. Since stepper motors are open loop

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -937,18 +937,16 @@ class Robot(object):
         :return: :dict with keys 'left' and 'right' and a model string for each
             mount, or 'uncommissioned' if no model string available
         """
-        left_data = self._driver.read_pipette_model('left')
-        if left_data:
-            left_data.update({
+        left_data = {
                 'mount_axis': 'z',
                 'plunger_axis': 'b'
-            })
-        right_data = self._driver.read_pipette_model('right')
-        if right_data:
-            right_data.update({
+            }
+        left_data.update(self._driver.read_pipette_model('left'))
+        right_data = {
                 'mount_axis': 'a',
                 'plunger_axis': 'c'
-            })
+            }
+        right_data.update(self._driver.read_pipette_model('right'))
         return {
             'left': left_data,
             'right': right_data

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -937,9 +937,21 @@ class Robot(object):
         :return: :dict with keys 'left' and 'right' and a model string for each
             mount, or 'uncommissioned' if no model string available
         """
+        left_data = self._driver.read_pipette_model('left')
+        if left_data:
+            left_data.update({
+                'mount_axis': 'z',
+                'plunger_axis': 'b'
+            })
+        right_data = self._driver.read_pipette_model('right')
+        if right_data:
+            right_data.update({
+                'mount_axis': 'a',
+                'plunger_axis': 'c'
+            })
         return {
-            'left': self._driver.read_pipette_model('left'),
-            'right': self._driver.read_pipette_model('right')
+            'left': left_data,
+            'right': right_data
         }
 
     def get_serial_ports_list(self):

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -104,6 +104,10 @@ def init(loop=None):
         '/motors/engaged', control.get_engaged_axes)
     server.app.router.add_post(
         '/motors/disengage', control.disengage_axes)
+    server.app.router.add_get(
+        '/robot/positions', control.position_info)
+    server.app.router.add_post(
+        '/robot/move', control.move)
     return server.app
 
 


### PR DESCRIPTION
## overview

Add HTTP endpoints needed for move, with info for moving a pipette to attach tip position and moving a mount to correct position for swapping pipettes (correct positions determined experimentally). Fixes #1017 and fixes #1009 

## changelog

- (feature) Add endpoint with info for correct position data
- (feature) Add move endpoint for both pipette and mount targets
- (bugfix) Add port back into api `make push` command
- (feature) Add api `make restart` command

## review requests

Mount move is still questionable. Both modes need to be tested on a robot.
