### PR TITLE
feat(app): Add all move positions to /robot API module

### DIFF
--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -1,7 +1,7 @@
 // @flow
 import type {PipetteConfig} from '@opentrons/labware-definitions'
 import type {RobotService} from '../../robot'
-import type {RobotMoveState, DeckCalStartState} from '../../http-api-client'
+import type {RobotMove, DeckCalStartState} from '../../http-api-client'
 
 export type OP = {
   title: string,
@@ -15,7 +15,7 @@ export type OP = {
 export type SP = {
   pipette: ?PipetteConfig,
   startRequest: DeckCalStartState,
-  moveRequest: RobotMoveState,
+  moveRequest: RobotMove,
 }
 
 export type DP = {

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -10,11 +10,11 @@ import type {State, Dispatch} from '../../types'
 import type {Robot, Mount} from '../../robot'
 import type {Direction, ChangePipetteProps} from './types'
 
-import type {RobotHome, RobotMoveState} from '../../http-api-client'
+import type {RobotHome, RobotMove} from '../../http-api-client'
 
 import {
   home,
-  moveToChangePipette,
+  moveRobotTo,
   fetchPipettes,
   disengagePipetteMotors,
   makeGetRobotMove,
@@ -87,7 +87,7 @@ type OP = {
 }
 
 type SP = {
-  moveRequest: RobotMoveState,
+  moveRequest: RobotMove,
   homeRequest: RobotHome,
   actualPipette: ?PipetteConfig,
   displayName: string,
@@ -197,8 +197,10 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
       .then(() => dispatch(push(parentUrl))),
     back: () => dispatch(goBack()),
     onPipetteSelect: (evt) => dispatch(push(`${baseUrl}/${evt.target.value}`)),
-    moveToFront: () => dispatch(moveToChangePipette(robot, mount))
-      .then(disengage),
+    moveToFront: () => dispatch(moveRobotTo(robot, {
+      mount,
+      position: 'change_pipette'
+    })).then(disengage),
     confirmPipette: () => checkPipette().then(() => dispatch(push(confirmUrl)))
   }
 }

--- a/app/src/components/ChangePipette/types.js
+++ b/app/src/components/ChangePipette/types.js
@@ -2,7 +2,7 @@
 import type {PipetteConfig} from '@opentrons/labware-definitions'
 import type {Mount} from '../../robot'
 
-import type {RobotMoveState, RobotHome} from '../../http-api-client'
+import type {RobotMove, RobotHome} from '../../http-api-client'
 
 import type {PipetteSelectionProps} from './PipetteSelection'
 
@@ -31,7 +31,7 @@ export type ChangePipetteProps = {
   baseUrl: string,
   confirmUrl: string,
   exitUrl: string,
-  moveRequest: RobotMoveState,
+  moveRequest: RobotMove,
   homeRequest: RobotHome,
   back: () => mixed,
   exit: () => mixed,

--- a/app/src/http-api-client/__tests__/robot.test.js
+++ b/app/src/http-api-client/__tests__/robot.test.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk'
 
 import client from '../client'
 import {
-  moveToChangePipette,
+  moveRobotTo,
   home,
   reducer,
   makeGetRobotMove,
@@ -31,8 +31,9 @@ describe('robot/*', () => {
     store = mockStore(state)
   })
 
-  describe('moveToChangePipette action creator', () => {
+  describe('moveRobotTo action creator', () => {
     const path = 'move'
+    const request = {position: 'change_pipette', mount: 'left'}
     const mockPositionsResponse = {
       positions: {
         change_pipette: {
@@ -53,43 +54,35 @@ describe('robot/*', () => {
 
       client.__setMockResponse(mockPositionsResponse, response)
 
-      return store.dispatch(moveToChangePipette(robot, 'left'))
-        .then(() => expect(client.mock.calls).toEqual([
-          [robot, 'GET', 'robot/positions'],
-          [robot, 'POST', 'robot/move', expected]
-        ]))
+      return store.dispatch(moveRobotTo(robot, request))
+      .then(() => expect(client.mock.calls).toEqual([
+        [robot, 'GET', 'robot/positions'],
+        [robot, 'POST', 'robot/move', expected]
+      ]))
     })
 
-    test('dispatches SET_ROBOT_MOVE_POSITION, ROBOT_REQUEST, ROBOT_SUCCESS', () => {
-      const request = {target: 'mount', mount: 'right', point: [4, 5, 6]}
+    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
       const expectedActions = [
-        {
-          type: 'api:SET_ROBOT_MOVE_POSITION',
-          payload: {robot, position: 'change_pipette'}
-        },
         {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
         {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
       ]
 
       client.__setMockResponse(mockPositionsResponse, response)
 
-      return store.dispatch(moveToChangePipette(robot, 'right'))
+      return store.dispatch(moveRobotTo(robot, request))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches SET_ROBOT_MOVE_POSITION, ROBOT_REQUEST, ROBOT_FAILURE', () => {
+    test('dispatches ROBOT_REQUEST amd ROBOT_FAILURE', () => {
       const error = {name: 'ResponseError', status: '400'}
       const expectedActions = [
-        {
-          type: 'api:SET_ROBOT_MOVE_POSITION',
-          payload: {robot, position: 'change_pipette'}
-        },
+        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
         {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
       ]
 
       client.__setMockError(error)
 
-      return store.dispatch(moveToChangePipette(robot, 'left'))
+      return store.dispatch(moveRobotTo(robot, request))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
@@ -143,20 +136,6 @@ describe('robot/*', () => {
 
       return store.dispatch(home(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
-    })
-  })
-
-  test('reducer handles SET_ROBOT_MOVE_POSITION', () => {
-    state = state.api
-    const action = {
-      type: 'api:SET_ROBOT_MOVE_POSITION',
-      payload: {robot, position: 'change_pipette'}
-    }
-
-    expect(reducer(state, action).robot).toEqual({
-      [NAME]: {
-        movePosition: 'change_pipette'
-      }
     })
   })
 
@@ -269,29 +248,17 @@ describe('robot/*', () => {
       const getMove = makeGetRobotMove()
 
       expect(getMove(state, robot)).toEqual({
-        ...state.api.robot[NAME].move,
-        position: 'change_pipette'
+        ...state.api.robot[NAME].move
       })
 
-      expect(getMove(state, {name: 'foo'})).toEqual({
-        inProgress: false,
-        error: null,
-        request: null,
-        response: null,
-        position: null
-      })
+      expect(getMove(state, {name: 'foo'})).toEqual({inProgress: false})
     })
 
     test('makeGetRobotHome', () => {
       const getHome = makeGetRobotHome()
 
       expect(getHome(state, robot)).toEqual(state.api.robot[NAME].home)
-      expect(getHome(state, {name: 'foo'})).toEqual({
-        inProgress: false,
-        error: null,
-        request: null,
-        response: null
-      })
+      expect(getHome(state, {name: 'foo'})).toEqual({inProgress: false})
     })
   })
 })

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -40,7 +40,7 @@ export type {
 } from './pipettes'
 
 export type {
-  RobotMoveState,
+  RobotMove,
   RobotHome
 } from './robot'
 
@@ -101,7 +101,7 @@ export {
 
 export {
   home,
-  moveToChangePipette,
+  moveRobotTo,
   clearRobotMoveResponse,
   makeGetRobotMove,
   makeGetRobotHome


### PR DESCRIPTION
## overview

This PR refactors the `/robot` API module to add all move positions to the action creator. This is necessary plumbing work for:

- Deck Calibration: Move to Attach Tip Position #1237
- Deck Calibration: Move to Z-Axis Point #976
- Deck Calibration: Calibrate XY Point 'A' #979 
- Deck Calibration: Calibrate XY Point 'B' #980 
- Deck Calibration: Calibrate XY Point 'C' #981 

## changelog

- feat(app): Add all move positions to /robot API module 

## review requests

This PR took the existing `moveToChangePipette` action creator, renamed it `moveRobotTo`, and gave it a position parameter to make it generic and applicable to all move positions:

```js
// old and busted
moveToChangePipette(robot, mount)

// new hotness
moveRobotTo(robot, {position: 'change_pipette', mount})
```

As a nice side-effect of this work, the `api:SET_ROBOT_MOVE_POSITION` action became unecessary so I removed it. I've tested that change pipette movements still work on Sunset, but a sanity check on another robot wouldn't be the worst.