### PR TITLE
feat(app): Allow user to force take control of robot

### DIFF
--- a/app/src/components/CalibrateDeck/InUseModal.js
+++ b/app/src/components/CalibrateDeck/InUseModal.js
@@ -1,13 +1,9 @@
 // @flow
 import * as React from 'react'
-
 import {Link} from 'react-router-dom'
-import {AlertModal, CheckboxField} from '@opentrons/components'
 
-type Props = {
-  parentUrl: string,
-  onBackClick?: () => mixed
-}
+import {AlertModal, CheckboxField} from '@opentrons/components'
+import type {CalibrateDeckProps} from './types'
 
 type State = {
   checkOne: boolean,
@@ -16,9 +12,13 @@ type State = {
 }
 const HEADING = 'Robot is currently in use'
 
-export default class InUseModal extends React.Component <Props, State> {
-  constructor (props: Props) {
+export default class InUseModal extends React.Component<
+  CalibrateDeckProps,
+  State
+> {
+  constructor (props: CalibrateDeckProps) {
     super(props)
+
     this.state = {
       checkOne: false,
       checkTwo: false,
@@ -27,35 +27,36 @@ export default class InUseModal extends React.Component <Props, State> {
   }
 
   render () {
+    const {parentUrl, forceStart} = this.props
     const canContinue = Object.keys(this.state).every(k => this.state[k])
 
     return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[
-        {children: 'cancel', Component: Link, to: this.props.parentUrl},
-        {children: 'continue', disabled: !canContinue}
-      ]}
-    >
-      <p>Are you sure you want to interrupt this robot?</p>
-      <div>
-        <CheckboxField
-          label="It can’t be undone"
-          onChange={() => this.setState({checkOne: !this.state.checkOne})}
-          value={this.state.checkOne}
-        />
-        <CheckboxField
-          label="Any work the robot is doing will be stopped"
-          onChange={() => this.setState({checkTwo: !this.state.checkTwo})}
-          value={this.state.checkTwo}
-        />
-        <CheckboxField
-          label="This is a good idea"
-          onChange={() => this.setState({checkThree: !this.state.checkThree})}
-          value={this.state.checkThree}
-        />
-      </div>
-    </AlertModal>
+      <AlertModal
+        heading={HEADING}
+        buttons={[
+          {children: 'cancel', Component: Link, to: parentUrl},
+          {children: 'continue', onClick: forceStart, disabled: !canContinue}
+        ]}
+      >
+        <p>Are you sure you want to interrupt this robot?</p>
+        <div>
+          <CheckboxField
+            label="It can’t be undone"
+            onChange={() => this.setState({checkOne: !this.state.checkOne})}
+            value={this.state.checkOne}
+          />
+          <CheckboxField
+            label="Any work the robot is doing will be stopped"
+            onChange={() => this.setState({checkTwo: !this.state.checkTwo})}
+            value={this.state.checkTwo}
+          />
+          <CheckboxField
+            label="This is a good idea"
+            onChange={() => this.setState({checkThree: !this.state.checkThree})}
+            value={this.state.checkThree}
+          />
+        </div>
+      </AlertModal>
     )
   }
 }

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -11,6 +11,7 @@ import type {OP, SP, DP, CalibrateDeckProps} from './types'
 import {getPipette} from '@opentrons/labware-definitions'
 
 import {
+  startDeckCalibration,
   makeGetRobotMove,
   makeGetDeckCalibrationStartState
 } from '../../http-api-client'
@@ -122,6 +123,7 @@ function makeMapStateToProps () {
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   return {
-    back: () => dispatch(goBack())
+    back: () => dispatch(goBack()),
+    forceStart: () => dispatch(startDeckCalibration(ownProps.robot, true))
   }
 }

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -20,6 +20,7 @@ export type SP = {
 
 export type DP = {
   back: () => mixed,
+  forceStart: () => mixed,
 }
 
 export type CalibrateDeckProps = OP & SP & DP


### PR DESCRIPTION
## overview

This PR closes #1235 by wiring up the Continue button of the InUseModal to `POST /calibration/deck/start {"force": true}`.

## changelog

- feat(app): Allow user to force take control of robot

## review requests

Please give this a shot on a virtual bot and a real life bot
