### PR TITLE
feat(app): Add action + reducer for starting deck calibration

### DIFF
--- a/app/src/http-api-client/__tests__/calibration.test.js
+++ b/app/src/http-api-client/__tests__/calibration.test.js
@@ -1,0 +1,187 @@
+// http api /calibration/** tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {
+  reducer,
+  startDeckCalibration
+} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const NAME = 'opentrons-dev'
+
+describe('/calibration/**', () => {
+  let robot
+  let state
+  let store
+
+  beforeEach(() => {
+    client.__clearMock()
+
+    robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
+    state = {api: {calibration: {}}}
+    store = mockStore(state)
+  })
+
+  describe('startDeckCalibration action creator', () => {
+    const path = 'deck/start'
+    const response = {
+      token: 'token',
+      pipette: {mount: 'left', model: 'p300_single_v1'}
+    }
+
+    test('calls POST /calibration/deck/start', () => {
+      const expected = {force: false}
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(startDeckCalibration(robot))
+        .then(() => expect(client).toHaveBeenCalledWith(
+          robot,
+          'POST',
+          'calibration/deck/start',
+          expected
+        ))
+    })
+
+    test('calls POST /calibration/deck/start with force: true', () => {
+      const expected = {force: true}
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(startDeckCalibration(robot, true))
+        .then(() => expect(client).toHaveBeenCalledWith(
+          robot,
+          'POST',
+          'calibration/deck/start',
+          expected
+        ))
+    })
+
+    test('dispatches CAL_REQUEST and CAL_SUCCESS', () => {
+      const request = {force: false}
+      const expectedActions = [
+        {type: 'api:CAL_REQUEST', payload: {robot, request, path}},
+        {type: 'api:CAL_SUCCESS', payload: {robot, response, path}}
+      ]
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(startDeckCalibration(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches CAL_REQUEST and CAL_FAILURE', () => {
+      const request = {force: false}
+      const error = {name: 'ResponseError', status: 409, message: ''}
+      const expectedActions = [
+        {type: 'api:CAL_REQUEST', payload: {robot, request, path}},
+        {type: 'api:CAL_FAILURE', payload: {robot, error, path}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(startDeckCalibration(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  const REDUCER_REQUEST_RESPONSE_TESTS = [
+    {
+      path: 'deck/start',
+      request: {},
+      response: {
+        token: 'token',
+        pipette: {mount: 'left', model: 'p300_single_v1'}
+      }
+    }
+  ]
+
+  REDUCER_REQUEST_RESPONSE_TESTS.forEach((spec) => {
+    const {path, request, response} = spec
+
+    describe(`reducer with /calibration/${path}`, () => {
+      beforeEach(() => {
+        state = state.api
+      })
+
+      test('handles CAL_REQUEST', () => {
+        const action = {
+          type: 'api:CAL_REQUEST',
+          payload: {path, robot, request}
+        }
+
+        expect(reducer(state, action).calibration).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              inProgress: true,
+              error: null,
+              response: null
+            }
+          }
+        })
+      })
+
+      test('handles CAL_SUCCESS', () => {
+        const action = {
+          type: 'api:CAL_SUCCESS',
+          payload: {path, robot, response}
+        }
+
+        state.calibration[NAME] = {
+          [path]: {
+            request,
+            inProgress: true,
+            error: null,
+            response: null
+          }
+        }
+
+        expect(reducer(state, action).calibration).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              response,
+              inProgress: false,
+              error: null
+            }
+          }
+        })
+      })
+
+      test('handles CAL_FAILURE', () => {
+        const error = {message: 'we did not do it!'}
+        const action = {
+          type: 'api:CAL_FAILURE',
+          payload: {path, robot, error}
+        }
+
+        state.calibration[NAME] = {
+          [path]: {
+            request,
+            inProgress: true,
+            error: null,
+            response: null
+          }
+        }
+
+        expect(reducer(state, action).calibration).toEqual({
+          [NAME]: {
+            [path]: {
+              request,
+              error,
+              response: null,
+              inProgress: false
+            }
+          }
+        })
+      })
+    })
+  })
+})

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -1,0 +1,174 @@
+// @flow
+// http api client module for /calibration/**
+import type {Action, ThunkPromiseAction} from '../types'
+import type {RobotService, Mount} from '../robot'
+import type {ApiCall, ApiRequestError} from './types'
+
+import client from './client'
+
+type DeckStartRequest = {
+  force?: boolean
+}
+
+type DeckStartResponse = {
+  token: string,
+  pipette: {
+    mount: Mount,
+    model: string
+  },
+}
+
+type CalRequest = DeckStartRequest
+
+type CalResponse = DeckStartResponse
+
+type RequestPath = 'deck/start'
+
+type CalRequestAction = {|
+  type: 'api:CAL_REQUEST',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    request: CalRequest,
+  |}
+|}
+
+type CalSuccessAction = {|
+  type: 'api:CAL_SUCCESS',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    response: CalResponse,
+  |}
+|}
+
+type CalFailureAction = {|
+  type: 'api:CAL_FAILURE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+    error: ApiRequestError,
+  |}
+|}
+
+export type CalibrationAction =
+  | CalRequestAction
+  | CalSuccessAction
+  | CalFailureAction
+
+type RobotCalState = {
+  'deck/start': ?ApiCall<DeckStartRequest, DeckStartResponse>
+}
+
+type CalState = {
+  [robotName: string]: ?RobotCalState
+}
+
+// const DECK: RequestPath = 'deck'
+const DECK_START: RequestPath = 'deck/start'
+
+// DEBUG(mc, 2018-04-30): remove when UI is wired
+global.startDeckCalibration = startDeckCalibration
+
+export function startDeckCalibration (
+  robot: RobotService,
+  force: boolean = false
+): ThunkPromiseAction {
+  const request = {force}
+
+  return (dispatch) => {
+    dispatch(calRequest(robot, DECK_START, request))
+
+    return client(robot, 'POST', `calibration/${DECK_START}`, request)
+      .then((res: DeckStartResponse) => calSuccess(robot, DECK_START, res))
+      .catch((err: ApiRequestError) => calFailure(robot, DECK_START, err))
+      .then(dispatch)
+  }
+}
+
+export function calibrationReducer (
+  state: ?CalState,
+  action: Action
+): CalState {
+  if (!state) return {}
+
+  let name
+  let path
+  let request
+  let response
+  let error
+  let stateByName
+
+  switch (action.type) {
+    case 'api:CAL_REQUEST':
+      ({path, request, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {request, inProgress: true, response: null, error: null}
+        }
+      }
+
+    case 'api:CAL_SUCCESS':
+      ({path, response, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {
+            ...stateByName[path],
+            response,
+            inProgress: false,
+            error: null
+          }
+        }
+      }
+
+    case 'api:CAL_FAILURE':
+      ({path, error, robot: {name}} = action.payload)
+      stateByName = state[name] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {
+            ...stateByName[path],
+            error,
+            inProgress: false
+          }
+        }
+      }
+  }
+
+  return state
+}
+
+function calRequest (
+  robot: RobotService,
+  path: RequestPath,
+  request: CalRequest
+): CalRequestAction {
+  return {type: 'api:CAL_REQUEST', payload: {robot, path, request}}
+}
+
+function calSuccess (
+  robot: RobotService,
+  path: RequestPath,
+  response: CalResponse
+): CalSuccessAction {
+  return {type: 'api:CAL_SUCCESS', payload: {robot, path, response}}
+}
+
+function calFailure (
+  robot: RobotService,
+  path: RequestPath,
+  error: ApiRequestError
+): CalFailureAction {
+  return {type: 'api:CAL_FAILURE', payload: {robot, path, error}}
+}

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -3,14 +3,12 @@
 
 import type {Error} from '../types'
 import type {RobotService} from '../robot'
+import type {ApiRequestError} from './client'
 
 type Method = 'GET' | 'POST'
 
-export type ApiRequestError = Error & {
-  url?: string,
-  status?: number,
-  statusText?: string,
-}
+// TODO(mc, 2018-04-30): deprecate importing this type from client
+export type {ApiRequestError}
 
 // not a real Error or Response so it can be copied across worker boundries
 function ResponseError (

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -1,6 +1,7 @@
 // @flow
 // robot HTTP API client module
 import {combineReducers} from 'redux'
+import {calibrationReducer, type CalibrationAction} from './calibration'
 import {healthReducer, type HealthAction} from './health'
 import {healthCheckReducer, type HealthCheckAction} from './health-check'
 import {motorsReducer, type MotorsAction} from './motors'
@@ -10,6 +11,7 @@ import {serverReducer, type ServerAction} from './server'
 import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
+  calibration: calibrationReducer,
   health: healthReducer,
   healthCheck: healthCheckReducer,
   motors: motorsReducer,
@@ -19,9 +21,7 @@ export const reducer = combineReducers({
   wifi: wifiReducer
 })
 
-export type {
-  ApiRequestError
-} from './client'
+export * from './types'
 
 export type {
   RobotHealth,
@@ -57,6 +57,7 @@ export type {
 export type State = $Call<typeof reducer>
 
 export type Action =
+  | CalibrationAction
   | HealthAction
   | HealthCheckAction
   | MotorsAction
@@ -64,6 +65,10 @@ export type Action =
   | RobotAction
   | ServerAction
   | WifiAction
+
+export {
+  startDeckCalibration
+} from './calibration'
 
 export {
   fetchHealth,

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -1,7 +1,13 @@
 // @flow
 // http api client types
 
-import type {ApiRequestError} from './client'
+import type {Error} from '../types'
+
+export type ApiRequestError = Error & {
+  url?: string,
+  status?: number,
+  statusText?: string,
+}
 
 export type ApiCall<T, U> = {
   /** request in progress flag */


### PR DESCRIPTION
## overview

This PR lays groundwork for #974, #1008, and #1238 by giving the API client the ability to call and keep track of the `POST /calibration/deck/start` endpoint (which checks that pipettes are present, issues a calibration session token, and returns a pipette to use for calibration).

This is a redux only PR because wiring to UI would've made the diff too large.

## changelog

- feat(app): Add action + reducer for starting deck calibration 

## review requests

Code review would be useful. You could wait until it's wired to UI in an upcoming PR to test functionality, or you could test on a real robot / virtual smoothie:

1. Launch the app and open the dev console
2. `> store.getState()`
3. Expand the state object up to and including `state.robot.connection.discoveredByName`
4. Right click on the robot you're testing with and select "Store as Global Variable"
    * Will store as `temp1`

- `> store.dispatch(startDeckCalibration(temp1))` - without `force`
- `> store.dispatch(startDeckCalibration(temp1, true))` - with `force`

Examine the state in the "Redux" tab for `state.api.calibration[robotName]`

Tested on sunset bot:

- [x] App stores token and calibration pipette on `POST /calibration/deck/start`
- [x] App stores 403 Forbidden error if robot has no pipettes attached
- [x] App stores 409 Conflict error is a previous calibration session has been started and not released
- [x] App stores token and calibration pipette when request is sent with `{"force": true}`