### PR TITLE
Api: log all serial data written/read over uart to file

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -55,7 +55,7 @@ def _write_to_device_and_return(cmd, device_connection):
     - Formats command
     - Wait for ack return
     - return parsed response'''
-    command = cmd + '\r\n'
+    command = cmd + '\r\n\r\n'
     device_connection.write(command.encode())
 
     response = device_connection.read_until(DRIVER_ACK)
@@ -91,10 +91,12 @@ def _attempt_command_recovery(command, serial_conn):
 def write_and_return(
         command, serial_connection, timeout=DEFAULT_WRITE_TIMEOUT):
     '''Write a command and return the response'''
+    log.info('Write -> {}'.format(command))
     clear_buffer(serial_connection)
     with serial_with_temp_timeout(
             serial_connection, timeout) as device_connection:
         response = _write_to_device_and_return(command, device_connection)
+    log.info('Read <- {}'.format(response))
     return response
 
 

--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -91,12 +91,12 @@ def _attempt_command_recovery(command, serial_conn):
 def write_and_return(
         command, serial_connection, timeout=DEFAULT_WRITE_TIMEOUT):
     '''Write a command and return the response'''
-    log.info('Write -> {}'.format(command))
+    log.debug('Write -> {}'.format(command))
     clear_buffer(serial_connection)
     with serial_with_temp_timeout(
             serial_connection, timeout) as device_connection:
         response = _write_to_device_and_return(command, device_connection)
-    log.info('Read <- {}'.format(response))
+    log.debug('Read <- {}'.format(response))
     return response
 
 

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -8,6 +8,7 @@ from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
 from opentrons.server import endpoints as endp
 from opentrons.server.endpoints import (wifi, control, update)
+from opentrons.util import environment
 from opentrons.deck_calibration import endpoints as dc_endp
 from logging.config import dictConfig
 
@@ -30,6 +31,8 @@ def log_init():
 
     level_value = logging._nameToLevel[ot_log_level]
 
+    serial_log_filename = environment.get_path('SERIAL_LOG_FILE')
+
     logging_config = dict(
         version=1,
         formatters={
@@ -41,7 +44,15 @@ def log_init():
         handlers={
             'debug': {
                 'class': 'logging.StreamHandler',
+                'formatter': 'basic'
+            },
+            'serial': {
+                'class': 'logging.handlers.RotatingFileHandler',
                 'formatter': 'basic',
+                'filename': serial_log_filename,
+                'maxBytes': 5000000,
+                'level': logging.DEBUG,
+                'backupCount': 3
             }
         },
         loggers={
@@ -60,6 +71,10 @@ def log_init():
             'opentrons.drivers.smoothie_drivers.driver_3_0': {
                 'handlers': ['debug'],
                 'level': level_value
+            },
+            'opentrons.drivers.smoothie_drivers.serial_communication': {
+                'handlers': ['serial'],
+                'level': logging.DEBUG
             }
         }
     )

--- a/api/opentrons/util/environment.py
+++ b/api/opentrons/util/environment.py
@@ -50,6 +50,7 @@ def refresh():
         'OT_CONFIG_FILE': os.path.join(APP_DATA_DIR, 'config.json'),
         'LOG_DIR': os.path.join(APP_DATA_DIR, 'logs'),
         'LOG_FILE': os.path.join(APP_DATA_DIR, 'logs', 'api.log'),
+        'SERIAL_LOG_FILE': os.path.join(APP_DATA_DIR, 'logs', 'serial.log'),
         'CONTAINERS_DIR': os.path.join(APP_DATA_DIR, 'containers'),
         'CONTAINERS_FILE':
             os.path.join(

--- a/api/opentrons/util/log.py
+++ b/api/opentrons/util/log.py
@@ -5,6 +5,7 @@ from opentrons.util import environment
 
 
 LOG_FILENAME = environment.get_path('LOG_FILE')
+SERIAL_LOG_FILENAME = environment.get_path('SERIAL_LOG_FILE')
 
 logging_config = dict(
     version=1,
@@ -30,10 +31,24 @@ logging_config = dict(
             'level': logging.INFO,
             'backupCount': 3
         },
+        'serial': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'basic',
+            'filename': SERIAL_LOG_FILENAME,
+            'maxBytes': 5000000,
+            'level': logging.DEBUG,
+            'backupCount': 3
+        }
     },
     root={
         'handlers': ['file'],
         'level': logging.DEBUG
+    },
+    loggers={
+        'opentrons.drivers.smoothie_drivers.serial_communication': {
+            'handlers': ['serial'],
+            'level': logging.DEBUG
+        }
     }
 )
 


### PR DESCRIPTION
## overview

To help debugging both hardware and software issues, this PR logs all messages written to and read from the serial port to a file.

Also adds an additional `'\r\n'` to the end of each message sent, to ensure that all responses read in end with `'ok\r\nok\r\n'`