### PR TITLE
Complib update AlertItem design

### DIFF
--- a/app/src/components/setup-instruments/Instruments.js
+++ b/app/src/components/setup-instruments/Instruments.js
@@ -61,6 +61,7 @@ export default function Instruments (props: Props) {
       <div>
         <AlertItem
           type='warning'
+          className={styles.alert}
           title={alertType === 'attach' ? ATTACH_ALERT : CHANGE_ALERT}
         />
         <p className={styles.wrong_pipette_message}>

--- a/app/src/components/setup-instruments/styles.css
+++ b/app/src/components/setup-instruments/styles.css
@@ -13,3 +13,9 @@
 
   margin-top: 1.5rem;
 }
+
+.alert {
+  @apply --absolute-fill;
+
+  bottom: auto;
+}

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -7,7 +7,7 @@ import styles from './alerts.css'
 
 export type AlertProps = {
   /** name constant of the icon to display */
-  type: 'success' | 'warning' | 'error',
+  type: 'success' | 'warning',
   /** title/main message of colored alert bar */
   title: string,
   /** Alert message body contents */
@@ -31,10 +31,6 @@ const ALERT_PROPS_BY_TYPE = {
   warning: {
     iconName: 'alert-circle',
     className: styles.warning
-  },
-  error: {
-    iconName: 'close-circle',
-    className: styles.error
   }
 }
 
@@ -45,7 +41,6 @@ export default function AlertItem (props: AlertProps) {
   const className = cx(
     styles.alert,
     alertProps.className,
-    {[styles.alert_body]: props.children},
     props.className
   )
 

--- a/components/src/alerts/AlertItem.md
+++ b/components/src/alerts/AlertItem.md
@@ -33,3 +33,16 @@ initialState = {alert: 'warning'}
   )}
 </div>
 ```
+
+Stackable:
+```js
+<div>
+  <AlertItem type='warning' onCloseClick={() => console.log('dismiss warning 1')} title={'Warning 1 with longer text longer text longer text longer text longer text longer text has X'} />
+  <AlertItem type='warning' title={'Warning 1 with longer text longer text longer text longer text longer text longer text no X'} />
+  <AlertItem type='warning' title={'Warning'} />
+  <AlertItem type='warning' onCloseClick={() => console.log('dismiss warning 3')} title={'Warning 3'} >
+    <p>Some additional info</p>
+  </AlertItem>
+  <AlertItem type='warning' onCloseClick={() => console.log('dismiss warning 4')} title={'Warning 4'} />
+</div>
+```

--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -1,10 +1,12 @@
 @import '..';
 
 .alert {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  font-size: var(--fs-body-2);
+  font-weight: var(--fw-regular);
+}
+
+.alert:not(:first-of-type) {
+  border-top: none;
 }
 
 .title_bar {
@@ -16,10 +18,12 @@
 }
 
 .title {
-  width: calc(100% - 3.5rem);
+  width: 100%;
 }
 
 .success {
+  border: 1px solid #60b120;
+
   & > .title_bar {
     background-color: #b6febc;
     color: #60b120;
@@ -31,6 +35,8 @@
 }
 
 .warning {
+  border: 1px solid var(--c-warning);
+
   & > .title_bar {
     background-color: #ffd58f;
     color: #7c4d00;
@@ -39,14 +45,6 @@
       fill: var(--c-warning);
     }
   }
-}
-
-.alert_body.success {
-  border: 1px solid #60b120;
-}
-
-.alert_body.warning {
-  border: 1px solid var(--c-warning);
 }
 
 .message {

--- a/protocol-designer/src/components/StepItem.js
+++ b/protocol-designer/src/components/StepItem.js
@@ -53,7 +53,7 @@ export default function StepItem (props: StepItemProps) {
     <TitledList
       className={styles.step_item}
       description={Description}
-      iconName={error ? 'alert' : iconName}
+      iconName={error ? 'alert-circle' : iconName}
       iconProps={{className: error ? styles.error_icon : ''}}
       {...{title, selected, onClick, onMouseEnter, onMouseLeave, onCollapseToggle: onCollapseToggle, collapsed}}
     >

--- a/protocol-designer/src/containers/Alert.css
+++ b/protocol-designer/src/containers/Alert.css
@@ -1,9 +1,0 @@
-@import '@opentrons/components';
-
-.alert {
-  position: relative;
-  border: 1px solid var(--c-warning);
-
-  /* NOTE Ian 2018-05-01: borders for AlertItem depend on contents, PD doesn't match App?
-  Also, missing X moves message to the right */
-}

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -4,7 +4,6 @@ import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {selectors} from '../file-data'
 import {AlertItem} from '@opentrons/components'
-import styles from './Alert.css'
 import type {BaseState} from '../types'
 import type {ErrorType, CommandCreatorError} from '../step-generation'
 
@@ -30,7 +29,6 @@ function Alerts (props: Props) {
     <div>
       {props.alerts.map((alert, key) =>
         <AlertItem
-          className={styles.alert}
           type='warning'
           key={key}
           title={alert.message}


### PR DESCRIPTION
## overview

`AlertItem` standardized to match Zeplin component library

### Run App
![image](https://user-images.githubusercontent.com/11590381/39550475-674080fc-4e2f-11e8-9506-e67ea55b62b9.png)

### PD
![2018-05-02 17-31-34 alerts stacked](https://user-images.githubusercontent.com/11590381/39550463-599eb3f6-4e2f-11e8-9d0a-64590296bef3.png)


## changelog

- Always has a border (before only had border when it had contents)
- Stackable (without doubling-up on borders)
- Missing X doesn't shift text to the left
- Typography matches design (I think???)
- Removed unused, unstyled `type='error'`

## review requests

Make sure the change pipettes alert in Run App looks OK, and "ran out of tips" looks OK. Also check out component library TODO-ADD-LINK-HERE