### PR TITLE
refactor(api): Make attach/detach DC commands more permissive

### DIFF
--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -197,7 +197,7 @@ async def detach_tip(data):
     mount = 'left' if session.current_mount == 'Z' else 'right'
     pipette = session.pipettes[mount]
 
-    if not session.pipettes[mount].tip_attached:
+    if not pipette.tip_attached:
         log.warning('detach tip called with no tip')
 
     pipette._remove_tip(session.tip_length)

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -22,15 +22,15 @@ async def test_add_and_remove_tip(dc_session):
 
     # Check correct attach command
     tip_length = 50
-    res1 = await endpoints.attach_tip({'tip-length': tip_length})
+    res1 = await endpoints.attach_tip({'tipLength': tip_length})
     assert res1.status == 200
     assert dc_session.tip_length == tip_length
     assert pip.tip_attached
 
-    # Check command in wrong state (tip already attached)
-    res2 = await endpoints.attach_tip({'tip-length': tip_length + 5})
-    assert res2.status == 400
-    assert dc_session.tip_length == tip_length
+    # Check command with tip already attached
+    res2 = await endpoints.attach_tip({'tipLength': tip_length + 5})
+    assert res2.status == 200
+    assert dc_session.tip_length == tip_length + 5
     assert pip.tip_attached
 
     # Check correct detach command
@@ -39,9 +39,11 @@ async def test_add_and_remove_tip(dc_session):
     assert dc_session.tip_length is None
     assert not pip.tip_attached
 
-    # Check command in wrong state (no tip)
+    # Check command with no tip
     res4 = await endpoints.detach_tip({})
-    assert res4.status == 400
+    assert res4.status == 200
+    assert dc_session.tip_length is None
+    assert not pip.tip_attached
 
 
 async def test_save_xy(dc_session):


### PR DESCRIPTION
## overview

This is a little ticket + PR refactor based on some front-end requirements. Unblocks #1366 

## changelog

- refactor(api): Make attach/detach DC commands more permissive
    - Attach / detach tip will **no longer 400 if tip is already on / off**
    - "tip-length" > "tipLength" because snake-case in keys is annoying

## review requests

Code review + please make sure attach and detach tip commands still work!
