### PR TITLE
API: adds endpoint to take picture from webcam

### DIFF
--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -304,8 +304,14 @@ async def take_picture(request):
     res = await proc.stdout.read()
     res = res.decode().strip()
     await proc.wait()
+
+    # TODO (andy - 2018-04-23) find better way of ensuring picture was taken
+    # TODO              and properly saved by ffmpeg
     if 'video:' in res and 'audio:' in res and 'subtitle:' in res:
         return web.json_response({'message': res}, status=500)
+    if not os.path.exists(filename):
+        return web.json_response({'message': 'picture not saved'}, status=500)
+
     return web.FileResponse(filename)
 
 

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -298,15 +298,14 @@ async def take_picture(request):
     cmd = 'ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1'  # NOQA
     proc = await asyncio.create_subprocess_shell(
         '{} {}'.format(cmd, filename),
-        stderr=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
         loop=request.loop)
 
-    rd = await proc.stderr.read()
-    error_msg = rd.decode().strip()
+    res = await proc.stdout.read()
+    res = res.decode().strip()
     await proc.wait()
-    if error_msg:
-        return web.json_response({"message": error_msg}, status=500)
-
+    if 'video:' in res and 'audio:' in res and 'subtitle:' in res:
+        return web.json_response({'message': res}, status=500)
     return web.FileResponse(filename)
 
 

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -298,12 +298,14 @@ async def take_picture(request):
     cmd = 'ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1'  # NOQA
     proc = await asyncio.create_subprocess_shell(
         '{} {}'.format(cmd, filename),
-        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
         loop=request.loop)
 
-    rd = await proc.stdout.read()
-    rd.decode().strip()
+    rd = await proc.stderr.read()
+    error_msg = rd.decode().strip()
     await proc.wait()
+    if error_msg:
+        return web.json_response({"message": error_msg}, status=500)
 
     return web.FileResponse(filename)
 

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -120,6 +120,8 @@ def init(loop=None):
         '/lights/on', control.turn_on_rail_lights)
     server.app.router.add_post(
         '/lights/off', control.turn_off_rail_lights)
+    server.app.router.add_get(
+        '/camera/picture', control.take_picture)
     server.app.router.add_post(
         '/server/update', update.install_api)
     server.app.router.add_post(

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -120,7 +120,7 @@ def init(loop=None):
         '/lights/on', control.turn_on_rail_lights)
     server.app.router.add_post(
         '/lights/off', control.turn_off_rail_lights)
-    server.app.router.add_get(
+    server.app.router.add_post(
         '/camera/picture', control.take_picture)
     server.app.router.add_post(
         '/server/update', update.install_api)


### PR DESCRIPTION
## overview

This PR adds an endpoint to the server which takes a single frame from images captured with `ffmpeg`, then returns that image as a `jpg` in the HTTP response.

This is most useful of QC testers so the camera can be tested over USB cable.