### PR TITLE
Add function to remove instruments from robot state

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -423,6 +423,11 @@ class Robot(object):
             point=(_x, _y, _z)
         )
 
+    def remove_instrument(self, mount):
+        instrument = self._instruments.pop(mount, None)
+        if instrument:
+            self.poses = pose_tracker.remove(self.poses, instrument)
+
     def add_warning(self, warning_msg):
         """
         Internal. Add a runtime warning to the queue.

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -254,6 +254,7 @@ async def home(request):
             if mount in ['left', 'right']:
                 pipette = instruments.Pipette(mount=mount)
                 pipette.home()
+                robot.remove_instrument(mount)
 
                 status = 200
                 message = "Pipette on {} homed successfully.".format(mount)

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -131,8 +131,10 @@ async def test_home_pipette(virtual_smoothie_env, loop, test_client):
         'mount': 'left'}
 
     res = await cli.post('/robot/home', json=test_data)
-
     assert res.status == 200
+
+    res2 = await cli.post('/robot/home', json=test_data)
+    assert res2.status == 200
 
 
 async def test_home_robot(virtual_smoothie_env, loop, test_client):


### PR DESCRIPTION
## overview

Add function to remove instrument from robot state, and use this to clear ephemeral instances in control endpoints. Fixes #1211 

## changelog

- (feature) Add function to remove instrument from robot state
- (fix) Clear ephemeral instances in control endpoints

## review requests
