### PR TITLE
feat(app): Add pipettes module to http-api-client redux module (WIP)

### DIFF
--- a/app/src/http-api-client/__tests__/pipettes.test.js
+++ b/app/src/http-api-client/__tests__/pipettes.test.js
@@ -1,0 +1,149 @@
+// pipettes api tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {reducer, fetchPipettes, makeGetRobotPipettes} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const NAME = 'opentrons-dev'
+
+describe('pipettes', () => {
+  let robot
+  let pipettes
+  let state
+  let store
+
+  beforeEach(() => {
+    client.__clearMock()
+
+    robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
+    pipettes = {
+      left: {model: 'p300_single', mount_axis: 'z', plunger_axis: 'b'},
+      right: {model: 'p10_multi', mount_axis: 'a', plunger_axis: 'c'}
+    }
+
+    state = {api: {pipettes: {}}}
+    store = mockStore(state)
+  })
+
+  describe('action creators', () => {
+    test('fetchPipettes calls GET /pipettes', () => {
+      client.__setMockResponse(pipettes)
+
+      return store.dispatch(fetchPipettes(robot))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'GET', 'pipettes'))
+    })
+
+    test('fetchPipettes dispatches PIPETTES_REQUEST + SUCCESS', () => {
+      const expectedActions = [
+        {type: 'api:PIPETTES_REQUEST', payload: {robot}},
+        {type: 'api:PIPETTES_SUCCESS', payload: {robot, pipettes}}
+      ]
+
+      client.__setMockResponse(pipettes)
+
+      return store.dispatch(fetchPipettes(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('fetchPipettes dispatches PIPETTES_REQUEST + FAILURE', () => {
+      const error = new Error('AH')
+      const expectedActions = [
+        {type: 'api:PIPETTES_REQUEST', payload: {robot}},
+        {type: 'api:PIPETTES_FAILURE', payload: {robot, error}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(fetchPipettes(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('reducer', () => {
+    beforeEach(() => {
+      state = state.api
+    })
+
+    test('handles PIPETTE_REQUEST with new robot', () => {
+      const action = {type: 'api:PIPETTES_REQUEST', payload: {robot}}
+
+      expect(reducer(state, action).pipettes).toEqual({
+        [NAME]: {inProgress: true, error: null}
+      })
+    })
+
+    test('handles PIPETTE_REQUEST with existing robot', () => {
+      state.pipettes[NAME] = {
+        inProgress: false,
+        error: new Error('AH'),
+        response: pipettes
+      }
+
+      const action = {type: 'api:PIPETTES_REQUEST', payload: {robot}}
+
+      expect(reducer(state, action).pipettes).toEqual({
+        [NAME]: {inProgress: true, error: null, response: pipettes}
+      })
+    })
+
+    test('handles PIPETTE_SUCCESS', () => {
+      state.pipettes[NAME] = {
+        inProgress: true,
+        error: null,
+        response: null
+      }
+
+      const action = {type: 'api:PIPETTES_SUCCESS', payload: {robot, pipettes}}
+
+      expect(reducer(state, action).pipettes).toEqual({
+        [NAME]: {inProgress: false, error: null, response: pipettes}
+      })
+    })
+
+    test('handles PIPETTES_FAILURE', () => {
+      state.pipettes[NAME] = {
+        inProgress: true,
+        error: null,
+        response: pipettes
+      }
+
+      const error = new Error('AH')
+      const action = {type: 'api:PIPETTES_FAILURE', payload: {robot, error}}
+
+      expect(reducer(state, action).pipettes).toEqual({
+        [NAME]: {inProgress: false, response: pipettes, error}
+      })
+    })
+  })
+
+  describe('selectors', () => {
+    test('makeGetRobotPipettes with exiting robot', () => {
+      const getRobotPipettes = makeGetRobotPipettes()
+      const robotPipettes = {
+        inProgress: false,
+        error: null,
+        response: pipettes
+      }
+
+      state.api.pipettes[NAME] = robotPipettes
+      expect(getRobotPipettes(state, robot)).toEqual(robotPipettes)
+    })
+
+    test('makeGetRobotPipettes with non-existent robot', () => {
+      const getRobotPipettes = makeGetRobotPipettes()
+
+      expect(getRobotPipettes(state, robot)).toEqual({
+        inProgress: false,
+        error: null,
+        response: null
+      })
+    })
+  })
+})

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -3,12 +3,14 @@
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
 import {healthCheckReducer, type HealthCheckAction} from './health-check'
+import {pipettesReducer, type PipettesAction} from './pipettes'
 import {serverReducer, type ServerAction} from './server'
 import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
   health: healthReducer,
   healthCheck: healthCheckReducer,
+  pipettes: pipettesReducer,
   server: serverReducer,
   wifi: wifiReducer
 })
@@ -42,6 +44,7 @@ export type State = $Call<typeof reducer>
 export type Action =
   | HealthAction
   | HealthCheckAction
+  | PipettesAction
   | ServerAction
   | WifiAction
 
@@ -59,6 +62,11 @@ export {
   healthCheckMiddleware,
   makeGetHealthCheckOk
 } from './health-check'
+
+export {
+  fetchPipettes,
+  makeGetRobotPipettes
+} from './pipettes'
 
 export {
   updateRobotServer,

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -1,0 +1,119 @@
+// @flow
+// pipette state from api
+import {createSelector, type Selector} from 'reselect'
+
+import type {State, Action, ThunkPromiseAction} from '../types'
+import type {BaseRobot, RobotService} from '../robot'
+
+import type {ApiCall} from './types'
+import client, {type ApiRequestError} from './client'
+
+type Pipette = {
+  model: ?string,
+  mount_axis: string,
+  plunger_axis: string,
+}
+
+type PipettesResponse = {
+  right: Pipette,
+  left: Pipette,
+}
+
+export type PipettesRequestAction = {|
+  type: 'api:PIPETTES_REQUEST',
+  payload: {|
+    robot: RobotService
+  |}
+|}
+
+export type PipettesSuccessAction = {|
+  type: 'api:PIPETTES_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    pipettes: PipettesResponse,
+  |}
+|}
+
+export type PipettesFailureAction = {|
+  type: 'api:PIPETTES_FAILURE',
+  payload: {|
+    robot: RobotService,
+    error: ApiRequestError,
+  |}
+|}
+
+export type PipettesAction =
+  | PipettesRequestAction
+  | PipettesSuccessAction
+  | PipettesFailureAction
+
+export type RobotPipettes = ApiCall<void, PipettesResponse>
+
+type PipettesState = {
+  [robotName: string]: ?RobotPipettes
+}
+
+// DEBUG(mc, 2018-03-30): remove before merge
+global.fetchPipettes = fetchPipettes
+
+export function fetchPipettes (robot: RobotService): ThunkPromiseAction {
+  return (dispatch) => {
+    dispatch({type: 'api:PIPETTES_REQUEST', payload: {robot}})
+
+    return client(robot, 'GET', 'pipettes')
+      .then((pipettes) => (
+        {type: 'api:PIPETTES_SUCCESS', payload: {robot, pipettes}}
+      )).catch((error) => (
+        {type: 'api:PIPETTES_FAILURE', payload: {robot, error}}
+      )).then((action) => dispatch(action))
+  }
+}
+
+export function pipettesReducer (
+  state: ?PipettesState,
+  action: Action
+): PipettesState {
+  if (state == null) return {}
+
+  let name
+  let pipettes
+  let error
+
+  switch (action.type) {
+    case 'api:PIPETTES_REQUEST':
+      ({robot: {name}} = action.payload)
+      return {
+        ...state,
+        [name]: {...state[name], error: null, inProgress: true}
+      }
+
+    case 'api:PIPETTES_SUCCESS':
+      ({pipettes, robot: {name}} = action.payload)
+      return {
+        ...state,
+        [name]: {error: null, response: pipettes, inProgress: false}
+      }
+
+    case 'api:PIPETTES_FAILURE':
+      ({error, robot: {name}} = action.payload)
+      return {
+        ...state,
+        [name]: {...state[name], error, inProgress: false}
+      }
+  }
+
+  return state
+}
+
+export const makeGetRobotPipettes = () => {
+  const selector: Selector<State, BaseRobot, RobotPipettes> = createSelector(
+    selectRobotPipettesState,
+    (state) => state || {inProgress: false, error: null, response: null}
+  )
+
+  return selector
+}
+
+function selectRobotPipettesState (state: State, props: BaseRobot) {
+  return state.api.pipettes[props.name]
+}


### PR DESCRIPTION
## overview

This PR adds app state for API's `GET /pipettes`

## changelog

- feat(app): Add pipettes module to http-api-client redux module 

## review requests

This doesn't work on Virtual Smoothie, and the UI is still WIP, so:

1. Launch `make -C app dev`
2. Open Devtools > Console
3. Grab a robot object
    1. `> store.getState()`
    2. expand object to `robot.connection.discoveredByName`
    3. Right click on the robot you're testing with and select "Store as global variable"
    4. Note the variable name (e.g. `temp1`)
4. `> store.dispatch(fetchPipettes(temp1))`
5.  Go to "Redux" tab
    - [ ] `state.api.pipettes` is updated by `api:PIPETTES_REQUEST`
    - [ ] `state.api.pipettes` is updated by `api:PIPETTES_RESPONSE`

### virtual smoothie

@btmorr and @Laura-Danielle at the moment we get the unhelpful default aiohttp `500` response on virtual smoothie. I don't know if we want to support this endpoint on virtual smoothie (it makes front-end dev harder if we don't), but perhaps we could look into doing a simple JSON 500 middleware with the Python exception message so we get something a little more helpful.

(Don't actually know the shape of a Python `Exception`, so this is for a JS `Error`)

```json
{
    "name": "SomeError",
    "message": "some description"
}
```

vs what we get right now:

```html
<html>
    <head>
        <title>500 Internal Server Error</title>
    </head>
    <body>
        <h1>500 Internal Server Error</h1>Server got itself in trouble
    </body>
</html>
```
