### PR TITLE
PD: show user "not enough tips" error

### DIFF
--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -1,3 +1,5 @@
+@import '..';
+
 .alert {
   position: absolute;
   top: 0;
@@ -34,7 +36,7 @@
     color: #7c4d00;
 
     & svg {
-      fill: #e28200;
+      fill: var(--c-warning);
     }
   }
 }
@@ -44,7 +46,7 @@
 }
 
 .alert_body.warning {
-  border: 1px solid #e28200;
+  border: 1px solid var(--c-warning);
 }
 
 .message {

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -68,11 +68,13 @@ export default function TitledList (props: ListProps) {
     [styles.clickable]: props.onClick
   })
 
+  const iconClass = cx(styles.title_bar_icon, iconProps && iconProps.className)
+
   return (
     <div className={className} {...{onMouseEnter, onMouseLeave}}>
       <div onClick={onClick} className={titleBarClass}>
         {iconName && (
-          <Icon {...iconProps} className={styles.title_bar_icon} name={iconName} />
+          <Icon {...iconProps} className={iconClass} name={iconName} />
         )}
         <h3 className={styles.title}>
           {props.title}

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -18,6 +18,7 @@
 
   /* general UI */
   --c-highlight: #5fd8ee;
+  --c-warning: #e28200;
 
   /* Misc */
   --c-overlay: rgba(0, 0, 0, 0.7);

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 
+import Alerts from '../containers/Alerts'
 import ConnectedMoreOptionsModal from '../containers/ConnectedMoreOptionsModal'
 import ConnectedNav from '../containers/ConnectedNav'
 import ConnectedStepEditForm from '../containers/ConnectedStepEditForm'
@@ -26,6 +27,7 @@ export default function ProtocolEditor () {
         <ConnectedSidebar />
         <div className={styles.main_page_wrapper}>
           <ConnectedTitleBar />
+          <Alerts />
 
           <div className={styles.main_page_content}>
             <ConnectedNewFileModal />

--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -123,3 +123,7 @@
   /* TODO Ian 2018-04-09 this border for highlight is also in lists.css in complib. Export from complib as class? */
   border: 2px solid var(--c-blue);
 }
+
+.error_icon {
+  fill: var(--c-warning);
+}

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -15,6 +15,7 @@ type StepItemProps = {
   description?: string,
   collapsed?: boolean,
   selected?: boolean,
+  error?: ?boolean,
   sourceLabwareName?: string,
   destLabwareName?: string,
   onClick?: (event: SyntheticEvent<>) => void,
@@ -33,6 +34,7 @@ export default function StepItem (props: StepItemProps) {
     destLabwareName,
     collapsed,
     selected,
+    error,
     onClick,
     onMouseEnter,
     onMouseLeave,
@@ -51,7 +53,9 @@ export default function StepItem (props: StepItemProps) {
     <TitledList
       className={styles.step_item}
       description={Description}
-      {...{iconName, title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
+      iconName={error ? 'alert' : iconName} // TODO change 'alert' to 'warning' when icon names are switched
+      iconProps={{className: error ? styles.error_icon : ''}}
+      {...{title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
     >
       {showLabwareHeader && <li className={styles.aspirate_dispense}>
           <span>ASPIRATE</span>

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -53,7 +53,7 @@ export default function StepItem (props: StepItemProps) {
     <TitledList
       className={styles.step_item}
       description={Description}
-      iconName={error ? 'alert' : iconName} // TODO change 'alert' to 'warning' when icon names are switched
+      iconName={error ? 'alert' : iconName}
       iconProps={{className: error ? styles.error_icon : ''}}
       {...{title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
     >

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -5,7 +5,7 @@ import pick from 'lodash/pick'
 import {SidePanel, TitledList} from '@opentrons/components'
 
 import {END_STEP} from '../steplist/types'
-import type {StepItemData, StepSubItemData, StepIdType, SubstepIdentifier} from '../steplist/types'
+import type {StepItemsWithSubsteps, StepIdType, SubstepIdentifier} from '../steplist/types'
 
 import StepItem from '../components/StepItem'
 import TransferishSubstep from '../components/TransferishSubstep'
@@ -17,7 +17,7 @@ type StepListProps = {
   errorStepId: ?StepIdType, // this is the first step with an error
   selectedStepId: StepIdTypeWithEnd | null,
   hoveredSubstep: SubstepIdentifier,
-  steps: Array<StepItemData & {substeps: StepSubItemData}>,
+  steps: Array<StepItemsWithSubsteps>,
   handleSubstepHover: SubstepIdentifier => mixed,
   handleStepItemClickById?: (StepIdTypeWithEnd) => (event?: SyntheticEvent<>) => mixed,
   handleStepItemCollapseToggleById?: (StepIdType) => (event?: SyntheticEvent<>) => mixed,

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -14,6 +14,7 @@ import StepCreationButton from '../containers/StepCreationButton'
 type StepIdTypeWithEnd = StepIdType | typeof END_STEP
 
 type StepListProps = {
+  errorStepId: ?StepIdType, // this is the first step with an error
   selectedStepId: StepIdTypeWithEnd | null,
   hoveredSubstep: SubstepIdentifier,
   steps: Array<StepItemData & {substeps: StepSubItemData}>,
@@ -61,6 +62,10 @@ export default function StepList (props: StepListProps) {
     >
       {props.steps && props.steps.map((step, key) => (
         <StepItem key={key}
+          error={(props.errorStepId && step.id)
+            ? (step.id >= props.errorStepId)
+            : false
+          }
           onClick={props.handleStepItemClickById && props.handleStepItemClickById(step.id)}
           onMouseEnter={props.handleStepHoverById && props.handleStepHoverById(step.id)}
           onCollapseToggle={

--- a/protocol-designer/src/containers/Alert.css
+++ b/protocol-designer/src/containers/Alert.css
@@ -1,0 +1,9 @@
+@import '@opentrons/components';
+
+.alert {
+  position: relative;
+  border: 1px solid var(--c-warning);
+
+  /* NOTE Ian 2018-05-01: borders for AlertItem depend on contents, PD doesn't match App?
+  Also, missing X moves message to the right */
+}

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from 'react'
+import type {Dispatch} from 'redux'
+import {connect} from 'react-redux'
+
+import {AlertItem} from '@opentrons/components'
+import styles from './Alert.css'
+import type {BaseState} from '../types'
+
+type ErrorType = string // TODO IMMEDIATELY import enum type
+
+type SP = {
+  alerts: Array<{
+    type: ErrorType,
+    message: string,
+    dismissId?: string // presence of dismissId allows alert to be dismissed
+  }>
+}
+
+type DP = {
+  onDismiss: (id: string) => () => mixed
+}
+
+type Props = SP & DP
+
+const captions: {[ErrorType]: string} = {
+  'TIP': 'Add another tip rack to an empty slot in Deck Setup'
+}
+
+function Alerts (props: Props) {
+  return (
+    <div>
+      {props.alerts.map((alert, key) =>
+        <AlertItem
+          className={styles.alert}
+          type='warning'
+          key={key}
+          title={alert.message}
+          onCloseClick={alert.dismissId
+            ? props.onDismiss(alert.dismissId)
+            : undefined
+          }
+        >
+          {captions[alert.type]}
+        </AlertItem>)
+      }
+    </div>
+  )
+}
+
+function mapStateToProps (state: BaseState): SP {
+  // TODO IMMEDIATELY: use selector
+  return {
+    alerts: [
+      {type: 'TEST', message: 'TEST Message is here', dismissId: '123'},
+      {type: 'TIP', message: 'TIP Message is here'},
+      {type: 'TEST', message: 'TEST Message is here', dismissId: '123'},
+      {type: 'TEST', message: 'TEST Message is here', dismissId: '123'}
+    ]
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch<*>): DP {
+  return {
+    onDismiss: (id: string) => () => console.log('dismiss warning here', id)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Alerts)

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -7,6 +7,7 @@ import {selectors} from '../steplist/reducers'
 import type {StepIdType, SubstepIdentifier} from '../steplist/types'
 import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
 import * as substepSelectors from '../top-selectors/substeps'
+import {selectors as fileDataSelectors} from '../file-data'
 import StepList from '../components/StepList'
 
 type StepIdTypeWithEnd = StepIdType | '__end__' // TODO import this; also used in StepList
@@ -17,6 +18,7 @@ type StateProps = {
   steps: $PropertyType<Props, 'steps'>,
   selectedStepId: $PropertyType<Props, 'selectedStepId'>,
   hoveredSubstep: $PropertyType<Props, 'hoveredSubstep'>,
+  errorStepId: $PropertyType<Props, 'errorStepId'>,
 }
 
 type DispatchProps = $Diff<Props, StateProps>
@@ -25,7 +27,8 @@ function mapStateToProps (state: BaseState): StateProps {
   return {
     steps: substepSelectors.allStepsWithSubsteps(state),
     selectedStepId: selectors.hoveredOrSelectedStepId(state),
-    hoveredSubstep: selectors.getHoveredSubstep(state)
+    hoveredSubstep: selectors.getHoveredSubstep(state),
+    errorStepId: fileDataSelectors.robotStateTimelineFull(state).errorStepId // TODO make mini selector
   }
 }
 

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -77,10 +77,10 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   let prevStepId: number = 0 // initial liquid state if stepId is null
   if (stepId === END_STEP) {
     // last liquid state
-    prevStepId = allWellContentsForSteps.length - 1
+    prevStepId = allWellContentsForSteps.length - 1 // TODO IMMEDIATELY not a good way to get prev step
   }
   if (typeof stepId === 'number') {
-    prevStepId = Math.max(stepId - 1, 0)
+    prevStepId = Math.max(stepId - 1, 0) // TODO IMMEDIATELY not a good way to get prev step
   }
 
   let wellContents = {}

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -110,7 +110,8 @@ export type RobotStateTimelineAcc = {
   formErrors: {[string]: string},
   timeline: Array<StepGeneration.CommandsAndRobotState>,
   robotState: StepGeneration.RobotState,
-  timelineErrors?: ?Array<StepGeneration.CommandCreatorError>
+  timelineErrors?: ?Array<StepGeneration.CommandCreatorError>,
+  errorStepId?: number
 }
 
 // exposes errors and last valid robotState
@@ -180,7 +181,8 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
       if (nextCommandsAndState.errors) {
         return {
           ...acc,
-          timelineErrors: nextCommandsAndState.errors
+          timelineErrors: nextCommandsAndState.errors,
+          errorStepId: stepId
         }
       }
       return {

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -106,19 +106,20 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   }
 )
 
-type RobotStateTimelineAcc = {
+export type RobotStateTimelineAcc = {
   formErrors: {[string]: string},
   timeline: Array<StepGeneration.CommandsAndRobotState>,
   robotState: StepGeneration.RobotState,
   timelineErrors?: ?Array<StepGeneration.CommandCreatorError>
 }
 
-export const robotStateTimeline: BaseState => Array<StepGeneration.CommandsAndRobotState> = createSelector(
+// exposes errors and last valid robotState
+export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSelector(
   steplistSelectors.validatedForms,
   steplistSelectors.orderedSteps,
   getInitialRobotState,
   (forms, orderedSteps, initialRobotState) => {
-    const result = orderedSteps.reduce((acc: RobotStateTimelineAcc, stepId): RobotStateTimelineAcc => {
+    const result: RobotStateTimelineAcc = orderedSteps.reduce((acc: RobotStateTimelineAcc, stepId): RobotStateTimelineAcc => {
       if (!isEmpty(acc.formErrors)) {
         // short-circut the reduce if there were errors with validating / processing the form
         return acc
@@ -200,6 +201,12 @@ export const robotStateTimeline: BaseState => Array<StepGeneration.CommandsAndRo
       console.log('Got timeline errors', result)
     }
 
-    return result.timeline
+    return result
   }
+)
+
+// TODO look at who uses this and see if they can use robotStateTimelineFull instead (or not)
+export const robotStateTimeline: Selector<Array<StepGeneration.CommandsAndRobotState>> = createSelector(
+  robotStateTimelineFull,
+  full => full.timeline
 )

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -5,7 +5,7 @@ import type {CommandCreatorError} from './types'
 export function insufficientTips (): CommandCreatorError {
   return {
     type: 'INSUFFICIENT_TIPS',
-    message: 'No more tips for pipette, cannot replace tip'
+    message: 'Not enough tips to complete action'
   }
 }
 

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -224,7 +224,7 @@ export function generateSubsteps (
       const namedIngredsByLabware = namedIngredsByLabwareAllSteps[prevStepId]
 
       if (!namedIngredsByLabware) {
-        // TODO IMMEDIATELY
+        // TODO Ian 2018-05-02 another assert candidate here
         console.warn(`No namedIngredsByLabware for previous step id ${prevStepId}`)
         return null
       }

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -217,7 +217,7 @@ export function generateSubsteps (
       valForm.validatedForm.stepType === 'transfer' ||
       valForm.validatedForm.stepType === 'consolidate'
     ) {
-      const namedIngredsByLabware = namedIngredsByLabwareAllSteps[stepId - 1]
+      const namedIngredsByLabware = namedIngredsByLabwareAllSteps[stepId - 1] // TODO IMMEDIATELY not a good way to get prev step
 
       const {
         pipette: pipetteId,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -3,6 +3,7 @@ import mapValues from 'lodash/mapValues'
 import range from 'lodash/range'
 
 import {getWellsForTips} from '../step-generation/utils'
+import {utils as steplistUtils} from '../steplist'
 
 import {
   formHasErrors,
@@ -193,9 +194,12 @@ export function generateSubsteps (
   validatedForms: {[StepIdType]: ValidFormAndErrors},
   allPipetteData: AllPipetteData,
   allLabwareTypes: AllLabwareTypes,
-  namedIngredsByLabwareAllSteps: NamedIngredsByLabwareAllSteps
+  namedIngredsByLabwareAllSteps: NamedIngredsByLabwareAllSteps,
+  orderedSteps: Array<StepIdType>
 ): SubSteps {
   return mapValues(validatedForms, (valForm: ValidFormAndErrors, stepId: StepIdType) => {
+    const prevStepId = steplistUtils.getPrevStepId(orderedSteps, stepId)
+
     // Don't try to render with errors. TODO LATER: presentational error state of substeps?
     if (valForm.validatedForm === null || formHasErrors(valForm)) {
       return null
@@ -217,7 +221,13 @@ export function generateSubsteps (
       valForm.validatedForm.stepType === 'transfer' ||
       valForm.validatedForm.stepType === 'consolidate'
     ) {
-      const namedIngredsByLabware = namedIngredsByLabwareAllSteps[stepId - 1] // TODO IMMEDIATELY not a good way to get prev step
+      const namedIngredsByLabware = namedIngredsByLabwareAllSteps[prevStepId]
+
+      if (!namedIngredsByLabware) {
+        // TODO IMMEDIATELY
+        console.warn(`No namedIngredsByLabware for previous step id ${prevStepId}`)
+        return null
+      }
 
       const {
         pipette: pipetteId,

--- a/protocol-designer/src/steplist/index.js
+++ b/protocol-designer/src/steplist/index.js
@@ -2,9 +2,11 @@
 // TODO Ian 2018-01-23 use this index.js for all `steplist` imports across PD
 import rootReducer, {selectors} from './reducers'
 import * as actions from './actions'
+import * as utils from './utils'
 
 export {
   actions,
   rootReducer,
-  selectors
+  selectors,
+  utils
 }

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -129,7 +129,8 @@ const savedStepForms = handleActions({
   SAVE_STEP_FORM: (state, action: SaveStepFormAction) => ({
     ...state,
     [action.payload.id]: action.payload
-  })
+  }),
+  DELETE_STEP: (state, action: DeleteStepAction) => omit(state, action.payload.toString())
 }, {})
 
 type CollapsedStepsState = {
@@ -265,7 +266,7 @@ const getCollapsedSteps = createSelector(
   (state: RootState) => state.collapsedSteps
 )
 
-const orderedStepsSelector = createSelector(
+const orderedStepsSelector: Selector<OrderedStepsState> = createSelector(
   rootSelector,
   (state: RootState) => state.orderedSteps
 )

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -406,8 +406,7 @@ const formSectionCollapseSelector: Selector<FormSectionState> = createSelector(
   s => s.formSectionCollapse
 )
 
-/** All Step data EXCEPT substeps */
-export const allSteps: Selector<Array<any>> = createSelector( // TODO Ian 2018-04-09 type this selector, no `any`
+export const allSteps: Selector<Array<StepItemData>> = createSelector(
   getSteps,
   orderedStepsSelector,
   getCollapsedSteps,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -84,14 +84,18 @@ export type StepSubItemData = TransferLikeSubstepItem | {|
   message: string
 |}
 
-export type StepItemData = {|
+export type StepItemData = {
   id: StepIdType,
   title: string,
   stepType: StepType,
-  description?: string,
-  sourceLabwareName?: string,
-  destLabwareName?: string
-|}
+  description?: ?string,
+  sourceLabwareName?: ?string,
+  destLabwareName?: ?string
+}
+
+export type StepItemsWithSubsteps = StepItemData & {
+  substeps: StepSubItemData | null
+}
 
 export type SubSteps = {[StepIdType]: StepSubItemData | null}
 

--- a/protocol-designer/src/steplist/utils.js
+++ b/protocol-designer/src/steplist/utils.js
@@ -1,0 +1,14 @@
+// @flow
+import {END_STEP, type StepIdType} from './types'
+
+export function getPrevStepId (
+  orderedSteps: Array<StepIdType>,
+  stepId: StepIdType | typeof END_STEP | null
+): StepIdType {
+  const stepIdx = orderedSteps.findIndex(idx => idx === stepId)
+  const prevStepId = (stepIdx === -1)
+  ? 0 // no previous step, use initial deck setup step 0
+  : orderedSteps[stepIdx] - 1
+
+  return prevStepId
+}

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -4,7 +4,7 @@ import mapValues from 'lodash/mapValues'
 
 import {equippedPipettes} from '../file-data/selectors/pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
-import {selectors as steplistSelectors} from '../steplist/reducers'
+import {selectors as steplistSelectors} from '../steplist'
 import {namedIngredsByLabware} from './well-contents'
 
 import {
@@ -25,9 +25,10 @@ export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = cre
   equippedPipettes,
   labwareIngredSelectors.getLabware,
   namedIngredsByLabware,
-  (_validatedForms, _pipetteData, _allLabware, _namedIngredsByLabware) => {
+  steplistSelectors.orderedSteps,
+  (_validatedForms, _pipetteData, _allLabware, _namedIngredsByLabware, _orderedSteps) => {
     const allLabwareTypes: {[labwareId: string]: string} = mapValues(_allLabware, (l: LabwareData) => l.type)
-    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _namedIngredsByLabware)
+    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _namedIngredsByLabware, _orderedSteps)
   }
 )
 

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -15,7 +15,9 @@ import type {Selector} from '../types'
 import type {LabwareData} from '../step-generation/types'
 import type {
   StepIdType,
-  StepSubItemData
+  StepSubItemData,
+  StepItemsWithSubsteps,
+  StepItemData
 } from '../steplist/types'
 
 export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
@@ -30,11 +32,11 @@ export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = cre
 )
 
 /** Mix-in substeps for each step. */
-export const allStepsWithSubsteps: * = createSelector(
+export const allStepsWithSubsteps: Selector<Array<StepItemsWithSubsteps>> = createSelector(
   steplistSelectors.allSteps,
   allSubsteps,
   (_allSteps, _allSubsteps) => {
-    return _allSteps.map((step: *, stepId: number) => ({
+    return _allSteps.map((step: StepItemData, stepId: StepIdType) => ({
       ...step,
       substeps: _allSubsteps[stepId]
     }))

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -44,7 +44,7 @@ function _wellContentsForWell (
   }
 }
 
-function _wellContentsForLabware (
+export function _wellContentsForLabware (
   labwareLiquids: SingleLabwareLiquidState,
   labwareId: string,
   labwareType: string
@@ -81,6 +81,24 @@ export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWe
           )
         }
       )
+    )
+  }
+)
+
+// const timelineFull = fileDataSelectors.robotStateTimelineFull(state)
+
+export const lastValidWellContents: Selector<{[labwareId: string]: AllWellContents}> = createSelector(
+  fileDataSelectors.robotStateTimelineFull,
+  (timelineFull) => {
+    return mapValues(
+      timelineFull.robotState.labware,
+      (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => {
+        return _wellContentsForLabware(
+          timelineFull.robotState.liquidState.labware[labwareId],
+          labwareId,
+          timelineFull.robotState.labware[labwareId].type
+        )
+      }
     )
   }
 )

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -85,8 +85,6 @@ export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWe
   }
 )
 
-// const timelineFull = fileDataSelectors.robotStateTimelineFull(state)
-
 export const lastValidWellContents: Selector<{[labwareId: string]: AllWellContents}> = createSelector(
   fileDataSelectors.robotStateTimelineFull,
   (timelineFull) => {


### PR DESCRIPTION
## overview

Closes (almost!) #1086 

## changelog

- Display errors StepList by showing error icons on the first error-ing step and all following steps
- Display errors in alert banners (they can stack)
- Tip error message matches design doc
- Safer access to prevStepId (stepId - 1 only works when there are no gaps) in SelectablePlate and generateSubsteps
- SelectablePlate falls back to last valid liquid state on the timeline when the timeline reducer bails out after encountering an error
- Clean up types of reducers - removed some `*` and `any` typing hacks

### Component library changes
- Added new color for alert border `--c-warning` to `colors.css`
- TitledList's IconProps.className was being overridden by the classname supplied by TitledList, modified TitledList so you can pass a className inside IconProps to the Icon (this was to make the alert in PD steplist orange)

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_not-enough-tips-ui-error/index.html

Can create steps without a tiprack - will get error. Can create additional steps. Adding a tiprack (or more, if you go thru a lot of tips) will make the error go away and everything should look normal again.

Error icon (`alert`) will show next to a step with an error, and all following steps

Hovering over steps in the steplist to see updates in liquid state and to see hovered wells doesn't work for a step with an error, or the steps subsequent to the erroring step. It will just show the last valid liquid state before the error happened.

You shouldn't see any warnings or errors in the console, except `formErrors` bugging you that the step form isn't saved, before you save it.