### PR TITLE
App: Robot in use modal

### DIFF
--- a/app/src/components/CalibrateDeck/InUseModal.js
+++ b/app/src/components/CalibrateDeck/InUseModal.js
@@ -1,0 +1,61 @@
+// @flow
+import * as React from 'react'
+
+import {Link} from 'react-router-dom'
+import {AlertModal, CheckboxField} from '@opentrons/components'
+
+type Props = {
+  parentUrl: string,
+  onBackClick?: () => mixed
+}
+
+type State = {
+  checkOne: boolean,
+  checkTwo: boolean,
+  checkThree: boolean,
+}
+const HEADING = 'Robot is currently in use'
+
+export default class InUseModal extends React.Component <Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      checkOne: false,
+      checkTwo: false,
+      checkThree: false
+    }
+  }
+
+  render () {
+    const canContinue = Object.keys(this.state).every(k => this.state[k])
+
+    return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {children: 'cancel', Component: Link, to: this.props.parentUrl},
+        {children: 'continue', disabled: !canContinue}
+      ]}
+    >
+      <p>Robot is currently in use</p>
+      <div>
+        <CheckboxField
+          label="It can’t be undone"
+          onChange={() => this.setState({checkOne: !this.state.checkOne})}
+          value={this.state.checkOne}
+        />
+        <CheckboxField
+          label="Any work the robot is doing will be stopped"
+          onChange={() => this.setState({checkTwo: !this.state.checkTwo})}
+          value={this.state.checkTwo}
+        />
+        <CheckboxField
+          label="This is a good idea"
+          onChange={() => this.setState({checkThree: !this.state.checkThree})}
+          value={this.state.checkThree}
+        />
+      </div>
+    </AlertModal>
+    )
+  }
+}

--- a/app/src/components/CalibrateDeck/InUseModal.js
+++ b/app/src/components/CalibrateDeck/InUseModal.js
@@ -37,7 +37,7 @@ export default class InUseModal extends React.Component <Props, State> {
         {children: 'continue', disabled: !canContinue}
       ]}
     >
-      <p>Robot is currently in use</p>
+      <p>Are you sure you want to interrupt this robot?</p>
       <div>
         <CheckboxField
           label="It can’t be undone"

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -18,6 +18,7 @@ import {
 import ClearDeckAlertModal from '../ClearDeckAlertModal'
 import RequestInProgressModal from './RequestInProgressModal'
 import AttachTipModal from './AttachTipModal'
+import InUseModal from './InUseModal'
 
 type Props = {
   match: Match,
@@ -72,7 +73,7 @@ function CalibrateDeckRouter (props: CalibrateDeckProps) {
 
     // conflict: token already issued
     if (status === 409) {
-      return 'TODO: deck calibration force control modal'
+      return (<InUseModal {...props} />)
     }
 
     // forbidden: no pipette attached

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -16,6 +16,7 @@
 
   display: flex;
   align-items: center;
+  line-height: 1;
 }
 
 .label_text {
@@ -31,11 +32,11 @@
   @apply --font-body-2-dark;
 
   font-weight: var(--fw-bold);
-  margin-bottom: 0.5rem;
 }
 
 .checkbox_icon {
   /* Icon for radiobutton and for checkbox */
+  display: block;
   width: 1.25rem;
   min-width: 1.25rem;
   color: var(--c-dark-gray);

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -82,6 +82,10 @@
   @apply --font-body-2-dark;
 
   padding: 1rem;
+
+  & > p {
+    padding-bottom: 1rem;
+  }
 }
 
 .alert_modal_heading {


### PR DESCRIPTION
## overview

Addresses UI checkboxes of #1235. Display In Use Modal if token already issued.

<img width="600" alt="screen shot 2018-05-01 at 5 33 58 pm" src="https://user-images.githubusercontent.com/3430313/39494826-e559dc6a-4d65-11e8-9491-e5e1b5831475.png">
<img width="600" alt="screen shot 2018-05-01 at 5 34 06 pm" src="https://user-images.githubusercontent.com/3430313/39494827-e56556e4-4d65-11e8-90b3-bee10f7249d5.png">

## changelog

- Display in use modal if robot token already issued
- Disable continue button (no action yet) until all checkboxes are checked
- Cancel button returns to RobotSettings
- Minor form/modal components stylings

## review requests
Standard review. 
1- Click [calibrate] button in RobotSettings
2- Click [cancel] when prompted with clear deck alert
3- Click [calibrate] button again
4- Confirm Robot In Use modal renders with no boxes checked, continue button disabled
5- Check all 3 boxes, [continue] should enable (continue click action not covered in this PR)