### PR TITLE
feat(app): Add action creator and reducer for POST /robot/move API

### DIFF
--- a/app/src/http-api-client/__tests__/robot.test.js
+++ b/app/src/http-api-client/__tests__/robot.test.js
@@ -1,0 +1,166 @@
+// robot/* api tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {
+  moveToChangePipette,
+  reducer
+} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const NAME = 'opentrons-dev'
+
+describe('robot/*', () => {
+  let robot
+  let state
+  let store
+
+  beforeEach(() => {
+    client.__clearMock()
+
+    robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
+    state = {api: {robot: {}}}
+    store = mockStore(state)
+  })
+
+  describe('moveToChangePipette action creator', () => {
+    const mockPositionsResponse = {
+      positions: {
+        change_pipette: {
+          target: 'mount',
+          left: [1, 2, 3],
+          right: [4, 5, 6]
+        }
+      }
+    }
+
+    test('calls GET /robot/positions', () => {
+      client.__setMockResponse(mockPositionsResponse)
+
+      return store.dispatch(moveToChangePipette(robot, 'left'))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'GET', 'robot/positions'))
+    })
+
+    test('calls POST /robot/move with positions response', () => {
+      const expected = {
+        target: 'mount',
+        mount: 'left',
+        point: [1, 2, 3]
+      }
+
+      client.__setMockResponse(mockPositionsResponse)
+
+      return store.dispatch(moveToChangePipette(robot, 'left'))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'POST', 'robot/move', expected))
+    })
+
+    // TODO(mc, 2018-04-10): need to improve client mock to handle successive
+    //   mock responses in order to test these
+    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS')
+    test('dispatches ROBOT_REQUEST and ROBOT_FAILURE')
+  })
+
+  test('reducer handles SET_ROBOT_MOVE_POSITION', () => {
+    state = state.api
+    const action = {
+      type: 'api:SET_ROBOT_MOVE_POSITION',
+      payload: {robot, position: 'change_pipette'}
+    }
+
+    expect(reducer(state, action).robot).toEqual({
+      [NAME]: {
+        movePosition: 'change_pipette'
+      }
+    })
+  })
+
+  describe('reducer with /robot/move', () => {
+    beforeEach(() => {
+      state = state.api
+    })
+
+    const path = 'move'
+    const request = {target: 'mount', mount: 'left', point: [1, 2, 3]}
+    const response = {message: 'we did it!'}
+
+    test('handles ROBOT_REQUEST', () => {
+      const action = {
+        type: 'api:ROBOT_REQUEST',
+        payload: {path, robot, request}
+      }
+
+      expect(reducer(state, action).robot).toEqual({
+        [NAME]: {
+          move: {
+            request,
+            inProgress: true,
+            error: null,
+            response: null
+          }
+        }
+      })
+    })
+
+    test('handles ROBOT_SUCCESS', () => {
+      const action = {
+        type: 'api:ROBOT_SUCCESS',
+        payload: {path, robot, response}
+      }
+
+      state.robot[NAME] = {
+        move: {
+          request,
+          inProgress: true,
+          error: null,
+          response: null
+        }
+      }
+
+      expect(reducer(state, action).robot).toEqual({
+        [NAME]: {
+          move: {
+            request,
+            response,
+            inProgress: false,
+            error: null
+          }
+        }
+      })
+    })
+
+    test('handles ROBOT_FAILURE', () => {
+      const error = {message: 'we did not do it!'}
+      const action = {
+        type: 'api:ROBOT_FAILURE',
+        payload: {path, robot, error}
+      }
+
+      state.robot[NAME] = {
+        move: {
+          request,
+          inProgress: true,
+          error: null,
+          response: null
+        }
+      }
+
+      expect(reducer(state, action).robot).toEqual({
+        [NAME]: {
+          move: {
+            request,
+            error,
+            response: null,
+            inProgress: false
+          }
+        }
+      })
+    })
+  })
+})

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -1,4 +1,4 @@
-// health api tests
+// wifi/* api tests
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -4,6 +4,7 @@ import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
 import {healthCheckReducer, type HealthCheckAction} from './health-check'
 import {pipettesReducer, type PipettesAction} from './pipettes'
+import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
 import {wifiReducer, type WifiAction} from './wifi'
 
@@ -11,6 +12,7 @@ export const reducer = combineReducers({
   health: healthReducer,
   healthCheck: healthCheckReducer,
   pipettes: pipettesReducer,
+  robot: robotReducer,
   server: serverReducer,
   wifi: wifiReducer
 })
@@ -50,6 +52,7 @@ export type Action =
   | HealthAction
   | HealthCheckAction
   | PipettesAction
+  | RobotAction
   | ServerAction
   | WifiAction
 
@@ -72,6 +75,10 @@ export {
   fetchPipettes,
   makeGetRobotPipettes
 } from './pipettes'
+
+export {
+  moveToChangePipette
+} from './robot'
 
 export {
   updateRobotServer,

--- a/app/src/http-api-client/robot.js
+++ b/app/src/http-api-client/robot.js
@@ -1,0 +1,232 @@
+// @flow
+//  HTTP API client module for /robot/**
+
+import type {ThunkPromiseAction, Action} from '../types'
+import type {Mount, BaseRobot, RobotService} from '../robot'
+
+import type {ApiCall} from './types'
+import client, {type ApiRequestError} from './client'
+
+type Point = [number, number, number]
+
+type Target = 'mount' | 'pipette'
+
+type Position = {
+  target: Target,
+  left: Point,
+  right: Point,
+}
+
+// TODO(mc, 2018-04-10): add other positions as necessary
+type Positions = {
+  change_pipette: Position
+}
+
+type PositionName = $Keys<Positions>
+
+type RobotPositionsResponse = {
+  positions: Positions
+}
+
+type RobotMoveRequest = {
+  target: Target,
+  point: Point,
+  mount: Mount,
+  model?: string,
+}
+
+type RobotMoveResponse = {
+  message: string
+}
+
+type RequestPath = 'move'
+
+type RobotRequest = RobotMoveRequest
+
+type RobotResponse = RobotMoveResponse
+
+type RobotRequestAction = {|
+  type: 'api:ROBOT_REQUEST',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    request: RobotRequest,
+  |}
+|}
+
+type RobotSuccessAction = {|
+  type: 'api:ROBOT_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    response: RobotResponse,
+  |}
+|}
+
+type RobotFailureAction = {|
+  type: 'api:ROBOT_FAILURE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    error: ApiRequestError,
+  |}
+|}
+
+type SetMovePositionAction = {|
+  type: 'api:SET_ROBOT_MOVE_POSITION',
+  payload: {|
+    robot: BaseRobot,
+    position: PositionName,
+  |}
+|}
+
+export type RobotAction =
+  | RobotRequestAction
+  | RobotSuccessAction
+  | RobotFailureAction
+  | SetMovePositionAction
+
+export type RobotMove = ApiCall<RobotMoveRequest, RobotMoveResponse>
+
+type RobotByNameState = {
+  movePosition?: PositionName,
+  move?: RobotMove,
+}
+
+type RobotState = {
+  [robotName: string]: ?RobotByNameState
+}
+
+const MOVE: RequestPath = 'move'
+
+// DEBUG
+global.moveToChangePipette = moveToChangePipette
+
+export function moveToChangePipette (
+  robot: RobotService,
+  mount: Mount
+): ThunkPromiseAction {
+  return (dispatch) => {
+    const position = 'change_pipette'
+
+    dispatch(setRobotMovePosition(robot, position))
+
+    return client(robot, 'GET', `robot/positions`)
+      .then((response: RobotPositionsResponse) => {
+        const {target, [mount]: point} = response.positions[position]
+        const request = {target, point, mount}
+
+        dispatch(robotRequest(robot, MOVE, request))
+        return client(robot, 'POST', 'robot/move', request)
+      })
+      .then(
+        (r: RobotMoveResponse) => dispatch(robotSuccess(robot, MOVE, r)),
+        (e: ApiRequestError) => dispatch(robotFailure(robot, MOVE, e))
+      )
+  }
+}
+
+function setRobotMovePosition (
+  robot: BaseRobot,
+  position: PositionName
+): SetMovePositionAction {
+  return {type: 'api:SET_ROBOT_MOVE_POSITION', payload: {robot, position}}
+}
+
+export function robotReducer (state: ?RobotState, action: Action): RobotState {
+  if (!state) return {}
+
+  let name
+  let path
+  let request
+  let response
+  let error
+  let stateByName
+
+  switch (action.type) {
+    case 'api:ROBOT_REQUEST':
+      ({path, request, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {request, inProgress: true, response: null, error: null}
+        }
+      }
+
+    case 'api:ROBOT_SUCCESS':
+      ({path, response, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {
+            ...stateByName[path],
+            response,
+            inProgress: false,
+            error: null
+          }
+        }
+      }
+
+    case 'api:ROBOT_FAILURE':
+      ({path, error, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {
+            ...stateByName[path],
+            error,
+            inProgress: false
+          }
+        }
+      }
+
+    case 'api:SET_ROBOT_MOVE_POSITION':
+      ({robot: {name}} = action.payload)
+
+      return {
+        ...state,
+        [name]: {
+          ...state[name],
+          movePosition: action.payload.position
+        }
+      }
+  }
+
+  return state
+}
+
+function robotRequest (
+  robot: RobotService,
+  path: RequestPath,
+  request: RobotRequest
+): RobotRequestAction {
+  return {type: 'api:ROBOT_REQUEST', payload: {robot, path, request}}
+}
+
+function robotSuccess (
+  robot: RobotService,
+  path: RequestPath,
+  response: RobotResponse
+): RobotSuccessAction {
+  return {
+    type: 'api:ROBOT_SUCCESS',
+    payload: {robot, path, response}
+  }
+}
+
+function robotFailure (
+  robot: RobotService,
+  path: RequestPath,
+  error: ApiRequestError
+): RobotFailureAction {
+  return {type: 'api:ROBOT_FAILURE', payload: {robot, path, error}}
+}


### PR DESCRIPTION
## overview

This PR adds redux plumbing to call `GET /robot/positions` and `POST /robot/move`. Part of #860.

## changelog

- feat(app): Add action creator and reducer for POST /robot/move API

## review requests

This PR includes debugging code to be removed by the UI wire-up PR. To test this on a robot:

1. Launch the app
2. `> store.getState()`
3. Expand the state object up to and including `state.robot.connection.discoveredByName`
4. Right click on the robot you're testing with and select "Store as Global Variable"
    * Will store as `temp1`

- [x] `> store.dispatch(moveToChangePipette(temp1, 'right'))`
- [x] `> store.dispatch(moveToChangePipette(temp1, 'left'))`

Examine the state in the "Redux" tab for `state.api.robot[robotName]`
