### PR TITLE
Multi-channel drop tips in middle of trash

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1013,6 +1013,9 @@ class Pipette:
             if 'rack' in location.get_parent().get_type():
                 half_tip_length = self._tip_length / 2
                 location = location.top(-half_tip_length)
+            elif 'trash' in location.get_parent().get_type():
+                loc, coords = location.top()
+                location = (loc, coords + (0, self.model_offset[1], 0))
             else:
                 location = location.top()
 

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -60,7 +60,7 @@ def log_init():
         loggers={
             '__main__': {
                 'handlers': ['debug'],
-                'level': level_value
+                'level': logging.INFO
             },
             'opentrons.server': {
                 'handlers': ['debug'],

--- a/api/opentrons/util/calibration_functions.py
+++ b/api/opentrons/util/calibration_functions.py
@@ -85,6 +85,7 @@ def probe_instrument(instrument, robot, tip_length=None) -> Point:
 
     safe_height = _calculate_safeheight(robot, Z_CROSSOVER_CLEARANCE)
 
+    log.info("Moving to safe z: {}".format(safe_height))
     robot.poses = instrument._move(robot.poses, z=safe_height)
 
     for axis, x, y, z, distance in hot_spots:
@@ -97,6 +98,7 @@ def probe_instrument(instrument, robot, tip_length=None) -> Point:
             x = x + center.x
             y = y + center.y
 
+        log.info("Moving to {}".format((x, y, z)))
         robot.poses = instrument._move(robot.poses, x=x, y=y)
         robot.poses = instrument._move(robot.poses, z=z)
 


### PR DESCRIPTION
## overview

Adjust pipette drop tip position for trash containers by the pipette config y offset. Fixes #1109 

## changelog

- (fix) Adjust pipette drop tip position for trash containers by the pipette config y offset

## review requests

Confirmed that the new test corresponds to reality on 🌔 🌔 
