### PR TITLE
fix(components): Fix wellContents in Plate becoming mandatory for every Well

### DIFF
--- a/app/src/components/CalibrateDeck/LabwareItem.js
+++ b/app/src/components/CalibrateDeck/LabwareItem.js
@@ -52,7 +52,7 @@ export default function LabwareItem (props: LabwareItemProps) {
   const item = (
     <LabwareContainer width={width} height={height} highlighted={highlighted}>
       <g className={plateClass}>
-        <Plate containerType={type} wellContents={{}} />
+        <Plate containerType={type} />
 
         {!showSpinner && (
           <ContainerNameOverlay containerName={name} containerType={type} />

--- a/components/src/deck/Plate.js
+++ b/components/src/deck/Plate.js
@@ -23,7 +23,7 @@ type WellDims = {
 
 export type PlateProps = {
   containerType: string,
-  wellContents: {[string]: SingleWell}, // Keyed by wellName, eg 'A1'
+  wellContents?: {[string]: ?SingleWell}, // Keyed by wellName, eg 'A1'
   showLabels?: boolean,
   selectable?: boolean,
   handleMouseOverWell?: (well: string) => (e: SyntheticMouseEvent<*>) => mixed,
@@ -77,7 +77,7 @@ export default class Plate extends React.Component<PlateProps> {
   createWell = (wellName: string) => {
     const { selectable, wellContents, handleMouseExitWell } = this.props
     const { originOffset, firstWell, containerLocations } = this.getContainerData()
-    const singleWellContents: SingleWell = wellContents[wellName]
+    const singleWellContents = wellContents && wellContents[wellName]
 
     // rectangular wells are centered around x, y
     const svgOffset = (typeof firstWell.width === 'number' && typeof firstWell.length === 'number')
@@ -92,18 +92,12 @@ export default class Plate extends React.Component<PlateProps> {
 
     const wellLocation = containerLocations[wellName]
 
-    const {highlighted, selected, error, fillColor} = singleWellContents
-
     return <Well
       key={wellName}
       {...{
+        ...singleWellContents,
         wellName,
         selectable,
-
-        fillColor,
-        highlighted,
-        selected,
-        error,
 
         wellLocation,
         svgOffset,

--- a/components/src/deck/Well.js
+++ b/components/src/deck/Well.js
@@ -7,10 +7,10 @@ import {SELECTABLE_WELL_CLASS} from '../constants.js'
 // import WellToolTip from '../components/WellToolTip.js' // TODO bring back tooltip in SVG, somehow
 
 export type SingleWell = {|
-  highlighted: boolean, // highlighted is the same as hovered
-  selected: boolean,
-  error: boolean,
   wellName: string,
+  highlighted?: ?boolean, // highlighted is the same as hovered
+  selected?: ?boolean,
+  error?: ?boolean,
   maxVolume?: number,
   fillColor?: ?string
 |}


### PR DESCRIPTION
## overview

#1258 broke the deck map in the app by assuming that every single well in a Plate would have an entry in the `wellContents` prop. The app does not use `wellContents`, so it threw when it got to the deckmap.

Should've caught this in review, so we (myself very much included) should be more diligent about testing these sorts of components changes across our stack. Could also have been caught by some simple snapshot tests in the app, which it may be time to start introducing.

## changelog

- fix(components): Fix wellContents in Plate becoming mandatory for every Well

## review requests

Please test in the app and PD
