### PR TITLE
Api: add other pipette models, and shift plunger positions 1mm

### DIFF
--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -79,6 +79,42 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
+    def P50_Single(
+            self,
+            mount,
+            trash_container='',
+            tip_racks=[],
+            aspirate_flow_rate=None,
+            dispense_flow_rate=None):
+
+        config = pipette_config.load('p50_single')
+
+        return self._create_pipette_from_config(
+            config=config,
+            mount=mount,
+            trash_container=trash_container,
+            tip_racks=tip_racks,
+            aspirate_flow_rate=aspirate_flow_rate,
+            dispense_flow_rate=dispense_flow_rate)
+
+    def P50_Multi(
+            self,
+            mount,
+            trash_container='',
+            tip_racks=[],
+            aspirate_flow_rate=None,
+            dispense_flow_rate=None):
+
+        config = pipette_config.load('p50_multi')
+
+        return self._create_pipette_from_config(
+            config=config,
+            mount=mount,
+            trash_container=trash_container,
+            tip_racks=tip_racks,
+            aspirate_flow_rate=aspirate_flow_rate,
+            dispense_flow_rate=dispense_flow_rate)
+
     def P300_Single(
             self,
             mount,
@@ -106,6 +142,24 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None):
 
         config = pipette_config.load('p300_multi')
+
+        return self._create_pipette_from_config(
+            config=config,
+            mount=mount,
+            trash_container=trash_container,
+            tip_racks=tip_racks,
+            aspirate_flow_rate=aspirate_flow_rate,
+            dispense_flow_rate=dispense_flow_rate)
+
+    def P1000_Single(
+            self,
+            mount,
+            trash_container='',
+            tip_racks=[],
+            aspirate_flow_rate=None,
+            dispense_flow_rate=None):
+
+        config = pipette_config.load('p1000_single')
 
         return self._create_pipette_from_config(
             config=config,

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -55,9 +55,9 @@ pipette_config = namedtuple(
 p10_single = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 2,
-        'blow_out': 0,
-        'drop_tip': -6
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
@@ -72,9 +72,9 @@ p10_single = pipette_config(
 p10_multi = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 2,
-        'blow_out': 0,
-        'drop_tip': -6
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -5
     },
     pick_up_current=0.2,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
@@ -86,12 +86,46 @@ p10_multi = pipette_config(
     tip_length=40  # TODO (andy): remove from pipette, move to tip-rack
 )
 
+p50_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -2.5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=3.08,
+    channels=1,
+    name='p50_single',
+    model_offset=(0.0, 0.0, Z_OFFSET_P50),
+    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
+)
+
+p50_multi = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -4
+    },
+    pick_up_current=0.3,
+    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=3.08,
+    channels=8,
+    name='p50_multi',
+    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
+    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
+)
+
 p300_single = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 2,
-        'blow_out': 0,
-        'drop_tip': -3.5
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -2.5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
@@ -106,9 +140,9 @@ p300_single = pipette_config(
 p300_multi = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 2,
-        'blow_out': 0,
-        'drop_tip': -5
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -4
     },
     pick_up_current=0.3,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
@@ -120,12 +154,32 @@ p300_multi = pipette_config(
     tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
 )
 
+p1000_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -2.5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=61.69,
+    channels=1,
+    name='p1000_single',
+    model_offset=(0.0, 0.0, Z_OFFSET_P1000),
+    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
+)
+
 
 configs = {
     'p10_single': p10_single,
     'p10_multi': p10_multi,
+    'p50_single': p50_single,
+    'p50_multi': p50_multi,
     'p300_single': p300_single,
-    'p300_multi': p300_multi
+    'p300_multi': p300_multi,
+    'p1000_single': p1000_single
 }
 
 

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -89,8 +89,8 @@ p10_multi = pipette_config(
 p50_single = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
+        'bottom': 4,
+        'blow_out': 2,
         'drop_tip': -2.5
     },
     pick_up_current=0.1,
@@ -106,8 +106,8 @@ p50_single = pipette_config(
 p50_multi = pipette_config(
     plunger_positions={
         'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
+        'bottom': 4,
+        'blow_out': 2,
         'drop_tip': -4
     },
     pick_up_current=0.3,

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -17,6 +17,22 @@ def test_pipette_models(robot):
     from opentrons import instruments, robot
 
     robot.reset()
+    p = instruments.P10_Single(mount='left')
+    assert p.channels == 1
+    assert p.max_volume > 10
+    p = instruments.P10_Multi(mount='right')
+    assert p.channels == 8
+    assert p.max_volume > 10
+
+    robot.reset()
+    p = instruments.P50_Single(mount='left')
+    assert p.channels == 1
+    assert p.max_volume > 50
+    p = instruments.P50_Multi(mount='right')
+    assert p.channels == 8
+    assert p.max_volume > 50
+
+    robot.reset()
     p = instruments.P300_Single(mount='left')
     assert p.channels == 1
     assert p.max_volume > 300
@@ -25,12 +41,9 @@ def test_pipette_models(robot):
     assert p.max_volume > 300
 
     robot.reset()
-    p = instruments.P10_Single(mount='left')
+    p = instruments.P1000_Single(mount='left')
     assert p.channels == 1
-    assert p.max_volume > 10
-    p = instruments.P10_Multi(mount='right')
-    assert p.channels == 8
-    assert p.max_volume > 10
+    assert p.max_volume > 1000
 
 
 def test_pipette_max_deck_height(robot):


### PR DESCRIPTION
## overview

This PR adds constructors for all available OT2 pipettes. Values for pick-up-current, and plunger-positions, are not final, but are still up to change from testing.

In addition, **all plunger positions have been shifted upwards 1 mm other that "top"**. This is because the homing switches are being changed to a new supplier, which has a 1mm lower engagement point. By shifting all pipette plunger positions up 1mm, we do not lose enough volume to drop below the pipette's advertised limit (`/tests/opentrons/labware` is ensuring this), and also **does not affect any accuracy findings** from our tests. Fixes #1133 .