### PR TITLE
Add tip length to pipette info endpoint

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 import opentrons.util.calibration_functions as calib
 from numpy import add, subtract
 from opentrons import commands, containers, drivers
+from opentrons.instruments import pipette_config
 from opentrons.broker import subscribe
 from opentrons.containers import Container
 from opentrons.data_storage import database, old_container_loading,\
@@ -920,11 +921,19 @@ class Robot(object):
                 'plunger_axis': 'b'
             }
         left_data.update(self._driver.read_pipette_model('left'))
+        left_model = left_data.get('model')
+        if left_model:
+            tip_length = pipette_config.configs[left_model].tip_length
+            left_data.update({'tip_length': tip_length})
         right_data = {
                 'mount_axis': 'a',
                 'plunger_axis': 'c'
             }
         right_data.update(self._driver.read_pipette_model('right'))
+        right_model = right_data.get('model')
+        if left_model:
+            tip_length = pipette_config.configs[right_model].tip_length
+            right_data.update({'tip_length': tip_length})
         return {
             'left': left_data,
             'right': right_data

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -23,11 +23,13 @@ async def get_attached_pipettes(request):
     {
       'left': {
         'model': 'p300_single',
+        'tip_length': 51.7,
         'mount_axis': 'z',
         'plunger_axis': 'b'
       },
       'right': {
         'model': 'p10_multi',
+        'tip_length': 40,
         'mount_axis': 'a',
         'plunger_axis': 'c'
       }

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -43,14 +43,17 @@ async def test_get_pipettes(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
+    model = list(configs.values())[0]
     expected = {
         'left': {
-            'model': list(configs.values())[0].name,
+            'model': model.name,
+            'tip_length': model.tip_length,
             'mount_axis': 'z',
             'plunger_axis': 'b'
         },
         'right': {
-            'model': list(configs.values())[0].name,
+            'model': model.name,
+            'tip_length': model.tip_length,
             'mount_axis': 'a',
             'plunger_axis': 'c'
         }


### PR DESCRIPTION
## overview

Add tip length to pipette info endpoint. Fixes #1121 

## changelog

- (feature) Add tip length to pipette info endpoint

## review requests

Make sure new data shape makes sense for use in FE of factory calibration flow
