### PR TITLE
Adds ability to set deck type through a feature flag

### DIFF
--- a/api/opentrons/config/feature_flags.py
+++ b/api/opentrons/config/feature_flags.py
@@ -49,3 +49,9 @@ def split_labware_definitions(): return get_feature_flag('split-labware-def')
 # - False: Otherwise the default
 # will be that you calibrate to the top
 def calibrate_to_bottom(): return get_feature_flag('calibrate-to-bottom')
+
+
+# dots_deck_type
+# - True: The deck layout has etched "dots"
+# - False: The deck layout has etched "crosses"
+def dots_deck_type(): return get_feature_flag('dots-deck-type')

--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -1,6 +1,6 @@
 from opentrons import robot
 from opentrons.robot.robot import Robot
-
+from opentrons.config import feature_flags as ff
 
 # Application constants
 SAFE_HEIGHT = 130
@@ -13,7 +13,7 @@ holes = 'holes'
 crosses = 'crosses'
 
 
-def dots_set(dot_flag):
+def dots_set():
     """
 
     :param dot_flag: a boolean represented whether the feature flag is set
@@ -21,7 +21,27 @@ def dots_set(dot_flag):
     then it will utilize old calibration points)
     :return:  List of calibration coordinates
     """
-    if dot_flag:
+    if ff.dots_deck_type():
+        slot_1_lower_left = (12.13, 6.0)
+        slot_3_lower_right = (380.87, 6.0)
+        slot_7_upper_left = (12.13, 261.0)
+    else:
+        slot_1_lower_left = (12.13, 9.0)
+        slot_3_lower_right = (380.87, 9.0)
+        slot_7_upper_left = (12.13, 258.0)
+
+    return [slot_1_lower_left, slot_3_lower_right, slot_7_upper_left]
+
+
+def cli_dots_set():
+    """
+
+    :param dot_flag: a boolean represented whether the feature flag is set
+    or not (if dots_deck_type is set to True
+    then it will utilize old calibration points)
+    :return:  List of calibration coordinates
+    """
+    if ff.dots_deck_type():
         slot_1_lower_left = (12.13, 6.0)
         slot_3_lower_right = (380.87, 6.0)
         slot_10_upper_left = (12.13, 351.5)

--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -1,6 +1,7 @@
 from opentrons import robot
 from opentrons.robot.robot import Robot
 
+
 # Application constants
 SAFE_HEIGHT = 130
 
@@ -9,6 +10,28 @@ right = 'A'
 
 dots = 'dots'
 holes = 'holes'
+crosses = 'crosses'
+
+
+def dots_set(dot_flag):
+    """
+
+    :param dot_flag: a boolean represented whether the feature flag is set
+    or not (if dots_deck_type is set to True
+    then it will utilize old calibration points)
+    :return:  List of calibration coordinates
+    """
+    if dot_flag:
+        slot_1_lower_left = (12.13, 6.0)
+        slot_3_lower_right = (380.87, 6.0)
+        slot_10_upper_left = (12.13, 351.5)
+    else:
+        slot_1_lower_left = (12.13, 9.0)
+        slot_3_lower_right = (380.87, 9.0)
+        slot_10_upper_left = (12.13, 348.5)
+
+    return [slot_1_lower_left, slot_3_lower_right, slot_10_upper_left]
+
 
 # Indicies into calibration matrix
 xyz_column = 3

--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -14,7 +14,6 @@ from opentrons import robot, instruments
 from opentrons.util.calibration_functions import probe_instrument
 from opentrons.deck_calibration.linal import solve, add_z, apply_transform
 from opentrons.deck_calibration import *
-from opentrons.config import feature_flags as ff
 
 # TODO: add tests for methods, split out current point behavior per comment
 # TODO:   below, and total result on robot against prior version of this app
@@ -350,23 +349,14 @@ def backup_configuration_and_reload(tag=None):
     clear_configuration_and_reload()
 
 
-expected_loc = dots_set(ff.dots_deck_type())
-expected_dots = {
-    1: expected_loc[0],
-    2: expected_loc[1],
-    3: expected_loc[2]
-}
+def get_calibration_points():
 
-# for machines that cannot reach the calibration dots, use the screw holes
-# TODO (ben 20180131): remove this once all robots can reach engraved points
-slot_4_screw_hole = (108.75, 92.8)
-slot_6_screw_hole = (373.75, 92.8)
-slot_11_screw_hole = (241.25, 273.80)
-expected_holes = {
-    1: slot_4_screw_hole,
-    2: slot_6_screw_hole,
-    3: slot_11_screw_hole
-}
+    expected_loc = cli_dots_set()
+    return {
+        1: expected_loc[0],
+        2: expected_loc[1],
+        3: expected_loc[2]
+    }
 
 
 def main():
@@ -401,13 +391,6 @@ def main():
         sys.exit()
     backup_configuration_and_reload()
 
-    # older machines cannot reach deck points, use the screw holes instead
-    res = input('Are you calibrating to the screw holes (y/[n])? ')
-    if res in ['y', 'Y', 'yes']:
-        calibration_points = expected_holes
-    else:
-        calibration_points = expected_dots
-
     robot.connect()
 
     # lights help the script user to see the points on the deck
@@ -418,7 +401,7 @@ def main():
     #  - 200ul tip is 51.7mm long when attached to a pipette
     #  - For xyz coordinates, (0, 0, 0) is the lower-left corner of the robot
     cli = CLITool(
-        point_set=calibration_points,
+        point_set=get_calibration_points(),
         tip_length=51.7)
     cli.ui_loop.run()
 

--- a/api/opentrons/deck_calibration/dc_main.py
+++ b/api/opentrons/deck_calibration/dc_main.py
@@ -14,6 +14,7 @@ from opentrons import robot, instruments
 from opentrons.util.calibration_functions import probe_instrument
 from opentrons.deck_calibration.linal import solve, add_z, apply_transform
 from opentrons.deck_calibration import *
+from opentrons.config import feature_flags as ff
 
 # TODO: add tests for methods, split out current point behavior per comment
 # TODO:   below, and total result on robot against prior version of this app
@@ -349,13 +350,11 @@ def backup_configuration_and_reload(tag=None):
     clear_configuration_and_reload()
 
 
-slot_1_lower_left = (12.13, 6.0)
-slot_3_lower_right = (380.87, 6.0)
-slot_10_upper_left = (12.13, 351.5)
+expected_loc = dots_set(ff.dots_deck_type())
 expected_dots = {
-    1: slot_1_lower_left,
-    2: slot_3_lower_right,
-    3: slot_10_upper_left
+    1: expected_loc[0],
+    2: expected_loc[1],
+    3: expected_loc[2]
 }
 
 # for machines that cannot reach the calibration dots, use the screw holes

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -31,18 +31,18 @@ def safe_points():
     # misalignment between the deck and the gantry.
     slot_1_lower_left, \
         slot_3_lower_right, \
-        slot_10_upper_left = expected_points().values()
+        slot_7_upper_left = expected_points().values()
     slot_1_safe_point = (
         slot_1_lower_left[0] + 5, slot_1_lower_left[1] + 5, 10)
     slot_3_safe_point = (
         slot_3_lower_right[0] - 5, slot_3_lower_right[1] + 5, 10)
-    slot_10_safe_point = (
-        slot_10_upper_left[0] + 5, slot_10_upper_left[1] - 5, 10)
+    slot_7_safe_point = (
+        slot_7_upper_left[0] + 5, slot_7_upper_left[1] - 5, 10)
 
     return {
         '1': slot_1_safe_point,
         '2': slot_3_safe_point,
-        '3': slot_10_safe_point}
+        '3': slot_7_safe_point}
 
 
 def _get_uuid() -> str:

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -3,8 +3,10 @@ from uuid import uuid1
 from opentrons.instruments import pipette_config
 from opentrons import instruments, robot
 from opentrons.robot import robot_configs
-from opentrons.deck_calibration import jog, position
+from opentrons.deck_calibration import jog, position, dots_set
 from opentrons.deck_calibration.linal import add_z, solve
+from opentrons.config import feature_flags as ff
+
 
 import logging
 import json
@@ -12,10 +14,9 @@ import json
 session = None
 log = logging.getLogger(__name__)
 
-slot_1_lower_left = (12.13, 6.0)
-slot_3_lower_right = (380.87, 6.0)
-slot_10_upper_left = (12.13, 351.5)
-
+slot_1_lower_left,\
+    slot_3_lower_right,\
+    slot_10_upper_left = dots_set(ff.dots_deck_type())
 # Safe points are defined as 5mm toward the center of the deck in x and y, and
 # 10mm above the deck. User is expect to jog to the critical point from the
 # corresponding safe point, to avoid collision depending on direction of

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -87,6 +87,7 @@ async def position_info(request):
     can easily access the pipette mount screws with a screwdriver. Attach tip
     position places either pipette roughly in the front-center of the deck area
     """
+    safe_pos1, safe_pos2, safe_pos3 = safe_points().values()
     return web.json_response({
         'positions': {
             'change_pipette': {
@@ -100,15 +101,15 @@ async def position_info(request):
             },
             'initial_calibration_1': {
                 'target': 'pipette',
-                'point': safe_points['1']
+                'point': safe_pos1
             },
             'initial_calibration_2': {
                 'target': 'pipette',
-                'point': safe_points['2']
+                'point': safe_pos2
             },
             'initial_calibration_3': {
                 'target': 'pipette',
-                'point': safe_points['3']
+                'point': safe_pos3
             }
         }
     })

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -47,3 +47,39 @@ def test_save_and_clear_config(mock_config):
 
     saved_config = robot_configs.load(filename)
     assert saved_config == old_config
+
+
+@pytest.fixture
+def deck_setup_flag(monkeypatch):
+    tmpd = tempfile.TemporaryDirectory()
+    monkeypatch.setattr(
+        ff, 'SETTINGS_PATH', os.path.join(tmpd.name, 'settings.json'))
+
+    print(tmpd)
+    print(os.path.abspath(os.path.join(tmpd.name, 'settings.json')))
+    ff.set_feature_flag('dots-deck-type', True)
+
+    print(ff.dots_deck_type())
+    yield
+
+    print(ff.dots_deck_type())
+
+
+async def test_new_deck_points(deck_setup_flag):
+    # Checks that the correct deck calibration points are being used
+    # if feature_flag is set (or not)
+    from opentrons.deck_calibration import dots_set
+
+    slot_1_lower_left,\
+        slot_3_lower_right,\
+        slot_10_upper_left = dots_set(ff.dots_deck_type())
+    # Check when feature_flag is set
+    assert slot_1_lower_left == (12.13, 6.0)
+    assert slot_3_lower_right == (380.87, 6.0)
+    assert slot_10_upper_left == (12.13, 351.5)
+
+    yield
+    # Check when feature_flag not set (default should be cross positions)
+    assert slot_1_lower_left == (12.13, 9.0)
+    assert slot_3_lower_right == (380.87, 9.0)
+    assert slot_10_upper_left == (12.13, 348.5)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -168,6 +168,17 @@ def split_labware_def():
     yield
     ff.set_feature_flag('split-labware-def', False)
 
+
+@pytest.fixture
+def dots_deck_type(monkeypatch):
+    tmpd = tempfile.TemporaryDirectory()
+    monkeypatch.setattr(
+        ff, 'SETTINGS_PATH', os.path.join(tmpd.name, 'settings.json'))
+
+    ff.set_feature_flag('dots-deck-type', True)
+    yield
+    ff.set_feature_flag('dots-deck-type', False)
+
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -169,16 +169,6 @@ def split_labware_def():
     ff.set_feature_flag('split-labware-def', False)
 
 
-@pytest.fixture
-def dots_deck_type(monkeypatch):
-    tmpd = tempfile.TemporaryDirectory()
-    monkeypatch.setattr(
-        ff, 'SETTINGS_PATH', os.path.join(tmpd.name, 'settings.json'))
-
-    ff.set_feature_flag('dots-deck-type', True)
-    yield
-    ff.set_feature_flag('dots-deck-type', False)
-
 # -----end feature flag fixtures-----------
 
 

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -93,9 +93,10 @@ async def test_save_z(dc_session):
 
 async def test_save_calibration_file(dc_session, monkeypatch):
     robot.reset()
+    expected_pos = endpoints.expected_points()
     dc_session.points = {
         k: (v[0], v[1] + 0.3)
-        for k, v in endpoints.expected_points.items()}
+        for k, v in expected_pos.items()}
     dc_session.z_value = 0.2
 
     persisted_data = []


### PR DESCRIPTION
## overview

There is an updated hardware revision to the deck which adds more visible "crosses" for calibration positions. This PR adds those values to the CLI/endpoints used for factory calibration.

## changelog

- Add a function to the init file of deck calibration that checks if a feature flag "dots_deck_type()" is set

## review requests
