### PR TITLE
fix(api): Use correct smoothie axis for DC Z jog

### DIFF
--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -226,15 +226,27 @@ async def run_jog(data):
     :return: The position you are moving to based on axis, direction, step
     given by the user.
     """
-    if session.current_mount:
-        message = jog(
-            data['axis'],
-            float(data['direction']),
-            float(data['step']))
-        status = 200
-    else:
-        message = "Current mount must be set before jogging"
+    global session
+    axis = data.get('axis')
+    direction = data.get('direction')
+    step = data.get('step')
+
+    if axis not in ('x', 'y', 'z'):
+        message = '"axis" must be "x", "y", or "z"'
         status = 400
+    elif direction not in (-1, 1):
+        message = '"direction" must be -1 or 1'
+        status = 400
+    elif step is None:
+        message = '"step" must be specified'
+        status = 400
+    else:
+        if axis == 'z':
+            axis = session.current_mount
+        position = jog(axis.upper(), direction, step)
+        message = 'Jogged to {}'.format(position)
+        status = 200
+
     return web.json_response({'message': message}, status=status)
 
 

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -226,7 +226,6 @@ async def run_jog(data):
     :return: The position you are moving to based on axis, direction, step
     given by the user.
     """
-    global session
     axis = data.get('axis')
     direction = data.get('direction')
     step = data.get('step')

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -117,9 +117,10 @@ async def test_save_calibration_file(dc_session, monkeypatch):
 
 
 # ------------ Session and token tests ----------------------
+# TODO(mc, 2018-05-02): this does not adequetly pipette selection logic
 async def test_create_session(async_client, monkeypatch):
     """
-    Tests that the GET request to initiate a session manager for factory
+    Tests that the POST request to initiate a session manager for factory
     calibration returns a good token.
     """
     dummy_token = 'Test Token'
@@ -134,7 +135,7 @@ async def test_create_session(async_client, monkeypatch):
         'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
     resp = await async_client.post('/calibration/deck/start')
     text = await resp.text()
-    print(text)
+
     assert json.loads(text) == expected
     assert resp.status == 201
 
@@ -270,14 +271,14 @@ async def test_incorrect_token(async_client, monkeypatch):
 
 
 # ------------ Router tests (integration) ----------------------
+# TODO(mc, 2018-05-02): this does not adequetly test z to smoothie axis logic
 async def test_set_and_jog_integration(async_client, monkeypatch):
     """
-    Test that the select model function and jog function works.
+    Test that the jog function works.
     Note that in order for the jog function to work, the following must
     be done:
     1. Create a session manager
-    2. Initialize a pipette
-    3. Select the current pipette
+
     Then jog requests will work as expected.
     """
     robot.reset()
@@ -292,23 +293,25 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     token_text = await token_res.json()
     token = token_text['token']
 
-    axis = 'Z'
-    direction = '1'
-    step = '3'
+    axis = 'z'
+    direction = 1
+    step = 3
+    # left pipette z carriage motor is smoothie axis "Z"
+    smoothie_axis = 'Z'
 
     robot.reset()
-    prior_x, prior_y, prior_z = dc.position('Z')
+    prior_x, prior_y, prior_z = dc.position(smoothie_axis)
     resp = await async_client.post(
         '/calibration/deck',
         json={
             'token': token,
             'command': 'jog',
-            'mount': 'left',
             'axis': axis,
             'direction': direction,
             'step': step
         })
 
     body = await resp.json()
+    msg = body.get('message')
 
-    assert body.get('message') == [prior_x, prior_y, prior_z + float(step)]
+    assert '{}'.format((prior_x, prior_y, prior_z + float(step))) in msg

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -117,7 +117,7 @@ async def test_save_calibration_file(dc_session, monkeypatch):
 
 
 # ------------ Session and token tests ----------------------
-# TODO(mc, 2018-05-02): this does not adequetly pipette selection logic
+# TODO(mc, 2018-05-02): this does not adequately pipette selection logic
 async def test_create_session(async_client, monkeypatch):
     """
     Tests that the POST request to initiate a session manager for factory
@@ -271,7 +271,7 @@ async def test_incorrect_token(async_client, monkeypatch):
 
 
 # ------------ Router tests (integration) ----------------------
-# TODO(mc, 2018-05-02): this does not adequetly test z to smoothie axis logic
+# TODO(mc, 2018-05-02): this does not adequately test z to smoothie axis logic
 async def test_set_and_jog_integration(async_client, monkeypatch):
     """
     Test that the jog function works.


### PR DESCRIPTION
## overview

This PR is serving as a bug ticket and its fix. The deck calibration jog endpoint was passing the `axis` parameter directly to the `jog` function. This was fine for `x` and `y`, but for `z` this was a problem because the calibration pipette's carriage z motor is `Z` for the left mount and `A` for the right mount.

The API now passes `session.current_mount` (which is, confusingly enough, either `Z` or `A` instead of `left` or `right`) as the jog axis if `z` comes in from the API client.

Unblocks #1246

## changelog

- fix(api): Use correct smoothie axis for DC Z jog 
- feat(api): Add parameter verification to `jog` endpoint
    - `axis` must be one of `"x"`, `"y"`, or `"z"`
    - `direction` must be `-1` or `1`
    - `step` must be present (actual verification of number type seemed like too much work for too little gain, though we should consider implementing schema-based verification at some point)


## review requests

Please give the code a once (or even twice?) over, especially for the tests I touched. The tests are a little inadequate for the pipette selection and `z` -> smoothie axis logic, but for now they're passing and testing something.

I also verified that this jogs the pipettes correctly on Sunset Bot
