### PR TITLE
fix(app): Show more accurate error messages in pipette swap failures

### DIFF
--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -16,11 +16,6 @@ const EXIT_BUTTON_MESSAGE_WRONG = 'keep pipette and exit setup'
 // display messages based on presence of wantedPipette and actualPipette
 export default function ConfirmPipette (props: ChangePipetteProps) {
   const {success, attachedWrong, actualPipette} = props
-  let exitButtonProps = {className: styles.confirm_button}
-
-  exitButtonProps = success
-    ? {...exitButtonProps, onClick: props.exit}
-    : {...exitButtonProps, Component: Link, to: props.exitUrl}
 
   return (
     <ModalPage

--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -14,7 +14,7 @@ const EXIT_BUTTON_MESSAGE = 'exit pipette setup'
 // note: direction prop is not valid inside this component
 // display messages based on presence of wantedPipette and actualPipette
 export default function ConfirmPipette (props: ChangePipetteProps) {
-  const {success, wantedPipette, actualPipette} = props
+  const {success, attachedWrong, actualPipette} = props
   let exitButtonProps = {className: styles.confirm_button}
 
   exitButtonProps = success
@@ -26,15 +26,16 @@ export default function ConfirmPipette (props: ChangePipetteProps) {
       titleBar={{
         title: props.title,
         subtitle: props.subtitle,
-        back: {onClick: props.back, disabled: !!success}
+        back: {
+          onClick: props.back,
+          disabled: success || attachedWrong
+        }
       }}
     >
       <Status {...props} />
-      {!success && wantedPipette && (
-        <FailureToDetect {...props} />
-      )}
+      <StatusDetails {...props} />
       {!success && (
-        <CheckAgainButton {...props} />
+        <TryAgainButton {...props} />
       )}
       {success && !actualPipette && (
         <AttachAnotherButton {...props} />
@@ -47,7 +48,7 @@ export default function ConfirmPipette (props: ChangePipetteProps) {
 }
 
 function Status (props: ChangePipetteProps) {
-  const {displayName, wantedPipette, success} = props
+  const {displayName, wantedPipette, attachedWrong, success} = props
   const iconName = success ? 'check-circle' : 'close-circle'
   const iconClass = cx(styles.confirm_icon, {
     [styles.success]: success,
@@ -56,14 +57,16 @@ function Status (props: ChangePipetteProps) {
 
   let message
 
-  if (wantedPipette) {
-    message = success
-     ? `${displayName} successfully attached.`
-     : `Unable to detect ${wantedPipette.displayName || ''}.`
+  if (wantedPipette && success) {
+    message = `${displayName} successfully attached.`
+  } else if (wantedPipette) {
+    message = attachedWrong
+      ? `Incorrect pipette attached (${displayName})`
+      : `Unable to detect ${wantedPipette.displayName || ''}.`
   } else {
     message = success
       ? 'Pipette is detached'
-      : `${displayName} is still attached`
+      : 'Pipette is not detached'
   }
 
   return (
@@ -74,23 +77,47 @@ function Status (props: ChangePipetteProps) {
   )
 }
 
-function FailureToDetect (props: ChangePipetteProps) {
-  return (
-    <div>
-      <img
-        className={styles.confirm_diagram}
-        src={getDiagramSrc({
-          ...props,
-          ...props.wantedPipette,
-          diagram: 'tab',
-          direction: 'attach'
-        })}
-      />
-      <p className={styles.confirm_failure_instructions}>
-        Check again to ensure that white connector tab is plugged into pipette.
-      </p>
-    </div>
-  )
+function StatusDetails (props: ChangePipetteProps) {
+  const {success, attachedWrong, wantedPipette, actualPipette} = props
+
+  if (!success) {
+    if (wantedPipette && attachedWrong) {
+      return (
+        <p className={styles.confirm_failure_instructions}>
+          The attached pipette does not match the {wantedPipette.displayName} pipette you had originally selected.
+        </p>
+      )
+    }
+
+    if (wantedPipette) {
+      return (
+        <div>
+          <img
+            className={styles.confirm_diagram}
+            src={getDiagramSrc({
+              ...props,
+              ...wantedPipette,
+              diagram: 'tab',
+              direction: 'attach'
+            })}
+          />
+          <p className={styles.confirm_failure_instructions}>
+            Check again to ensure that white connector tab is plugged into pipette.
+          </p>
+        </div>
+      )
+    }
+
+    if (actualPipette) {
+      return (
+        <p className={styles.confirm_failure_instructions}>
+          Check again to ensure that pipette is unplugged and entirely detached from robot.
+        </p>
+      )
+    }
+  }
+
+  return null
 }
 
 function AttachAnotherButton (props: ChangePipetteProps) {
@@ -105,13 +132,36 @@ function AttachAnotherButton (props: ChangePipetteProps) {
   )
 }
 
-function CheckAgainButton (props: ChangePipetteProps) {
+function TryAgainButton (props: ChangePipetteProps) {
+  const {
+    baseUrl,
+    checkPipette,
+    attachedWrong,
+    wantedPipette,
+    actualPipette
+  } = props
+
+  let buttonProps
+
+  if (wantedPipette && attachedWrong) {
+    buttonProps = {
+      Component: Link,
+      to: baseUrl.replace(`/${wantedPipette.model}`, ''),
+      children: 'detach and try again'
+    }
+  } else if (actualPipette) {
+    buttonProps = {
+      onClick: checkPipette,
+      children: 'confirm pipette is detached'
+    }
+  } else {
+    buttonProps = {
+      onClick: checkPipette,
+      children: 'have robot check connection again'
+    }
+  }
+
   return (
-    <PrimaryButton
-      className={styles.confirm_button}
-      onClick={props.checkPipette}
-    >
-      have robot check connection again
-    </PrimaryButton>
+    <PrimaryButton {...buttonProps} className={styles.confirm_button} />
   )
 }

--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -10,6 +10,7 @@ import {getDiagramSrc} from './InstructionStep'
 import styles from './styles.css'
 
 const EXIT_BUTTON_MESSAGE = 'exit pipette setup'
+const EXIT_BUTTON_MESSAGE_WRONG = 'keep pipette and exit setup'
 
 // note: direction prop is not valid inside this component
 // display messages based on presence of wantedPipette and actualPipette
@@ -40,9 +41,7 @@ export default function ConfirmPipette (props: ChangePipetteProps) {
       {success && !actualPipette && (
         <AttachAnotherButton {...props} />
       )}
-      <PrimaryButton {...exitButtonProps}>
-        {EXIT_BUTTON_MESSAGE}
-      </PrimaryButton>
+      <ExitButton {...props} />
     </ModalPage>
   )
 }
@@ -163,5 +162,22 @@ function TryAgainButton (props: ChangePipetteProps) {
 
   return (
     <PrimaryButton {...buttonProps} className={styles.confirm_button} />
+  )
+}
+
+function ExitButton (props: ChangePipetteProps) {
+  const {exit, exitUrl, success, attachedWrong} = props
+  const children = attachedWrong
+    ? EXIT_BUTTON_MESSAGE_WRONG
+    : EXIT_BUTTON_MESSAGE
+
+  let exitButtonProps = {children, className: styles.confirm_button}
+
+  exitButtonProps = success
+    ? {...exitButtonProps, onClick: exit}
+    : {...exitButtonProps, Component: Link, to: exitUrl}
+
+  return (
+    <PrimaryButton {...exitButtonProps} />
   )
 }

--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -10,6 +10,9 @@ import PipetteSelection from './PipetteSelection'
 import InstructionStep from './InstructionStep'
 import styles from './styles.css'
 
+const ATTACH_CONFIRM = 'have robot check connection'
+const DETACH_CONFIRM = 'confirm pipette is detached'
+
 export default function Instructions (props: ChangePipetteProps) {
   const {wantedPipette, actualPipette} = props
 
@@ -31,7 +34,9 @@ export default function Instructions (props: ChangePipetteProps) {
       {(actualPipette || wantedPipette) && (
         <div>
           <Steps {...props} />
-          <CheckButton onClick={props.confirmPipette} />
+          <CheckButton onClick={props.confirmPipette}>
+            {actualPipette ? DETACH_CONFIRM : ATTACH_CONFIRM}
+          </CheckButton>
         </div>
       )}
     </ModalPage>
@@ -103,8 +108,6 @@ function CheckButton (props: ButtonProps) {
     <PrimaryButton
       {...props}
       className={styles.check_pipette_button}
-    >
-      have robot check connection
-    </PrimaryButton>
+    />
   )
 }

--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -17,7 +17,7 @@ export default function Instructions (props: ChangePipetteProps) {
     ...props,
     back: wantedPipette
       ? {onClick: props.back}
-      : {Component: Link, to: props.exitUrl}
+      : {Component: Link, to: props.exitUrl, children: 'exit'}
   }
 
   return (

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -93,6 +93,7 @@ type SP = {
   displayName: string,
   direction: Direction,
   success: boolean,
+  attachedWrong: boolean,
 }
 
 type DP = {
@@ -147,6 +148,12 @@ function makeMapStateToProps () {
       (actualPipette && actualPipette.model)
     )
 
+    const attachedWrong = !!(
+      !success &&
+      wantedPipette &&
+      actualPipette
+    )
+
     const displayName = (
       (actualPipette && actualPipette.displayName) ||
       (wantedPipette && wantedPipette.displayName) ||
@@ -157,6 +164,7 @@ function makeMapStateToProps () {
       actualPipette,
       direction,
       success,
+      attachedWrong,
       displayName,
       moveRequest: getRobotMove(state, ownProps.robot),
       homeRequest: getRobotHome(state, ownProps.robot)

--- a/app/src/components/ChangePipette/styles.css
+++ b/app/src/components/ChangePipette/styles.css
@@ -91,7 +91,7 @@
 
 .confirm_failure_instructions {
   text-align: center;
-  margin-bottom: 5rem;
+  margin-bottom: 3rem;
 }
 
 .confirm_button {

--- a/app/src/components/ChangePipette/types.js
+++ b/app/src/components/ChangePipette/types.js
@@ -26,6 +26,7 @@ export type ChangePipetteProps = {
   displayName: string,
   direction: Direction,
   success: boolean,
+  attachedWrong: boolean,
   parentUrl: string,
   baseUrl: string,
   confirmUrl: string,


### PR DESCRIPTION
## overview

This PR is serving as a combo PR and ticket to "finish" up Change Pipettes for real. Aligns the error messages of pipette swap with the screens:

1. Pipette not attached

    <img width="555" alt="screenshot 2018-04-25 14 34 42" src="https://user-images.githubusercontent.com/2963448/39265741-0aadadf4-4896-11e8-9f86-589b92a77d32.png">

2. Incorrect pipette attached
    
     <img width="560" alt="screenshot 2018-04-25 16 44 22" src="https://user-images.githubusercontent.com/2963448/39271790-0b30b372-48a8-11e8-8dec-09ab5d7ebcef.png">

3. Pipette not detached

    <img width="601" alt="screenshot 2018-04-25 14 34 23" src="https://user-images.githubusercontent.com/2963448/39265782-21df8b32-4896-11e8-8ba6-48a79c9959f6.png">

## changelog

- fix(app): Show more accurate error messages in pipette swap failures
- fix(app): Change back button to read "Exit" when it will exit

## review requests

Easiest to test on a real robot. If testing on virtual smoothie, switch line 143 in `app/src/components/ChangePipette/index.js` to null to simulate a pipette removal (thanks hot reload).
