### PR TITLE
fix(app): Fix wrong Card button sizing and stuck robot list highlight

### DIFF
--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -1,6 +1,7 @@
 // @flow
 // item in a RobotList
 import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
@@ -20,7 +21,9 @@ type DP = {
   disconnect: () => mixed
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(RobotListItem)
+export default withRouter(
+  connect(makeMapStateToProps, mapDispatchToProps)(RobotListItem)
+)
 
 function makeMapStateToProps () {
   const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import {withRouter} from 'react-router'
 import {connect} from 'react-redux'
 
 import type {State, Dispatch} from '../../types'
@@ -28,9 +27,7 @@ type DispatchProps = {
 
 type Props = StateProps & DispatchProps
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ConnectPanel)
-)
+export default connect(mapStateToProps, mapDispatchToProps)(ConnectPanel)
 
 function ConnectPanel (props: Props) {
   return (
@@ -38,6 +35,7 @@ function ConnectPanel (props: Props) {
       <div>
         <RobotList>
           {props.robots.map((robot) => (
+            // $FlowFixMe: flow-typed withRouter def throwing bogus errors
             <RobotItem key={robot.name} {...robot} />
           ))}
         </RobotList>

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -110,10 +110,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-
-  & > button {
-    height: 3rem;
-  }
 }
 
 .card_column {


### PR DESCRIPTION
## overview

Minor robot settings page cleanup

## changelog

- Fix incorrect button sizing in `Card`s
- Fix robot list highlighting broken by #1074 
    - Missing `withRouter`... my bad (again)

## review requests

Standard review. Ensure the robot list highlights properly when you click robots and that the buttons in `Card`s are uniform (and the refresh buttons are square).

This will mess-up the currently commented out pipette card, but I have fixes for that in an upcoming PR.
