### PR TITLE
(pd) restyle & show volumes + labware names in step item

### DIFF
--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -1,7 +1,8 @@
-/* TODO Ian 2018-01-11 Use shades of gray for arrows and text */
+@import '@opentrons/components';
 
 .step_item {
   margin: 0.25rem 0;
+  color: var(--c-dark-gray);
 }
 
 .step_item ol {
@@ -28,7 +29,9 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 0 0.5rem;
+  padding: 0.5rem;
+  border-top: 2px solid var(--c-light-gray);
+  text-align: center;
 }
 
 .step_subitem > * {
@@ -41,14 +44,34 @@
 .step_subitem svg {
   flex: 1;
   height: 1.5rem;
+  color: var(--c-med-gray);
+}
+
+.step_subitem .volume_cell {
+  color: var(--c-med-gray);
+  overflow: visible;
+  text-align: right;
 }
 
 /* Step Subitem Column Header */
 
 .step_subitem_column_header {
   composes: step_subitem;
+  border: none;
 }
 
 .step_subitem_column_header > * {
   flex: 2;
+}
+
+/* Aspirate / dispense headers */
+.aspirate_dispense {
+  display: flex;
+  padding: 0.5rem;
+  font-size: var(--fs-body-1);
+  text-align: center;
+}
+
+.aspirate_dispense * {
+  flex: 1;
 }

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -53,6 +53,10 @@ export default function StepItem (props: StepItemProps) {
       description={Description}
       {...{iconName, title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
     >
+      {showLabwareHeader && <li className={styles.aspirate_dispense}>
+          <span>ASPIRATE</span>
+          <span>DISPENSE</span>
+      </li>}
       {showLabwareHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <span>{sourceLabwareName}</span>
         <Icon name={iconName} />

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -21,7 +21,7 @@ type StepListProps = {
   handleStepHoverById?: (StepIdTypeWithEnd | null) => (event?: SyntheticEvent<>) => mixed
 }
 
-function generateSubsteps (substeps) {
+function generateSubstepItems (substeps) {
   if (!substeps) {
     // no substeps, form is probably not finished (or it's "deck-setup" stepType)
     return null
@@ -75,7 +75,7 @@ export default function StepList (props: StepListProps) {
             'collapsed'
           ])}
         >
-          {generateSubsteps(step.substeps)}
+          {generateSubstepItems(step.substeps)}
         </StepItem>
       ))}
       <TitledList title='END' iconName='check'

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -53,7 +53,10 @@ function generateSubstepItems (substeps) {
 
 export default function StepList (props: StepListProps) {
   return (
-    <SidePanel title='Protocol Step List'>
+    <SidePanel
+      title='Protocol Step List'
+      onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}
+    >
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -53,10 +53,7 @@ function generateSubsteps (substeps) {
 
 export default function StepList (props: StepListProps) {
   return (
-    <SidePanel
-      title='Protocol Step List'
-      onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}
-    >
+    <SidePanel title='Protocol Step List'>
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 
-import {Icon} from '@opentrons/components'
 import type {TransferishStepItem} from '../steplist/types'
 import styles from './StepItem.css'
 
@@ -9,13 +8,18 @@ export type StepSubItemProps = TransferishStepItem /* & {|
   onMouseOver?: (event: SyntheticEvent<>) => void
 |} */
 
+const VOLUME_DIGITS = 1
+
 // This "transferish" substep component is for transfer/distribute/consolidate
 export default function TransferishSubstep (props: StepSubItemProps) {
   return props.rows.map((row, key) =>
     <li key={key} className={styles.step_subitem} /* onMouseOver={onMouseOver} */>
       <span>{row.sourceIngredientName}</span>
       <span className={styles.emphasized_cell}>{row.sourceWell}</span>
-      <Icon name='arrow right' />
+      <span className={styles.volume_cell}>{
+        typeof row.volume === 'number' &&
+        `${parseFloat(row.volume.toFixed(VOLUME_DIGITS))} μL`
+      }</span>
       <span className={styles.emphasized_cell}>{row.destWell}</span>
       <span>{row.destIngredientName}</span>
     </li>

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -16,10 +16,8 @@ import type {
 function _transferSubsteps (form: *, stepId: StepIdType) {
   const {
     sourceWells,
-    destWells
-    // sourceLabware, // TODO: show labware & volume, see new designs
-    // destLabware,
-    // volume
+    destWells,
+    volume
   } = form
 
   return {
@@ -31,7 +29,8 @@ function _transferSubsteps (form: *, stepId: StepIdType) {
       sourceIngredientName: 'ING1', // TODO get ingredients for source/dest wells
       destIngredientName: 'ING2',
       sourceWell: sourceWells[i],
-      destWell: destWells[i]
+      destWell: destWells[i],
+      volume
     }))
   }
 }
@@ -53,6 +52,7 @@ function _consolidateSubsteps (form: *, stepId: StepIdType) {
   return {
     stepType: 'consolidate',
     parentStepId: stepId,
+    // TODO Ian 2018-03-02 break up steps when pipette too small
     rows: [
       ...sourceWells.map((sourceWell, i) => ({
         substepId: i,
@@ -65,6 +65,7 @@ function _consolidateSubsteps (form: *, stepId: StepIdType) {
   }
 }
 
+// NOTE: This is the fn used by the `allSubsteps` selector
 export function generateSubsteps (validatedForms: {[StepIdType]: ValidFormAndErrors}): SubSteps {
   return mapValues(validatedForms, (valForm: ValidFormAndErrors, stepId: StepIdType) => {
     // Don't try to render with errors. TODO LATER: presentational error state of substeps?

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -39,13 +39,15 @@ function _transferSubsteps (form: *, stepId: StepIdType) {
 function _consolidateSubsteps (form: *, stepId: StepIdType) {
   const {
     sourceWells,
-    destWell
+    destWell,
+    volume
   } = form
 
   const destWellSubstep = {
     destWell,
-    sourceIngredientName: 'ING1',
-    destIngredientName: 'ING2'
+    sourceIngredientName: 'ING1', // TODO Ian 2018-03-20 proper ingredient name & groupId/color
+    destIngredientName: 'ING2',
+    volume: volume * sourceWells.length
   }
 
   return {
@@ -55,7 +57,8 @@ function _consolidateSubsteps (form: *, stepId: StepIdType) {
       ...sourceWells.map((sourceWell, i) => ({
         substepId: i,
         sourceWell: sourceWell,
-        sourceIngredientName: 'ING1'
+        sourceIngredientName: 'ING1',
+        volume: volume
       })),
       destWellSubstep
     ]

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -332,7 +332,12 @@ const allSteps = createSelector(
           : null
       }
 
-      const additionalFormFields = (savedForm.stepType === 'transfer' || savedForm.stepType === 'distribute' || savedForm.stepType === 'consolidate')
+      // optional form fields for "transferish" steps
+      const additionalFormFields = (
+        savedForm.stepType === 'transfer' ||
+        savedForm.stepType === 'distribute' ||
+        savedForm.stepType === 'consolidate'
+      )
         ? {
           sourceLabwareName: getLabwareName(savedForm['aspirate--labware']),
           destLabwareName: getLabwareName(savedForm['dispense--labware'])
@@ -342,8 +347,8 @@ const allSteps = createSelector(
       return {
         ...steps[id],
 
-        description: savedForm['step-details'],
         ...additionalFormFields,
+        description: savedForm['step-details'],
 
         collapsed: collapsedSteps[id],
         substeps: _allSubsteps[id]

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -374,7 +374,7 @@ const selectedStepSelector = createSelector(
 const deckSetupMode = createSelector(
   getSteps,
   selectedStepId,
-  (steps, selectedStepId) => (selectedStepId !== null && steps[selectedStepId])
+  (steps, selectedStepId) => (selectedStepId !== null && selectedStepId !== '__end__' && steps[selectedStepId])
     ? steps[selectedStepId].stepType === 'deck-setup'
     : false
 )

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -31,7 +31,8 @@ export type TransferishStepItem = {|
     sourceIngredientName?: string,
     destIngredientName?: string,
     sourceWell?: string,
-    destWell?: string
+    destWell?: string,
+    volume?: number
   |}>
 |}
 
@@ -51,12 +52,20 @@ export type StepItemData = {|
   id: StepIdType,
   title: string,
   stepType: StepType,
-  description?: string
+  description?: string,
+  sourceLabwareName?: string,
+  destLabwareName?: string
 |}
 
 export type SubSteps = {[StepIdType]: StepSubItemData | null}
 
+export type FormModalFields = {|
+  'step-name': string,
+  'step-details': string
+|}
+
 export type TransferForm = {|
+  ...FormModalFields,
   stepType: 'transfer',
   id: StepIdType,
 
@@ -88,6 +97,7 @@ export type TransferForm = {|
 |}
 
 export type ConsolidateForm = {|
+  ...FormModalFields,
   stepType: 'consolidate',
   id: StepIdType,
 
@@ -119,6 +129,7 @@ export type ConsolidateForm = {|
 |}
 
 export type PauseForm = {|
+  ...FormModalFields,
   stepType: 'pause',
   id: StepIdType,
 
@@ -126,7 +137,7 @@ export type PauseForm = {|
   'pause-hour'?: string,
   'pause-minute'?: string,
   'pause-second'?: string,
-  'pause-message'?: string,
+  'pause-message'?: string
 |}
 
 export type FormData = TransferForm | ConsolidateForm | PauseForm
@@ -153,8 +164,3 @@ export type PauseFormData = {|
 
 // TODO gradually create & use definitions from step-generation/types.js
 export type ProcessedFormData = TransferFormData | PauseFormData | ConsolidateFormData
-
-export type FormModalFields = {
-  'step-name': string,
-  'step-details': string
-}


### PR DESCRIPTION
Closes #972 

## overview

New styles for step item

* Still have placeholder ING1 ING2 ingredients
* Still does not correctly break large volumes into small volumes (these substep rows are a cartoon version of the real command generation, it doesn't show every aspirate/dispense but only some of them, so it needs its own miniature implementation of volume splitting)

![image](https://user-images.githubusercontent.com/11590381/37683334-b0a964c8-2c62-11e8-862d-641961068d46.png)

## changelog

* Restyle step item & substep item to match design: transfer & consolidate (not distribute)
* Show source and dest labware names
* Support notes (add from the "more options" modal)
* Clean up selectors a bit

## review requests

nothing special