### PR TITLE
API: default probe coordinate pulled from CAD

### DIFF
--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -365,6 +365,7 @@ def main():
         calibration_points = expected_dots
 
     robot.connect()
+    robot.turn_on_rail_lights()
 
     # Notes:
     #  - 200ul tip is 51.7mm long when attached to a pipette
@@ -386,5 +387,6 @@ if __name__ == "__main__":
     # Register hook to reboot the robot after exiting this tool (regardless of
     # whether this process exits normally or not)
     atexit.register(notify_and_restart)
+    atexit.register(robot.turn_off_rail_lights)
 
     main()

--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -126,7 +126,7 @@ class CLITool:
         """
         Increase the jog resolution without overrunning the list of values
         """
-        if self._steps_index < len(self._steps):
+        if self._steps_index < len(self._steps) - 1:
             self._steps_index = self._steps_index + 1
         return 'step: {}'.format(self.current_step())
 
@@ -365,7 +365,10 @@ def main():
         calibration_points = expected_dots
 
     robot.connect()
+
+    # lights help the script user to see the points on the deck
     robot.turn_on_rail_lights()
+    atexit.register(robot.turn_off_rail_lights)
 
     # Notes:
     #  - 200ul tip is 51.7mm long when attached to a pipette
@@ -387,6 +390,5 @@ if __name__ == "__main__":
     # Register hook to reboot the robot after exiting this tool (regardless of
     # whether this process exits normally or not)
     atexit.register(notify_and_restart)
-    atexit.register(robot.turn_off_rail_lights)
 
     main()

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -110,7 +110,7 @@ def _get_default():
         version=1,
         steps_per_mm='M92 X80.00 Y80.00 Z400 A400 B768 C768',
         acceleration='M204 S10000 X3000 Y2000 Z1500 A1500 B2000 C2000',
-        probe_center=(295.0, 300.0, probe_height),
+        probe_center=(293.03, 301.27, probe_height),
         probe_dimensions=(35.0, 40.0, probe_height + 5.0),
         gantry_calibration=[
             [ 1.00, 0.00, 0.00,  0.00],


### PR DESCRIPTION
## overview

Tiny PR, updates the default probe-center coordinate to the position calculated from the machine's CAD model.

This only affects the first time a machine is tip-probed during factory calibration. After that, this value is never used again.

needs following testing:

- [x] Remove machine's `config.json`
- [x] Deck calibrate, save the new `config.json`
- [x] Check that `probe_center` value is not be present in config
- [x] Tip-probe in App, save the new `config.json`
- [x] Check that `instrument_offset` values are present
- [x] Check that `probe_center` value is unchanged from previous config