### PR TITLE
Use existing pipette in control functions

### DIFF
--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -244,10 +244,6 @@ async def test_move_pipette(virtual_smoothie_env, loop, test_client):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
     robot.home()
-    # from opentrons.trackers import pose_tracker
-    # print("Before: {}".format(tuple(
-    #             pose_tracker.absolute(
-    #                 robot.poses, robot._actuators['right']['carriage']))))
     data = {
         'target': 'pipette',
         'point': [100, 200, 50],
@@ -256,8 +252,28 @@ async def test_move_pipette(virtual_smoothie_env, loop, test_client):
     }
     res = await cli.post('/robot/move', json=data)
     assert res.status == 200
-    # text = await res.text()
-    # print("Final: {}".format(tuple(
-    #             pose_tracker.absolute(
-    #                 robot.poses, robot._actuators['right']['carriage']))))
-    # print("=-> Result: {}".format(text))
+
+
+async def test_move_and_home_existing_pipette(
+        virtual_smoothie_env, loop, test_client):
+    from opentrons import instruments
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+    robot.reset()
+    robot.home()
+    instruments.P300_Single(mount='right')
+    move_data = {
+        'target': 'pipette',
+        'point': [100, 200, 50],
+        'mount': 'right',
+        'model': 'p300_single_v1'
+    }
+    res = await cli.post('/robot/move', json=move_data)
+    assert res.status == 200
+
+    move_data = {
+        'target': 'pipette',
+        'mount': 'right'
+    }
+    res1 = await cli.post('/robot/home', json=move_data)
+    assert res1.status == 200


### PR DESCRIPTION
## overview

If a pipette is already on a mount, use that pipette instance in control endpoints. Fixes #1302 

## changelog

- (refactor) If a pipette is already on a mount, use that pipette instance in control endpoints

## review requests

@mcous Please double-check to ensure that this unblocks deck calibration functions
