### PR TITLE
fix(app-shell): Fix dev/prod electron version mismatch

### DIFF
--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -1,6 +1,6 @@
 {
   "appId": "com.opentrons.ot-app",
-  "electronVersion": "1.6.11",
+  "electronVersion": "1.8.3",
   "files": [
     "node_modules/**/*",
     "lib/**/*",


### PR DESCRIPTION
## overview

I updated the dev version of electron in #1051 but completely forgot to also update the prod version in `app-shell/electron-builder.json`, which resulted in the prod build being completely unable to launch:

<img width="428" alt="screenshot 2018-03-19 14 43 17" src="https://user-images.githubusercontent.com/2963448/37615666-3b5c5b32-2b84-11e8-8904-3a13de2f04f4.png">

This PR fixes that oversight

## changelog

- fix(app-shell): Fix dev/prod electron version mismatch

## review requests

Ensure the prod version of the Run App launches on your machine. See `CONTRIBUTING.md` on how to build/launch the prod version or use the build links from Slack
