### PR TITLE
pd: show wells for substep

### DIFF
--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -25,7 +25,7 @@ export type StepType = $Keys<typeof stepIconsByType>
 export type StepIdType = number
 
 export type SubstepIdentifier = {|
-  stepId: string | number,
+  stepId: StepIdType,
   substepId: number
 |} | null
 


### PR DESCRIPTION
## overview

Closes #1096 

Shows source/dest wells for single/multi channel transfer/consolidate steps, when you mouseover a substep.

![2018-04-10 substep hover wells](https://user-images.githubusercontent.com/11590381/38581142-ea746fae-3cd9-11e8-97eb-4df1690bba5b.gif)

## changelog

* When a substep is hovered in the Redux state, the `_getSelectedWellsForSubstep` selector-helper fn is used to pull out source/dest wells for each labware for that step.

## review requests

Play around with it, see if you can break it, some different cases are:
* Source and dest in the same labware vs 2 different labware
* single vs multi channel step
* transfer vs consolidate

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_show-wells-for-substep/index.html#/