### PR TITLE
Add endpoints for attach/detach tips and save xy

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -10,6 +10,12 @@ right = 'A'
 dots = 'dots'
 holes = 'holes'
 
+# Indicies into calibration matrix
+xyz_column = 3
+x_row = 0
+y_row = 1
+z_row = 2
+
 
 def position(axis: str):
     """
@@ -28,9 +34,11 @@ def jog(axis, direction, step):
     return position(axis)
 
 
-def get_z(rbt: Robot) -> float:
-    return rbt.config.gantry_calibration[2][3]
-
-
-def set_z(rbt: Robot, value: float):
-    rbt.config.gantry_calibration[2][3] = value
+def set_calibration_value(rbt: Robot, axis: str, value: float):
+    if axis is 'x':
+        row = x_row
+    elif axis is 'y':
+        row = y_row
+    else:
+        row = z_row
+    rbt.config.gantry_calibration[row][xyz_column] = value


### PR DESCRIPTION
## overview

Add endpoints for attach tip, detach tip, and save xy. Fixes #952 and fixes #1122 

## changelog

- (feature) Add "save xy" endopint
- (feature) Add "attach tip" and "detach tip" endpoints

## review requests

- Take a look at packet shape and validation and make sure it makes sense.
- Is attach/detach deck calibration specific activity, or should it be moved to the "control" endpoints like "move_to"? On one hand, the general action should probably be "pick_up_tip" from a tiprack, but on the other there are things like tip probe that also have "attach tip" separate from a tiprack