### PR TITLE
PD Liquid Tracking: Display liquid state timeline

### DIFF
--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -122,6 +122,8 @@ exports[`TitledList renders TitledList with children correctly 1`] = `
   <div
     className="title_bar"
     onClick={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -146,6 +148,8 @@ exports[`TitledList renders TitledList with optional icon correctly 1`] = `
   <div
     className="title_bar"
     onClick={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -163,6 +167,8 @@ exports[`TitledList renders TitledList without icon correctly 1`] = `
   <div
     className="title_bar"
     onClick={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -180,6 +186,8 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
   <div
     className="title_bar"
     onClick={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -217,6 +225,8 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
   <div
     className="title_bar"
     onClick={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     <h3
       className="title"

--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -118,12 +118,12 @@ exports[`ListItem renders ListItem without icon correctly 1`] = `
 exports[`TitledList renders TitledList with children correctly 1`] = `
 <div
   className="titled_list"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"
     onClick={undefined}
-    onMouseEnter={undefined}
-    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -144,12 +144,12 @@ exports[`TitledList renders TitledList with children correctly 1`] = `
 exports[`TitledList renders TitledList with optional icon correctly 1`] = `
 <div
   className="titled_list"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"
     onClick={undefined}
-    onMouseEnter={undefined}
-    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -163,12 +163,12 @@ exports[`TitledList renders TitledList with optional icon correctly 1`] = `
 exports[`TitledList renders TitledList without icon correctly 1`] = `
 <div
   className="titled_list"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"
     onClick={undefined}
-    onMouseEnter={undefined}
-    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -182,12 +182,12 @@ exports[`TitledList renders TitledList without icon correctly 1`] = `
 exports[`TitledList renders collapsed TitledList correctly 1`] = `
 <div
   className="titled_list"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"
     onClick={undefined}
-    onMouseEnter={undefined}
-    onMouseLeave={undefined}
   >
     <h3
       className="title"
@@ -221,12 +221,12 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
 exports[`TitledList renders expanded TitledList correctly 1`] = `
 <div
   className="titled_list"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"
     onClick={undefined}
-    onMouseEnter={undefined}
-    onMouseLeave={undefined}
   >
     <h3
       className="title"

--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -141,6 +141,25 @@ exports[`TitledList renders TitledList with children correctly 1`] = `
 </div>
 `;
 
+exports[`TitledList renders TitledList with onMouseEnter & onMouseLeave correctly 1`] = `
+<div
+  className="titled_list"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="title_bar"
+    onClick={undefined}
+  >
+    <h3
+      className="title"
+    >
+      foo
+    </h3>
+  </div>
+</div>
+`;
+
 exports[`TitledList renders TitledList with optional icon correctly 1`] = `
 <div
   className="titled_list"

--- a/components/src/__tests__/__snapshots__/nav.test.js.snap
+++ b/components/src/__tests__/__snapshots__/nav.test.js.snap
@@ -29,6 +29,8 @@ exports[`NavButton renders nav button with icon correctly 1`] = `
 exports[`SidePanel renders SidePanel correctly 1`] = `
 <div
   className="panel closed"
+  onMouseEnter={undefined}
+  onMouseLeave={undefined}
 >
   <div
     className="title_bar"

--- a/components/src/__tests__/lists.test.js
+++ b/components/src/__tests__/lists.test.js
@@ -39,6 +39,16 @@ describe('TitledList', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('renders TitledList with onMouseEnter & onMouseLeave correctly', () => {
+    function someFn () {}
+
+    const tree = Renderer.create(
+      <TitledList title='foo' onMouseEnter={someFn} onMouseLeave={someFn}/>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
   test('renders TitledList with optional icon correctly', () => {
     const tree = Renderer.create(
       <TitledList title='foo' icon={FLASK} />

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -7,7 +7,7 @@ import styles from './buttons.css'
 
 export type ButtonProps = {
   /** click handler */
-  onClick?: (event: SyntheticEvent<>) => mixed,
+  onClick?: (event: SyntheticMouseEvent<>) => mixed,
   /** title attribute */
   title?: string,
   /** disabled attribute (setting disabled removes onClick) */

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -69,8 +69,8 @@ export default function TitledList (props: ListProps) {
   })
 
   return (
-    <div className={className}>
-      <div {...{onClick, onMouseEnter, onMouseLeave}} className={titleBarClass}>
+    <div className={className} {...{onMouseEnter, onMouseLeave}}>
+      <div onClick={onClick} className={titleBarClass}>
         {iconName && (
           <Icon {...iconProps} className={styles.title_bar_icon} name={iconName} />
         )}

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -22,6 +22,10 @@ type ListProps = {
   description?: React.Node,
   /** optional click action (on title div, not children) */
   onClick?: (event: SyntheticEvent<>) => void,
+  /** optional mouseEnter action */
+  onMouseEnter?: (event: SyntheticEvent<>) => mixed,
+  /** optional mouseLeave action */
+  onMouseLeave?: (event: SyntheticEvent<>) => mixed,
   /** caret click action; if defined, list is expandable and carat is visible */
   onCollapseToggle?: (event: SyntheticEvent<>) => void,
   /** collapse the list if true (false by default) */
@@ -36,7 +40,7 @@ type ListProps = {
  * An ordered list with optional title, icon, and description.
  */
 export default function TitledList (props: ListProps) {
-  const {iconName, disabled, onCollapseToggle, iconProps} = props
+  const {iconName, disabled, onCollapseToggle, iconProps, onMouseEnter, onMouseLeave} = props
   const collapsible = onCollapseToggle != null
 
   const onClick = !disabled
@@ -45,7 +49,7 @@ export default function TitledList (props: ListProps) {
 
   // clicking on the carat will not call props.onClick,
   // so prevent bubbling up if there is an onCollapseToggle fn
-  const handleCollapseToggle = e => {
+  const handleCollapseToggle = (e: SyntheticEvent<>) => {
     if (onCollapseToggle && !disabled) {
       e.stopPropagation()
       onCollapseToggle(e)
@@ -66,7 +70,7 @@ export default function TitledList (props: ListProps) {
 
   return (
     <div className={className}>
-      <div onClick={onClick} className={titleBarClass}>
+      <div {...{onClick, onMouseEnter, onMouseLeave}} className={titleBarClass}>
         {iconName && (
           <Icon {...iconProps} className={styles.title_bar_icon} name={iconName} />
         )}

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -21,13 +21,13 @@ type ListProps = {
   /** component with descriptive text about the list */
   description?: React.Node,
   /** optional click action (on title div, not children) */
-  onClick?: (event: SyntheticEvent<>) => void,
+  onClick?: (event: SyntheticMouseEvent<>) => mixed,
   /** optional mouseEnter action */
-  onMouseEnter?: (event: SyntheticEvent<>) => mixed,
+  onMouseEnter?: (event: SyntheticMouseEvent<>) => mixed,
   /** optional mouseLeave action */
-  onMouseLeave?: (event: SyntheticEvent<>) => mixed,
+  onMouseLeave?: (event: SyntheticMouseEvent<>) => mixed,
   /** caret click action; if defined, list is expandable and carat is visible */
-  onCollapseToggle?: (event: SyntheticEvent<>) => void,
+  onCollapseToggle?: (event: SyntheticMouseEvent<>) => void,
   /** collapse the list if true (false by default) */
   collapsed?: boolean,
   /** highlights the whole TitledList if true */
@@ -49,7 +49,7 @@ export default function TitledList (props: ListProps) {
 
   // clicking on the carat will not call props.onClick,
   // so prevent bubbling up if there is an onCollapseToggle fn
-  const handleCollapseToggle = (e: SyntheticEvent<>) => {
+  const handleCollapseToggle = (e: SyntheticMouseEvent<>) => {
     if (onCollapseToggle && !disabled) {
       e.stopPropagation()
       onCollapseToggle(e)

--- a/components/src/nav/SidePanel.js
+++ b/components/src/nav/SidePanel.js
@@ -10,9 +10,9 @@ type SidePanelProps= {
   title: string,
   children: React.Node,
   isClosed?: boolean,
-  onCloseClick?: (event: SyntheticEvent<>) => void,
-  onMouseEnter?: (event: SyntheticEvent<>) => mixed,
-  onMouseLeave?: (event: SyntheticEvent<>) => mixed,
+  onCloseClick?: (event: SyntheticMouseEvent<>) => mixed,
+  onMouseEnter?: (event: SyntheticMouseEvent<>) => mixed,
+  onMouseLeave?: (event: SyntheticMouseEvent<>) => mixed,
 }
 
 export default function SidePanel (props: SidePanelProps) {

--- a/components/src/nav/SidePanel.js
+++ b/components/src/nav/SidePanel.js
@@ -10,7 +10,9 @@ type SidePanelProps= {
   title: string,
   children: React.Node,
   isClosed?: boolean,
-  onCloseClick?: (event: SyntheticEvent<>) => void
+  onCloseClick?: (event: SyntheticEvent<>) => void,
+  onMouseEnter?: (event: SyntheticEvent<>) => mixed,
+  onMouseLeave?: (event: SyntheticEvent<>) => mixed,
 }
 
 export default function SidePanel (props: SidePanelProps) {
@@ -26,7 +28,7 @@ export default function SidePanel (props: SidePanelProps) {
   const className = classnames(styles.panel, {[styles.closed]: !open})
 
   return (
-    <div className={className}>
+    <div className={className} onMouseEnter={props.onMouseEnter} onMouseLeave={props.onMouseLeave}>
       <div className={styles.title_bar}>
         <h2 className={styles.title}>
           {props.title}

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -18,6 +18,8 @@ type StepItemProps = {
   sourceLabwareName?: string,
   destLabwareName?: string,
   onClick?: (event: SyntheticEvent<>) => void,
+  onMouseEnter?: (event: SyntheticEvent<>) => mixed,
+  onMouseLeave?: (event: SyntheticEvent<>) => mixed,
   onCollapseToggle?: (event: SyntheticEvent<>) => void,
   children?: React.Node
 }
@@ -32,6 +34,8 @@ export default function StepItem (props: StepItemProps) {
     collapsed,
     selected,
     onClick,
+    onMouseEnter,
+    onMouseLeave,
     onCollapseToggle,
     children
   } = props
@@ -47,7 +51,7 @@ export default function StepItem (props: StepItemProps) {
     <TitledList
       className={styles.step_item}
       description={Description}
-      {...{iconName, title, selected, onClick, onCollapseToggle: onCollapseToggle, collapsed}}
+      {...{iconName, title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
     >
       {showLabwareHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <span>{sourceLabwareName}</span>

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -15,7 +15,8 @@ type StepListProps = {
   selectedStepId?: number,
   steps: Array<StepItemData & {substeps: StepSubItemData}>,
   handleStepItemClickById?: number => (event?: SyntheticEvent<>) => void,
-  handleStepItemCollapseToggleById?: number => (event?: SyntheticEvent<>) => void
+  handleStepItemCollapseToggleById?: number => (event?: SyntheticEvent<>) => void,
+  handleStepHoverById?: (number | null) => (event?: SyntheticEvent<>) => mixed
 }
 
 function generateSubsteps (substeps) {
@@ -58,6 +59,8 @@ export default function StepList (props: StepListProps) {
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
+          onMouseEnter={props.handleStepHoverById && props.handleStepHoverById(step.id)}
+          onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}
           onCollapseToggle={
             (step.stepType === 'deck-setup' || !props.handleStepItemCollapseToggleById)
               ? null // Deck Setup steps are not collapsible

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -51,16 +51,14 @@ function generateSubsteps (substeps) {
 
 export default function StepList (props: StepListProps) {
   return (
-    <SidePanel title='Protocol Step List'>
-
-      {/* TODO: Ian 2018-01-16 figure out if 'Deck Setup' is a Step or something else... */}
-      {/* <TitledList className={styles.step_item} iconName='flask' title='Deck Setup' /> */}
-
+    <SidePanel
+      title='Protocol Step List'
+      onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}
+    >
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
           onMouseEnter={props.handleStepHoverById && props.handleStepHoverById(step.id)}
-          onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}
           onCollapseToggle={
             (step.stepType === 'deck-setup' || !props.handleStepItemCollapseToggleById)
               ? null // Deck Setup steps are not collapsible

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -4,20 +4,21 @@ import type {BaseState, ThunkDispatch} from '../types'
 
 import {selectors} from '../steplist/reducers'
 import type {StepIdType} from '../steplist/types'
-import {selectStep, toggleStepCollapsed} from '../steplist/actions'
+import {selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
 import StepList from '../components/StepList'
 
 function mapStateToProps (state: BaseState) {
   return {
     steps: selectors.allSteps(state),
-    selectedStepId: selectors.selectedStepId(state)
+    selectedStepId: selectors.hoveredOrSelectedStepId(state)
   }
 }
 
 function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
   return {
     handleStepItemClickById: (id: StepIdType) => () => dispatch(selectStep(id)),
-    handleStepItemCollapseToggleById: (id: StepIdType) => () => dispatch(toggleStepCollapsed(id))
+    handleStepItemCollapseToggleById: (id: StepIdType) => () => dispatch(toggleStepCollapsed(id)),
+    handleStepHoverById: (id: StepIdType) => () => dispatch(hoverOnStep(id))
   }
 }
 

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -4,6 +4,8 @@ import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
 import SelectablePlate from '../components/SelectablePlate.js'
 import { selectors } from '../labware-ingred/reducers'
+import {selectors as steplistSelectors} from '../steplist/reducers'
+import {selectors as fileSelectors} from '../file-data'
 import { preselectWells, selectWells } from '../labware-ingred/actions'
 import type {BaseState} from '../types'
 
@@ -32,10 +34,17 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   }
 
   const labware = selectors.getLabware(state)[containerId]
+  const stepId = steplistSelectors.hoveredOrSelectedStepId(state)
+  const allWellContentsForSteps = fileSelectors.allWellContentsForSteps(state)
+
+  const wellContents = (stepId !== null) && allWellContentsForSteps[stepId]
+    ? allWellContentsForSteps[stepId][containerId]
+    : {}
 
   return {
     containerId,
-    wellContents: selectors.wellContentsAllLabware(state)[containerId],
+    // wellContents: selectors.wellContentsAllLabware(state)[containerId], // TODO don't need this selector anymore
+    wellContents,
     containerType: labware.type,
     selectable: ownProps.selectable
   }

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -35,15 +35,16 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
 
   const labware = selectors.getLabware(state)[containerId]
   const stepId = steplistSelectors.hoveredOrSelectedStepId(state)
+  const prevStepId = stepId === null ? 0 : Math.max(stepId - 1, 0)
   const allWellContentsForSteps = fileSelectors.allWellContentsForSteps(state)
 
-  const wellContents = (stepId !== null) && allWellContentsForSteps[stepId]
-    ? allWellContentsForSteps[stepId][containerId]
+  const wellContents = allWellContentsForSteps[prevStepId]
+    ? allWellContentsForSteps[prevStepId][containerId]
     : {}
 
   return {
     containerId,
-    // wellContents: selectors.wellContentsAllLabware(state)[containerId], // TODO don't need this selector anymore
+    // wellContents: selectors.wellContentsAllLabware(state)[containerId], // TODO Ian 2018-03-19 don't need this selector anymore? Remove
     wellContents,
     containerType: labware.type,
     selectable: ownProps.selectable

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -175,10 +175,12 @@ function _wellContentsForLabware (labwareLiquids: LabwareLiquidState): WellConte
       highlighted: false,
       maxVolume: 123, // TODO refactor so all these fields aren't needed
       wellName: well,
-      groupId: Object.keys(wellContents).filter(groupId =>
-        wellContents[groupId] &&
-        wellContents[groupId].volume > 0
-      )
+      groupId: wellContents
+        ? Object.keys(wellContents).filter(groupId =>
+          wellContents[groupId] &&
+          wellContents[groupId].volume > 0
+        )
+        : null
     })
   )
 }

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -166,7 +166,6 @@ export const robotStateTimeline: BaseState => Array<$Call<StepGeneration.Command
 )
 
 function _wellContentsForLabware (labwareLiquids: LabwareLiquidState): WellContents {
-  console.log({labwareLiquids})
   return mapValues(
     labwareLiquids,
     (wellContents: {[groupId: string]: {volume: number}}, well: string) => ({

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -117,6 +117,11 @@ export const selectStep = (stepId: StepIdType): ThunkAction<*> =>
     }
   }
 
+export const hoverOnStep = (stepId: StepIdType | null) => ({
+  type: 'HOVER_ON_STEP',
+  payload: stepId
+})
+
 export type SaveStepFormAction = {
   type: 'SAVE_STEP_FORM',
   payload: {

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -161,6 +161,12 @@ const selectedStep = handleActions({
   DELETE_STEP: () => null
 }, INITIAL_DECK_SETUP_ID)
 
+type HoveredStepState = SelectedStepState
+
+const hoveredStep = handleActions({
+  HOVER_ON_STEP: (state: HoveredStepState, action) => action.payload
+}, null)
+
 type StepCreationButtonExpandedState = boolean
 
 const stepCreationButtonExpanded = handleActions({
@@ -181,6 +187,7 @@ export type RootState = {|
   collapsedSteps: CollapsedStepsState,
   orderedSteps: OrderedStepsState,
   selectedStep: SelectedStepState,
+  hoveredStep: HoveredStepState,
   stepCreationButtonExpanded: StepCreationButtonExpandedState
 |}
 
@@ -193,6 +200,7 @@ export const _allReducers = {
   collapsedSteps,
   orderedSteps,
   selectedStep,
+  hoveredStep,
   stepCreationButtonExpanded
 }
 
@@ -217,6 +225,19 @@ const formModalData = createSelector(
 const selectedStepId = createSelector(
   rootSelector,
   (state: RootState) => state.selectedStep
+)
+
+const hoveredStepId = createSelector(
+  rootSelector,
+  (state: RootState) => state.hoveredStep
+)
+
+const hoveredOrSelectedStepId = createSelector(
+  hoveredStepId,
+  selectedStepId,
+  (hoveredId, selectedId) => hoveredId !== null
+    ? hoveredId
+    : selectedId
 )
 
 const orderedStepsSelector = (state: BaseState) => rootSelector(state).orderedSteps
@@ -274,7 +295,15 @@ const allSteps = createSelector(
 const selectedStepSelector = createSelector(
   allSteps,
   selectedStepId,
-  (allSteps, selectedStepId) => allSteps && selectedStepId !== null && allSteps[selectedStepId]
+  (allSteps, selectedStepId) => {
+    const stepId = selectedStepId
+
+    if (!allSteps || stepId === null) {
+      return null
+    }
+
+    return allSteps[stepId]
+  }
 )
 
 const deckSetupMode = createSelector(
@@ -295,6 +324,7 @@ export const selectors = {
   orderedSteps: orderedStepsSelector,
   selectedStep: selectedStepSelector,
   selectedStepId, // TODO replace with selectedStep: selectedStepSelector
+  hoveredOrSelectedStepId,
   selectedStepFormData: createSelector(
     (state: BaseState) => rootSelector(state).savedStepForms,
     (state: BaseState) => rootSelector(state).selectedStep,


### PR DESCRIPTION
Closes #961

Closes first part of #1049:

> Whole card is highlighted when hovering over card header

## overview

Mousing over a Step on the Step List highlights it, setting the liquid state display. This highlighting/mouseover behavior is new in this PR.

If no Step is highlighted, the selected step (last one that was clicked on, or newly-created one) sets the liquid state display.

The liquid state for the highlighted or selected step is pulled from the robot state timeline, and displayed on the deck.

![2018-03-19--liquid-tracking-timetravel](https://user-images.githubusercontent.com/11590381/37619401-c7780c00-2b8f-11e8-822c-b0700d5e75f7.gif)

Currently not supported: wells with multiple ingredients are supposed to turn gray, instead they take on the color of one of their ingredients (arbitrary). Todo in another PR.

## changelog

### Component library
* `SidePanel` & `TitledList`: added onMouseEnter & onMouseLeave props

### PD
* `HOVER_ON_STEP` action hooked up to `onMouseEnter` + `onMouseLeave` in step list steps
* `allWellContentsForSteps` selector gets `wellContents` for `Plate`'s props from each liquidState in the robot state timeline


## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_display-liquid-state-timeline/index.html

Don't forget a tiprack on the deck - we're still deciding how "not enough tips / ran out of tips" will show up, for now it throws an error :(

`Consolidate` only, still