### PR TITLE
Add notification to Robots icon if robot update available

### DIFF
--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -1,5 +1,6 @@
 // @flow
 // nav button container
+import * as React from 'react'
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 
@@ -9,6 +10,7 @@ import {
   selectors as robotSelectors,
   constants as robotConstants
 } from '../../robot'
+import {getAnyRobotUpdateAvailable} from '../../http-api-client'
 
 import type {IconName} from '@opentrons/components'
 import {NavButton, FILE, CALIBRATE, CONNECT, RUN, MORE} from '@opentrons/components'
@@ -19,8 +21,8 @@ type OwnProps = {
 
 type StateProps = {
   iconName: IconName,
-  title: string,
-  url: string
+  title?: string,
+  url?: string
 }
 
 export default withRouter(connect(mapStateToProps)(NavButton))
@@ -36,6 +38,7 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
   const isConnected = (
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
   )
+  const robotNotification = getAnyRobotUpdateAvailable(state)
 
   // TODO(mc, 2018-03-08): move this logic to the Calibrate page
   let calibrateUrl
@@ -51,11 +54,12 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
     }
   }
 
-  const NAV_ITEM_BY_NAME = {
+  const NAV_ITEM_BY_NAME: {[string]: React.ElementProps<typeof NavButton>} = {
     connect: {
       iconName: CONNECT,
       title: 'robot',
-      url: '/robots'
+      url: '/robots',
+      notification: robotNotification
     },
     upload: {
       disabled: !isConnected || isRunning,

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -8,6 +8,7 @@ import {
   makeGetAvailableRobotUpdate,
   makeGetRobotUpdateRequest,
   makeGetRobotRestartRequest,
+  getAnyRobotUpdateAvailable,
   restartRobotServer,
   reducer
 } from '..'
@@ -72,6 +73,21 @@ describe('server API client', () => {
         .toBe(state.api.server[robot.name].restart)
       expect(getRestartRequest(state, {name: 'foo'}))
         .toEqual({inProgress: false})
+    })
+
+    test('getAnyRobotUpdateAvailable is true if any robot has update', () => {
+      state.api.server.anotherBot = {availableUpdate: null}
+      expect(getAnyRobotUpdateAvailable(state)).toBe(true)
+
+      state = {
+        api: {
+          server: {
+            ...state.api.server,
+            [robot.name]: {availableUpdate: null}
+          }
+        }
+      }
+      expect(getAnyRobotUpdateAvailable(state)).toBe(false)
     })
   })
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -65,7 +65,8 @@ export {
   restartRobotServer,
   makeGetAvailableRobotUpdate,
   makeGetRobotUpdateRequest,
-  makeGetRobotRestartRequest
+  makeGetRobotRestartRequest,
+  getAnyRobotUpdateAvailable
 } from './server'
 
 export {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -206,8 +206,18 @@ export const makeGetRobotRestartRequest = () => {
   return selector
 }
 
+export const getAnyRobotUpdateAvailable: Selector<State, void, boolean> =
+  createSelector(
+    selectServerState,
+    (state) => Object.keys(state).some((name) => state[name].availableUpdate)
+  )
+
+function selectServerState (state: State) {
+  return state.api.server
+}
+
 function selectRobotServerState (state: State, props: RobotService) {
-  return state.api.server[props.name]
+  return selectServerState(state)[props.name]
 }
 
 function getUpdateRequestBody () {

--- a/components/src/__tests__/__snapshots__/nav.test.js.snap
+++ b/components/src/__tests__/__snapshots__/nav.test.js.snap
@@ -5,6 +5,8 @@ exports[`NavButton renders nav button with icon correctly 1`] = `
   className="button disabled"
   disabled="false"
   onClick={undefined}
+  title={undefined}
+  type="button"
 >
   <svg
     aria-hidden="true"

--- a/components/src/nav/NavButton.js
+++ b/components/src/nav/NavButton.js
@@ -4,7 +4,8 @@ import {NavLink} from 'react-router-dom'
 import classnames from 'classnames'
 
 import styles from './navbar.css'
-import {type IconName, Icon} from '../icons'
+import {Button} from '../buttons'
+import {NotificationIcon, CIRCLE, type IconName} from '../icons'
 
 type NavButtonProps= {
   /** optional click event for nav button */
@@ -20,38 +21,48 @@ type NavButtonProps= {
   /** optional title to display below the icon */
   title?: string,
   /** Icon name for button's icon */
-  iconName: IconName
+  iconName: IconName,
+  /** Display a notification dot */
+  notification?: boolean,
 }
 
 export default function NavButton (props: NavButtonProps) {
+  const {url} = props
   const className = classnames(
     styles.button,
     {[styles.disabled]: props.disabled},
     {[styles.bottom]: props.isBottom},
     props.className
   )
-  if (props.url) {
-    return (
-      <NavLink
-        className={className}
-        disabled={props.disabled}
-        onClick={props.onClick}
-        to={props.url}
-        activeClassName={styles.active}
-      >
-        <Icon name={props.iconName} className={styles.icon} />
-        {props.title && (<span className={styles.title}>{props.title}</span>)}
-      </NavLink>
-    )
+
+  let buttonProps = {
+    className: className,
+    disabled: props.disabled,
+    onClick: props.onClick
   }
+
+  if (url) {
+    buttonProps = {
+      ...buttonProps,
+      Component: NavLink,
+      to: url,
+      activeClassName: styles.active
+    }
+  }
+
   return (
-    <button
-      className={className}
-      disabled={props.disabled}
-      onClick={props.onClick}
-    >
-      <Icon name={props.iconName} className={styles.icon} />
-      {props.title && (<span className={styles.title}>{props.title}</span>)}
-    </button>
+    <Button {...buttonProps}>
+      <NotificationIcon
+        name={props.iconName}
+        childName={props.notification ? CIRCLE : null}
+        className={styles.icon}
+        childClassName={styles.notification}
+      />
+      {props.title && (
+        <span className={styles.title}>
+          {props.title}
+        </span>
+      )}
+    </Button>
   )
 }

--- a/components/src/nav/navbar.css
+++ b/components/src/nav/navbar.css
@@ -9,6 +9,7 @@
   border-right: var(--bd-light);
 }
 
+/* TODO(mc, 2018-03-21): @apply --button-default? */
 .button {
   display: block;
   position: relative;
@@ -67,4 +68,8 @@ revisit once we have a need for more than one icon aligned to bottom.
   max-width: 100%;
   height: 100%;
   color: var(--c-med-gray);
+}
+
+.notification {
+  color: var(--c-orange);
 }


### PR DESCRIPTION
## overview

This PR closes #806 by adding the notification dot to the Nav Bar

**No update available**

<img width="407" alt="screenshot 2018-03-21 16 47 58" src="https://user-images.githubusercontent.com/2963448/37736567-9e5a8638-2d27-11e8-96bf-8ca997a45407.png">

**Update available**

<img width="434" alt="screenshot 2018-03-21 16 43 44" src="https://user-images.githubusercontent.com/2963448/37736544-927cb39a-2d27-11e8-9ea5-784570c493e5.png">

## changelog

- feat(app): Add selector that returns true if any robot is updatable
- feat(components): Cleanup NavButton and add notification prop
    - I switched `NavButton` from `button` to `@opentrons/components::Button`
    - In the future we should consolidate styling, too
- feat(app): Display notification in navbar if robot update available 

## review requests

Standard review! @IanLondon can you triple check my NavButton changes don't mess with PD. Otherwise I think there's continuing work that needs to happen with the app's NavBar architecture, so feel free to point anything out because it may be easy enough to tack on here.