### PR TITLE
feat(app): Add POST /calibration/deck to calibration API module

### DIFF
--- a/app/src/http-api-client/__tests__/robot.test.js
+++ b/app/src/http-api-client/__tests__/robot.test.js
@@ -239,18 +239,14 @@ describe('robot/*', () => {
     beforeEach(() => {
       state.api.robot[NAME] = {
         home: {inProgress: true},
-        move: {inProgress: true},
-        movePosition: 'change_pipette'
+        move: {inProgress: true}
       }
     })
 
     test('makeGetRobotMove', () => {
       const getMove = makeGetRobotMove()
 
-      expect(getMove(state, robot)).toEqual({
-        ...state.api.robot[NAME].move
-      })
-
+      expect(getMove(state, robot)).toEqual(state.api.robot[NAME].move)
       expect(getMove(state, {name: 'foo'})).toEqual({inProgress: false})
     })
 

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -26,8 +26,8 @@ type DeckStartResponse = {
 }
 
 type DeckCalRequest =
-  | {| command: 'attach_tip', tipLength: number |}
-  | {| command: 'detach_tip' |}
+  | {| command: 'attach tip', tipLength: number |}
+  | {| command: 'detach tip' |}
   | {| command: 'jog', axis: JogAxis, direction: JogDirection, step: number |}
   | {| command: 'save xy', point: DeckCalPoint |}
   | {| command: 'save z' |}

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -7,6 +7,12 @@ import type {ApiCall, ApiRequestError} from './types'
 
 import client from './client'
 
+export type JogAxis = 'x' | 'y' | 'z'
+
+export type JogDirection = -1 | 1
+
+export type DeckCalPoint = 1 | 2 | 3
+
 type DeckStartRequest = {
   force?: boolean
 }
@@ -15,15 +21,30 @@ type DeckStartResponse = {
   token: string,
   pipette: {
     mount: Mount,
-    model: string
+    model: string,
   },
 }
 
-type CalRequest = DeckStartRequest
+type DeckCalRequest =
+  | {| command: 'attach_tip', tipLength: number |}
+  | {| command: 'detach_tip' |}
+  | {| command: 'jog', axis: JogAxis, direction: JogDirection, step: number |}
+  | {| command: 'save xy', point: DeckCalPoint |}
+  | {| command: 'save z' |}
+  | {| command: 'save transform' |}
+  | {| command: 'release' |}
 
-type CalResponse = DeckStartResponse
+type DeckCalResponse = {
+  message: string,
+}
 
-type RequestPath = 'deck/start'
+type CalRequest = DeckStartRequest | DeckCalRequest
+
+type CalResponse = DeckStartResponse | DeckCalResponse
+
+type RequestPath =
+  | 'deck/start'
+  | 'deck'
 
 type CalRequestAction = {|
   type: 'api:CAL_REQUEST',
@@ -59,16 +80,19 @@ export type CalibrationAction =
 
 export type DeckCalStartState = ApiCall<DeckStartRequest, DeckStartResponse>
 
+export type DeckCalCommandState = ApiCall<DeckCalRequest, DeckCalResponse>
+
 type RobotCalState = {
-  'deck/start'?: DeckCalStartState
+  'deck/start'?: DeckCalStartState,
+  deck?: DeckCalCommandState,
 }
 
 type CalState = {
   [robotName: string]: ?RobotCalState
 }
 
-// const DECK: RequestPath = 'deck'
-const DECK_START: RequestPath = 'deck/start'
+const DECK: 'deck' = 'deck'
+const DECK_START: 'deck/start' = 'deck/start'
 
 export function startDeckCalibration (
   robot: RobotService,
@@ -82,6 +106,24 @@ export function startDeckCalibration (
     return client(robot, 'POST', `calibration/${DECK_START}`, request)
       .then((res: DeckStartResponse) => calSuccess(robot, DECK_START, res))
       .catch((err: ApiRequestError) => calFailure(robot, DECK_START, err))
+      .then(dispatch)
+  }
+}
+
+export function deckCalibrationCommand (
+  robot: RobotService,
+  request: DeckCalRequest
+): ThunkPromiseAction {
+  return (dispatch, getState) => {
+    const state = getRobotCalState(getState(), robot)
+    const startState = getStartStateFromCalState(state)
+    const token = startState.response && startState.response.token
+
+    dispatch(calRequest(robot, DECK, request))
+
+    return client(robot, 'POST', `calibration/${DECK}`, {...request, token})
+      .then((res: DeckCalResponse) => calSuccess(robot, DECK, res))
+      .catch((err: ApiRequestError) => calFailure(robot, DECK, err))
       .then(dispatch)
   }
 }
@@ -151,15 +193,42 @@ export function calibrationReducer (
 
 export function makeGetDeckCalibrationStartState () {
   const sel: Selector<State, BaseRobot, DeckCalStartState> = createSelector(
-    selectRobotCalState,
-    (state) => state[DECK_START] || {inProgress: false}
+    getRobotCalState,
+    getStartStateFromCalState
   )
 
   return sel
 }
 
-function selectRobotCalState (state: State, props: BaseRobot): RobotCalState {
+export function makeGetDeckCalibrationCommandState () {
+  const sel: Selector<State, BaseRobot, DeckCalCommandState> = createSelector(
+    getRobotCalState,
+    getDeckStateFromCalState
+  )
+
+  return sel
+}
+
+function getRobotCalState (state: State, props: BaseRobot): RobotCalState {
   return state.api.calibration[props.name] || {}
+}
+
+function getStartStateFromCalState (state: RobotCalState): DeckCalStartState {
+  return state[DECK_START] || {
+    inProgress: false,
+    error: null,
+    request: null,
+    response: null
+  }
+}
+
+function getDeckStateFromCalState (state: RobotCalState): DeckCalCommandState {
+  return state[DECK] || {
+    inProgress: false,
+    error: null,
+    request: null,
+    response: null
+  }
 }
 
 function calRequest (

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -24,7 +24,11 @@ export const reducer = combineReducers({
 export * from './types'
 
 export type {
-  DeckCalStartState
+  DeckCalStartState,
+  DeckCalCommandState,
+  JogAxis,
+  JogDirection,
+  DeckCalPoint
 } from './calibration'
 
 export type {
@@ -72,7 +76,9 @@ export type Action =
 
 export {
   startDeckCalibration,
-  makeGetDeckCalibrationStartState
+  deckCalibrationCommand,
+  makeGetDeckCalibrationStartState,
+  makeGetDeckCalibrationCommandState
 } from './calibration'
 
 export {


### PR DESCRIPTION
## overview

This is an app plumbing PR that adds all `POST /calibration/deck` commands to the `calibration` module of the HTTP API client. Accordingly, it lays groundwork for:

- Deck Calibration: Move to Z-Axis Point #976
- Deck Calibration: Save Z Calibration #978
- Deck Calibration: Calibrate XY Point 'A' #979
- Deck Calibration: Calibrate XY Point 'B' #980
- Deck Calibration: Calibrate XY Point 'C' #981
- Deck Calibration: Save Calibration #982
- Deck Calibration: Jog Controls Function #1246

Example usage:

```js
// jog
// note that token is not passed; the thunk pulls it from state instead
const action = deckCalibrationCommand(robot, {
  command: 'jog',
  axis: 'x',
  direction: -1,
  step: 0.25
})
dispatch(action)
```

Commands:

```js
type DeckCalRequest =
  | {| command: 'attach tip', tipLength: number |}
  | {| command: 'detach tip' |}
  | {| command: 'jog', axis: JogAxis, direction: JogDirection, step: number |}
  | {| command: 'save xy', point: DeckCalPoint |}
  | {| command: 'save z' |}
  | {| command: 'save transform' |}
  | {| command: 'release' |}
```

## changelog

- feat(app): Add POST /calibration/deck to calibration API module

## review requests

Behavior to be tested in the wiring PRs, so please just give this one a code review.
