### PR TITLE
Institute Robot's Rules of Order

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -95,8 +95,10 @@ def init(loop=None):
         '/server/update_firmware', update.update_firmware)
     server.app.router.add_post(
         '/server/restart', control.restart)
-    server.app.router.add_get(
-        '/calibration/deck', dc_endp.start)
+    server.app.router.add_post(
+        '/calibration/deck/start', dc_endp.start)
+    server.app.router.add_post(
+        '/calibration/deck/release', dc_endp.release)
     server.app.router.add_post(
         '/calibration/deck', dc_endp.dispatch)
     server.app.router.add_get(

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -1,4 +1,4 @@
-
+import json
 from opentrons import robot
 from opentrons.server.main import init
 from opentrons import deck_calibration as dc
@@ -14,6 +14,7 @@ async def test_create_session(
     """
     app = init(loop)
     cli = await loop.create_task(test_client(app))
+    endpoints.session = None
 
     dummy_token = 'Test Token'
 
@@ -23,15 +24,75 @@ async def test_create_session(
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
     expected = {'token': dummy_token}
-    resp = await cli.get('/calibration/deck')
+    resp = await cli.post('/calibration/deck/start')
+    text = await resp.text()
+    assert json.loads(text) == expected
+    assert resp.status == 201
+
+
+async def test_release(
+        virtual_smoothie_env, loop, test_client):
+    """
+    Tests that the GET request to initiate a session manager for factory
+    calibration returns an error if a session is in progress, and can be
+    overridden.
+    """
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+    endpoints.session = None
+
+    resp = await cli.post('/calibration/deck/start')
+    assert resp.status == 201
+
+    resp1 = await cli.post('/calibration/deck/start')
+    assert resp1.status == 409
+
+    resp2 = await cli.post('/calibration/deck/release')
+    assert resp2.status == 200
+    assert endpoints.session is None
+
+    resp3 = await cli.post('/calibration/deck/start')
+    assert resp3.status == 201
+
+
+async def test_forcing_new_session(
+        virtual_smoothie_env, loop, test_client, monkeypatch):
+    """
+    Tests that the GET request to initiate a session manager for factory
+    calibration returns an error if a session is in progress, and can be
+    overridden.
+    """
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+    endpoints.session = None
+
+    dummy_token = 'Test Token'
+
+    def uuid_mock():
+        nonlocal dummy_token
+        dummy_token = dummy_token + '+'
+        return dummy_token
+
+    monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
+
+    resp = await cli.post('/calibration/deck/start')
     text = await resp.json()
     assert resp.status == 201
+    expected = {'token': dummy_token}
     assert text == expected
+
+    resp1 = await cli.post('/calibration/deck/start')
+    assert resp1.status == 409
+
+    resp2 = await cli.post('/calibration/deck/start', json={'force': 'true'})
+    text2 = await resp2.json()
+    assert resp2.status == 201
+    expected2 = {'token': dummy_token}
+    assert text2 == expected2
 
 
 async def test_incorrect_token(
         virtual_smoothie_env, test_client, loop, monkeypatch):
-
     """
     Test that putting in an incorrect token for a POST request does not work
     after a session was already created with a different token.
@@ -39,6 +100,7 @@ async def test_incorrect_token(
     robot.reset()
     app = init(loop)
     client = await loop.create_task(test_client(app))
+    endpoints.session = None
 
     dummy_token = 'Test Token'
 
@@ -47,7 +109,7 @@ async def test_incorrect_token(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    await client.get('/calibration/deck')
+    await client.post('/calibration/deck/start')
 
     resp = await client.post(
         '/calibration/deck',
@@ -72,6 +134,7 @@ async def test_init_pipette(
     robot.reset()
     app = init(loop)
     client = await loop.create_task(test_client(app))
+    endpoints.session = None
 
     dummy_token = 'Test Token'
 
@@ -80,7 +143,7 @@ async def test_init_pipette(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    token_res = await client.get('/calibration/deck')
+    token_res = await client.post('/calibration/deck/start')
     token_text = await token_res.json()
     token = token_text['token']
 
@@ -112,6 +175,7 @@ async def test_set_and_jog(
     """
     app = init(loop)
     client = await loop.create_task(test_client(app))
+    endpoints.session = None
 
     dummy_token = 'Test Token'
 
@@ -120,7 +184,7 @@ async def test_set_and_jog(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    token_res = await client.get('/calibration/deck')
+    token_res = await client.post('/calibration/deck/start')
     token_text = await token_res.json()
     token = token_text['token']
 


### PR DESCRIPTION
## overview

Adds protections to the deck calibration start endpoint to protect against accidentally starting a new session over top of an existing one, with flag to be able to force override. Fixes #1010 

## changelog

- (feature) Add protections to deck calibration start endpoint, with force override
- (feature) Add release endpoint for end of calibration
- (chore) Clean up some request handling syntax

## review requests

Check to make sure routes, verbs, and bodies make sense