### PR TITLE
removes robot homing from start script

### DIFF
--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -11,10 +11,6 @@ nginx
 # enable SSH over ethernet
 inetd -e /etc/inetd.conf
 
-# Home robot
-echo "Homing Robot... this may take a few seconds."
-python -c "from opentrons import robot; robot.connect(); robot.home()"
-
 # If user boot script exists, run it
 mkdir -p /data/boot.d
 run-parts /data/boot.d


### PR DESCRIPTION
## overview

This PR removes the automatic home when the bot first powers up. Forcing all machines and testing jigs/rigs to home when powered on is disruptive for assembly, qc, and testing teams. Also it's just not a good idea to have the machine out in the field move without a user initiating the action.

This home-on-boot is not needed for accuracy, because the App and any calibration procedures already are preceded by a home. Also, the home-on-boot is not needed to alert the user that bot is on and ready, because the bot's button turns BLUE when it is ready.