### PR TITLE
feat(app): Disable plunger during change

### DIFF
--- a/app/__util__/mock-promise.js
+++ b/app/__util__/mock-promise.js
@@ -11,3 +11,15 @@ export function mockRejectedValue (mock, value) {
     process.nextTick(() => reject(value))
   }))
 }
+
+export function mockResolvedValueOnce (mock, value) {
+  mock.mockImplementationOnce(() => new Promise((resolve) => {
+    process.nextTick(() => resolve(value))
+  }))
+}
+
+export function mockRejectedValueOnce (mock, value) {
+  mock.mockImplementationOnce(() => new Promise((resolve, reject) => {
+    process.nextTick(() => reject(value))
+  }))
+}

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -16,6 +16,7 @@ import {
   home,
   moveToChangePipette,
   fetchPipettes,
+  disengagePipetteMotors,
   makeGetRobotMove,
   makeGetRobotHome,
   makeGetRobotPipettes
@@ -165,15 +166,18 @@ function makeMapStateToProps () {
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {confirmUrl, parentUrl, baseUrl, robot, mount} = ownProps
+  const disengage = () => dispatch(disengagePipetteMotors(robot, mount))
+  const checkPipette = () => disengage()
+    .then(() => dispatch(fetchPipettes(robot)))
 
   return {
+    checkPipette,
     exit: () => dispatch(home(robot, mount))
       .then(() => dispatch(push(parentUrl))),
     back: () => dispatch(goBack()),
     onPipetteSelect: (evt) => dispatch(push(`${baseUrl}/${evt.target.value}`)),
-    moveToFront: () => dispatch(moveToChangePipette(robot, mount)),
-    checkPipette: () => dispatch(fetchPipettes(robot)),
-    confirmPipette: () => dispatch(fetchPipettes(robot))
-      .then(() => dispatch(push(confirmUrl)))
+    moveToFront: () => dispatch(moveToChangePipette(robot, mount))
+      .then(disengage),
+    confirmPipette: () => checkPipette().then(() => dispatch(push(confirmUrl)))
   }
 }

--- a/app/src/http-api-client/__mocks__/client.js
+++ b/app/src/http-api-client/__mocks__/client.js
@@ -1,33 +1,23 @@
 // mock http api client
 'use strict'
 
-let _mockResponse = null
-let _mockError = null
+const {
+  mockResolvedValueOnce,
+  mockRejectedValueOnce
+} = require('../../../__util__/mock-promise')
 
-const client = module.exports = jest.fn(() => {
-  if (_mockResponse) {
-    return new Promise((resolve) => process.nextTick(() => {
-      resolve(_mockResponse)
-    }))
-  }
+const client = module.exports = jest.fn()
 
-  return new Promise((resolve, reject) => process.nextTick(() => {
-    reject(_mockError || new Error('Mock values not seeded'))
-  }))
-})
-
-client.__setMockResponse = function setMockResponse (response) {
-  _mockError = null
-  _mockResponse = response
+client.__setMockResponse = function setMockResponse (...responses) {
+  client.mockReset()
+  responses.forEach((r) => mockResolvedValueOnce(client, r))
 }
 
-client.__setMockError = function setMockError (error) {
-  _mockResponse = null
-  _mockError = error
+client.__setMockError = function setMockError (...errors) {
+  client.mockReset()
+  errors.forEach((e) => mockRejectedValueOnce(client, e))
 }
 
 client.__clearMock = function clearMockResponses () {
-  _mockResponse = null
-  _mockError = null
-  client.mockClear()
+  client.mockReset()
 }

--- a/app/src/http-api-client/__mocks__/health.js
+++ b/app/src/http-api-client/__mocks__/health.js
@@ -1,5 +1,6 @@
 // mock health module
 'use strict'
+
 const health = module.exports = jest.genMockFromModule('../health')
 
 health.__mockThunk = jest.fn(() => new Promise((resolve) => {

--- a/app/src/http-api-client/__tests__/motors.test.js
+++ b/app/src/http-api-client/__tests__/motors.test.js
@@ -1,0 +1,95 @@
+// http api /motors/** enpoints tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {disengagePipetteMotors} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const NAME = 'opentrons-dev'
+
+describe('/motors/**', () => {
+  let robot
+  let state
+  let store
+
+  beforeEach(() => {
+    client.__clearMock()
+
+    robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
+    state = {
+      api: {
+        pipettes: {},
+        motors: {}
+      }
+    }
+
+    store = mockStore(state)
+  })
+
+  describe('disengagePipetteMotors action creator', () => {
+    const path = 'disengage'
+    const mockPipettesResponse = {
+      left: {mount_axis: 'z', plunger_axis: 'b'},
+      right: {mount_axis: 'a', plunger_axis: 'c'}
+    }
+    const response = {message: 'we did it'}
+
+    test('calls GET /pipettes then POST /motors/disengage with axes', () => {
+      const expected = {axes: ['a', 'c']}
+
+      client.__setMockResponse(mockPipettesResponse, response)
+
+      // use mock.calls to verify call order
+      return store.dispatch(disengagePipetteMotors(robot, ['right']))
+        .then(() => expect(client.mock.calls).toEqual([
+          [robot, 'GET', 'pipettes'],
+          [robot, 'POST', 'motors/disengage', expected]
+        ]))
+    })
+
+    test('skips GET /pipettes call if axes are in state', () => {
+      const expected = {axes: ['z', 'b']}
+
+      state.api.pipettes = {[NAME]: {response: mockPipettesResponse}}
+      client.__setMockResponse(response)
+
+      // use mock.calls to verify call order
+      return store.dispatch(disengagePipetteMotors(robot, ['left']))
+        .then(() => expect(client.mock.calls).toEqual([
+          [robot, 'POST', 'motors/disengage', expected]
+        ]))
+    })
+
+    test('dispatches MOTORS_REQUEST and MOTORS_SUCCESS', () => {
+      const request = {mounts: ['left', 'right']}
+      const expectedActions = [
+        {type: 'api:MOTORS_REQUEST', payload: {robot, request, path}},
+        {type: 'api:MOTORS_SUCCESS', payload: {robot, response, path}}
+      ]
+
+      client.__setMockResponse(mockPipettesResponse, response)
+
+      return store.dispatch(disengagePipetteMotors(robot, ['left', 'right']))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches MOTORS_REQUEST and MOTORS_FAILURE', () => {
+      const request = {mounts: ['left', 'right']}
+      const error = {name: 'ResponseError', status: '400'}
+      const expectedActions = [
+        {type: 'api:MOTORS_REQUEST', payload: {robot, request, path}},
+        {type: 'api:MOTORS_FAILURE', payload: {robot, error, path}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(disengagePipetteMotors(robot, ['left', 'right']))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+})

--- a/app/src/http-api-client/__tests__/motors.test.js
+++ b/app/src/http-api-client/__tests__/motors.test.js
@@ -45,7 +45,7 @@ describe('/motors/**', () => {
       client.__setMockResponse(mockPipettesResponse, response)
 
       // use mock.calls to verify call order
-      return store.dispatch(disengagePipetteMotors(robot, ['right']))
+      return store.dispatch(disengagePipetteMotors(robot, 'right'))
         .then(() => expect(client.mock.calls).toEqual([
           [robot, 'GET', 'pipettes'],
           [robot, 'POST', 'motors/disengage', expected]
@@ -59,7 +59,7 @@ describe('/motors/**', () => {
       client.__setMockResponse(response)
 
       // use mock.calls to verify call order
-      return store.dispatch(disengagePipetteMotors(robot, ['left']))
+      return store.dispatch(disengagePipetteMotors(robot, 'left'))
         .then(() => expect(client.mock.calls).toEqual([
           [robot, 'POST', 'motors/disengage', expected]
         ]))
@@ -74,7 +74,7 @@ describe('/motors/**', () => {
 
       client.__setMockResponse(mockPipettesResponse, response)
 
-      return store.dispatch(disengagePipetteMotors(robot, ['left', 'right']))
+      return store.dispatch(disengagePipetteMotors(robot, 'left', 'right'))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -88,7 +88,7 @@ describe('/motors/**', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(disengagePipetteMotors(robot, ['left', 'right']))
+      return store.dispatch(disengagePipetteMotors(robot, 'left', 'right'))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -3,6 +3,7 @@
 import {combineReducers} from 'redux'
 import {healthReducer, type HealthAction} from './health'
 import {healthCheckReducer, type HealthCheckAction} from './health-check'
+import {motorsReducer, type MotorsAction} from './motors'
 import {pipettesReducer, type PipettesAction} from './pipettes'
 import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
@@ -11,6 +12,7 @@ import {wifiReducer, type WifiAction} from './wifi'
 export const reducer = combineReducers({
   health: healthReducer,
   healthCheck: healthCheckReducer,
+  motors: motorsReducer,
   pipettes: pipettesReducer,
   robot: robotReducer,
   server: serverReducer,
@@ -57,6 +59,7 @@ export type State = $Call<typeof reducer>
 export type Action =
   | HealthAction
   | HealthCheckAction
+  | MotorsAction
   | PipettesAction
   | RobotAction
   | ServerAction
@@ -76,6 +79,10 @@ export {
   healthCheckMiddleware,
   makeGetHealthCheckOk
 } from './health-check'
+
+export {
+  disengagePipetteMotors
+} from './motors'
 
 export {
   fetchPipettes,

--- a/app/src/http-api-client/motors.js
+++ b/app/src/http-api-client/motors.js
@@ -1,0 +1,121 @@
+// @flow
+// http api client module for /motors/** endpoints
+import type {ThunkPromiseAction} from '../types'
+import type {Mount, RobotService} from '../robot'
+
+import type {PipettesResponse} from './pipettes'
+import client, {type ApiRequestError} from './client'
+
+export type MotorAxis = 'a' | 'b' | 'c' | 'x' | 'y' | 'z'
+
+// not the actual request body because we combine multiple api calls
+type DisengageRequest = {
+  mounts: Array<Mount>,
+}
+
+type DisengageResponse = {
+  message: string,
+}
+
+type RequestPath = 'disengage'
+
+type MotorsRequest = DisengageRequest
+
+type MotorsResponse = DisengageResponse
+
+type MotorsRequestAction = {|
+  type: 'api:MOTORS_REQUEST',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    request: MotorsRequest,
+  |}
+|}
+
+type MotorsSuccessAction = {|
+  type: 'api:MOTORS_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    response: MotorsResponse,
+  |}
+|}
+
+type MotorsFailureAction = {|
+  type: 'api:MOTORS_FAILURE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    error: ApiRequestError,
+  |}
+|}
+
+export type MotorsAction =
+  | MotorsRequestAction
+  | MotorsSuccessAction
+  | MotorsFailureAction
+
+const DISENGAGE: RequestPath = 'disengage'
+
+export function disengagePipetteMotors (
+  robot: RobotService,
+  mounts: Array<Mount>
+): ThunkPromiseAction {
+  return (dispatch, getState) => {
+    const pipettesState = getState().api.pipettes[robot.name]
+
+    dispatch(motorsRequest(robot, DISENGAGE, {mounts}))
+
+    // pull motor axes from state if available, otherwise hit GET /pipettes
+    const getPipettes = pipettesState && pipettesState.response
+      ? Promise.resolve(pipettesState.response)
+      : client(robot, 'GET', 'pipettes')
+
+    return getPipettes
+      .then((pipettes: PipettesResponse) => {
+        const axes = mounts.reduce((result, mount) => result.concat(
+          pipettes[mount].mount_axis,
+          pipettes[mount].plunger_axis
+        ), [])
+
+        return client(robot, 'POST', 'motors/disengage', {axes})
+      })
+      .then(
+        (response) => motorsSuccess(robot, DISENGAGE, response),
+        (error) => motorsFailure(robot, DISENGAGE, error)
+      )
+      .then(dispatch)
+  }
+}
+
+// TODO(mc, 2018-04-24): track motor request state
+export function motorsReducer () {
+  return {}
+}
+
+function motorsRequest (
+  robot: RobotService,
+  path: RequestPath,
+  request: MotorsRequest
+): MotorsRequestAction {
+  return {type: 'api:MOTORS_REQUEST', payload: {robot, path, request}}
+}
+
+function motorsSuccess (
+  robot: RobotService,
+  path: RequestPath,
+  response: MotorsResponse
+): MotorsSuccessAction {
+  return {
+    type: 'api:MOTORS_SUCCESS',
+    payload: {robot, path, response}
+  }
+}
+
+function motorsFailure (
+  robot: RobotService,
+  path: RequestPath,
+  error: ApiRequestError
+): MotorsFailureAction {
+  return {type: 'api:MOTORS_FAILURE', payload: {robot, path, error}}
+}

--- a/app/src/http-api-client/motors.js
+++ b/app/src/http-api-client/motors.js
@@ -59,7 +59,7 @@ const DISENGAGE: RequestPath = 'disengage'
 
 export function disengagePipetteMotors (
   robot: RobotService,
-  mounts: Array<Mount>
+  ...mounts: Array<Mount>
 ): ThunkPromiseAction {
   return (dispatch, getState) => {
     const pipettesState = getState().api.pipettes[robot.name]

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -6,13 +6,14 @@ import type {State, Action, ThunkPromiseAction} from '../types'
 import type {BaseRobot, RobotService} from '../robot'
 
 import type {ApiCall} from './types'
+import type {MotorAxis} from './motors'
 import client, {type ApiRequestError} from './client'
 
 // TODO(mc, 2018-03-30): mount, volume, and channels should come from the API
 export type Pipette = {
   model: ?string,
-  mount_axis: string,
-  plunger_axis: string,
+  mount_axis: MotorAxis,
+  plunger_axis: MotorAxis,
 }
 
 export type PipettesResponse = {

--- a/app/src/http-api-client/robot.js
+++ b/app/src/http-api-client/robot.js
@@ -1,5 +1,5 @@
 // @flow
-//  HTTP API client module for /robot/**
+// HTTP API client module for /robot/**
 import {createSelector, type Selector} from 'reselect'
 import type {State, ThunkPromiseAction, Action} from '../types'
 import type {Mount, BaseRobot, RobotService} from '../robot'


### PR DESCRIPTION
## overview

This PR addresses the last remaining checkbox in #860 

## changelog

- test(app): Add tests for POST /robot/move using improved client mock
- feat(app): Add motors module to call POST /motors/disengage
- feat(app): Disengage pipettes during swap after move and before check 

## review requests

No UI changes in this, just behavioral changes with API interactions.

You can test this out on virtual smoothie or a real robot (I'll be testing on a real one). Keep an eye on the network tab in the devtools to ensure that `POST /motors/disengage` is being sent (and responded to) with the correct axes. It should make the request:

- Immediately following the move to front request (POST /robot/move)
- Immediately preceding any pipette check (GET /pipettes)
