### PR TITLE
Pd ingred pill labels

### DIFF
--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -63,6 +63,32 @@ exports[`PageTabs renders PageTabs correctly 1`] = `
 </nav>
 `;
 
+exports[`Pill renders Pill correctly 1`] = `
+<span
+  className="pill foo"
+  style={
+    Object {
+      "backgroundColor": "blue",
+    }
+  }
+>
+  Blue
+</span>
+`;
+
+exports[`Pill renders Pill correctly with inverted text 1`] = `
+<span
+  className="pill foo invert_text"
+  style={
+    Object {
+      "backgroundColor": "blue",
+    }
+  }
+>
+  Blue
+</span>
+`;
+
 exports[`RefreshCard renders correctly 1`] = `
 <section
   className="card"

--- a/components/src/__tests__/structure.test.js
+++ b/components/src/__tests__/structure.test.js
@@ -9,7 +9,8 @@ import {
   Card,
   RefreshCard,
   LabeledValue,
-  Splash
+  Splash,
+  Pill
 } from '..'
 
 describe('TitleBar', () => {
@@ -208,6 +209,24 @@ describe('Splash', () => {
   test('renders correctly with custom props', () => {
     const tree = Renderer.create(
       <Splash iconName='flask-outline' className='swag' />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('Pill', () => {
+  test('renders Pill correctly', () => {
+    const tree = Renderer.create(
+      <Pill color='blue' className='foo'>Blue</Pill>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('renders Pill correctly with inverted text', () => {
+    const tree = Renderer.create(
+      <Pill color='blue' className='foo' invertTextColor>Blue</Pill>
     ).toJSON()
 
     expect(tree).toMatchSnapshot()

--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -2,6 +2,8 @@
 
 // ========= STYLE ================
 
+export const MIXED_WELL_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in colors.css
+
 // TODO factor into CSS or constants or elsewhere
 export const swatchColors = (n: number) => {
   const colors = [

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -15,13 +15,13 @@ import type {LabwareLocations} from '../labware-types'
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
-type singleWell = {|
+export type SingleWell = {|
   highlighted: boolean,
   preselected: boolean,
   selected: boolean,
   wellName: string,
   maxVolume: number,
-  groupId: string | null
+  fillColor?: ?string
 |}
 
 type wellDims = { // TODO similar to type in Well.js. DRY it up
@@ -35,7 +35,7 @@ type wellDims = { // TODO similar to type in Well.js. DRY it up
 
 export type PlateProps = {
   containerType: string,
-  wellContents: {[string]: singleWell}, // Keyed by wellName, eg 'A1'
+  wellContents: {[string]: SingleWell}, // Keyed by wellName, eg 'A1'
   showLabels?: boolean,
   selectable?: boolean
 }
@@ -81,7 +81,7 @@ export default class Plate extends React.Component<PlateProps> {
   createWell = (wellName: string) => {
     const { selectable, wellContents } = this.props
     const { originOffset, firstWell, containerLocations } = this.getContainerData()
-    const singleWellContents: singleWell = wellContents[wellName]
+    const singleWellContents: SingleWell = wellContents[wellName]
 
     // rectangular wells are centered around x, y
     const svgOffset = (typeof firstWell.width === 'number' && typeof firstWell.length === 'number')
@@ -96,13 +96,13 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
-    const { preselected = false, selected = false, groupId = undefined } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
+    const { preselected = false, selected = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
 
     return <Well
       key={wellName}
       {...{
         wellName,
-        groupId,
+        fillColor,
         selectable,
         selected,
         preselected,

--- a/components/src/deck/Plate.md
+++ b/components/src/deck/Plate.md
@@ -4,7 +4,7 @@ Selectable `96-flat` example, with row/column labels and with well A1 filled:
 <svg height='200' width='300' viewBox='0 0 125 90'>
   <Plate
     containerType='96-flat'
-    wellContents={{A1: {groupId: 0}}}
+    wellContents={{A1: {fillColor: 'green'}}}
     showLabels
   />
 </svg>

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -1,15 +1,14 @@
 // @flow
 import React from 'react'
 import cx from 'classnames'
-import isNil from 'lodash/isNil'
 
 import styles from './Well.css'
-import { SELECTABLE_WELL_CLASS, swatchColors } from '../constants.js'
+import {SELECTABLE_WELL_CLASS} from '../constants.js'
 // import WellToolTip from '../components/WellToolTip.js' // TODO bring back tooltip in SVG, somehow
 
 type Props = {
   wellName: string,
-  groupId: string | null, // TODO Ian 2017-12-13 groupId represents an Ingredient Group ID, should be handled outside of this component.
+  fillColor?: ?string,
   selectable: boolean,
   selected: boolean,
   preselected: boolean,
@@ -29,15 +28,13 @@ type Props = {
 export default function Well (props: Props) {
   const {
     wellName,
-    groupId,
+    fillColor,
     selectable,
     selected,
     preselected,
     wellLocation,
     svgOffset
   } = props
-
-  const isFilled = !isNil(groupId)
 
   const className = cx(styles.well, {
     [SELECTABLE_WELL_CLASS]: selectable,
@@ -46,9 +43,7 @@ export default function Well (props: Props) {
   })
 
   const style = {
-    '--fill-color': isFilled
-      ? swatchColors(parseInt(groupId, 10))
-      : 'transparent'
+    '--fill-color': fillColor || 'transparent'
   }
 
   const commonProps = {

--- a/components/src/deck/Well.md
+++ b/components/src/deck/Well.md
@@ -2,7 +2,7 @@
 <svg width='100' height='100'>
   <Well
     wellName='A1'
-    groupId='0'
+    fillColor='blue'
     wellLocation={{x: 0, y: 0, length: 100, width: 20}}
     svgOffset={{x: 0, y: 0}}
   />
@@ -13,7 +13,7 @@
 <svg width='100' height='100'>
   <Well
     wellName='A1'
-    groupId='1'
+    fillColor='red'
     wellLocation={{x: 0, y: 0, diameter: 50}}
     svgOffset={{x: 25, y: 25}}
   />

--- a/components/src/deck/index.js
+++ b/components/src/deck/index.js
@@ -2,6 +2,7 @@
 import Deck from './Deck'
 import LabwareContainer from './LabwareContainer'
 import Plate from './Plate'
+import type {SingleWell} from './Plate'
 import Well from './Well'
 
 import {ContainerNameOverlay} from './ContainerNameOverlay'
@@ -19,4 +20,8 @@ export {
   Plate,
   SlotOverlay,
   Well
+}
+
+export type {
+  SingleWell
 }

--- a/components/src/structure/Pill.css
+++ b/components/src/structure/Pill.css
@@ -1,0 +1,11 @@
+@import '..';
+
+.pill {
+  border-radius: var(--bd-radius-pill);
+  color: var(--c-white);
+  padding: 0.5em;
+}
+
+.invert_text {
+  color: var(--c-black);
+}

--- a/components/src/structure/Pill.css
+++ b/components/src/structure/Pill.css
@@ -6,6 +6,11 @@
   padding: 0.5em;
 }
 
+.pill:empty::before {
+  /* zero width space to give empty pill the same line height */
+  content: "\200b";
+}
+
 .invert_text {
   color: var(--c-black);
 }

--- a/components/src/structure/Pill.js
+++ b/components/src/structure/Pill.js
@@ -5,7 +5,7 @@ import styles from './Pill.css'
 
 type Props = {
   /** background color of pill (any CSS color string) */
-  color?: string,
+  color?: ?string,
   /** text black, instead of default white */
   invertTextColor?: ?boolean,
   /** additional class name */

--- a/components/src/structure/Pill.js
+++ b/components/src/structure/Pill.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import styles from './Pill.css'
+
+type Props = {
+  /** background color of pill (any CSS color string) */
+  color?: string,
+  /** text black, instead of default white */
+  invertTextColor?: ?boolean,
+  /** additional class name */
+  className?: string,
+  /** contents of the pill */
+  children?: React.Node
+  // TODO LATER Ian 2018-04-11 mouse event handlers (eg for triggering tooltip)
+}
+
+/**
+ * Colored Pill containing text or other contents
+ */
+function Pill (props: Props) {
+  const className = cx(
+    styles.pill,
+    props.className,
+    {[styles.invert_text]: props.invertTextColor}
+  )
+
+  return <span
+    style={{backgroundColor: props.color}}
+    className={className}
+  >
+    {props.children}
+  </span>
+}
+
+export default Pill

--- a/components/src/structure/Pill.md
+++ b/components/src/structure/Pill.md
@@ -4,5 +4,10 @@
   <Pill color='green'>Green</Pill>
   <Pill invertTextColor>Colorless Inverted</Pill>
   <Pill color='yellow' invertTextColor>Yellow Inverted</Pill>
+
+  <p>
+    <span>Empty pill still has same height:</span>
+    <Pill color='pink' />
+  </p>
 </div>
 ```

--- a/components/src/structure/Pill.md
+++ b/components/src/structure/Pill.md
@@ -1,0 +1,8 @@
+```js
+<div>
+  <Pill color='blue'>Blue</Pill>
+  <Pill color='green'>Green</Pill>
+  <Pill invertTextColor>Colorless Inverted</Pill>
+  <Pill color='yellow' invertTextColor>Yellow Inverted</Pill>
+</div>
+```

--- a/components/src/structure/index.js
+++ b/components/src/structure/index.js
@@ -6,6 +6,7 @@ import Card from './Card'
 import RefreshCard from './RefreshCard'
 import Splash from './Splash'
 import LabeledValue from './LabeledValue'
+import Pill from './Pill'
 
 // types
 export type {PageTabProps} from './PageTabs'
@@ -16,5 +17,6 @@ export {
   Card,
   RefreshCard,
   Splash,
-  LabeledValue
+  LabeledValue,
+  Pill
 }

--- a/components/src/styles/borders.css
+++ b/components/src/styles/borders.css
@@ -2,6 +2,7 @@
 
 :root {
   --bd-radius-default: 2px;
+  --bd-radius-pill: 12px;
   --bd-width-default: 2px;
   --bd-light: var(--bd-width-default) solid var(--c-light-gray);
 }

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -19,6 +19,8 @@
   /* Misc */
   --c-overlay: rgba(0, 0, 0, 0.7);
   --c-plate-bg: #ccc;
+  --c-white: #fff;
+  --c-black: #000;
   --c-green: #7ed321;
   --c-red: #f00000;
   --c-orange: #f5a623;

--- a/protocol-designer/src/components/IngredPill.js
+++ b/protocol-designer/src/components/IngredPill.js
@@ -16,7 +16,8 @@ function IngredPill (props: Props) {
   const {ingreds} = props
 
   if (!ingreds || ingreds.length === 0) {
-    return <span />
+    // Invisible Pill, but has correct height/margin/etc for spacing
+    return <Pill />
   }
 
   const color = (ingreds.length === 1)

--- a/protocol-designer/src/components/IngredPill.js
+++ b/protocol-designer/src/components/IngredPill.js
@@ -4,21 +4,24 @@ import {Pill} from '@opentrons/components'
 import type {NamedIngred} from '../steplist/types'
 import {swatchColors} from '../constants.js'
 
+// TODO Ian 2018-04-12 is there a better place for FALLBACK_COLOR? complib?
+// It's a string for a CSS color representing the color of mixed-ingred wells
+const FALLBACK_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in colors.css in complib
+
 type Props = {
   ingreds: ?Array<NamedIngred>
 }
 
 function IngredPill (props: Props) {
   const {ingreds} = props
-  const fallBackColor = 'gray' // TODO const?
 
-  if (!ingreds) {
+  if (!ingreds || ingreds.length === 0) {
     return <span />
   }
 
   const color = (ingreds.length === 1)
     ? swatchColors(ingreds[0].id)
-    : fallBackColor
+    : FALLBACK_COLOR
 
   return <Pill color={color}>{
     ingreds.map(ingred => ingred.name).join(',')

--- a/protocol-designer/src/components/IngredPill.js
+++ b/protocol-designer/src/components/IngredPill.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+import {Pill} from '@opentrons/components'
+import type {NamedIngred} from '../steplist/types'
+import {swatchColors} from '../constants.js'
+
+type Props = {
+  ingreds: ?Array<NamedIngred>
+}
+
+function IngredPill (props: Props) {
+  const {ingreds} = props
+  const fallBackColor = 'gray' // TODO const?
+
+  if (!ingreds) {
+    return <span />
+  }
+
+  const color = (ingreds.length === 1)
+    ? swatchColors(ingreds[0].id)
+    : fallBackColor
+
+  return <Pill color={color}>{
+    ingreds.map(ingred => ingred.name).join(',')
+  }</Pill>
+}
+
+export default IngredPill

--- a/protocol-designer/src/components/IngredPill.js
+++ b/protocol-designer/src/components/IngredPill.js
@@ -1,12 +1,8 @@
 // @flow
 import * as React from 'react'
-import {Pill} from '@opentrons/components'
+import {Pill, MIXED_WELL_COLOR} from '@opentrons/components'
 import type {NamedIngred} from '../steplist/types'
 import {swatchColors} from '../constants.js'
-
-// TODO Ian 2018-04-12 is there a better place for FALLBACK_COLOR? complib?
-// It's a string for a CSS color representing the color of mixed-ingred wells
-const FALLBACK_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in colors.css in complib
 
 type Props = {
   ingreds: ?Array<NamedIngred>
@@ -22,7 +18,7 @@ function IngredPill (props: Props) {
 
   const color = (ingreds.length === 1)
     ? swatchColors(ingreds[0].id)
-    : FALLBACK_COLOR
+    : MIXED_WELL_COLOR
 
   return <Pill color={color}>{
     ingreds.map(ingred => ingred.name).join(',')

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -2,7 +2,12 @@
 // Wrap Plate with a SelectionRect.
 import * as React from 'react'
 import mapValues from 'lodash/mapValues'
-import {swatchColors, Plate, type SingleWell} from '@opentrons/components'
+import {
+  swatchColors,
+  Plate,
+  MIXED_WELL_COLOR,
+  type SingleWell
+} from '@opentrons/components'
 
 import SelectionRect from '../components/SelectionRect.js'
 import type {AllWellContents, WellContents} from '../labware-ingred/types'
@@ -35,8 +40,6 @@ function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
 }
 
 function getFillColor (groupIds: Array<string>): ?string {
-  const FALLBACK_COLOR = 'gray'
-
   if (groupIds.length === 0) {
     return null
   }
@@ -45,7 +48,7 @@ function getFillColor (groupIds: Array<string>): ?string {
     return swatchColors(parseInt(groupIds[0]))
   }
 
-  return FALLBACK_COLOR
+  return MIXED_WELL_COLOR
 }
 
 export default function SelectablePlate (props: Props) {

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -1,10 +1,11 @@
 // @flow
 // Wrap Plate with a SelectionRect.
-import React from 'react'
-import { Plate } from '@opentrons/components'
+import * as React from 'react'
+import mapValues from 'lodash/mapValues'
+import {swatchColors, Plate, type SingleWell} from '@opentrons/components'
 
 import SelectionRect from '../components/SelectionRect.js'
-import type {AllWellContents} from '../labware-ingred/types'
+import type {AllWellContents, WellContents} from '../labware-ingred/types'
 import type {RectEvent} from '../collision-types'
 
 export type Props = {
@@ -14,6 +15,42 @@ export type Props = {
   onSelectionDone: RectEvent,
   containerId: string,
   selectable?: boolean
+}
+
+type PlateProps = React.ElementProps<typeof Plate>
+type PlateWellContents = $PropertyType<PlateProps, 'wellContents'>
+function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
+  return mapValues(
+    wc,
+    (well: WellContents): SingleWell => ({
+      wellName: well.wellName,
+      selected: well.selected,
+      preselected: well.preselected,
+      highlighted: well.highlighted,
+      maxVolume: well.maxVolume,
+
+      fillColor: getFillColor(well.groupIds)
+    })
+  )
+}
+
+function getFillColor (groupIds: Array<string>): ?string {
+  const FALLBACK_COLOR = 'gray'
+  if (!groupIds) {
+    // TODO DEBUG
+    console.warn('falsey groupIds ?!?!')
+    return 'black'
+  }
+
+  if (groupIds.length === 0) {
+    return null
+  }
+
+  if (groupIds.length === 1) {
+    return swatchColors(parseInt(groupIds[0]))
+  }
+
+  return FALLBACK_COLOR
 }
 
 export default function SelectablePlate (props: Props) {
@@ -28,7 +65,7 @@ export default function SelectablePlate (props: Props) {
 
   const plate = <Plate
     selectable={selectable}
-    wellContents={wellContents}
+    wellContents={wellContentsGroupIdsToColor(wellContents)}
     containerType={containerType}
     containerId={containerId}
     showLabels={selectable}

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -36,11 +36,6 @@ function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
 
 function getFillColor (groupIds: Array<string>): ?string {
   const FALLBACK_COLOR = 'gray'
-  if (!groupIds) {
-    // TODO DEBUG
-    console.warn('falsey groupIds ?!?!')
-    return 'black'
-  }
 
   if (groupIds.length === 0) {
     return null

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -2,7 +2,10 @@
 import * as React from 'react'
 import cx from 'classnames'
 import last from 'lodash/last'
+import uniqBy from 'lodash/uniqBy'
+
 import {Icon} from '@opentrons/components'
+import IngredPill from './IngredPill'
 
 import styles from './StepItem.css'
 
@@ -19,8 +22,6 @@ export type StepSubItemProps = {|
 type MultiChannelSubstepProps = {|
   volume: ?string,
   rowGroup: Array<StepItemSourceDestRowMulti>,
-  sourceIngredientName: ?string,
-  destIngredientName: ?string,
   highlighted?: boolean,
   onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
   onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed
@@ -48,9 +49,7 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
     const {
       volume,
       rowGroup,
-      highlighted,
-      sourceIngredientName
-      // destIngredientName
+      highlighted
     } = this.props
 
     const lastGroupSourceWell = last(rowGroup).sourceWell
@@ -73,7 +72,13 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
       >
         {/* TODO special class for this substep subheader thing?? */}
         <li className={styles.step_subitem}>
-          <span>{sourceIngredientName}</span>
+          <IngredPill ingreds={uniqBy(
+            rowGroup.reduce((acc, row) => (row.sourceIngredients)
+              ? [...acc, ...row.sourceIngredients]
+              : acc,
+            []),
+            ingred => ingred.id
+          )}>{'TODO'}</IngredPill>
           <span className={styles.emphasized_cell}>{sourceWellRange}</span>
           <span className={styles.volume_cell}>{volume && `${volume} μL`}</span>
           <span className={styles.emphasized_cell}>{destWellRange}</span>
@@ -86,11 +91,11 @@ class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, {col
         {!collapsed && rowGroup.map((row, rowKey) =>
           // Channel rows (1 for each channel in multi-channel pipette)
           <li className={styles.step_subitem_channel_row} key={rowKey}>
-            <span>{row.sourceIngredientName}</span>
+            <IngredPill ingreds={row.sourceIngredients} />
             <span className={styles.emphasized_cell}>{row.sourceWell}</span>
             <span className={styles.volume_cell}>{volume && `${volume} μL`}</span>
             <span className={styles.emphasized_cell}>{row.destWell}</span>
-            <span>{row.destIngredientName}</span>
+            <IngredPill ingreds={row.destIngredients} />
           </li>
       )}
       </ol>
@@ -124,8 +129,6 @@ export default function TransferishSubstep (props: TransferishSubstepProps) {
           })}
           onMouseLeave={() => onSelectSubstep(null)}
           // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
-          sourceIngredientName='ING11'
-          destIngredientName='ING12'
           highlighted={!!hoveredSubstep &&
             hoveredSubstep.stepId === substeps.parentStepId &&
             hoveredSubstep.substepId === groupKey
@@ -152,14 +155,14 @@ export default function TransferishSubstep (props: TransferishSubstepProps) {
       })}
       onMouseLeave={() => onSelectSubstep(null)}
     >
-      <span>{row.sourceIngredientName}</span>
+      <IngredPill ingreds={row.sourceIngredients} />
       <span className={styles.emphasized_cell}>{row.sourceWell}</span>
       <span className={styles.volume_cell}>{
         typeof row.volume === 'number' &&
         `${parseFloat(row.volume.toFixed(VOLUME_DIGITS))} μL`
       }</span>
       <span className={styles.emphasized_cell}>{row.destWell}</span>
-      <span>{row.destIngredientName}</span>
+      <IngredPill ingreds={row.destIngredients} />
     </li>
   )
 }

--- a/protocol-designer/src/components/TransferishSubstep.js
+++ b/protocol-designer/src/components/TransferishSubstep.js
@@ -10,14 +10,14 @@ import IngredPill from './IngredPill'
 import styles from './StepItem.css'
 
 import type {
-  TransferishStepItem,
+  TransferLikeSubstepItem,
   StepItemSourceDestRowMulti,
   SubstepIdentifier,
   NamedIngred
 } from '../steplist/types'
 
 export type StepSubItemProps = {|
-  substeps: TransferishStepItem
+  substeps: TransferLikeSubstepItem
 |}
 
 const DEFAULT_COLLAPSED_STATE = true
@@ -232,7 +232,7 @@ export default function TransferishSubstep (props: TransferishSubstepProps) {
         substepId
       })}
       onMouseLeave={() => onSelectSubstep(null)}
-      volume={row.volume} // TODO IMMEDIATELY PARSE!!
+      volume={row.volume}
       sourceIngredients={row.sourceIngredients}
       sourceWells={row.sourceWell}
       destIngredients={row.destIngredients}

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -6,6 +6,7 @@ import type {BaseState, ThunkDispatch} from '../types'
 import {selectors} from '../steplist/reducers'
 import type {StepIdType, SubstepIdentifier} from '../steplist/types'
 import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
+import * as substepSelectors from '../top-selectors/substeps'
 import StepList from '../components/StepList'
 
 type StepIdTypeWithEnd = StepIdType | '__end__' // TODO import this; also used in StepList
@@ -22,7 +23,7 @@ type DispatchProps = $Diff<Props, StateProps>
 
 function mapStateToProps (state: BaseState): StateProps {
   return {
-    steps: selectors.allSteps(state),
+    steps: substepSelectors.allStepsWithSubsteps(state),
     selectedStepId: selectors.hoveredOrSelectedStepId(state),
     hoveredSubstep: selectors.getHoveredSubstep(state)
   }

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -6,7 +6,8 @@ import mapValues from 'lodash/mapValues'
 import SelectablePlate from '../components/SelectablePlate.js'
 import {selectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
-import {selectors as fileSelectors} from '../file-data'
+import * as highlightSelectors from '../top-selectors/substep-highlight'
+import * as wellContentsSelectors from '../top-selectors/well-contents'
 import {preselectWells, selectWells} from '../labware-ingred/actions'
 
 import {END_STEP} from '../steplist/types'
@@ -40,7 +41,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
 
   const labware = selectors.getLabware(state)[containerId]
   const stepId = steplistSelectors.hoveredOrSelectedStepId(state)
-  const allWellContentsForSteps = fileSelectors.allWellContentsForSteps(state)
+  const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
   const deckSetupMode = steplistSelectors.deckSetupMode(state)
 
   let prevStepId: number = 0 // initial liquid state if stepId is null
@@ -52,7 +53,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     prevStepId = Math.max(stepId - 1, 0)
   }
 
-  const highlightedWells = deckSetupMode ? {} : fileSelectors.wellHighlightsForSteps(state)[prevStepId]
+  const highlightedWells = deckSetupMode ? {} : highlightSelectors.wellHighlightsForSteps(state)[prevStepId]
 
   let wellContents = {}
   if (deckSetupMode) {

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -2,13 +2,17 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
+import mapValues from 'lodash/mapValues'
 import SelectablePlate from '../components/SelectablePlate.js'
-import { selectors } from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import {selectors as fileSelectors} from '../file-data'
-import { preselectWells, selectWells } from '../labware-ingred/actions'
-import type {BaseState} from '../types'
+import {preselectWells, selectWells} from '../labware-ingred/actions'
+
 import {END_STEP} from '../steplist/types'
+
+import type {WellContents} from '../labware-ingred/types'
+import type {BaseState} from '../types'
 
 type OwnProps = {
   containerId?: string,
@@ -37,6 +41,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   const labware = selectors.getLabware(state)[containerId]
   const stepId = steplistSelectors.hoveredOrSelectedStepId(state)
   const allWellContentsForSteps = fileSelectors.allWellContentsForSteps(state)
+  const deckSetupMode = steplistSelectors.deckSetupMode(state)
 
   let prevStepId: number = 0 // initial liquid state if stepId is null
   if (stepId === END_STEP) {
@@ -47,11 +52,27 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     prevStepId = Math.max(stepId - 1, 0)
   }
 
-  const wellContents = (steplistSelectors.deckSetupMode(state))
+  const highlightedWells = deckSetupMode ? {} : fileSelectors.wellHighlightsForSteps(state)[prevStepId]
+
+  let wellContents = {}
+  if (deckSetupMode) {
     // selection for deck setup
-    ? selectors.wellContentsAllLabware(state)[containerId]
+    wellContents = selectors.wellContentsAllLabware(state)[containerId]
+  } else {
     // well contents for step, not deck setup mode
-    : allWellContentsForSteps[prevStepId] ? allWellContentsForSteps[prevStepId][containerId] : {}
+    const wellContentsWithoutHighlight = (allWellContentsForSteps[prevStepId])
+      ? allWellContentsForSteps[prevStepId][containerId]
+      : {}
+    // TODO Ian 2018-04-11 separate out selected/highlighted state from wellContents props of Plate,
+    // so you don't have to do this merge
+    wellContents = mapValues(
+      wellContentsWithoutHighlight,
+      (wellContents: WellContents, well: string) => ({
+        ...wellContents,
+        selected: highlightedWells && highlightedWells[containerId] && highlightedWells[containerId][well]
+      })
+    )
+  }
 
   return {
     containerId,

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -1,17 +1,13 @@
 // @flow
 import {createSelector} from 'reselect'
 import isEmpty from 'lodash/isEmpty'
-import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
-import {computeWellAccess} from '@opentrons/labware-definitions'
 import type {BaseState, Selector} from '../../types'
 import * as StepGeneration from '../../step-generation'
 import {selectors as steplistSelectors} from '../../steplist/reducers'
 import {equippedPipettes} from './pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
-import {getAllWellsForLabware} from '../../constants'
-import type {IngredInstance, WellContents, AllWellContents} from '../../labware-ingred/types'
-import type {ProcessedFormData, StepSubItemData} from '../../steplist/types'
+import type {IngredInstance} from '../../labware-ingred/types'
 
 const all96Tips = reduce( // TODO Ian 2018-04-05 mapValues
   StepGeneration.tiprackWellNamesFlat,
@@ -21,7 +17,6 @@ const all96Tips = reduce( // TODO Ian 2018-04-05 mapValues
 
 type LiquidState = $PropertyType<StepGeneration.RobotState, 'liquidState'>
 type LabwareLiquidState = $PropertyType<LiquidState, 'labware'>
-type SingleLabwareLiquidState = {[well: string]: StepGeneration.LocationLiquidState}
 
 /** getLabwareLiquidState reshapes data from labwareIngreds.ingredLocations reducer
   * to match RobotState.liquidState.labware's shape
@@ -185,227 +180,5 @@ export const robotStateTimeline: BaseState => Array<$Call<StepGeneration.Command
     }
 
     return result.timeline
-  }
-)
-
-function _wellContentsForWell (
-  liquidVolState: StepGeneration.LocationLiquidState,
-  well: string
-): WellContents {
-  // TODO IMMEDIATELY Ian 2018-03-23 why is liquidVolState missing sometimes (eg first call with trashId)? Thus the liquidVolState || {}
-  const ingredGroupIdsWithContent = Object.keys(liquidVolState || {}).filter(groupId =>
-      liquidVolState[groupId] &&
-      liquidVolState[groupId].volume > 0
-    )
-
-  return {
-    preselected: false,
-    selected: false,
-    highlighted: false,
-    maxVolume: Infinity, // TODO Ian 2018-03-23 refactor so all these fields aren't needed
-    wellName: well,
-    groupId: ingredGroupIdsWithContent[0] || null // TODO Ian 2018-03-23 show 'gray' when there are multiple group ids.
-  }
-}
-
-function _wellContentsForLabware (
-  labwareLiquids: SingleLabwareLiquidState,
-  labwareId: string,
-  labwareType: string
-): AllWellContents {
-  const allWellsForContainer = getAllWellsForLabware(labwareType)
-
-  return reduce(
-    allWellsForContainer,
-    (wellAcc, well: string): {[well: string]: WellContents} => ({
-      ...wellAcc,
-      [well]: _wellContentsForWell(labwareLiquids[well], well)
-    }),
-    {}
-  )
-}
-
-function _wellsForPipette (pipetteChannels: 1 | 8, labwareType: string, wells: Array<string>): Array<string> {
-  // `wells` is all the wells that pipette's channel 1 interacts with.
-  if (pipetteChannels === 8) {
-    return wells.reduce((acc, well) => {
-      const setOfWellsForMulti = computeWellAccess(labwareType, well)
-
-      return setOfWellsForMulti
-        ? [...acc, ...setOfWellsForMulti]
-        : acc // setOfWellsForMulti is null
-    }, [])
-  }
-  // single-channel
-  return wells
-}
-
-function _getSelectedWellsForStep (
-  form: ProcessedFormData,
-  labwareId: string,
-  robotState: StepGeneration.RobotState
-): Array<string> {
-  if (form.stepType === 'pause') {
-    return []
-  }
-
-  const pipetteId = form.pipette
-  // TODO Ian 2018-04-02 use robotState selectors here
-  const pipetteChannels = robotState.instruments[pipetteId].channels
-  const labwareType = robotState.labware[labwareId].type
-
-  const getWells = (wells: Array<string>) => _wellsForPipette(pipetteChannels, labwareType, wells)
-
-  let wells = []
-
-  // If we're moving liquids within a single labware,
-  // both the source and dest wells together need to be selected.
-  if (form.stepType === 'transfer') {
-    if (form.sourceLabware === labwareId) {
-      wells.push(...getWells(form.sourceWells))
-    }
-    if (form.destLabware === labwareId) {
-      wells.push(...getWells(form.destWells))
-    }
-  }
-  if (form.stepType === 'consolidate') {
-    if (form.sourceLabware === labwareId) {
-      wells.push(...getWells(form.sourceWells))
-    }
-    if (form.destLabware === labwareId) {
-      wells.push(...getWells([form.destWell]))
-    }
-  }
-  // TODO Ian 2018-03-23 once distribute is supported
-  // if (form.stepType === 'distribute') {
-  //   ...
-  // }
-  return wells
-}
-
-/** Scan through given substep rows to get a list of source/dest wells for the given labware */
-function _getSelectedWellsForSubstep (
-  form: ProcessedFormData,
-  labwareId: string,
-  substeps: StepSubItemData | null,
-  substepId: number
-): Array<string> {
-  if (substeps === null) {
-    return []
-  }
-
-  function getWells (wellField): Array<string> {
-    if (substeps && substeps.rows && substeps.rows[substepId]) {
-      // single-channel
-      const well = substeps.rows[substepId][wellField]
-      return well ? [well] : []
-    }
-
-    if (substeps && substeps.multiRows && substeps.multiRows[substepId]) {
-      // multi-channel
-      return substeps.multiRows[substepId].reduce((acc, multiRow) => {
-        const well = multiRow[wellField]
-        return well ? [...acc, well] : acc
-      }, [])
-    }
-    return []
-  }
-
-  let wells: Array<string> = []
-  if (form.sourceLabware && form.sourceLabware === labwareId) {
-    wells.push(...getWells('sourceWell'))
-  }
-  if (form.destLabware && form.destLabware === labwareId) {
-    wells.push(...getWells('destWell'))
-  }
-
-  return wells
-}
-
-type AllWellHighlights = {[wellName: string]: true} // NOTE: all keys are true
-type AllWellHighlightsAllLabware = {[labwareId: string]: AllWellHighlights}
-export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>> = createSelector(
-  robotStateTimeline,
-  steplistSelectors.validatedForms,
-  steplistSelectors.hoveredStepId,
-  steplistSelectors.getHoveredSubstep,
-  steplistSelectors.allSubsteps,
-  (_robotStateTimeline, _forms, _hoveredStepId, _hoveredSubstep, _allSubsteps) => {
-    function highlightedWellsForLabwareAtStep (
-      labwareLiquids: SingleLabwareLiquidState,
-      labwareId: string,
-      robotState: StepGeneration.RobotState,
-      form: ProcessedFormData,
-      formIdx: number
-    ): AllWellHighlights {
-      let selectedWells: Array<string> = []
-      if (form && _hoveredStepId === formIdx) {
-        // only show selected wells when user is **hovering** over the step
-        if (_hoveredSubstep) {
-          // wells for hovered substep
-          selectedWells = _getSelectedWellsForSubstep(
-            form,
-            labwareId,
-            _allSubsteps[_hoveredSubstep.stepId],
-            _hoveredSubstep.substepId
-          )
-        } else {
-          // wells for step overall
-          selectedWells = _getSelectedWellsForStep(form, labwareId, robotState)
-        }
-      }
-
-      // return selected wells eg {A1: true, B4: true}
-      const selectedWellsResult = selectedWells.reduce((acc, well) => ({...acc, [well]: true}), {})
-      console.log({selectedWellsResult, selectedWells, robotState, form, formIdx, _hoveredSubstep, _hoveredStepId})
-      return selectedWellsResult
-    }
-
-    function highlightedWellsForTimelineFrame (liquidState, timelineIdx): AllWellHighlightsAllLabware {
-      const robotState = _robotStateTimeline[timelineIdx].robotState
-      const formIdx = timelineIdx + 1 // add 1 to make up for initial deck setup action
-      const form = _forms[formIdx] && _forms[formIdx].validatedForm
-
-      // replace value of each labware with highlighted wells info
-      return mapValues(
-        liquidState,
-        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => (form)
-          ? highlightedWellsForLabwareAtStep(
-            labwareLiquids,
-            labwareId,
-            robotState,
-            form,
-            formIdx
-          )
-        : {} // no form -> no highlighted wells
-      )
-    }
-
-    const liquidStateTimeline = _robotStateTimeline.map(t => t.robotState.liquidState.labware)
-    return liquidStateTimeline.map(highlightedWellsForTimelineFrame)
-  }
-)
-
-export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWellContents}>> = createSelector(
-  robotStateTimeline,
-  steplistSelectors.validatedForms,
-  (_robotStateTimeline, _forms) => {
-    const liquidStateTimeline = _robotStateTimeline.map(t => t.robotState.liquidState.labware)
-
-    return liquidStateTimeline.map(
-      (liquidState, timelineIdx) => mapValues(
-        liquidState,
-        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => {
-          const robotState = _robotStateTimeline[timelineIdx].robotState
-          const labwareType = robotState.labware[labwareId].type
-
-          return _wellContentsForLabware(
-            labwareLiquids,
-            labwareId,
-            labwareType
-          )
-        }
-      )
-    )
   }
 )

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -166,8 +166,7 @@ const defaultWellContents = {
   highlighted: false,
   hovered: false,
   preselected: false,
-  selected: false,
-  groupId: null
+  selected: false
 }
 
 const container1MaxVolume = 400
@@ -265,7 +264,6 @@ describe('wellContentsAllLabware', () => {
         A1: {
           ...defaultWellContents,
           selected: true,
-          groupId: '0',
           maxVolume: container1MaxVolume
         },
         A2: {
@@ -275,7 +273,6 @@ describe('wellContentsAllLabware', () => {
         B1: {
           ...defaultWellContents,
           selected: true,
-          groupId: '0',
           maxVolume: container1MaxVolume
         },
         B2: {

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -486,7 +486,6 @@ const _getWellContents = (
 
   return reduce(allLocations, (acc: AllWellContents, location: JsonWellData, wellName: string): AllWellContents => {
     const groupIds = groupIdsForWell(wellName)
-    const groupIdFields = {groupId: groupIds[0] || null}
 
     const isHighlighted = highlightedWells ? (wellName in highlightedWells) : false
 
@@ -499,7 +498,7 @@ const _getWellContents = (
         hovered: !!(highlightedWells && isHighlighted && Object.keys(highlightedWells).length === 1),
 
         maxVolume: location['total-liquid-volume'] || Infinity,
-        ...groupIdFields // TODO Ian 2018-03-07 this should be a color, >1 => gray ?
+        groupIds
       }
     }
   }, {})

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -21,7 +21,7 @@ export type IngredInstance = {
 
 type IngredInstanceFlat = {|
   labwareId: string,
-  groupId: string,
+  groupIds: Array<string>,
   well: string,
   volume: number
 |}
@@ -32,7 +32,7 @@ export type WellContents = {| // non-ingredient well state
   highlighted: boolean,
   maxVolume: number,
   wellName: string, // eg 'A1', 'A2' etc
-  groupId: string | null // TODO Ian 2018-03-07 this should be color, not groupId.
+  groupIds: Array<string>
 |}
 
 export type AllWellContents = {

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -14,7 +14,7 @@ import type {
   SubSteps,
   PauseFormData,
   TransferFormData,
-  TransferishStepItem,
+  TransferLikeSubstepItem,
   NamedIngredsByLabwareAllSteps
 } from './types'
 
@@ -29,7 +29,7 @@ type AllLabwareTypes = {[labwareId: string]: string}
 function _transferSubsteps (
   form: TransferFormData,
   transferLikeFields: *
-): TransferishStepItem {
+): TransferLikeSubstepItem {
   const {
     sourceWells,
     destWells
@@ -107,7 +107,7 @@ function _transferSubsteps (
 function _consolidateSubsteps (
   form: ConsolidateFormData,
   transferLikeFields: *
-): TransferishStepItem {
+): TransferLikeSubstepItem {
   const {
     sourceWells,
     destWell

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -63,14 +63,29 @@ function _transferSubsteps (
           const sourceWell = sourceWellsForTips[channel]
           const destWell = destWellsForTips[channel]
 
-          const sourceIngredients = allWellContents[form.sourceLabware][sourceWell].groupIds
+          function fakeHackGroupIdsToIngred (groupIds: Array<string>) {
+            // HACK HACK HACK
+            // TODO Ian 2018-04-11 need to pass this in -- should it be pre-processed, eg instead of using wellContents?
+            return groupIds.map(id => ({
+              id: parseInt(id),
+              name: id
+            }))
+          }
+
+          const sourceIngredients = fakeHackGroupIdsToIngred(
+            allWellContents[form.sourceLabware][sourceWell].groupIds
+          )
+
+          const destIngredients = fakeHackGroupIdsToIngred(
+            // TODO Ian 2018-04-11 should dest be PREVIOUS liquid state?
+            allWellContents[form.destLabware][destWell].groupIds
+          )
 
           return {
             substepId: i,
             channelId: channel,
-            // TODO LATER Ian 2018-04-06 ingredient name & color passed in from store
             sourceIngredients,
-            destIngredients: [{id: 1, name: 'ING2'}], // TODO CONNECT
+            destIngredients,
             sourceWell,
             destWell
           }

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -64,7 +64,7 @@ import {equippedPipettes} from '../file-data/selectors/pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 // import {allWellContentsForSteps} from '../file-data/selectors/commands' // TODO IMMEDIATELY this circular import breaks stuff FIXME
 
-const allWellContentsForSteps = () => ({}) // TODO HACK
+const allWellContentsForSteps = () => [] // TODO HACK
 
 type FormState = FormData | null
 

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -62,6 +62,9 @@ import type {LabwareData} from '../step-generation/types'
 // External selectors
 import {equippedPipettes} from '../file-data/selectors/pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+// import {allWellContentsForSteps} from '../file-data/selectors/commands' // TODO IMMEDIATELY this circular import breaks stuff FIXME
+
+const allWellContentsForSteps = () => ({}) // TODO HACK
 
 type FormState = FormData | null
 
@@ -333,9 +336,10 @@ const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSele
   validatedForms,
   equippedPipettes,
   labwareIngredSelectors.getLabware,
-  (_validatedForms, _pipetteData, _allLabware) => {
+  allWellContentsForSteps,
+  (_validatedForms, _pipetteData, _allLabware, _allWellContentsForSteps) => {
     const allLabwareTypes: {[labwareId: string]: string} = mapValues(_allLabware, (l: LabwareData) => l.type)
-    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes)
+    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _allWellContentsForSteps)
   }
 )
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -34,14 +34,15 @@ export type NamedIngred = {|
   name: string
 |}
 
-export type NamedIngredsByLabwareAllSteps = Array<{[labwareId: string]: {[well: string]: NamedIngred}}>
+export type NamedIngredsByLabware = {[labwareId: string]: {[well: string]: Array<NamedIngred>}}
+export type NamedIngredsByLabwareAllSteps = Array<NamedIngredsByLabware>
 
 export type StepItemSourceDestRow = {|
   substepId: number, // TODO should this be a string or is this ID properly a number?
   sourceIngredients?: Array<NamedIngred>,
   destIngredients?: Array<NamedIngred>,
-  sourceWell?: string,
-  destWell?: string
+  sourceWell?: ?string,
+  destWell?: ?string
 |}
 
 export type StepItemSourceDestRowMulti = {|
@@ -55,6 +56,7 @@ export type TransferishStepItemSingleChannel = {|
   parentStepId: StepIdType,
   rows: Array<{|
     ...StepItemSourceDestRow,
+    substepId: number,
     volume?: number
   |}>
 |}
@@ -68,6 +70,7 @@ export type TransferishStepItemMultiChannel = {|
   // NOTE: "Row" means a tabular row on the steplist, NOT a "row" of wells on the deck
 |}
 
+// TODO IMMEDIATELY Rename. It's TransferishSubsteps!
 export type TransferishStepItem = TransferishStepItemSingleChannel | TransferishStepItemMultiChannel
 
 export type StepSubItemData = TransferishStepItem | {|

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -29,10 +29,15 @@ export type SubstepIdentifier = {|
   substepId: number
 |} | null
 
+export type NamedIngred = {|
+  id: number,
+  name: string
+|}
+
 export type StepItemSourceDestRow = {|
   substepId: number, // TODO should this be a string or is this ID properly a number?
-  sourceIngredientName?: string,
-  destIngredientName?: string,
+  sourceIngredients?: Array<NamedIngred>,
+  destIngredients?: Array<NamedIngred>,
   sourceWell?: string,
   destWell?: string
 |}

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -50,7 +50,7 @@ export type StepItemSourceDestRowMulti = {|
   channelId: number
 |}
 
-export type TransferishStepItemSingleChannel = {|
+export type TransferLikeSubstepItemSingleChannel = {|
   multichannel: false,
   stepType: 'transfer' | 'consolidate' | 'distribute',
   parentStepId: StepIdType,
@@ -61,7 +61,7 @@ export type TransferishStepItemSingleChannel = {|
   |}>
 |}
 
-export type TransferishStepItemMultiChannel = {|
+export type TransferLikeSubstepItemMultiChannel = {|
   multichannel: true,
   stepType: 'transfer' | 'consolidate' | 'distribute',
   parentStepId: StepIdType,
@@ -70,10 +70,9 @@ export type TransferishStepItemMultiChannel = {|
   // NOTE: "Row" means a tabular row on the steplist, NOT a "row" of wells on the deck
 |}
 
-// TODO IMMEDIATELY Rename. It's TransferishSubsteps!
-export type TransferishStepItem = TransferishStepItemSingleChannel | TransferishStepItemMultiChannel
+export type TransferLikeSubstepItem = TransferLikeSubstepItemSingleChannel | TransferLikeSubstepItemMultiChannel
 
-export type StepSubItemData = TransferishStepItem | {|
+export type StepSubItemData = TransferLikeSubstepItem | {|
   stepType: 'pause',
   waitForUserInput: false,
   hours: number,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -34,6 +34,8 @@ export type NamedIngred = {|
   name: string
 |}
 
+export type NamedIngredsByLabwareAllSteps = Array<{[labwareId: string]: {[well: string]: NamedIngred}}>
+
 export type StepItemSourceDestRow = {|
   substepId: number, // TODO should this be a string or is this ID properly a number?
   sourceIngredients?: Array<NamedIngred>,

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -146,9 +146,7 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
       }
 
       // return selected wells eg {A1: true, B4: true}
-      const selectedWellsResult = selectedWells.reduce((acc, well) => ({...acc, [well]: true}), {})
-      console.log({selectedWellsResult, selectedWells, robotState, form, formIdx, _hoveredSubstep, _hoveredStepId})
-      return selectedWellsResult
+      return selectedWells.reduce((acc, well) => ({...acc, [well]: true}), {})
     }
 
     function highlightedWellsForTimelineFrame (liquidState, timelineIdx): AllWellHighlightsAllLabware {

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -1,0 +1,177 @@
+// @flow
+import {createSelector} from 'reselect'
+import {computeWellAccess} from '@opentrons/labware-definitions'
+
+import mapValues from 'lodash/mapValues'
+
+import {allSubsteps} from './substeps'
+import * as StepGeneration from '../step-generation'
+import {selectors as steplistSelectors} from '../steplist/reducers'
+import {selectors as fileDataSelectors} from '../file-data'
+
+import type {Selector} from '../types'
+import type {ProcessedFormData, StepSubItemData} from '../steplist/types'
+
+type SingleLabwareLiquidState = {[well: string]: StepGeneration.LocationLiquidState}
+
+type AllWellHighlights = {[wellName: string]: true} // NOTE: all keys are true
+type AllWellHighlightsAllLabware = {[labwareId: string]: AllWellHighlights}
+
+function _wellsForPipette (pipetteChannels: 1 | 8, labwareType: string, wells: Array<string>): Array<string> {
+  // `wells` is all the wells that pipette's channel 1 interacts with.
+  if (pipetteChannels === 8) {
+    return wells.reduce((acc, well) => {
+      const setOfWellsForMulti = computeWellAccess(labwareType, well)
+
+      return setOfWellsForMulti
+        ? [...acc, ...setOfWellsForMulti]
+        : acc // setOfWellsForMulti is null
+    }, [])
+  }
+  // single-channel
+  return wells
+}
+
+function _getSelectedWellsForStep (
+  form: ProcessedFormData,
+  labwareId: string,
+  robotState: StepGeneration.RobotState
+): Array<string> {
+  if (form.stepType === 'pause') {
+    return []
+  }
+
+  const pipetteId = form.pipette
+  // TODO Ian 2018-04-02 use robotState selectors here
+  const pipetteChannels = robotState.instruments[pipetteId].channels
+  const labwareType = robotState.labware[labwareId].type
+
+  const getWells = (wells: Array<string>) => _wellsForPipette(pipetteChannels, labwareType, wells)
+
+  let wells = []
+
+  // If we're moving liquids within a single labware,
+  // both the source and dest wells together need to be selected.
+  if (form.stepType === 'transfer') {
+    if (form.sourceLabware === labwareId) {
+      wells.push(...getWells(form.sourceWells))
+    }
+    if (form.destLabware === labwareId) {
+      wells.push(...getWells(form.destWells))
+    }
+  }
+  if (form.stepType === 'consolidate') {
+    if (form.sourceLabware === labwareId) {
+      wells.push(...getWells(form.sourceWells))
+    }
+    if (form.destLabware === labwareId) {
+      wells.push(...getWells([form.destWell]))
+    }
+  }
+  // TODO Ian 2018-03-23 once distribute is supported
+  // if (form.stepType === 'distribute') {
+  //   ...
+  // }
+  return wells
+}
+
+/** Scan through given substep rows to get a list of source/dest wells for the given labware */
+function _getSelectedWellsForSubstep (
+  form: ProcessedFormData,
+  labwareId: string,
+  substeps: StepSubItemData | null,
+  substepId: number
+): Array<string> {
+  if (substeps === null) {
+    return []
+  }
+
+  function getWells (wellField): Array<string> {
+    if (substeps && substeps.rows && substeps.rows[substepId]) {
+      // single-channel
+      const well = substeps.rows[substepId][wellField]
+      return well ? [well] : []
+    }
+
+    if (substeps && substeps.multiRows && substeps.multiRows[substepId]) {
+      // multi-channel
+      return substeps.multiRows[substepId].reduce((acc, multiRow) => {
+        const well = multiRow[wellField]
+        return well ? [...acc, well] : acc
+      }, [])
+    }
+    return []
+  }
+
+  let wells: Array<string> = []
+  if (form.sourceLabware && form.sourceLabware === labwareId) {
+    wells.push(...getWells('sourceWell'))
+  }
+  if (form.destLabware && form.destLabware === labwareId) {
+    wells.push(...getWells('destWell'))
+  }
+
+  return wells
+}
+
+export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>> = createSelector(
+  fileDataSelectors.robotStateTimeline,
+  steplistSelectors.validatedForms,
+  steplistSelectors.hoveredStepId,
+  steplistSelectors.getHoveredSubstep,
+  allSubsteps,
+  (_robotStateTimeline, _forms, _hoveredStepId, _hoveredSubstep, _allSubsteps) => {
+    function highlightedWellsForLabwareAtStep (
+      labwareLiquids: SingleLabwareLiquidState,
+      labwareId: string,
+      robotState: StepGeneration.RobotState,
+      form: ProcessedFormData,
+      formIdx: number
+    ): AllWellHighlights {
+      let selectedWells: Array<string> = []
+      if (form && _hoveredStepId === formIdx) {
+        // only show selected wells when user is **hovering** over the step
+        if (_hoveredSubstep) {
+          // wells for hovered substep
+          selectedWells = _getSelectedWellsForSubstep(
+            form,
+            labwareId,
+            _allSubsteps[_hoveredSubstep.stepId],
+            _hoveredSubstep.substepId
+          )
+        } else {
+          // wells for step overall
+          selectedWells = _getSelectedWellsForStep(form, labwareId, robotState)
+        }
+      }
+
+      // return selected wells eg {A1: true, B4: true}
+      const selectedWellsResult = selectedWells.reduce((acc, well) => ({...acc, [well]: true}), {})
+      console.log({selectedWellsResult, selectedWells, robotState, form, formIdx, _hoveredSubstep, _hoveredStepId})
+      return selectedWellsResult
+    }
+
+    function highlightedWellsForTimelineFrame (liquidState, timelineIdx): AllWellHighlightsAllLabware {
+      const robotState = _robotStateTimeline[timelineIdx].robotState
+      const formIdx = timelineIdx + 1 // add 1 to make up for initial deck setup action
+      const form = _forms[formIdx] && _forms[formIdx].validatedForm
+
+      // replace value of each labware with highlighted wells info
+      return mapValues(
+        liquidState,
+        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => (form)
+          ? highlightedWellsForLabwareAtStep(
+            labwareLiquids,
+            labwareId,
+            robotState,
+            form,
+            formIdx
+          )
+        : {} // no form -> no highlighted wells
+      )
+    }
+
+    const liquidStateTimeline = _robotStateTimeline.map(t => t.robotState.liquidState.labware)
+    return liquidStateTimeline.map(highlightedWellsForTimelineFrame)
+  }
+)

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -1,0 +1,42 @@
+// @flow
+import {createSelector} from 'reselect'
+import mapValues from 'lodash/mapValues'
+
+import {equippedPipettes} from '../file-data/selectors/pipettes'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors as steplistSelectors} from '../steplist/reducers'
+import {allWellContentsForSteps} from './well-contents'
+
+import {
+  generateSubsteps
+} from '../steplist/generateSubsteps' // TODO Ian 2018-04-11 move generateSubsteps closer to this substeps.js file?
+
+import type {Selector} from '../types'
+import type {LabwareData} from '../step-generation/types'
+import type {
+  StepIdType,
+  StepSubItemData
+} from '../steplist/types'
+
+export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
+  steplistSelectors.validatedForms,
+  equippedPipettes,
+  labwareIngredSelectors.getLabware,
+  allWellContentsForSteps,
+  (_validatedForms, _pipetteData, _allLabware, _allWellContentsForSteps) => {
+    const allLabwareTypes: {[labwareId: string]: string} = mapValues(_allLabware, (l: LabwareData) => l.type)
+    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _allWellContentsForSteps)
+  }
+)
+
+/** Mix-in substeps for each step. */
+export const allStepsWithSubsteps: * = createSelector(
+  steplistSelectors.allSteps,
+  allSubsteps,
+  (_allSteps, _allSubsteps) => {
+    return _allSteps.map((step: *, stepId: number) => ({
+      ...step,
+      substeps: _allSubsteps[stepId]
+    }))
+  }
+)

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -5,7 +5,7 @@ import mapValues from 'lodash/mapValues'
 import {equippedPipettes} from '../file-data/selectors/pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
-import {allWellContentsForSteps} from './well-contents'
+import {namedIngredsByLabware} from './well-contents'
 
 import {
   generateSubsteps
@@ -22,10 +22,10 @@ export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = cre
   steplistSelectors.validatedForms,
   equippedPipettes,
   labwareIngredSelectors.getLabware,
-  allWellContentsForSteps,
-  (_validatedForms, _pipetteData, _allLabware, _allWellContentsForSteps) => {
+  namedIngredsByLabware,
+  (_validatedForms, _pipetteData, _allLabware, _namedIngredsByLabware) => {
     const allLabwareTypes: {[labwareId: string]: string} = mapValues(_allLabware, (l: LabwareData) => l.type)
-    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _allWellContentsForSteps)
+    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _namedIngredsByLabware)
   }
 )
 

--- a/protocol-designer/src/top-selectors/well-contents.js
+++ b/protocol-designer/src/top-selectors/well-contents.js
@@ -1,0 +1,76 @@
+// @flow
+import {createSelector} from 'reselect'
+
+import mapValues from 'lodash/mapValues'
+
+import reduce from 'lodash/reduce'
+import * as StepGeneration from '../step-generation'
+import {selectors as steplistSelectors} from '../steplist/reducers'
+import {selectors as fileDataSelectors} from '../file-data'
+import {getAllWellsForLabware} from '../constants'
+
+import type {Selector} from '../types'
+import type {WellContents, AllWellContents} from '../labware-ingred/types'
+
+type SingleLabwareLiquidState = {[well: string]: StepGeneration.LocationLiquidState}
+
+function _wellContentsForWell (
+  liquidVolState: StepGeneration.LocationLiquidState,
+  well: string
+): WellContents {
+  // TODO IMMEDIATELY Ian 2018-03-23 why is liquidVolState missing sometimes (eg first call with trashId)? Thus the liquidVolState || {}
+  const ingredGroupIdsWithContent = Object.keys(liquidVolState || {}).filter(groupId =>
+      liquidVolState[groupId] &&
+      liquidVolState[groupId].volume > 0
+    )
+
+  return {
+    preselected: false,
+    selected: false,
+    highlighted: false,
+    maxVolume: Infinity, // TODO Ian 2018-03-23 refactor so all these fields aren't needed
+    wellName: well,
+    groupId: ingredGroupIdsWithContent[0] || null // TODO Ian 2018-03-23 show 'gray' when there are multiple group ids.
+  }
+}
+
+function _wellContentsForLabware (
+  labwareLiquids: SingleLabwareLiquidState,
+  labwareId: string,
+  labwareType: string
+): AllWellContents {
+  const allWellsForContainer = getAllWellsForLabware(labwareType)
+
+  return reduce(
+    allWellsForContainer,
+    (wellAcc, well: string): {[well: string]: WellContents} => ({
+      ...wellAcc,
+      [well]: _wellContentsForWell(labwareLiquids[well], well)
+    }),
+    {}
+  )
+}
+
+export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWellContents}>> = createSelector(
+  fileDataSelectors.robotStateTimeline,
+  steplistSelectors.validatedForms,
+  (_robotStateTimeline, _forms) => {
+    const liquidStateTimeline = _robotStateTimeline.map(t => t.robotState.liquidState.labware)
+
+    return liquidStateTimeline.map(
+      (liquidState, timelineIdx) => mapValues(
+        liquidState,
+        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => {
+          const robotState = _robotStateTimeline[timelineIdx].robotState
+          const labwareType = robotState.labware[labwareId].type
+
+          return _wellContentsForLabware(
+            labwareLiquids,
+            labwareId,
+            labwareType
+          )
+        }
+      )
+    )
+  }
+)

--- a/protocol-designer/src/top-selectors/well-contents.js
+++ b/protocol-designer/src/top-selectors/well-contents.js
@@ -30,7 +30,7 @@ function _wellContentsForWell (
     highlighted: false,
     maxVolume: Infinity, // TODO Ian 2018-03-23 refactor so all these fields aren't needed
     wellName: well,
-    groupId: ingredGroupIdsWithContent[0] || null // TODO Ian 2018-03-23 show 'gray' when there are multiple group ids.
+    groupIds: ingredGroupIdsWithContent
   }
 }
 


### PR DESCRIPTION
## overview

Closes #1050 

This PR makes a lot of changes so that the ingredients in wells, in the world of `Well` and `Plate` style `wellContents`, support multiple ingredients. The way of representing ingredients in `wellContents` style data/props used to be a single ingredient `groupId` -- this was an artifact of the design of the old ingredient/labware selector prototype. Now instead of `groupId`, it's an array: `groupIds`.

Sorry for the ugly diff! This required a significant change in a core part of PD, which is why I've been kicking this "well contents pluralization" can down the road until now when it's needed.

![2018-04-12 color ingred substeps](https://user-images.githubusercontent.com/11590381/38705229-e16b6a68-3e76-11e8-9a59-1621cb4bbed8.gif)


## changelog
- Refactor to have array of group ids in wells, not single group id
- Refactor to pass in `fillColor`, not `groupId`, to Plate / Well.
- In PD, wells with multiple ingredients become gray. (Before, wells with multiple ingredients were an arbitrary color of some single one of its ingredients)
- New `Pill` component in component library
- Volumes as shown in substeps are rounded: `1.0` => `1`, `1.05` => `1.1`, and "uL" is not shown for 8-channel substeps. (Discussed with @howisthisnamenottakenyet but no ticket / writeup)

And the actual feature:
- Substeps show all ingredients of source and dest wells (for consolidate, only the last substep group shows dests), and those ingredients are color-coded.

## PR notes
I also moved up some higher-order selectors to `top-selectors/` dir to avoid some crazy circular dependencies. I don't love `top-selectors/` but I thought `selectors/` by itself was too ambiguous, and the files in there aren't really related other than having dependencies on the other selectors. I like the idea of having very simple low-level selectors that live alongside the reducers, and then higher-level selectors that dip into several different "atoms" and compose data more broadly across the larger Redux state.


## review requests

* Try all substep display style variants (2 x 2 = 4):
  * Transfer / consolidate
  * Single / multi channel

* Make sure there's no weird edge case changes to Deck/Plate/Well that mess up the Run App! I tested myself, but I might not have thought of some unusual deck state. It looks like the only use of `wellContents` is `<Plate containerType={type} wellContents={{}} />` in `LabwareItem.js`, so the changes I made to `wellContents` shouldn't affect Run App.

* @howisthisnamenottakenyet please play around with different decimal volumes and make sure they're parsed as you intended in the substeps.

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_ingred-pill-labels/index.html