### PR TITLE
feat(app, app-shell): App update state tracking

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -18,28 +18,23 @@ env := cross-env NODE_ENV
 noop := cd .
 
 # build and publish options
-# TODO(mc, 2018-03-27): move all this to some sort of envfile
-mainline_branches := master edge $(OT_TAG)
-feature_branch := $(filter-out $(mainline_branches),$(OT_BRANCH))
-
 dist_files := "dist/**/Opentrons-v*"
 update_files := "dist/@(alpha|beta|latest)*.@(yml|json)"
 publish_dir := dist/publish
 
-# build suffix to add to artifacts
-# if branch is master or edge -> b$(BUILD_NUMBER)
-# if branch is something else -> b$(BUILD_NUMBER)-$(BRANCH_NAME)
-# else -> dev
-branch_suffix := $(and $(feature_branch),-$(feature_branch))
-build := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
+# TODO(mc, 2018-03-27): move all this to some sort of envfile
+# build id suffix to add to artifacts
+# if no build number -> dev
+# if tagged build (branch == tag) -> b$(BUILD_NUMBER)
+# if branch exists -> b$(BUILD_NUMBER)-$(BRANCH_NAME)
+branch := $(filter-out $(OT_TAG),$(OT_BRANCH))
+branch_suffix := $(and $(branch),-$(branch))
+build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
 
 # only copy update files publish directory on tagged builds
 publish_update := $(OT_TAG)
 
-builder := $(env)=production BUILD=$(build) electron-builder \
-	--publish=never \
-	-c.publish.bucket=$(OT_BUCKET_APP) \
-	-c.publish.path=$(OT_FOLDER_APP)
+builder := $(env)=production BUILD_ID=$(build_id) electron-builder -p never
 
 # standard targets
 #####################################################################
@@ -108,4 +103,4 @@ _dist-collect-artifacts:
 
 .PHONY: dev
 dev:
-	$(env)=development PORT=$(port) electron lib/main.js
+	$(env)=development PORT=$(port) electron .

--- a/app-shell/dev-app-update.yml
+++ b/app-shell/dev-app-update.yml
@@ -1,0 +1,5 @@
+provider: s3
+bucket: opentrons-app
+path: builds
+# TODO(mc, 2018-03-28): switch to latest when we have a "latest" release
+channel: beta

--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -18,7 +18,7 @@
       "filter": ["**/*"]
     }
   ],
-  "artifactName": "${productName}-v${version}-${os}-${env.BUILD}.${ext}",
+  "artifactName": "${productName}-v${version}-${os}-${env.BUILD_ID}.${ext}",
   "asar": true,
   "dmg": {
     "backgroundColor": "white",
@@ -55,7 +55,9 @@
     "category": "Science"
   },
   "publish": {
-    "provider": "s3"
+    "provider": "s3",
+    "bucket": "${env.OT_BUCKET_APP}",
+    "path": "${env.OT_FOLDER_APP}"
   },
   "generateUpdatesFilesForAllChannels": true
 }

--- a/app-shell/lib/update.js
+++ b/app-shell/lib/update.js
@@ -1,0 +1,34 @@
+// app updater
+'use strict'
+
+const log = require('electron-log')
+const {autoUpdater} = require('electron-updater')
+const semver = require('semver')
+
+autoUpdater.logger = log
+autoUpdater.autoDownload = false
+
+module.exports = {
+  getCurrentVersion,
+  checkForUpdates
+}
+
+function getCurrentVersion () {
+  return autoUpdater.currentVersion
+}
+
+function checkForUpdates () {
+  return autoUpdater.checkForUpdates()
+    .then((result) => {
+      const {updateInfo: {version}} = result
+
+      // TODO(mc, 2018-03-28): electron-updater doesn't indicate if an
+      //   update is available through the promise result interface;
+      //   re-evaluate this custom logic
+      if (semver.gt(version, getCurrentVersion())) {
+        return version
+      }
+
+      return null
+    })
+}

--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -3,6 +3,8 @@
 
 const path = require('path')
 
+jest.mock('electron-updater', () => ({autoUpdater: {}}))
+
 const __mockRemotes = {}
 
 const __clearMock = () => {

--- a/app/__tests__/util.js
+++ b/app/__tests__/util.js
@@ -1,0 +1,13 @@
+// test utility functions
+
+export function mockResolvedValue (mock, value) {
+  mock.mockImplementation(() => new Promise((resolve) => {
+    process.nextTick(() => resolve(value))
+  }))
+}
+
+export function mockRejectedValue (mock, value) {
+  mock.mockImplementation(() => new Promise((resolve, reject) => {
+    process.nextTick(() => reject(value))
+  }))
+}

--- a/app/src/components/RobotSettings/ConnectivityCard.js
+++ b/app/src/components/RobotSettings/ConnectivityCard.js
@@ -101,7 +101,7 @@ function ConnectivityCard (props: Props) {
           onSubmit={configure}
         />
       </RefreshCard>
-      {(configError || configResponse) && (
+      {(!!configError || !!configResponse) && (
         <WifiConnectModal
           onClose={(configError
             ? clearFailedConfigure

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -1,13 +1,12 @@
 // @flow
 // robot HTTP API client
 
+import type {Error} from '../types'
 import type {RobotService} from '../robot'
 
 type Method = 'GET' | 'POST'
 
-export type ApiRequestError = {
-  name: string,
-  message: string,
+export type ApiRequestError = Error & {
   url?: string,
   status?: number,
   statusText?: string,

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -9,6 +9,9 @@ import {NAME as ROBOT_NAME, reducer as robotReducer} from './robot'
 // api state
 import {reducer as httpApiReducer} from './http-api-client'
 
+// app shell state
+import {shellReducer} from './shell'
+
 // analytics state
 import {NAME as ANALYTICS_NAME, reducer as analyticsReducer} from './analytics'
 
@@ -16,5 +19,6 @@ export default combineReducers({
   [ROBOT_NAME]: robotReducer,
   [ANALYTICS_NAME]: analyticsReducer,
   api: httpApiReducer,
+  shell: shellReducer,
   router: routerReducer
 })

--- a/app/src/shell/__tests__/shell.test.js
+++ b/app/src/shell/__tests__/shell.test.js
@@ -1,0 +1,155 @@
+// tests for the shell module
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import electron from 'electron'
+
+import {mockResolvedValue, mockRejectedValue} from '../../../__tests__/util'
+
+import {checkForShellUpdates, shellReducer, getShellUpdate} from '..'
+
+jest.mock('electron')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+const mockUpdate = electron.__mockRemotes['./update']
+
+describe('app shell module', () => {
+  let state
+
+  beforeEach(() => {
+    electron.__clearMock()
+
+    state = {
+      shell: {
+        update: {
+          inProgress: false,
+          available: null,
+          error: null
+        }
+      }
+    }
+  })
+
+  describe('checkForShellUpdates action creator', () => {
+    test('handles successful check with update available', () => {
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'shell:START_UPDATE_CHECK'},
+        {
+          type: 'shell:FINISH_UPDATE_CHECK',
+          payload: {available: '42.0.0', error: null}
+        }
+      ]
+
+      mockResolvedValue(mockUpdate.checkForUpdates, '42.0.0')
+
+      return store.dispatch(checkForShellUpdates())
+        .then(() => {
+          expect(mockUpdate.checkForUpdates).toHaveBeenCalled()
+          expect(store.getActions()).toEqual(expectedActions)
+        })
+    })
+
+    test('handles successful check with no update', () => {
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'shell:START_UPDATE_CHECK'},
+        {
+          type: 'shell:FINISH_UPDATE_CHECK',
+          payload: {available: null, error: null}
+        }
+      ]
+
+      mockResolvedValue(mockUpdate.checkForUpdates, null)
+
+      return store.dispatch(checkForShellUpdates())
+        .then(() => {
+          expect(mockUpdate.checkForUpdates).toHaveBeenCalled()
+          expect(store.getActions()).toEqual(expectedActions)
+        })
+    })
+
+    test('handles check error', () => {
+      const store = mockStore({})
+      const expectedActions = [
+        {type: 'shell:START_UPDATE_CHECK'},
+        {
+          type: 'shell:FINISH_UPDATE_CHECK',
+          payload: {error: new Error('AH')}
+        }
+      ]
+
+      mockRejectedValue(mockUpdate.checkForUpdates, new Error('AH'))
+
+      return store.dispatch(checkForShellUpdates())
+        .then(() => {
+          expect(mockUpdate.checkForUpdates).toHaveBeenCalled()
+          expect(store.getActions()).toEqual(expectedActions)
+        })
+    })
+  })
+
+  describe('reducer', () => {
+    beforeEach(() => {
+      state = state.shell
+    })
+
+    test('initial state', () => {
+      expect(shellReducer(null, {})).toEqual(state)
+    })
+
+    test('handles START_UPDATE_CHECK', () => {
+      const action = {type: 'shell:START_UPDATE_CHECK'}
+
+      expect(shellReducer(state, action)).toEqual({
+        update: {
+          inProgress: true,
+          available: null,
+          error: null
+        }
+      })
+    })
+
+    test('handles FINISH_UPDATE_CHECK success', () => {
+      state.update.inProgress = true
+      state.update.error = new Error('some stale error')
+
+      const action = {
+        type: 'shell:FINISH_UPDATE_CHECK',
+        payload: {available: '42.0.0', error: null}
+      }
+
+      expect(shellReducer(state, action)).toEqual({
+        update: {
+          inProgress: false,
+          available: '42.0.0',
+          error: null
+        }
+      })
+    })
+
+    test('handles FINISH_UPDATE_CHECK error', () => {
+      state.update.inProgress = true
+      state.update.available = '42.0.0'
+
+      const action = {
+        type: 'shell:FINISH_UPDATE_CHECK',
+        payload: {error: new Error('AH')}
+      }
+
+      expect(shellReducer(state, action)).toEqual({
+        update: {
+          inProgress: false,
+          available: '42.0.0',
+          error: new Error('AH')
+        }
+      })
+    })
+  })
+
+  describe('shell selectors', () => {
+    test('getShellUpdate selector', () => {
+      expect(getShellUpdate(state)).toBe(state.shell.update)
+    })
+  })
+})

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -1,0 +1,80 @@
+// @flow
+// desktop shell module
+import {remote} from 'electron'
+
+import type {State, Action, ThunkPromiseAction, Error} from '../types'
+
+const {checkForUpdates} = remote.require('./update')
+
+type ShellState = {
+  update: {
+    inProgress: boolean,
+    available: ?string,
+    error: ?Error,
+  },
+}
+
+const INITIAL_STATE: ShellState = {
+  update: {
+    inProgress: false,
+    available: null,
+    error: null
+  }
+}
+
+type StartUpdateCheckAction = {|
+  type: 'shell:START_UPDATE_CHECK'
+|}
+
+type FinishUpdateCheckAction = {|
+  type: 'shell:FINISH_UPDATE_CHECK',
+  payload: {|
+    available: ?string,
+    error: ?Error
+  |}
+|}
+
+export type ShellAction =
+  | StartUpdateCheckAction
+  | FinishUpdateCheckAction
+
+export function checkForShellUpdates (): ThunkPromiseAction {
+  return (dispatch) => {
+    dispatch({type: 'shell:START_UPDATE_CHECK'})
+
+    return checkForUpdates()
+      .then((available: ?string) => ({available, error: null}))
+      .catch((error: Error) => ({error}))
+      .then((payload) => dispatch({
+        type: 'shell:FINISH_UPDATE_CHECK',
+        payload
+      }))
+  }
+}
+
+export function shellReducer (
+  state: ?ShellState,
+  action: Action
+): ShellState {
+  if (!state) return INITIAL_STATE
+
+  switch (action.type) {
+    case 'shell:START_UPDATE_CHECK':
+      return {...state, update: {...state.update, inProgress: true}}
+
+    case 'shell:FINISH_UPDATE_CHECK':
+      return {
+        ...state,
+        update: {...state.update, ...action.payload, inProgress: false}}
+  }
+
+  return state
+}
+
+export function getShellUpdate (state: State) {
+  return state.shell.update
+}
+
+// DEBUG(mc, 2018-03-28): code review helpers, remove once UI is in place
+global.checkForShellUpdates = checkForShellUpdates
+global.getShellUpdate = getShellUpdate

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -9,6 +9,7 @@ import type {
 import typeof reducer from './reducer'
 import type {Action as RobotAction} from './robot'
 import type {Action as HttpApiAction} from './http-api-client'
+import type {ShellAction} from './shell'
 
 export type State = $Call<reducer>
 
@@ -17,6 +18,7 @@ export type GetState = () => State
 export type Action =
   | RobotAction
   | HttpApiAction
+  | ShellAction
 
 export type ActionType = $PropertyType<Action, 'type'>
 
@@ -43,3 +45,5 @@ type PlainDispatch = ReduxDispatch<Action>
 type ThunkDispatch = (thunk: ThunkAction) => ?Action
 
 type ThunkPromiseDispatch = (thunk: ThunkPromiseAction) => Promise<?Action>
+
+export type Error = {name: string, message: string}


### PR DESCRIPTION
## overview

This PR adds app update state tracking to the app-shell and app. It does not cover any UI. Initial state work for #810 and #811.

## changelog

- feat(app-shell): Tweak artifact name and add update module
    - Branch is now always present in the filename for non-tagged builds
    - Allows us to differentiate between a regular CI build and a release CI build
        - `Opentrons-v3.0.0-beta.2-mac-b1234.zip` vs
        - `Opentrons-v3.0.0-beta.2-mac-b1234-edge.zip`
- feat(app): Add shell module to redux with app update state 

## review requests

Standard review! Added some (temporary) global hooks for testing:

1. `make -C app dev`
2. Open the app devtools
3. Observe state in "Redux > State" tab
    - [ ] `state.shell.update` -> `{inProgress: false, available: null, error: null}`
4. In the devtools console: `> store.dispatch(checkForShellUpdates())`
    - [ ] `shell:START_UPDATE_CHECK` action is dispatched
    - [ ] `state.shell.update` -> `{inProgress: true, available: null, error: null}`
    - [ ] `shell:FINISH_UPDATE_CHECK` action is dispatched with payload `{available: null, error: null}`
    - [ ] `state.shell.update` -> `{inProgress: false, available: null, error: null}`
5. Close app
6. Modify `app-shell/package.json :: version` to be lower than `3.0.0-beta.2`
7. Repeat (4)
    - [ ] `shell:START_UPDATE_CHECK` action is dispatched
    - [ ] `state.shell.update` -> `{inProgress: true, available: null, error: null}`
    - [ ] `shell:FINISH_UPDATE_CHECK` action is dispatched with payload `{available: "3.0.0-beta.2", error: null}`
    - [ ] `state.shell.update` -> `{inProgress: false, available: "3.0.0-beta.2", error: null}`
