### PR TITLE
QC: print out the old pipette ID before writing new ID

### DIFF
--- a/api/opentrons/tools/write_pipette_memory.py
+++ b/api/opentrons/tools/write_pipette_memory.py
@@ -40,6 +40,25 @@ def write_identifiers(robot, mount, new_id, new_model):
     _assert_the_same(new_model, read_model['model'])
 
 
+def check_previous_data(robot, mount):
+    old_id = robot._driver.read_pipette_id(mount)
+    if old_id.get('pipette_id'):
+        old_id = old_id.get('pipette_id')
+    else:
+        old_id = None
+    old_model = robot._driver.read_pipette_model(mount)
+    if old_model.get('model'):
+        old_model = old_model.get('model')
+    else:
+        old_model = None
+    if old_id and old_model:
+        print(
+            'Overwriting old data: id={0}, model={1}'.format(
+                old_id, old_model))
+    else:
+        print('No old data on this pipette')
+
+
 def _assert_the_same(a, b):
     if a != b:
         raise Exception(WRITE_FAIL_MESSAGE)
@@ -71,6 +90,7 @@ def main(robot):
     try:
         barcode = _user_submitted_barcode(32)
         model = _parse_model_from_barcode(barcode)
+        check_previous_data(robot, 'right')
         write_identifiers(robot, 'right', barcode, model)
         print('PASS: Saved -> {}'.format(barcode))
     except KeyboardInterrupt:


### PR DESCRIPTION
## overview

To help QC testers know if a pipette has been properly QC'ed in SZ, this update simply prints out the previously written serial number just before writing a new one to the pipette.