### PR TITLE
fix(app): Fix calibration list styling broken by #1074

### DIFF
--- a/app/src/components/SetupPanel/InstrumentListItem.js
+++ b/app/src/components/SetupPanel/InstrumentListItem.js
@@ -11,6 +11,7 @@ import {
 } from '@opentrons/components'
 
 import type {Mount, Instrument} from '../../robot'
+import styles from './styles.css'
 
 type Props = {
   isRunning: boolean,
@@ -45,9 +46,11 @@ export default function InstrumentListItem (props: Props) {
       confirmed={confirmed}
       iconName={iconName}
     >
-      <span>{capitalize(mount)}</span>
-      <span>{description}</span>
-      <span>{name}</span>
+      <div className={styles.item_info}>
+        <span>{capitalize(mount)}</span>
+        <span>{description}</span>
+        <span>{name}</span>
+      </div>
     </ListItem>
   )
 }

--- a/app/src/components/SetupPanel/LabwareListItem.js
+++ b/app/src/components/SetupPanel/LabwareListItem.js
@@ -36,18 +36,20 @@ export default function LabwareListItem (props: Props) {
       onClick={onClick}
       iconName={iconName}
     >
-      <span>Slot {slot}</span>
-      {isTiprack && (
-        <span>
-          <span className={styles.tiprack_item_mount}>
-            {calibratorMount && calibratorMount.charAt(0).toUpperCase()}
+      <div className={styles.item_info}>
+        <span>Slot {slot}</span>
+        {isTiprack && (
+          <span>
+            <span className={styles.tiprack_item_mount}>
+              {calibratorMount && calibratorMount.charAt(0).toUpperCase()}
+            </span>
+            Tiprack
           </span>
-          Tiprack
+        )}
+        <span>
+          {type}
         </span>
-      )}
-      <span>
-        {type}
-      </span>
+      </div>
     </ListItem>
   )
 }

--- a/app/src/components/SetupPanel/styles.css
+++ b/app/src/components/SetupPanel/styles.css
@@ -11,25 +11,8 @@
   padding-right: 0.75rem;
 }
 
-.run_message {
-  margin: 1rem;
-  font-size: 0.75rem;
-  line-height: 1.5;
-}
-
-.run_message_item {
-  margin-bottom: 0.5rem;
-}
-
-.run_message_item:last-child {
-  margin-bottom: 0;
-}
-
-.button_run {
-  margin: 1rem;
-  width: calc(100% - 2rem);
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
+.item_info {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
 }


### PR DESCRIPTION
## overview

#1074 broke the calibration lists because `InstrumentListItem` and `LabwareListItem` were relying on the `ListItem` child wrapper to render properly. This PR keeps `ListItem` generic and adds the wrapping div + styling to InstrumentListItem and LabwareListItem directly

## changelog

- fix(app): Fix calibration list styling broken by #1074 

## review requests

Standard review. Sorry for not catching this myself prior to 1074 merge; it was a pretty obvious break.
