### PR TITLE
Pd select substep hover

### DIFF
--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -51,11 +51,6 @@
   margin: 0;
 }
 
-/* Last .step_subitem */
-.step_item ol li:last-child {
-  border-bottom: none;
-}
-
 .step_item h3 {
   text-transform: uppercase;
 }
@@ -117,4 +112,9 @@
 
 .inner_carat {
   @apply --clickable;
+}
+
+.highlighted_substep {
+  /* TODO Ian 2018-04-09 this border for highlight is also in lists.css in complib. Export from complib as class? */
+  border: 2px solid var(--c-blue);
 }

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -114,7 +114,12 @@
   @apply --clickable;
 }
 
-.highlighted_substep {
+.substep {
+  /* Invisible border for padding */
+  border: 2px solid transparent;
+}
+
+.highlighted {
   /* TODO Ian 2018-04-09 this border for highlight is also in lists.css in complib. Export from complib as class? */
   border: 2px solid var(--c-blue);
 }

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -5,7 +5,7 @@ import pick from 'lodash/pick'
 import {SidePanel, TitledList} from '@opentrons/components'
 
 import {END_STEP} from '../steplist/types'
-import type {StepItemData, StepSubItemData, StepIdType, SelectSubstepPayload} from '../steplist/types'
+import type {StepItemData, StepSubItemData, StepIdType, SubstepIdentifier} from '../steplist/types'
 
 import StepItem from '../components/StepItem'
 import TransferishSubstep from '../components/TransferishSubstep'
@@ -15,14 +15,15 @@ type StepIdTypeWithEnd = StepIdType | typeof END_STEP
 
 type StepListProps = {
   selectedStepId: StepIdTypeWithEnd | null,
+  hoveredSubstep: SubstepIdentifier,
   steps: Array<StepItemData & {substeps: StepSubItemData}>,
-  handleSubstepHover: SelectSubstepPayload => mixed,
+  handleSubstepHover: SubstepIdentifier => mixed,
   handleStepItemClickById?: (StepIdTypeWithEnd) => (event?: SyntheticEvent<>) => mixed,
   handleStepItemCollapseToggleById?: (StepIdType) => (event?: SyntheticEvent<>) => mixed,
   handleStepHoverById?: (StepIdTypeWithEnd | null) => (event?: SyntheticEvent<>) => mixed,
 }
 
-function generateSubstepItems (substeps, onSelectSubstep) {
+function generateSubstepItems (substeps, onSelectSubstep, hoveredSubstep) {
   if (!substeps) {
     // no substeps, form is probably not finished (or it's "deck-setup" stepType)
     return null
@@ -35,6 +36,7 @@ function generateSubstepItems (substeps, onSelectSubstep) {
     // all these step types share the same substep display
     return <TransferishSubstep
       substeps={substeps}
+      hoveredSubstep={hoveredSubstep}
       onSelectSubstep={onSelectSubstep} // TODO use action
     />
   }
@@ -66,7 +68,10 @@ export default function StepList (props: StepListProps) {
               ? null // Deck Setup steps are not collapsible
               : props.handleStepItemCollapseToggleById(step.id)
           }
-          selected={!isNil(props.selectedStepId) && step.id === props.selectedStepId}
+          selected={
+            props.hoveredSubstep === null && // don't show selected border on the Step when there's a Substep being hovered
+            !isNil(props.selectedStepId) && step.id === props.selectedStepId
+          }
           {...pick(step, [
             'title',
             'stepType',
@@ -78,7 +83,7 @@ export default function StepList (props: StepListProps) {
             'collapsed'
           ])}
         >
-          {generateSubstepItems(step.substeps, props.handleSubstepHover)}
+          {generateSubstepItems(step.substeps, props.handleSubstepHover, props.hoveredSubstep)}
         </StepItem>
       ))}
 

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -4,24 +4,25 @@ import isNil from 'lodash/isNil'
 import pick from 'lodash/pick'
 import {SidePanel, TitledList} from '@opentrons/components'
 
-import {END_STEP, type StepItemData, type StepSubItemData, type StepIdType} from '../steplist/types'
+import {END_STEP} from '../steplist/types'
+import type {StepItemData, StepSubItemData, StepIdType, SelectSubstepPayload} from '../steplist/types'
+
 import StepItem from '../components/StepItem'
 import TransferishSubstep from '../components/TransferishSubstep'
 import StepCreationButton from '../containers/StepCreationButton'
 
-// import styles from '../components/StepItem.css' // TODO: Ian 2018-01-11 This is just for "Labware & Ingredient Setup" right now, can remove later
-
 type StepIdTypeWithEnd = StepIdType | typeof END_STEP
 
 type StepListProps = {
-  selectedStepId?: StepIdTypeWithEnd,
+  selectedStepId: StepIdTypeWithEnd | null,
   steps: Array<StepItemData & {substeps: StepSubItemData}>,
+  handleSubstepHover: SelectSubstepPayload => mixed,
   handleStepItemClickById?: (StepIdTypeWithEnd) => (event?: SyntheticEvent<>) => mixed,
-  handleStepItemCollapseToggleById?: (StepIdTypeWithEnd) => (event?: SyntheticEvent<>) => mixed,
-  handleStepHoverById?: (StepIdTypeWithEnd | null) => (event?: SyntheticEvent<>) => mixed
+  handleStepItemCollapseToggleById?: (StepIdType) => (event?: SyntheticEvent<>) => mixed,
+  handleStepHoverById?: (StepIdTypeWithEnd | null) => (event?: SyntheticEvent<>) => mixed,
 }
 
-function generateSubstepItems (substeps) {
+function generateSubstepItems (substeps, onSelectSubstep) {
   if (!substeps) {
     // no substeps, form is probably not finished (or it's "deck-setup" stepType)
     return null
@@ -32,7 +33,10 @@ function generateSubstepItems (substeps) {
     substeps.stepType === 'distribute'
   ) {
     // all these step types share the same substep display
-    return <TransferishSubstep substeps={substeps} />
+    return <TransferishSubstep
+      substeps={substeps}
+      onSelectSubstep={onSelectSubstep} // TODO use action
+    />
   }
 
   if (substeps.stepType === 'pause') {
@@ -74,7 +78,7 @@ export default function StepList (props: StepListProps) {
             'collapsed'
           ])}
         >
-          {generateSubstepItems(step.substeps)}
+          {generateSubstepItems(step.substeps, props.handleSubstepHover)}
         </StepItem>
       ))}
 

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -69,7 +69,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
       <ol
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}
-        className={highlighted ? styles.highlighted_substep : ''}
+        className={cx(styles.substep, {[styles.highlighted]: highlighted})}
       >
         {/* TODO special class for this substep subheader thing?? */}
         <li className={styles.step_subitem}>
@@ -140,7 +140,7 @@ export default function TransferishSubstep (props: TransferishSubstepProps) {
     <li key={substepId}
       className={cx(
         styles.step_subitem,
-        {[styles.highlighted_substep]:
+        {[styles.highlighted]:
           !!hoveredSubstep &&
           hoveredSubstep.stepId === substeps.parentStepId &&
           substepId === hoveredSubstep.substepId

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -7,19 +7,22 @@ import styles from './StepItem.css'
 
 import type {
   TransferishStepItem,
-  StepItemSourceDestRowMulti
+  StepItemSourceDestRowMulti,
+  SelectSubstepPayload
 } from '../steplist/types'
 
 export type StepSubItemProps = {|
   substeps: TransferishStepItem
 |}
 
-type MultiChannelSubstepProps = {
+type MultiChannelSubstepProps = {|
   volume: ?string,
   rowGroup: Array<StepItemSourceDestRowMulti>,
   sourceIngredientName: ?string,
-  destIngredientName: ?string
-}
+  destIngredientName: ?string,
+  onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
+  onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed
+|}
 
 const VOLUME_DIGITS = 1
 const DEFAULT_COLLAPSED_STATE = true
@@ -60,7 +63,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
     const collapsed = this.state.collapsed
 
     return (
-      <ol>
+      <ol onMouseEnter={this.props.onMouseEnter} onMouseLeave={this.props.onMouseLeave}>
         {/* TODO special class for this substep subheader thing?? */}
         <li className={styles.step_subitem}>
           <span>{sourceIngredientName}</span>
@@ -88,9 +91,14 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
   }
 }
 
+type TransferishSubstepProps = {|
+  ...StepSubItemProps,
+  onSelectSubstep: SelectSubstepPayload => mixed
+|}
+
 // This "transferish" substep component is for transfer/distribute/consolidate
-export default function TransferishSubstep (props: StepSubItemProps) {
-  const {substeps} = props
+export default function TransferishSubstep (props: TransferishSubstepProps) {
+  const {substeps, onSelectSubstep} = props
   if (substeps.multichannel) {
     // multi-channel row item (collapsible)
     return <li>
@@ -102,6 +110,11 @@ export default function TransferishSubstep (props: StepSubItemProps) {
             ? substeps.volume.toFixed(VOLUME_DIGITS)
             : null
           }
+          onMouseEnter={() => onSelectSubstep({
+            stepId: substeps.parentStepId,
+            substepId: groupKey
+          })}
+          onMouseLeave={() => onSelectSubstep(null)}
           // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
           sourceIngredientName='ING11'
           destIngredientName='ING12'
@@ -112,7 +125,14 @@ export default function TransferishSubstep (props: StepSubItemProps) {
 
   // single-channel row item
   return substeps.rows.map((row, key) =>
-    <li key={key} className={styles.step_subitem} /* onMouseOver={onMouseOver} */>
+    <li key={key}
+      className={styles.step_subitem}
+      onMouseEnter={() => onSelectSubstep({
+        stepId: substeps.parentStepId,
+        substepId: row.substepId
+      })}
+      onMouseLeave={() => onSelectSubstep(null)}
+    >
       <span>{row.sourceIngredientName}</span>
       <span className={styles.emphasized_cell}>{row.sourceWell}</span>
       <span className={styles.volume_cell}>{

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -4,8 +4,8 @@ import {connect} from 'react-redux'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import {selectors} from '../steplist/reducers'
-import type {StepIdType, SelectSubstepPayload} from '../steplist/types'
-import {selectSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
+import type {StepIdType, SubstepIdentifier} from '../steplist/types'
+import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
 import StepList from '../components/StepList'
 
 type StepIdTypeWithEnd = StepIdType | '__end__' // TODO import this; also used in StepList
@@ -13,8 +13,9 @@ type StepIdTypeWithEnd = StepIdType | '__end__' // TODO import this; also used i
 type Props = React.ElementProps<typeof StepList>
 
 type StateProps = {
+  steps: $PropertyType<Props, 'steps'>,
   selectedStepId: $PropertyType<Props, 'selectedStepId'>,
-  steps: $PropertyType<Props, 'steps'>
+  hoveredSubstep: $PropertyType<Props, 'hoveredSubstep'>,
 }
 
 type DispatchProps = $Diff<Props, StateProps>
@@ -22,13 +23,14 @@ type DispatchProps = $Diff<Props, StateProps>
 function mapStateToProps (state: BaseState): StateProps {
   return {
     steps: selectors.allSteps(state),
-    selectedStepId: selectors.hoveredOrSelectedStepId(state)
+    selectedStepId: selectors.hoveredOrSelectedStepId(state),
+    hoveredSubstep: selectors.getHoveredSubstep(state)
   }
 }
 
 function mapDispatchToProps (dispatch: ThunkDispatch<*>): DispatchProps {
   return {
-    handleSubstepHover: (payload: SelectSubstepPayload) => dispatch(selectSubstep(payload)),
+    handleSubstepHover: (payload: SubstepIdentifier) => dispatch(hoverOnSubstep(payload)),
 
     handleStepItemClickById: (id: StepIdTypeWithEnd) => () => dispatch(selectStep(id)),
     handleStepItemCollapseToggleById: (id: StepIdType) => () => dispatch(toggleStepCollapsed(id)),

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -1,24 +1,38 @@
 // @flow
+import * as React from 'react'
 import {connect} from 'react-redux'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import {selectors} from '../steplist/reducers'
-import type {StepIdType} from '../steplist/types'
-import {selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
+import type {StepIdType, SelectSubstepPayload} from '../steplist/types'
+import {selectSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
 import StepList from '../components/StepList'
 
-function mapStateToProps (state: BaseState) {
+type StepIdTypeWithEnd = StepIdType | '__end__' // TODO import this; also used in StepList
+
+type Props = React.ElementProps<typeof StepList>
+
+type StateProps = {
+  selectedStepId: $PropertyType<Props, 'selectedStepId'>,
+  steps: $PropertyType<Props, 'steps'>
+}
+
+type DispatchProps = $Diff<Props, StateProps>
+
+function mapStateToProps (state: BaseState): StateProps {
   return {
     steps: selectors.allSteps(state),
     selectedStepId: selectors.hoveredOrSelectedStepId(state)
   }
 }
 
-function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DispatchProps {
   return {
-    handleStepItemClickById: (id: StepIdType) => () => dispatch(selectStep(id)),
+    handleSubstepHover: (payload: SelectSubstepPayload) => dispatch(selectSubstep(payload)),
+
+    handleStepItemClickById: (id: StepIdTypeWithEnd) => () => dispatch(selectStep(id)),
     handleStepItemCollapseToggleById: (id: StepIdType) => () => dispatch(toggleStepCollapsed(id)),
-    handleStepHoverById: (id: StepIdType) => () => dispatch(hoverOnStep(id))
+    handleStepHoverById: (id: StepIdTypeWithEnd | null) => () => dispatch(hoverOnStep(id))
   }
 }
 

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -3,7 +3,7 @@ import type {Dispatch} from 'redux'
 
 import {selectors} from './reducers'
 import {END_STEP} from './types'
-import type {StepType, StepIdType, FormSectionNames, FormModalFields} from './types'
+import type {StepType, StepIdType, FormSectionNames, FormModalFields, SelectSubstepPayload} from './types'
 import type {GetState, ThunkAction, ThunkDispatch} from '../types'
 
 type EndStepId = typeof END_STEP
@@ -96,6 +96,11 @@ export type SelectStepAction = {
   type: 'SELECT_STEP',
   payload: StepIdType | EndStepId
 }
+
+export const selectSubstep = (payload: SelectSubstepPayload) => ({
+  type: 'SELECT_SUBSTEP',
+  payload: payload
+})
 
 export const selectStep = (stepId: StepIdType | EndStepId): ThunkAction<*> =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {

--- a/protocol-designer/src/steplist/actions.js
+++ b/protocol-designer/src/steplist/actions.js
@@ -3,7 +3,7 @@ import type {Dispatch} from 'redux'
 
 import {selectors} from './reducers'
 import {END_STEP} from './types'
-import type {StepType, StepIdType, FormSectionNames, FormModalFields, SelectSubstepPayload} from './types'
+import type {StepType, StepIdType, FormSectionNames, FormModalFields, SubstepIdentifier} from './types'
 import type {GetState, ThunkAction, ThunkDispatch} from '../types'
 
 type EndStepId = typeof END_STEP
@@ -97,8 +97,8 @@ export type SelectStepAction = {
   payload: StepIdType | EndStepId
 }
 
-export const selectSubstep = (payload: SelectSubstepPayload) => ({
-  type: 'SELECT_SUBSTEP',
+export const hoverOnSubstep = (payload: SubstepIdentifier): * => ({
+  type: 'HOVER_ON_SUBSTEP',
   payload: payload
 })
 

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -18,7 +18,8 @@ import type {
   StepIdType,
   StepSubItemData,
   FormSectionState,
-  FormModalFields
+  FormModalFields,
+  SubstepIdentifier
 } from './types'
 
 import {
@@ -49,6 +50,7 @@ import type {
 import {
   cancelStepForm, // TODO try collapsing them all into a single Action type
   saveStepForm,
+  hoverOnSubstep,
   changeFormInput,
   expandAddStepButton,
   hoverOnStep,
@@ -178,6 +180,10 @@ const hoveredStep = handleActions({
   HOVER_ON_STEP: (state: HoveredStepState, action: ActionType<typeof hoverOnStep>) => action.payload
 }, null)
 
+const hoveredSubstep = handleActions({
+  HOVER_ON_SUBSTEP: (state: SubstepIdentifier, action: ActionType<typeof hoverOnSubstep>) => action.payload
+}, null)
+
 type StepCreationButtonExpandedState = boolean
 
 const stepCreationButtonExpanded = handleActions({
@@ -199,6 +205,7 @@ export type RootState = {|
   orderedSteps: OrderedStepsState,
   selectedStep: SelectedStepState,
   hoveredStep: HoveredStepState,
+  hoveredSubstep: SubstepIdentifier,
   stepCreationButtonExpanded: StepCreationButtonExpandedState
 |}
 
@@ -212,6 +219,7 @@ export const _allReducers = {
   orderedSteps,
   selectedStep,
   hoveredStep,
+  hoveredSubstep,
   stepCreationButtonExpanded
 }
 
@@ -241,6 +249,11 @@ const selectedStepId = createSelector(
 const hoveredStepId = createSelector(
   rootSelector,
   (state: RootState) => state.hoveredStep
+)
+
+const getHoveredSubstep: Selector<SubstepIdentifier> = createSelector(
+  rootSelector,
+  (state: RootState) => state.hoveredSubstep
 )
 
 const hoveredOrSelectedStepId: Selector<StepIdType | typeof END_STEP | null> = createSelector(
@@ -490,6 +503,7 @@ export const selectors = {
   selectedStepId, // TODO replace with selectedStep: selectedStepSelector
   hoveredStepId,
   hoveredOrSelectedStepId,
+  getHoveredSubstep,
   selectedStepFormData: selectedStepFormDataSelector,
   formData,
   formModalData,

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -327,7 +327,7 @@ const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSele
 )
 
 /** All Step data needed for Step List */
-const allSteps = createSelector(
+const allSteps: Selector<any> = createSelector( // TODO Ian 2018-04-09 type this selector, no `any`
   getSteps,
   orderedStepsSelector,
   getCollapsedSteps,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -24,7 +24,7 @@ export type StepType = $Keys<typeof stepIconsByType>
 
 export type StepIdType = number
 
-export type SelectSubstepPayload = {|
+export type SubstepIdentifier = {|
   stepId: string | number,
   substepId: number
 |} | null

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -24,6 +24,11 @@ export type StepType = $Keys<typeof stepIconsByType>
 
 export type StepIdType = number
 
+export type SelectSubstepPayload = {|
+  stepId: string | number,
+  substepId: number
+|} | null
+
 export type StepItemSourceDestRow = {|
   substepId: number, // TODO should this be a string or is this ID properly a number?
   sourceIngredientName?: string,


### PR DESCRIPTION
Closes #1049 

(Screencap note: resize jitter on substeps should be fixed. But it still exists on the Step card, since that's using TitledList's `selected` prop)
![2018-04-09 select substep hover](https://user-images.githubusercontent.com/11590381/38523970-0e852524-3c1b-11e8-9455-37be5912e4c2.gif)

## overview

This highlights substeps when you hover over them. Should work for both single-channel and multichannel style substeps -- for multi, the whole 8-channel/8-row group is a single "substep" and gets highlighted as one thing.

## changelog

* action, reducer, selector, and relevant props for hoveredSubstep to work
* Updated types for `ConnectedStepList` -- they were just implicitly typed before, I think this was originally typed when I was newly adapting Flow.

## review requests

* Try consolidate / transfer with single/multi channel, substeps should highlight when you mouseover them. Whenever substeps are hovered, the big-box-highlight for the step is not shown, but under the hood the Step is still selected.
* Highlighted wells will not update, that's the next PR!

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_select-substep-hover/index.html