### PR TITLE
feat(api): Log HTTP handler exceptions and respond with traceback in JSON

### DIFF
--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -25,7 +25,7 @@ CALL_NACK_MESSAGE = 4
 
 
 class Server(object):
-    def __init__(self, root=None, loop=None):
+    def __init__(self, root=None, loop=None, middlewares=()):
         self.monitor_events_task = None
         self.loop = loop or asyncio.get_event_loop()
         self.objects = {}
@@ -39,7 +39,7 @@ class Server(object):
         self.clients = {}
         self.tasks = []
 
-        self.app = web.Application(loop=loop)
+        self.app = web.Application(loop=loop, middlewares=middlewares)
         self.app.router.add_get('/', self.handler)
         self.app.on_shutdown.append(self.on_shutdown)
 


### PR DESCRIPTION
## overview

`aiohttp` has a default exception response if the `handler` raises:

```html
<html>
<head>
  <title>500 Internal Server Error</title>
</head>
<body>
  <h1>
    500 Internal Server Error
  </h1>
  Server got itself in trouble
</body>
</html>
```

This is not super helpful, so this PR adds a [middleware](https://aiohttp.readthedocs.io/en/stable/web_advanced.html#middlewares) to log `handler` exceptions...

```
2018-04-18 16:16:39,315 __main__ ERROR [Line 90] Exception in handler for request <Request GET /pipettes >
Traceback (most recent call last):
  File "/data/packages/usr/local/lib/python3.6/site-packages/opentrons/server/main.py", line 88, in error_middleware
    response = await handler(request)
  File "/data/packages/usr/local/lib/python3.6/site-packages/opentrons/server/endpoints/control.py", line 43, in get_attached_pipettes
    return web.json_response(robot.get_attached_pipettes())
  File "/data/packages/usr/local/lib/python3.6/site-packages/opentrons/robot/robot.py", line 931, in get_attached_pipettes
    tip_length = pipette_config.configs[left_model].tip_length
KeyError: 'p10_multi_v1'
```

...and to respond with exception details in JSON...

```json
{
    "message": "An unexpected error occured - 'p10_multi_v1'",
    "traceback": "Traceback (most recent call last):\n  File \"/data/packages/usr/local/lib/python3.6/site-packages/opentrons/server/main.py\", line 88, in error_middleware\n    response = await handler(request)\n  File \"/data/packages/usr/local/lib/python3.6/site-packages/opentrons/server/endpoints/control.py\", line 43, in get_attached_pipettes\n    return web.json_response(robot.get_attached_pipettes())\n  File \"/data/packages/usr/local/lib/python3.6/site-packages/opentrons/robot/robot.py\", line 931, in get_attached_pipettes\n    tip_length = pipette_config.configs[left_model].tip_length\nKeyError: 'p10_multi_v1'\n"
}
```

## changelog

- feat(api): Log HTTP handler exceptions and respond with traceback in JSON

## review requests

You can see this in action at the moment by trying to hit `GET /pipettes` on Sunset