### PR TITLE
Pd step generation handle errors

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -194,7 +194,12 @@ export const robotStateTimeline: BaseState => Array<StepGeneration.CommandsAndRo
 
     if (!isEmpty(result.formErrors)) {
       // TODO 2018-03-01 remove later
-      console.warn('Got form errors while constructing timeline', result)
+      console.log('Got form errors while constructing timeline', result)
+    }
+
+    if (result.timelineErrors) {
+      // TODO 2018-04-30 remove later
+      console.log('Got timeline errors', result)
     }
 
     return result.timeline

--- a/protocol-designer/src/step-generation/blowout.js
+++ b/protocol-designer/src/step-generation/blowout.js
@@ -1,5 +1,6 @@
 // @flow
-import type {RobotState, CommandCreator, PipetteLabwareFields} from './'
+import * as errorCreators from './errorCreators'
+import type {RobotState, CommandCreator, CommandCreatorError, PipetteLabwareFields} from './'
 
 import updateLiquidState from './dispenseUpdateLiquidState'
 
@@ -7,14 +8,24 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
   /** Blowout with given args. Requires tip. */
   const {pipette, labware, well} = args
 
+  const actionName = 'blowout'
+  let errors: Array<CommandCreatorError> = []
+
   const pipetteData = prevRobotState.instruments[pipette]
 
+  // TODO Ian 2018-04-30 this logic using command creator args + robotstate to push errors
+  // is duplicated across several command creators (eg aspirate & blowout overlap).
+  // You can probably make higher-level error creator util fns to be more DRY
   if (!pipetteData) {
-    throw new Error(`Attempted to blowout with pipette id "${pipette}", this pipette was not found under "instruments"`)
+    errors.push(errorCreators.pipetteDoesNotExist({actionName, pipette}))
   }
 
   if (prevRobotState.tipState.pipettes[pipette] === false) {
-    throw new Error(`Attempted to blowout with no tip on pipette ${pipette} from ${labware} well ${well}`)
+    errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
+  }
+
+  if (errors.length > 0) {
+    return {errors}
   }
 
   const commands = [{

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -24,7 +24,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
     // bail out before doing anything else
     return {
       errors: [errorCreators.pipetteDoesNotExist({actionName, pipette: data.pipette})]
-    } // TODO test
+    }
   }
 
   // TODO error on negative data.disposalVolume?

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -4,6 +4,7 @@ import flatMap from 'lodash/flatMap'
 import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators} from './'
 import mix from './mix'
+import * as errorCreators from './errorCreators'
 import type {ConsolidateFormData, RobotState, CommandCreator} from './'
 
 const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotState: RobotState) => {
@@ -16,9 +17,14 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
 
     A single uniform volume will be aspirated from every source well.
   */
+  const actionName = 'consolidate'
+
   const pipetteData = prevRobotState.instruments[data.pipette]
   if (!pipetteData) {
-    throw new Error('Consolidate called with pipette that does not exist in robotState, pipette id: ' + data.pipette) // TODO test
+    // bail out before doing anything else
+    return {
+      errors: [errorCreators.pipetteDoesNotExist({actionName, pipette: data.pipette})]
+    } // TODO test
   }
 
   // TODO error on negative data.disposalVolume?

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -1,13 +1,21 @@
 // @flow
-import type {RobotState, CommandCreator, AspirateDispenseArgs} from './'
+import * as errorCreators from './errorCreators'
 import updateLiquidState from './dispenseUpdateLiquidState'
+import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseArgs} from './'
 
 /** Dispense with given args. Requires tip. */
 const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
   const {pipette, volume, labware, well} = args
 
+  const actionName = 'dispense'
+  let errors: Array<CommandCreatorError> = []
+
   if (prevRobotState.tipState.pipettes[pipette] === false) {
-    throw new Error(`Attempted to dispense with no tip on pipette: ${volume} uL with ${pipette} from ${labware}'s well ${well}`)
+    errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
+  }
+
+  if (errors.length > 0) {
+    return {errors}
   }
 
   const commands = [{

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -1,0 +1,43 @@
+// @flow
+/** Utility fns to create reusable CommandCreatorErrors */
+import type {CommandCreatorError} from './types'
+
+export function insufficientTips (): CommandCreatorError {
+  return {
+    type: 'INSUFFICIENT_TIPS',
+    message: 'No more tips for pipette, cannot replace tip'
+  }
+}
+
+export function noTipOnPipette (args: {
+  actionName: string,
+  pipette: string,
+  labware: string,
+  well: string
+}): CommandCreatorError {
+  const {actionName, pipette, labware, well} = args
+  return {
+    message: `Attempted to ${actionName} with no tip on pipette: ${pipette} from ${labware}'s well ${well}`,
+    type: 'NO_TIP_ON_PIPETTE'
+  }
+}
+
+export function pipetteDoesNotExist (args: {actionName: string, pipette: string}): CommandCreatorError {
+  const {actionName, pipette} = args
+  return {
+    message: `Attempted to ${actionName} with pipette id "${pipette}", this pipette was not found under "instruments"`,
+    type: 'PIPETTE_DOES_NOT_EXIST'
+  }
+}
+
+export function pipetteVolumeExceeded (args: {
+  actionName: string,
+  volume: string | number,
+  maxVolume: string | number
+}): CommandCreatorError {
+  const {actionName, volume, maxVolume} = args
+  return {
+    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
+    type: 'PIPETTE_VOLUME_EXCEEDED'
+  }
+}

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -1,8 +1,11 @@
 // @flow
-import blowout from '../blowout'
-import {createRobotState} from './fixtures'
+import _blowout from '../blowout'
+import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures'
 
 import updateLiquidState from '../dispenseUpdateLiquidState'
+
+const blowout = commandCreatorNoErrors(_blowout)
+const blowoutWithErrors = commandCreatorHasErrors(_blowout)
 
 jest.mock('../dispenseUpdateLiquidState')
 
@@ -54,19 +57,29 @@ describe('blowout', () => {
   })
 
   test('blowout with invalid pipette ID should throw error', () => {
-    expect(() => blowout({
+    const result = blowoutWithErrors({
       pipette: 'badPipette',
       labware: 'sourcePlateId',
       well: 'A1'
-    })(robotStateWithTip)).toThrow(/Attempted to blowout with pipette id .* this pipette was not found/)
+    })(robotStateWithTip)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'PIPETTE_DOES_NOT_EXIST'
+    })
   })
 
   test('blowout with no tip should throw error', () => {
-    expect(() => blowout({
+    const result = blowoutWithErrors({
       pipette: 'p300SingleId',
       labware: 'sourcePlateId',
       well: 'A1'
-    })(initialRobotState)).toThrow(/Attempted to blowout with no tip on pipette/)
+    })(initialRobotState)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'NO_TIP_ON_PIPETTE'
+    })
   })
 
   describe('liquid tracking', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -5,11 +5,13 @@ import {
   createEmptyLiquidState,
   getTipColumn,
   getTiprackTipstate,
-  commandCreatorNoErrors
+  commandCreatorNoErrors,
+  commandCreatorHasErrors
 } from './fixtures'
 import _consolidate from '../consolidate'
 
 const consolidate = commandCreatorNoErrors(_consolidate)
+const consolidateWithErrors = commandCreatorHasErrors(_consolidate)
 
 const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
@@ -1528,6 +1530,21 @@ describe('consolidate single-channel', () => {
       }
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
+  })
+
+  test('invalid pipette ID should return error', () => {
+    const data = {
+      ...baseData,
+      sourceWells: ['A1', 'A2'],
+      volume: 150,
+      changeTip: 'once',
+      pipette: 'no-such-pipette-id-here'
+    }
+
+    const result = consolidateWithErrors(data)(robotInitialState)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].type).toEqual('PIPETTE_DOES_NOT_EXIST')
   })
 
   test('delay after dispense') // TODO Ian 2018-04-05 support delay in consolidate

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -1,7 +1,15 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotStateFixture, createEmptyLiquidState, getTipColumn, getTiprackTipstate} from './fixtures'
-import {consolidate} from '../'
+import {
+  createRobotStateFixture,
+  createEmptyLiquidState,
+  getTipColumn,
+  getTiprackTipstate,
+  commandCreatorNoErrors
+} from './fixtures'
+import _consolidate from '../consolidate'
+
+const consolidate = commandCreatorNoErrors(_consolidate)
 
 const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
@@ -127,6 +135,7 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
+
     expect(result.commands).toEqual([
       {
         command: 'pick-up-tip',
@@ -397,6 +406,7 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
+
     expect(result.commands).toEqual([
       {
         command: 'pick-up-tip',
@@ -473,6 +483,7 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
+
     expect(result.commands).toEqual([
       {
         command: 'pick-up-tip',
@@ -624,6 +635,7 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
+
     expect(result.commands).toEqual([
       {
         command: 'pick-up-tip',
@@ -788,6 +800,7 @@ describe('consolidate single-channel', () => {
     }
 
     const result = consolidate(data)(robotInitialState)
+
     expect(result.commands).toEqual([
       {
         command: 'pick-up-tip',

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -1,10 +1,17 @@
 // @flow
-import {createRobotState} from './fixtures'
-import dispense from '../dispense'
+import {
+  createRobotState,
+  commandCreatorNoErrors,
+  commandCreatorHasErrors
+} from './fixtures'
+import _dispense from '../dispense'
 
 import updateLiquidState from '../dispenseUpdateLiquidState'
 
 jest.mock('../dispenseUpdateLiquidState')
+
+const dispense = commandCreatorNoErrors(_dispense)
+const dispenseWithErrors = commandCreatorHasErrors(_dispense)
 
 describe('dispense', () => {
   let initialRobotState
@@ -54,12 +61,17 @@ describe('dispense', () => {
     })
 
     test('dispensing without tip should throw error', () => {
-      expect(() => dispense({
+      const result = dispenseWithErrors({
         pipette: 'p300SingleId',
         volume: 50,
         labware: 'sourcePlateId',
         well: 'A1'
-      })(initialRobotState)).toThrow(/Attempted to dispense with no tip on pipette/)
+      })(initialRobotState)
+
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toMatchObject({
+        type: 'NO_TIP_ON_PIPETTE'
+      })
     })
 
     // TODO Ian 2018-02-12... what is excessive volume?

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -1,9 +1,11 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotState} from './fixtures'
-import dropTip from '../dropTip'
+import {createRobotState, commandCreatorNoErrors} from './fixtures'
+import _dropTip from '../dropTip'
 
 import updateLiquidState from '../dispenseUpdateLiquidState'
+
+const dropTip = commandCreatorNoErrors(_dropTip)
 
 jest.mock('../dispenseUpdateLiquidState')
 
@@ -60,7 +62,9 @@ describe('dropTip', () => {
 
   describe('replaceTip: single channel', () => {
     test('drop tip if there is a tip', () => {
-      const result = dropTip('p300SingleId')(makeRobotState({singleHasTips: true, multiHasTips: true}))
+      const result = dropTip('p300SingleId')(makeRobotState({singleHasTips: true, multiHasTips: true})
+      )
+
       expect(result.commands).toEqual([{
         command: 'drop-tip',
         pipette: 'p300SingleId',

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures.js
@@ -6,6 +6,26 @@ import range from 'lodash/range'
 import reduce from 'lodash/reduce'
 import {tiprackWellNamesFlat} from '../'
 import type {RobotState, PipetteData, LabwareData} from '../'
+import type {CommandsAndRobotState, CommandCreatorErrorResponse} from '../types'
+
+/** Used to wrap command creators in tests, effectively casting their results
+ **  to normal response or error response
+ **/
+export const commandCreatorNoErrors = (command: *) => (commandArgs: *) => (state: RobotState): CommandsAndRobotState => {
+  const result = command(commandArgs)(state)
+  if (result.errors) {
+    throw new Error('expected no errors, got ' + JSON.stringify(result.errors))
+  }
+  return result
+}
+
+export const commandCreatorHasErrors = (command: *) => (commandArgs: *) => (state: RobotState): CommandCreatorErrorResponse => {
+  const result = command(commandArgs)(state)
+  if (!result.errors) {
+    throw new Error('expected errors')
+  }
+  return result
+}
 
 // Eg {A1: true, B1: true, ...}
 type WellTipState = {[wellName: string]: boolean}

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -1,9 +1,11 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotState, getTiprackTipstate, getTipColumn} from './fixtures'
-import {replaceTip} from '../'
+import {createRobotState, getTiprackTipstate, getTipColumn, commandCreatorNoErrors} from './fixtures'
+import _replaceTip from '../replaceTip'
 
 import updateLiquidState from '../dispenseUpdateLiquidState'
+
+const replaceTip = commandCreatorNoErrors(_replaceTip)
 
 jest.mock('../dispenseUpdateLiquidState')
 

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -1,6 +1,13 @@
 // @flow
-import touchTip from '../touchTip'
-import {createRobotState} from './fixtures'
+import _touchTip from '../touchTip'
+import {
+  createRobotState,
+  commandCreatorNoErrors,
+  commandCreatorHasErrors
+} from './fixtures'
+
+const touchTip = commandCreatorNoErrors(_touchTip)
+const touchTipWithErrors = commandCreatorHasErrors(_touchTip)
 
 describe('touchTip', () => {
   const _robotFixtureArgs = {
@@ -31,18 +38,28 @@ describe('touchTip', () => {
   })
 
   test('touchTip with invalid pipette ID should throw error', () => {
-    expect(() => touchTip({
+    const result = touchTipWithErrors({
       pipette: 'badPipette',
       labware: 'sourcePlateId',
       well: 'A1'
-    })(robotStateWithTip)).toThrow(/Attempted to touchTip with pipette id .* this pipette was not found/)
+    })(robotStateWithTip)
+
+    expect(result.errors).toEqual([{
+      message: 'Attempted to touchTip with pipette id "badPipette", this pipette was not found under "instruments"',
+      type: 'PIPETTE_DOES_NOT_EXIST'
+    }])
   })
 
   test('touchTip with no tip should throw error', () => {
-    expect(() => touchTip({
+    const result = touchTipWithErrors({
       pipette: 'p300SingleId',
       labware: 'sourcePlateId',
       well: 'A1'
-    })(initialRobotState)).toThrow(/Attempted to touchTip with no tip on pipette/)
+    })(initialRobotState)
+
+    expect(result.errors).toEqual([{
+      message: 'Attempted to touchTip with no tip on pipette: p300SingleId from sourcePlateId\'s well A1',
+      type: 'NO_TIP_ON_PIPETTE'
+    }])
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -178,6 +178,20 @@ test('transfer with multiple sets of wells', () => {
   // TODO Ian 2018-04-02 robotState, liquidState checks
 })
 
+test('invalid pipette ID should throw error', () => {
+  transferArgs = {
+    ...transferArgs,
+    pipette: 'no-such-pipette-id-here'
+  }
+
+  const result = transferWithErrors(transferArgs)(robotInitialState)
+
+  expect(result.errors).toHaveLength(1)
+  expect(result.errors[0]).toMatchObject({
+    type: 'PIPETTE_DOES_NOT_EXIST'
+  })
+})
+
 describe('single transfer exceeding pipette max', () => {
   beforeEach(() => {
     transferArgs = {

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -1,8 +1,11 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotState} from './fixtures' // getTipColumn, getTiprackTipstate, createEmptyLiquidState
-import transfer from '../transfer'
+import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures' // getTipColumn, getTiprackTipstate, createEmptyLiquidState
+import _transfer from '../transfer'
 import {FIXED_TRASH_ID} from '../../constants'
+
+const transfer = commandCreatorNoErrors(_transfer)
+const transferWithErrors = commandCreatorHasErrors(_transfer)
 
 let transferArgs
 let robotInitialState
@@ -78,10 +81,12 @@ describe('pick up tip if no tip on pipette', () => {
       changeTip: 'never'
     }
 
-    expect(
-      // $FlowFixMe // TODO Ian 2018-04-02: here, flow doesn't like transferArgs fields
-      () => transfer(transferArgs)(robotInitialState)
-    ).toThrow(/Attempted to aspirate with no tip.*/)
+    const result = transferWithErrors(transferArgs)(robotInitialState)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'NO_TIP_ON_PIPETTE'
+    })
   })
 })
 

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -34,19 +34,18 @@ describe('reduceCommandCreators', () => {
   })
 
   const divideCreator: any = (num: number) => (prevState: CountState) => {
-    let errors = []
-
     if (num === 0) {
-      errors.push({
-        message: 'Cannot divide by zero',
-        type: 'DIVIDE_BY_ZERO'
-      })
+      return {
+        errors: [{
+          message: 'Cannot divide by zero',
+          type: 'DIVIDE_BY_ZERO'
+        }]
+      }
     }
 
     return {
       commands: [`command: divide by ${num}`],
-      robotState: {count: prevState.count / num},
-      errors
+      robotState: {count: prevState.count / num}
     }
   }
 

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -25,14 +25,12 @@ describe('reduceCommandCreators', () => {
   type CountState = {count: number}
   const addCreator: any = (num: number) => (prevState: CountState) => ({
     commands: [`command: add ${num}`],
-    robotState: {count: prevState.count + num},
-    errors: null
+    robotState: {count: prevState.count + num}
   })
 
   const multiplyCreator: any = (num: number) => (prevState: CountState) => ({
     commands: [`command: multiply by ${num}`],
-    robotState: {count: prevState.count * num},
-    errors: null
+    robotState: {count: prevState.count * num}
   })
 
   const divideCreator: any = (num: number) => (prevState: CountState) => {
@@ -72,16 +70,15 @@ describe('reduceCommandCreators', () => {
       multiplyCreator(3)
     ])(initialState)
 
-    expect(result.errors).toEqual([{
-      message: 'Cannot divide by zero',
-      type: 'DIVIDE_BY_ZERO'
-    }])
-
-    expect(result.errorStep).toEqual(1) // divide step passed the error
-
-    expect(result.commands).toEqual(['command: add 4'])
-
-    expect(result.robotState).toEqual({count: 9}) // state after prev adding step
+    expect(result).toEqual({
+      robotState: {count: 9}, // last valid state before division error
+      commands: ['command: add 4'], // last valid set of commands before division error
+      errors: [{
+        message: 'Cannot divide by zero',
+        type: 'DIVIDE_BY_ZERO'
+      }],
+      errorStep: 1 // divide step passed the error
+    })
   })
 })
 

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -31,7 +31,7 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
     // bail out before doing anything else
     return {
       errors: [errorCreators.pipetteDoesNotExist({actionName, pipette: data.pipette})]
-    } // TODO test
+    }
   }
 
   // TODO error on negative data.disposalVolume?

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -6,8 +6,8 @@ import aspirate from './aspirate'
 import dispense from './dispense'
 import replaceTip from './replaceTip'
 import {reduceCommandCreators} from './utils'
-// blowout, repeatArray
 import touchTip from './touchTip'
+import * as errorCreators from './errorCreators'
 import type {TransferFormData, RobotState, CommandCreator} from './'
 
 const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: RobotState) => {
@@ -24,9 +24,14 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
   */
 
   // TODO Ian 2018-04-02 following ~10 lines are identical to first lines of consolidate.js...
+  const actionName = 'transfer'
+
   const pipetteData = prevRobotState.instruments[data.pipette]
   if (!pipetteData) {
-    throw new Error('Consolidate called with pipette that does not exist in robotState, pipette id: ' + data.pipette) // TODO test
+    // bail out before doing anything else
+    return {
+      errors: [errorCreators.pipetteDoesNotExist({actionName, pipette: data.pipette})]
+    } // TODO test
   }
 
   // TODO error on negative data.disposalVolume?

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -174,17 +174,26 @@ export type Command = {|
   volume: number
 |}
 
-export type ErrorType = 'INSUFFICIENT_TIPS' // TODO Ian 2018-04-30 add in gradually: 'MISMATCHED_SOURCE_DEST_WELLS' | 'LABWARE_DOES_NOT_EXIST'
+export type ErrorType =
+  | 'INSUFFICIENT_TIPS'
+  | 'MISMATCHED_SOURCE_DEST_WELLS'
+  | 'LABWARE_DOES_NOT_EXIST'
+  | 'PIPETTE_DOES_NOT_EXIST'
+  | 'NO_TIP_ON_PIPETTE'
+  | 'PIPETTE_VOLUME_EXCEEDED'
 
 export type CommandCreatorError = {|
   message: string,
   type: ErrorType
 |}
 
-export type CommandCreator = (prevRobotState: RobotState) => {|
+export type CommandsAndRobotState = {|
   commands: Array<Command>,
-  robotState: RobotState,
-  // truthy `errors` key indicates errors while creating commands
-  errors: ?Array<CommandCreatorError>,
-  errorStep?: number,
+  robotState: RobotState
 |}
+
+export type CommandCreatorErrorResponse = {
+  errors: Array<CommandCreatorError>
+}
+
+export type CommandCreator = (prevRobotState: RobotState) => CommandsAndRobotState | CommandCreatorErrorResponse

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -174,7 +174,17 @@ export type Command = {|
   volume: number
 |}
 
+export type ErrorType = 'INSUFFICIENT_TIPS' // TODO Ian 2018-04-30 add in gradually: 'MISMATCHED_SOURCE_DEST_WELLS' | 'LABWARE_DOES_NOT_EXIST'
+
+export type CommandCreatorError = {|
+  message: string,
+  type: ErrorType
+|}
+
 export type CommandCreator = (prevRobotState: RobotState) => {|
   commands: Array<Command>,
-  robotState: RobotState
+  robotState: RobotState,
+  // truthy `errors` key indicates errors while creating commands
+  errors: ?Array<CommandCreatorError>,
+  errorStep?: number,
 |}

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -38,11 +38,10 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
 
         return {
           robotState: next.robotState,
-          commands: [...prev.commands, ...next.commands],
-          errors: null
+          commands: [...prev.commands, ...next.commands]
         }
       },
-      {robotState: cloneDeep(prevRobotState), commands: [], errors: null}
+      {robotState: cloneDeep(prevRobotState), commands: []}
       // TODO: should I clone here (for safety) or is it safe enough?
       // Should I avoid cloning in the CommandCreators themselves and just do it pre-emptively in here?
     )


### PR DESCRIPTION
## overview

Closes #1276 

For the TL;DR, see the new test in `protocol-designer/src/step-generation/test-with-flow/utils.test.js` (line 64: `'error in a command short-circuits the command creation pipeline'`)

## changelog

- Changes `step-generation`'s command creators. Instead of throwing an error, they now return an error state if they are called with arguments and/or RobotState that doesn't make sense. The last viable RobotState and commands array is passed down.

- Eg if you run out of tips in PD now, it doesn't white screen. The error is only visible if you look at the console: `Got timeline errors` and inside `timelineErrors` you'll see:

```javascript
{
  message : "No more tips for pipette, cannot replace tip",
  type: "INSUFFICIENT_TIPS"
}
```

- Since the tests in `step-generation` are typed, flow gets mad when you try to access `result.robotState` because the command creator might have returned `{error: *}` instead of `{commands: Commands[], robotState: RobotState}` To get around this, I used `commandCreatorNoErrors` and `commandCreatorHasErrors` in the tests which enforce that the result of the command creator is one type or the other.

- Created some `errorCreators` to make the errors from the command creators more consistent

## review requests

Mostly code review, there are no UI changes in this PR (#1086 will actually bring these `timelineErrors` into UI world). But play around with PD and see if you can get it to break. Also confirm that running out of tips won't white screen.