### PR TITLE
Update AlertModal style to match designs

### DIFF
--- a/app/src/components/ChangePipette/styles.css
+++ b/app/src/components/ChangePipette/styles.css
@@ -12,7 +12,6 @@
 .alert_list {
   list-style-type: none;
   padding-left: 3rem;
-  margin-top: 1rem;
 
   & > li {
     line-height: 2;

--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -917,6 +917,26 @@ exports[`icons usb renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons warning renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  height={undefined}
+  style={undefined}
+  version="1.1"
+  viewBox="0 0 24 24"
+  width={undefined}
+  x={undefined}
+  y={undefined}
+>
+  <path
+    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons wifi renders correctly 1`] = `
 <svg
   aria-hidden="true"

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -9,16 +9,33 @@ exports[`modals AlertModal renders correctly 1`] = `
     onClick={[Function]}
   />
   <div
-    className="modal_contents"
+    className="modal_contents alert_modal_wrapper"
   >
+    <div
+      className="alert_modal_heading"
+    >
+      <svg
+        aria-hidden="true"
+        className="alert_modal_icon"
+        fill="currentColor"
+        height={undefined}
+        style={undefined}
+        version="1.1"
+        viewBox="0 0 24 24"
+        width={undefined}
+        x={undefined}
+        y={undefined}
+      >
+        <path
+          d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+          fillRule="evenodd"
+        />
+      </svg>
+      heading
+    </div>
     <div
       className="alert_modal_contents"
     >
-      <div
-        className="alert_modal_heading"
-      >
-        heading
-      </div>
       children
     </div>
     <div
@@ -56,7 +73,7 @@ exports[`modals ContinueModal renders correctly 1`] = `
     onClick={[Function]}
   />
   <div
-    className="modal_contents"
+    className="modal_contents alert_modal_wrapper"
   >
     <div
       className="alert_modal_contents"

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -73,7 +73,7 @@ exports[`modals ContinueModal renders correctly 1`] = `
     onClick={[Function]}
   />
   <div
-    className="modal_contents alert_modal_wrapper"
+    className="modal_contents alert_modal_wrapper no_alert_header"
   >
     <div
       className="alert_modal_contents"

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -5,6 +5,10 @@ const ICON_DATA_BY_NAME = {
     viewBox: '0 0 24 24',
     path: 'M13.2 13.2h-2.4V6h2.4v7.2zm0 4.8h-2.4v-2.4h2.4V18zM12 0C5.373 0 0 5.373 0 12A12 12 0 1 0 12 0z'
   },
+  'warning': {
+    viewBox: '0 0 24 24',
+    path: 'M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z'
+  },
   'arrow-left': {
     viewBox: '0 0 24 24',
     path: 'M18 11.242v1.516H8.91l4.166 4.166L12 18l-6-6 6-6 1.076 1.076-4.167 4.166z'

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -25,9 +25,12 @@ type Props = {
  */
 export default function AlertModal (props: Props) {
   const {heading, buttons, className, onCloseClick} = props
+  const wrapperStyle = heading
+    ? styles.alert_modal_wrapper
+    : cx(styles.alert_modal_wrapper, styles.no_alert_header)
 
   return (
-    <Modal className={className} contentsClassName={styles.alert_modal_wrapper} onCloseClick={onCloseClick}>
+    <Modal className={className} contentsClassName={wrapperStyle} onCloseClick={onCloseClick}>
       {heading && (
         <div className={styles.alert_modal_heading}>
           <Icon name='warning' className={styles.alert_modal_icon} />

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 
 import {OutlineButton, type ButtonProps} from '../buttons'
+import {Icon} from '../icons'
 import Modal from './Modal'
 import styles from './modals.css'
 
@@ -26,13 +27,14 @@ export default function AlertModal (props: Props) {
   const {heading, buttons, className, onCloseClick} = props
 
   return (
-    <Modal className={className} onCloseClick={onCloseClick}>
+    <Modal className={className} contentsClassName={styles.alert_modal_wrapper} onCloseClick={onCloseClick}>
+      {heading && (
+        <div className={styles.alert_modal_heading}>
+          <Icon name='warning' className={styles.alert_modal_icon} />
+          {heading}
+        </div>
+      )}
       <div className={styles.alert_modal_contents}>
-        {heading && (
-          <div className={styles.alert_modal_heading}>
-            {heading}
-          </div>
-        )}
         {props.children}
       </div>
       {buttons && (

--- a/components/src/modals/AlertModal.md
+++ b/components/src/modals/AlertModal.md
@@ -27,3 +27,32 @@ const alertContents = {
   )}
 </div>
 ```
+
+Alert modal without heading prop:
+
+```js
+initialState = {alert: 'foo'}
+
+const alertContents = {
+  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+}
+
+;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>
+    Alert foo
+  </FlatButton>
+  {state.alert && (
+    <AlertModal
+      onCloseClick={() => setState({alert: ''})}
+      buttons={[
+        {children: 'foo', onClick: () => setState({alert: 'foo'})},
+        {children: 'bar', onClick: () => setState({alert: 'bar'})},
+        {children: 'close', onClick: () => setState({alert: ''})}
+      ]}
+    >
+      {alertContents[state.alert]}
+    </AlertModal>
+  )}
+</div>
+```

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -37,6 +37,12 @@
   background-color: white;
 }
 
+.alert_modal_wrapper {
+  border-radius: 0;
+  position: relative;
+  padding-top: 4rem;
+}
+
 .spinner_modal_contents {
   @apply --modal-contents;
   @apply --font-body-2-light;
@@ -63,13 +69,26 @@
 .alert_modal_contents {
   @apply --font-body-2-dark;
 
-  padding: 0.5rem 1rem;
+  padding: 1rem;
 }
 
 .alert_modal_heading {
   @apply --font-header-dark;
 
-  margin-bottom: 0.5rem;
+  font-weight: normal;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  background-color: #e0e0e0;
+}
+
+.alert_modal_icon {
+  height: 1.125rem;
+  margin-right: 0.75rem;
 }
 
 .alert_modal_buttons {

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -43,6 +43,10 @@
   padding-top: 4rem;
 }
 
+.no_alert_header {
+  padding-top: 1.5rem;
+}
+
 .spinner_modal_contents {
   @apply --modal-contents;
   @apply --font-body-2-light;


### PR DESCRIPTION
## overview
This PR addresses #1236. Designs for the alert modals have changed and this is simply some chore work to update comp libs AlertModals before implementing router logic for Deck Calibration screens. 

Updated alert modal can be seen here in the change pipettes clear deck alert modal:

<img width="1025" alt="screen shot 2018-04-26 at 1 12 48 pm" src="https://user-images.githubusercontent.com/3430313/39320966-a4dcbb96-4953-11e8-89d0-3e701d938b8b.png">

## changelog

- Alert modal now has a header with gray bg, and warning icon, no border-radius
- Warning icon added to icon-data

## review requests
Please review app alerts and PD alerts. 
@IanLondon I'm not sure if this affects your PD screens so this PR is mainly to make sure I didn't mess with your screens before moving on. I think the only screen affected is the create new protocol modal.
<img width="600" alt="screen shot 2018-04-26 at 3 54 33 pm" src="https://user-images.githubusercontent.com/3430313/39361768-e9e73010-49f1-11e8-9b8d-98f99867577c.png">





@mike while previewing run screen alerts I saw a potential second icon (lightbulb) i'm punting on that for now and hardcoding the warning icon for current alerts.
https://s3-us-west-2.amazonaws.com/opentrons-components/comp_update-alert-modal/index.html#alertmodal