### PR TITLE
feat(app): Enable pipettes card and drive it with API state

### DIFF
--- a/app/src/components/RobotSettings/AttachedInstrumentsCard.js
+++ b/app/src/components/RobotSettings/AttachedInstrumentsCard.js
@@ -1,32 +1,64 @@
-// RobotSettings card for wifi status
+// @flow
+// attached pipettes container card
 import * as React from 'react'
+import {connect} from 'react-redux'
+
+import type {State} from '../../types'
+import type {Robot} from '../../robot'
+import type {Pipette} from '../../http-api-client'
+import {makeGetRobotPipettes, fetchPipettes} from '../../http-api-client'
+
 import InstrumentInfo from './InstrumentInfo'
-import {Card} from '@opentrons/components'
+import {RefreshCard} from '@opentrons/components'
+
+type OP = Robot
+
+type SP = {
+  inProgress: boolean,
+  left: ?Pipette,
+  right: ?Pipette,
+}
+
+type DP = {
+  fetchPipettes: () => mixed
+}
+
+type Props = OP & SP & DP
 
 const TITLE = 'Pipettes'
 
-export default function AttachedInstrumentsCard (props) {
-  // TODO (ka 2018-3-14): not sure where this will be comining from in state so mocking it up for styling purposes
-  // here I am assuming they key and  mount will always exist and some sort of presence of a pipette indicator will affect InstrumentInfo
-  // delete channels and volume in either elft or right to view value and button message change
-  // apologies for the messy logic, hard to anticipate what is returned just yet
-  const attachedInstruments = {
-    left: {
-      mount: 'left',
-      channels: 8,
-      volume: 300
-    },
-    right: {
-      mount: 'right',
-      channels: 1,
-      volume: 10
-    }
-  }
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(AttachedInstrumentsCard)
 
+function AttachedInstrumentsCard (props: Props) {
   return (
-    <Card title={TITLE} >
-      <InstrumentInfo {...attachedInstruments.left}/>
-      <InstrumentInfo {...attachedInstruments.right} />
-    </Card>
+    <RefreshCard
+      title={TITLE}
+      name={props.name}
+      refresh={props.fetchPipettes}
+      refreshing={props.inProgress}
+    >
+      <InstrumentInfo mount='left' {...props.left} />
+      <InstrumentInfo mount='right' {...props.right} />
+    </RefreshCard>
   )
+}
+
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
+  const getRobotPipettes = makeGetRobotPipettes()
+
+  return (state, ownProps) => {
+    const {inProgress, response} = getRobotPipettes(state, ownProps)
+    const {left, right} = response || {left: null, right: null}
+
+    return {inProgress, left, right}
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  return {
+    fetchPipettes: () => dispatch(fetchPipettes(ownProps))
+  }
 }

--- a/app/src/components/RobotSettings/InstrumentInfo.js
+++ b/app/src/components/RobotSettings/InstrumentInfo.js
@@ -1,37 +1,58 @@
+// @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {LabeledValue, OutlineButton, InstrumentDiagram} from '@opentrons/components'
+
+import type {Mount} from '../../robot'
+
+import {
+  LabeledValue,
+  OutlineButton,
+  InstrumentDiagram
+} from '@opentrons/components'
 import styles from './styles.css'
 
-const LEFT_LABEL = 'Left pipette'
-const RIGHT_LABEL = 'Right pipette'
-export default function InstrumentInfo (props) {
-  const label = props.mount === 'left'
-    ? LEFT_LABEL
-    : RIGHT_LABEL
-  const value = props.volume
-    ? `${props.channels}-channel p${props.volume}`
-    : 'no pipette attached'
-  const buttonText = props.volume
+type Props = {
+  mount: Mount,
+  model: ?string,
+}
+
+// TODO(mc, 2018-03-30): volume and channels should come from the API
+const RE_CHANNELS = /p\d+_(single|multi)/
+
+const LABEL_BY_MOUNT = {
+  left: 'Left pipette',
+  right: 'Right pipette'
+}
+
+export default function InstrumentInfo (props: Props) {
+  const {mount, model} = props
+  const label = LABEL_BY_MOUNT[mount]
+  const channelsMatch = model && model.match(RE_CHANNELS)
+  const channels = channelsMatch && channelsMatch[1]
+  const buttonText = props.model
     ? 'change'
     : 'attach'
-  const className = cx(
-    styles.instrument_card, {
-      [styles.left]: props.mount === 'left',
-      [styles.right]: props.mount === 'right'
-    }
-  )
+
+  const className = cx(styles.instrument_card, {
+    [styles.right]: props.mount === 'right'
+  })
+
   return (
     <div className={className}>
       <LabeledValue
         label={label}
-        value={value}
+        value={(model || 'None').split('_').join(' ')}
       />
       <OutlineButton disabled>
         {buttonText}
       </OutlineButton>
       <div className={styles.image}>
-        {props.channels && (<InstrumentDiagram channels={props.channels}/>)}
+        {channels && (
+          <InstrumentDiagram
+            channels={channels === 'multi' ? 8 : 1}
+            className={styles.instrument_diagram}
+          />
+        )}
       </div>
     </div>
   )

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -5,7 +5,7 @@ import {Route} from 'react-router'
 import type {Robot} from '../../robot'
 
 import StatusCard from './StatusCard'
-// import AttachedInstrumentsCard from './AttachedInstrumentsCard'
+import AttachedInstrumentsCard from './AttachedInstrumentsCard'
 import InformationCard from './InformationCard'
 import ConnectivityCard from './ConnectivityCard'
 import CalibrationCard from './CalibrationCard'
@@ -23,9 +23,9 @@ export default function RobotSettings (props: Props) {
       <div className={styles.row}>
         <StatusCard {...props} />
       </div>
-      {/* <div className={styles.row}>
-      <AttachedInstrumentsCard {...props} />
-      </div> */}
+      <div className={styles.row}>
+        <AttachedInstrumentsCard {...props} />
+      </div>
       <div className={styles.row}>
         <InformationCard {...props} updateUrl={updateUrl} />
       </div>

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -56,6 +56,7 @@
   display: flex;
   position: relative;
   flex-direction: row;
+  align-items: center;
   justify-content: space-between;
   height: 4rem;
   padding-top: 1rem;
@@ -66,20 +67,22 @@
   }
 }
 
-.image {
-  height: 8rem;
-  width: 1.75rem;
-  position: relative;
-  top: -4rem;
-  border: 1px solid var(--c-light-gray);
-  overflow: hidden;
+.instrument_diagram {
+  height: 100%;
+  padding: 0 0 0.5rem;
+  text-align: center;
+
+  & * {
+    height: 100%;
+    width: auto;
+  }
 }
 
-.image div img {
-  width: 100%;
-  height: auto;
-  position: absolute;
-  top: -40%;
+.image {
+  height: 8rem;
+  width: 2.25rem;
+  margin-top: -3rem;
+  border: 1px solid var(--c-light-gray);
 }
 
 .right {

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -26,6 +26,11 @@ export type {
 } from './health'
 
 export type {
+  Pipette,
+  RobotPipettes
+} from './pipettes'
+
+export type {
   RobotServerUpdate,
   RobotServerRestart
 } from './server'

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -8,7 +8,8 @@ import type {BaseRobot, RobotService} from '../robot'
 import type {ApiCall} from './types'
 import client, {type ApiRequestError} from './client'
 
-type Pipette = {
+// TODO(mc, 2018-03-30): mount, volume, and channels should come from the API
+export type Pipette = {
   model: ?string,
   mount_axis: string,
   plunger_axis: string,


### PR DESCRIPTION
## overview

This PR contains the UI implementation of #862

## changelog

- feat(app): Enable pipettes card and drive it with API state 

## review requests

See #862 for test plan. Stuff to note:

- ~The `/pipettes` API **does not work with virtual smoothie**~
    - Fixed by #1134 
- The screens list an example pipette as (e.g.) "*-channel P300"
    - At the moment all we get back from the API is a model id, e.g. "p300_multi"
    - i.e. we don't get number of channels nor volume
    - Rather than parsing it out the model string, I decided just to display it with the `_` replaced with a space, e.g. "p300 multi"