### PR TITLE
feat(app): Add POST /robot/home to HTTP API client (WIP)

### DIFF
--- a/app/src/http-api-client/__tests__/robot.test.js
+++ b/app/src/http-api-client/__tests__/robot.test.js
@@ -5,7 +5,10 @@ import thunk from 'redux-thunk'
 import client from '../client'
 import {
   moveToChangePipette,
-  reducer
+  home,
+  reducer,
+  makeGetRobotMove,
+  makeGetRobotHome
 } from '..'
 
 jest.mock('../client')
@@ -67,6 +70,58 @@ describe('robot/*', () => {
     test('dispatches ROBOT_REQUEST and ROBOT_FAILURE')
   })
 
+  describe('home action creator', () => {
+    const path = 'home'
+    const response = {message: 'success'}
+
+    test('calls POST /robot/home to home robot', () => {
+      const expectedBody = {target: 'robot'}
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(home(robot))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'POST', 'robot/home', expectedBody))
+    })
+
+    test('calls POST /robot/home to home a pipette', () => {
+      const expectedBody = {target: 'pipette', mount: 'right'}
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(home(robot, 'right'))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'POST', 'robot/home', expectedBody))
+    })
+
+    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
+      const request = {target: 'pipette', mount: 'left'}
+      const expectedActions = [
+        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
+        {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
+      ]
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(home(robot, 'left'))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches ROBOT_REQUEST and ROBOT_FAILURE', () => {
+      const request = {target: 'robot'}
+      const error = {name: 'ResponseError', status: '400'}
+      const expectedActions = [
+        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
+        {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(home(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
   test('reducer handles SET_ROBOT_MOVE_POSITION', () => {
     state = state.api
     const action = {
@@ -81,85 +136,137 @@ describe('robot/*', () => {
     })
   })
 
-  describe('reducer with /robot/move', () => {
-    beforeEach(() => {
-      state = state.api
-    })
+  const REDUCER_REQUEST_RESPONSE_TESTS = [
+    {
+      path: 'move',
+      request: {target: 'mount', mount: 'left', point: [1, 2, 3]},
+      response: {message: 'we did it!'}
+    },
+    {
+      path: 'home',
+      request: {target: 'pipette', mount: 'left'},
+      response: {message: 'we did it!'}
+    }
+  ]
 
-    const path = 'move'
-    const request = {target: 'mount', mount: 'left', point: [1, 2, 3]}
-    const response = {message: 'we did it!'}
+  REDUCER_REQUEST_RESPONSE_TESTS.forEach((spec) => {
+    const {path, request, response} = spec
 
-    test('handles ROBOT_REQUEST', () => {
-      const action = {
-        type: 'api:ROBOT_REQUEST',
-        payload: {path, robot, request}
-      }
+    describe(`reducer with /robot/${path}`, () => {
+      beforeEach(() => {
+        state = state.api
+      })
 
-      expect(reducer(state, action).robot).toEqual({
-        [NAME]: {
-          move: {
+      test('handles ROBOT_REQUEST', () => {
+        const action = {
+          type: 'api:ROBOT_REQUEST',
+          payload: {path, robot, request}
+        }
+
+        expect(reducer(state, action).robot).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              inProgress: true,
+              error: null,
+              response: null
+            }
+          }
+        })
+      })
+
+      test('handles ROBOT_SUCCESS', () => {
+        const action = {
+          type: 'api:ROBOT_SUCCESS',
+          payload: {path, robot, response}
+        }
+
+        state.robot[NAME] = {
+          [path]: {
             request,
             inProgress: true,
             error: null,
             response: null
           }
         }
+
+        expect(reducer(state, action).robot).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              response,
+              inProgress: false,
+              error: null
+            }
+          }
+        })
+      })
+
+      test('handles ROBOT_FAILURE', () => {
+        const error = {message: 'we did not do it!'}
+        const action = {
+          type: 'api:ROBOT_FAILURE',
+          payload: {path, robot, error}
+        }
+
+        state.robot[NAME] = {
+          [path]: {
+            request,
+            inProgress: true,
+            error: null,
+            response: null
+          }
+        }
+
+        expect(reducer(state, action).robot).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              error,
+              response: null,
+              inProgress: false
+            }
+          }
+        })
+      })
+    })
+  })
+
+  describe('selectors', () => {
+    beforeEach(() => {
+      state.api.robot[NAME] = {
+        home: {inProgress: true},
+        move: {inProgress: true},
+        movePosition: 'change_pipette'
+      }
+    })
+
+    test('makeGetRobotMove', () => {
+      const getMove = makeGetRobotMove()
+
+      expect(getMove(state, robot)).toEqual({
+        ...state.api.robot[NAME].move,
+        position: 'change_pipette'
+      })
+
+      expect(getMove(state, {name: 'foo'})).toEqual({
+        inProgress: false,
+        error: null,
+        request: null,
+        response: null,
+        position: null
       })
     })
 
-    test('handles ROBOT_SUCCESS', () => {
-      const action = {
-        type: 'api:ROBOT_SUCCESS',
-        payload: {path, robot, response}
-      }
+    test('makeGetRobotHome', () => {
+      const getHome = makeGetRobotHome()
 
-      state.robot[NAME] = {
-        move: {
-          request,
-          inProgress: true,
-          error: null,
-          response: null
-        }
-      }
-
-      expect(reducer(state, action).robot).toEqual({
-        [NAME]: {
-          move: {
-            request,
-            response,
-            inProgress: false,
-            error: null
-          }
-        }
-      })
-    })
-
-    test('handles ROBOT_FAILURE', () => {
-      const error = {message: 'we did not do it!'}
-      const action = {
-        type: 'api:ROBOT_FAILURE',
-        payload: {path, robot, error}
-      }
-
-      state.robot[NAME] = {
-        move: {
-          request,
-          inProgress: true,
-          error: null,
-          response: null
-        }
-      }
-
-      expect(reducer(state, action).robot).toEqual({
-        [NAME]: {
-          move: {
-            request,
-            error,
-            response: null,
-            inProgress: false
-          }
-        }
+      expect(getHome(state, robot)).toEqual(state.api.robot[NAME].home)
+      expect(getHome(state, {name: 'foo'})).toEqual({
+        inProgress: false,
+        error: null,
+        request: null,
+        response: null
       })
     })
   })

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -34,7 +34,8 @@ export type {
 } from './pipettes'
 
 export type {
-  RobotMoveState
+  RobotMoveState,
+  RobotHome
 } from './robot'
 
 export type {
@@ -82,9 +83,11 @@ export {
 } from './pipettes'
 
 export {
+  home,
   moveToChangePipette,
+  clearRobotMoveResponse,
   makeGetRobotMove,
-  clearRobotMoveResponse
+  makeGetRobotHome
 } from './robot'
 
 export {


### PR DESCRIPTION
## overview

**PR is currently a WIP, but open for review on what's in**

This PR addresses the final checkbox of #865 - On exit pipette is homed.

## changelog

- feat(app): Add POST /robot/home to HTTP API client 
- TBD

## review requests

This is gonna need robot testing!