### PR TITLE
Correct orientation of labware from containers.create

### DIFF
--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -89,11 +89,11 @@ def create(name, grid, spacing, diameter, depth, volume=0):
     for r in range(rows):
         for c in range(columns):
             well = Well(properties=properties)
-            well_name = chr(c + ord('A')) + str(1 + r)
+            well_name = chr(r + ord('A')) + str(1 + c)
             coordinates = (c * col_spacing, r * row_spacing, 0)
             custom_container.add(well, well_name, coordinates)
     database.save_new_container(custom_container, name)
-    return custom_container
+    return database.load_container(name)
 
 
 # FIXME: [Jared - 8/31/17] This is not clean

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -99,6 +99,9 @@ def clear_feature_flags():
     ff_file = config.get_config_index().get('featureFlagFile')
     if os.path.exists(ff_file):
         os.remove(ff_file)
+    yield
+    if os.path.exists(ff_file):
+        os.remove(ff_file)
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -1,9 +1,7 @@
 import math
 import unittest
 
-from opentrons.data_storage import database
 from opentrons.containers import (
-    create as containers_create,
     load as containers_load,
     list as containers_list
 )
@@ -14,35 +12,7 @@ from opentrons.containers.placeable import (
     Well,
     Deck,
     Slot)
-from opentrons.config import feature_flags as ff
 from tests.opentrons import generate_plate
-
-
-def test_containers_create(robot):
-    container_name = 'plate_for_testing_containers_create'
-    containers_create(
-        name=container_name,
-        grid=(8, 12),
-        spacing=(9, 9),
-        diameter=4,
-        depth=8,
-        volume=1000)
-
-    p = containers_load(robot, container_name, '1')
-    assert len(p) == 96
-    assert len(p.cols) == 12
-    assert len(p.rows) == 8
-    assert p.get_parent() == robot.deck['1']
-    assert p['C3'] == p[18]
-    assert p['C3'].max_volume() == 1000
-    for i, w in enumerate(p):
-        assert w == p[i]
-
-    assert container_name in containers_list()
-
-    if not ff.split_labware_definitions():
-        database.delete_container(container_name)
-        assert container_name not in containers_list()
 
 
 class ContainerTestCase(unittest.TestCase):


### PR DESCRIPTION
## overview

Fix orientation of `containers.create` for both old and new labware. Fixes #1354 

## changelog

- (fix) Reverse orientation of rows and columns in `containers.create`

## review requests

@Laura-Danielle how will this affect existing protocols?
