### PR TITLE
fix(pd): Revert bundle src switch from relative to absolute

### DIFF
--- a/protocol-designer/index.html
+++ b/protocol-designer/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Opentrons Protocol Designer Prototype</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
-    <link href="/bundle.css" rel="stylesheet">
+    <link href="./bundle.css" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>
-    <script src="/bundle.js"></script>
+    <script src="./bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## overview

I absentmindedly made a change to how `bundle.js` and `bundle.css` were loading in protocol designer's `index.html` from relative paths to absolute paths in #1093. This [broke](https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/edge/index.html) the `s3` deploy of protocol designer.

This PR reverts that change.

## changelog

- fix(pd): Revert bundle src switch from relative to absolute 

## review requests

Make sure the s3 deploy of protocol designer works for this branch: https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_fix-s3-deploy/index.html (after CI completes)