### PR TITLE
PD: Transfer step

### DIFF
--- a/protocol-designer/src/components/StepEditForm.js
+++ b/protocol-designer/src/components/StepEditForm.js
@@ -102,7 +102,7 @@ export default function StepEditForm (props: Props) {
                 <div className={styles.field_row}>
                   <CheckboxField label='Mix' {...formConnector('aspirate--mix--checkbox')} />
                   <InputField units='μL' {...formConnector('aspirate--mix--volume')} />
-                  <InputField units='Times' {...formConnector('aspirate--mix--time')} />
+                  <InputField units='Times' {...formConnector('aspirate--mix--times')} />
                 </div>
                 <div className={styles.field_row}>
                   <CheckboxField label='Disposal volume' className={styles.column_2_3}

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -1,0 +1,17 @@
+// @flow
+
+// TODO Ian 2018-04-05 move all form types into here, instead of separating form fields and processed form data
+
+export type MixArgs = {|
+  volume: number,
+  times: number
+|}
+
+export type SharedFormDataFields = {|
+  /** Optional user-readable name for this step */
+  name: ?string,
+  /** Optional user-readable description/notes for this step */
+  description: ?string,
+|}
+
+export type ChangeTipOptions = 'always' | 'once' | 'never'

--- a/protocol-designer/src/step-generation/aspirateUpdateLiquidState.js
+++ b/protocol-designer/src/step-generation/aspirateUpdateLiquidState.js
@@ -4,7 +4,6 @@ import {mergeLiquid, splitLiquid, getWellsForTips} from './utils'
 import type {RobotState, PipetteData} from './'
 
 type LiquidState = $PropertyType<RobotState, 'liquidState'>
-// type LocationLiquidState = {[ingredId: string]: {volume: number}}
 
 export default function updateLiquidState (
   args: {

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -2,7 +2,8 @@
 import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 import {FIXED_TRASH_ID} from '../constants'
-import {aspirate, dispense, blowout, replaceTip, repeatArray, touchTip, reduceCommandCreators} from './'
+import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators} from './'
+import mix from './mix'
 import type {ConsolidateFormData, RobotState, CommandCreator} from './'
 
 const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotState: RobotState) => {
@@ -82,26 +83,8 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         ]
         : []
 
-      // TODO factor out createMix helper fn
-      function createMix (pipette: string, labware: string, well: string, volume: number, times: number) {
-        return repeatArray([
-          aspirate({
-            pipette,
-            volume,
-            labware,
-            well
-          }),
-          dispense({
-            pipette,
-            volume,
-            labware,
-            well
-          })
-        ], times)
-      }
-
       const mixBeforeCommands = (data.mixFirstAspirate)
-        ? createMix(
+        ? mix(
           data.pipette,
           data.sourceLabware,
           sourceWellChunk[0],
@@ -112,7 +95,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
 
       const preWetTipCommands = (data.preWetTip)
         // Pre-wet tip is equivalent to a single mix, with volume equal to the consolidate volume.
-        ? createMix(
+        ? mix(
           data.pipette,
           data.sourceLabware,
           sourceWellChunk[0],
@@ -122,7 +105,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         : []
 
       const mixAfterCommands = (data.mixInDestination)
-        ? createMix(
+        ? mix(
           data.pipette,
           data.destLabware,
           data.destWell,
@@ -164,14 +147,3 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
 }
 
 export default consolidate
-
-// return { // TODO: figure out where outside consolidate this annotation happens
-//   robotState: robotState,
-//   atomicCommands: {
-//     annotation: {
-//       name: data.name,
-//       description: data.description
-//     },
-//     commands
-//   }
-// }

--- a/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
+++ b/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
@@ -3,10 +3,9 @@ import cloneDeep from 'lodash/cloneDeep'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import {splitLiquid, mergeLiquid, getWellsForTips} from './utils'
-import type {RobotState, PipetteData} from './'
+import type {RobotState, LocationLiquidState, PipetteData} from './'
 
 type LiquidState = $PropertyType<RobotState, 'liquidState'>
-type LocationLiquidState = {[ingredId: string]: {volume: number}}
 
 export default function updateLiquidState (
   args: {

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -6,6 +6,7 @@ import dispense from './dispense'
 import dropTip from './dropTip'
 import replaceTip from './replaceTip'
 import touchTip from './touchTip'
+import transfer from './transfer'
 export * from './robotStateSelectors'
 export * from './types'
 export * from './data'
@@ -18,5 +19,6 @@ export {
   dispense,
   dropTip,
   replaceTip,
-  touchTip
+  touchTip,
+  transfer
 }

--- a/protocol-designer/src/step-generation/mix.js
+++ b/protocol-designer/src/step-generation/mix.js
@@ -1,0 +1,21 @@
+// @flow
+import aspirate from './aspirate'
+import dispense from './dispense'
+import {repeatArray} from './utils'
+
+export default function mix (pipette: string, labware: string, well: string, volume: number, times: number) {
+  return repeatArray([
+    aspirate({
+      pipette,
+      volume,
+      labware,
+      well
+    }),
+    dispense({
+      pipette,
+      volume,
+      labware,
+      well
+    })
+  ], times)
+}

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -1,6 +1,7 @@
 // @flow
 import {tiprackWellNamesByCol, tiprackWellNamesFlat} from './'
-import type {PipetteChannels, RobotState} from './'
+import type {Channels} from '@opentrons/components'
+import type {RobotState} from './'
 import sortBy from 'lodash/sortBy'
 
 // SELECTOR UTILITIES
@@ -12,7 +13,7 @@ export function sortLabwareBySlot (robotState: RobotState) {
 // SELECTORS
 
 export function _getNextTip (
-  pipetteChannels: PipetteChannels,
+  pipetteChannels: Channels,
   tiprackWellsState: {[wellName: string]: boolean
 }): string | null {
   /** Given a tiprack's wells state, return the well of the next available tip
@@ -31,7 +32,7 @@ export function _getNextTip (
   return fullColumn ? fullColumn[0] : null
 }
 
-export function getNextTiprack (pipetteChannels: PipetteChannels, robotState: RobotState) {
+export function getNextTiprack (pipetteChannels: Channels, robotState: RobotState) {
   /** Returns the next tiprack that has tips.
     Tipracks are any labwareIds that exist in tipState.tipracks.
     For 8-channel pipette, tipracks need a full column of tips.

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -1516,6 +1516,9 @@ describe('consolidate single-channel', () => {
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
+
+  test('delay after dispense') // TODO Ian 2018-04-05 support delay in consolidate
+  test('air gap') // TODO Ian 2018-04-05 determine air gap behavior
 })
 
 describe('consolidate multi-channel', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -1,0 +1,726 @@
+// @flow
+import merge from 'lodash/merge'
+import {createRobotState} from './fixtures' // getTipColumn, getTiprackTipstate, createEmptyLiquidState
+import transfer from '../transfer'
+import {FIXED_TRASH_ID} from '../../constants'
+
+let transferArgs
+let robotInitialState
+
+beforeEach(() => {
+  transferArgs = {
+    stepType: 'transfer',
+    name: 'Transfer Test',
+    description: 'test blah blah',
+    pipette: 'p300SingleId',
+
+    sourceLabware: 'sourcePlateId',
+    destLabware: 'destPlateId',
+
+    preWetTip: false,
+    touchTipAfterAspirate: false,
+    disposalVolume: null,
+    mixBeforeAspirate: null,
+
+    touchTipAfterDispense: false,
+    mixInDestination: null,
+    delayAfterDispense: null,
+    blowout: null
+  }
+
+  robotInitialState = createRobotState({
+    sourcePlateType: '96-flat',
+    destPlateType: '96-flat',
+    tipracks: [200],
+    fillPipetteTips: true,
+    fillTiprackTips: true
+  })
+})
+
+describe('pick up tip if no tip on pipette', () => {
+  beforeEach(() => {
+    transferArgs = {
+      ...transferArgs,
+      sourceWells: ['A1'],
+      destWells: ['B2'],
+      volume: 30
+    }
+
+    // no tip on pipette
+    robotInitialState.tipState.pipettes.p300SingleId = false
+  })
+
+  const changeTipOptions = ['once', 'always']
+
+  changeTipOptions.forEach(changeTip => {
+    test(`...${changeTip}`, () => {
+      transferArgs = {
+        ...transferArgs,
+        changeTip
+      }
+
+      const result = transfer(transferArgs)(robotInitialState)
+
+      expect(result.commands[0]).toEqual(
+        {
+          command: 'pick-up-tip',
+          pipette: 'p300SingleId',
+          labware: 'tiprack1Id',
+          well: 'A1'
+        }
+      )
+    })
+  })
+
+  test('...never (should not pick up tip, and fail)', () => {
+    transferArgs = {
+      ...transferArgs,
+      changeTip: 'never'
+    }
+
+    expect(
+      // $FlowFixMe // TODO Ian 2018-04-02: here, flow doesn't like transferArgs fields
+      () => transfer(transferArgs)(robotInitialState)
+    ).toThrow(/Attempted to aspirate with no tip.*/)
+  })
+})
+
+test('single transfer: 1 source & 1 dest', () => {
+  transferArgs = {
+    ...transferArgs,
+    sourceWells: ['A1'],
+    destWells: ['B2'],
+    changeTip: 'never',
+    volume: 30
+  }
+
+  robotInitialState.liquidState.labware.sourcePlateId.A1 = {'0': {volume: 200}}
+
+  const result = transfer(transferArgs)(robotInitialState)
+  expect(result.commands).toEqual([
+    {
+      command: 'aspirate',
+      labware: 'sourcePlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'A1'
+    },
+    {
+      command: 'dispense',
+      labware: 'destPlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'B2'
+    }
+  ])
+
+  expect(result.robotState.liquidState).toEqual(merge(
+    {},
+    robotInitialState.liquidState,
+    {
+      labware: {
+        sourcePlateId: {A1: {'0': {volume: 200 - 30}}},
+        destPlateId: {B2: {'0': {volume: 30}}}
+      },
+      pipettes: {
+        p300SingleId: {'0': {'0': {volume: 0}}} // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+      }
+    }
+  ))
+})
+
+test('transfer with multiple sets of wells', () => {
+  transferArgs = {
+    ...transferArgs,
+    sourceWells: ['A1', 'A2'],
+    destWells: ['B2', 'C2'],
+    changeTip: 'never',
+    volume: 30
+  }
+  const result = transfer(transferArgs)(robotInitialState)
+  expect(result.commands).toEqual([
+    {
+      command: 'aspirate',
+      labware: 'sourcePlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'A1'
+    },
+    {
+      command: 'dispense',
+      labware: 'destPlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'B2'
+    },
+
+    {
+      command: 'aspirate',
+      labware: 'sourcePlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'A2'
+    },
+    {
+      command: 'dispense',
+      labware: 'destPlateId',
+      pipette: 'p300SingleId',
+      volume: 30,
+      well: 'C2'
+    }
+  ])
+
+  // TODO Ian 2018-04-02 robotState, liquidState checks
+})
+
+describe('single transfer exceeding pipette max', () => {
+  beforeEach(() => {
+    transferArgs = {
+      ...transferArgs,
+      sourceWells: ['A1'],
+      destWells: ['B2'],
+      volume: 350
+    }
+    // tip setup: tiprack's A1 has tip, pipette has no tip
+    robotInitialState.tipState.tipracks.tiprack1Id.A1 = true
+    robotInitialState.tipState.pipettes.p300SingleId = false
+    // liquid setup
+    robotInitialState.liquidState.labware.sourcePlateId.A1 = {'0': {volume: 400}}
+  })
+
+  test('changeTip="once"', () => {
+    transferArgs = {
+      ...transferArgs,
+      changeTip: 'once'
+    }
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'A1'
+      },
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'B2'
+      },
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'B2'
+      }
+    ])
+
+    expect(result.robotState.liquidState).toEqual(merge(
+      {},
+      robotInitialState.liquidState,
+      {
+        labware: {
+          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
+          destPlateId: {B2: {'0': {volume: 350}}}
+        },
+        pipettes: {
+          p300SingleId: {'0': {'0': {volume: 0}}} // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+        }
+      }
+    ))
+  })
+
+  test('changeTip="always"', () => {
+    transferArgs = {
+      ...transferArgs,
+      changeTip: 'always'
+    }
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'A1'
+      },
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'B2'
+      },
+
+      // replace tip before next asp-disp chunk
+      {
+        command: 'drop-tip',
+        pipette: 'p300SingleId',
+        labware: FIXED_TRASH_ID,
+        well: 'A1'
+      },
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'B1'
+      },
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'B2'
+      }
+    ])
+
+    expect(result.robotState.liquidState).toEqual(merge(
+      {},
+      robotInitialState.liquidState,
+      {
+        labware: {
+          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
+          destPlateId: {B2: {'0': {volume: 350}}},
+          [FIXED_TRASH_ID]: result.robotState.liquidState.labware[FIXED_TRASH_ID] // Ignore liquid contents of trash. TODO LATER make this more elegant
+        },
+        pipettes: {
+          p300SingleId: {'0': {'0': {volume: 0}}} // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+        }
+      }
+    ))
+  })
+
+  test('changeTip="never"', () => {
+    transferArgs = {
+      ...transferArgs,
+      changeTip: 'never'
+    }
+    // begin with tip on pipette
+    robotInitialState.tipState.pipettes.p300SingleId = true
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      // no pick up tip
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'B2'
+      },
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'B2'
+      }
+    ])
+
+    expect(result.robotState.liquidState).toEqual(merge(
+      {},
+      robotInitialState.liquidState,
+      {
+        labware: {
+          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
+          destPlateId: {B2: {'0': {volume: 350}}}
+        },
+        pipettes: {
+          p300SingleId: {'0': {'0': {volume: 0}}} // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+        }
+      }
+    ))
+  })
+})
+
+describe('advanced options', () => {
+  beforeEach(() => {
+    transferArgs = {
+      ...transferArgs,
+      sourceWells: ['A1'],
+      destWells: ['B1'],
+      changeTip: 'never'
+    }
+  })
+  describe('...aspirate options', () => {
+    test('pre-wet tip should aspirate and dispense transfer volume from source well of each subtransfer', () => {
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        preWetTip: true
+      }
+
+      const result = transfer(transferArgs)(robotInitialState)
+      expect(result.commands).toEqual([
+        // pre-wet aspirate/dispense
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+
+        // "real" aspirate/dispenses
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        }
+      ])
+    })
+
+    test('touch-tip after aspirate should touch-tip on each source well, for every aspirate', () => {
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        touchTipAfterAspirate: true
+      }
+
+      const result = transfer(transferArgs)(robotInitialState)
+      expect(result.commands).toEqual([
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'touch-tip',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'touch-tip',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        }
+      ])
+    })
+
+    test('touch-tip after dispense should touch-tip on each dest well, for every dispense', () => {
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        touchTipAfterDispense: true
+      }
+
+      const result = transfer(transferArgs)(robotInitialState)
+      expect(result.commands).toEqual([
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+        {
+          command: 'touch-tip',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          well: 'B1'
+        },
+
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        },
+        {
+          command: 'touch-tip',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          well: 'B1'
+        }
+      ])
+    })
+
+    test('mix before aspirate', () => {
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        mixBeforeAspirate: {
+          volume: 250,
+          times: 2
+        }
+      }
+
+      // helper fn for less verbose `commands` below
+      const mixCommands = [
+        // mix 1
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'A1'
+        },
+        // mix 2
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'A1'
+        }
+      ]
+
+      const result = transfer(transferArgs)(robotInitialState)
+      expect(result.commands).toEqual([
+        ...mixCommands,
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+
+        ...mixCommands,
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        }
+      ])
+    })
+    test('air gap => ???') // TODO determine behavior
+    test('disposal volume => ???') // TODO determine behavior
+  })
+
+  describe('...dispense options', () => {
+    test('mix after dispense', () => {
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        mixInDestination: {
+          volume: 250,
+          times: 2
+        }
+      }
+
+      // helper fn for less verbose `commands` below
+      const mixCommands = [
+        // mix 1
+        {
+          command: 'aspirate',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'B1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'B1'
+        },
+        // mix 2
+        {
+          command: 'aspirate',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'B1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 250,
+          well: 'B1'
+        }
+      ]
+
+      const result = transfer(transferArgs)(robotInitialState)
+      expect(result.commands).toEqual([
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+        ...mixCommands,
+
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        },
+        ...mixCommands
+      ])
+    })
+    test('delay after dispense') // TODO
+    test('blowout should blowout in specified labware after each dispense') // TODO
+  })
+})

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -567,7 +567,7 @@ describe('advanced options', () => {
         }
       }
 
-      // helper fn for less verbose `commands` below
+      // written here for less verbose `commands` below
       const mixCommands = [
         // mix 1
         {
@@ -651,7 +651,7 @@ describe('advanced options', () => {
         }
       }
 
-      // helper fn for less verbose `commands` below
+      // written here for less verbose `commands` below
       const mixCommands = [
         // mix 1
         {
@@ -720,7 +720,56 @@ describe('advanced options', () => {
         ...mixCommands
       ])
     })
-    test('delay after dispense') // TODO
+
+    test.skip('delay after dispense', () => { // TODO Ian 2018-04-05 support delay in transfer. REMOVE SKIP
+      transferArgs = {
+        ...transferArgs,
+        volume: 350,
+        delayAfterDispense: 100
+      }
+
+      const result = transfer(transferArgs)(robotInitialState)
+
+      const delayCommand = {
+        command: 'delay',
+        wait: 100,
+        message: null
+      }
+
+      expect(result.commands).toEqual([
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 300,
+          well: 'B1'
+        },
+        delayCommand,
+
+        {
+          command: 'aspirate',
+          labware: 'sourcePlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'A1'
+        },
+        {
+          command: 'dispense',
+          labware: 'destPlateId',
+          pipette: 'p300SingleId',
+          volume: 50,
+          well: 'B1'
+        },
+        delayCommand
+      ])
+    })
     test('blowout should blowout in specified labware after each dispense') // TODO
   })
 })

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -1,0 +1,133 @@
+// @flow
+import flatMap from 'lodash/flatMap'
+import zip from 'lodash/zip'
+import mix from './mix'
+import aspirate from './aspirate'
+import dispense from './dispense'
+import replaceTip from './replaceTip'
+import {reduceCommandCreators} from './utils'
+// blowout, repeatArray
+import touchTip from './touchTip'
+import type {TransferFormData, RobotState, CommandCreator} from './'
+
+const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: RobotState) => {
+  /**
+    Transfer will iterate through a set of 1 or more source and destination wells.
+    For each pair, it will aspirate from the source well, then dispense into the destination well.
+    This pair of 1 source well and 1 dest well is internally called a "sub-transfer".
+
+    If the volume to aspirate from a source well exceeds the max volume of the pipette,
+    then each sub-transfer will be chunked into multiple asp-disp, asp-disp commands.
+
+    A single uniform volume will be aspirated from every source well and dispensed into every dest well.
+    In other words, all the sub-transfers will use the same uniform volume.
+  */
+
+  // TODO Ian 2018-04-02 following ~10 lines are identical to first lines of consolidate.js...
+  const pipetteData = prevRobotState.instruments[data.pipette]
+  if (!pipetteData) {
+    throw new Error('Consolidate called with pipette that does not exist in robotState, pipette id: ' + data.pipette) // TODO test
+  }
+
+  // TODO error on negative data.disposalVolume?
+  const disposalVolume = (data.disposalVolume && data.disposalVolume > 0)
+    ? data.disposalVolume
+    : 0
+
+  const effectiveTransferVol = pipetteData.maxVolume - disposalVolume
+
+  const chunksPerSubTransfer = Math.ceil(
+    data.volume / effectiveTransferVol
+  )
+  const lastSubTransferVol = data.volume - ((chunksPerSubTransfer - 1) * effectiveTransferVol)
+
+  // volume of each chunk in a sub-transfer
+  const subTransferVolumes: Array<number> = Array(chunksPerSubTransfer - 1)
+    .fill(effectiveTransferVol)
+    .concat(lastSubTransferVol)
+
+  const sourceDestPairs = zip(data.sourceWells, data.destWells)
+  const CommandCreators = flatMap(
+    sourceDestPairs,
+    (wellPair: [string, string], pairIdx: number): Array<CommandCreator> => {
+      const [sourceWell, destWell] = wellPair
+
+      return flatMap(
+        subTransferVolumes,
+        (subTransferVol: number, chunkIdx: number): Array<CommandCreator> => {
+          // TODO IMMEDIATELY disposal vol ^^^
+          const tipCommands: Array<CommandCreator> = (
+            (data.changeTip === 'once' && chunkIdx === 0) ||
+            data.changeTip === 'always')
+              ? [replaceTip(data.pipette)]
+              : []
+
+          const preWetTipCommands = (data.preWetTip && chunkIdx === 0)
+            ? mix(data.pipette, data.sourceLabware, sourceWell, Math.max(subTransferVol), 1)
+            : []
+
+          const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
+            ? mix(
+              data.pipette,
+              data.sourceLabware,
+              sourceWell,
+              data.mixBeforeAspirate.volume,
+              data.mixBeforeAspirate.times
+            )
+            : []
+
+          const touchTipAfterAspirateCommands = (data.touchTipAfterAspirate)
+            ? [touchTip({
+              pipette: data.pipette,
+              labware: data.sourceLabware,
+              well: sourceWell
+            })]
+            : []
+
+          const touchTipAfterDispenseCommands = (data.touchTipAfterDispense)
+            ? [touchTip({
+              pipette: data.pipette,
+              labware: data.destLabware,
+              well: destWell
+            })]
+            : []
+
+          const mixInDestinationCommands = (data.mixInDestination)
+            ? mix(
+              data.pipette,
+              data.destLabware,
+              destWell,
+              data.mixInDestination.volume,
+              data.mixInDestination.times
+            )
+            : []
+
+          return [
+            ...tipCommands,
+            ...preWetTipCommands,
+            ...mixBeforeAspirateCommands,
+            aspirate({
+              pipette: data.pipette,
+              volume: subTransferVol,
+              labware: data.sourceLabware,
+              well: sourceWell
+            }),
+            ...touchTipAfterAspirateCommands,
+            dispense({
+              pipette: data.pipette,
+              volume: subTransferVol,
+              labware: data.destLabware,
+              well: destWell
+            }),
+            ...touchTipAfterDispenseCommands,
+            ...mixInDestinationCommands
+          ]
+        }
+      )
+    }
+  )
+
+  return reduceCommandCreators(CommandCreators)(prevRobotState)
+}
+
+export default transfer

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -110,6 +110,8 @@ export type LabwareData = {
   */
 type TipId = string
 
+export type LocationLiquidState = {[ingredGroup: string]: {volume: number}}
+
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
   instruments: {
@@ -131,20 +133,12 @@ export type RobotState = {|
   liquidState: {
     pipettes: {
       [pipetteId: string]: {
-        [tipId: TipId]: {
-          [ingredGroup: string]: {
-            volume: number
-          }
-        }
+        [tipId: TipId]: LocationLiquidState
       }
     },
     labware: {
       [labwareId: string]: {
-        [well: string]: {
-          [ingredGroup: string]: {
-            volume: number
-          }
-        }
+        [well: string]: LocationLiquidState
       }
     }
   }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -1,20 +1,6 @@
 // @flow
-
 import type {DeckSlot, Mount, Channels} from '@opentrons/components'
-
-export type MixArgs = {|
-  volume: number,
-  times: number
-|}
-
-type SharedFormDataFields = {|
-  /** Optional user-readable name for this step */
-  name: ?string,
-  /** Optional user-readable description/notes for this step */
-  description: ?string,
-|}
-
-type ChangeTipOptions = 'always' | 'once' | 'never'
+import type {MixArgs, SharedFormDataFields, ChangeTipOptions} from '../form-types'
 
 export type ConsolidateFormData = {|
   ...SharedFormDataFields,
@@ -106,13 +92,11 @@ export type TransferFormData = {|
   blowout: ?string // TODO LATER LabwareId export type here instead of string?
 |}
 
-export type PipetteChannels = Channels // TODO Ian 2018-02-27 rename PipetteChannels -> Channels
-
 export type PipetteData = {| // TODO refactor all 'pipette fields', split PipetteData into its own export type
   id: string, // TODO PipetteId export type here instead of string?
   mount: Mount,
   maxVolume: number,
-  channels: PipetteChannels
+  channels: Channels
 |}
 
 export type LabwareData = {

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -7,13 +7,19 @@ export type MixArgs = {|
   times: number
 |}
 
-export type ConsolidateFormData = {|
-  stepType: 'consolidate',
-
+type SharedFormDataFields = {|
   /** Optional user-readable name for this step */
   name: ?string,
   /** Optional user-readable description/notes for this step */
   description: ?string,
+|}
+
+type ChangeTipOptions = 'always' | 'once' | 'never'
+
+export type ConsolidateFormData = {|
+  ...SharedFormDataFields,
+
+  stepType: 'consolidate',
 
   pipette: string, // PipetteId. TODO IMMEDIATELY/SOON make this match in the form
 
@@ -38,9 +44,54 @@ export type ConsolidateFormData = {|
     'once': get a new tip at the beginning of the consolidate step, and use it throughout
     'never': reuse the tip from the last step
   */
-  changeTip: 'always' | 'once' | 'never', // TODO extract this enum as its own export type
+  changeTip: ChangeTipOptions,
   /** Mix in first well in chunk */
   mixFirstAspirate: ?MixArgs,
+  /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
+  disposalVolume: ?number,
+
+  // ===== DISPENSE SETTINGS =====
+  /** Mix in destination well after dispense */
+  mixInDestination: ?MixArgs,
+  /** Touch tip in destination well after dispense */
+  touchTipAfterDispense: boolean,
+  /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
+  delayAfterDispense: ?number,
+  /** If given, blow out in the specified labware after dispense at the end of each asp-asp-dispense cycle */
+  blowout: ?string // TODO LATER LabwareId export type here instead of string?
+|}
+
+export type TransferFormData = {|
+  // TODO IMMEDIATELY use "mixin types" for shared fields across FormData types.
+  ...SharedFormDataFields,
+  stepType: 'transfer',
+
+  pipette: string, // PipetteId. TODO IMMEDIATELY/SOON make this match in the form
+
+  sourceWells: Array<string>,
+  destWells: Array<string>,
+
+  sourceLabware: string,
+  destLabware: string,
+  /** Volume to aspirate from each source well. Different volumes across the
+    source wells isn't currently supported
+  */
+  volume: number,
+
+  // ===== ASPIRATE SETTINGS =====
+  /** Pre-wet tip with ??? uL liquid from the first source well. */
+  preWetTip: boolean,
+  /** Touch tip after every aspirate */
+  touchTipAfterAspirate: boolean,
+  /**
+    For transfer, changeTip means:
+    'always': before each aspirate, get a fresh tip
+    'once': get a new tip at the beginning of the transfer step, and use it throughout
+    'never': reuse the tip from the last step
+  */
+  changeTip: ChangeTipOptions,
+  /** Mix in first well in chunk */
+  mixBeforeAspirate: ?MixArgs,
   /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
   disposalVolume: ?number,
 

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -59,16 +59,13 @@ export function formHasErrors (form: {errors: {[string]: string}}): boolean {
 }
 
 function _vapTransfer (formData: TransferForm): ValidationAndErrors<TransferFormData> {
-  // TODO when transfer is supported in step-generation,
-  // combine this with consolidate since args are similar
+  // TODO LATER Ian 2018-04-05 combine this with consolidate since args are similar
   // and clean up the parsing errors
   const pipette = formData['aspirate--pipette']
   const sourceWells = formData['aspirate--wells'] ? formData['aspirate--wells'].split(',') : []
   const destWells = formData['dispense--wells'] ? formData['dispense--wells'].split(',') : []
   const sourceLabware = formData['aspirate--labware']
   const destLabware = formData['dispense--labware']
-
-  // TODO Ian 2018-04-02 several of these fields are the same btw transfer & consolidate, factor 'em out
 
   const blowout = formData['dispense--blowout--labware']
 

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -195,7 +195,7 @@ function _vapConsolidate (formData: ConsolidateForm): ValidationAndErrors<Consol
   const mixFirstAspirate = formData['aspirate--mix--checkbox']
     ? {
       volume: parseFloat(formData['aspirate--mix--volume']),
-      times: parseInt(formData['aspirate--mix--time']) // TODO handle unparseable
+      times: parseInt(formData['aspirate--mix--times']) // TODO handle unparseable
     }
     : null
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -112,7 +112,7 @@ export type ConsolidateForm = {|
   'aspirate--air-gap--volume'?: string,
   'aspirate--mix--checkbox'?: boolean,
   'aspirate--mix--volume'?: string,
-  'aspirate--mix--time'?: string,
+  'aspirate--mix--times'?: string,
   'aspirate--disposal-vol--checkbox'?: boolean,
   'aspirate--disposal-vol--volume'?: string,
   'aspirate--change-tip'?: 'once' | 'never' | 'always',

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,6 +1,7 @@
 // @flow
 import type {IconName} from '@opentrons/components'
 import type {ConsolidateFormData} from '../step-generation'
+import type {MixArgs, SharedFormDataFields, ChangeTipOptions} from '../form-types'
 
 // sections of the form that are expandable/collapsible
 export type FormSectionState = {aspirate: boolean, dispense: boolean}
@@ -78,7 +79,7 @@ export type TransferForm = {|
   'aspirate--air-gap--volume'?: string,
   'aspirate--mix--checkbox'?: boolean,
   'aspirate--mix--volume'?: string,
-  'aspirate--mix--time'?: string,
+  'aspirate--mix--times'?: string,
   'aspirate--disposal-vol--checkbox'?: boolean,
   'aspirate--disposal-vol--volume'?: string,
   'aspirate--change-tip'?: 'once' | 'never' | 'always',
@@ -143,13 +144,48 @@ export type PauseForm = {|
 export type FormData = TransferForm | ConsolidateForm | PauseForm
 
 export type TransferFormData = {|
+  // TODO Ian 2018-04-05 use "mixin types" like SharedFormDataFields for shared fields across FormData types.
+  ...SharedFormDataFields,
   stepType: 'transfer',
-  pipette: string, // pipette ID
+
+  pipette: string, // PipetteId. TODO IMMEDIATELY/SOON make this match in the form
+
   sourceWells: Array<string>,
   destWells: Array<string>,
+
   sourceLabware: string,
   destLabware: string,
-  volume: number
+  /** Volume to aspirate from each source well. Different volumes across the
+    source wells isn't currently supported
+  */
+  volume: number,
+
+  // ===== ASPIRATE SETTINGS =====
+  /** Pre-wet tip with ??? uL liquid from the first source well. */
+  preWetTip: boolean,
+  /** Touch tip after every aspirate */
+  touchTipAfterAspirate: boolean,
+  /**
+    For transfer, changeTip means:
+    'always': before each aspirate, get a fresh tip
+    'once': get a new tip at the beginning of the transfer step, and use it throughout
+    'never': reuse the tip from the last step
+  */
+  changeTip: ChangeTipOptions,
+  /** Mix in first well in chunk */
+  mixBeforeAspirate: ?MixArgs,
+  /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
+  disposalVolume: ?number,
+
+  // ===== DISPENSE SETTINGS =====
+  /** Mix in destination well after dispense */
+  mixInDestination: ?MixArgs,
+  /** Touch tip in destination well after dispense */
+  touchTipAfterDispense: boolean,
+  /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
+  delayAfterDispense: ?number,
+  /** If given, blow out in the specified labware after dispense at the end of each asp-asp-dispense cycle */
+  blowout: ?string // TODO LATER LabwareId export type here instead of string?
 |}
 
 export type PauseFormData = {|


### PR DESCRIPTION
## overview

Implements the "Transfer" step: now transfer steps update tip/liquid state in RobotState, and generate commands.

Closes #720 

NOTE: "delay", "air gap", and "disposal volume" form fields are not yet supported in either Consolidate or Transfer. For delay, it will be implemented when the Pause Step is implemented. For air gap / disposal vol, we still have yet to determine what exactly their behavior will be in some edge cases.

Also you'll see that Consolidate and Transfer form processing/validation share some code. I'm planning to be more DRY and concise once there are a few more Steps implemented.

## changelog
* minor types cleanup
* implement transfer form parsing and command generator `transfer.js`
* reusable `mix.js` utility fn for command generators (factored out of `consolidate.js`)

## review requests

* make some transfer commands in PD
* make sure liquid tracking is updated appropriately
* download the file (click the page, then the "Download" button) and inspect the JSON, particularly the `commands`

Also, `transfer.test.js` has some of the good stuff, but GitHub collapses the diff