### PR TITLE
Add debug logging and environment read endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,6 @@ ENV ETHERNET_STATIC_IP=fd00:0000:cafe:fefe::1
 ENV ETHERNET_NETWORK_PREFIX=fd00:0000:cafe:fefe::
 ENV ETHERNET_NETWORK_PREFIX_LENGTH=64
 
-# Some shells are not inheriting environment variables from PID 1
-# so we are setting them explicitly
-RUN echo "export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SYSTEM_BUS_ADDRESS" >> /etc/profile && \
-    echo "export PYTHONPATH=$PYTHONPATH" >> /etc/profile && \
-    echo "export PATH=$PATH" >> /etc/profile && \
-    echo "export RUNNING_ON_PI=$RUNNING_ON_PI" >> /etc/profile && \
-    echo "export OT_SMOOTHIE_ID=$OT_SMOOTHIE_ID" >> /etc/profile
-
 # See compute/README.md for details. Make sure to keep them in sync
 RUN apk add --update \
       util-linux \
@@ -70,7 +62,6 @@ ENV LABWARE_DEF /etc/labware
 ENV AUDIO_FILES /etc/audio
 ENV USER_DEFN_ROOT /data/user_storage/opentrons_data/labware
 ENV OT_SETTINGS_DIR /etc/robot-data/
-RUN echo "export OT_SETTINGS_DIR=$OT_SETTINGS_DIR" >> /etc/profile
 COPY ./labware-definitions/robot-data /etc/robot-data
 COPY ./compute/conf/jupyter_notebook_config.py /root/.jupyter/
 COPY ./labware-definitions/definitions /etc/labware
@@ -114,14 +105,29 @@ RUN sed -i "s/{ETHERNET_NETWORK_PREFIX}/$ETHERNET_NETWORK_PREFIX/g" /etc/radvd.c
 
 # All newly installed packages will go to persistent storage
 ENV PIP_ROOT /data/packages
-RUN echo "export PIP_ROOT=$PIP_ROOT" >> /etc/profile
 
 # Generate keys for dropbear
 RUN ssh_key_gen.sh
 
 # Generate the id that we will later check to see if that's the
 # new container and that local Opentrons API package should be deleted
-RUN echo "export CONTAINER_ID=$(uuidgen)" >> /etc/profile
+# and persist all environment variables from the docker definition,
+# because they are sometimes not picked up from PID 1
+RUN echo "export CONTAINER_ID=$(uuidgen)" >> /etc/profile && \
+    echo "export ETHERNET_STATIC_IP=$ETHERNET_STATIC_IP" >> /etc/profile && \
+    echo "export OT_SETTINGS_DIR=$OT_SETTINGS_DIR" >> /etc/profile && \
+    echo "export OT_SERVER_PORT=$OT_SERVER_PORT" >> /etc/profile && \
+    echo "export OT_SERVER_UNIX_SOCKET_PATH=$OT_SERVER_UNIX_SOCKET_PATH" >> /etc/profile && \
+    echo "export PIP_ROOT=$PIP_ROOT" >> /etc/profile && \
+    echo "export LABWARE_DEF=$LABWARE_DEF" >> /etc/profile && \
+    echo "export USER_DEFN_ROOT=$USER_DEFN_ROOT" >> /etc/profile && \
+    echo "export AUDIO_FILES=$AUDIO_FILES" >> /etc/profile && \
+    echo "export PIPENV_VENV_IN_PROJECT=$PIPENV_VENV_IN_PROJECT" >> /etc/profile && \
+    echo "export DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SYSTEM_BUS_ADDRESS" >> /etc/profile && \
+    echo "export PYTHONPATH=$PYTHONPATH" >> /etc/profile && \
+    echo "export PATH=$PATH" >> /etc/profile && \
+    echo "export RUNNING_ON_PI=$RUNNING_ON_PI" >> /etc/profile && \
+    echo "export OT_SMOOTHIE_ID=$OT_SMOOTHIE_ID" >> /etc/profile
 
 # Updates, HTTPS (for future use), API, SSH for link-local over USB
 EXPOSE 80 443 31950

--- a/api/opentrons/server/endpoints/update.py
+++ b/api/opentrons/server/endpoints/update.py
@@ -156,3 +156,11 @@ async def get_feature_flag(request):
     """
     res = ff.get_all_feature_flags()
     return web.json_response(res)
+
+
+async def environment(request):
+    res = dict(os.environ)
+    api_keys = filter(lambda x: "KEY" in x, list(res.keys()))
+    for key in api_keys:
+        res.pop(key)
+    return web.json_response(res)

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -144,6 +144,8 @@ def init(loop=None):
         '/robot/home', control.home)
     server.app.router.add_get(
         '/settings', update.get_feature_flag)
+    server.app.router.add_get(
+        '/settings/environment', update.environment)
     server.app.router.add_post(
         '/settings/set', update.set_feature_flag)
 


### PR DESCRIPTION
## overview

Add debug logging to sql database, and an endpoint to check the server process' environment to make it easier to debug failures that might be due to mis-set environment variables.

## changelog

- (feature) Add environment endpoint
- (chore) Add debug logging to sql

## review requests

Tested on :moon: :moon: