### PR TITLE
API: removes command echo from beginning of smoothie responses

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -45,7 +45,7 @@ def _parse_smoothie_response(response, command):
         # the sent command at the beginning of its response
         # This checks for this echo, and strips the command from the response
         if command in parsed_response:
-            parsed_response = parsed_response.replace(command, '')
+            parsed_response = parsed_response.replace(command, b'')
         return parsed_response.strip()
     else:
         return None

--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -38,10 +38,15 @@ def serial_with_temp_timeout(serial_connection, timeout):
     serial_connection.timeout = saved_timeout
 
 
-def _parse_smoothie_response(response):
+def _parse_smoothie_response(response, command):
     if DRIVER_ACK in response:
         parsed_response = response.split(DRIVER_ACK)[0]
-        return parsed_response
+        # smoothieware can enter a weird state, where it repeats back
+        # the sent command at the beginning of its response
+        # This checks for this echo, and strips the command from the response
+        if command in parsed_response:
+            parsed_response = parsed_response.replace(command, '')
+        return parsed_response.strip()
     else:
         return None
 
@@ -60,7 +65,7 @@ def _write_to_device_and_return(cmd, device_connection):
 
     response = device_connection.read_until(DRIVER_ACK)
 
-    clean_response = _parse_smoothie_response(response)
+    clean_response = _parse_smoothie_response(response, cmd)
     if clean_response:
         return clean_response.decode()
     return ''


### PR DESCRIPTION
## overview

Smoothieware has gotten into this weird state where it will repeat the command sent to it, followed by it's own response. None of the GCode commands we use would ever expect to see the sent command within it's own response.

This has been isolated to happen outside OT2 machine and is solved by power cycling or resetting smoothieware, and also does not include the return and newline character `'\r\n'` that would be there if it were an exact copy of the sent bytes.

```
[send] -> G28.2X
[receive] <- G28.2X ok\r\nok\r\n
```

This PR replaces that command in the string with an empty string

```
[send] -> G28.2X
[receive] <- ok\r\nok\r\n
```