### PR TITLE
Pause step generates commands

### DIFF
--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -43,11 +43,15 @@ function generateSubstepItems (substeps, onSelectSubstep, hoveredSubstep) {
   }
 
   if (substeps.stepType === 'pause') {
-    // TODO: style pause stuff
-    if (substeps.waitForUserInput) {
+    if (substeps.wait === true) {
+      // Show message if waiting indefinitely
       return <li>{substeps.message}</li>
     }
-    const {hours, minutes, seconds} = substeps
+    if (!substeps.meta) {
+      // No message or time, show nothing
+      return null
+    }
+    const {hours, minutes, seconds} = substeps.meta
     return <li>{hours} hr {minutes} m {seconds} s</li>
   }
 

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -148,8 +148,11 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
         }
       }
 
+      // un-nest to make flow happy
+      const validatedForm = form.validatedForm
+
       // put form errors into accumulator
-      if (!form.validatedForm) {
+      if (!validatedForm) {
         return {
           ...acc,
           formErrors: form.errors
@@ -159,11 +162,14 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
       // finally, deal with valid step forms
       let nextCommandsAndState
 
-      if (form.validatedForm.stepType === 'consolidate') {
-        nextCommandsAndState = StepGeneration.consolidate(form.validatedForm)(acc.robotState)
+      if (validatedForm.stepType === 'consolidate') {
+        nextCommandsAndState = StepGeneration.consolidate(validatedForm)(acc.robotState)
       }
-      if (form.validatedForm.stepType === 'transfer') {
-        nextCommandsAndState = StepGeneration.transfer(form.validatedForm)(acc.robotState)
+      if (validatedForm.stepType === 'transfer') {
+        nextCommandsAndState = StepGeneration.transfer(validatedForm)(acc.robotState)
+      }
+      if (validatedForm.stepType === 'pause') {
+        nextCommandsAndState = StepGeneration.delay(validatedForm)(acc.robotState)
       }
 
       if (!nextCommandsAndState) {
@@ -172,7 +178,7 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
           ...acc,
           formErrors: {
             ...acc.formErrors,
-            'STEP NOT IMPLEMENTED': form.validatedForm.stepType
+            'STEP NOT IMPLEMENTED': validatedForm.stepType
           }
         }
       }

--- a/protocol-designer/src/step-generation/delay.js
+++ b/protocol-designer/src/step-generation/delay.js
@@ -1,0 +1,15 @@
+// @flow
+import type {PauseFormData, RobotState, CommandCreator} from './'
+
+const pause = (data: PauseFormData): CommandCreator => (prevRobotState: RobotState) => {
+  return {
+    robotState: prevRobotState,
+    commands: [{
+      command: 'delay',
+      message: data.message,
+      wait: data.wait
+    }]
+  }
+}
+
+export default pause

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -2,6 +2,7 @@
 import aspirate from './aspirate'
 import blowout from './blowout'
 import consolidate from './consolidate'
+import delay from './delay'
 import dispense from './dispense'
 import dropTip from './dropTip'
 import replaceTip from './replaceTip'
@@ -16,6 +17,7 @@ export {
   aspirate,
   blowout,
   consolidate,
+  delay,
   dispense,
   dropTip,
   replaceTip,

--- a/protocol-designer/src/step-generation/test-with-flow/delay.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/delay.test.js
@@ -1,0 +1,60 @@
+// @flow
+import _delay from '../delay'
+import {commandCreatorNoErrors} from './fixtures'
+
+const delay = commandCreatorNoErrors(_delay)
+
+const getRobotInitialState = (): any => {
+  // This particular state shouldn't matter for delay
+  return {}
+}
+
+describe('delay indefinitely', () => {
+  test('...', () => {
+    const robotInitialState = getRobotInitialState()
+    const message = 'delay indefinitely message'
+
+    const result = delay({
+      message,
+      description: 'description',
+      name: 'name',
+      wait: true
+    })(robotInitialState)
+
+    expect(result.robotState).toEqual(getRobotInitialState())
+    expect(result.robotState).toBe(robotInitialState) // same object
+
+    expect(result.commands).toEqual([
+      {
+        command: 'delay',
+        wait: true,
+        message
+      }
+    ])
+  })
+})
+
+describe('delay for a given time', () => {
+  test('...', () => {
+    const robotInitialState = getRobotInitialState()
+    const message = 'delay 95.5 secs message'
+
+    const result = delay({
+      message,
+      description: 'description',
+      name: 'name',
+      wait: 95.5
+    })(robotInitialState)
+
+    expect(result.robotState).toEqual(getRobotInitialState())
+    expect(result.robotState).toBe(robotInitialState) // same object
+
+    expect(result.commands).toEqual([
+      {
+        command: 'delay',
+        wait: 95.5,
+        message
+      }
+    ])
+  })
+})

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -92,6 +92,18 @@ export type TransferFormData = {|
   blowout: ?string // TODO LATER LabwareId export type here instead of string?
 |}
 
+export type PauseFormData = {|
+  ...SharedFormDataFields,
+  stepType: 'pause',
+  message?: string,
+  wait: number | true,
+  meta: ?{
+    hours?: number,
+    minutes?: number,
+    seconds?: number
+  }
+|}
+
 export type PipetteData = {| // TODO refactor all 'pipette fields', split PipetteData into its own export type
   id: string, // TODO PipetteId export type here instead of string?
   mount: Mount,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,7 +1,6 @@
 // @flow
 import type {IconName} from '@opentrons/components'
-import type {ConsolidateFormData} from '../step-generation'
-import type {MixArgs, SharedFormDataFields, ChangeTipOptions} from '../form-types'
+import type {ConsolidateFormData, PauseFormData, TransferFormData} from '../step-generation'
 
 // sections of the form that are expandable/collapsible
 export type FormSectionState = {aspirate: boolean, dispense: boolean}
@@ -72,17 +71,9 @@ export type TransferLikeSubstepItemMultiChannel = {|
 
 export type TransferLikeSubstepItem = TransferLikeSubstepItemSingleChannel | TransferLikeSubstepItemMultiChannel
 
-export type StepSubItemData = TransferLikeSubstepItem | {|
-  stepType: 'pause',
-  waitForUserInput: false,
-  hours: number,
-  minutes: number,
-  seconds: number
-|} | {|
-  stepType: 'pause',
-  waitForUserInput: true,
-  message: string
-|}
+export type StepSubItemData =
+  | TransferLikeSubstepItem
+  | PauseFormData // Pause substep uses same data as processed form
 
 export type StepItemData = {
   id: StepIdType,
@@ -187,61 +178,6 @@ export type BlankForm = {
   stepType: StepType,
   id: StepIdType
 }
-
-export type TransferFormData = {|
-  // TODO Ian 2018-04-05 use "mixin types" like SharedFormDataFields for shared fields across FormData types.
-  ...SharedFormDataFields,
-  stepType: 'transfer',
-
-  pipette: string, // PipetteId. TODO IMMEDIATELY/SOON make this match in the form
-
-  sourceWells: Array<string>,
-  destWells: Array<string>,
-
-  sourceLabware: string,
-  destLabware: string,
-  /** Volume to aspirate from each source well. Different volumes across the
-    source wells isn't currently supported
-  */
-  volume: number,
-
-  // ===== ASPIRATE SETTINGS =====
-  /** Pre-wet tip with ??? uL liquid from the first source well. */
-  preWetTip: boolean,
-  /** Touch tip after every aspirate */
-  touchTipAfterAspirate: boolean,
-  /**
-    For transfer, changeTip means:
-    'always': before each aspirate, get a fresh tip
-    'once': get a new tip at the beginning of the transfer step, and use it throughout
-    'never': reuse the tip from the last step
-  */
-  changeTip: ChangeTipOptions,
-  /** Mix in first well in chunk */
-  mixBeforeAspirate: ?MixArgs,
-  /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
-  disposalVolume: ?number,
-
-  // ===== DISPENSE SETTINGS =====
-  /** Mix in destination well after dispense */
-  mixInDestination: ?MixArgs,
-  /** Touch tip in destination well after dispense */
-  touchTipAfterDispense: boolean,
-  /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
-  delayAfterDispense: ?number,
-  /** If given, blow out in the specified labware after dispense at the end of each asp-asp-dispense cycle */
-  blowout: ?string // TODO LATER LabwareId export type here instead of string?
-|}
-
-export type PauseFormData = {|
-  stepType: 'pause',
-  waitForUserInput: boolean,
-  seconds: number, // s/m/h only needed by substep...
-  minutes: number,
-  hours: number,
-  totalSeconds: number,
-  message: string
-|}
 
 // TODO gradually create & use definitions from step-generation/types.js
 export type ProcessedFormData = TransferFormData | PauseFormData | ConsolidateFormData


### PR DESCRIPTION
Closes #727

## overview

Adding a Pause step should create substep (as it did before), and add the `delay` command as specified in [JSON schema 1.0.0](https://github.com/IanLondon/opentrons-json-schema/blob/master/schema.json#L273) (except, the PD json overall doesn't match the schema yet, eg `commands` vs `subprocedure`. This PR is just for the `delay` part)

## changelog

- delay command and tests
- modify Pause form validation (mostly cleanup)
- remove duplicate `TransferFormData` type definition
- most of the diff is pulling a nested value out of an object and putting it in a const so flow doesn't freak out (`valForm.validatedForm -> validatedForm` diff)

## review requests

- Make a protocol with Pause, Consolidate, and Transfer steps and save it -- the JSON should look correct