### PR TITLE
Complib, PD: styling to match design reqs & cleanup well props

### DIFF
--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -16,7 +16,7 @@ import type {LabwareLocations} from '../labware-types'
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
-type WellDims = { // TODO similar to type in Well.js. DRY it up
+type WellDims = {
   ...WellLocation,
   maxVolume: number
 }
@@ -84,7 +84,7 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
-    const { highlighted = false, selected = false, error = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
+    const {highlighted, selected, error, fillColor} = singleWellContents
 
     return <Well
       key={wellName}

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -10,26 +10,14 @@ import { SLOT_WIDTH, SLOT_HEIGHT } from './constants.js'
 
 import styles from './Plate.css'
 import Well from './Well'
+import type {SingleWell, WellLocation} from './Well'
 import type {LabwareLocations} from '../labware-types'
 
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
-export type SingleWell = {|
-  highlighted: boolean,
-  preselected: boolean,
-  selected: boolean,
-  wellName: string,
-  maxVolume: number,
-  fillColor?: ?string
-|}
-
-type wellDims = { // TODO similar to type in Well.js. DRY it up
-  x: number,
-  y: number,
-  length?: number,
-  width?: number,
-  diameter?: number,
+type WellDims = { // TODO similar to type in Well.js. DRY it up
+  ...WellLocation,
   maxVolume: number
 }
 
@@ -55,7 +43,7 @@ function FallbackPlate () {
 
 type LabwareData = {
   originOffset: {x: number, y: number},
-  firstWell: wellDims,
+  firstWell: WellDims,
   containerLocations: LabwareLocations,
   allWellNames: Array<string>
 }
@@ -71,7 +59,7 @@ export default class Plate extends React.Component<PlateProps> {
     const infoForContainerType = defaultContainers.containers[containerType]
     const originOffset = infoForContainerType['origin-offset'] || {x: 0, y: 0}
     const containerLocations = infoForContainerType.locations
-    const firstWell: wellDims = containerLocations['A1']
+    const firstWell: WellDims = containerLocations['A1']
 
     const allWellNames = Object.keys(containerLocations)
 
@@ -96,16 +84,19 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
-    const { preselected = false, selected = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
+    const { highlighted = false, selected = false, error = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
 
     return <Well
       key={wellName}
       {...{
         wellName,
-        fillColor,
         selectable,
+
+        fillColor,
+        highlighted,
         selected,
-        preselected,
+        error,
+
         wellLocation,
         svgOffset
       }

--- a/components/src/deck/Well.css
+++ b/components/src/deck/Well.css
@@ -1,10 +1,31 @@
-.well {
+@import '@opentrons/components';
+
+/* Well fill contents, the "bottom layer" */
+
+.well_fill {
+  fill: currentColor;
+}
+
+/* Styles for border + overlay, the "top layer" */
+
+.well_border {
   stroke-width: 0.4;
   stroke: black;
-  fill: var(--fill-color);
+  fill: transparent;
 }
 
 .selected {
   stroke-width: 1;
-  stroke: blue;
+  stroke: var(--c-blue);
+  fill: color(gray(180) alpha(50%));
+}
+
+.highlighted {
+  stroke-width: 1;
+  stroke: var(--c-blue);
+}
+
+.error {
+  stroke-width: 1;
+  stroke: var(--c-red);
 }

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -6,19 +6,27 @@ import styles from './Well.css'
 import {SELECTABLE_WELL_CLASS} from '../constants.js'
 // import WellToolTip from '../components/WellToolTip.js' // TODO bring back tooltip in SVG, somehow
 
-type Props = {
-  wellName: string,
-  fillColor?: ?string,
-  selectable: boolean,
+export type SingleWell = {|
+  highlighted: boolean, // highlighted is the same as hovered
   selected: boolean,
-  preselected: boolean,
-  wellLocation: {
-    x: number,
-    y: number,
-    length?: number,
-    width?: number,
-    diameter?: number
-  },
+  error: boolean,
+  wellName: string,
+  maxVolume?: number,
+  fillColor?: ?string
+|}
+
+export type WellLocation = {
+  x: number,
+  y: number,
+  length?: number,
+  width?: number,
+  diameter?: number
+}
+
+type Props = {
+  ...SingleWell,
+  selectable: boolean,
+  wellLocation: WellLocation,
   svgOffset: {
     x: number,
     y: number
@@ -28,28 +36,29 @@ type Props = {
 export default function Well (props: Props) {
   const {
     wellName,
-    fillColor,
     selectable,
+    highlighted,
     selected,
-    preselected,
+    error,
     wellLocation,
     svgOffset
   } = props
 
-  const className = cx(styles.well, {
-    [SELECTABLE_WELL_CLASS]: selectable,
-    [styles.selected]: selected,
-    [styles.preselected]: preselected
-  })
+  const fillColor = props.fillColor || 'transparent'
 
-  const style = {
-    '--fill-color': fillColor || 'transparent'
-  }
+  const wellOverlayClassname = cx(
+    styles.well_border,
+    {
+      [SELECTABLE_WELL_CLASS]: selectable,
+      [styles.selected]: selected,
+      [styles.selected_overlay]: selected,
+      [styles.highlighted]: highlighted,
+      [styles.error]: error
+    }
+  )
 
-  const commonProps = {
-    className,
-    'data-wellname': wellName,
-    style
+  const selectionProps = {
+    'data-wellname': wellName
   }
 
   const isRect = typeof wellLocation.length === 'number' && typeof wellLocation.width === 'number'
@@ -57,24 +66,52 @@ export default function Well (props: Props) {
 
   // flip x and y coordinates for landscape (default-containers.json is in portrait)
   // TODO: Ian 2017-12-13 is there a better way to tell flow:
-  // "if this has diameter, it's circleWell type. if this has length & widht, it's rectWell type" ?
+  // "if this has diameter, it's circleWell type. if this has length & width, it's rectWell type" ?
   if (isRect) {
-    return <rect
-      {...commonProps}
-      x={wellLocation.y + svgOffset.y}
-      y={wellLocation.x + svgOffset.x}
-      width={wellLocation.length}
-      height={wellLocation.width}
-    />
+    const rectProps = {
+      x: wellLocation.y + svgOffset.y,
+      y: wellLocation.x + svgOffset.x,
+      width: wellLocation.length,
+      height: wellLocation.width
+    }
+
+    return <g>
+      {/* Fill contents */}
+      <rect
+        {...rectProps}
+        className={styles.well_fill}
+        color={fillColor}
+      />
+      {/* Border + overlay */}
+      <rect
+        {...selectionProps}
+        {...rectProps}
+        className={wellOverlayClassname}
+      />
+    </g>
   }
 
   if (isCircle) {
-    return <circle
-      {...commonProps}
-      cx={wellLocation.y + svgOffset.y}
-      cy={wellLocation.x + svgOffset.x}
-      r={(wellLocation.diameter || 0) / 2}
-    />
+    const circleProps = {
+      cx: wellLocation.y + svgOffset.y,
+      cy: wellLocation.x + svgOffset.x,
+      r: (wellLocation.diameter || 0) / 2
+    }
+
+    return <g>
+      {/* Fill contents */}
+      <circle
+        {...circleProps}
+        className={styles.well_fill}
+        color={fillColor}
+      />
+      {/* Border + overlay */}
+      <circle
+        {...selectionProps}
+        {...circleProps}
+        className={wellOverlayClassname}
+      />
+    </g>
   }
 
   console.warn('Invalid well: neither rectangle or circle: ' + JSON.stringify(wellLocation))

--- a/components/src/deck/Well.md
+++ b/components/src/deck/Well.md
@@ -1,21 +1,22 @@
 ```js
-<svg width='100' height='100'>
+<svg width='200' height='200'>
   <Well
     wellName='A1'
-    fillColor='blue'
-    wellLocation={{x: 0, y: 0, length: 100, width: 20}}
-    svgOffset={{x: 0, y: 0}}
+    fillColor='yellow'
+    selected
+    wellLocation={{x: 0, y: 0, length: 150, width: 50}}
+    svgOffset={{x: 10, y: 10}}
   />
 </svg>
 ```
 
 ```js
-<svg width='100' height='100'>
+<svg width='200' height='200'>
   <Well
     wellName='A1'
     fillColor='red'
     wellLocation={{x: 0, y: 0, diameter: 50}}
-    svgOffset={{x: 25, y: 25}}
+    svgOffset={{x: 45, y: 45}}
   />
 </svg>
 ```

--- a/components/src/deck/index.js
+++ b/components/src/deck/index.js
@@ -2,8 +2,8 @@
 import Deck from './Deck'
 import LabwareContainer from './LabwareContainer'
 import Plate from './Plate'
-import type {SingleWell} from './Plate'
 import Well from './Well'
+import type {SingleWell} from './Well'
 
 import {ContainerNameOverlay} from './ContainerNameOverlay'
 import {EmptyDeckSlot} from './EmptyDeckSlot'

--- a/protocol-designer/src/components/IngredientSelectionModal.css
+++ b/protocol-designer/src/components/IngredientSelectionModal.css
@@ -5,18 +5,3 @@
 
   background-color: rgba(100, 100, 100, 0.8);
 }
-
-/* TODO Ian 2018-02-21 REMOVE this: */
-
-/* .ingredient_panel_sidebar {
-  float: left;
-  display: inline-block;
-  position: relative;
-  height: 100%;
-  width: var(--ingredient_panel_sidebar_width);
-  border-right: 3px solid gray;
-} */
-
-.container_detail {
-  margin: 1rem 2rem;
-}

--- a/protocol-designer/src/components/IngredientSelectionModal.js
+++ b/protocol-designer/src/components/IngredientSelectionModal.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 
-import { SLOT_WIDTH, SLOT_HEIGHT } from '../constants.js'
+import SingleLabware from './SingleLabware'
 import styles from './IngredientSelectionModal.css'
 
 import SelectablePlate from '../containers/SelectablePlate.js'
@@ -21,11 +21,9 @@ export default function IngredientSelectionModal (props: Props) {
 
       <IngredientPropertiesForm />
 
-      <div className={styles.container_detail}>
-        <svg width='100%' height='100%' viewBox={`0 0 ${SLOT_WIDTH} ${SLOT_HEIGHT}`}>
-          <SelectablePlate showLabels selectable />
-        </svg>
-      </div>
+      <SingleLabware>
+        <SelectablePlate showLabels selectable />
+      </SingleLabware>
     </div>
   )
 }

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -29,9 +29,10 @@ function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
     wc,
     (well: WellContents): SingleWell => ({
       wellName: well.wellName,
-      selected: well.selected,
-      preselected: well.preselected,
+
       highlighted: well.highlighted,
+      selected: well.selected,
+      error: well.error,
       maxVolume: well.maxVolume,
 
       fillColor: getFillColor(well.groupIds)

--- a/protocol-designer/src/components/SingleLabware.css
+++ b/protocol-designer/src/components/SingleLabware.css
@@ -1,4 +1,4 @@
 .single_labware {
-  margin-top: 1rem;
-  height: 70%;
+  margin: 2rem auto;
+  max-width: 50rem;
 }

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -76,20 +76,22 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     // TODO Ian 2018-04-11 separate out selected/highlighted state from wellContents props of Plate,
     // so you don't have to do this merge. This well selected state & data really needs cleanup!
 
+    let highlightedWells = {}
     let selectedWells = {}
 
     if (wellSelectionModeForContainer) {
       const wellSelectionState = wellSelectionSelectors.getSelectedWells(state)
       selectedWells = wellSelectionState.selected
     } else {
-      const highlightedWells = highlightSelectors.wellHighlightsForSteps(state)[prevStepId]
-      selectedWells = (highlightedWells && highlightedWells[containerId]) || {}
+      const highlightedWellsAllLabware = highlightSelectors.wellHighlightsForSteps(state)[prevStepId]
+      highlightedWells = (highlightedWellsAllLabware && highlightedWellsAllLabware[containerId]) || {}
     }
 
     wellContents = mapValues(
       wellContentsWithoutHighlight,
       (wellContents: WellContents, well: string) => ({
         ...wellContents,
+        highlighted: highlightedWells[well],
         selected: selectedWells[well]
       })
     )

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -27,9 +27,9 @@ type IngredInstanceFlat = {|
 |}
 
 export type WellContents = {| // non-ingredient well state
-  preselected: boolean,
-  selected: boolean,
   highlighted: boolean,
+  selected: boolean,
+  error: boolean,
   maxVolume: number,
   wellName: string, // eg 'A1', 'A2' etc
   groupIds: Array<string>

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -35,9 +35,9 @@ function _wellContentsForWell (
     )
 
   return {
-    preselected: false,
-    selected: false,
     highlighted: false,
+    selected: false,
+    error: false,
     maxVolume: Infinity, // TODO Ian 2018-03-23 refactor so all these fields aren't needed
     wellName: well,
     groupIds: ingredGroupIdsWithContent


### PR DESCRIPTION
## overview

Addresses #1187 - to close it, the "highlighted" state needs to happen when user hovers over wells in either Ingred Selection modal or Well Selection modal. The hover behavior will be follow-up PR.

![image](https://user-images.githubusercontent.com/11590381/39252704-45c3a898-4874-11e8-98d0-53931d59833f.png)


## design background

Wells have an optional fillColor, and they have 4 states:
* Default
* Highlighted (aka "hovered" in designs, but in PD it's "highlighted" b/c sometimes this is when the well itself is hovered, and other times an item on the Step List is hovered / selected and causes this "highlighted" state)
* Selected
* Error

## changelog

### New styles for wells.

The SVG for circle / rect wells both is in 2 layers: 

TOP:
- border. default = thin black, selected/highlighted: thick blue, or error: thick red
- transparent light gray overlay, which lays over the bottom layer. Overlay is only shown when well is selected

BOTTOM: the fill color of the well, if any

An alternative to the 2-layers thing could be using a JS color library to add the gray "selected" overlay to the fillColor string itself, but I figured that I oughta leave the styling to CSS unless it becomes a performance problem with 2x the wells. (Or an alternative alternative would be to make a CSS class for every color, and for every color mixed with gray -- seems fragile)

### Other cleanup

* Well: replaced `var(--fill-color)` with setting `color` attr on the circle/svg node and using `fill: currentColor` -- suggestion from @mcous. One less annoying postcss error!
* Cleaned up types of Plate and Well in complib
* Removed "preselected" well prop since "highlighted" does the same thing
* Give `SingleLabware` a reasonable max size on big screens
* Used `SingleLabware` in `IngredientSelectionModal` which was half the point of making `SingleLabware` a few PRs ago, oops
* Correctly use `selected` vs `highlighted` props in SelectablePlate container

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/comp_well-selection-styling/index.html

Still-missing features: 8-channel is not yet really supported for well selection modal, and don't forget a tiprack or it'll white-screen

Play around with ingredient selector and with well selection for steps, everything should look OK, should match design:

https://user-images.githubusercontent.com/35570080/38695657-e4a6270c-3e5a-11e8-8e34-589cf366004a.png