### PR TITLE
Implement jog increment selection

### DIFF
--- a/app/src/components/ChangePipette/RequestInProgressModal.js
+++ b/app/src/components/ChangePipette/RequestInProgressModal.js
@@ -30,7 +30,7 @@ export default function RequestInProgressModal (props: ChangePipetteProps) {
       }}
     >
       <Icon name='ot-spinner' spin className={styles.in_progress_icon} />
-      <p>
+      <p className={styles.progress_message}>
         {message}
       </p>
     </TitledModal>

--- a/app/src/components/ChangePipette/styles.css
+++ b/app/src/components/ChangePipette/styles.css
@@ -52,6 +52,7 @@
   flex-direction: column;
   font-style: italic;
   text-align: center;
+  z-index: 4;
 }
 
 .in_progress_icon {

--- a/app/src/components/LabwareCalibration/ConfirmModal.js
+++ b/app/src/components/LabwareCalibration/ConfirmModal.js
@@ -1,6 +1,7 @@
 // @flow
 // labware calibration controls modal
 import * as React from 'react'
+import cx from 'classnames'
 
 import type {Labware} from '../../robot'
 
@@ -22,6 +23,11 @@ export default function ConfirmModal (props: Props) {
     labware.calibration === 'picked-up'
   )
 
+  // TODO (ka 2018-4-18): this is a temporary workaround for a stlye over ride for in progress screens with transparate bg
+  const contentsStyle = labware.calibration.match(/^(moving-to-slot|picking-up|dropping-tip|confirming)$/)
+    ? cx(styles.modal_contents, styles.in_progress_contents)
+    : styles.modal_contents
+
   const titleBar = {
     title: 'Calibrate Deck',
     subtitle: labware.type,
@@ -31,7 +37,7 @@ export default function ConfirmModal (props: Props) {
   return (
     <ModalPage
       titleBar={titleBar}
-      contentsClassName={styles.modal_contents}
+      contentsClassName={contentsStyle}
     >
       <ConfirmModalContents {...labware} />
     </ModalPage>

--- a/app/src/components/LabwareCalibration/ConfirmPositionContents.js
+++ b/app/src/components/LabwareCalibration/ConfirmPositionContents.js
@@ -5,6 +5,7 @@ import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 
 import {
+  selectors as robotSelectors,
   actions as robotActions,
   type Instrument,
   type Labware,
@@ -18,17 +19,22 @@ import {PrimaryButton} from '@opentrons/components'
 import ConfirmPositionDiagram from './ConfirmPositionDiagram'
 import JogControls, {type JogControlsProps} from './JogControls'
 
+type StateProps = {
+  currentJogDistance: number
+}
+
 type OwnProps = Labware & {
   calibrator: Instrument
 }
 
 type DispatchProps = JogControlsProps & {
-  onConfirmClick: () => void
+  onConfirmClick: () => void,
+  onIncrementSelect: (event: SyntheticInputEvent<>) => mixed,
 }
 
 type Props = OwnProps & DispatchProps
 
-export default connect(null, mapDispatchToProps)(ConfirmPositionContents)
+export default connect(mapStateToProps, mapDispatchToProps)(ConfirmPositionContents)
 
 function ConfirmPositionContents (props: Props) {
   const {isTiprack, onConfirmClick, calibrator: {channels}} = props
@@ -60,10 +66,16 @@ const JOG_BUTTONS: Array<{
   {name: 'down', axis: 'z', direction: -1}
 ]
 
+function mapStateToProps (state): StateProps {
+  return {
+    currentJogDistance: robotSelectors.getJogDistance(state)
+  }
+}
+
 function mapDispatchToProps (
   dispatch: Dispatch<*>,
   ownProps: OwnProps
-): Props {
+): any {
   const {slot, isTiprack, calibrator: {mount}} = ownProps
 
   const jogButtons = JOG_BUTTONS.map((button) => {
@@ -82,6 +94,10 @@ function mapDispatchToProps (
   return {
     ...ownProps,
     jogButtons,
+    onIncrementSelect: (event) => {
+      const step = Number(event.target.value)
+      dispatch(robotActions.setJogDistance(step))
+    },
     onConfirmClick: () => { dispatch(onConfirmAction) }
   }
 }

--- a/app/src/components/LabwareCalibration/JogControls.js
+++ b/app/src/components/LabwareCalibration/JogControls.js
@@ -16,11 +16,13 @@ import styles from './styles.css'
 
 type JogButtonProps = {
   name: JogButtonName,
-  onClick: () => void
+  onClick: () => void,
 }
 
 export type JogControlsProps = Labware & {
-  jogButtons: Array<JogButtonProps>
+  jogButtons: Array<JogButtonProps>,
+  currentJogDistance: number,
+  onIncrementSelect: (event: SyntheticInputEvent<*>) => mixed,
 }
 
 const ARROW_ICONS_BY_NAME: {[JogButtonName]: IconName} = {
@@ -33,6 +35,7 @@ const ARROW_ICONS_BY_NAME: {[JogButtonName]: IconName} = {
 }
 
 export default function JogControls (props: JogControlsProps) {
+  console.log(props.currentJogDistance)
   return (
     <div className={styles.jog_container}>
       <div className={styles.jog_controls}>
@@ -51,14 +54,13 @@ export default function JogControls (props: JogControlsProps) {
         <span className={styles.increment_group}>
         <RadioGroup
           className={styles.increment_item}
-          disabled
-          value={'1'}
+          value={`${props.currentJogDistance}`}
           options={[
             {name: '0.1 mm', value: '0.1'},
             {name: '1 mm', value: '1'},
             {name: '10 mm', value: '10'}
           ]}
-          onChange={e => (console.log(e.target.value))}
+          onChange={props.onIncrementSelect}
         />
       </span>
       </div>

--- a/app/src/components/LabwareCalibration/styles.css
+++ b/app/src/components/LabwareCalibration/styles.css
@@ -23,6 +23,10 @@
   border-radius: 0.5rem;
 }
 
+.in_progress_contents {
+  background-color: transparent;
+}
+
 .position_diagram,
 .jog_container {
   width: 100%;
@@ -105,7 +109,6 @@
 .increment_group {
   grid-row: 2;
   grid-column: 9/11;
-  opacity: 0.3; /* TODO: (ka 2018-4-17): disabling the RadioGroup until UI is wired to state */
 }
 
 .increment_item {

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -109,6 +109,7 @@ export type LabwareCalibrationAction = {|
     | 'robot:DROP_TIP_AND_HOME'
     | 'robot:CONFIRM_TIPRACK'
     | 'robot:UPDATE_OFFSET'
+    | 'robot:SET_JOG_DISTANCE'
   ),
   payload: {|
     mount: Mount,
@@ -170,7 +171,7 @@ export const actionTypes = {
 
   RETURN_TIP: makeRobotActionName('RETURN_TIP'),
   RETURN_TIP_RESPONSE: makeRobotActionName('RETURN_TIP_RESPONSE'),
-  TOGGLE_JOG_DISTANCE: makeRobotActionName('TOGGLE_JOG_DISTANCE'),
+  SET_JOG_DISTANCE: makeRobotActionName('SET_JOG_DISTANCE'),
   CONFIRM_LABWARE: makeRobotActionName('CONFIRM_LABWARE'),
 
   // protocol run controls
@@ -422,8 +423,8 @@ export const actions = {
     return {type: 'robot:MOVE_TO_SUCCESS', payload: {}}
   },
 
-  toggleJogDistance () {
-    return {type: actionTypes.TOGGLE_JOG_DISTANCE}
+  setJogDistance (step: number) {
+    return {type: 'robot:SET_JOG_DISTANCE', payload: step}
   },
 
   jog (

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -81,5 +81,3 @@ export const MULTI_CHANNEL = 'multi'
 // jogging
 export const JOG_DIRECTION_NEG = -1
 export const JOG_DIRECTION_POS = 1
-export const JOG_DISTANCE_SLOW_MM = 0.25
-export const JOG_DISTANCE_FAST_MM = 4

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -15,11 +15,6 @@ import type {
   CalibrationFailureAction
 } from '../actions'
 
-import {
-  JOG_DISTANCE_SLOW_MM,
-  JOG_DISTANCE_FAST_MM
-} from '../constants'
-
 // calibration request types
 // TODO(mc, 2018-01-10): these should match up with the request actions;
 //   explore how to link these concepts effectively
@@ -62,13 +57,12 @@ const {
   MOVE_TO_FRONT_RESPONSE,
   PROBE_TIP,
   PROBE_TIP_RESPONSE,
-  TOGGLE_JOG_DISTANCE,
   CONFIRM_LABWARE
 } = actionTypes
 
 const INITIAL_STATE: State = {
   deckPopulated: true,
-  jogDistance: JOG_DISTANCE_SLOW_MM,
+  jogDistance: 0.1,
 
   // TODO(mc, 2018-01-22): combine these into subreducer
   probedByMount: {},
@@ -144,6 +138,9 @@ export default function calibrationReducer (
     case 'robot:DISCONNECT_RESPONSE':
       return handleDisconnectResponse(state, action)
 
+    case 'robot:SET_JOG_DISTANCE':
+      return handleSetJogDistance(state, action)
+
     // TODO(mc, 20187-01-26): caution - not covered by flow yet
     case SESSION: return handleSession(state, action)
     case SET_DECK_POPULATED: return handleSetDeckPopulated(state, action)
@@ -151,7 +148,6 @@ export default function calibrationReducer (
     case MOVE_TO_FRONT_RESPONSE: return handleMoveToFrontResponse(state, action)
     case PROBE_TIP: return handleProbeTip(state, action)
     case PROBE_TIP_RESPONSE: return handleProbeTipResponse(state, action)
-    case TOGGLE_JOG_DISTANCE: return handleToggleJog(state, action)
     case CONFIRM_LABWARE: return handleConfirmLabware(state, action)
   }
 
@@ -485,12 +481,10 @@ function handleConfirmTiprackFailure (
   }
 }
 
-function handleToggleJog (state: State, action: any) {
+function handleSetJogDistance (state: State, action: any) {
   return {
     ...state,
-    jogDistance: state.jogDistance === JOG_DISTANCE_SLOW_MM
-      ? JOG_DISTANCE_FAST_MM
-      : JOG_DISTANCE_SLOW_MM
+    jogDistance: Number(action.payload)
   }
 }
 

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -293,10 +293,9 @@ describe('robot actions', () => {
     expect(actions.moveToResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('toggle jog distance action', () => {
-    const expected = {type: actionTypes.TOGGLE_JOG_DISTANCE}
-
-    expect(actions.toggleJogDistance()).toEqual(expected)
+  test('set jog distance action', () => {
+    const expected = {type: 'robot:SET_JOG_DISTANCE', payload: 10}
+    expect(actions.setJogDistance(10)).toEqual(expected)
   })
 
   test('JOG action', () => {

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -1,5 +1,5 @@
 // calibration reducer tests
-import {reducer, actionTypes, constants} from '../'
+import {reducer, actionTypes} from '../'
 
 describe('robot reducer - calibration', () => {
   test('initial state', () => {
@@ -7,7 +7,7 @@ describe('robot reducer - calibration', () => {
 
     expect(state).toEqual({
       deckPopulated: true,
-      jogDistance: constants.JOG_DISTANCE_SLOW_MM,
+      jogDistance: 0.1,
 
       // intrument probed + basic tip-tracking flags
       // TODO(mc, 2018-01-22): combine these into subreducer
@@ -509,16 +509,16 @@ describe('robot reducer - calibration', () => {
     })
   })
 
-  test('handles TOGGLE_JOG_DISTANCE action', () => {
-    const slow = {calibration: {jogDistance: constants.JOG_DISTANCE_SLOW_MM}}
-    const fast = {calibration: {jogDistance: constants.JOG_DISTANCE_FAST_MM}}
-    const action = {type: actionTypes.TOGGLE_JOG_DISTANCE}
+  test('handles SET_JOG_DISTANCE action', () => {
+    const state = {
+      calibration: {
+        jogDistance: 10
+      }
+    }
 
-    expect(reducer(slow, action).calibration).toEqual({
-      jogDistance: constants.JOG_DISTANCE_FAST_MM
-    })
-    expect(reducer(fast, action).calibration).toEqual({
-      jogDistance: constants.JOG_DISTANCE_SLOW_MM
+    const action = {type: 'robot:SET_JOG_DISTANCE', payload: 1}
+    expect(reducer(state, action).calibration).toEqual({
+      jogDistance: 1
     })
   })
 

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -40,6 +40,10 @@
   min-width: 1.25rem;
   color: var(--c-dark-gray);
 
+  &:hover {
+    cursor: pointer;
+  }
+
   &.error {
     color: var(--c-mustard);
   }


### PR DESCRIPTION
## overview

This PR closes  #1150 and wires up the Select Jog Increment radio groups in jog controls. Its worth noting that right now, jog controls are still using RPC. While testing, I noticed a few issues with in progress spinner modals in the `ChangePipette` and `LabwareCalibration` UIs. Did my best to match design screens again.

## changelog

- enable increment radio group
- add cursor: pointer to radio/checkbox in comp_lib
- add `setJogDistance` action and `getJogDistance` selector
- fixed a modal in progress screen styles in change pipette and labware calibration modals
- update tests

## review requests
Standard review. Please click through an entire calibration on an actual robot to test `inProgress` spinners in labware calibration. Most importantly, check setJogDistance and actual jogging action behaving as expected in the wild.