### PR TITLE
Adds specified versions for jupyter dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,11 @@ RUN apk add --update \
 # site-packages and cleaning up the one created by python3 package.
 RUN cp -r /usr/lib/python3.6/site-packages /usr/local/lib/python3.6/ && \
     rm -rf /usr/lib/python3.6
-RUN pip install pipenv==9.0.3 jupyter
+RUN pip install --force-reinstall \
+    pipenv==9.0.3 \
+    jupyter==1.0.0 \
+    tornado==4.5.1 \
+    pyzmq==16.0.2
 
 # Copy server files and data into the container. Note: any directories that
 # you wish to copy into the container must be excluded from the .dockerignore


### PR DESCRIPTION
## overview

Forces library packages tornado and zmq to be compatible versions (i.e. 4.5.1 and 16.0.2 respectively). See issue https://github.com/jupyter/notebook/issues/3407. Fixes #1066 .

## changelog
- Forces the versions of jupyter, tornado, pyzmq in the docker file
- Tested in the devbots application, moved one robot over from a separate application that
had a broken jupyter notebook and it was also successful.

## review requests

