### PR TITLE
Add change/attach pipette warning modal

### DIFF
--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+import type {Robot, Mount} from '../../robot'
+import {AlertModal} from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = {
+  robot: Robot,
+  mount: Mount,
+  backUrl: string
+}
+
+const HEADING = 'Before continuing, remove from deck:'
+
+export default function ChangePipette (props: Props) {
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {children: 'cancel', Component: Link, to: props.backUrl},
+        {children: 'move pipette to front', disabled: true, className: styles.alert_button}
+      ]}
+    >
+      <ul className={styles.alert_list}>
+        <li>All tipracks</li>
+        <li>All labware</li>
+      </ul>
+    </AlertModal>
+  )
+}

--- a/app/src/components/ChangePipette/styles.css
+++ b/app/src/components/ChangePipette/styles.css
@@ -1,0 +1,16 @@
+@import '@opentrons/components';
+
+.alert_list {
+  list-style-type: none;
+  padding-left: 3rem;
+  margin-top: 1rem;
+
+  & > li {
+    line-height: 2;
+  }
+}
+
+.alert_button {
+  width: auto;
+  padding: initial 1.5rem;
+}

--- a/app/src/components/RobotSettings/AttachedInstrumentsCard.js
+++ b/app/src/components/RobotSettings/AttachedInstrumentsCard.js
@@ -40,8 +40,8 @@ function AttachedInstrumentsCard (props: Props) {
       refresh={props.fetchPipettes}
       refreshing={props.inProgress}
     >
-      <InstrumentInfo mount='left' {...props.left} />
-      <InstrumentInfo mount='right' {...props.right} />
+      <InstrumentInfo mount='left' name={props.name} {...props.left} />
+      <InstrumentInfo mount='right' name={props.name} {...props.right} />
     </RefreshCard>
   )
 }

--- a/app/src/components/RobotSettings/InstrumentInfo.js
+++ b/app/src/components/RobotSettings/InstrumentInfo.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import {Link} from 'react-router-dom'
 import cx from 'classnames'
 
 import type {Mount} from '../../robot'
@@ -14,6 +15,7 @@ import styles from './styles.css'
 type Props = {
   mount: Mount,
   model: ?string,
+  name: string
 }
 
 // TODO(mc, 2018-03-30): volume and channels should come from the API
@@ -25,13 +27,14 @@ const LABEL_BY_MOUNT = {
 }
 
 export default function InstrumentInfo (props: Props) {
-  const {mount, model} = props
+  const {mount, model, name} = props
   const label = LABEL_BY_MOUNT[mount]
   const channelsMatch = model && model.match(RE_CHANNELS)
   const channels = channelsMatch && channelsMatch[1]
   const buttonText = props.model
     ? 'change'
     : 'attach'
+  const url = `/robots/${name}/pipettes/${mount}`
 
   const className = cx(styles.instrument_card, {
     [styles.right]: props.mount === 'right'
@@ -43,7 +46,7 @@ export default function InstrumentInfo (props: Props) {
         label={label}
         value={(model || 'None').split('_').join(' ')}
       />
-      <OutlineButton disabled>
+      <OutlineButton Component={Link} to={url}>
         {buttonText}
       </OutlineButton>
       <div className={styles.image}>

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -94,7 +94,7 @@
     order: 1;
   }
 
-  & > button {
+  & > a {
     order: 3;
   }
 }

--- a/app/src/pages/Robots.js
+++ b/app/src/pages/Robots.js
@@ -2,7 +2,7 @@
 // connect and configure robots page
 import React from 'react'
 import {connect} from 'react-redux'
-import {withRouter, Redirect, type ContextRouter} from 'react-router'
+import {withRouter, Route, Redirect, type ContextRouter} from 'react-router'
 
 import type {State, Dispatch} from '../types'
 import {
@@ -14,6 +14,7 @@ import {
 import {TitleBar, Splash} from '@opentrons/components'
 import Page from '../components/Page'
 import RobotSettings, {ConnectAlertModal} from '../components/RobotSettings'
+import ChangePipette from '../components/ChangePipette'
 
 type StateProps = {
   robot: ?Robot,
@@ -43,11 +44,22 @@ function RobotSettingsPage (props: Props) {
     return (<Redirect to={url.replace(`/${name}`, '')} />)
   }
 
+  if (!robot) return (<Page><Splash /></Page>)
+
   return (
     <Page>
-      {!robot && (<Splash />)}
-      {robot && (<TitleBar title={robot.name} />)}
-      {robot && (<RobotSettings {...robot} />)}
+      <TitleBar title={robot.name} />
+      <RobotSettings {...robot} />
+
+      <Route path={`${url}/pipettes/:mount`} render={(props) => (
+        // $FlowFixMe: params.mount is a ?string, ChangePipette wants Mount
+        <ChangePipette
+          backUrl={url}
+          robot={robot}
+          mount={props.match.params.mount}
+        />
+      )} />
+
       {showConnectAlert && (
         <ConnectAlertModal onCloseClick={closeConnectAlert} />
       )}


### PR DESCRIPTION
## overview

This PR addresses #860. 
 - User initiates a pipette attachment or change via button.
 - Alert modal tells them to remove labware and tipracks
 - User is able to cancel or ~continue with pipette change~

## changelog

- change/attach button now link
- route to initial alert modal `/robots/:name/pipettes/:mount`
- back button functional,  continue wit move to front to be addressed in later PR

## review requests
Standard Review. 
- Go to connectivity panel
- view any robot
- click attach/change button modal with warning message should render, back button should bring user back to robot settings page, continue button disabled.


