### PR TITLE
Pd hover to see labware and wells

### DIFF
--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -145,7 +145,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
   const canAddIngreds = hasName && !nonFillableContainers.includes(containerType)
 
   return (
-    <LabwareContainer {...{height, width, slot}} highlighted={deckSetupMode && highlighted}>
+    <LabwareContainer {...{height, width, slot}} highlighted={highlighted}>
       {/* The actual deck slot container: rendering of container, or rendering of empty slot */}
       {slotIsOccupied
         ? <SlotWithContainer {...{containerType, containerName, containerId}} />

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -36,3 +36,15 @@ export const getMaxVolumes = (containerType: string): WellVolumes => {
   console.warn(`Container type ${containerType} not in default-containers.json, max vol defaults to 30000`)
   return {default: 300}
 }
+
+/** All wells for labware, in arbitrary order. */
+export function getAllWellsForLabware (labwareType: string): Array<string> {
+  const cont: VolumeJson = defaultContainers.containers[labwareType]
+  if (!cont) {
+    console.error(`getAllWellsForLabware: invalid labware type "${labwareType}"`)
+    return []
+  }
+  return Object.keys(cont.locations)
+}
+
+export const FIXED_TRASH_ID: 'trashId' = 'trashId'

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -45,19 +45,27 @@ type DispatchProps = {
 type StateProps = $Diff<Props, DispatchProps>
 
 function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
+  const {slot} = ownProps
   const container = selectors.containersBySlot(state)[ownProps.slot]
   const containerInfo = (container)
     ? { containerType: container.type, containerId: container.containerId, containerName: container.name }
     : {}
+
+  const deckSetupMode = steplistSelectors.deckSetupMode(state)
   return {
     ...containerInfo,
-    slot: ownProps.slot,
+    slot,
     canAdd: selectors.canAdd(state),
     activeModals: selectors.activeModals(state),
     labwareToCopy: selectors.labwareToCopy(state),
-    highlighted: selectors.selectedContainerSlot(state) === ownProps.slot ||
-      selectors.canAdd(state) === ownProps.slot,
-    deckSetupMode: steplistSelectors.deckSetupMode(state)
+    highlighted: (deckSetupMode)
+      // in deckSetupMode, labware is highlighted when selected (currently editing ingredients)
+      // or when targeted by an open "Add Labware" modal
+      ? (selectors.selectedContainerSlot(state) === slot ||
+      selectors.canAdd(state) === slot)
+      // outside of deckSetupMode, labware is highlighted when step/substep is hovered
+      : steplistSelectors.hoveredStepLabware(state).includes(container && container.containerId),
+    deckSetupMode
   }
 }
 

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -55,7 +55,6 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
 
   return {
     containerId,
-    // wellContents: selectors.wellContentsAllLabware(state)[containerId], // TODO Ian 2018-03-19 don't need this selector anymore? Remove
     wellContents,
     containerType: labware.type,
     selectable: ownProps.selectable

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -47,9 +47,11 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     prevStepId = Math.max(stepId - 1, 0)
   }
 
-  const wellContents = allWellContentsForSteps[prevStepId]
-    ? allWellContentsForSteps[prevStepId][containerId]
-    : {}
+  const wellContents = (steplistSelectors.deckSetupMode(state))
+    // selection for deck setup
+    ? selectors.wellContentsAllLabware(state)[containerId]
+    // well contents for step, not deck setup mode
+    : allWellContentsForSteps[prevStepId] ? allWellContentsForSteps[prevStepId][containerId] : {}
 
   return {
     containerId,

--- a/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
+++ b/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
@@ -5,7 +5,7 @@ import {getLabwareLiquidState} from '../selectors'
 // you should export fixures for each labwareState & ingredLocs
 // then import here instead of copy-paste
 const labwareState = {
-  'default-trash': {
+  'FIXED_TRASH_ID': {
     type: 'trash-box',
     name: 'Trash',
     slot: '12'
@@ -87,7 +87,7 @@ describe('getLabwareLiquidState', () => {
           '1': {volume: 222}
         }
       },
-      'default-trash': {}
+      'FIXED_TRASH_ID': {}
     })
   })
 })

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -244,27 +244,31 @@ function _getSelectedWellsForStep (
 
   const getWells = (wells: Array<string>) => _wellsForPipette(pipetteChannels, labwareType, wells)
 
+  let wells = []
+
+  // If we're moving liquids within a single labware,
+  // both the source and dest wells together need to be selected.
   if (form.stepType === 'transfer') {
     if (form.sourceLabware === labwareId) {
-      return getWells(form.sourceWells)
+      wells.push(...getWells(form.sourceWells))
     }
     if (form.destLabware === labwareId) {
-      return getWells(form.destWells)
+      wells.push(...getWells(form.destWells))
     }
   }
   if (form.stepType === 'consolidate') {
     if (form.sourceLabware === labwareId) {
-      return getWells(form.sourceWells)
+      wells.push(...getWells(form.sourceWells))
     }
     if (form.destLabware === labwareId) {
-      return getWells([form.destWell])
+      wells.push(...getWells([form.destWell]))
     }
   }
   // TODO Ian 2018-03-23 once distribute is supported
   // if (form.stepType === 'distribute') {
   //   ...
   // }
-  return []
+  return wells
 }
 
 export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWellContents}>> = createSelector(

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -19,7 +19,7 @@ const baseIngredFields2 = {
 }
 
 const containerState = {
-  'default-trash': {
+  'FIXED_TRASH_ID': {
     type: 'trash-box',
     name: 'Trash',
     slot: '12'
@@ -123,7 +123,7 @@ const ingredsByLabwareXXSingleIngred = {
   },
   'container2Id': {},
   'container3Id': {},
-  'default-trash': {}
+  'FIXED_TRASH_ID': {}
 }
 
 const ingredsByLabwareXXTwoIngred = {
@@ -159,7 +159,7 @@ const ingredsByLabwareXXTwoIngred = {
       }
     }
   },
-  'default-trash': {}
+  'FIXED_TRASH_ID': {}
 }
 
 const defaultWellContents = {
@@ -251,7 +251,7 @@ describe('wellContentsAllLabware', () => {
     expect(
       singleIngredResult
     ).toMatchObject({
-      'default-trash': {
+      'FIXED_TRASH_ID': {
         A1: defaultWellContents
       },
       container2Id: {

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -143,7 +143,7 @@ export const copyLabware = (slot: DeckSlot) => (dispatch: Dispatch<CopyLabware>,
       fromContainer,
       toContainer: uuid() + ':' + fromContainer.split(':')[1],
       // 'toContainer' is the containerId of the new clone.
-      // So you get 'uuid:containerType', or 'uuid:undefined' if you're cloning 'default-trash'.
+      // So you get 'uuid:containerType', or 'uuid:undefined' if you're cloning 'FIXED_TRASH_ID'.
       toSlot: slot
     }
   })

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -9,7 +9,7 @@ import pick from 'lodash/pick'
 import pickBy from 'lodash/pickBy'
 import reduce from 'lodash/reduce'
 
-import {getMaxVolumes, defaultContainers, sortedSlotnames} from '../../constants.js'
+import {getMaxVolumes, defaultContainers, sortedSlotnames, FIXED_TRASH_ID} from '../../constants.js'
 import {uuid} from '../../utils.js'
 
 import type {DeckSlot} from '@opentrons/components'
@@ -85,9 +85,9 @@ type ContainersState = {
 }
 
 const initialLabwareState = {
-  'default-trash': {
-    id: 'default-trash',
-    type: 'trash-box',
+  [FIXED_TRASH_ID]: {
+    id: FIXED_TRASH_ID,
+    type: 'trash-box', // TODO Ian 2018-03-23 Change to 'fixed-trash' using new defs
     name: 'Trash',
     slot: '12'
   }

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -1,6 +1,7 @@
 // @flow
 import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
+import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, repeatArray, touchTip, reduceCommandCreators} from './'
 import type {ConsolidateFormData, RobotState, CommandCreator} from './'
 
@@ -75,7 +76,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         ? [
           blowout({
             pipette: data.pipette,
-            labware: 'trashId', // TODO trash ID should be a constant
+            labware: FIXED_TRASH_ID,
             well: 'A1'
           })
         ]

--- a/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
+++ b/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
@@ -54,7 +54,7 @@ export default function updateLiquidState (
       ...acc,
       [wellForTip]: mergeLiquid(
         splitLiquidStates[`${tipIdx}`].dest,
-        prevLiquidState.labware[labwareId][wellForTip]
+        prevLiquidState.labware[labwareId][wellForTip] || {} // TODO Ian 2018-04-02 use robotState selector. (Liquid state falls back to {} for empty well)
       )
     }
   }, {})

--- a/protocol-designer/src/step-generation/dropTip.js
+++ b/protocol-designer/src/step-generation/dropTip.js
@@ -1,5 +1,6 @@
 // @flow
 import type {CommandCreator, RobotState} from './'
+import {FIXED_TRASH_ID} from '../constants'
 import cloneDeep from 'lodash/cloneDeep'
 import updateLiquidState from './dispenseUpdateLiquidState'
 
@@ -12,8 +13,6 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
     }
   }
 
-  const trashId = 'trashId'
-
   const nextRobotState: RobotState = cloneDeep(prevRobotState)
 
   nextRobotState.tipState.pipettes[pipetteId] = false
@@ -22,7 +21,7 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
     {
       command: 'drop-tip',
       pipette: pipetteId,
-      labware: trashId, // TODO Ian 2018-02-09 will we always have this trash in robotState? If so, put the ID in constants (or cooked into RobotState type itself).
+      labware: FIXED_TRASH_ID,
       well: 'A1' // TODO: Is 'A1' of the trash always the right place to drop tips?
     }
   ]
@@ -34,7 +33,7 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
       liquidState: updateLiquidState({
         pipetteId: pipetteId,
         pipetteData: prevRobotState.instruments[pipetteId],
-        labwareId: trashId,
+        labwareId: FIXED_TRASH_ID,
         labwareType: 'fixed-trash',
         volume: prevRobotState.instruments[pipetteId].maxVolume, // update liquid state as if it was a dispense, but with max volume of pipette
         well: 'A1'

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -416,6 +416,7 @@ export const selectors = {
   orderedSteps: orderedStepsSelector,
   selectedStep: selectedStepSelector,
   selectedStepId, // TODO replace with selectedStep: selectedStepSelector
+  hoveredStepId,
   hoveredOrSelectedStepId,
   selectedStepFormData: createSelector(
     getSavedForms,

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -373,10 +373,37 @@ const selectedStepSelector = createSelector(
 
 const deckSetupMode = createSelector(
   getSteps,
-  selectedStepId,
+  hoveredOrSelectedStepId,
   (steps, selectedStepId) => (selectedStepId !== null && selectedStepId !== '__end__' && steps[selectedStepId])
     ? steps[selectedStepId].stepType === 'deck-setup'
     : false
+)
+
+/** Array of labware (labwareId's) involved in hovered Step, or [] */
+const hoveredStepLabware: Selector<Array<string>> = createSelector(
+  validatedForms,
+  hoveredStepId,
+  (_forms, _hoveredStep) => {
+    const blank = []
+    if (typeof _hoveredStep !== 'number' || !_forms[_hoveredStep]) {
+      return blank
+    }
+
+    const stepForm = _forms[_hoveredStep].validatedForm
+
+    if (
+      !stepForm ||
+      stepForm === null ||
+      stepForm.stepType === 'pause' // no labware involved
+    ) {
+      return blank
+    }
+
+    const src = stepForm.sourceLabware
+    const dest = stepForm.destLabware
+
+    return [src, dest]
+  }
 )
 
 export const selectors = {
@@ -446,7 +473,8 @@ export const selectors = {
     rootSelector,
     s => s.formSectionCollapse
   ),
-  deckSetupMode
+  deckSetupMode,
+  hoveredStepLabware
 }
 
 export default rootReducer


### PR DESCRIPTION
Closes #1083 

## overview

Highlighting over a step will show labware & wells involved in that step, and still shows the liquid state at the beginning of that step.

This supports consolidate right now. Once transfer command is built, there is groundwork for that too.

Example: consolidating from deep well to 96 flat:
![2018-03-23 17-11 pd highlight labware wells](https://user-images.githubusercontent.com/11590381/37853624-dede9c34-2ebd-11e8-88f1-a8fc7979210e.gif)


## changelog

* Stuff above
* Use constant for fixed trash ID.

## review requests

Try it out, make sure to include a tip rack and to only use consolidate. Try it with single-channel and 8-channel, make sure it works as you'd expect.