### PR TITLE
Move pipette configs into data and make load function lazy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,9 @@ RUN pip install --force-reinstall \
 ENV LABWARE_DEF /etc/labware
 ENV AUDIO_FILES /etc/audio
 ENV USER_DEFN_ROOT /data/user_storage/opentrons_data/labware
+ENV OT_SETTINGS_DIR /etc/robot-data/
+RUN echo "export OT_SETTINGS_DIR=$OT_SETTINGS_DIR" >> /etc/profile
+COPY ./labware-definitions/robot-data /etc/robot-data
 COPY ./compute/conf/jupyter_notebook_config.py /root/.jupyter/
 COPY ./labware-definitions/definitions /etc/labware
 COPY ./audio/ /etc/audio

--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -51,7 +51,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p10_single')
+        config = pipette_config.load('p10_single_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -69,7 +69,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p10_multi')
+        config = pipette_config.load('p10_multi_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -87,7 +87,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p50_single')
+        config = pipette_config.load('p50_single_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -105,7 +105,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p50_multi')
+        config = pipette_config.load('p50_multi_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -123,7 +123,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p300_single')
+        config = pipette_config.load('p300_single_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -141,7 +141,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p300_multi')
+        config = pipette_config.load('p300_multi_v1')
 
         return self._create_pipette_from_config(
             config=config,
@@ -159,7 +159,7 @@ class InstrumentsWrapper(object):
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        config = pipette_config.load('p1000_single')
+        config = pipette_config.load('p1000_single_v1')
 
         return self._create_pipette_from_config(
             config=config,

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -267,6 +267,11 @@ class SmoothieDriver_3_0_0:
         else:
             res = self._read_from_pipette(
                 GCODES['READ_INSTRUMENT_MODEL'], mount)
+            if res and not res.endswith('_v1'):
+                # Backward compatibility for pipettes programmed with model
+                # strings that did not include the _v# designation
+                res = res + '_v1'
+
         return {'model': res}
 
     def write_pipette_id(self, mount, data_string):

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -1,25 +1,64 @@
+import os
+import json
 from collections import namedtuple
 
 
-# multi-channel pipettes share the same dimensional offsets
-DISTANCE_BETWEEN_NOZZLES = 9
-NUM_MULTI_CHANNEL_NOZZLES = 8
-MULTI_LENGTH = (NUM_MULTI_CHANNEL_NOZZLES - 1) * DISTANCE_BETWEEN_NOZZLES
-Y_OFFSET_MULTI = MULTI_LENGTH / 2
-Z_OFFSET_MULTI = -25.8
+FILE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-# single-channel pipettes have different lengths
-Z_OFFSET_P10 = -13  # longest single-channel pipette
-Z_OFFSET_P50 = 0
-Z_OFFSET_P300 = 0
-Z_OFFSET_P1000 = 20  # shortest single-channel pipette
 
-# Default number of seconds to aspirate/dispense a pipette's full volume,
-# and these times were chosen to mimic normal human-pipetting motions.
-# However, accurate speeds are dependent on environment (ex: liquid viscosity),
-# therefore a pipette's flow-rates (ul/sec) should be set by protocol writer
-DEFAULT_ASPIRATE_SECONDS = 2
-DEFAULT_DISPENSE_SECONDS = 1
+def config_dir():
+    return os.environ.get(
+        'OT_SETTINGS_DIR',
+        os.path.abspath(os.path.join(
+            FILE_DIR, '..', '..', '..', 'labware-definitions', 'robot-data')))
+
+
+pipette_config = namedtuple(
+    'pipette_config',
+    [
+        'plunger_positions',
+        'pick_up_current',
+        'aspirate_flow_rate',
+        'dispense_flow_rate',
+        'ul_per_mm',
+        'channels',
+        'name',
+        'model_offset',
+        'tip_length'  # TODO (andy): remove from pipette, move to tip-rack
+    ]
+)
+
+
+def _load_config_from_file(pipette_model: str) -> pipette_config:
+    with open(os.path.join(config_dir(), 'pipette-config.json')) as conf:
+        all_configs = json.load(conf)
+        cfg = all_configs[pipette_model]
+        return pipette_config(
+            plunger_positions={
+                'top': cfg['plunger-positions']['top'],
+                'bottom': cfg['plunger-positions']['bottom'],
+                'blow_out': cfg['plunger-positions']['blow-out'],
+                'drop_tip': cfg['plunger-positions']['drop-tip']
+            },
+            pick_up_current=cfg['pick-up-current'],
+            aspirate_flow_rate=cfg['aspirate-flow-rate'],
+            dispense_flow_rate=cfg['dispense-flow-rate'],
+            ul_per_mm=cfg['ul-per-mm'],
+            channels=cfg['channels'],
+            name=pipette_model,
+            model_offset=cfg['model-offset'],
+            tip_length=cfg['tip-length']
+        )
+
+# Notes:
+# - multi-channel pipettes share the same dimensional offsets
+# - single-channel pipettes have different lengths
+# - Default number of seconds to aspirate/dispense a pipette's full volume,
+#     and these times were chosen to mimic normal human-pipetting motions.
+#     However, accurate speeds are dependent on environment (ex: liquid
+#     viscosity), therefore a pipette's flow-rates (ul/sec) should be set by
+#     protocol writer
+
 
 # model-specific ID's, saved with each Pipette's memory
 # used to identifiy what model pipette is currently connected to machine
@@ -37,151 +76,28 @@ PIPETTE_MODEL_IDENTIFIERS = {
     }
 }
 
-pipette_config = namedtuple(
-    'pipette_config',
-    [
-        'plunger_positions',
-        'pick_up_current',
-        'aspirate_flow_rate',
-        'dispense_flow_rate',
-        'ul_per_mm',
-        'channels',
-        'name',
-        'model_offset',
-        'tip_length'  # TODO (andy): remove from pipette, move to tip-rack
-    ]
-)
-
-p10_single = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
-    channels=1,
-    name='p10_single',
-    model_offset=(0.0, 0.0, Z_OFFSET_P10),
-    tip_length=40  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p10_multi = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -5
-    },
-    pick_up_current=0.2,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
-    channels=8,
-    name='p10_multi',
-    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
-    tip_length=40  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p50_single = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 4,
-        'blow_out': 2,
-        'drop_tip': -2.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
-    channels=1,
-    name='p50_single',
-    model_offset=(0.0, 0.0, Z_OFFSET_P50),
-    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p50_multi = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 4,
-        'blow_out': 2,
-        'drop_tip': -4
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
-    channels=8,
-    name='p50_multi',
-    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
-    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p300_single = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -2.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
-    channels=1,
-    name='p300_single',
-    model_offset=(0.0, 0.0, Z_OFFSET_P300),
-    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p300_multi = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -4
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
-    channels=8,
-    name='p300_multi',
-    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
-    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
-)
-
-p1000_single = pipette_config(
-    plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -2.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=61.69,
-    channels=1,
-    name='p1000_single',
-    model_offset=(0.0, 0.0, Z_OFFSET_P1000),
-    tip_length=60  # TODO (andy): remove from pipette, move to tip-rack
-)
-
 
 configs = {
-    'p10_single': p10_single,
-    'p10_multi': p10_multi,
-    'p50_single': p50_single,
-    'p50_multi': p50_multi,
-    'p300_single': p300_single,
-    'p300_multi': p300_multi,
-    'p1000_single': p1000_single
-}
+    model: _load_config_from_file(model)
+    for model in [
+        'p10_single_v1',
+        'p10_multi_v1',
+        'p50_single_v1',
+        'p50_multi_v1',
+        'p300_single_v1',
+        'p300_multi_v1',
+        'p1000_single_v1']}
 
 
-def load(pipette_model: str):
-    return configs[pipette_model]
+def load(pipette_model: str) -> pipette_config:
+    """
+    Lazily loads pipette config data from disk. This means that changes to the
+    configuration data should be picked up on newly instantiated objects
+    without requiring a restart. If :param pipette_model is not in the top-
+    level keys of the "pipette-config.json" file, this function will raise a
+    KeyError
+    :param pipette_model: a pipette model string corresponding to a top-level
+        key in the "pipette-config.json" file
+    :return: a `pipette_config` instance
+    """
+    return _load_config_from_file(pipette_model)

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -30,25 +30,195 @@ pipette_config = namedtuple(
 
 
 def _load_config_from_file(pipette_model: str) -> pipette_config:
-    with open(os.path.join(config_dir(), 'pipette-config.json')) as conf:
-        all_configs = json.load(conf)
-        cfg = all_configs[pipette_model]
-        return pipette_config(
-            plunger_positions={
-                'top': cfg['plunger-positions']['top'],
-                'bottom': cfg['plunger-positions']['bottom'],
-                'blow_out': cfg['plunger-positions']['blow-out'],
-                'drop_tip': cfg['plunger-positions']['drop-tip']
-            },
-            pick_up_current=cfg['pick-up-current'],
-            aspirate_flow_rate=cfg['aspirate-flow-rate'],
-            dispense_flow_rate=cfg['dispense-flow-rate'],
-            ul_per_mm=cfg['ul-per-mm'],
-            channels=cfg['channels'],
-            name=pipette_model,
-            model_offset=cfg['model-offset'],
-            tip_length=cfg['tip-length']
-        )
+    config_file = os.path.join(config_dir(), 'pipette-config.json')
+    if os.path.exists(config_file):
+        with open(config_file) as conf:
+            all_configs = json.load(conf)
+            cfg = all_configs[pipette_model]
+            res = pipette_config(
+                plunger_positions={
+                    'top': cfg['plunger-positions']['top'],
+                    'bottom': cfg['plunger-positions']['bottom'],
+                    'blow_out': cfg['plunger-positions']['blow-out'],
+                    'drop_tip': cfg['plunger-positions']['drop-tip']
+                },
+                pick_up_current=cfg['pick-up-current'],
+                aspirate_flow_rate=cfg['aspirate-flow-rate'],
+                dispense_flow_rate=cfg['dispense-flow-rate'],
+                ul_per_mm=cfg['ul-per-mm'],
+                channels=cfg['channels'],
+                name=pipette_model,
+                model_offset=cfg['model-offset'],
+                tip_length=cfg['tip-length']
+            )
+    else:
+        res = None
+    return res
+
+
+# ------------------------- deprecated data ---------------------------
+# This section is left in as a fall-back until the settings file is
+# available on all robots. Currently, getting the settings file onto
+# the robots requires a Resin push, which involves some pain to users
+# because it restarts the robot--even if a protocol run is in progress.
+# The preferred solution is to implement a server endpoint that will
+# accept a data packet and save it in the robot, the same way that API
+# server updates are currently done. Once that is in place, the app can
+# ship the required data to the robot and this fallback data can be
+# removed from server code. Delete from here to "end deprecated data"
+# below, and remove the `select_config` call from the `config` dict
+# comprehension.
+DISTANCE_BETWEEN_NOZZLES = 9
+NUM_MULTI_CHANNEL_NOZZLES = 8
+MULTI_LENGTH = (NUM_MULTI_CHANNEL_NOZZLES - 1) * DISTANCE_BETWEEN_NOZZLES
+Y_OFFSET_MULTI = MULTI_LENGTH / 2
+Z_OFFSET_MULTI = -25.8
+
+Z_OFFSET_P10 = -13  # longest single-channel pipette
+Z_OFFSET_P50 = 0
+Z_OFFSET_P300 = 0
+Z_OFFSET_P1000 = 20  # shortest single-channel pipette
+
+DEFAULT_ASPIRATE_SECONDS = 2
+DEFAULT_DISPENSE_SECONDS = 1
+
+p10_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=0.617,
+    channels=1,
+    name='p10_single_v1',
+    model_offset=(0.0, 0.0, Z_OFFSET_P10),
+    tip_length=40
+)
+
+p10_multi = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -5
+    },
+    pick_up_current=0.2,
+    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=0.617,
+    channels=8,
+    name='p10_multi_v1',
+    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
+    tip_length=40
+)
+
+p50_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 4,
+        'blow_out': 2,
+        'drop_tip': -2.5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=3.08,
+    channels=1,
+    name='p50_single_v1',
+    model_offset=(0.0, 0.0, Z_OFFSET_P50),
+    tip_length=60
+)
+
+p50_multi = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 4,
+        'blow_out': 2,
+        'drop_tip': -4
+    },
+    pick_up_current=0.3,
+    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=3.08,
+    channels=8,
+    name='p50_multi_v1',
+    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
+    tip_length=60
+)
+
+p300_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -2.5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=18.51,
+    channels=1,
+    name='p300_single_v1',
+    model_offset=(0.0, 0.0, Z_OFFSET_P300),
+    tip_length=60
+)
+
+p300_multi = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -4
+    },
+    pick_up_current=0.3,
+    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=18.51,
+    channels=8,
+    name='p300_multi_v1',
+    model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
+    tip_length=60
+)
+
+p1000_single = pipette_config(
+    plunger_positions={
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -2.5
+    },
+    pick_up_current=0.1,
+    aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
+    dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
+    ul_per_mm=61.69,
+    channels=1,
+    name='p1000_single_v1',
+    model_offset=(0.0, 0.0, Z_OFFSET_P1000),
+    tip_length=60
+)
+
+fallback_configs = {
+    'p10_single_v1': p10_single,
+    'p10_multi_v1': p10_multi,
+    'p50_single_v1': p50_single,
+    'p50_multi_v1': p50_multi,
+    'p300_single_v1': p300_single,
+    'p300_multi_v1': p300_multi,
+    'p1000_single_v1': p1000_single
+}
+
+
+def select_config(model: str):
+    cfg = _load_config_from_file(model)
+    if not cfg:
+        cfg = fallback_configs.get(model)
+    return cfg
+# ----------------------- end deprecated data -------------------------
+
 
 # Notes:
 # - multi-channel pipettes share the same dimensional offsets
@@ -78,7 +248,7 @@ PIPETTE_MODEL_IDENTIFIERS = {
 
 
 configs = {
-    model: _load_config_from_file(model)
+    model: select_config(model)
     for model in [
         'p10_single_v1',
         'p10_multi_v1',

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -930,13 +930,14 @@ class Robot(object):
         if left_model:
             tip_length = pipette_config.configs[left_model].tip_length
             left_data.update({'tip_length': tip_length})
+
         right_data = {
                 'mount_axis': 'a',
                 'plunger_axis': 'c'
             }
         right_data.update(self._driver.read_pipette_model('right'))
         right_model = right_data.get('model')
-        if left_model:
+        if right_model:
             tip_length = pipette_config.configs[right_model].tip_length
             right_data.update({'tip_length': tip_length})
         return {

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -22,13 +22,13 @@ async def get_attached_pipettes(request):
     ```
     {
       'left': {
-        'model': 'p300_single',
+        'model': 'p300_single_v1',
         'tip_length': 51.7,
         'mount_axis': 'z',
         'plunger_axis': 'b'
       },
       'right': {
-        'model': 'p10_multi',
+        'model': 'p10_multi_v1',
         'tip_length': 40,
         'mount_axis': 'a',
         'plunger_axis': 'c'

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -275,6 +275,61 @@ async def test_jog_calibrate_top(
     robot = model.robot
 
     container = model.container._container
+    container_coords1 = container.coordinates()
+    pos1 = pose_tracker.absolute(robot.poses, container[0])
+    coordinates1 = container[0].coordinates()
+
+    main_router.calibration_manager.move_to(model.instrument, model.container)
+    main_router.calibration_manager.jog(model.instrument, 1, 'x')
+    main_router.calibration_manager.jog(model.instrument, 2, 'y')
+    main_router.calibration_manager.jog(model.instrument, 3, 'z')
+
+    main_router.calibration_manager.update_container_offset(
+        model.container,
+        model.instrument
+    )
+
+    container_coords2 = container.coordinates()
+    pos2 = pose_tracker.absolute(robot.poses, container[0])
+    coordinates2 = container[0].coordinates()
+
+    assert isclose(
+        array([*container_coords1]) + (1, 2, 3),
+        array([*container_coords2])).all()
+    assert isclose(pos1 + (1, 2, 3), pos2).all()
+    assert isclose(
+        array([*coordinates1]) + (1, 2, 3),
+        array([*coordinates2])).all()
+
+    main_router.calibration_manager.pick_up_tip(
+        model.instrument,
+        model.container
+    )
+
+    # NOTE: only check XY, as the instrument moves up after tip pickup
+    assert isclose(
+        pose_tracker.absolute(robot.poses, container[0])[:-1],
+        pose_tracker.absolute(robot.poses, model.instrument._instrument)[:-1]
+    ).all()
+
+
+async def test_jog_calibrate_top_new(
+        split_labware_def,
+        user_definition_dirs,
+        main_router,
+        model,
+        monkeypatch):
+
+    # Check that the old behavior remains the same without the feature flag
+    from numpy import array, isclose
+    from opentrons.trackers import pose_tracker
+    import tempfile
+    temp = tempfile.gettempdir()
+    monkeypatch.setenv('USER_DEFN_ROOT', temp)
+
+    robot = model.robot
+
+    container = model.container._container
     pos1 = pose_tracker.absolute(robot.poses, container[0])
     coordinates1 = container[0].coordinates()
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -313,7 +313,7 @@ def test_read_and_write_pipettes(model):
     driver.simulating = False
     read_model = driver.read_pipette_model('left')
     driver.simulating = True
-    assert read_model == {'model': test_model}
+    assert read_model == {'model': test_model + '_v1'}
 
     driver._send_command = types.MethodType(_old_send_command, driver)
 

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -9,12 +9,13 @@ from opentrons.robot import robot_configs
 # ------------ Function tests (unit) ----------------------
 async def test_init_pipette(dc_session):
     robot.reset()
+    model = 'p10_single_v1'
     data = {
         'mount': 'left',
-        'model': 'p10_single'}
+        'model': model}
     await endpoints.init_pipette(data)
     actual = dc_session.pipettes.get('left').name
-    expected = pipette_config.p10_single.name
+    expected = pipette_config.configs[model].name
     assert actual == expected
 
 
@@ -97,7 +98,7 @@ async def test_save_z(dc_session):
     await endpoints.save_z({})
 
     new_z = dc_session.z_value
-    pipette_z_offset = pipette_config.p10_single.model_offset[-1]
+    pipette_z_offset = pipette_config.configs['p10_single_v1'].model_offset[-1]
     expected_z = z_target - pipette_z_offset
     assert new_z == expected_z
 
@@ -227,7 +228,7 @@ async def test_incorrect_token(async_client, monkeypatch):
             'token': 'FAKE TOKEN',
             'command': 'init pipette',
             'mount': 'left',
-            'model': 'p10_single'
+            'model': 'p10_single_v1'
         })
 
     assert resp.status == 403
@@ -258,12 +259,12 @@ async def test_init_pipette_integration(async_client, monkeypatch):
             'token': token,
             'command': 'init pipette',
             'mount': 'left',
-            'model': 'p10_single'
+            'model': 'p10_single_v1'
         })
 
     body = await resp.json()
 
-    assert body['pipettes']['left'] == 'p10_single'
+    assert body['pipettes']['left'] == 'p10_single_v1'
     assert endpoints.session.pipettes.get('right') is None
 
 
@@ -294,7 +295,7 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
             'token': token,
             'command': 'init pipette',
             'mount': 'left',
-            'model': 'p10_single'
+            'model': 'p10_single_v1'
         })
 
     await async_client.post(

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -252,7 +252,7 @@ async def test_move_pipette(virtual_smoothie_env, loop, test_client):
         'target': 'pipette',
         'point': [100, 200, 50],
         'mount': 'right',
-        'model': 'p300_single'
+        'model': 'p300_single_v1'
     }
     res = await cli.post('/robot/move', json=data)
     assert res.status == 200

--- a/labware-definitions/robot-data/pipette-config.json
+++ b/labware-definitions/robot-data/pipette-config.json
@@ -1,0 +1,121 @@
+{
+  "p10_single_v1": {
+    "display-name": "P10 Single",
+    "nominal-max-volume-ul": 10,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 3,
+      "blow-out": 1,
+      "drop-tip": -5
+    },
+    "pick-up-current": 0.1,
+    "aspirate-flow-rate": 5,
+    "dispense-flow-rate": 10,
+    "ul-per-mm": 0.617,
+    "channels": 1,
+    "model-offset": [0.0, 0.0, -13],
+    "tip-length": 40
+  },
+  "p10_multi_v1": {
+    "display-name": "P10 Multi",
+    "nominal-max-volume-ul": 10,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 3,
+      "blow-out": 1,
+      "drop-tip": -5
+    },
+    "pick-up-current": 0.2,
+    "aspirate-flow-rate": 5,
+    "dispense-flow-rate": 10,
+    "ul-per-mm": 0.617,
+    "channels": 8,
+    "model-offset": [0.0, 28.0, -25.8],
+    "tip-length": 40
+  },
+  "p50_single_v1": {
+    "display-name": "P50 Single",
+    "nominal-max-volume-ul": 50,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 4,
+      "blow-out": 2,
+      "drop-tip": -2.5
+    },
+    "pick-up-current": 0.1,
+    "aspirate-flow-rate": 25,
+    "dispense-flow-rate": 50,
+    "ul-per-mm": 3.08,
+    "channels": 1,
+    "model-offset": [0.0, 0.0, 0.0],
+    "tip-length": 60
+  },
+  "p50_multi_v1": {
+    "display-name": "P50 Multi",
+    "nominal-max-volume-ul": 50,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 4,
+      "blow-out": 2,
+      "drop-tip": -4
+    },
+    "pick-up-current": 0.3,
+    "aspirate-flow-rate": 25,
+    "dispense-flow-rate": 50,
+    "ul-per-mm": 3.08,
+    "channels": 8,
+    "model-offset": [0.0, 28.0, -25.8],
+    "tip-length": 60
+  },
+  "p300_single_v1": {
+    "display-name": "P300 Single",
+    "nominal-max-volume-ul": 300,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 3,
+      "blow-out": 1,
+      "drop-tip": -2.5
+    },
+    "pick-up-current": 0.1,
+    "aspirate-flow-rate": 150,
+    "dispense-flow-rate": 300,
+    "ul-per-mm": 18.51,
+    "channels": 1,
+    "model-offset": [0.0, 0.0, 0.0],
+    "tip-length": 60
+  },
+  "p300_multi_v1": {
+    "display-name": "P300 Multi",
+    "nominal-max-volume-ul": 300,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 3,
+      "blow-out": 1,
+      "drop-tip": -4
+    },
+    "pick-up-current": 0.3,
+    "aspirate-flow-rate": 150,
+    "dispense-flow-rate": 300,
+    "ul-per-mm": 18.51,
+    "channels": 8,
+    "model-offset": [0.0, 28.0, -25.8],
+    "tip-length": 60
+  },
+  "p1000_single_v1": {
+    "display-name": "P1000 Single",
+    "nominal-max-volume-ul": 1000,
+    "plunger-positions": {
+      "top": 18,
+      "bottom": 3,
+      "blow-out": 1,
+      "drop-tip": -2.5
+    },
+    "pick-up-current": 0.1,
+    "aspirate-flow-rate": 500,
+    "dispense-flow-rate": 1000,
+    "ul-per-mm": 61.69,
+    "channels": 1,
+    "model-offset": [0.0, 0.0, 20.0],
+    "tip-length": 60
+  }
+}


### PR DESCRIPTION
## overview

Fix a typo in the pipette info endpoint, and move pipette model config values to data where it can be imported and used directly in JS apps. Fixes #1222 

## changelog

- (fix) Fix typo in pipette info endpoint
- (feature) Move pipette config data to json files that can be imported by JS apps

## review requests

Tested on 🌔 🌔 
