### PR TITLE
Connectivity: Move Refresh and Spinner to Top

### DIFF
--- a/app/src/components/ConnectPanel/connect-panel.css
+++ b/app/src/components/ConnectPanel/connect-panel.css
@@ -7,6 +7,8 @@
 
 .robot_item {
   text-transform: uppercase;
+  margin-bottom: 0.25rem;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
 }
 
 .robot_item_icon {
@@ -59,7 +61,7 @@
 }
 
 .scan_progress {
-  width: 5rem;
+  width: 1.9rem;
 }
 
 .scan_button {

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -33,13 +33,13 @@ function ConnectPanel (props: Props) {
   return (
     <SidePanel title='Robots'>
       <div>
+        <ScanStatus {...props} />
         <RobotList>
           {props.robots.map((robot) => (
             // $FlowFixMe: flow-typed withRouter def throwing bogus errors
             <RobotItem key={robot.name} {...robot} />
           ))}
         </RobotList>
-        <ScanStatus {...props} />
       </div>
     </SidePanel>
   )


### PR DESCRIPTION
## overview

This PR closes #1024. Moves refresh button/spinner on connect panel above the robot list. It also adds some spacing between robot items and the slight box shadow to match design screens.

<img width="800" alt="screen shot 2018-04-02 at 3 23 21 pm" src="https://user-images.githubusercontent.com/3430313/38211907-f2e1f4d2-3689-11e8-883b-86ca86964e13.png">
<img width="800" alt="screen shot 2018-04-02 at 3 23 49 pm" src="https://user-images.githubusercontent.com/3430313/38211908-f2efa276-3689-11e8-9bcc-b1988b10fa1c.png">


## changelog

- shrink spinner size
- move spinner/button before robot list
- add spacing between robot items (addresses design comment)

## review requests
Standard Review.