### PR TITLE
Changes pipette home endpoint to where you can home robot or pipette

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -125,7 +125,7 @@ def init(loop=None):
     server.app.router.add_post(
         '/robot/move', control.move)
     server.app.router.add_post(
-        '/robot/home_pipette', control.home_pipette)
+        '/robot/home', control.home)
     server.app.router.add_get(
         '/settings', update.get_feature_flag)
     server.app.router.add_post(

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -124,10 +124,23 @@ async def test_home_pipette(virtual_smoothie_env, loop, test_client):
     cli = await loop.create_task(test_client(app))
 
     test_data = {
-        'model': 'p300_single',
+        'target': 'pipette',
         'mount': 'left'}
 
-    res = await cli.post('/robot/home_pipette', json=test_data)
+    res = await cli.post('/robot/home', json=test_data)
+
+    assert res.status == 200
+
+
+async def test_home_robot(virtual_smoothie_env, loop, test_client):
+
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    test_data = {
+        'target': 'robot'}
+
+    res = await cli.post('/robot/home', json=test_data)
 
     assert res.status == 200
 
@@ -138,39 +151,31 @@ async def test_home_pipette_bad_request(
     cli = await loop.create_task(test_client(app))
 
     test_data = {}
-    res = await cli.post('/robot/home_pipette', json=test_data)
+    res = await cli.post('/robot/home', json=test_data)
 
     assert res.status == 400
 
     test_data_2 = {
-        'model': 'fake_pipette',
-        'mount': 'left'}
+        'target': 'pipette',
+        'mount': 'fake_mount'}
 
-    res2 = await cli.post('/robot/home_pipette', json=test_data_2)
+    res2 = await cli.post('/robot/home', json=test_data_2)
 
     assert res2.status == 400
 
     test_data_3 = {
-        'model': 'p300_single',
-        'mount': 'fake_mount'}
+        'mount': 'left'}
 
-    res3 = await cli.post('/robot/home_pipette', json=test_data_3)
+    res3 = await cli.post('/robot/home', json=test_data_3)
 
     assert res3.status == 400
 
     test_data_4 = {
-        'mount': 'left'}
+        'target': 'pipette'}
 
-    res4 = await cli.post('/robot/home_pipette', json=test_data_4)
+    res4 = await cli.post('/robot/home', json=test_data_4)
 
     assert res4.status == 400
-
-    test_data_5 = {
-        'model': 'p300_single'}
-
-    res5 = await cli.post('/robot/home_pipette', json=test_data_5)
-
-    assert res5.status == 400
 
 
 async def test_move_bad_request(virtual_smoothie_env, loop, test_client):


### PR DESCRIPTION
## overview

Generalizes the home endpoint so that a user can choose to either home the robot or the pipette. Refers to #999.

## changelog
- Changes endpoint name from 'robot/pipette_home' to 'robot/home'
- Checks for target first and ignores mount unless target is found to be 'pipette'
- Uses generic pipette constructor instead of 'create_pipette_from_config'

## review requests
