### PR TITLE
feat(app): Wrong pipette alert in tip probe

### DIFF
--- a/app/src/components/setup-instruments/styles.css
+++ b/app/src/components/setup-instruments/styles.css
@@ -1,0 +1,15 @@
+@import '@opentrons/components';
+
+.instrument {
+  position: relative;
+}
+
+.instrument_info {
+  padding: 1rem 1.5rem;
+}
+
+.wrong_pipette_message {
+  @apply --font-body-2-dark;
+
+  margin-top: 1.5rem;
+}

--- a/app/src/pages/SetupInstruments.js
+++ b/app/src/pages/SetupInstruments.js
@@ -7,6 +7,7 @@ import {Route, Redirect, type ContextRouter} from 'react-router'
 import type {State} from '../types'
 import type {Instrument} from '../robot'
 import {selectors as robotSelectors} from '../robot'
+import {makeGetRobotPipettes} from '../http-api-client'
 
 import Page from '../components/Page'
 import TipProbe from '../components/TipProbe'
@@ -39,7 +40,7 @@ function SetupInstrumentsPage (props: Props) {
     <Page>
       <SessionHeader />
       <InstrumentTabs {...{instruments, currentInstrument}} />
-      <Instruments {...{instruments, currentInstrument}} />
+      <Instruments {...props} />
       {currentInstrument && (
         <TipProbe
           {...currentInstrument}
@@ -60,9 +61,17 @@ function SetupInstrumentsPage (props: Props) {
 
 function makeMapStateToProps (): (State, OwnProps) => StateProps {
   const getCurrentInstrument = robotSelectors.makeGetCurrentInstrument()
+  const getAttachedPipettes = makeGetRobotPipettes()
 
-  return (state, props) => ({
-    instruments: robotSelectors.getInstruments(state),
-    currentInstrument: getCurrentInstrument(state, props)
-  })
+  return (state, props) => {
+    const name = robotSelectors.getConnectedRobotName(state)
+    const pipettesResponse = getAttachedPipettes(state, {name})
+
+    return {
+      name,
+      instruments: robotSelectors.getInstruments(state),
+      currentInstrument: getCurrentInstrument(state, props),
+      actualPipettes: pipettesResponse.response
+    }
+  }
 }

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -45,8 +45,10 @@ export default function AlertItem (props: AlertProps) {
   const className = cx(
     styles.alert,
     alertProps.className,
-    {[styles.alert_body]: props.children}
+    {[styles.alert_body]: props.children},
+    props.className
   )
+
   return (
     <div className={className}>
       <div className={styles.title_bar}>

--- a/components/src/instrument-diagram/InstrumentInfo.js
+++ b/components/src/instrument-diagram/InstrumentInfo.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import cx from 'classnames'
 
 import type {Mount} from '../robot-types'
@@ -20,7 +20,11 @@ export type InstrumentInfoProps = {
   /** usually 1 or 8 */
   channels?: number,
   /** classes to apply */
-  className?: string
+  className?: string,
+  /** classes to apply to the info group child */
+  infoClassName?: string,
+  /** children to display under the info */
+  children?: React.Node,
 }
 
 export default function InstrumentInfo (props: InstrumentInfoProps) {
@@ -33,11 +37,15 @@ export default function InstrumentInfo (props: InstrumentInfoProps) {
 
   return (
     <div className={className}>
-      <div className={styles.pipette_info}>
+      <div className={cx(styles.pipette_info, props.infoClassName)}>
         <InfoItem title={'pipette'} value={props.description} />
         <InfoItem title={'suggested tip type'} value={props.tipType} />
+        {props.children}
       </div>
-      <InstrumentDiagram channels={props.channels} className={styles.pipette_icon} />
+      <InstrumentDiagram
+        channels={props.channels}
+        className={styles.pipette_icon}
+      />
     </div>
   )
 }

--- a/components/src/instrument-diagram/instrument.css
+++ b/components/src/instrument-diagram/instrument.css
@@ -4,9 +4,8 @@
   margin: 0 auto;
   min-width: 40rem;
   max-width: 45rem;
-  padding: 0 1rem 2rem;
+  padding-bottom: 2rem;
   display: grid;
-  grid-column-gap: 0.25rem;
   grid-template-columns: 50% 50%;
   grid-template-areas: 'left right';
 }


### PR DESCRIPTION
## overview

This PR addresses #861, with two adjustments to the requirements listed in the ticket:

1. App will direct users to the robot settings page to change pipettes rather than incorporating the change modal in the calibration page
2. Due to various concerns in both the app and the API, the app will _not_ prevent the user from proceeding to tip probe
    - The information available to the app to determine an "incorrect" pipette is not completely reliable
    - Accordingly, I'm not comfortable blocking tip probe
    - See #1260 for some of the story, also RPC is making this worse

## changelog


- feat(components): Add/fix children/styling for InstrumentInfo and AlertItem
- feat(app): Add alert in tip probe if pipette is incorrect 

## review requests

Standard code review + robot testing. Virtual smoothie testing works, but is a little annoying because everything is hardcoded to P10 Single. Follow the test plan in #861 by messing around with existing protocols in `data`

@IanLondon this PR touches AlertItem and IntrumentInfo in components lib so please make sure I didn't mess with PD.

Styling isn't very accurate to screens, but after talking to @pantslakz, this page is kind of in flux. I elected to use as much of what we already have (in terms of components) without too much concern for getting it "right" in anticipation of a future UI pass. 
