### PR TITLE
fix(app): Fix some typos

### DIFF
--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -15,7 +15,7 @@ type Props = {
   response: ?WifiConfigureResponse
 }
 
-const SUCCESS_TITLE = 'Succsesfully connected to '
+const SUCCESS_TITLE = 'Successfully connected to '
 const FAILURE_TITLE = 'Could not join network'
 
 const SUCCESS_MESSAGE = 'Your robot has successfully connected to WiFi and should appear in the robot list shortly. If not, try refreshing the list manually or rebooting the robot.'

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -197,8 +197,8 @@ export default function client (dispatch) {
     // return setTimeout(() => dispatch(actions.return_tipResponse()), 1000)
 
     remote.calibration_manager.return_tip(instrument)
-    .then(() => dispatch(actions.returnTipRepsonse()))
-    .catch((error) => dispatch(actions.returnTipRepsonse(error)))
+    .then(() => dispatch(actions.returnTipResponse()))
+    .catch((error) => dispatch(actions.returnTipResponse(error)))
   }
 
   function moveTo (state, action) {


### PR DESCRIPTION
## overview

This PR fixes a couple typos (one in code, one in copy) that didn't break anything but were annoying

## changelog


- fix(app): Fix typo in return tip handler (code typo)
- fix(app): Fix typo in WiFi confirmation modal (copy typo)

## review requests

Nothing special
