### PR TITLE
Disambiguate feature flag path environment variable

### DIFF
--- a/api/opentrons/config/feature_flags.py
+++ b/api/opentrons/config/feature_flags.py
@@ -3,11 +3,11 @@ import json
 
 
 # In order to specify a location for the settings.json file, export the
-# OT_SETTINGS_DIR environment variable. For example,
-# `export OT_SETTINGS_DIR=$HOME` would cause the server to look in the user's
+# OT_FLAG_DIR environment variable. For example,
+# `export OT_FLAG_DIR=$HOME` would cause the server to look in the user's
 # home directory for a file named 'settings.json'. Primarily used to override
 # feature flags during development.
-OVERRIDE_SETTINGS_DIR = os.environ.get('OT_SETTINGS_DIR')
+OVERRIDE_SETTINGS_DIR = os.environ.get('OT_FLAG_DIR')
 DEFAULT_SETTINGS_DIR = '/data'
 SETTINGS_FILE = 'settings.json'
 


### PR DESCRIPTION
## overview

Change feature flag path override environment variable to disambiguate from labware definition location.

## changelog

- (fix) Change override environment variable for feature flag file path to OT_FLAG_DIR

## review requests

Tested on Kaja's robot
