### PR TITLE
feat(app): Add intercom boot and update on page change

### DIFF
--- a/app/src/analytics/gtm-config.js
+++ b/app/src/analytics/gtm-config.js
@@ -1,10 +1,7 @@
 // google tag manager config for webpack and app
 'use strict'
 
-const ID = process.env.NODE_ENV === 'production'
-  ? 'GTM-T2569M8'
-  : 'GTM-595XX7F'
-
+const ID = 'GTM-595XX7F'
 const DATA_LAYER_NAME = 'dataLayer'
 
 // use commonjs exports for webpack access

--- a/app/src/analytics/intercom-config.js
+++ b/app/src/analytics/intercom-config.js
@@ -1,0 +1,6 @@
+// intercom config for webpack and app
+'use strict'
+
+module.exports = {
+  id: 'bsgvg3q7'
+}

--- a/app/src/index.hbs
+++ b/app/src/index.hbs
@@ -9,6 +9,7 @@
 
   <script src="http://cdn.auth0.com/js/lock/10.14.0/lock.min.js"></script>
 
+  {{! TODO(mc, 2018-04-24): remove GTM }}
   {{! Google Tag Manager }}
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -18,7 +19,9 @@
   {{! End Google Tag Manager }}
 
   {{! Intercom }}
-  <!-- <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/bsgvg3q7';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script> -->
+  <script>
+    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/{{htmlWebpackPlugin.options.intercomConfig.id}}';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+  </script>
   {{! End Intercom }}
 </head>
 

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -11,7 +11,11 @@ import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 import {checkForShellUpdates} from './shell'
 import {healthCheckMiddleware} from './http-api-client'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
-import {middleware as analyticsMiddleware} from './analytics'
+import {
+  initialize as initializeAnalytics,
+  middleware as analyticsMiddleware
+} from './analytics'
+
 import reducer from './reducer'
 
 // components
@@ -62,3 +66,7 @@ if (process.env.NODE_ENV === 'development') {
 store.dispatch(checkForShellUpdates())
 
 renderApp()
+
+initializeAnalytics({
+  intercom: process.env.DISABLE_INTERCOM !== '1'
+})

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -14,6 +14,7 @@ const devServerConfig = require('./webpack/dev-server')
 const {productName} = require('@opentrons/app-shell/package.json')
 const {description, author} = require('./package.json')
 const gtmConfig = require('./src/analytics/gtm-config')
+const intercomConfig = require('./src/analytics/intercom-config')
 
 const DEV = process.env.NODE_ENV !== 'production'
 const ANALYZER = process.env.ANALYZER === 'true'
@@ -62,7 +63,8 @@ const plugins = [
     template: './src/index.hbs',
     description,
     author,
-    gtmConfig
+    gtmConfig,
+    intercomConfig
   }),
 
   new ScriptExtHtmlWebpackPlugin({


### PR DESCRIPTION
## overview

This PR closes #1224 by re-enabling the Intercom snippet, disabling the app v2 GTM config that tried to do intercom stuff, and adding an intercom update call during page change as detailed in their [SPA setup](https://developers.intercom.com/docs/integrate-intercom-in-a-single-page-app).

## changelog

- feat(app): Add intercom boot and update on page change 

## review requests

I recommend testing this by talking to yourself in Intercom. Also, please note that you may disable intercom by setting the DISABLE_INTERCOM env var to `1`:

```shell
make dev DISABLE_INTERCOM=1
```