### PR TITLE
Remove slot offset from labware offset when saving new calibration data

### DIFF
--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -77,30 +77,30 @@
         },
         "multidict": {
             "hashes": [
-                "sha256:0462372fc74e4c061335118a4a5992b9a618d6c584b028ef03cf3e9b88a960e2",
-                "sha256:068e91060e3e211441b1a31f5e65de88fc346490e1fae583c35a75a5295c8ef7",
-                "sha256:0fd4d255adcbab3341d64a2fff5acce23409e57bb94e626485dea3db70ddc35e",
-                "sha256:16c78b10e897a512aa34ab1969982e42246e53077ae903c1b334926e1ea832d1",
-                "sha256:241c11614f64535e213ea143efa8b7e598793256601fc795e77075bdfa54f5d6",
-                "sha256:288e8f94fb6f586e7386c1f22c979ce3ec866ab23371fa8fef1dd526cd4dfde1",
-                "sha256:3508bea4974ee30fabcf7c8852fca7d9d54d496eaa068bee8311e0ac4df4ade3",
-                "sha256:503ae54582601b0ff647731fee5efcdff5db1f4da0350febb31b628236a5f0b5",
-                "sha256:50de6f3786ba868ffb7d78d4bcacf0928321f9892366b2f4a0426bba644e3f25",
-                "sha256:608f7eef60e6558418d7da6551dd3d07ccc1290ecc85755d781bd8100322ea5b",
-                "sha256:63663541d395ffe4d51a3c021467d0a7b46c965b63fa1646cb46e2e2f1f36415",
-                "sha256:65546242d0c481c0daf0ef20c1be81c075fb763c5f4346f18f748b422fc40f32",
-                "sha256:6d5f6f26f9025756035c473167b39c5a72e4e519a2286c9399d21f6682e4e5bc",
-                "sha256:84a1cb5320f1494cd444ca3bd09ddba2e0af0cb210f9263bcf17357ab22671a1",
-                "sha256:93f1af99bbe75c854370460a60823d6726f9af2196818a64346000d02e074ed7",
-                "sha256:b46ec31bb7729eaa678a3bb1c999460902df1e295fcc093b9aa5f2c7e68d5803",
-                "sha256:cd172509bfc9144395204dd2c0eb305ae5e89f8ad1714ffd7d793607c53c3244",
-                "sha256:d99819e9e15e1295a31a757360cab65bc96162870f90c29432564bd8e8999aca",
-                "sha256:e04b5bf8581718cf84c1c60bda40221d926ceb06f942ebabfc3baf467a1e34be",
-                "sha256:e13265feabb1fa26f9cd49cbafd9b5de70ad768093ddb092af477c9823f44f0e",
-                "sha256:ea8a18ea02bf84981ec93faded773a866554666f13955c92139127892c4bb45c",
-                "sha256:fb4412490324705dcd2172baa8a3ea58ae23c5f982476805cad58ae929fe2a52"
+                "sha256:0dcf4f2893bf22839c7bd825f688d5fe60c8eb989b4eb817103a71d7f84058e5",
+                "sha256:1524bb334b605f6c7cf447e19e70d6fb96f68aefefe018bdceb9674572548c45",
+                "sha256:1b93d1b72b12566a6e238acb4f547cdf6de069c5b555faabfe9071852434b61a",
+                "sha256:24052724195e46872739faa10c611957bbaceae28eec92e1ce49150b115ec5ed",
+                "sha256:27643705c5a04cfbf7834b914e5367618f77b2692f920c734b18f476ea328f04",
+                "sha256:2b07135edc953e6a7e94d8628868715093efb015fc6a0ebf54c5ecd84064e5f8",
+                "sha256:3876b617228d60d655062f9ddaecb0f770777b8ae753e661de9a7d5eb4ef2933",
+                "sha256:3f11e31935d20822c977397e9ec868ab2287c82461bc74663c7df1bd8a5b61d0",
+                "sha256:4e0dbf5a204c462d6b129b9598e5124077244a9b91c255c5341f679472dc54a5",
+                "sha256:5a56ec27a528fce6a3fdf537929b039b8af01edec761b09f7fcde3915d3fbbe7",
+                "sha256:5bd46d01a49264f059d4c7b1f26cb5cbbcacb549edb77ad5caa2070ec4bffe47",
+                "sha256:6e5128658f82cd8d1830f159027c2be0af496b1b6aa710353a6c862a9285bc89",
+                "sha256:6ef4cf27db3424bcc6e7f9ead3abee53bca2c3a1db5821585cb3e386ae55178f",
+                "sha256:7aeccfbc7ccc29dcceca11ee295f5a267b093d90cf50808d4649d87e72bdbd89",
+                "sha256:7c43ca71db568e13d301e3a6153996a3e0da5d4b19c3517d2418fa5775d2d173",
+                "sha256:9deae50f23511e5639fadf8df68917027535e090b163c5bbb03e26f6a208dbfc",
+                "sha256:aab8e9063ff623387f72c04b55c43211da2edd4e0db9943057522a995c330877",
+                "sha256:ae1002b4c793a6b88c8208c8a312038185ffcf76a57fdbe6c5d0f62052737a65",
+                "sha256:af340843de65c4d678379e8e0b5bcfd2e614da8ed666f1ba006704fe456edbba",
+                "sha256:d3161a3697f8a332aa86da1402f4020499d50ccedc6eb3d8a40d5e3aca3c2afd",
+                "sha256:eafe84d62e45b17c82483a6b4b1a9757c91a1d6d9511d8b32ded52936582fdcb",
+                "sha256:f16c517bb33c8ce75ba5e8d5212e3591bc59f4ab837b5b9906a3ee5868180449"
             ],
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "numpy": {
             "hashes": [
@@ -295,14 +295,6 @@
             ],
             "version": "==0.14"
         },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.0'",
-            "version": "==1.0.2"
-        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
@@ -343,32 +335,40 @@
             ],
             "version": "==0.6.1"
         },
-        "multidict": {
+        "more-itertools": {
             "hashes": [
-                "sha256:0462372fc74e4c061335118a4a5992b9a618d6c584b028ef03cf3e9b88a960e2",
-                "sha256:068e91060e3e211441b1a31f5e65de88fc346490e1fae583c35a75a5295c8ef7",
-                "sha256:0fd4d255adcbab3341d64a2fff5acce23409e57bb94e626485dea3db70ddc35e",
-                "sha256:16c78b10e897a512aa34ab1969982e42246e53077ae903c1b334926e1ea832d1",
-                "sha256:241c11614f64535e213ea143efa8b7e598793256601fc795e77075bdfa54f5d6",
-                "sha256:288e8f94fb6f586e7386c1f22c979ce3ec866ab23371fa8fef1dd526cd4dfde1",
-                "sha256:3508bea4974ee30fabcf7c8852fca7d9d54d496eaa068bee8311e0ac4df4ade3",
-                "sha256:503ae54582601b0ff647731fee5efcdff5db1f4da0350febb31b628236a5f0b5",
-                "sha256:50de6f3786ba868ffb7d78d4bcacf0928321f9892366b2f4a0426bba644e3f25",
-                "sha256:608f7eef60e6558418d7da6551dd3d07ccc1290ecc85755d781bd8100322ea5b",
-                "sha256:63663541d395ffe4d51a3c021467d0a7b46c965b63fa1646cb46e2e2f1f36415",
-                "sha256:65546242d0c481c0daf0ef20c1be81c075fb763c5f4346f18f748b422fc40f32",
-                "sha256:6d5f6f26f9025756035c473167b39c5a72e4e519a2286c9399d21f6682e4e5bc",
-                "sha256:84a1cb5320f1494cd444ca3bd09ddba2e0af0cb210f9263bcf17357ab22671a1",
-                "sha256:93f1af99bbe75c854370460a60823d6726f9af2196818a64346000d02e074ed7",
-                "sha256:b46ec31bb7729eaa678a3bb1c999460902df1e295fcc093b9aa5f2c7e68d5803",
-                "sha256:cd172509bfc9144395204dd2c0eb305ae5e89f8ad1714ffd7d793607c53c3244",
-                "sha256:d99819e9e15e1295a31a757360cab65bc96162870f90c29432564bd8e8999aca",
-                "sha256:e04b5bf8581718cf84c1c60bda40221d926ceb06f942ebabfc3baf467a1e34be",
-                "sha256:e13265feabb1fa26f9cd49cbafd9b5de70ad768093ddb092af477c9823f44f0e",
-                "sha256:ea8a18ea02bf84981ec93faded773a866554666f13955c92139127892c4bb45c",
-                "sha256:fb4412490324705dcd2172baa8a3ea58ae23c5f982476805cad58ae929fe2a52"
+                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
+                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
+                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
             ],
             "version": "==4.1.0"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:0dcf4f2893bf22839c7bd825f688d5fe60c8eb989b4eb817103a71d7f84058e5",
+                "sha256:1524bb334b605f6c7cf447e19e70d6fb96f68aefefe018bdceb9674572548c45",
+                "sha256:1b93d1b72b12566a6e238acb4f547cdf6de069c5b555faabfe9071852434b61a",
+                "sha256:24052724195e46872739faa10c611957bbaceae28eec92e1ce49150b115ec5ed",
+                "sha256:27643705c5a04cfbf7834b914e5367618f77b2692f920c734b18f476ea328f04",
+                "sha256:2b07135edc953e6a7e94d8628868715093efb015fc6a0ebf54c5ecd84064e5f8",
+                "sha256:3876b617228d60d655062f9ddaecb0f770777b8ae753e661de9a7d5eb4ef2933",
+                "sha256:3f11e31935d20822c977397e9ec868ab2287c82461bc74663c7df1bd8a5b61d0",
+                "sha256:4e0dbf5a204c462d6b129b9598e5124077244a9b91c255c5341f679472dc54a5",
+                "sha256:5a56ec27a528fce6a3fdf537929b039b8af01edec761b09f7fcde3915d3fbbe7",
+                "sha256:5bd46d01a49264f059d4c7b1f26cb5cbbcacb549edb77ad5caa2070ec4bffe47",
+                "sha256:6e5128658f82cd8d1830f159027c2be0af496b1b6aa710353a6c862a9285bc89",
+                "sha256:6ef4cf27db3424bcc6e7f9ead3abee53bca2c3a1db5821585cb3e386ae55178f",
+                "sha256:7aeccfbc7ccc29dcceca11ee295f5a267b093d90cf50808d4649d87e72bdbd89",
+                "sha256:7c43ca71db568e13d301e3a6153996a3e0da5d4b19c3517d2418fa5775d2d173",
+                "sha256:9deae50f23511e5639fadf8df68917027535e090b163c5bbb03e26f6a208dbfc",
+                "sha256:aab8e9063ff623387f72c04b55c43211da2edd4e0db9943057522a995c330877",
+                "sha256:ae1002b4c793a6b88c8208c8a312038185ffcf76a57fdbe6c5d0f62052737a65",
+                "sha256:af340843de65c4d678379e8e0b5bcfd2e614da8ed666f1ba006704fe456edbba",
+                "sha256:d3161a3697f8a332aa86da1402f4020499d50ccedc6eb3d8a40d5e3aca3c2afd",
+                "sha256:eafe84d62e45b17c82483a6b4b1a9757c91a1d6d9511d8b32ded52936582fdcb",
+                "sha256:f16c517bb33c8ce75ba5e8d5212e3591bc59f4ab837b5b9906a3ee5868180449"
+            ],
+            "version": "==4.2.0"
         },
         "numpydoc": {
             "hashes": [
@@ -387,30 +387,33 @@
         },
         "pkginfo": {
             "hashes": [
-                "sha256:31a49103180ae1518b65d3f4ce09c784e2bc54e338197668b4fb7dc539521024",
-                "sha256:bb1a6aeabfc898f5df124e7e00303a5b3ec9a489535f346bfbddb081af93f89e"
+                "sha256:5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474",
+                "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },
         "py": {
             "hashes": [
-                "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
-                "sha256:ca18943e28235417756316bfada6cd96b23ce60dd532642690dcfdaba988a76d"
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
             ],
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
+                "sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0",
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "pydocstyle": {
             "hashes": [
@@ -454,6 +457,14 @@
             ],
             "version": "==2.2.0"
         },
+        "pyreadline": {
+            "hashes": [
+                "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1",
+                "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e",
+                "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"
+            ],
+            "version": "==2.1"
+        },
         "pytest": {
             "hashes": [
                 "sha256:062027955bccbc04d2fcd5d79690947e018ba31abe4c90b2c6721abec734261b",
@@ -480,17 +491,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
-                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
-                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
-                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
+                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
+                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
             ],
-            "version": "==2018.3"
+            "version": "==2018.4"
         },
         "requests": {
             "hashes": [
@@ -537,10 +541,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:9bd200335ee4429381e81bd82c08d16b59a5228a11e1ae71222b31646b3533f3",
-                "sha256:f1c098cd12cfb39190805d0c771198af0a734ba63b381ea99d72ea38770525c7"
+                "sha256:597e7526c85df881d51e094360181a84533aede1cb3f5a1cada8bbd4de557efd",
+                "sha256:fe3d218d5b61993d415aa2a9db6dd64c0e4cefb90164ebb197ef3b1d99f531dc"
             ],
-            "version": "==4.19.7"
+            "version": "==4.23.0"
         },
         "twine": {
             "hashes": [

--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -1,3 +1,4 @@
+# pylama:ignore=E252
 import sqlite3
 # import warnings
 from typing import List
@@ -92,8 +93,6 @@ def _create_well_obj_in_db(db, container_name: str, well: Well):
     )
 
 
-# FIXME: This has ugly output because of the way that
-# wells are added to containers. fix this by fixing placeables....
 def _load_well_object_from_db(db, well_data):
     container_name, location, x, y, z, \
         depth, volume, diameter, length, width = well_data
@@ -136,8 +135,8 @@ def _get_db_version(db):
 
 def _calculate_offset(labware: Container) -> dict:
     new_definition = serializers.labware_to_json(labware)
-    base_definition = ldef.load_json(new_definition['metadata']['name'])
-
+    base_definition = ldef.load_json(
+        new_definition['metadata']['name'], with_offset=False)
     first_well = list(base_definition['wells'].keys())[0]
     base_well = base_definition['wells'][first_well]
     new_well = new_definition['wells'][first_well]

--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -8,15 +8,16 @@ from opentrons.util.vector import Vector
 from opentrons.data_storage import labware_definitions as ldef
 from opentrons.data_storage import serializers
 from opentrons.config import feature_flags as fflags
+import logging
 
+log = logging.getLogger(__file__)
 database_path = environment.get_path('DATABASE_FILE')
 
 # ======================== Private Functions ======================== #
 
 
 def _parse_container_obj(container: Container):
-    # TODO: figure out how the output of this fn is used--what needs to change
-    # TODO: since all container._coordinates are now (0, 0, 0)
+    # Note: in the new labware system, container coordinates are always (0,0,0)
     return dict(zip('xyz', container._coordinates))
 
 
@@ -141,10 +142,14 @@ def _calculate_offset(labware: Container) -> dict:
     base_well = base_definition['wells'][first_well]
     new_well = new_definition['wells'][first_well]
 
+    slot_coords = labware.parent.coordinates()
+
     x, y, z = [
-        new_well[axis] - base_well[axis]
+        new_well[axis] - base_well[axis] - slot_coords[axis]
         for axis in 'xyz'
     ]
+    log.debug("Calculated offset for {} in {}: {}".format(
+        labware.get_name(), labware.get_parent(), (x, y, z)))
     return {'x': x, 'y': y, 'z': z}
 # ======================== END Private Functions ======================== #
 

--- a/api/opentrons/data_storage/serializers.py
+++ b/api/opentrons/data_storage/serializers.py
@@ -1,3 +1,4 @@
+# pylama:ignore=E252
 from opentrons.containers.placeable import Well, Container
 from opentrons.util.vector import Vector
 from numbers import Number

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -37,8 +37,6 @@ def calibrate_container_with_delta(
         delta_y, delta_z, save, new_container_name=None
 ):
 
-    if ff.split_labware_definitions():
-        delta_z = delta_z - container[0].properties['height']
     delta = Point(delta_x, delta_y, delta_z)
 
     new_coordinates = change_base(

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -283,7 +283,6 @@ async def test_jog_calibrate_top(
     main_router.calibration_manager.jog(model.instrument, 2, 'y')
     main_router.calibration_manager.jog(model.instrument, 3, 'z')
 
-    # Todo: make tests use a tmp dir instead of a real one
     main_router.calibration_manager.update_container_offset(
         model.container,
         model.instrument

--- a/api/tests/opentrons/database/test_database.py
+++ b/api/tests/opentrons/database/test_database.py
@@ -36,11 +36,11 @@ def test_well_from_container_load():
 def test_container_parse():
     robot.reset()
     plate = containers_load(robot, '96-flat', '1')
-    assert database._parse_container_obj(plate) == {
-        'x': 14.34,
-        'y': 11.24,
-        'z': 10.50
-    }
+    if ff.split_labware_definitions():
+        expected = {'x': 0, 'y': 0, 'z': 0}
+    else:
+        expected = {'x': 14.34, 'y': 11.24, 'z': 10.50}
+    assert database._parse_container_obj(plate) == expected
 
 
 def test_load_persisted_container():

--- a/api/tests/opentrons/database/test_labware_definitions.py
+++ b/api/tests/opentrons/database/test_labware_definitions.py
@@ -48,15 +48,26 @@ def test_load_offset():
 
 def test_load_labware():
     # Tests for finding definition and offset file in user definition dir
-    lw = ldef._load(test_defn_root, test_user_defn_root, test_lw_name)
+    lw = ldef._load(
+        test_defn_root, test_user_defn_root, test_lw_name, with_offset=True)
     assert lw['wells']['A1']['x'] == expected_final_x
     assert lw['wells']['A1']['y'] == expected_final_y
     assert lw['wells']['A1']['z'] == expected_final_z
 
     # Tests for finding definition in default dir and no offset file
     real_lw_name = '6-well-plate'
-    real_lw = ldef._load(test_defn_root, test_user_defn_root, real_lw_name)
+    real_lw = ldef._load(
+        test_defn_root, test_user_defn_root, real_lw_name, with_offset=True)
     assert real_lw['metadata']['name'] == real_lw_name
+
+
+def test_load_without_offset():
+    # Tests for loading definition without offset, even if offset file exists
+    lw = ldef._load(
+        test_defn_root, test_user_defn_root, test_lw_name, with_offset=False)
+    assert lw['wells']['A1']['x'] == expected_x
+    assert lw['wells']['A1']['y'] == expected_y
+    assert lw['wells']['A1']['z'] == expected_z
 
 
 def test_list_labware():

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -77,6 +77,7 @@ def test_aspirate_move_to():
     tip_rack = containers_load(robot, 'tiprack-200ul', '3')
     p300 = instruments.P300_Single(
         mount='left', tip_racks=[tip_rack])
+    p300.pick_up_tip()
 
     x, y, z = (161.0, 116.7, 0.0)
     plate = containers_load(robot, '96-flat', '1')
@@ -87,7 +88,6 @@ def test_aspirate_move_to():
     robot.poses = p300._move(robot.poses, x=x, y=y, z=z)
     robot.calibrate_container_with_instrument(plate, p300, False)
 
-    p300.pick_up_tip()
     p300.aspirate(100, location)
     current_pos = pose_tracker.absolute(
         robot.poses,

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -156,7 +156,7 @@ def test_drop_tip_default_trash(virtual_smoothie_env):
 
 def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
     import tempfile
-    temp = tempfile.gettempdir()
+    temp = tempfile.mkdtemp()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)
     robot.reset()
 
@@ -178,7 +178,7 @@ def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
 def test_calibrate_labware_new(
         virtual_smoothie_env, monkeypatch, split_labware_def):
     import tempfile
-    temp = tempfile.gettempdir()
+    temp = tempfile.mkdtemp()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)
     robot.reset()
 


### PR DESCRIPTION
## overview

Save correct offset data when calibrating labware using new definitions (this functionality is still behind a feature flag, and there may be issues with aspirate and dispense default target locations). Fixes #704, fixes #1142, and relates to #1143 

## changelog

- (fix) Subtract slot offset from well offset when saving labware offset data

## review requests

Set the feature flag on a robot, and run protocols to see that calibrations behave as expected (the first pass for each labware will be like calibrating from a completely fresh machine)
- [x] Once you've calibrated a labware in the new system, does the calibration persist into runs and the next calibration session?
- [x] Does the pipette go to the calibrated top of the well on a `pipette.move_to(plate[0])`?
- [x] Does it go to the correct point at the bottom of the well for aspirate/dispense (likely to fail)