### PR TITLE
Refactor feature flags

### DIFF
--- a/api/opentrons/config/feature_flags.py
+++ b/api/opentrons/config/feature_flags.py
@@ -1,26 +1,54 @@
 import os
+import json
+
+SETTINGS_PATH = '/data/settings.json'
 
 
-def _get_feature_flag(name: str) -> bool:
-    return bool(os.environ.get(name))
+def get_feature_flag(name: str) -> bool:
+    settings = get_all_feature_flags()
+    return bool(settings.get(name))
+
+
+def get_all_feature_flags() -> dict:
+    try:
+        if os.path.exists(SETTINGS_PATH):
+            with open(SETTINGS_PATH, 'r') as fd:
+                settings = json.load(fd)
+        else:
+            settings = {}
+    except Exception as e:
+        print("Error: {}".format(e))
+        settings = {}
+    return settings
+
+
+def set_feature_flag(name: str, value):
+    if os.path.exists(SETTINGS_PATH):
+        with open(SETTINGS_PATH, 'r') as fd:
+            settings = json.load(fd)
+        settings[name] = value
+    else:
+        settings = {name: value}
+    with open(SETTINGS_PATH, 'w') as fd:
+        json.dump(settings, fd)
 
 
 # short_fixed_trash
 # - True ('55.0'): Old (55mm tall) fixed trash
 # - False:         77mm tall fixed trash
 # - EOL: when all short fixed trash containers have been replaced
-def short_fixed_trash(): return _get_feature_flag('OT2_PROBE_HEIGHT')
+def short_fixed_trash(): return get_feature_flag('short-fixed-trash')
 
 
 # split_labware_definitions
 # - True:  Use new labware definitions (See: labware_definitions.py and
 #          serializers.py)
 # - False: Use sqlite db
-def split_labware_definitions(): return _get_feature_flag('SPLIT_LABWARE_DEF')
+def split_labware_definitions(): return get_feature_flag('split-labware-def')
 
 
 # calibrate_to_bottom
 # - True:  You must calibrate your containers to bottom
 # - False: Otherwise the default
 # will be that you calibrate to the top
-def calibrate_to_bottom(): return _get_feature_flag('CALIBRATE_BOTTOM')
+def calibrate_to_bottom(): return get_feature_flag('calibrate-to-bottom')

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 
 import opentrons.util.calibration_functions as calib
 from numpy import add, subtract
-from opentrons import commands, containers, drivers, helpers
+from opentrons import commands, containers, drivers
 from opentrons.broker import subscribe
 from opentrons.containers import Container
 from opentrons.data_storage import database, old_container_loading,\
@@ -319,7 +319,7 @@ class Robot(object):
         for i in range(seconds):
             self.turn_off_button_light()
             sleep(0.25)
-            self.turn_on_blue_button_light()
+            self.turn_on_button_light()
             sleep(0.25)
 
     def setup_gantry(self):
@@ -480,15 +480,6 @@ class Robot(object):
             self.INSTRUMENT_DRIVERS_CACHE[key] = motor_obj
         return motor_obj
 
-    def flip_coordinates(self, coordinates):
-        """
-        Flips between Deck and Robot coordinate systems.
-
-        TODO: Add image explaining coordinate systems.
-        """
-        dimensions = self._driver.get_dimensions()
-        return helpers.flip_coordinates(coordinates, dimensions)
-
     def connect(self, port=None, options=None):
         """
         Connects the robot to a serial port.
@@ -510,21 +501,6 @@ class Robot(object):
         for module in self.modules:
             module.connect()
         self.fw_version = self._driver.get_fw_version()
-
-        # device = None
-        # if not port or port == drivers.VIRTUAL_SMOOTHIE_PORT:
-        #     device = drivers.get_virtual_driver(options)
-        # else:
-        #     device = drivers.get_serial_driver(port)
-        #
-        # self._driver = device
-        # self.smoothie_drivers['live'] = device
-
-        # set virtual smoothie do have same dimensions as real smoothie
-        # ot_v = device.ot_version
-        # self.smoothie_drivers['simulate'].ot_version = ot_v
-        # self.smoothie_drivers['simulate_switches'].ot_version = ot_v
-        # self.smoothie_drivers['null'].ot_version = ot_v
 
     def _update_axis_homed(self, *args):
         for a in args:
@@ -552,8 +528,8 @@ class Robot(object):
 
         Examples
         --------
-        >>> from opentrons import Robot
-        >>> robot.connect('Virtual Smoothie')
+        >>> from opentrons import robot
+        >>> robot.connect()
         >>> robot.home()
         """
 
@@ -640,7 +616,7 @@ class Robot(object):
 
         Examples
         --------
-        >>> from opentrons import Robot
+        >>> from opentrons import robot
         >>> robot.reset() # doctest: +ELLIPSIS
         <opentrons.robot.robot.Robot object at ...>
         >>> robot.connect('Virtual Smoothie')

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -109,6 +109,10 @@ def init(loop=None):
         '/robot/positions', control.position_info)
     server.app.router.add_post(
         '/robot/move', control.move)
+    server.app.router.add_get(
+        '/settings', update.get_feature_flag)
+    server.app.router.add_post(
+        '/settings/set', update.set_feature_flag)
 
     return server.app
 

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -1,19 +1,9 @@
 from unittest import mock
 from functools import partial
 from tests.opentrons.conftest import state
-
-import pytest
-
 from opentrons.util import calibration_functions
 
 state = partial(state, 'calibration')
-
-
-@pytest.fixture
-def calibrate_bottom_env(monkeypatch):
-    monkeypatch.setenv('CALIBRATE_BOTTOM', 'true')
-    yield
-    monkeypatch.delenv('CALIBRATE_BOTTOM', '')
 
 
 async def test_tip_probe(main_router, model):
@@ -176,7 +166,7 @@ async def test_move_to_top(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
-async def test_move_to_bottom(main_router, model, calibrate_bottom_env):
+async def test_move_to_bottom(main_router, model, calibrate_bottom_flag):
 
     with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
         main_router.calibration_manager.move_to(
@@ -233,7 +223,7 @@ async def test_jog_calibrate_bottom(
         user_definition_dirs,
         main_router,
         model,
-        calibrate_bottom_env):
+        calibrate_bottom_flag):
 
     # Check that the feature flag correctly implements calibrate to bottom
     from numpy import array, isclose

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from opentrons.api import models
 from opentrons.data_storage import database
 from opentrons.server import rpc
+from opentrons.config import feature_flags as ff
 
 # Uncomment to enable logging during tests
 
@@ -99,6 +100,31 @@ def dummy_db(tmpdir):
     yield None
     database.change_database(MAIN_TESTER_DB)
     os.remove(temp_db_path)
+
+
+# -------feature flag fixtures-------------
+@pytest.fixture
+def calibrate_bottom_flag(monkeypatch):
+    tmpd = tempfile.TemporaryDirectory()
+    monkeypatch.setattr(
+        ff, 'SETTINGS_PATH', os.path.join(tmpd.name, 'settings.json'))
+
+    ff.set_feature_flag('calibrate-to-bottom', 'true')
+    yield
+    monkeypatch.delenv('calibrate-to-bottom', '')
+
+
+@pytest.fixture
+def short_trash_flag(monkeypatch):
+    tmpd = tempfile.TemporaryDirectory()
+    monkeypatch.setattr(
+        ff, 'SETTINGS_PATH', os.path.join(tmpd.name, 'settings.json'))
+
+    ff.set_feature_flag('short-fixed-trash', 'true')
+    yield
+    monkeypatch.delenv('short-fixed-trash', '')
+
+# -----end feature flag fixtures-----------
 
 
 @pytest.fixture

--- a/api/tests/opentrons/robot/test_robots_config.py
+++ b/api/tests/opentrons/robot/test_robots_config.py
@@ -1,9 +1,7 @@
-def test_old_probe_height(monkeypatch):
+def test_old_probe_height(monkeypatch, short_trash_flag):
     from opentrons.robot import robot_configs
 
-    monkeypatch.setenv('OT2_PROBE_HEIGHT', '55.0')
     cfg = robot_configs.load()
-    monkeypatch.delenv('OT2_PROBE_HEIGHT')
 
     assert cfg.probe_center[2] == 55.0
     assert cfg.probe_dimensions[2] == 60.0


### PR DESCRIPTION
## overview

Refactor feature flags to use persistent data instead of environment variables because of unpredictable/undesirable behavior in Resin, and a couple of trivial fixes

## changelog

- (refactor) Make feature flags use persistent data instead of environment variables
- (chore) Remove some dead code and update comment imports in robot

## review requests

Tested on 🌔 🌔  and demo'ed to @Kadee80 