### PR TITLE
complib: TitledList doesn't resize-jitter when 'selected' is toggled

### DIFF
--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -28,7 +28,7 @@
     cursor: pointer;
     color: var(--c-font-dark);
     background: transparent;
-    border-radius: 2px;
+    border-radius: var(--bd-radius-default);
 
     &:hover {
       background-color: color(var(--c-bg-light) shade(5%));

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -22,8 +22,12 @@
   background-color: white;
 }
 
+.titled_list {
+  border: var(--bd-width-default) solid transparent;
+}
+
 .titled_list_selected {
-  border: 2px solid var(--c-blue);
+  border-color: var(--c-blue);
 }
 
 .title_bar {

--- a/components/src/styles/borders.css
+++ b/components/src/styles/borders.css
@@ -1,5 +1,7 @@
 @import './colors.css';
 
 :root {
-  --bd-light: 2px solid var(--c-light-gray);
+  --bd-radius-default: 2px;
+  --bd-width-default: 2px;
+  --bd-light: var(--bd-width-default) solid var(--c-light-gray);
 }


### PR DESCRIPTION
## overview

Currently, TitledList has no border, so when it is `selected` and acquires a 2px border it gets resized.

This PR gives TitledList a transparent 2px border so toggling `selected` doesn't resize its contents.

Also while I was at it, I got took the `2px` for button's border-radius and another `2px` for TitledList's border width and made them both into variables in `borders.css`

## changelog

.

## review requests

This should remove the resize-jitter when you mouseover across steps in the StepList in PD, and the only change in Run App should be a tiny bit more spacing around the `TitledList`s in the calibration screen sidepanel. (Also in complib you should see that selecting/deselecting TitledList no longer resizes it.)