### PR TITLE
No pipette, no session!

### DIFF
--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -385,9 +385,11 @@ async def start(request):
             robot.remove_instrument('right')
         session = SessionManager()
         res = init_pipette()
-        data = {'token': session.id, 'pipette': res}
-        status = 201
-        if not res:
+        if res:
+            status = 201
+            data = {'token': session.id, 'pipette': res}
+        else:
+            session = None
             status = 403
             data = {'message': 'Error, pipette not recognized'}
     else:
@@ -403,7 +405,7 @@ async def dispatch(request):
     """
     if session:
         message = ''
-        data = await request.post()
+        data = await request.json()
         try:
             log.info("Dispatching {}".format(data))
             _id = data.get('token')

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -139,6 +139,43 @@ async def test_create_session(async_client, monkeypatch):
     assert resp.status == 201
 
 
+async def test_create_session_fail(async_client, monkeypatch):
+    """
+    Tests that the GET request to initiate a session manager for factory
+    calibration returns a good token.
+    """
+    from opentrons.robot.robot import Robot
+    dummy_token = 'Test Token'
+
+    def uuid_mock():
+        return dummy_token
+
+    monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
+
+    def dummy_get_pipettes(self):
+        return {
+            'left': {
+                'mount_axis': 'z',
+                'plunger_axis': 'b',
+                'model': None
+            },
+            'right': {
+                'mount_axis': 'a',
+                'plunger_axis': 'c',
+                'model': None
+            }
+        }
+
+    monkeypatch.setattr(Robot, 'get_attached_pipettes', dummy_get_pipettes)
+
+    resp = await async_client.post('/calibration/deck/start')
+    text = await resp.text()
+    print(text)
+    assert json.loads(text) == {'message': 'Error, pipette not recognized'}
+    assert resp.status == 403
+    assert endpoints.session is None
+
+
 async def test_release(async_client):
     """
     Tests that the GET request to initiate a session manager for factory
@@ -158,7 +195,7 @@ async def test_release(async_client):
     # Release
     resp2 = await async_client.post(
         '/calibration/deck',
-        data={
+        json={
             'token': token,
             'command': 'release'
         })
@@ -222,7 +259,7 @@ async def test_incorrect_token(async_client, monkeypatch):
 
     resp = await async_client.post(
         '/calibration/deck',
-        data={
+        json={
             'token': 'FAKE TOKEN',
             'command': 'init pipette',
             'mount': 'left',
@@ -263,7 +300,7 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     prior_x, prior_y, prior_z = dc.position('Z')
     resp = await async_client.post(
         '/calibration/deck',
-        data={
+        json={
             'token': token,
             'command': 'jog',
             'mount': 'left',


### PR DESCRIPTION
## overview

There, I fixed it

## changelog

- (refactor) During deck calibration, if no pipettes are attached, do not create a SessionManager
