### PR TITLE
Adds specified position for pipette to move to z point

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -12,6 +12,8 @@ dots = 'dots'
 holes = 'holes'
 crosses = 'crosses'
 
+z_pos = (170.5, 129.0, 5.0)
+
 
 def dots_set():
     """

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -9,6 +9,7 @@ from opentrons import robot, instruments
 from opentrons.instruments import pipette_config
 from opentrons.trackers import pose_tracker
 from opentrons.deck_calibration.endpoints import safe_points
+from opentrons.deck_calibration import z_pos
 
 log = logging.getLogger(__name__)
 
@@ -110,6 +111,11 @@ async def position_info(request):
             'initial_calibration_3': {
                 'target': 'pipette',
                 'point': safe_pos3
+            },
+            'z_calibration': {
+                'target': 'pipette',
+                'point': z_pos
+
             }
         }
     })

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -120,6 +120,14 @@ async def test_robot_info(virtual_smoothie_env, loop, test_client):
     assert len(body['positions']['change_pipette']['right']) == 3
     assert body['positions']['attach_tip']['target'] == 'pipette'
     assert len(body['positions']['attach_tip']['point']) == 3
+    assert body['positions']['initial_calibration_1']['target'] == 'pipette'
+    assert len(body['positions']['initial_calibration_1']['point']) == 3
+    assert body['positions']['initial_calibration_2']['target'] == 'pipette'
+    assert len(body['positions']['initial_calibration_2']['point']) == 3
+    assert body['positions']['initial_calibration_3']['target'] == 'pipette'
+    assert len(body['positions']['initial_calibration_3']['point']) == 3
+    assert body['positions']['z_calibration']['target'] == 'pipette'
+    assert len(body['positions']['z_calibration']['point']) == 3
 
 
 async def test_home_pipette(virtual_smoothie_env, loop, test_client):


### PR DESCRIPTION
## overview

Fixes #1240. Choose point (170.5, 129.0, 5.0) for z "safe" position.

## changelog

- Adds z position into robot/positions endpoint
- Adds a test that checks this info is returned in robot/positions
- Adds test for deck calibration points 1,2,3 as I did not see where they were being tested

## review requests

Let me know if you think the position should be some where else. Right now it's on the mid-bottom left side of slot 5.