### PR TITLE
PD Multi-channel substeps in step list

### DIFF
--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -1,5 +1,39 @@
 @import '@opentrons/components';
 
+:root {
+  --step_subitem: {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 0.5rem;
+    border-top: 2px solid var(--c-light-gray);
+    text-align: center;
+
+    & > * {
+      flex: 1;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    & svg {
+      flex: 1;
+      height: 1.5rem;
+      color: var(--c-med-gray);
+    }
+
+    & .volume_cell {
+      color: var(--c-med-gray);
+      overflow: visible;
+      text-align: right;
+    }
+  };
+}
+
+.step_subitem {
+  @apply --step_subitem;
+}
+
 .step_item {
   margin: 0.25rem 0;
   color: var(--c-dark-gray);
@@ -23,40 +57,11 @@
   font-weight: bold;
 }
 
-/* Step Subitem */
-
-.step_subitem {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 0.5rem;
-  border-top: 2px solid var(--c-light-gray);
-  text-align: center;
-}
-
-.step_subitem > * {
-  flex: 1;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.step_subitem svg {
-  flex: 1;
-  height: 1.5rem;
-  color: var(--c-med-gray);
-}
-
-.step_subitem .volume_cell {
-  color: var(--c-med-gray);
-  overflow: visible;
-  text-align: right;
-}
-
 /* Step Subitem Column Header */
 
 .step_subitem_column_header {
-  composes: step_subitem;
+  @apply --step_subitem;
+
   border: none;
 }
 
@@ -82,7 +87,8 @@
 
 /* Multi-channel row representing a single channel */
 .step_subitem_channel_row {
-  composes: step_subitem;
+  @apply --step_subitem;
+
   border-bottom: 1px var(--c-med-gray) dashed;
   background-color: var(--c-light-gray);
 }

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -69,11 +69,15 @@
   display: flex;
   padding: 0.5rem;
   font-size: var(--fs-body-1);
-  text-align: center;
+  text-align: left;
+
+  & .spacer {
+    flex: 1;
+  }
 }
 
 .aspirate_dispense * {
-  flex: 1;
+  flex: 2;
 }
 
 /* Multi-channel row representing a single channel */

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -75,3 +75,10 @@
 .aspirate_dispense * {
   flex: 1;
 }
+
+/* Multi-channel row representing a single channel */
+.step_subitem_channel_row {
+  composes: step_subitem;
+  border-bottom: 1px var(--c-med-gray) dashed;
+  background-color: var(--c-light-gray);
+}

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -8,30 +8,37 @@
     padding: 0.5rem;
     border-top: 2px solid var(--c-light-gray);
     text-align: center;
+  };
 
-    & > * {
-      flex: 1;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-
-    & svg {
-      flex: 1;
-      height: 1.5rem;
-      color: var(--c-med-gray);
-    }
-
-    & .volume_cell {
-      color: var(--c-med-gray);
-      overflow: visible;
-      text-align: right;
-    }
+  --subitem_cell: {
+    flex: 2;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   };
 }
 
 .step_subitem {
   @apply --step_subitem;
+
+  & > * {
+    @apply --subitem_cell;
+
+    flex: 1;
+  }
+
+  & svg {
+    /* Subitem group carat */
+    flex: 1;
+    height: 1.5rem;
+    color: var(--c-med-gray);
+  }
+
+  & .volume_cell {
+    color: var(--c-med-gray);
+    overflow: visible;
+    text-align: right;
+  }
 }
 
 .step_item {
@@ -63,10 +70,19 @@
   @apply --step_subitem;
 
   border: none;
-}
 
-.step_subitem_column_header > * {
-  flex: 2;
+  & svg {
+    /* Source labware -> Dest Labware arrow icon */
+    flex: 1;
+    height: 1.5rem;
+    color: var(--c-med-gray);
+  }
+
+  & > * {
+    @apply --subitem_cell;
+
+    text-align: left;
+  }
 }
 
 /* Aspirate / dispense headers */
@@ -79,10 +95,10 @@
   & .spacer {
     flex: 1;
   }
-}
 
-.aspirate_dispense * {
-  flex: 2;
+  & * {
+    flex: 2;
+  }
 }
 
 /* Multi-channel row representing a single channel */
@@ -91,6 +107,10 @@
 
   border-bottom: 1px var(--c-med-gray) dashed;
   background-color: var(--c-light-gray);
+
+  & > * {
+    @apply --subitem_cell;
+  }
 }
 
 /* Inner collapse carat */

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -82,3 +82,9 @@
   border-bottom: 1px var(--c-med-gray) dashed;
   background-color: var(--c-light-gray);
 }
+
+/* Inner collapse carat */
+
+.inner_carat {
+  @apply --clickable;
+}

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -55,11 +55,13 @@ export default function StepItem (props: StepItemProps) {
     >
       {showLabwareHeader && <li className={styles.aspirate_dispense}>
           <span>ASPIRATE</span>
+          <span className={styles.spacer}/>
           <span>DISPENSE</span>
       </li>}
       {showLabwareHeader && <li className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <span>{sourceLabwareName}</span>
-        <Icon name={iconName} />
+        {/* This is always a "transfer icon" (arrow pointing right) for any step: */}
+        <Icon name='ot-transfer' />
         <span>{destLabwareName}</span>
       </li>}
       {children}

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -32,11 +32,7 @@ function generateSubstepItems (substeps) {
     substeps.stepType === 'distribute'
   ) {
     // all these step types share the same substep display
-    return <TransferishSubstep
-      rows={substeps.rows}
-      parentStepId={substeps.parentStepId}
-      stepType={substeps.stepType}
-    />
+    return <TransferishSubstep substeps={substeps} />
   }
 
   if (substeps.stepType === 'pause') {

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -99,7 +99,7 @@ export default function TransferishSubstep (props: StepSubItemProps) {
           key={groupKey}
           rowGroup={rowGroup}
           volume={typeof substeps.volume === 'number'
-            ? parseFloat(substeps.volume.toFixed(VOLUME_DIGITS)).toString()
+            ? substeps.volume.toFixed(VOLUME_DIGITS)
             : null
           }
           // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -1,18 +1,116 @@
 // @flow
 import * as React from 'react'
+import last from 'lodash/last'
+import {Icon} from '@opentrons/components'
 
-import type {TransferishStepItem} from '../steplist/types'
 import styles from './StepItem.css'
 
-export type StepSubItemProps = TransferishStepItem /* & {|
-  onMouseOver?: (event: SyntheticEvent<>) => void
-|} */
+import type {
+  TransferishStepItem,
+  StepItemSourceDestRowMulti
+  // TransferishStepItemMultiChannel
+} from '../steplist/types'
+
+export type StepSubItemProps = {|
+  substeps: TransferishStepItem
+|}
+
+type MultiChannelSubstepProps = {
+  groupKey: number,
+  volume: ?number,
+  rowGroup: Array<StepItemSourceDestRowMulti>,
+  sourceIngredientName: ?string,
+  destIngredientName: ?string
+}
 
 const VOLUME_DIGITS = 1
+const DEFAULT_COLLAPSED_STATE = true
+
+class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {collapsed: boolean}> {
+  constructor (props: MultiChannelSubstepProps) {
+    super(props)
+    this.state = {
+      collapsed: DEFAULT_COLLAPSED_STATE
+    }
+  }
+
+  handleToggleCollapsed = () => {
+    this.setState({
+      ...this.state,
+      collapsed: !this.state.collapsed
+    })
+  }
+
+  render () {
+    const {
+      volume,
+      rowGroup,
+      groupKey,
+      sourceIngredientName,
+      destIngredientName
+    } = this.props
+
+    const sourceWellRange = `${rowGroup[0].sourceWell || ''}:${last(rowGroup).sourceWell || ''}`
+    const destWellRange = `${rowGroup[0].destWell || ''}:${last(rowGroup).destWell || ''}`
+
+    const collapsed = this.state.collapsed
+
+    return (
+      <ol key={groupKey}>
+        {/* TODO special class for this substep subheader thing?? */}
+        <li className={styles.step_subitem}>
+          <span>{sourceIngredientName}</span>
+          <span className={styles.emphasized_cell}>{sourceWellRange}</span>
+          <span className={styles.volume_cell}>{
+            typeof volume === 'number' &&
+            `${parseFloat(volume.toFixed(VOLUME_DIGITS))} μL`
+          }</span>
+          <span className={styles.emphasized_cell}>{destWellRange}</span>
+          <span>{destIngredientName}</span>
+          <span onClick={() => this.handleToggleCollapsed()}>
+            <Icon name={collapsed ? 'chevron-down' : 'chevron-right'} />
+          </span>
+        </li>
+
+        {!collapsed && rowGroup.map((row, rowKey) =>
+          // Channel rows (1 for each channel in multi-channel pipette)
+          <li className={styles.step_subitem_channel_row} key={rowKey}>
+            <span>{row.sourceIngredientName}</span>
+            <span className={styles.emphasized_cell}>{row.sourceWell}</span>
+            <span className={styles.volume_cell}>{
+              typeof volume === 'number' &&
+              `${parseFloat(volume.toFixed(VOLUME_DIGITS))} μL`
+            }</span>
+            <span className={styles.emphasized_cell}>{row.destWell}</span>
+            <span>{row.destIngredientName}</span>
+          </li>
+      )}
+      </ol>
+    )
+  }
+}
 
 // This "transferish" substep component is for transfer/distribute/consolidate
 export default function TransferishSubstep (props: StepSubItemProps) {
-  return props.rows.map((row, key) =>
+  const {substeps} = props
+  if (substeps.multichannel) {
+    // multi-channel row item (collapsible)
+    return <li>
+      {substeps.multiRows.map((rowGroup, groupKey) =>
+        <MultiChannelSubstep
+          groupKey={groupKey}
+          rowGroup={rowGroup}
+          volume={substeps.volume}
+          // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
+          sourceIngredientName='SRC'
+          destIngredientName='DEST'
+        />
+      )}
+    </li>
+  }
+
+  // single-channel row item
+  return substeps.rows.map((row, key) =>
     <li key={key} className={styles.step_subitem} /* onMouseOver={onMouseOver} */>
       <span>{row.sourceIngredientName}</span>
       <span className={styles.emphasized_cell}>{row.sourceWell}</span>

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -8,7 +8,6 @@ import styles from './StepItem.css'
 import type {
   TransferishStepItem,
   StepItemSourceDestRowMulti
-  // TransferishStepItemMultiChannel
 } from '../steplist/types'
 
 export type StepSubItemProps = {|
@@ -17,7 +16,7 @@ export type StepSubItemProps = {|
 
 type MultiChannelSubstepProps = {
   groupKey: number,
-  volume: ?number,
+  volume: ?string,
   rowGroup: Array<StepItemSourceDestRowMulti>,
   sourceIngredientName: ?string,
   destIngredientName: ?string
@@ -61,13 +60,10 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
         <li className={styles.step_subitem}>
           <span>{sourceIngredientName}</span>
           <span className={styles.emphasized_cell}>{sourceWellRange}</span>
-          <span className={styles.volume_cell}>{
-            typeof volume === 'number' &&
-            `${parseFloat(volume.toFixed(VOLUME_DIGITS))} μL`
-          }</span>
+          <span className={styles.volume_cell}>{volume && `${volume} μL`}</span>
           <span className={styles.emphasized_cell}>{destWellRange}</span>
           <span>{destIngredientName}</span>
-          <span onClick={() => this.handleToggleCollapsed()}>
+          <span className={styles.inner_carat} onClick={() => this.handleToggleCollapsed()}>
             <Icon name={collapsed ? 'chevron-down' : 'chevron-right'} />
           </span>
         </li>
@@ -77,10 +73,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
           <li className={styles.step_subitem_channel_row} key={rowKey}>
             <span>{row.sourceIngredientName}</span>
             <span className={styles.emphasized_cell}>{row.sourceWell}</span>
-            <span className={styles.volume_cell}>{
-              typeof volume === 'number' &&
-              `${parseFloat(volume.toFixed(VOLUME_DIGITS))} μL`
-            }</span>
+            <span className={styles.volume_cell}>{volume && `${volume} μL`}</span>
             <span className={styles.emphasized_cell}>{row.destWell}</span>
             <span>{row.destIngredientName}</span>
           </li>
@@ -100,7 +93,10 @@ export default function TransferishSubstep (props: StepSubItemProps) {
         <MultiChannelSubstep
           groupKey={groupKey}
           rowGroup={rowGroup}
-          volume={substeps.volume}
+          volume={typeof substeps.volume === 'number'
+            ? parseFloat(substeps.volume.toFixed(VOLUME_DIGITS)).toString()
+            : null
+          }
           // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
           sourceIngredientName='SRC'
           destIngredientName='DEST'

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -47,8 +47,15 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
       // destIngredientName
     } = this.props
 
-    const sourceWellRange = `${rowGroup[0].sourceWell || ''}:${last(rowGroup).sourceWell || ''}`
-    const destWellRange = `${rowGroup[0].destWell || ''}:${last(rowGroup).destWell || ''}`
+    const lastGroupSourceWell = last(rowGroup).sourceWell
+    const sourceWellRange = (rowGroup[0].sourceWell && lastGroupSourceWell)
+      ? `${rowGroup[0].sourceWell}:${lastGroupSourceWell}`
+      : ''
+
+    const lastGroupDestWell = last(rowGroup).destWell
+    const destWellRange = (rowGroup[0].destWell && lastGroupDestWell)
+      ? `${rowGroup[0].destWell}:${lastGroupDestWell}`
+      : ''
 
     const collapsed = this.state.collapsed
 

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -15,7 +15,6 @@ export type StepSubItemProps = {|
 |}
 
 type MultiChannelSubstepProps = {
-  groupKey: number,
   volume: ?string,
   rowGroup: Array<StepItemSourceDestRowMulti>,
   sourceIngredientName: ?string,
@@ -44,7 +43,6 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
     const {
       volume,
       rowGroup,
-      groupKey,
       sourceIngredientName
       // destIngredientName
     } = this.props
@@ -55,7 +53,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
     const collapsed = this.state.collapsed
 
     return (
-      <ol key={groupKey}>
+      <ol>
         {/* TODO special class for this substep subheader thing?? */}
         <li className={styles.step_subitem}>
           <span>{sourceIngredientName}</span>
@@ -64,7 +62,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
           <span className={styles.emphasized_cell}>{destWellRange}</span>
           {/* <span>{destIngredientName}</span> */}
           <span className={styles.inner_carat} onClick={() => this.handleToggleCollapsed()}>
-            <Icon name={collapsed ? 'chevron-down' : 'chevron-right'} />
+            <Icon name={collapsed ? 'chevron-down' : 'chevron-up'} />
           </span>
         </li>
 
@@ -91,7 +89,7 @@ export default function TransferishSubstep (props: StepSubItemProps) {
     return <li>
       {substeps.multiRows.map((rowGroup, groupKey) =>
         <MultiChannelSubstep
-          groupKey={groupKey}
+          key={groupKey}
           rowGroup={rowGroup}
           volume={typeof substeps.volume === 'number'
             ? parseFloat(substeps.volume.toFixed(VOLUME_DIGITS)).toString()

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -45,8 +45,8 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
       volume,
       rowGroup,
       groupKey,
-      sourceIngredientName,
-      destIngredientName
+      sourceIngredientName
+      // destIngredientName
     } = this.props
 
     const sourceWellRange = `${rowGroup[0].sourceWell || ''}:${last(rowGroup).sourceWell || ''}`
@@ -62,7 +62,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
           <span className={styles.emphasized_cell}>{sourceWellRange}</span>
           <span className={styles.volume_cell}>{volume && `${volume} μL`}</span>
           <span className={styles.emphasized_cell}>{destWellRange}</span>
-          <span>{destIngredientName}</span>
+          {/* <span>{destIngredientName}</span> */}
           <span className={styles.inner_carat} onClick={() => this.handleToggleCollapsed()}>
             <Icon name={collapsed ? 'chevron-down' : 'chevron-right'} />
           </span>
@@ -98,8 +98,8 @@ export default function TransferishSubstep (props: StepSubItemProps) {
             : null
           }
           // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
-          sourceIngredientName='SRC'
-          destIngredientName='DEST'
+          sourceIngredientName='ING11'
+          destIngredientName='ING12'
         />
       )}
     </li>

--- a/protocol-designer/src/file-data/selectors/pipettes.js
+++ b/protocol-designer/src/file-data/selectors/pipettes.js
@@ -1,6 +1,6 @@
 // @flow
 import {createSelector} from 'reselect'
-import type {BaseState} from '../../types'
+import type {BaseState, Selector} from '../../types'
 import reduce from 'lodash/reduce'
 import type {DropdownOption} from '@opentrons/components'
 import type {PipetteData} from '../../step-generation'
@@ -47,7 +47,7 @@ export const equippedPipetteOptions: BaseState => Array<DropdownOption> = create
 // TODO LATER factor out into own file
 // Shows pipettes by ID, not mount
 type PipettesById = {[pipetteId: string]: PipetteData}
-export const equippedPipettes = createSelector(
+export const equippedPipettes: Selector<PipettesById> = createSelector(
   rootSelector,
   pipettes => reduce(pipettes, (acc: PipettesById, pipetteData: ?PipetteData): PipettesById => {
     return (pipetteData)

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -4,6 +4,7 @@ import type {
   StepType,
   StepIdType,
   FormData,
+  BlankForm,
   ProcessedFormData,
   TransferForm,
   ConsolidateForm,
@@ -33,7 +34,7 @@ function getMixData (formData, checkboxField, volumeField, timesField) {
     : null
 }
 
-export const generateNewForm = (stepId: StepIdType, stepType: StepType) => {
+export const generateNewForm = (stepId: StepIdType, stepType: StepType): BlankForm => {
   // Add default values to a new step form
   const baseForm = {
     id: stepId,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -17,7 +17,7 @@ import type {
 
 import type {PipetteData} from '../step-generation/types'
 
-type AllPipetteData = {[pipetteId: string]: ?PipetteData} // TODO make general type, key by ID not mount?
+type AllPipetteData = {[pipetteId: string]: PipetteData} // TODO make general type, key by ID not mount?
 type AllLabwareTypes = {[labwareId: string]: string}
 
 function _transferSubsteps (

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -2,6 +2,8 @@
 import mapValues from 'lodash/mapValues'
 import range from 'lodash/range'
 
+import {getWellsForTips} from '../step-generation/utils'
+
 import {
   formHasErrors,
   type ValidFormAndErrors
@@ -13,20 +15,70 @@ import type {
   PauseFormData
 } from './types'
 
-function _transferSubsteps (form: *, stepId: StepIdType) {
+import type {PipetteData} from '../step-generation/types'
+
+type AllPipetteData = {[pipetteId: string]: ?PipetteData} // TODO make general type, key by ID not mount?
+type AllLabwareTypes = {[labwareId: string]: string}
+
+function _transferSubsteps (
+  form: *,
+  pipetteData: AllPipetteData,
+  allLabwareTypes: AllLabwareTypes,
+  stepId: StepIdType
+) {
   const {
     sourceWells,
     destWells,
     volume
   } = form
 
-  return {
+  const commonFields = {
     stepType: 'transfer',
-    parentStepId: stepId,
+    parentStepId: stepId
+  }
+
+  // TODO Ian 2018-04-06 use assert here
+  if (!pipetteData[form.pipette]) {
+    console.warn(`Pipette "${form.pipette}" does not exist, step ${stepId} can't determine channels`)
+  }
+
+  const sourceLabwareType = allLabwareTypes[form.sourceLabware]
+  const destLabwareType = allLabwareTypes[form.destLabware]
+
+  if (pipetteData[form.pipette] && pipetteData[form.pipette].channels > 1) {
+    const channels = pipetteData[form.pipette].channels
+    // multichannel
+    return {
+      ...commonFields,
+      multichannel: true,
+      volume,
+      multiRows: range(sourceWells.length).map(i => {
+        const sourceWellsForTips = getWellsForTips(channels, sourceLabwareType, sourceWells[i]).wellsForTips
+        const destWellsForTips = getWellsForTips(channels, destLabwareType, destWells[i]).wellsForTips
+
+        return range(channels).map(channel =>
+          ({
+            substepId: i,
+            channelId: channel,
+            // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
+            sourceIngredientName: 'ING1',
+            destIngredientName: 'ING2',
+            sourceWell: sourceWellsForTips[channel],
+            destWell: destWellsForTips[channel]
+          })
+        )
+      })
+    }
+  }
+
+  return {
+    ...commonFields,
+    multichannel: false,
     // TODO Ian 2018-03-02 break up steps when pipette too small
     rows: range(sourceWells.length).map(i => ({
       substepId: i,
-      sourceIngredientName: 'ING1', // TODO get ingredients for source/dest wells
+      // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
+      sourceIngredientName: 'ING1',
       destIngredientName: 'ING2',
       sourceWell: sourceWells[i],
       destWell: destWells[i],
@@ -35,7 +87,12 @@ function _transferSubsteps (form: *, stepId: StepIdType) {
   }
 }
 
-function _consolidateSubsteps (form: *, stepId: StepIdType) {
+function _consolidateSubsteps (
+  form: *,
+  pipetteData: AllPipetteData,
+  allLabwareTypes: AllLabwareTypes,
+  stepId: StepIdType
+) {
   const {
     sourceWells,
     destWell,
@@ -66,7 +123,11 @@ function _consolidateSubsteps (form: *, stepId: StepIdType) {
 }
 
 // NOTE: This is the fn used by the `allSubsteps` selector
-export function generateSubsteps (validatedForms: {[StepIdType]: ValidFormAndErrors}): SubSteps {
+export function generateSubsteps (
+  validatedForms: {[StepIdType]: ValidFormAndErrors},
+  allPipetteData: AllPipetteData,
+  allLabwareTypes: AllLabwareTypes
+): SubSteps {
   return mapValues(validatedForms, (valForm: ValidFormAndErrors, stepId: StepIdType) => {
     // Don't try to render with errors. TODO LATER: presentational error state of substeps?
     if (valForm.validatedForm === null || formHasErrors(valForm)) {
@@ -79,7 +140,7 @@ export function generateSubsteps (validatedForms: {[StepIdType]: ValidFormAndErr
     }
 
     if (valForm.validatedForm.stepType === 'transfer') {
-      return _transferSubsteps(valForm.validatedForm, stepId)
+      return _transferSubsteps(valForm.validatedForm, allPipetteData, allLabwareTypes, stepId)
     }
 
     if (valForm.validatedForm.stepType === 'pause') {
@@ -89,7 +150,7 @@ export function generateSubsteps (validatedForms: {[StepIdType]: ValidFormAndErr
     }
 
     if (valForm.validatedForm.stepType === 'consolidate') {
-      return _consolidateSubsteps(valForm.validatedForm, stepId)
+      return _consolidateSubsteps(valForm.validatedForm, allPipetteData, allLabwareTypes, stepId)
     }
 
     console.warn('allSubsteps doesnt support step type: ', valForm.validatedForm.stepType, stepId)

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -13,6 +13,7 @@ import type {BaseState, Selector} from '../types'
 import {END_STEP} from './types'
 import type {
   FormData,
+  BlankForm,
   StepItemData,
   StepIdType,
   StepSubItemData,
@@ -382,7 +383,8 @@ const selectedStepSelector = createSelector(
   }
 )
 
-const deckSetupMode = createSelector(
+/** True if app is in Deck Setup Mode. */
+const deckSetupMode: Selector<boolean> = createSelector(
   getSteps,
   hoveredOrSelectedStepId,
   (steps, selectedStepId) => (selectedStepId !== null && selectedStepId !== '__end__' && steps[selectedStepId])
@@ -417,12 +419,12 @@ const hoveredStepLabware: Selector<Array<string>> = createSelector(
   }
 )
 
-const stepCreationButtonExpandedSelector = createSelector(
+const stepCreationButtonExpandedSelector: Selector<boolean> = createSelector(
   rootSelector,
   (state: RootState) => state.stepCreationButtonExpanded
 )
 
-const selectedStepFormDataSelector = createSelector(
+const selectedStepFormDataSelector: Selector<boolean | FormData | BlankForm> = createSelector(
   getSavedForms,
   selectedStepId,
   getSteps,
@@ -447,7 +449,7 @@ const selectedStepFormDataSelector = createSelector(
   }
 )
 
-const nextStepId = createSelector( // generates the next step ID to use
+const nextStepId: Selector<number> = createSelector( // generates the next step ID to use
   getSteps,
   (_steps): number => {
     const allStepIds = Object.keys(_steps).map(stepId => parseInt(stepId))
@@ -457,16 +459,16 @@ const nextStepId = createSelector( // generates the next step ID to use
   }
 )
 
-const currentFormErrors = (state: BaseState) => {
+const currentFormErrors: Selector<null | {[errorName: string]: string}> = (state: BaseState) => {
   const form = formData(state)
   return form && validateAndProcessForm(form).errors // TODO refactor selectors
 }
 
-const currentFormCanBeSaved = createSelector(
+const currentFormCanBeSaved: Selector<boolean | null> = createSelector(
   formData,
   selectedStepId,
   allSteps,
-  (formData, selectedStepId, allSteps): boolean | null =>
+  (formData, selectedStepId, allSteps) =>
     ((typeof selectedStepId === 'number') && allSteps[selectedStepId] && formData)
       ? !formHasErrors(
         validateAndProcessForm(formData)
@@ -474,7 +476,7 @@ const currentFormCanBeSaved = createSelector(
       : null
 )
 
-const formSectionCollapseSelector = createSelector(
+const formSectionCollapseSelector: Selector<FormSectionState> = createSelector(
   rootSelector,
   s => s.formSectionCollapse
 )

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -53,6 +53,8 @@ import {
   toggleStepCollapsed
 } from './actions'
 
+import type {PipetteData} from '../step-generation/types'
+
 type FormState = FormData | null
 
 // the `form` state holds temporary form info that is saved or thrown away with "cancel".
@@ -310,7 +312,24 @@ const validatedForms: Selector<{[StepIdType]: ValidFormAndErrors}> = createSelec
 
 const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
   validatedForms,
-  generateSubsteps
+  state => (state.fileData.pipettes
+    ? reduce(state.fileData.pipettes, (acc, pipetteData: ?PipetteData) => {
+      return (pipetteData)
+      ? {
+        ...acc,
+        [pipetteData.id]: pipetteData
+      }
+      : acc
+    }, {})
+    : {}), // TODO IMMEDIATELY IMPORT SELECTOR FROM file-data HACK HACK HACK
+
+  state => reduce(state.labwareIngred.containers, (acc, containerData, containerId) => ({
+    ...acc,
+    [containerId]: containerData.type
+  }), {}), // TODO IMPORT SELECTOR FROM labwareIngred HACK HACK
+
+  (_validatedForms, _pipetteData, _allLabwareTypes) =>
+    generateSubsteps(_validatedForms, _pipetteData, _allLabwareTypes)
 )
 
 // TODO Ian 2018-03-20 use selectors, don't create them here

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -24,18 +24,39 @@ export type StepType = $Keys<typeof stepIconsByType>
 
 export type StepIdType = number
 
-export type TransferishStepItem = {|
+export type StepItemSourceDestRow = {|
+  substepId: number, // TODO should this be a string or is this ID properly a number?
+  sourceIngredientName?: string,
+  destIngredientName?: string,
+  sourceWell?: string,
+  destWell?: string
+|}
+
+export type StepItemSourceDestRowMulti = {|
+  ...StepItemSourceDestRow,
+  channelId: number
+|}
+
+export type TransferishStepItemSingleChannel = {|
+  multichannel: false,
   stepType: 'transfer' | 'consolidate' | 'distribute',
   parentStepId: StepIdType,
   rows: Array<{|
-    substepId: number, // TODO should this be a string or is this ID properly a number?
-    sourceIngredientName?: string,
-    destIngredientName?: string,
-    sourceWell?: string,
-    destWell?: string,
+    ...StepItemSourceDestRow,
     volume?: number
   |}>
 |}
+
+export type TransferishStepItemMultiChannel = {|
+  multichannel: true,
+  stepType: 'transfer' | 'consolidate' | 'distribute',
+  parentStepId: StepIdType,
+  volume?: number, // uniform volume for all steps
+  multiRows: Array<Array<StepItemSourceDestRowMulti>> // Array of arrays.
+  // NOTE: "Row" means a tabular row on the steplist, NOT a "row" of wells on the deck
+|}
+
+export type TransferishStepItem = TransferishStepItemSingleChannel | TransferishStepItemMultiChannel
 
 export type StepSubItemData = TransferishStepItem | {|
   stepType: 'pause',

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -164,6 +164,12 @@ export type PauseForm = {|
 
 export type FormData = TransferForm | ConsolidateForm | PauseForm
 
+export type BlankForm = {
+  ...FormModalFields,
+  stepType: StepType,
+  id: StepIdType
+}
+
 export type TransferFormData = {|
   // TODO Ian 2018-04-05 use "mixin types" like SharedFormDataFields for shared fields across FormData types.
   ...SharedFormDataFields,


### PR DESCRIPTION
## overview

Closes #1095 

"Substeps" are the rows within a StepItem on the StepList. Each substep represents aspirate & dispense commands inside a step (it's not the literal aspirate/dispense commands, but a "cartoon" of them, because including all aspirates/dispenses for mix and blowout etc would make substeps lengthy & hard to read).

This PR introduces "substep groups" for steps using an 8-channel pipette - a "substep group" expands each substep into a group of 8 rows, 1 for each tip. These groups are collapsible.

![image](https://user-images.githubusercontent.com/11590381/38507976-f662ee56-3beb-11e8-9375-bf6c1ff78a4a.png)

More fun example with 96 to 384 well matchup:
![image](https://user-images.githubusercontent.com/11590381/38508372-096b2e90-3bed-11e8-9ce5-9e4cdb5bafdf.png)


## changelog
* generateSubsteps supports multi-channel substep data format for:
  * transfer
  * consolidate

* minor style updates for StepItem (icon always `->` btw labware, left-align ASPIRATE/DISPENSE)

## review requests

* Try transfer & consolidate with 8-channel -- do they match design (& not blow up?)
* Try expand / collapse behavior for substep groups

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_multi-ch-substep-list/index.html