### PR TITLE
On last calibrated labware, drop tip and proceed to run

### DIFF
--- a/app/src/components/LabwareCalibration/InfoBox.js
+++ b/app/src/components/LabwareCalibration/InfoBox.js
@@ -66,7 +66,7 @@ function InfoBox (props: Props) {
       showButton = !labware.isMoving
       buttonText = button.isNext
         ? `Move to next ${button.type}`
-        : `Calibrate ${button.type}`
+        : `return tip and proceed to run`
     }
   }
 
@@ -128,9 +128,12 @@ function mergeProps (
       type: robotSelectors.labwareType(_buttonTarget),
       isNext: _buttonTargetIsNext,
       onClick: () => {
-        if (_calibratorMount) {
+        if (_calibratorMount && _buttonTargetIsNext) {
           dispatch(robotActions.moveTo(_calibratorMount, _buttonTarget.slot))
           dispatch(push(`/calibrate/labware/${_buttonTarget.slot}`))
+        } else if (_calibratorMount) {
+          dispatch(robotActions.returnTip(_calibratorMount))
+          dispatch(push(`/run`))
         }
       },
       text: 'foobar'

--- a/app/src/components/calibration-info.css
+++ b/app/src/components/calibration-info.css
@@ -33,7 +33,7 @@
 .info_left,
 .info_right {
   flex: 0 0 50%;
-  padding: 1rem 1.5rem;
+  padding: 1rem 1rem;
 
   & p {
     @apply --font-body-2-dark;

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -60,6 +60,13 @@ export type ConnectResponseAction = {|
   |},
 |}
 
+export type ReturnTipResponseAction = {|
+  type: 'robot:RETURN_TIP_RESPONSE',
+  payload: {|
+    error: ?{message: string}
+  |}
+|}
+
 export type ClearConnectResponseAction = {|
   type: 'robot:CLEAR_CONNECT_RESPONSE',
 |}
@@ -120,6 +127,7 @@ export type CalibrationSuccessAction = {
     | 'robot:DROP_TIP_AND_HOME_SUCCESS'
     | 'robot:CONFIRM_TIPRACK_SUCCESS'
     | 'robot:UPDATE_OFFSET_SUCCESS'
+    | 'robot:RETURN_TIP_SUCCESS'
   ),
   payload: {
     isTiprack?: boolean,
@@ -135,6 +143,7 @@ export type CalibrationFailureAction = {|
     | 'robot:DROP_TIP_AND_HOME_FAILURE'
     | 'robot:CONFIRM_TIPRACK_FAILURE'
     | 'robot:UPDATE_OFFSET_FAILURE'
+    | 'robot:RETURN_TIP_FAILURE'
   ),
   error: true,
   payload: Error
@@ -158,6 +167,9 @@ export const actionTypes = {
   MOVE_TO_FRONT_RESPONSE: makeRobotActionName('MOVE_TO_FRONT_RESPONSE'),
   PROBE_TIP: makeRobotActionName('PROBE_TIP'),
   PROBE_TIP_RESPONSE: makeRobotActionName('PROBE_TIP_RESPONSE'),
+
+  RETURN_TIP: makeRobotActionName('RETURN_TIP'),
+  RETURN_TIP_RESPONSE: makeRobotActionName('RETURN_TIP_RESPONSE'),
   TOGGLE_JOG_DISTANCE: makeRobotActionName('TOGGLE_JOG_DISTANCE'),
   CONFIRM_LABWARE: makeRobotActionName('CONFIRM_LABWARE'),
 
@@ -190,6 +202,7 @@ export type Action =
   | LabwareCalibrationAction
   | CalibrationResponseAction
   | CalibrationFailureAction
+  | ReturnTipResponseAction
 
 export const actions = {
   discover (): DiscoverAction {
@@ -373,6 +386,20 @@ export const actions = {
 
   confirmProbed (instrument: Mount): ConfirmProbedAction {
     return {type: 'robot:CONFIRM_PROBED', payload: instrument}
+  },
+
+  returnTip (instrument: Mount) {
+    return tagForRobotApi({type: actionTypes.RETURN_TIP, payload: {instrument}})
+  },
+
+  returnTipResponse (error: ?Error = null) {
+    const action: {type: string, error: boolean, payload?: Error} = {
+      type: actionTypes.RETURN_TIP_RESPONSE,
+      error: error != null
+    }
+    if (error) action.payload = error
+
+    return action
   },
 
   moveTo (mount: Mount, slot: Slot): LabwareCalibrationAction {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -43,6 +43,7 @@ export default function client (dispatch) {
       case 'robot:MOVE_TO': return moveTo(state, action)
       case 'robot:JOG': return jog(state, action)
       case 'robot:UPDATE_OFFSET': return updateOffset(state, action)
+      case actionTypes.RETURN_TIP: return returnTip(state, action)
       case actionTypes.RUN: return run(state, action)
       case actionTypes.PAUSE: return pause(state, action)
       case actionTypes.RESUME: return resume(state, action)
@@ -186,6 +187,18 @@ export default function client (dispatch) {
     remote.calibration_manager.tip_probe(instrument)
       .then(() => dispatch(actions.probeTipResponse()))
       .catch((error) => dispatch(actions.probeTipResponse(error)))
+  }
+
+  function returnTip (state, action) {
+    const {payload: {instrument: mount}} = action
+    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+
+    // FIXME(mc, 2017-10-05): DEBUG CODE
+    // return setTimeout(() => dispatch(actions.return_tipResponse()), 1000)
+
+    remote.calibration_manager.return_tip(instrument)
+    .then(() => dispatch(actions.returnTipRepsonse()))
+    .catch((error) => dispatch(actions.returnTipRepsonse(error)))
   }
 
   function moveTo (state, action) {


### PR DESCRIPTION
## overview
This PR closes #1036. After final labware is calibrated,  [calibrate] button changes to [drop tip and proceed to run]. 

<img width="800" alt="screen shot 2018-03-28 at 3 00 14 pm" src="https://user-images.githubusercontent.com/3430313/38050878-7d2b3534-329a-11e8-8955-ebe7788eaca2.png">
<img width="800" alt="screen shot 2018-03-28 at 3 00 29 pm" src="https://user-images.githubusercontent.com/3430313/38050902-893a5c88-329a-11e8-9c14-596c6422d236.png">
<img width="800" alt="screen shot 2018-03-28 at 3 00 52 pm" src="https://user-images.githubusercontent.com/3430313/38050907-8cadf460-329a-11e8-963a-7d2dc51a8338.png">

## changelog

- Add return tip actions and response actions
- Implement return tip in infobox
- Tested on son of moon moon

## review requests

Standard review, test on robot please. @btmorr and I tested together on son-of-moon-moon in person.

- [ ] Upload applicable protocol (matches robots installed pipettes)
- [ ] Calibrate All labware
- [ ] Confirm last labware button text = [drop tip and proceed to run]
- [ ] Confirm last labware button click drops the tip and proceeds to run screen
