### PR TITLE
feat/refactor: Update pipette defs based on UX and FE

### DIFF
--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -37,19 +37,19 @@ def _load_config_from_file(pipette_model: str) -> pipette_config:
             cfg = all_configs[pipette_model]
             res = pipette_config(
                 plunger_positions={
-                    'top': cfg['plunger-positions']['top'],
-                    'bottom': cfg['plunger-positions']['bottom'],
-                    'blow_out': cfg['plunger-positions']['blow-out'],
-                    'drop_tip': cfg['plunger-positions']['drop-tip']
+                    'top': cfg['plungerPositions']['top'],
+                    'bottom': cfg['plungerPositions']['bottom'],
+                    'blow_out': cfg['plungerPositions']['blowOut'],
+                    'drop_tip': cfg['plungerPositions']['dropTip']
                 },
-                pick_up_current=cfg['pick-up-current'],
-                aspirate_flow_rate=cfg['aspirate-flow-rate'],
-                dispense_flow_rate=cfg['dispense-flow-rate'],
-                ul_per_mm=cfg['ul-per-mm'],
+                pick_up_current=cfg['pickUpCurrent'],
+                aspirate_flow_rate=cfg['aspirateFlowRate'],
+                dispense_flow_rate=cfg['dispenseFlowRate'],
+                ul_per_mm=cfg['ulPerMm'],
                 channels=cfg['channels'],
                 name=pipette_model,
-                model_offset=cfg['model-offset'],
-                tip_length=cfg['tip-length']
+                model_offset=cfg['modelOffset'],
+                tip_length=cfg['tipLength']
             )
     else:
         res = None

--- a/labware-definitions/js/index.js
+++ b/labware-definitions/js/index.js
@@ -8,6 +8,10 @@ import labwareDefinitions from '../build/labware.json'
 // Sorted list of all labware
 const labwareList: Array<string> = Object.keys(labwareDefinitions).sort()
 
+export * from './types'
+
+export * from './pipettes'
+
 export {
   computeWellAccess,
   getLabware,

--- a/labware-definitions/js/pipettes.js
+++ b/labware-definitions/js/pipettes.js
@@ -1,0 +1,35 @@
+// @flow
+import pipetteConfigByModel from '../robot-data/pipette-config.json'
+
+const allModels: Array<string> = Object.keys(pipetteConfigByModel)
+
+export type PipetteChannels = 1 | 8
+
+export type PipetteConfig = {
+  model: string,
+  displayName: string,
+  nominalMaxVolumeUl: number,
+  plungerPositions: {
+    top: number,
+    bottom: number,
+    blowOut: number,
+    dropTip: number,
+  },
+  pickUpCurrent: number,
+  aspirateFlowRate: number,
+  dispenseFlowRate: number,
+  ulPerMm: number,
+  channels: PipetteChannels,
+  modelOffset: [number, number, number],
+  tipLength: number,
+}
+
+export function getPipette (model: string): ?PipetteConfig {
+  const config = pipetteConfigByModel[model]
+
+  return config && {...config, model: model}
+}
+
+export function getAllPipetteModels () {
+  return [...allModels]
+}

--- a/labware-definitions/js/pipettes.js
+++ b/labware-definitions/js/pipettes.js
@@ -1,8 +1,6 @@
 // @flow
 import pipetteConfigByModel from '../robot-data/pipette-config.json'
 
-const allModels: Array<string> = Object.keys(pipetteConfigByModel)
-
 export type PipetteChannels = 1 | 8
 
 export type PipetteConfig = {
@@ -24,12 +22,42 @@ export type PipetteConfig = {
   tipLength: number,
 }
 
+type SortableProps =
+  | 'nominalMaxVolumeUl'
+  | 'channels'
+
+// models sorted by channels and then volume by default
+const ALL_MODELS: Array<string> = Object
+  .keys(pipetteConfigByModel)
+  .sort(comparePipettes(['channels', 'nominalMaxVolumeUl']))
+
 export function getPipette (model: string): ?PipetteConfig {
   const config = pipetteConfigByModel[model]
 
   return config && {...config, model: model}
 }
 
-export function getAllPipetteModels () {
-  return [...allModels]
+export function getPipetteModels (...sortBy: Array<SortableProps>) {
+  const models = [...ALL_MODELS]
+
+  if (sortBy.length) models.sort(comparePipettes(sortBy))
+
+  return models
+}
+
+function comparePipettes (sortBy: Array<SortableProps>) {
+  return (modelA, modelB) => {
+    // any cast is because we know these pipettes exist
+    const a: PipetteConfig = (getPipette(modelA): any)
+    const b: PipetteConfig = (getPipette(modelB): any)
+
+    let i
+    for (i = 0; i < sortBy.length; i++) {
+      const sortKey = sortBy[i]
+      if (a[sortKey] < b[sortKey]) return -1
+      if (a[sortKey] > b[sortKey]) return 1
+    }
+
+    return 0
+  }
 }

--- a/labware-definitions/robot-data/pipette-config.json
+++ b/labware-definitions/robot-data/pipette-config.json
@@ -1,121 +1,121 @@
 {
   "p10_single_v1": {
-    "display-name": "P10 Single",
-    "nominal-max-volume-ul": 10,
-    "plunger-positions": {
+    "displayName": "P10 Single-Channel",
+    "nominalMaxVolumeUl": 10,
+    "plungerPositions": {
       "top": 18,
       "bottom": 3,
-      "blow-out": 1,
-      "drop-tip": -5
+      "blowOut": 1,
+      "dropTip": -5
     },
-    "pick-up-current": 0.1,
-    "aspirate-flow-rate": 5,
-    "dispense-flow-rate": 10,
-    "ul-per-mm": 0.617,
+    "pickUpCurrent": 0.1,
+    "aspirateFlowRate": 5,
+    "dispenseFlowRate": 10,
+    "ulPerMm": 0.617,
     "channels": 1,
-    "model-offset": [0.0, 0.0, -13],
-    "tip-length": 40
+    "modelOffset": [0.0, 0.0, -13],
+    "tipLength": 40
   },
   "p10_multi_v1": {
-    "display-name": "P10 Multi",
-    "nominal-max-volume-ul": 10,
-    "plunger-positions": {
+    "displayName": "P10 8-Channel",
+    "nominalMaxVolumeUl": 10,
+    "plungerPositions": {
       "top": 18,
       "bottom": 3,
-      "blow-out": 1,
-      "drop-tip": -5
+      "blowOut": 1,
+      "dropTip": -5
     },
-    "pick-up-current": 0.2,
-    "aspirate-flow-rate": 5,
-    "dispense-flow-rate": 10,
-    "ul-per-mm": 0.617,
+    "pickUpCurrent": 0.2,
+    "aspirateFlowRate": 5,
+    "dispenseFlowRate": 10,
+    "ulPerMm": 0.617,
     "channels": 8,
-    "model-offset": [0.0, 28.0, -25.8],
-    "tip-length": 40
+    "modelOffset": [0.0, 28.0, -25.8],
+    "tipLength": 40
   },
   "p50_single_v1": {
-    "display-name": "P50 Single",
-    "nominal-max-volume-ul": 50,
-    "plunger-positions": {
+    "displayName": "P50 Single-Channel",
+    "nominalMaxVolumeUl": 50,
+    "plungerPositions": {
       "top": 18,
       "bottom": 4,
-      "blow-out": 2,
-      "drop-tip": -2.5
+      "blowOut": 2,
+      "dropTip": -2.5
     },
-    "pick-up-current": 0.1,
-    "aspirate-flow-rate": 25,
-    "dispense-flow-rate": 50,
-    "ul-per-mm": 3.08,
+    "pickUpCurrent": 0.1,
+    "aspirateFlowRate": 25,
+    "dispenseFlowRate": 50,
+    "ulPerMm": 3.08,
     "channels": 1,
-    "model-offset": [0.0, 0.0, 0.0],
-    "tip-length": 60
+    "modelOffset": [0.0, 0.0, 0.0],
+    "tipLength": 60
   },
   "p50_multi_v1": {
-    "display-name": "P50 Multi",
-    "nominal-max-volume-ul": 50,
-    "plunger-positions": {
+    "displayName": "P50 8-Channel",
+    "nominalMaxVolumeUl": 50,
+    "plungerPositions": {
       "top": 18,
       "bottom": 4,
-      "blow-out": 2,
-      "drop-tip": -4
+      "blowOut": 2,
+      "dropTip": -4
     },
-    "pick-up-current": 0.3,
-    "aspirate-flow-rate": 25,
-    "dispense-flow-rate": 50,
-    "ul-per-mm": 3.08,
+    "pickUpCurrent": 0.3,
+    "aspirateFlowRate": 25,
+    "dispenseFlowRate": 50,
+    "ulPerMm": 3.08,
     "channels": 8,
-    "model-offset": [0.0, 28.0, -25.8],
-    "tip-length": 60
+    "modelOffset": [0.0, 28.0, -25.8],
+    "tipLength": 60
   },
   "p300_single_v1": {
-    "display-name": "P300 Single",
-    "nominal-max-volume-ul": 300,
-    "plunger-positions": {
+    "displayName": "P300 Single-Channel",
+    "nominalMaxVolumeUl": 300,
+    "plungerPositions": {
       "top": 18,
       "bottom": 3,
-      "blow-out": 1,
-      "drop-tip": -2.5
+      "blowOut": 1,
+      "dropTip": -2.5
     },
-    "pick-up-current": 0.1,
-    "aspirate-flow-rate": 150,
-    "dispense-flow-rate": 300,
-    "ul-per-mm": 18.51,
+    "pickUpCurrent": 0.1,
+    "aspirateFlowRate": 150,
+    "dispenseFlowRate": 300,
+    "ulPerMm": 18.51,
     "channels": 1,
-    "model-offset": [0.0, 0.0, 0.0],
-    "tip-length": 60
+    "modelOffset": [0.0, 0.0, 0.0],
+    "tipLength": 60
   },
   "p300_multi_v1": {
-    "display-name": "P300 Multi",
-    "nominal-max-volume-ul": 300,
-    "plunger-positions": {
+    "displayName": "P300 8-Channel",
+    "nominalMaxVolumeUl": 300,
+    "plungerPositions": {
       "top": 18,
       "bottom": 3,
-      "blow-out": 1,
-      "drop-tip": -4
+      "blowOut": 1,
+      "dropTip": -4
     },
-    "pick-up-current": 0.3,
-    "aspirate-flow-rate": 150,
-    "dispense-flow-rate": 300,
-    "ul-per-mm": 18.51,
+    "pickUpCurrent": 0.3,
+    "aspirateFlowRate": 150,
+    "dispenseFlowRate": 300,
+    "ulPerMm": 18.51,
     "channels": 8,
-    "model-offset": [0.0, 28.0, -25.8],
-    "tip-length": 60
+    "modelOffset": [0.0, 28.0, -25.8],
+    "tipLength": 60
   },
   "p1000_single_v1": {
-    "display-name": "P1000 Single",
-    "nominal-max-volume-ul": 1000,
-    "plunger-positions": {
+    "displayName": "P1000 Single-channel",
+    "nominalMaxVolumeUl": 1000,
+    "plungerPositions": {
       "top": 18,
       "bottom": 3,
-      "blow-out": 1,
-      "drop-tip": -2.5
+      "blowOut": 1,
+      "dropTip": -2.5
     },
-    "pick-up-current": 0.1,
-    "aspirate-flow-rate": 500,
-    "dispense-flow-rate": 1000,
-    "ul-per-mm": 61.69,
+    "pickUpCurrent": 0.1,
+    "aspirateFlowRate": 500,
+    "dispenseFlowRate": 1000,
+    "ulPerMm": 61.69,
     "channels": 1,
-    "model-offset": [0.0, 0.0, 20.0],
-    "tip-length": 60
+    "modelOffset": [0.0, 0.0, 20.0],
+    "tipLength": 60
   }
 }


### PR DESCRIPTION
## overview

Based on discussions with UX as well as app needs for swap pipettes, this PR adjusts the format of `pipette-config.json` and adds a couple JS functions to retrieve known pipette models and pipette configs by model name.

This PR is functioning as a small ticket for Swap Pipettes

## changelog

- feat(lw-defs): Improve pipette config definitions for dev and UX
- refactor(api): Refactor pipette config JSON retrieval for new format 

## review requests

Please make sure this didn't break the API @btmorr. @pantslakz can you look at the new `displayName` values in `pipette-config.json` and verify they line up with what we discussed?

Otherwise JS sanity check would be good from @Opentrons/js 
