### PR TITLE
Compute: Start server even if no robot-config is present

### DIFF
--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -30,7 +30,6 @@ config_path=`python -c "from opentrons.util import environment; print(environmen
 
 if [ ! -e "$config_path" ]; then
     echo "Config file not found. Please perform factory calibration and then restart robot"
-    while true; do sleep 1; done
 fi
 
 export ENABLE_NETWORKING_ENDPOINTS=true


### PR DESCRIPTION
## overview

If the server is not running, then a machine/testing-rig is not able to have it's software updated, nor is it able to be connected to by the App.

Currently, within `/computer/scripts/start.sh`, if there is no robot-config file, then the server is never launched, preventing any robot-update from happening.

While nobody would ever want to use the App to labware-calibrate a robot that hasn't been deck/factory-calibrated, it is however very useful to update freshly-assembled robots or testing-rig with the App regardless of the deck calibration.