### PR TITLE
Add no pipette attached and generic error modals

### DIFF
--- a/app/src/components/CalibrateDeck/ErrorModal.js
+++ b/app/src/components/CalibrateDeck/ErrorModal.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+import {AlertModal} from '@opentrons/components'
+import {type ApiRequestError} from '../../http-api-client'
+
+type Props = {
+  closeUrl: string,
+  error: ApiRequestError
+}
+
+const HEADING = 'Error'
+export default function ErrorModal (props: Props) {
+  const {error, closeUrl} = props
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {children: 'close', Component: Link, to: closeUrl}
+      ]}
+    >
+      <p>Something went wrong</p>
+      {error.message}
+    </AlertModal>
+  )
+}

--- a/app/src/components/CalibrateDeck/NoPipetteModal.js
+++ b/app/src/components/CalibrateDeck/NoPipetteModal.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+import {AlertModal} from '@opentrons/components'
+
+type Props = {
+  parentUrl: string,
+}
+
+const HEADING = 'No pipette attached'
+export default function NoPipetteModal (props: Props) {
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {children: 'close', Component: Link, to: props.parentUrl}
+      ]}
+    >
+      <p>Please attach a pipette before attempting to calibrate robot.</p>
+    </AlertModal>
+  )
+}

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -19,6 +19,8 @@ import ClearDeckAlertModal from '../ClearDeckAlertModal'
 import RequestInProgressModal from './RequestInProgressModal'
 import AttachTipModal from './AttachTipModal'
 import InUseModal from './InUseModal'
+import NoPipetteModal from './NoPipetteModal'
+import ErrorModal from './ErrorModal'
 
 type Props = {
   match: Match,
@@ -61,7 +63,7 @@ export default function CalibrateDeck (props: Props) {
 }
 
 function CalibrateDeckRouter (props: CalibrateDeckProps) {
-  const {startRequest, moveRequest, baseUrl} = props
+  const {startRequest, moveRequest, baseUrl, parentUrl} = props
   const clearDeckProps = {
     cancelText: 'cancel',
     continueText: 'move pipette to front',
@@ -78,10 +80,10 @@ function CalibrateDeckRouter (props: CalibrateDeckProps) {
 
     // forbidden: no pipette attached
     if (status === 403) {
-      return 'TODO: no pipettes attached modal'
+      return (<NoPipetteModal {...props}/>)
     }
-
-    return 'TODO: unexpected error starting calibration'
+    // TODO: (ka 2018-5-2) kept props generic in case we decide to reuse
+    return (<ErrorModal closeUrl={parentUrl} error={startRequest.error}/>)
   }
 
   if (!moveRequest.inProgress && !moveRequest.response) {


### PR DESCRIPTION
## overview

This PR closes #974 and sneaks in a little generic error modal to Deck Calibration.

## changelog

- Add NoPipetteModal to Calibrate Deck
- Add generic error modal as a catchall to Calibrate Deck

## review requests
 Detach pipettes (moon moon is currently with detached pipettes I believe) and click [calibrate] in RobotSettings page. 
*note:* You will probably have to restart the robot to release the previous token.

