### PR TITLE
feat(app): Wire "Calibrate" button to POST /calibration/deck/start

### DIFF
--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -1,14 +1,25 @@
 // @flow
-import type {RobotMoveState} from '../../http-api-client'
+import type {PipetteConfig} from '@opentrons/labware-definitions'
+import type {RobotService} from '../../robot'
+import type {RobotMoveState, DeckCalStartState} from '../../http-api-client'
 
-export type CalibrateDeckProps = {
+export type OP = {
   title: string,
   subtitle: string,
+  robot: RobotService,
   parentUrl: string,
   baseUrl: string,
-  confirmUrl: string,
   exitUrl: string,
+}
+
+export type SP = {
+  pipette: ?PipetteConfig,
+  startRequest: DeckCalStartState,
   moveRequest: RobotMoveState,
-  moveToFront: () => mixed,
+}
+
+export type DP = {
   back: () => mixed,
 }
+
+export type CalibrateDeckProps = OP & SP & DP

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -1,29 +1,48 @@
 // @flow
 // Card for displaying/initiating factory calibration
 import * as React from 'react'
-import {Link} from 'react-router-dom'
+import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+
 import type {Robot} from '../../robot'
+import {startDeckCalibration} from '../../http-api-client'
 import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
 
-type Props = Robot
+type OP = Robot
+
+type DP = {
+  start: () => mixed
+}
+
+type Props = OP & DP
 
 const TITLE = 'Initial robot calibration'
-const LAST_RUN_LABEL = 'Last Run:'
+const LAST_RUN_LABEL = 'Last Run'
 const CALIBRATION_MESSAGE = 'Calibrate your robot to initial factory settings to ensure accuracy.'
 
-export default function CalibrationCard (props: Props) {
-  const {name} = props
-  const lastCalibrated = 'never'
-  const url = `/robots/${name}/deck-calibration/step-1`
+export default connect(null, mapDispatchToProps)(CalibrationCard)
+
+function CalibrationCard (props: Props) {
+  const {start} = props
+
   return (
     <Card title={TITLE} description={CALIBRATION_MESSAGE}>
     <LabeledValue
       label={LAST_RUN_LABEL}
-      value={lastCalibrated}
+      value='Never'
     />
-    <OutlineButton Component={Link} to={url}>
+    <OutlineButton onClick={start}>
       Calibrate
     </OutlineButton>
     </Card>
   )
+}
+
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  const stepOneUrl = `/robots/${ownProps.name}/deck-calibration/step-1`
+
+  return {
+    start: () => dispatch(startDeckCalibration(ownProps))
+      .then(() => dispatch(push(stepOneUrl)))
+  }
 }

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -1,7 +1,8 @@
 // @flow
 // http api client module for /calibration/**
-import type {Action, ThunkPromiseAction} from '../types'
-import type {RobotService, Mount} from '../robot'
+import {createSelector, type Selector} from 'reselect'
+import type {State, Action, ThunkPromiseAction} from '../types'
+import type {BaseRobot, RobotService, Mount} from '../robot'
 import type {ApiCall, ApiRequestError} from './types'
 
 import client from './client'
@@ -56,8 +57,10 @@ export type CalibrationAction =
   | CalSuccessAction
   | CalFailureAction
 
+export type DeckCalStartState = ApiCall<DeckStartRequest, DeckStartResponse>
+
 type RobotCalState = {
-  'deck/start': ?ApiCall<DeckStartRequest, DeckStartResponse>
+  'deck/start'?: DeckCalStartState
 }
 
 type CalState = {
@@ -66,9 +69,6 @@ type CalState = {
 
 // const DECK: RequestPath = 'deck'
 const DECK_START: RequestPath = 'deck/start'
-
-// DEBUG(mc, 2018-04-30): remove when UI is wired
-global.startDeckCalibration = startDeckCalibration
 
 export function startDeckCalibration (
   robot: RobotService,
@@ -147,6 +147,19 @@ export function calibrationReducer (
   }
 
   return state
+}
+
+export function makeGetDeckCalibrationStartState () {
+  const sel: Selector<State, BaseRobot, DeckCalStartState> = createSelector(
+    selectRobotCalState,
+    (state) => state[DECK_START] || {inProgress: false}
+  )
+
+  return sel
+}
+
+function selectRobotCalState (state: State, props: BaseRobot): RobotCalState {
+  return state.api.calibration[props.name] || {}
 }
 
 function calRequest (

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -24,6 +24,10 @@ export const reducer = combineReducers({
 export * from './types'
 
 export type {
+  DeckCalStartState
+} from './calibration'
+
+export type {
   RobotHealth,
   HealthSuccessAction,
   HealthFailureAction
@@ -67,7 +71,8 @@ export type Action =
   | WifiAction
 
 export {
-  startDeckCalibration
+  startDeckCalibration,
+  makeGetDeckCalibrationStartState
 } from './calibration'
 
 export {


### PR DESCRIPTION
## overview

This PR wires `POST /calibration/deck/start` to the Calibrate button in the RobotSettings page. Because that endpoint handles issuing the token and selecting a pipette to use for calibration, merging this PR:

- Addresses checkboxes 1 and 3 of #974
- Closes #1008
- Addresses checkbox 3 of #1235
- Closes #1236

## changelog

- feat(app): Wire "Calibrate" button to POST /calibration/deck/start

## review requests

Standard review. Expected behavior:

- On first click of "Calibrate" (i.e. no token issued) with pipette(s) attached
    - [x] App proceeds to Clear Deck Alert Modal
- On second click (i.e. token already issued)
    - [x] App does not proceed to Clear Deck modal
    - [x] App displays TODO message at bottom of screen about forcing control
- On first click without pipettes attached 
    - [x] App does not proceed to Clear Deck modal
    - [x] App displays TODO message at bottom of screen about pipettes

Please note that "first" and "second" clicks are from the perspective of the API, not the app. In other words, you'll want to relaunch the API to reset the token state.