### PR TITLE
fix(app): Guard RPC client against malformed session responses

### DIFF
--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -107,7 +107,7 @@ export default function client (dispatch) {
           // TODO(mc, 2017-10-09): This seems like an API responsibility
           remote.session_manager.session = apiSession
           // TODO(mc, 2017-10-12) batch these updates and don't hardcode URL
-          handleApiSession(apiSession, true)
+          handleApiSession(apiSession)
         })
         .catch((error) => dispatch(actions.sessionResponse(error)))
     }
@@ -313,23 +313,27 @@ export default function client (dispatch) {
       clearRunTimerInterval()
     }
 
-    // TODO(mc, 2017-08-30): Use a reduce
-    ;(commands || []).forEach(makeHandleCommand())
-    ;(instruments || []).forEach(apiInstrumentToInstrument)
-    ;(containers || []).forEach(apiContainerToContainer)
+    try {
+      // TODO(mc, 2017-08-30): Use a reduce
+      ;(commands || []).forEach(makeHandleCommand())
+      ;(instruments || []).forEach(apiInstrumentToInstrument)
+      ;(containers || []).forEach(apiContainerToContainer)
 
-    const payload = {
-      name,
-      state,
-      errors: [],
-      protocolText: protocol_text,
-      protocolCommands,
-      protocolCommandsById,
-      instrumentsByMount,
-      labwareBySlot
+      const payload = {
+        name,
+        state,
+        errors: [],
+        protocolText: protocol_text,
+        protocolCommands,
+        protocolCommandsById,
+        instrumentsByMount,
+        labwareBySlot
+      }
+
+      dispatch(actions.sessionResponse(null, payload))
+    } catch (error) {
+      dispatch(actions.sessionResponse(error))
     }
-
-    dispatch(actions.sessionResponse(null, payload))
 
     function makeHandleCommand (depth = 0) {
       return function handleCommand (command) {

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -262,6 +262,16 @@ describe('api client', () => {
       return sendConnect()
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
+
+    test('sends error if received malformed session from API', () => {
+      const expected = actions.sessionResponse(expect.anything())
+
+      session.commands = [{foo: 'bar'}]
+      session.command_log = null
+
+      return sendConnect()
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
   })
 
   describe('calibration', () => {


### PR DESCRIPTION
## overview

This PR is a client-side workaround for #1021 by guarding against malformed (as far as the app is concerned) RPC session responses.

## changelog

- fix(app): Guard RPC client against malformed session responses 

## review requests

Test on robot?
