### PR TITLE
Go to top of well at beginning of calibration motion

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -4,7 +4,6 @@ from copy import copy
 from opentrons.util import calibration_functions
 from opentrons.broker import publish
 from opentrons import robot
-from opentrons.config import feature_flags as fflags
 
 from .models import Container
 
@@ -107,13 +106,7 @@ class CalibrationManager:
         inst = instrument._instrument
         cont = container._container
 
-        if fflags.calibrate_to_bottom():
-            if 'tiprack' in container.name:
-                target = cont[0]
-            else:
-                target = cont[0].bottom()
-        else:
-            target = cont[0]
+        target = cont[0]
 
         log.info('Moving {} to {} in {}'.format(
             instrument.name, container.name, container.slot))

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -166,19 +166,6 @@ async def test_move_to_top(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
-async def test_move_to_bottom(main_router, model, calibrate_bottom_flag):
-
-    with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
-        main_router.calibration_manager.move_to(
-            model.instrument,
-            model.container)
-
-        move_to.assert_called_with(model.container._container[0].bottom())
-
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
-
-
 async def test_jog(main_router, model):
     with mock.patch('opentrons.util.calibration_functions.jog_instrument') as jog:  # NOQA
         for distance, axis in zip((1, 2, 3), 'xyz'):
@@ -237,11 +224,13 @@ async def test_jog_calibrate_bottom(
         src=container[0],
         dst=robot.deck)
     coordinates1 = container.coordinates()
+    height = container['A1'].properties['height']
 
     main_router.calibration_manager.move_to(model.instrument, model.container)
     main_router.calibration_manager.jog(model.instrument, 1, 'x')
     main_router.calibration_manager.jog(model.instrument, 2, 'y')
     main_router.calibration_manager.jog(model.instrument, 3, 'z')
+    main_router.calibration_manager.jog(model.instrument, -height, 'z')
 
     # Todo: make tests use a tmp dir instead of a real one
     main_router.calibration_manager.update_container_offset(


### PR DESCRIPTION
## overview

Quick fix to calibrate flow to prevent crash when switching a robot to calibrate to bottom

## changelog

- (fix) calibrate to bottom move goes to top of well and then user should jog to bottom

## review requests
