### PR TITLE
Removes set mount endpoint and init pipette endpoint adds pipette initialization into start endpoint

### DIFF
--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -10,10 +10,10 @@ from opentrons.robot import robot_configs
 async def test_init_pipette(dc_session):
     robot.reset()
     model = 'p10_single_v1'
-    data = {
-        'mount': 'left',
-        'model': model}
+
+    data = {}
     await endpoints.init_pipette(data)
+
     actual = dc_session.pipettes.get('left').name
     expected = pipette_config.configs[model].name
     assert actual == expected
@@ -258,13 +258,12 @@ async def test_init_pipette_integration(async_client, monkeypatch):
         data={
             'token': token,
             'command': 'init pipette',
-            'mount': 'left',
-            'model': 'p10_single_v1'
         })
 
     body = await resp.json()
 
-    assert body['pipettes']['left'] == 'p10_single_v1'
+    assert body['pipette']['model'] == 'p10_single_v1'
+    assert body['pipette']['mount'] == 'left'
     assert endpoints.session.pipettes.get('right') is None
 
 
@@ -278,6 +277,7 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     3. Select the current pipette
     Then jog requests will work as expected.
     """
+    robot.reset()
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -293,17 +293,7 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
         '/calibration/deck',
         data={
             'token': token,
-            'command': 'init pipette',
-            'mount': 'left',
-            'model': 'p10_single_v1'
-        })
-
-    await async_client.post(
-        '/calibration/deck',
-        data={
-            'token': token,
-            'command': 'select pipette',
-            'mount': 'left'
+            'command': 'init pipette'
         })
 
     axis = 'Z'

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -7,18 +7,6 @@ from opentrons.robot import robot_configs
 
 
 # ------------ Function tests (unit) ----------------------
-async def test_init_pipette(dc_session):
-    robot.reset()
-    model = 'p10_single_v1'
-
-    data = {}
-    await endpoints.init_pipette(data)
-
-    actual = dc_session.pipettes.get('left').name
-    expected = pipette_config.configs[model].name
-    assert actual == expected
-
-
 async def test_add_and_remove_tip(dc_session):
     robot.reset()
     mount = 'left'
@@ -140,9 +128,12 @@ async def test_create_session(async_client, monkeypatch):
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    expected = {'token': dummy_token}
+    expected = {
+        'token': dummy_token,
+        'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
     resp = await async_client.post('/calibration/deck/start')
     text = await resp.text()
+    print(text)
     assert json.loads(text) == expected
     assert resp.status == 201
 
@@ -153,6 +144,8 @@ async def test_release(async_client):
     calibration returns an error if a session is in progress, and can be
     overridden.
     """
+    robot.reset()
+
     resp = await async_client.post('/calibration/deck/start')
     assert resp.status == 201
     body = await resp.json()
@@ -181,6 +174,7 @@ async def test_forcing_new_session(async_client, monkeypatch):
     calibration returns an error if a session is in progress, and can be
     overridden.
     """
+    robot.reset()
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -192,8 +186,10 @@ async def test_forcing_new_session(async_client, monkeypatch):
 
     resp = await async_client.post('/calibration/deck/start')
     text = await resp.json()
+
     assert resp.status == 201
-    expected = {'token': dummy_token}
+    expected = {'token': dummy_token,
+                'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
     assert text == expected
 
     resp1 = await async_client.post('/calibration/deck/start')
@@ -203,7 +199,8 @@ async def test_forcing_new_session(async_client, monkeypatch):
         '/calibration/deck/start', json={'force': 'true'})
     text2 = await resp2.json()
     assert resp2.status == 201
-    expected2 = {'token': dummy_token}
+    expected2 = {'token': dummy_token,
+                 'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
     assert text2 == expected2
 
 
@@ -235,38 +232,6 @@ async def test_incorrect_token(async_client, monkeypatch):
 
 
 # ------------ Router tests (integration) ----------------------
-async def test_init_pipette_integration(async_client, monkeypatch):
-    """
-    Test that initializing a pipette works as expected with a correctly formed
-    packet/ POST request.
-
-    """
-    robot.reset()
-    dummy_token = 'Test Token'
-
-    def uuid_mock():
-        return dummy_token
-
-    monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
-
-    token_res = await async_client.post('/calibration/deck/start')
-    token_text = await token_res.json()
-    token = token_text['token']
-
-    resp = await async_client.post(
-        '/calibration/deck',
-        data={
-            'token': token,
-            'command': 'init pipette',
-        })
-
-    body = await resp.json()
-
-    assert body['pipette']['model'] == 'p10_single_v1'
-    assert body['pipette']['mount'] == 'left'
-    assert endpoints.session.pipettes.get('right') is None
-
-
 async def test_set_and_jog_integration(async_client, monkeypatch):
     """
     Test that the select model function and jog function works.
@@ -288,13 +253,6 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     token_res = await async_client.post('/calibration/deck/start')
     token_text = await token_res.json()
     token = token_text['token']
-
-    await async_client.post(
-        '/calibration/deck',
-        data={
-            'token': token,
-            'command': 'init pipette'
-        })
 
     axis = 'Z'
     direction = '1'


### PR DESCRIPTION
## overview

This PR gives full control of pipette selection to the back end so that the optimal pipette is used for deck calibration.

Fixes #1257

## changelog

- 'set_current_mount' and 'init pipette' are no longer endpoints, but helper functions
- Starting a calibration session now returns the following packet:
{ 'token': "",
 'pipette': { 'mount': "",
                  'model': ""}}
- When you release a session or start a new session, it now removes previously mounted pipettes.

## review requests
- More tests I should add?
- Am I handling uncommissioned pipettes in the expected way? @mcous 
- Do names make sense still for the endpoints?
