### PR TITLE
Fixes delay timeout error

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1,6 +1,7 @@
 import itertools
 import warnings
 import logging
+import time
 
 from opentrons import commands
 from opentrons.containers import unpack_location
@@ -31,6 +32,10 @@ DEFAULT_PLUNGE_CURRENT = 0.1
 
 SHAKE_OFF_TIPS_SPEED = 50
 SHAKE_OFF_TIPS_DISTANCE = 2
+
+
+def _sleep(seconds):
+    time.sleep(seconds)
 
 
 class PipetteTip:
@@ -1301,14 +1306,16 @@ class Pipette:
         ----------
 
         seconds: float
-            The number of seconds to freeeze in place.
+            The number of seconds to freeze in place.
         """
 
         minutes += int(seconds / 60)
         seconds = seconds % 60
         seconds += float(minutes * 60)
 
-        self.instrument_actuator.delay(seconds)
+        self.robot.pause()
+        _sleep(seconds)
+        self.robot.resume()
 
         return self
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -195,7 +195,7 @@ def test_delay_calls(monkeypatch):
     p200.delay(seconds=4, minutes=1)
 
     assert 'pause' in cmd
-    assert 'sleep 64' in cmd
+    assert 'sleep 64.0' in cmd
     assert 'resume' in cmd
 
 


### PR DESCRIPTION
## overview

Fixes #1028 where the pipette.delay() command was timing out past 60 second intervals.

## changelog

- Utilizes robot.pause(), robot.resume() and time.sleep() to perform timed delays
instead of the built in delay function from the driver.
- As a residual effect, adds in 'Pausing robot operation' and 'resuming robot operation' under
published commands for delay.
- Adds a test to ensure that pipette.delay is calling robot pause/resume

Tested on Young 🌔 using the following protocol:
```
from opentrons import containers, instruments

p200rack = containers.load('tiprack-200ul', '4')

source_plate = containers.load('96-PCR-flat', '11')

dest_plates = [
    containers.load('96-PCR-flat', '3'),
    containers.load('96-PCR-flat', '6'),
    containers.load('96-PCR-flat', '9'),
    containers.load('96-PCR-flat', '8'),
    containers.load('96-PCR-flat', '5'),
    containers.load('96-PCR-flat', '7')
]

p200_multi = instruments.P300_Multi(
    mount="left",
    tip_racks=[p200rack]
)

p200_multi.pick_up_tip()

def run_custom_protocol(odd_volume: float=45, even_volume: float=90,
                        number_of_destination_plates: int=6):
    if number_of_destination_plates > len(dest_plates):
        raise RuntimeError((
            'Number of destination plates is too high. {} was specified, ' +
            'but the max is {}').format(
                number_of_destination_plates, len(dest_plates)))

    # map odd_volume to all odd rows of all 6 destination plates
    for i in range(0, 12, 2):
        target_rows = [plate.cols(i) for plate in dest_plates]
        p200_multi.distribute(odd_volume, source_plate.cols(i), target_rows)

    p200_multi.delay(minutes=3)
    # map even_volume to all even rows of all 6 destination plates
    for i in range(1, 12, 2):
        target_rows = [d.cols(i) for d in dest_plates]
        p200_multi.distribute(even_volume, source_plate.cols(i), target_rows)

run_custom_protocol(**{'odd_volume': 45.0, 'even_volume': 90.0, 'number_of_destination_plates': 6})
```

## review requests
