### PR TITLE
Api: left-mount offset during deck calibration

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -42,3 +42,9 @@ def set_calibration_value(rbt: Robot, axis: str, value: float):
     else:
         row = z_row
     rbt.config.gantry_calibration[row][xyz_column] = value
+
+
+def apply_mount_offset(point: tuple) -> tuple:
+    px, py, pz = point
+    mx, my, mz = robot.config.mount_offset
+    return (px - mx, py - my, pz - mz)

--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -92,6 +92,8 @@ class CLITool:
             'corner8': (190.65, 227.57, self._tip_length),
             'corner9': (330.14, 222.78, self._tip_length)}
 
+        self._left_mount_point = self._expected_points[1]
+
         self.key_map = {
             '-': lambda: self.decrease_step(),
             '=': lambda: self.increase_step(),
@@ -109,13 +111,14 @@ class CLITool:
             'down': lambda: self._jog('Y', -1, self.current_step()),
             'left': lambda: self._jog('X', -1, self.current_step()),
             'right': lambda: self._jog('X', +1, self.current_step()),
-            '1': lambda: self.validate(self._expected_points[1], 1),
-            '2': lambda: self.validate(self._expected_points[2], 2),
-            '3': lambda: self.validate(self._expected_points[3], 3),
-            '4': lambda: self.validate(self._test_points['slot5'], 4),
-            '5': lambda: self.validate(self._test_points['corner3'], 5),
-            '6': lambda: self.validate(self._test_points['corner8'], 6),
-            '7': lambda: self.validate(self._test_points['corner9'], 7)
+            'l': lambda: self.validate(self._left_mount_point, 0, left),
+            '1': lambda: self.validate(self._expected_points[1], 1, right),
+            '2': lambda: self.validate(self._expected_points[2], 2, right),
+            '3': lambda: self.validate(self._expected_points[3], 3, right),
+            '4': lambda: self.validate(self._test_points['slot5'], 4, right),
+            '5': lambda: self.validate(self._test_points['corner3'], 5, right),
+            '6': lambda: self.validate(self._test_points['corner8'], 6, right),
+            '7': lambda: self.validate(self._test_points['corner9'], 7, right)
         }
 
     def current_step(self):
@@ -137,6 +140,16 @@ class CLITool:
         if self._steps_index > 0:
             self._steps_index = self._steps_index - 1
         return 'step: {}'.format(self.current_step())
+
+    def _deck_to_driver_coords(self, point):
+        point = array(list(point) + [1])
+        x, y, z, _ = dot(self._calibration_matrix, point)
+        return (x, y, z)
+
+    def _driver_to_deck_coords(self, point):
+        point = array(list(point) + [1])
+        x, y, z, _ = dot(inv(self._calibration_matrix), point)
+        return (x, y, z)
 
     def _position(self):
         """
@@ -171,11 +184,22 @@ class CLITool:
         current position once the 'Enter' key is pressed to the 'actual points'
         vector.
         """
-        self._actual_points[self._current_point] = self._position()[:-1]
+        if self._current_pipette is left:
+            msg = self.save_mount_offset()
+        else:
+            self._actual_points[self._current_point] = self._position()[:-1]
+            msg = 'saved #{}: {}'.format(
+                self._current_point, self._actual_points[self._current_point])
+        return msg
 
-        msg = 'saved #{}: {}'.format(
-            self._current_point, self._actual_points[self._current_point])
-
+    def save_mount_offset(self) -> str:
+        cx, cy, cz = self._driver_to_deck_coords(self._position())
+        ex, ey, ez = self._left_mount_point
+        dx, dy, dz = (cx - ex, cy - ey, cz - ez)
+        mx, my, mz = robot.config.mount_offset
+        robot.config._replace(mount_offset=(mx + dx, my + dy, mz + dz))
+        msg = 'saved mount-offset: {}'.format(
+            robot.config.mount_offset)
         return msg
 
     def save_transform(self) -> str:
@@ -208,31 +232,34 @@ class CLITool:
         self._calibration_matrix[2][3] = new_z
         return 'saved Z-Offset: {}'.format(new_z)
 
-    def validate(self, point: (float, float, float), point_num: int) -> str:
+    def validate(
+            self,
+            point: (float, float, float),
+            point_num: int,
+            pipette: str) -> str:
         """
         :param point: Expected values from mechanical drawings
         :param point_num: The current position attempting to be validated
-
 
         :return:
         """
         # TODO (ben 20180201): create a function in linal module so we don't
         # TODO                 have to do dot product & etc here
-        v = array(list(point) + [1])
-        x, y, z, _ = dot(
-            inv(self._calibration_matrix), list(self._position()) + [1])
 
-        if z < SAFE_HEIGHT:
-            _, _, z, _ = dot(self._calibration_matrix, [x, y, SAFE_HEIGHT, 1])
-            robot._driver.move({self._current_pipette: z})
-
-        x, y, z, _ = dot(self._calibration_matrix, v)
-        robot._driver.move({'X': x, 'Y': y})
-        robot._driver.move({self._current_pipette: z})
-
+        self._current_pipette = pipette
         self._current_point = point_num
 
-        return 'moving to point {}'.format(point)
+        cx, cy, cz = self._driver_to_deck_coords(self._position())
+
+        if cz < SAFE_HEIGHT:
+            _, _, sz = self._deck_to_driver_coords((cx, cy, SAFE_HEIGHT))
+            robot._driver.move({self._current_pipette: sz})
+
+        tx, ty, tz = self._deck_to_driver_coords(point)
+        robot._driver.move({'X': tx, 'Y': ty})
+        robot._driver.move({self._current_pipette: tz})
+
+        return 'moved to point {}'.format(point)
 
     def exit(self):
         raise urwid.ExitMainLoop

--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -92,7 +92,18 @@ class CLITool:
             'corner8': (190.65, 227.57, self._tip_length),
             'corner9': (330.14, 222.78, self._tip_length)}
 
-        self._left_mount_point = self._expected_points[1]
+        lx, ly, lz = self._expected_points[1]
+        mx, my, mz = robot.config.mount_offset
+        self._left_mount_point = (
+            lx - mx,
+            ly - my,
+            lz - mz
+        )
+        self._left_mount_test_point = (
+            self._left_mount_point[0],
+            self._left_mount_point[1],
+            self._left_mount_point[2] + 5  # add 5mm to avoid collisions
+        )
 
         self.key_map = {
             '-': lambda: self.decrease_step(),
@@ -111,7 +122,7 @@ class CLITool:
             'down': lambda: self._jog('Y', -1, self.current_step()),
             'left': lambda: self._jog('X', -1, self.current_step()),
             'right': lambda: self._jog('X', +1, self.current_step()),
-            'l': lambda: self.validate(self._left_mount_point, 0, left),
+            'l': lambda: self.validate(self._left_mount_test_point, 0, left),
             '1': lambda: self.validate(self._expected_points[1], 1, right),
             '2': lambda: self.validate(self._expected_points[2], 2, right),
             '3': lambda: self.validate(self._expected_points[3], 3, right),
@@ -197,7 +208,8 @@ class CLITool:
         ex, ey, ez = self._left_mount_point
         dx, dy, dz = (cx - ex, cy - ey, cz - ez)
         mx, my, mz = robot.config.mount_offset
-        robot.config._replace(mount_offset=(mx + dx, my + dy, mz + dz))
+        robot.config = robot.config._replace(
+            mount_offset=(mx + dx, my + dy, mz + dz))
         msg = 'saved mount-offset: {}'.format(
             robot.config.mount_offset)
         return msg
@@ -246,20 +258,27 @@ class CLITool:
         # TODO (ben 20180201): create a function in linal module so we don't
         # TODO                 have to do dot product & etc here
 
+        _, _, cz = self._driver_to_deck_coords(self._position())
+        if self._current_pipette != pipette and cz < SAFE_HEIGHT:
+            self.move_to_safe_height()
+
         self._current_pipette = pipette
         self._current_point = point_num
 
-        cx, cy, cz = self._driver_to_deck_coords(self._position())
-
+        _, _, cz = self._driver_to_deck_coords(self._position())
         if cz < SAFE_HEIGHT:
-            _, _, sz = self._deck_to_driver_coords((cx, cy, SAFE_HEIGHT))
-            robot._driver.move({self._current_pipette: sz})
+            self.move_to_safe_height()
 
         tx, ty, tz = self._deck_to_driver_coords(point)
         robot._driver.move({'X': tx, 'Y': ty})
         robot._driver.move({self._current_pipette: tz})
 
         return 'moved to point {}'.format(point)
+
+    def move_to_safe_height(self):
+        cx, cy, _ = self._driver_to_deck_coords(self._position())
+        _, _, sz = self._deck_to_driver_coords((cx, cy, SAFE_HEIGHT))
+        robot._driver.move({self._current_pipette: sz})
 
     def exit(self):
         raise urwid.ExitMainLoop


### PR DESCRIPTION
## overview

This PR adds a step to the factory-calibration CLI tool, in order to save the left-mount to right-mount offset.

Previously this offset was assumed to be identical, but because there is a +/- 5mm tolerance found on machines, this mount-offset is needed to ensure the tip-probe is not missed.

The found offset is saved within `robot_config`, named `mount_offset`, with a default of `(-34, 0, 0)`

The changes in the PR are to the CLI tool only, which is separate from the UI facing deck-calibration methods. The only users of the methods in this PR will be in-house QC testers.

### Testing script

Ran the below script after running the deck-calibration CLI tool, and visually verified they were aligned to the same point on the deck.

```python
from opentrons import robot, instruments

robot.connect()

left = instruments.P300_Single(mount='left')
right = instruments.P300_Single(mount='right')
left._add_tip(tip_length=51.7)
right._add_tip(tip_length=51.7)

# move to the calibration dot
robot.poses = left._move(robot.poses, x=12.13, y=6, z=0)      # move to the dot
robot.poses = left._move(robot.poses, x=12.13, y=6, z=100)  # get it out of the way
robot.poses = right._move(robot.poses, x=12.13, y=6, z=0)      # move to the dot
robot.poses = right._move(robot.poses, x=12.13, y=6, z=100)  # get it out of the way

# move to the bottom-left corner of slot 5
left.move_to(robot.deck['5'])
right.move_to(robot.deck['5'])
```


### `robot_config` contents after deck calibration

```json
{
    "gantry_calibration": [
        [
            0.999728806204914,
            0.0008683068017366104,
            0.0,
            -4.001920260076024
        ],
        [
            0.0016271627705158455,
            0.9997105643994212,
            0.0,
            2.1819991291971164
        ],
        [
            0.0,
            0.0,
            1.0,
            -25.80000000000001
        ],
        [
            -6.264209483981372e-18,
            0.0,
            0.0,
            1.0
        ]
    ],
    "mount_offset": [
        -36.30114844427558,
        0.6039191387765879,
        0.5999999999999943
    ],
    "probe_center": [
        293.0365564156408,
        301.3017582970467,
        74.64700000000006
    ]
}
```