### PR TITLE
Connect robot actions and state to AttachPipette UI

### DIFF
--- a/app/src/components/ChangePipette/CheckPipettesButton.js
+++ b/app/src/components/ChangePipette/CheckPipettesButton.js
@@ -1,19 +1,17 @@
 // @flow
 import * as React from 'react'
-import {Link} from 'react-router-dom'
 
 import {PrimaryButton} from '@opentrons/components'
 import styles from './styles.css'
 
 type Props = {
-  url: string,
+  onClick: () => mixed
 }
 
 export default function CheckPipettesButton (props: Props) {
   return (
     <PrimaryButton
-      Component={Link}
-      to={props.url}
+      onClick={props.onClick}
       className={styles.check_pipette_button}
     >
       have robot check connection

--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -18,10 +18,10 @@ type Props = {
   channels: Channels,
   direction: Direction,
   mount: Mount,
-  error?: ?{message: ?string},
+  success: ?boolean,
   exitUrl: string,
   exit: () => mixed,
-  // confirm: () => mixed,
+  confirm: () => mixed,
   onBackClick: () => mixed,
 }
 
@@ -52,16 +52,16 @@ export default function ConfirmPipette (props: Props) {
 }
 
 function Status (props: Props) {
-  const {name, error} = props
-  const iconName = error ? 'close-circle' : 'check-circle'
+  const {name, success} = props
+  const iconName = success ? 'check-circle' : 'close-circle'
   const iconClass = cx(styles.confirm_icon, {
-    [styles.success]: !error,
-    [styles.failure]: error
+    [styles.success]: success,
+    [styles.failure]: !success
   })
 
-  const message = error
-    ? `Unable to detect ${name}.`
-    : `${name} succesfully attached.`
+  const message = success
+    ? `${name} succesfully attached.`
+    : `Unable to detect ${name}.`
 
   return (
     <div className={styles.confirm_status}>
@@ -72,7 +72,7 @@ function Status (props: Props) {
 }
 
 function FailureToDetect (props: Props) {
-  if (!props.error) return null
+  if (props.success) return null
 
   return (
     <div>
@@ -83,7 +83,7 @@ function FailureToDetect (props: Props) {
       <p className={styles.confirm_failure_instructions}>
         Check again to ensure that white connector tab is plugged into pipette.
       </p>
-      <PrimaryButton className={styles.confirm_button}>
+      <PrimaryButton className={styles.confirm_button} onClick={props.confirm}>
         have robot check connection again
       </PrimaryButton>
     </div>

--- a/app/src/components/RobotSettings/AttachedInstrumentsCard.js
+++ b/app/src/components/RobotSettings/AttachedInstrumentsCard.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import type {State} from '../../types'
 import type {Robot} from '../../robot'
 import type {Pipette} from '../../http-api-client'
-import {makeGetRobotPipettes, fetchPipettes} from '../../http-api-client'
+import {makeGetRobotPipettes, fetchPipettes, clearRobotMoveResponse} from '../../http-api-client'
 
 import InstrumentInfo from './InstrumentInfo'
 import {RefreshCard} from '@opentrons/components'
@@ -20,7 +20,8 @@ type SP = {
 }
 
 type DP = {
-  fetchPipettes: () => mixed
+  fetchPipettes: () => mixed,
+  clearMove: () => mixed,
 }
 
 type Props = OP & SP & DP
@@ -40,8 +41,8 @@ function AttachedInstrumentsCard (props: Props) {
       refresh={props.fetchPipettes}
       refreshing={props.inProgress}
     >
-      <InstrumentInfo mount='left' name={props.name} {...props.left} />
-      <InstrumentInfo mount='right' name={props.name} {...props.right} />
+      <InstrumentInfo mount='left' name={props.name} {...props.left} onClick={props.clearMove} />
+      <InstrumentInfo mount='right' name={props.name} {...props.right} onClick={props.clearMove} />
     </RefreshCard>
   )
 }
@@ -59,6 +60,7 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   return {
-    fetchPipettes: () => dispatch(fetchPipettes(ownProps))
+    fetchPipettes: () => dispatch(fetchPipettes(ownProps)),
+    clearMove: () => dispatch(clearRobotMoveResponse(ownProps))
   }
 }

--- a/app/src/components/RobotSettings/InstrumentInfo.js
+++ b/app/src/components/RobotSettings/InstrumentInfo.js
@@ -15,7 +15,8 @@ import styles from './styles.css'
 type Props = {
   mount: Mount,
   model: ?string,
-  name: string
+  name: string,
+  onClick: () => mixed,
 }
 
 // TODO(mc, 2018-03-30): volume and channels should come from the API
@@ -27,7 +28,7 @@ const LABEL_BY_MOUNT = {
 }
 
 export default function InstrumentInfo (props: Props) {
-  const {mount, model, name} = props
+  const {mount, model, name, onClick} = props
   const label = LABEL_BY_MOUNT[mount]
   const channelsMatch = model && model.match(RE_CHANNELS)
   const channels = channelsMatch && channelsMatch[1]
@@ -46,7 +47,7 @@ export default function InstrumentInfo (props: Props) {
         label={label}
         value={(model || 'None').split('_').join(' ')}
       />
-      <OutlineButton Component={Link} to={url}>
+      <OutlineButton Component={Link} to={url} onClick={onClick}>
         {buttonText}
       </OutlineButton>
       <div className={styles.image}>

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -29,8 +29,13 @@ export type {
 
 export type {
   Pipette,
+  PipettesResponse,
   RobotPipettes
 } from './pipettes'
+
+export type {
+  RobotMoveState
+} from './robot'
 
 export type {
   RobotServerUpdate,
@@ -77,7 +82,9 @@ export {
 } from './pipettes'
 
 export {
-  moveToChangePipette
+  moveToChangePipette,
+  makeGetRobotMove,
+  clearRobotMoveResponse
 } from './robot'
 
 export {

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -15,7 +15,7 @@ export type Pipette = {
   plunger_axis: string,
 }
 
-type PipettesResponse = {
+export type PipettesResponse = {
   right: Pipette,
   left: Pipette,
 }
@@ -53,9 +53,6 @@ export type RobotPipettes = ApiCall<void, PipettesResponse>
 type PipettesState = {
   [robotName: string]: ?RobotPipettes
 }
-
-// DEBUG(mc, 2018-03-30): remove before merge
-global.fetchPipettes = fetchPipettes
 
 export function fetchPipettes (robot: RobotService): ThunkPromiseAction {
   return (dispatch) => {


### PR DESCRIPTION
## overview

This PR connects the UI and state for Attach Pipette flow from Robot settings page. 

- User clicks [attach] and is prompted to clear deck alert

<img width="1020" alt="screen shot 2018-04-11 at 2 38 47 pm" src="https://user-images.githubusercontent.com/3430313/38636469-48dc5054-3d96-11e8-8f92-ac8dd72ff9c5.png">

- User clicks [move pipette to front] and in progress screen/message displays

<img width="1021" alt="screen shot 2018-04-10 at 3 19 50 pm" src="https://user-images.githubusercontent.com/3430313/38636482-4e6b185c-3d96-11e8-8859-ba3e6d97baa3.png">

- Once pipette has moved to attach/detach front position, user is prompted to select new pipette to attach
<img width="1020" alt="screen shot 2018-04-11 at 2 39 19 pm" src="https://user-images.githubusercontent.com/3430313/38636496-5a56113a-3d96-11e8-813a-dbbabbac28f9.png">

- On selecting a pipette the corresponding attach diagrams/text display

<img width="1022" alt="screen shot 2018-04-11 at 2 39 29 pm" src="https://user-images.githubusercontent.com/3430313/38636502-5e2d7c26-3d96-11e8-8015-c65d096fcc89.png">

- [Have robot check connection] checks attached vs expected attached pipettes, results in error screen or success 

<img width="1024" alt="screen shot 2018-04-11 at 2 39 42 pm" src="https://user-images.githubusercontent.com/3430313/38636508-60f159b4-3d96-11e8-91d5-d3eca41fe184.png">
<img width="1024" alt="screen shot 2018-04-11 at 2 39 57 pm" src="https://user-images.githubusercontent.com/3430313/38636511-631b5dde-3d96-11e8-9cac-69924988dc8a.png">

addresses #860 #862 #863 #864 

## changelog

- Add `moveToChangePipette` action to `ClearDeckAlertModal
- Add `clearRobotMoveResponse` action  to `IntrumentInfo` button
- Add `confirmPipette` action to `ConfirmPipette`
- TODO in subsequent PRs: 
  - Add home action/ to exit buttons
  - Refactor ChangePipette routes/containers

## review requests

Please test with virtual smoothie and actual robot. 
Rather than attaching/detaching a new pipette
 - choose the expected pipette (either the hardcoded on virtual smoothie, or existing pipette on robot) and click through for success screen
- choose different pipette (either the hardcoded on virtual smoothie, or existing pipette on robot) and click through for error screen

*known bug*  moon moon does not currently detect attached pipettes