### PR TITLE
Add RequestInProgressModal to ChangePipette

### DIFF
--- a/app/src/components/ChangePipette/RequestInProgressModal.js
+++ b/app/src/components/ChangePipette/RequestInProgressModal.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react'
+
+import {Icon} from '@opentrons/components'
+
+import TitledModal from './TitledModal'
+import styles from './styles.css'
+
+type Props = {
+  title: string,
+  subtitle: string,
+  onBackClick: () => mixed,
+  message: string
+}
+
+// TODO (ka 2018-4-10): move this component to util/ or at least up a level for reuse for tip probe
+export default function RequestInProgressModal (props: Props) {
+  return (
+    <TitledModal
+      contentsClassName={styles.in_progress_contents}
+      title={props.title}
+      subtitle={props.subtitle}
+      onBackClick={props.onBackClick}
+      backClickDisabled
+    >
+      <Icon name='ot-spinner' spin className={styles.in_progress_icon} />
+      <p>{props.message}</p>
+    </TitledModal>
+  )
+}

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -14,6 +14,7 @@ import PipetteSelection, {type PipetteSelectionProps} from './PipetteSelection'
 import AttachPipetteInstructions from './AttachPipetteInstructions'
 import CheckPipettesButton from './CheckPipettesButton'
 import ConfirmPipette from './ConfirmPipette'
+import RequestInProgressModal from './RequestInProgressModal'
 
 type OP = {
   robot: Robot,
@@ -50,12 +51,26 @@ const PIPETTES = [
 export default connect(mapStateToProps, mapDispatchToProps)(ChangePipette)
 
 function ChangePipette (props: OP & SP & DP) {
-  const {mount, baseUrl, closeUrl, onPipetteSelect} = props
+  const {mount, baseUrl, closeUrl, onPipetteSelect, moveToFrontRequest} = props
   const subtitle = `${mount} carriage`
+  const progressMessage = mount === 'right'
+    ? 'Right pipette carriage moving to front and left.'
+    : 'Left pipette carriage moving to front and right.'
 
   // if (!moveToFrontRequest.inProgress && !moveToFrontRequest.response) {
   //   return (<ClearDeckAlertModal {...props} onContinueClick={moveToFront} />)
   // }
+
+  if (moveToFrontRequest.inProgress) {
+    return (
+      <RequestInProgressModal
+        title={TITLE}
+        subtitle={subtitle}
+        onBackClick={props.close}
+        mount={mount}
+        message={progressMessage}
+      />)
+  }
 
   return (
     <Switch>

--- a/app/src/components/ChangePipette/styles.css
+++ b/app/src/components/ChangePipette/styles.css
@@ -1,5 +1,14 @@
 @import '@opentrons/components';
 
+:root {
+
+  --bg-modal-transparent: {
+    max-width: 30rem;
+    padding-top: 3rem;
+    background-color: transparent;
+  };
+}
+
 .alert_list {
   list-style-type: none;
   padding-left: 3rem;
@@ -40,12 +49,24 @@
   border-radius: 0.5rem;
 }
 
+.in_progress_contents {
+  @apply --bg-modal-transparent;
+  @apply --font-body-2-light;
+  @apply --center-children;
+
+  flex-direction: column;
+  font-style: italic;
+  text-align: center;
+}
+
+.in_progress_icon {
+  width: 7.5rem;
+  margin-bottom: 3rem;
+}
+
 .confirm_pipette_contents {
   @apply --font-header-light;
-
-  max-width: 30rem;
-  padding-top: 3rem;
-  background-color: transparent;
+  @apply --bg-modal-transparent;
 }
 
 .confirm_status {


### PR DESCRIPTION
## overview
This PR adds (currently hidden) InProgressModal to ChangePipette. 
Addresses #860

<img width="1021" alt="pipette move to front in progress" src="https://user-images.githubusercontent.com/3430313/38578828-0fcccce4-3cd3-11e8-867b-73ad1fc96d69.png">

## changelog

- (Feature) add in progress screen as `InProgressModal` to ChangePipettes
  - Currently resides in ChangePipette
  - Takes title, subtitle, and message a props for reuse later in tip probe

## review requests
To view `InProgressModal` change line 64 in `app/src/components/ChangePipette/index.js
from: 
```
  if (moveToFrontRequest.inProgress) {
```
to:
```
  if (!moveToFrontRequest.inProgress) {
```