### PR TITLE
build(pd): Remove google-fonts-webpack-plugin

### DIFF
--- a/protocol-designer/index.html
+++ b/protocol-designer/index.html
@@ -4,10 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Opentrons Protocol Designer Prototype</title>
-    <link rel="stylesheet" href="./bundle.css" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
+    <link href="/bundle.css" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>
-    <script src="./bundle.js"></script>
+    <script src="/bundle.js"></script>
   </body>
 </html>

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@opentrons/components": "3.0.0-beta.1",
     "classnames": "^2.2.5",
-    "google-fonts-webpack-plugin": "^0.4.3",
     "lodash": "^4.17.4",
     "normalize.css": "^7.0.0",
     "prop-types": "^15.6.0",

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -3,7 +3,6 @@
 const path = require('path')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
-const GoogleFontsPlugin = require('google-fonts-webpack-plugin')
 
 const {rules} = require('@opentrons/webpack-config')
 
@@ -43,10 +42,6 @@ module.exports = {
       filename: 'bundle.css',
       disable: DEV,
       ignoreOrder: true
-    }),
-
-    new GoogleFontsPlugin({
-      fonts: [{ family: 'Open Sans' }]
     })
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,10 +1407,6 @@ buble@^0.18.0:
     os-homedir "^1.0.1"
     vlq "^0.2.2"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-
 buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
@@ -3991,15 +3987,6 @@ gonzales-pe@^4.0.3:
   dependencies:
     minimist "1.1.x"
 
-google-fonts-webpack-plugin@^0.4.3:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/google-fonts-webpack-plugin/-/google-fonts-webpack-plugin-0.4.4.tgz#deb897a8ba9097aa7ac78e31c532e266b3b701f9"
-  dependencies:
-    lodash "^4.17.4"
-    node-fetch "^1.6.3"
-    webpack-sources "^0.2.0"
-    yauzl "^2.8.0"
-
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -6049,7 +6036,7 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^1.0.1, node-fetch@^1.6.3:
+node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -8587,10 +8574,6 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
-
 source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
@@ -8625,7 +8608,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -9790,13 +9773,6 @@ webpack-merge@^4.1.1:
   dependencies:
     lodash "^4.17.4"
 
-webpack-sources@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.2.3.tgz#17c62bfaf13c707f9d02c479e0dcdde8380697fb"
-  dependencies:
-    source-list-map "^1.1.1"
-    source-map "~0.5.3"
-
 webpack-sources@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
@@ -10154,11 +10130,4 @@ yauzl@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
   dependencies:
-    fd-slicer "~1.0.1"
-
-yauzl@^2.8.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
-  dependencies:
-    buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"


### PR DESCRIPTION
## overview

The API that backs the google-fonts-webpack-plugin is [down as at the time of writing](https://github.com/majodev/google-webfonts-helper/issues/46) and [breaking our builds](https://travis-ci.org/Opentrons/opentrons/jobs/358204047#L1504). This PR removes the plugin from the PD build pipeline in favor of just using `fonts.google.com` to get our builds back to green.

We can reevaluate how we want to handle webfonts with PD once @IanLondon is back.

## changelog

- build(pd): Remove google-fonts-webpack-plugin 

## review requests

Please ensure `make -C protocol-designer dev` and `make -C protocol-designer build` still run on your machine, and that there's no font-based regressions between [edge's build](https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/edge/index.html#/) and [this branch's build](https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_remove-google-fonts-wp-plugin/index.html#/)