### PR TITLE
PD: new interaction & design for well selection

### DIFF
--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -16,7 +16,11 @@ import type {LabwareLocations} from '../labware-types'
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
+<<<<<<< d04d868a69088a8252d6cea59b4b98b9deba3285
 type WellDims = {
+=======
+type WellDims = { // TODO similar to type in Well.js. DRY it up
+>>>>>>> cleanup well props & styling to match design reqs
   ...WellLocation,
   maxVolume: number
 }
@@ -84,7 +88,11 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
+<<<<<<< d04d868a69088a8252d6cea59b4b98b9deba3285
     const {highlighted, selected, error, fillColor} = singleWellContents
+=======
+    const { highlighted = false, selected = false, error = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
+>>>>>>> cleanup well props & styling to match design reqs
 
     return <Well
       key={wellName}

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -16,11 +16,7 @@ import type {LabwareLocations} from '../labware-types'
 const rectStyle = {rx: 6, transform: 'translate(0.8 0.8) scale(0.985)'} // SVG styles not allowed in CSS (round corners) -- also stroke gets cut off so needs to be transformed
 // TODO (Eventually) Ian 2017-12-07 where should non-CSS SVG styles belong?
 
-<<<<<<< d04d868a69088a8252d6cea59b4b98b9deba3285
 type WellDims = {
-=======
-type WellDims = { // TODO similar to type in Well.js. DRY it up
->>>>>>> cleanup well props & styling to match design reqs
   ...WellLocation,
   maxVolume: number
 }
@@ -88,11 +84,7 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
-<<<<<<< d04d868a69088a8252d6cea59b4b98b9deba3285
     const {highlighted, selected, error, fillColor} = singleWellContents
-=======
-    const { highlighted = false, selected = false, error = false, fillColor = '' } = (singleWellContents || {}) // ignored/removed: highlighed, hovered
->>>>>>> cleanup well props & styling to match design reqs
 
     return <Well
       key={wellName}

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -26,7 +26,8 @@ export type PlateProps = {
   wellContents: {[string]: SingleWell}, // Keyed by wellName, eg 'A1'
   showLabels?: boolean,
   selectable?: boolean,
-  handleMouseOverWell?: (well: string) => (e: SyntheticMouseEvent<*>) => mixed
+  handleMouseOverWell?: (well: string) => (e: SyntheticMouseEvent<*>) => mixed,
+  handleMouseExitWell?: (e: SyntheticMouseEvent<*>) => mixed
 }
 
 const plateOutline = <rect {...rectStyle} x='0' y='0' width={SLOT_WIDTH} height={SLOT_HEIGHT} stroke='black' fill='white' />
@@ -74,7 +75,7 @@ export default class Plate extends React.Component<PlateProps> {
   }
 
   createWell = (wellName: string) => {
-    const { selectable, wellContents } = this.props
+    const { selectable, wellContents, handleMouseExitWell } = this.props
     const { originOffset, firstWell, containerLocations } = this.getContainerData()
     const singleWellContents: SingleWell = wellContents[wellName]
 
@@ -107,7 +108,8 @@ export default class Plate extends React.Component<PlateProps> {
         wellLocation,
         svgOffset,
 
-        onMouseOver: this.handleMouseOverWell(wellName)
+        onMouseOver: this.handleMouseOverWell(wellName),
+        onMouseLeave: handleMouseExitWell
       }
     } />
   }

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -25,7 +25,8 @@ export type PlateProps = {
   containerType: string,
   wellContents: {[string]: SingleWell}, // Keyed by wellName, eg 'A1'
   showLabels?: boolean,
-  selectable?: boolean
+  selectable?: boolean,
+  handleMouseOverWell?: (well: string) => (e: SyntheticMouseEvent<*>) => mixed
 }
 
 const plateOutline = <rect {...rectStyle} x='0' y='0' width={SLOT_WIDTH} height={SLOT_HEIGHT} stroke='black' fill='white' />
@@ -66,6 +67,12 @@ export default class Plate extends React.Component<PlateProps> {
     return { originOffset, firstWell, containerLocations, allWellNames }
   }
 
+  handleMouseOverWell = (well: string) => {
+    return this.props.handleMouseOverWell
+      ? this.props.handleMouseOverWell(well)
+      : undefined
+  }
+
   createWell = (wellName: string) => {
     const { selectable, wellContents } = this.props
     const { originOffset, firstWell, containerLocations } = this.getContainerData()
@@ -98,7 +105,9 @@ export default class Plate extends React.Component<PlateProps> {
         error,
 
         wellLocation,
-        svgOffset
+        svgOffset,
+
+        onMouseOver: this.handleMouseOverWell(wellName)
       }
     } />
   }

--- a/components/src/deck/Well.css
+++ b/components/src/deck/Well.css
@@ -16,13 +16,13 @@
 
 .selected {
   stroke-width: 1;
-  stroke: var(--c-blue);
-  fill: color(gray(180) alpha(50%));
+  stroke: var(--c-highlight);
+  fill: color(var(--c-highlight) alpha(20%));
 }
 
 .highlighted {
   stroke-width: 1;
-  stroke: var(--c-blue);
+  stroke: var(--c-highlight);
 }
 
 .error {

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -30,7 +30,8 @@ type Props = {
   svgOffset: {
     x: number,
     y: number
-  }
+  },
+  onMouseOver?: (e: SyntheticMouseEvent<*>) => mixed
 }
 
 export default function Well (props: Props) {
@@ -41,7 +42,8 @@ export default function Well (props: Props) {
     selected,
     error,
     wellLocation,
-    svgOffset
+    svgOffset,
+    onMouseOver
   } = props
 
   const fillColor = props.fillColor || 'transparent'
@@ -58,7 +60,8 @@ export default function Well (props: Props) {
   )
 
   const selectionProps = {
-    'data-wellname': wellName
+    'data-wellname': wellName,
+    onMouseOver
   }
 
   const isRect = typeof wellLocation.length === 'number' && typeof wellLocation.width === 'number'

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -31,7 +31,8 @@ type Props = {
     x: number,
     y: number
   },
-  onMouseOver?: (e: SyntheticMouseEvent<*>) => mixed
+  onMouseOver?: (e: SyntheticMouseEvent<*>) => mixed,
+  onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed
 }
 
 export default function Well (props: Props) {
@@ -43,7 +44,8 @@ export default function Well (props: Props) {
     error,
     wellLocation,
     svgOffset,
-    onMouseOver
+    onMouseOver,
+    onMouseLeave
   } = props
 
   const fillColor = props.fillColor || 'transparent'
@@ -61,7 +63,8 @@ export default function Well (props: Props) {
 
   const selectionProps = {
     'data-wellname': wellName,
-    onMouseOver
+    onMouseOver,
+    onMouseLeave
   }
 
   const isRect = typeof wellLocation.length === 'number' && typeof wellLocation.width === 'number'

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -16,6 +16,9 @@
   --c-bg-selected: #d1d1d1;
   --c-bg-selected-light: #f1f1f1;
 
+  /* general UI */
+  --c-highlight: #5fd8ee;
+
   /* Misc */
   --c-overlay: rgba(0, 0, 0, 0.7);
   --c-plate-bg: #ccc;

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -13,17 +13,21 @@ import SelectionRect from '../components/SelectionRect.js'
 import type {AllWellContents, WellContents} from '../labware-ingred/types'
 import type {RectEvent} from '../collision-types'
 
-export type Props = {
-  wellContents: AllWellContents,
-  containerType: string,
-  onSelectionMove: RectEvent,
-  onSelectionDone: RectEvent,
-  containerId: string, // used by container
-  selectable?: boolean
-}
-
 type PlateProps = React.ElementProps<typeof Plate>
 type PlateWellContents = $PropertyType<PlateProps, 'wellContents'>
+
+export type Props = {
+  wellContents: AllWellContents,
+  containerType: $PropertyType<PlateProps, 'containerType'>,
+
+  selectable?: $PropertyType<PlateProps, 'selectable'>,
+  handleMouseOverWell?: $PropertyType<PlateProps, 'handleMouseOverWell'>,
+
+  onSelectionMove: RectEvent,
+  onSelectionDone: RectEvent,
+  containerId: string // used by container
+}
+
 function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
   return mapValues(
     wc,
@@ -58,7 +62,8 @@ export default function SelectablePlate (props: Props) {
     containerType,
     onSelectionMove,
     onSelectionDone,
-    selectable
+    selectable,
+    handleMouseOverWell
   } = props
 
   const plate = <Plate
@@ -66,6 +71,7 @@ export default function SelectablePlate (props: Props) {
     wellContents={wellContentsGroupIdsToColor(wellContents)}
     containerType={containerType}
     showLabels={selectable}
+    handleMouseOverWell={handleMouseOverWell}
   />
 
   if (!selectable) return plate // don't wrap plate with SelectionRect

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -22,6 +22,7 @@ export type Props = {
 
   selectable?: $PropertyType<PlateProps, 'selectable'>,
   handleMouseOverWell?: $PropertyType<PlateProps, 'handleMouseOverWell'>,
+  handleMouseExitWell?: $PropertyType<PlateProps, 'handleMouseExitWell'>,
 
   onSelectionMove: RectEvent,
   onSelectionDone: RectEvent,
@@ -63,15 +64,19 @@ export default function SelectablePlate (props: Props) {
     onSelectionMove,
     onSelectionDone,
     selectable,
-    handleMouseOverWell
+    handleMouseOverWell,
+    handleMouseExitWell
   } = props
 
   const plate = <Plate
-    selectable={selectable}
-    wellContents={wellContentsGroupIdsToColor(wellContents)}
-    containerType={containerType}
+    {...{
+      selectable,
+      containerType,
+      handleMouseOverWell,
+      handleMouseExitWell
+    }}
     showLabels={selectable}
-    handleMouseOverWell={handleMouseOverWell}
+    wellContents={wellContentsGroupIdsToColor(wellContents)}
   />
 
   if (!selectable) return plate // don't wrap plate with SelectionRect

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -3,15 +3,20 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
 import mapValues from 'lodash/mapValues'
+
 import SelectablePlate from '../components/SelectablePlate.js'
+
+import {getCollidingWells} from '../utils'
+import {SELECTABLE_WELL_CLASS} from '../constants'
+import {END_STEP} from '../steplist/types'
+
 import {selectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import * as highlightSelectors from '../top-selectors/substep-highlight'
 import * as wellContentsSelectors from '../top-selectors/well-contents'
+
 import {preselectWells, selectWells} from '../labware-ingred/actions'
 import wellSelectionSelectors from '../well-selection/selectors'
-
-import {END_STEP} from '../steplist/types'
 
 import type {WellContents} from '../labware-ingred/types'
 import type {BaseState} from '../types'
@@ -26,7 +31,8 @@ type Props = React.ElementProps<typeof SelectablePlate>
 
 type DispatchProps = {
   onSelectionMove: $PropertyType<Props, 'onSelectionMove'>,
-  onSelectionDone: $PropertyType<Props, 'onSelectionDone'>
+  onSelectionDone: $PropertyType<Props, 'onSelectionDone'>,
+  handleMouseOverWell: $PropertyType<Props, 'handleMouseOverWell'>
 }
 
 type StateProps = $Diff<Props, DispatchProps>
@@ -107,8 +113,17 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
 
 function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
   return {
-    onSelectionMove: (e, rect) => dispatch(preselectWells(e, rect)),
-    onSelectionDone: (e, rect) => dispatch(selectWells(e, rect))
+    onSelectionMove: (e, rect) => dispatch(preselectWells(
+      e,
+      getCollidingWells(rect, SELECTABLE_WELL_CLASS)
+    )),
+    onSelectionDone: (e, rect) => dispatch(selectWells(
+      e,
+      getCollidingWells(rect, SELECTABLE_WELL_CLASS)
+    )),
+    handleMouseOverWell: (well: string) => (e) => {
+      console.log('TODO well:', well)
+    }
   }
 }
 

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -3,8 +3,7 @@ import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 import max from 'lodash/max'
 
-import { SELECTABLE_WELL_CLASS } from '../constants'
-import {uuid, getCollidingWells} from '../utils'
+import {uuid} from '../utils'
 import {selectors} from './reducers'
 import wellSelectionSelectors from '../well-selection/selectors'
 
@@ -95,16 +94,16 @@ type WellSelectionPayload = {|
 
 export const preselectWells = createAction(
   'HIGHLIGHT_WELLS',
-  (e: MouseEvent, rect: GenericRect): WellSelectionPayload => ({
-    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
+  (e: MouseEvent, wells: Wells): WellSelectionPayload => ({
+    wells,
     append: e.shiftKey
   })
 )
 
 export const selectWells = createAction(
   'SELECT_WELLS',
-  (e: MouseEvent, rect: GenericRect): WellSelectionPayload => ({
-    wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
+  (e: MouseEvent, wells: Wells): WellSelectionPayload => ({
+    wells,
     append: e.shiftKey
   })
 )

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -94,7 +94,7 @@ type WellSelectionPayload = {|
 |}
 
 export const preselectWells = createAction(
-  'PRESELECT_WELLS',
+  'HIGHLIGHT_WELLS',
   (e: MouseEvent, rect: GenericRect): WellSelectionPayload => ({
     wells: getCollidingWells(rect, SELECTABLE_WELL_CLASS),
     append: e.shiftKey

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -11,7 +11,6 @@ import type {GetState} from '../types'
 import {editableIngredFields} from './types'
 import type {IngredInputFields, Wells} from './types'
 import type {DeckSlot} from '@opentrons/components'
-import type {GenericRect} from '../collision-types'
 
 // Payload mappers
 const xyToSingleWellObj = (x: string, y: string): Wells => ({ [(x + ',' + y)]: [x, y] })
@@ -94,7 +93,7 @@ type WellSelectionPayload = {|
 
 export const preselectWells = createAction(
   'HIGHLIGHT_WELLS',
-  (e: MouseEvent, wells: Wells): WellSelectionPayload => ({
+  (e: MouseEvent | SyntheticMouseEvent<*>, wells: Wells): WellSelectionPayload => ({
     wells,
     append: e.shiftKey
   })
@@ -102,7 +101,7 @@ export const preselectWells = createAction(
 
 export const selectWells = createAction(
   'SELECT_WELLS',
-  (e: MouseEvent, wells: Wells): WellSelectionPayload => ({
+  (e: MouseEvent | SyntheticMouseEvent<*>, wells: Wells): WellSelectionPayload => ({
     wells,
     append: e.shiftKey
   })

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -10,7 +10,7 @@ import wellSelectionSelectors from '../well-selection/selectors'
 import type {GetState} from '../types'
 import {editableIngredFields} from './types'
 import type {IngredInputFields, Wells} from './types'
-import type {DeckSlot} from '@opentrons/components'
+import type {DeckSlot, Channels} from '@opentrons/components'
 
 // Payload mappers
 const xyToSingleWellObj = (x: string, y: string): Wells => ({ [(x + ',' + y)]: [x, y] })
@@ -88,23 +88,27 @@ export const modifyContainer = createAction(
 
 type WellSelectionPayload = {|
   wells: Wells,
-  append: boolean // true if user is holding shift key
+  labwareType: string,
+  pipetteChannels: Channels
 |}
 
-export const preselectWells = createAction(
+const _wellSelectPayloadMapper = (
+  args: WellSelectionPayload
+): WellSelectionPayload => args
+
+export const highlightWells = createAction(
   'HIGHLIGHT_WELLS',
-  (e: MouseEvent | SyntheticMouseEvent<*>, wells: Wells): WellSelectionPayload => ({
-    wells,
-    append: e.shiftKey
-  })
+  _wellSelectPayloadMapper
 )
 
 export const selectWells = createAction(
   'SELECT_WELLS',
-  (e: MouseEvent | SyntheticMouseEvent<*>, wells: Wells): WellSelectionPayload => ({
-    wells,
-    append: e.shiftKey
-  })
+  _wellSelectPayloadMapper
+)
+
+export const deselectWells = createAction(
+  'DESELECT_WELLS',
+  _wellSelectPayloadMapper
 )
 
 // ===== well hovering =====

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
@@ -59,8 +59,8 @@ describe('wellContentsAllLabware', () => {
     containerState, // all labware
     ingredsByLabwareXXSingleIngred,
     {containerId: 'container1Id'}, // selected labware
-    {highlighted: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
-    {A3: 'A3'} // highlighted (TODO: is this used?)
+    {A1: 'A1', B1: 'B1'}, // selected
+    {A3: 'A3'} // highlighted
   )
 
   // TODO: 2nd test case
@@ -68,8 +68,8 @@ describe('wellContentsAllLabware', () => {
   //   containerState, // all labware
   //   ingredsByLabwareXXTwoIngred,
   //   containerState.container2Id, // selected labware
-  //   {highlighted: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
-  //   {A3: 'A3'} // highlighted (TODO: is this used?)
+  //   {A1: 'A1', B1: 'B1'}, // selected
+  //   {A3: 'A3'} // highlighted
   // )
 
   test('container has expected number of wells', () => {

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
@@ -49,8 +49,6 @@ const ingredsByLabwareXXSingleIngred = {
 
 const defaultWellContents = {
   highlighted: false,
-  hovered: false,
-  preselected: false,
   selected: false
 }
 
@@ -61,7 +59,7 @@ describe('wellContentsAllLabware', () => {
     containerState, // all labware
     ingredsByLabwareXXSingleIngred,
     {containerId: 'container1Id'}, // selected labware
-    {preselected: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
+    {highlighted: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
     {A3: 'A3'} // highlighted (TODO: is this used?)
   )
 
@@ -70,7 +68,7 @@ describe('wellContentsAllLabware', () => {
   //   containerState, // all labware
   //   ingredsByLabwareXXTwoIngred,
   //   containerState.container2Id, // selected labware
-  //   {preselected: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
+  //   {highlighted: {}, selected: {A1: 'A1', B1: 'B1'}}, // selected
   //   {A3: 'A3'} // highlighted (TODO: is this used?)
   // )
 

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -109,7 +109,7 @@ export const selectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
   labwareIngredSelectors.selectedContainerType,
   (selectedWells, selectedContainerType) => {
-    const selectedWellNames = Object.keys(selectedWells.selected)
+    const selectedWellNames = Object.keys(selectedWells)
     if (!selectedContainerType) {
       console.warn('No container type selected, cannot get max volume')
       return Infinity

--- a/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
@@ -61,7 +61,8 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
   labwareIngredSelectors.ingredientsByLabware,
   labwareIngredSelectors.getSelectedContainer,
   wellSelectionSelectors.getSelectedWells,
-  (_labware: {[id: string]: LabwareData}, _ingredsByLabware, _selectedLabware, _selectedWells) => {
+  wellSelectionSelectors.getHighlightedWells,
+  (_labware: {[id: string]: LabwareData}, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
     const allLabwareIds = Object.keys(_labware)
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: AllWellContents | null}, labwareId: string) => {
@@ -75,8 +76,8 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
           _labware[labwareId].type,
           ingredsForLabware,
           // Only give _getWellContents the selection data if it's a selected container
-          isSelectedLabware ? _selectedWells.selected : null,
-          isSelectedLabware ? _selectedWells.highlighted : null
+          isSelectedLabware ? _selectedWells : null,
+          isSelectedLabware ? _highlightedWells : null
         )
         : null
       }

--- a/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
@@ -14,11 +14,8 @@ import {defaultContainers} from '../../constants.js'
 const _getWellContents = (
   containerType: ?string,
   __ingredientsForContainer: IngredsForLabware,
-  selectedWells: {
-    preselected: Wells,
-    selected: Wells
-  } | null,
-  highlightedWells: Wells | null
+  selectedWells: ?Wells,
+  highlightedWells: ?Wells
 ): AllWellContents | null => {
   // selectedWells and highlightedWells args may both be null,
   // they're only relevant to the selected container.
@@ -47,16 +44,11 @@ const _getWellContents = (
   return reduce(allLocations, (acc: AllWellContents, location: JsonWellData, wellName: string): AllWellContents => {
     const groupIds = groupIdsForWell(wellName)
 
-    const isHighlighted = highlightedWells ? (wellName in highlightedWells) : false
-
     return {
       ...acc,
       [wellName]: {
-        preselected: selectedWells ? wellName in selectedWells.preselected : false,
-        selected: selectedWells ? wellName in selectedWells.selected : false,
-        highlighted: isHighlighted, // TODO remove 'highlighted' state?
-        hovered: !!(highlightedWells && isHighlighted && Object.keys(highlightedWells).length === 1),
-
+        highlighted: highlightedWells ? (wellName in highlightedWells) : false,
+        selected: selectedWells ? wellName in selectedWells : false,
         maxVolume: location['total-liquid-volume'] || Infinity,
         groupIds
       }
@@ -69,8 +61,7 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
   labwareIngredSelectors.ingredientsByLabware,
   labwareIngredSelectors.getSelectedContainer,
   wellSelectionSelectors.getSelectedWells,
-  wellSelectionSelectors.getHighlightedWells, // TODO Ian 2018-03-08: is 'highlighted' used?
-  (_labware: {[id: string]: LabwareData}, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
+  (_labware: {[id: string]: LabwareData}, _ingredsByLabware, _selectedLabware, _selectedWells) => {
     const allLabwareIds = Object.keys(_labware)
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: AllWellContents | null}, labwareId: string) => {
@@ -84,8 +75,8 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
           _labware[labwareId].type,
           ingredsForLabware,
           // Only give _getWellContents the selection data if it's a selected container
-          isSelectedLabware ? _selectedWells : null,
-          isSelectedLabware ? _highlightedWells : null
+          isSelectedLabware ? _selectedWells.selected : null,
+          isSelectedLabware ? _selectedWells.highlighted : null
         )
         : null
       }

--- a/protocol-designer/src/utils.js
+++ b/protocol-designer/src/utils.js
@@ -1,7 +1,7 @@
 // @flow
 import * as componentLibrary from '@opentrons/components'
 import type {BoundingRect, GenericRect} from './collision-types'
-
+import type {Wells} from './labware-ingred/types'
 export const { humanize, wellNameSplit } = componentLibrary
 
 export type FormConnectorFactory<F> = (
@@ -69,7 +69,7 @@ export function clientRectToBoundingRect (rect: ClientRect): BoundingRect {
   }
 }
 
-export const getCollidingWells = (rectPositions: GenericRect, selectableClassname: string) => {
+export const getCollidingWells = (rectPositions: GenericRect, selectableClassname: string): Wells => {
   // Returns obj of selected wells under a collision rect
   // Result: {'0,1': [0, 1], '0,2': [0, 2]}] where numbers are well positions: (column, row).
   const { x0, y0, x1, y1 } = rectPositions
@@ -90,7 +90,7 @@ export const getCollidingWells = (rectPositions: GenericRect, selectableClassnam
     )
   )
 
-  const collidedWellData = collidedElems.reduce((acc, elem) => {
+  const collidedWellData = collidedElems.reduce((acc: Wells, elem) => {
     if ('wellname' in elem.dataset) {
       const wellName = elem.dataset['wellname']
       return {...acc, [wellName]: wellName}

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -5,7 +5,7 @@ import {changeFormInput} from '../steplist/actions'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import type {Wells} from '../labware-ingred/types'
 
-// TODO Ian 2018-04-19 Move selectWells & preselectWells actions from labware-ingred into this file
+// TODO Ian 2018-04-19 Move selectWells & highlightWells actions from labware-ingred into this file
 
 // Well selection modal
 export type OpenWellSelectionModalPayload = {

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -12,9 +12,8 @@ type SelectedWellsState = {|
 |}
 const selectedWellsInitialState: SelectedWellsState = {highlighted: {}, selected: {}}
 const selectedWells = handleActions({
-  HIGHLIGHT_WELLS: (state, action: ActionType<typeof actions.preselectWells>) => action.payload.append
-    ? {...state, highlighted: action.payload.wells}
-    : {selected: {}, highlighted: action.payload.wells},
+  HIGHLIGHT_WELLS: (state, action: ActionType<typeof actions.preselectWells>) =>
+    ({...state, highlighted: action.payload.wells}),
 
   SELECT_WELLS: (state, action: ActionType<typeof actions.selectWells>) => ({
     highlighted: {},

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -5,20 +5,19 @@ import {handleActions, type ActionType} from 'redux-actions'
 import type {Wells} from '../labware-ingred/types'
 import * as actions from '../labware-ingred/actions'
 import type {OpenWellSelectionModalPayload} from './actions'
-import typeof {openWellSelectionModal} from './actions'
 
 type SelectedWellsState = {|
-  preselected: Wells,
+  highlighted: Wells,
   selected: Wells
 |}
-const selectedWellsInitialState: SelectedWellsState = {preselected: {}, selected: {}}
+const selectedWellsInitialState: SelectedWellsState = {highlighted: {}, selected: {}}
 const selectedWells = handleActions({
-  PRESELECT_WELLS: (state, action: ActionType<typeof actions.preselectWells>) => action.payload.append
-    ? {...state, preselected: action.payload.wells}
-    : {selected: {}, preselected: action.payload.wells},
+  HIGHLIGHT_WELLS: (state, action: ActionType<typeof actions.preselectWells>) => action.payload.append
+    ? {...state, highlighted: action.payload.wells}
+    : {selected: {}, highlighted: action.payload.wells},
 
   SELECT_WELLS: (state, action: ActionType<typeof actions.selectWells>) => ({
-    preselected: {},
+    highlighted: {},
     selected: {
       ...(action.payload.append ? state.selected : {}),
       ...action.payload.wells
@@ -39,7 +38,7 @@ const highlightedIngredients = handleActions({
 
 type WellSelectionModalState = OpenWellSelectionModalPayload | null
 const wellSelectionModal = handleActions({
-  OPEN_WELL_SELECTION_MODAL: (state, action: ActionType<openWellSelectionModal>) => action.payload,
+  OPEN_WELL_SELECTION_MODAL: (state, action: {payload: OpenWellSelectionModalPayload}) => action.payload,
   CLOSE_WELL_SELECTION_MODAL: () => null
 }, null)
 

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -1,4 +1,5 @@
 // @flow
+import omit from 'lodash/omit'
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
@@ -10,17 +11,25 @@ type SelectedWellsState = {|
   highlighted: Wells,
   selected: Wells
 |}
+
+function deleteWells (initialWells: Wells, wellsToRemove: Wells): Wells {
+  // remove given wells from a set of wells
+  return omit(initialWells, Object.keys(wellsToRemove))
+}
+
 const selectedWellsInitialState: SelectedWellsState = {highlighted: {}, selected: {}}
 const selectedWells = handleActions({
-  HIGHLIGHT_WELLS: (state, action: ActionType<typeof actions.preselectWells>) =>
+  HIGHLIGHT_WELLS: (state, action: ActionType<typeof actions.highlightWells>) =>
     ({...state, highlighted: action.payload.wells}),
 
   SELECT_WELLS: (state, action: ActionType<typeof actions.selectWells>) => ({
     highlighted: {},
-    selected: {
-      ...(action.payload.append ? state.selected : {}),
-      ...action.payload.wells
-    }
+    selected: {...state.selected, ...action.payload.wells}
+  }),
+
+  DESELECT_WELLS: (state, action: ActionType<typeof actions.deselectWells>) => ({
+    highlighted: {},
+    selected: deleteWells(state.selected, action.payload.wells)
   }),
   // Actions that cause "deselect everything" behavior:
   EDIT_MODE_INGREDIENT_GROUP: () => selectedWellsInitialState,

--- a/protocol-designer/src/well-selection/selectors.js
+++ b/protocol-designer/src/well-selection/selectors.js
@@ -37,12 +37,12 @@ const selectedWellNames: Selector<Array<string>> = createSelector(
   })
 )
 
-// TODO Ian 2018-04-19 this is a confusing name, it gets {selected: Wells, highlighted: Wells.}. Refactor.
-const getSelectedWells = (state: BaseState) => rootSelector(state).selectedWells
+const getSelectedWells = (state: BaseState) => rootSelector(state).selectedWells.selected
+const getHighlightedWells = (state: BaseState) => rootSelector(state).selectedWells.highlighted
 
 const numWellsSelected: Selector<number> = createSelector(
   getSelectedWells,
-  selectedWells => Object.keys(selectedWells.selected).length
+  selectedWells => Object.keys(selectedWells).length
 )
 
 // TODO Ian 2018-04-24 is 'highlightedIngredients' useful?
@@ -60,6 +60,6 @@ export default {
   selectedWellNames,
   numWellsSelected,
   getSelectedWells,
-  // getHighlightedWells,
+  getHighlightedWells,
   wellSelectionModalData
 }

--- a/protocol-designer/src/well-selection/selectors.js
+++ b/protocol-designer/src/well-selection/selectors.js
@@ -37,7 +37,7 @@ const selectedWellNames: Selector<Array<string>> = createSelector(
   })
 )
 
-// TODO Ian 2018-04-19 this is a confusing name, it gets {selected: Wells, preselected: Wells.}. Refactor.
+// TODO Ian 2018-04-19 this is a confusing name, it gets {selected: Wells, highlighted: Wells.}. Refactor.
 const getSelectedWells = (state: BaseState) => rootSelector(state).selectedWells
 
 const numWellsSelected: Selector<number> = createSelector(
@@ -45,7 +45,11 @@ const numWellsSelected: Selector<number> = createSelector(
   selectedWells => Object.keys(selectedWells.selected).length
 )
 
-const getHighlightedWells = (state: BaseState) => rootSelector(state).highlightedIngredients.wells
+// TODO Ian 2018-04-24 is 'highlightedIngredients' useful?
+// Should HOVER_WELL_BEGIN / HOVER_WELL_END be removed in favor of HIGHLIGHT_WELLS?
+// or the other way around?
+
+// const getHighlightedWells = (state: BaseState) => rootSelector(state).highlightedIngredients.wells
 
 const wellSelectionModalData: Selector<*> = createSelector(
   rootSelector,
@@ -56,6 +60,6 @@ export default {
   selectedWellNames,
   numWellsSelected,
   getSelectedWells,
-  getHighlightedWells,
+  // getHighlightedWells,
   wellSelectionModalData
 }


### PR DESCRIPTION
Closes #1186, and adding hover-to-highlight closes #1187 

## overview

New interactivity design for well selection in both **ingredient selector** and **well selector**:

* When not dragging mouse:
    * hovering over a well highlights it
    * leaving a well un-highlights it

* dragging a selection over several wells highlights it
* holding shift puts you in "eraser" mode, so your selection rectangle then removes wells from your selection. Shift + Click also removes the well you click.
* if you're **not** holding shift and you click and drag, you're in "add to selection" mode. All wells you drag over are added to your selection, and your selection isn't cleared (before, your previous selection was cleared, b/c shift used to be "append mode" -- that's gone, selection always appends now). And click without drag also adds a well.

## changelog

- Stuff above for new interaction design
- Complib: New `--c-highlight` color in `colors.css` (this is part of @howisthisnamenottakenyet 's new component color palette)
- Clean up / standardize / simplify actions related to well highlighting & selection
- Scaffolding for 8-channel support (ie including labware type and pipette # channels in well selection action payload)

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_well-highlighted-cleanup/index.html

This PR affects the interaction & appearance of hovering over and selecting wells, in both:
* Ingredient creation modal
* Well selection modal

8-channel still not supported yet!

### General

- Does well selection feel nice to use? Anything weird?

### Code review
- Is there a more elegant way to do the mouseover-related hover than wiring up handlers for onMouseOver & onMouseLeave thru SelectablePlate to Plate to Well? Or is it simple enough as-is?