### PR TITLE
Changes function the pipettte load method uses

### DIFF
--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -270,4 +270,4 @@ def load(pipette_model: str) -> pipette_config:
         key in the "pipette-config.json" file
     :return: a `pipette_config` instance
     """
-    return _load_config_from_file(pipette_model)
+    return select_config(pipette_model)


### PR DESCRIPTION
## overview

There was a bug introduced into beta.8 software on robots that were updated via the app (no docker re-build). The bug resulted in protocols not being able to be uploaded as pipette configs were not loaded properly from constructors and thus returned a 'NoneType' error.

## changelog

- Changes method that is used in pipette_config.py 'load' function from _load_config_from_file() -> select_config()

## review requests
