### PR TITLE
ci(appveyor): Set build info in PS because CMD is bad at undefined vars

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,11 @@ environment:
   OT_BUCKET_APP: opentrons-app
   OT_FOLDER_APP: builds
 
-  OT_BUILD: '%APPVEYOR_BUILD_NUMBER%'
-  OT_BRANCH: '%APPVEYOR_REPO_BRANCH%'
-
 init:
-  # set OT_TAG in a script because APPVEYOR_REPO_TAG_NAME may be undefined
-  - if %APPVEYOR_REPO_TAG% == true set OT_TAG=%APPVEYOR_REPO_TAG_NAME%
+  # set vars in ps scripts because cmd is terrible at undefined vars
+  - ps: $env:OT_TAG = $env:APPVEYOR_REPO_TAG_NAME
+  - ps: $env:OT_BUILD = $env:APPVEYOR_BUILD_NUMBER
+  - ps: $env:OT_BRANCH = $env:APPVEYOR_REPO_BRANCH
 
 platform: x64
 


### PR DESCRIPTION
## overview

As you may have noticed, our latest Windows release build came in with the filename:

```
Opentrons-v3.0.0-beta.7-win-b3676-%APPVEYOR_REPO_BRANCH%.exe
```

This PR updates the AppVeyor config to use PowerShell to set build info environment variables rather than `cmd.exe` or the AppVeyor `env` block, because they do weird stuff with undefined environment variables (as described below) that PowerShell does not do.

## changelog

- ci(appveyor): Set build info in PS because CMD is bad at undefined vars 

## debrief

1. Normally on AppVeyor (as well as Travis), a tag build sets both the tag name and branch name env vars to the tag name
2. Our CI configs take CI specific env vars and rename them to standard ones
    * e.g. `OT_BRANCH: '%APPVEYOR_REPO_BRANCH%'`
3. When naming the app asset, we check if the tag env var matches the branch env var and proceed accordingly
4. In `cmd.exe`, if an environment variable is undefined, trying to set another variable to the same value results in something crazy because windows
    ```shell
    set FOO=%SOMETHING_UNDEFINED%
    echo %FOO%
    # expected (by me) output > 
    # actual output > %SOMETHING_UNDEFINED%
    ```
5. We already knew about (3) and dealt with it for one specific env var we knew could be undefined
6. Out of nowhere (possibly an AppVeyor bug), `%APPVEYOR_REPO_BRANCH%` is no longer set on tag builds
    * We did not expect this variable to ever be undefined
    * OT_TAG == v3.0.0-beta.7, OT_BRANCH == %APPVEYOR_REPO_BRANCH%
    * OT_TAG != OT_BRANCH

This is why `%APPVEYOR_REPO_BRANCH%` ended up in our artifact name.
