### PR TITLE
Add save_z endpoint and revise endpoint style

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -1,5 +1,5 @@
 from opentrons import robot
-
+from opentrons.robot.robot import Robot
 
 # Application constants
 SAFE_HEIGHT = 130
@@ -11,20 +11,13 @@ dots = 'dots'
 holes = 'holes'
 
 
-def position(pipette):
+def position(axis: str):
     """
     Read position from driver into a tuple and map 3-rd value
     to the axis of a pipette currently used
     """
-    try:
-
-        p = robot._driver.position
-        res = (p['X'], p['Y'], p[pipette.upper()])
-    except KeyError:
-        # for some reason we are sometimes getting
-        # key error in dict returned from driver
-        pass
-    return res
+    p = robot._driver.position
+    return (p['X'], p['Y'], p[axis.upper()])
 
 
 def jog(axis, direction, step):
@@ -33,3 +26,11 @@ def jog(axis, direction, step):
         {axis: robot._driver.position[axis] + direction * step})
 
     return position(axis)
+
+
+def get_z(rbt: Robot) -> float:
+    return rbt.config.gantry_calibration[2][3]
+
+
+def set_z(rbt: Robot, value: float):
+    rbt.config.gantry_calibration[2][3] = value

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -1,8 +1,8 @@
 from aiohttp import web
 from uuid import uuid1
 from opentrons.instruments import pipette_config
-from opentrons import instruments
-from opentrons.deck_calibration import jog
+from opentrons import instruments, robot
+from opentrons.deck_calibration import jog, position, get_z, set_z
 import logging
 import json
 
@@ -27,95 +27,154 @@ class SessionManager:
         self.id = _get_uuid()
         self.pipettes = {}
         self.current_mount = None
-        self.router = {'jog': self.run_jog,
-                       'init pipette': self.init_pipette,
-                       'select pipette': self.set_current_mount}
 
-    async def init_pipette(self, data):
-        """
-        Initializes pipette on a mount
 
-        :param data: Information obtained from a POST request.
-        The content type is application/json.
+# -------------- Route Fns -----------------------------------------------
+# Note: endpoints should not call these functions directly, to ensure that
+# session protections are applied--should be called through the dispatch
+# endpoint
+# ------------------------------------------------------------------------
+async def init_pipette(data):
+    """
+    Initializes pipette on a mount
+
+    :param data: Information obtained from a POST request.
+    The content type is application/json.
+    The correct packet form should be as follows:
+    {
+    'token': UUID token from current session start
+    'command': 'init pipette'
+    'mount': Can be 'right' or 'left' represents pipette mounts
+    'model': Can be from the list of pipettes found in `pipette_config.configs`
+    }
+    :return: The pipette types currently mounted.
+    """
+    global session
+    assert data['mount'] in ['left', 'right']
+    assert data['model'] in pipette_config.configs.keys()
+
+    config = pipette_config.load(data['model'])
+    pipette = instruments._create_pipette_from_config(
+        mount=data['mount'], config=config)
+    session.pipettes[data['mount']] = pipette
+
+    log.info("Pipette info {}".format(session.pipettes))
+
+    res = {'pipettes': {}}
+    left = session.pipettes.get('left')
+    right = session.pipettes.get('right')
+
+    if left:
+        res['pipettes']['left'] = left.name
+    if right:
+        res['pipettes']['right'] = right.name
+    status = 200
+    return web.json_response(res, status=status)
+
+
+async def set_current_mount(params):
+    """
+    Choose the pipette in which to execute commands
+    :param params: Information obtained from a POST request.
+    The content type is application/json.
+    The correct packet form should be as follows:
+    {
+    'token': UUID token from current session start
+    'command': 'select pipette'
+    'mount': Can be 'right' or 'left' represents pipette mounts
+    }
+    :return: The selected pipette
+    """
+    global session
+    mount = params.get('mount')
+    if mount in ['left', 'right']:
+        session.current_mount = 'A' if params['mount'] is 'right' else 'Z'
+        msg = 'Mount: {}'.format(session.current_mount)
+        status = 200
+    else:
+        msg = 'Error: mount must be "left" or "right", got "{}"'.format(
+                mount)
+        status = 400
+    return web.json_response({'message': msg}, status=status)
+
+
+async def run_jog(data):
+    """
+    Allow the user to jog the selected pipette around the deck map
+    :param data: Information obtained from a POST request.
+    The content type is application/json
+    The correct packet form should be as follows:
+    {
+    'token': UUID token from current session start
+    'command': 'jog'
+    'axis': The current axis you wish to move
+    'direction': The direction you wish to move (+ or -)
+    'step': The increment you wish to move
+    }
+    :return: The position you are moving to based on axis, direction, step
+    given by the user.
+    """
+    if session.current_mount:
+        message = jog(
+            data['axis'],
+            float(data['direction']),
+            float(data['step']))
+        status = 200
+    else:
+        message = "Current mount must be set before jogging"
+        status = 400
+    return web.json_response({'message': message}, status=status)
+
+
+async def save_z(data):
+    """
+    Save the current Z height value for the calibration data
         The correct packet form should be as follows:
-        {
-        'token': UUID token from current session start
-        'command': 'init pipette'
-        'mount': Can be 'right' or 'left' represents pipette mounts
-        'model': Can be from the list of pipettes found under
-        pipette_config.configs
-        }
-        :return: The pipette types currently mounted.
-        """
-        assert data['mount'] in ['left', 'right']
-        assert data['model'] in pipette_config.configs.keys()
+    {
+    'token': UUID token from current session start
+    'command': 'save z'
+    'tip-length': a float representing how much the length of a pipette
+        increases when a tip is added
+    }
+    """
+    tip_length = data.get('tip-length')
+    if not tip_length:
+        message = "tip-length must be specified"
+        status = 400
+    else:
+        actual_z = position(session.current_mount)[-1]
+        set_z(robot, actual_z - tip_length)
+        message = "Saved z: {}".format(get_z(robot))
+        status = 200
+    return web.json_response({'message': message}, status=status)
 
-        config = pipette_config.load(data['model'])
-        pipette = instruments._create_pipette_from_config(
-            mount=data['mount'], config=config)
-        self.pipettes[data['mount']] = pipette
 
-        log.info("Pipette info {}".format(self.pipettes))
+async def release(data):
+    """
+    Release a session
+    """
+    global session
+    session = None
+    return web.json_response({"message": "calibration session released"})
 
-        res = {'pipettes': {}}
-        left = self.pipettes.get('left')
-        right = self.pipettes.get('right')
+# ---------------------- End Route Fns -------------------------
 
-        if left:
-            res['pipettes']['left'] = left.name
-        if right:
-            res['pipettes']['right'] = right.name
-
-        return web.json_response(res)
-
-    async def set_current_mount(self, params):
-        """
-        Choose the pipette in which to execute commands
-        :param params: Information obtained from a POST request.
-        The content type is application/json.
-        The correct packet form should be as follows:
-        {
-        'token': UUID token from current session start
-        'command': 'select pipette'
-        'mount': Can be 'right' or 'left' represents pipette mounts
-        }
-        :return: The selected pipette
-        """
-        assert params['mount'] in ['left', 'right']
-        self.current_mount = params['mount']
-
-        return web.json_response({'mount': self.current_mount})
-
-    async def run_jog(self, data):
-        """
-        Allow the user to jog the selected pipette around the deck map
-        :param data: Information obtained from a POST request.
-        The content type is application/json
-        The correct packet form should be as follows:
-        {
-        'token': UUID token from current session start
-        'command': 'jog'
-        'axis': The current axis you wish to move
-        'direction': The direction you wish to move (+ or -)
-        'step': The increment you wish to move
-        }
-        :return: The position you are moving to based on axis, direction, step
-        given by the user.
-        """
-        if self.current_mount:
-            res = jog(
-                data['axis'],
-                float(data['direction']),
-                float(data['step']))
-        else:
-            res = None
-        return web.json_response({'result': res})
+# Router must be defined after all route functions
+router = {'jog': run_jog,
+          'init pipette': init_pipette,
+          'select pipette': set_current_mount,
+          'save z': save_z,
+          'release': release}
 
 
 async def start(request):
     """
     Begins the session manager for factory calibration, if a session is not
-    already in progress, or if the "force" key is specified in the request.
+    already in progress, or if the "force" key is specified in the request. To
+    force, use the following body:
+    {
+      "force": true
+    }
     :return: The current session ID token or an error message
     """
     global session
@@ -123,6 +182,7 @@ async def start(request):
     try:
         body = await request.json()
     except json.decoder.JSONDecodeError:
+        # Body will be null for requests without parameters (normal operation)
         log.debug("No body in {}".format(request))
         body = {}
 
@@ -137,33 +197,38 @@ async def start(request):
     return web.json_response(data, status=status)
 
 
-async def release(request):
-    """
-    Release a session
-    """
-    global session
-    session = None
-    return web.json_response({"message": "calibration session released"})
-
-
 async def dispatch(request):
     """
     Routes commands to subhandlers based on the command field in the body.
     """
-    data = await request.post()
-    try:
-        log.info("Dispatching {}".format(data))
-        _id = data['token']
-        command = data['command']
+    if session:
+        message = ''
+        data = await request.post()
+        try:
+            log.info("Dispatching {}".format(data))
+            _id = data.get('token')
+            if not _id:
+                message = '"token" field required for calibration requests'
+                raise AssertionError
+            command = data.get('command')
+            if not command:
+                message = '"command" field required for calibration requests'
+                raise AssertionError
 
-        if _id == session.id:
-            res = await session.router[command](data)
-        else:
+            if _id == session.id:
+                res = await router[command](data)
+            else:
+                res = web.json_response(
+                    {'message': 'Invalid token: {}'.format(_id)}, status=403)
+        except AssertionError:
+            res = web.json_response({'message': message}, status=400)
+        except Exception as e:
             res = web.json_response(
-                {'error': 'Invalid token: {}'.format(_id)}, status=403)
-    except Exception as e:
+                {'message': 'Exception {} raised by dispatch of {}: {}'.format(
+                    type(e), data, e)},
+                status=500)
+    else:
         res = web.json_response(
-            {'error': 'Exception {} raised by dispatch of {}: {}'.format(
-                type(e), data, e)},
-            status=500)
+            {'message': 'Session must be started before issuing commands'},
+            status=418)
     return res

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -98,8 +98,6 @@ def init(loop=None):
     server.app.router.add_post(
         '/calibration/deck/start', dc_endp.start)
     server.app.router.add_post(
-        '/calibration/deck/release', dc_endp.release)
-    server.app.router.add_post(
         '/calibration/deck', dc_endp.dispatch)
     server.app.router.add_get(
         '/pipettes', control.get_attached_pipettes)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -16,6 +16,8 @@ from opentrons.api import models
 from opentrons.data_storage import database
 from opentrons.server import rpc
 from opentrons.config import feature_flags as ff
+from opentrons.server.main import init
+from opentrons.deck_calibration import endpoints
 
 # Uncomment to enable logging during tests
 
@@ -125,6 +127,24 @@ def short_trash_flag(monkeypatch):
     monkeypatch.delenv('short-fixed-trash', '')
 
 # -----end feature flag fixtures-----------
+
+
+@pytest.fixture
+async def async_client(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+    endpoints.session = None
+    return cli
+
+
+@pytest.fixture
+def dc_session(virtual_smoothie_env, monkeypatch):
+    """
+    Mock session manager for deck calibation
+    """
+    ses = endpoints.SessionManager()
+    monkeypatch.setattr(endpoints, 'session', ses)
+    return ses
 
 
 @pytest.fixture

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -1,21 +1,55 @@
 import json
-from opentrons import robot
-from opentrons.server.main import init
+from opentrons import robot, instruments
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
+from opentrons.instruments import pipette_config
 
 
-# Session and token tests
-async def test_create_session(
-        virtual_smoothie_env, loop, test_client, monkeypatch):
+# ------------ Function tests (unit) ----------------------
+async def test_init_pipette(dc_session):
+    robot.reset()
+    data = {
+        'mount': 'left',
+        'model': 'p10_single'}
+    await endpoints.init_pipette(data)
+    actual = dc_session.pipettes.get('left').name
+    expected = pipette_config.p10_single.name
+    assert actual == expected
+
+
+async def test_save_z(dc_session):
+    robot.reset()
+    mount = 'left'
+    pip = instruments.P10_Single(mount=mount)
+    dc_session.pipettes = {mount: pip}
+    dc_session.current_mount = 'Z'
+
+    robot.home()
+
+    tip_length = 25
+    dc_session.pipettes.get(mount)._add_tip(tip_length)
+
+    data = {
+        'tip-length': tip_length
+    }
+
+    z_target = 80.0
+    dc_session.pipettes.get(mount).move_to((robot.deck, (0, 0, z_target)))
+
+    await endpoints.save_z(data)
+
+    new_z = dc.get_z(robot)
+    pipette_z_offset = pipette_config.p10_single.model_offset[-1]
+    expected_z = z_target - pipette_z_offset
+    assert new_z == expected_z
+
+
+# ------------ Session and token tests ----------------------
+async def test_create_session(async_client, monkeypatch):
     """
     Tests that the GET request to initiate a session manager for factory
     calibration returns a good token.
     """
-    app = init(loop)
-    cli = await loop.create_task(test_client(app))
-    endpoints.session = None
-
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -24,48 +58,46 @@ async def test_create_session(
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
     expected = {'token': dummy_token}
-    resp = await cli.post('/calibration/deck/start')
+    resp = await async_client.post('/calibration/deck/start')
     text = await resp.text()
     assert json.loads(text) == expected
     assert resp.status == 201
 
 
-async def test_release(
-        virtual_smoothie_env, loop, test_client):
+async def test_release(async_client):
     """
     Tests that the GET request to initiate a session manager for factory
     calibration returns an error if a session is in progress, and can be
     overridden.
     """
-    app = init(loop)
-    cli = await loop.create_task(test_client(app))
-    endpoints.session = None
-
-    resp = await cli.post('/calibration/deck/start')
+    resp = await async_client.post('/calibration/deck/start')
     assert resp.status == 201
+    body = await resp.json()
+    token = body.get('token')
 
-    resp1 = await cli.post('/calibration/deck/start')
+    resp1 = await async_client.post('/calibration/deck/start')
     assert resp1.status == 409
 
-    resp2 = await cli.post('/calibration/deck/release')
+    # Release
+    resp2 = await async_client.post(
+        '/calibration/deck',
+        data={
+            'token': token,
+            'command': 'release'
+        })
     assert resp2.status == 200
     assert endpoints.session is None
 
-    resp3 = await cli.post('/calibration/deck/start')
+    resp3 = await async_client.post('/calibration/deck/start')
     assert resp3.status == 201
 
 
-async def test_forcing_new_session(
-        virtual_smoothie_env, loop, test_client, monkeypatch):
+async def test_forcing_new_session(async_client, monkeypatch):
     """
     Tests that the GET request to initiate a session manager for factory
     calibration returns an error if a session is in progress, and can be
     overridden.
     """
-    app = init(loop)
-    cli = await loop.create_task(test_client(app))
-    endpoints.session = None
-
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -75,33 +107,29 @@ async def test_forcing_new_session(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    resp = await cli.post('/calibration/deck/start')
+    resp = await async_client.post('/calibration/deck/start')
     text = await resp.json()
     assert resp.status == 201
     expected = {'token': dummy_token}
     assert text == expected
 
-    resp1 = await cli.post('/calibration/deck/start')
+    resp1 = await async_client.post('/calibration/deck/start')
     assert resp1.status == 409
 
-    resp2 = await cli.post('/calibration/deck/start', json={'force': 'true'})
+    resp2 = await async_client.post(
+        '/calibration/deck/start', json={'force': 'true'})
     text2 = await resp2.json()
     assert resp2.status == 201
     expected2 = {'token': dummy_token}
     assert text2 == expected2
 
 
-async def test_incorrect_token(
-        virtual_smoothie_env, test_client, loop, monkeypatch):
+async def test_incorrect_token(async_client, monkeypatch):
     """
     Test that putting in an incorrect token for a POST request does not work
     after a session was already created with a different token.
     """
     robot.reset()
-    app = init(loop)
-    client = await loop.create_task(test_client(app))
-    endpoints.session = None
-
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -109,9 +137,9 @@ async def test_incorrect_token(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    await client.post('/calibration/deck/start')
+    await async_client.post('/calibration/deck/start')
 
-    resp = await client.post(
+    resp = await async_client.post(
         '/calibration/deck',
         data={
             'token': 'FAKE TOKEN',
@@ -123,19 +151,14 @@ async def test_incorrect_token(
     assert resp.status == 403
 
 
-# Router tests
-async def test_init_pipette(
-        virtual_smoothie_env, test_client, loop, monkeypatch):
+# ------------ Router tests (integration) ----------------------
+async def test_init_pipette_integration(async_client, monkeypatch):
     """
     Test that initializing a pipette works as expected with a correctly formed
     packet/ POST request.
 
     """
     robot.reset()
-    app = init(loop)
-    client = await loop.create_task(test_client(app))
-    endpoints.session = None
-
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -143,11 +166,11 @@ async def test_init_pipette(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    token_res = await client.post('/calibration/deck/start')
+    token_res = await async_client.post('/calibration/deck/start')
     token_text = await token_res.json()
     token = token_text['token']
 
-    resp = await client.post(
+    resp = await async_client.post(
         '/calibration/deck',
         data={
             'token': token,
@@ -162,8 +185,7 @@ async def test_init_pipette(
     assert endpoints.session.pipettes.get('right') is None
 
 
-async def test_set_and_jog(
-        virtual_smoothie_env, test_client, loop, monkeypatch):
+async def test_set_and_jog_integration(async_client, monkeypatch):
     """
     Test that the select model function and jog function works.
     Note that in order for the jog function to work, the following must
@@ -173,10 +195,6 @@ async def test_set_and_jog(
     3. Select the current pipette
     Then jog requests will work as expected.
     """
-    app = init(loop)
-    client = await loop.create_task(test_client(app))
-    endpoints.session = None
-
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -184,11 +202,11 @@ async def test_set_and_jog(
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    token_res = await client.post('/calibration/deck/start')
+    token_res = await async_client.post('/calibration/deck/start')
     token_text = await token_res.json()
     token = token_text['token']
 
-    await client.post(
+    await async_client.post(
         '/calibration/deck',
         data={
             'token': token,
@@ -197,7 +215,7 @@ async def test_set_and_jog(
             'model': 'p10_single'
         })
 
-    await client.post(
+    await async_client.post(
         '/calibration/deck',
         data={
             'token': token,
@@ -211,7 +229,7 @@ async def test_set_and_jog(
 
     robot.reset()
     prior_x, prior_y, prior_z = dc.position('Z')
-    resp = await client.post(
+    resp = await async_client.post(
         '/calibration/deck',
         data={
             'token': token,
@@ -222,7 +240,6 @@ async def test_set_and_jog(
             'step': step
         })
 
-    print(resp)
     body = await resp.json()
 
-    assert body['result'] == [prior_x, prior_y, prior_z + float(step)]
+    assert body.get('message') == [prior_x, prior_y, prior_z + float(step)]


### PR DESCRIPTION
## overview

Add "save z" endpoint to factory calibration dispatcher. Fixes #950 

## changelog

- (feature) Add "save z" command to factory calibration endpoints
- (refactor) Move methods to functions and improve testing style

## review requests
