### PR TITLE
API: disengages all motors when reading from pipette

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -627,6 +627,8 @@ class SmoothieDriver_3_0_0:
         Read from an attached pipette's internal memory. The gcode used
         determines which portion of memory is read and returned.
 
+        All motors must be disengaged to consistently read over I2C lines
+
         gcode:
             String (str) containing a GCode
             either 'READ_INSTRUMENT_ID' or 'READ_INSTRUMENT_MODEL'
@@ -638,6 +640,8 @@ class SmoothieDriver_3_0_0:
         if not mount:
             raise ValueError('Unexpected mount: {}'.format(mount))
         try:
+            self.disengage_axis('XYZABC')
+            self.delay(CURRENT_CHANGE_DELAY)
             res = self._send_command(gcode + mount)
             res = _parse_instrument_data(res)
             assert mount in res


### PR DESCRIPTION
## overview

This will require a hardware fix, but on Moon-Moon the pipettes are able to be consistently read after fully disengaging the motors. This is a hardware error that should be addressed asap.
