### PR TITLE
tweak StepCreationButton padding

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.css
+++ b/protocol-designer/src/components/StepCreationButton.css
@@ -1,6 +1,6 @@
 .step_creation_button {
   position: relative;
-  padding: 0 2rem;
+  padding: 1rem 2rem 1.25rem 2rem;
 }
 
 .buttons_popover {


### PR DESCRIPTION
World's smallest PR! :earth_africa: 

More padding, even on top & bottom, for Add Step button

![image](https://user-images.githubusercontent.com/11590381/39313366-d1c1b3fa-493f-11e8-8b63-bbb1c796da6d.png)

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_tweak-add-step-button-spacing/index.html