### PR TITLE
restyle StepCreationButton; break out into component from container

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.css
+++ b/protocol-designer/src/components/StepCreationButton.css
@@ -1,0 +1,10 @@
+.step_creation_button {
+  position: relative;
+  padding: 0 2rem;
+}
+
+.buttons_popover {
+  position: absolute;
+  left: 2rem;
+  right: 2rem;
+}

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -1,0 +1,57 @@
+// @flow
+import * as React from 'react'
+import styles from './StepCreationButton.css'
+
+import {PrimaryButton} from '@opentrons/components'
+import {stepIconsByType} from '../steplist/types'
+import type {StepType} from '../steplist/types'
+
+type StepCreationButtonProps = {
+  onStepClick?: StepType => (event?: SyntheticEvent<*>) => mixed,
+  onExpandClick?: (event?: SyntheticEvent<*>) => mixed,
+  onClickAway?: (event?: MouseEvent | SyntheticEvent<*>) => mixed, // TODO is there away around this 2-event union?
+  expanded?: boolean
+}
+
+class StepCreationButton extends React.Component<StepCreationButtonProps> {
+  ref: ?HTMLDivElement
+  handleAllClicks = (e: MouseEvent) => {
+    // TODO Ian 2018-03-23 this isn't working correctly now,
+    // but should onMouseLeave take care of this behavior instead, anyway?
+    if (this.ref && (e.currentTarget instanceof HTMLElement) && !this.ref.contains(e.currentTarget)) {
+      this.props.expanded && this.props.onClickAway && this.props.onClickAway(e)
+    }
+  }
+
+  componentDidMount () {
+    document.addEventListener('click', this.handleAllClicks, true)
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('click', this.handleAllClicks, true)
+  }
+
+  render () {
+    const {expanded, onExpandClick, onStepClick, onClickAway} = this.props
+    const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause']
+
+    return (
+      <div className={styles.step_creation_button} ref={ref => { this.ref = ref }} onMouseLeave={onClickAway}>
+        <PrimaryButton onClick={expanded ? onClickAway : onExpandClick}>+ Add Step</PrimaryButton>
+        <div className={styles.buttons_popover}>
+          {expanded && supportedSteps.map(stepType =>
+            <PrimaryButton
+              key={stepType}
+              onClick={onStepClick && onStepClick(stepType)}
+              iconName={stepIconsByType[stepType]}
+            >
+              {stepType}
+            </PrimaryButton>
+          )}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default StepCreationButton

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -81,12 +81,13 @@ export default function StepList (props: StepListProps) {
           {generateSubstepItems(step.substeps)}
         </StepItem>
       ))}
+
+      <StepCreationButton />
       <TitledList title='END' iconName='check'
         onClick={props.handleStepItemClickById && props.handleStepItemClickById(END_STEP)}
         onMouseEnter={props.handleStepHoverById && props.handleStepHoverById(END_STEP)}
         selected={props.selectedStepId === END_STEP}
       />
-      <StepCreationButton />
     </SidePanel>
   )
 }

--- a/protocol-designer/src/containers/StepCreationButton.js
+++ b/protocol-designer/src/containers/StepCreationButton.js
@@ -1,67 +1,30 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
+import StepCreationButton from '../components/StepCreationButton'
 
-import {PrimaryButton} from '@opentrons/components'
 import {addStep, expandAddStepButton} from '../steplist/actions'
 import {selectors} from '../steplist/reducers'
-import {stepIconsByType} from '../steplist/types'
 import type {StepType} from '../steplist/types'
 import type {BaseState, ThunkDispatch} from '../types'
 
-type StepCreationButtonProps = {
-  onStepClick?: StepType => (event?: SyntheticEvent<*>) => void,
-  onExpandClick?: (event?: SyntheticEvent<*>) => void,
-  onClickAway?: (event?: MouseEvent | SyntheticEvent<*>) => void, // TODO is there away around this 2-event union?
-  expanded?: boolean
+type Props = React.ElementProps<typeof StepCreationButton>
+
+type StateProps = {
+  expanded: $PropertyType<Props, 'expanded'>
 }
 
-class StepCreationButton extends React.Component<StepCreationButtonProps> {
-  ref: ?HTMLDivElement
-  handleAllClicks = (e: MouseEvent) => {
-    if (this.ref && (e.currentTarget instanceof HTMLElement) && !this.ref.contains(e.currentTarget)) {
-      this.props.expanded && this.props.onClickAway && this.props.onClickAway(e)
-    }
-  }
+type DispatchProps = $Diff<Props, StateProps>
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleAllClicks, true)
-  }
-
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleAllClicks, true)
-  }
-
-  render () {
-    const {expanded, onExpandClick, onStepClick, onClickAway} = this.props
-    const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause']
-
-    return (
-      <div ref={ref => { this.ref = ref }}>
-        <PrimaryButton onClick={expanded ? onClickAway : onExpandClick}>+ Add Step</PrimaryButton>
-        {expanded && supportedSteps.map(stepType =>
-          <PrimaryButton
-            key={stepType}
-            onClick={onStepClick && onStepClick(stepType)}
-            iconName={stepIconsByType[stepType]}
-          >
-            {stepType}
-          </PrimaryButton>
-        )}
-      </div>
-    )
-  }
-}
-
-function mapStateToProps (state: BaseState) {
+function mapStateToProps (state: BaseState): StateProps {
   return ({
     expanded: selectors.stepCreationButtonExpanded(state)
   })
 }
 
-function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DispatchProps {
   return {
-    onStepClick: stepType => () => dispatch(addStep({stepType})),
+    onStepClick: (stepType: StepType) => () => dispatch(addStep({stepType})),
     onExpandClick: () => dispatch(expandAddStepButton(true)),
     onClickAway: () => dispatch(expandAddStepButton(false))
   }


### PR DESCRIPTION
## overview

Closes #963 (which was mostly closed by #1075) by restyling the "ADD STEP" button to have it appear above the END step, and popover the END step when expanded.

![2018-03-23--add-step-restyle](https://user-images.githubusercontent.com/11590381/37839149-1f5228f4-2e90-11e8-8102-5916f8b2f068.gif)

## changelog

* "Add Step" is less wide, to match design
* "Add Step" lays over END step when expanded
* `onMouseLeave` collapses "Add Step" (click elsewhere behavior is broken, is probably not necessary?)
* Factor out StepCreationButton container to separate component, add css, properly type mapStateToProps + mapDispatchToProps

## review requests

Nothing special, try it out

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_add-step-popover-style/index.html