### PR TITLE
complib: restyle InputField focus state

### DIFF
--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -82,7 +82,8 @@
   }
 
   &:focus-within {
-    background-color: var(--c-light-blue);
+    background-color: var(--c-white);
+    box-shadow: 0 0.125rem 0.25rem 0 color(var(--c-black) alpha(0.5));
   }
 
   & .suffix {


### PR DESCRIPTION
## overview

Closes #1290 

![image](https://user-images.githubusercontent.com/11590381/39596299-e2cd4aa6-4edf-11e8-93d1-1098ec11d7e6.png)

## changelog

- When InputField has focus, show dropshadow and white background (previously, focus was indicated by light blue background)

## review requests

- :ocean: 