### PR TITLE
chore(app,app-shell): Use consitent app title

### DIFF
--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -1,5 +1,4 @@
 {
-  "productName": "Opentrons",
   "appId": "com.opentrons.app",
   "electronVersion": "1.8.3",
   "files": [

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opentrons/app-shell",
+  "productName": "Opentrons",
   "version": "3.0.0-beta.3",
   "description": "Opentrons desktop application",
   "main": "lib/main.js",

--- a/app/package.json
+++ b/app/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@opentrons/app-shell": "3.0.0-beta.3",
     "@opentrons/webpack-config": "3.0.0-beta.3",
     "babel-core": "^6.25.0",
     "babel-jest": "^20.0.3",

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -10,6 +10,8 @@ const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer')
 
 const {rules: namedRules} = require('@opentrons/webpack-config')
 const devServerConfig = require('./webpack/dev-server')
+
+const {productName} = require('@opentrons/app-shell/package.json')
 const {description, author} = require('./package.json')
 const gtmConfig = require('./src/analytics/gtm-config')
 
@@ -56,7 +58,7 @@ const plugins = [
   }),
 
   new HtmlWebpackPlugin({
-    title: 'OT App',
+    title: productName,
     template: './src/index.hbs',
     description,
     author,


### PR DESCRIPTION
## overview

Little chore PR to make sure the app uses a consistent title throughout the browser title and Electron menus.

## changelog

- chore(app,app-shell): Use consitent app title 

## review requests

Launch the app, make sure the app title + the name in File, etc. menus is "Opentrons" rather than "OT App", "@opentrons/app-shell", or anything else weird like that
