### PR TITLE
Pd distribute command

### DIFF
--- a/protocol-designer/src/components/StepEditForm.js
+++ b/protocol-designer/src/components/StepEditForm.js
@@ -72,7 +72,10 @@ export default function StepEditForm (props: Props) {
     )
   }
 
-  if (formData.stepType === 'transfer' || formData.stepType === 'consolidate') {
+  if (formData.stepType === 'transfer' ||
+    formData.stepType === 'consolidate' ||
+    formData.stepType === 'distribute'
+  ) {
     return (
       <div className={styles.form}>
         <FormSection title='Aspirate'
@@ -159,9 +162,10 @@ export default function StepEditForm (props: Props) {
               initialSelectedWells={formData['dispense--wells']}
               formFieldAccessor={'dispense--wells'}
             />
-            {formData.stepType === 'transfer' && <FormGroup label='Volume:'>
-              <InputField units='μL' {...formConnector('volume')} />
-            </FormGroup>}
+            {(formData.stepType === 'transfer' || formData.stepType === 'distribute') &&
+              <FormGroup label='Volume:'>
+                <InputField units='μL' {...formConnector('volume')} />
+              </FormGroup>}
           </div>
 
           <div className={styles.row_wrapper}>

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -168,6 +168,9 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
       if (validatedForm.stepType === 'transfer') {
         nextCommandsAndState = StepGeneration.transfer(validatedForm)(acc.robotState)
       }
+      if (validatedForm.stepType === 'distribute') {
+        nextCommandsAndState = StepGeneration.distribute(validatedForm)(acc.robotState)
+      }
       if (validatedForm.stepType === 'pause') {
         nextCommandsAndState = StepGeneration.delay(validatedForm)(acc.robotState)
       }

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -28,9 +28,11 @@ export type FormModalFields = {|
   'step-details': string
 |}
 
+export type TransferLikeStepType = 'transfer' | 'consolidate' | 'distribute'
+
 export type TransferLikeForm = {|
   ...FormModalFields,
-  stepType: 'transfer' | 'consolidate', // TODO add distribute
+  stepType: TransferLikeStepType,
   id: StepIdType,
 
   'aspirate--labware'?: string,

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -131,7 +131,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         ? [
           blowout({
             pipette: data.pipette,
-            labware: data.blowout,
+            labware: data.blowout, // TODO Ian 2018-05-04 more explicit test for non-trash blowout destination
             well: 'A1' // TODO LATER: should user be able to specify the blowout well?
           })
         ]

--- a/protocol-designer/src/step-generation/distribute.js
+++ b/protocol-designer/src/step-generation/distribute.js
@@ -4,7 +4,7 @@ import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 // import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators} from './'
-// import mix from './mix'
+import mix from './mix'
 import * as errorCreators from './errorCreators'
 import type {DistributeFormData, RobotState, CommandCreator} from './'
 
@@ -100,8 +100,19 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
         ]
         : []
 
+      const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
+        ? mix(
+          data.pipette,
+          data.sourceLabware,
+          data.sourceWell,
+          data.mixBeforeAspirate.volume,
+          data.mixBeforeAspirate.times
+        )
+        : []
+
       return [
         ...tipCommands,
+        ...mixBeforeAspirateCommands,
         aspirate({
           pipette,
           volume: data.volume * destWellChunk.length + disposalVolume,
@@ -109,6 +120,7 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
           well: data.sourceWell
         }),
         ...touchTipAfterAspirateCommand,
+
         ...dispenseCommands,
         ...blowoutCommands
       ]

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -2,6 +2,7 @@
 import aspirate from './aspirate'
 import blowout from './blowout'
 import consolidate from './consolidate'
+import distribute from './distribute'
 import delay from './delay'
 import dispense from './dispense'
 import dropTip from './dropTip'
@@ -17,6 +18,7 @@ export {
   aspirate,
   blowout,
   consolidate,
+  distribute,
   delay,
   dispense,
   dropTip,

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -130,6 +130,7 @@ describe('consolidate single-channel', () => {
   })
 
   test('Single-channel with exceeding pipette max: A1 A2 A3 A4 to B1, 150uL with p300', () => {
+    // TODO Ian 2018-05-03 is this a duplicate of exceeding max with changeTip="once"???
     const data = {
       ...baseData,
       volume: 150,

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -1,22 +1,24 @@
 // @flow
 import _distribute from '../distribute'
 // import merge from 'lodash/merge'
-import {createRobotState, commandCreatorNoErrors} from './fixtures' // getTipColumn, getTiprackTipstate, createEmptyLiquidState, commandCreatorHasErrors
+import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures'
 import type {DistributeFormData} from '../types'
 const distribute = commandCreatorNoErrors(_distribute)
-// const distributeWithErrors = commandCreatorHasErrors(_distribute)
+const distributeWithErrors = commandCreatorHasErrors(_distribute)
 
 let mixinArgs
 let robotInitialState
 let robotInitialStatePipettesLackTips
+let dropTipSingleChannel
+let blowoutSingleToDestPlateA1
 
 beforeEach(() => {
   mixinArgs = {
     stepType: 'distribute',
     name: 'distribute test',
     description: 'test blah blah',
-    pipette: 'p300SingleId',
 
+    pipette: 'p300SingleId',
     sourceLabware: 'sourcePlateId',
     destLabware: 'destPlateId',
 
@@ -26,9 +28,10 @@ beforeEach(() => {
     mixBeforeAspirate: null,
 
     touchTipAfterDispense: false,
-    // mixInDestination: null, // SHOULD NOT BE IN FORM DATA
     delayAfterDispense: null,
-    blowout: null
+    // NOTE: setting "blowout to dest plate" in standard args for these tests to make sure
+    // we're not just blowing out to trashId and ignoring the given blowout labware
+    blowout: 'destPlateId'
   }
 
   robotInitialState = createRobotState({
@@ -46,17 +49,31 @@ beforeEach(() => {
     fillPipetteTips: true,
     fillTiprackTips: false
   })
+
+  dropTipSingleChannel = {
+    command: 'drop-tip',
+    pipette: 'p300SingleId',
+    labware: 'trashId',
+    well: 'A1'
+  }
+
+  blowoutSingleToDestPlateA1 = {
+    command: 'blowout',
+    pipette: 'p300SingleId',
+    labware: mixinArgs.blowout,
+    well: 'A1'
+  }
 })
 
-describe('distribute single-channel', () => {
-  test('minimal distribute: 60uL from A1 -> A2, A3; no tip pickup', () => {
+describe('distribute: minimal example', () => {
+  test('single channel; 60uL from A1 -> A2, A3; no tip pickup', () => {
     // TODO Ian 2018-05-03 distributeArgs needs to be typed because the
     // commandCreatorNoErrors wrapper casts the arg type to any :(
     const distributeArgs: DistributeFormData = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
-      changeTip: 'once',
+      changeTip: 'never',
       volume: 60
     }
     const result = distribute(distributeArgs)(robotInitialState)
@@ -82,18 +99,162 @@ describe('distribute single-channel', () => {
         pipette: 'p300SingleId',
         volume: 60,
         well: 'A3'
-      }
+      },
+      blowoutSingleToDestPlateA1
     ])
   })
 })
 
-describe('exceeding pipette max', () => {
-  test('multiple asp-disp-disp chunks', () => {
+describe('tip handling for multiple distribute chunks', () => {
+  test('changeTip: "once"', () => {
     const distributeArgs: DistributeFormData = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
       changeTip: 'once',
+      volume: 150
+    }
+
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      dropTipSingleChannel,
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'A1'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      blowoutSingleToDestPlateA1,
+
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      },
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test('changeTip: "always"', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'always',
+      volume: 150
+    }
+
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      dropTipSingleChannel,
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'A1'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      blowoutSingleToDestPlateA1,
+
+      // next chunk, change tip
+      dropTipSingleChannel,
+      {
+        command: 'pick-up-tip',
+        pipette: 'p300SingleId',
+        labware: 'tiprack1Id',
+        well: 'B1'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      },
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test('changeTip: "never" with carried-over tip', () => {
+    // NOTE: this has been used as BASE CASE for the "advanced settings" tests
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
       volume: 150
     }
     const result = distribute(distributeArgs)(robotInitialState)
@@ -120,6 +281,7 @@ describe('exceeding pipette max', () => {
         volume: 150,
         well: 'A3'
       },
+      blowoutSingleToDestPlateA1,
       {
         command: 'aspirate',
         labware: 'sourcePlateId',
@@ -140,10 +302,332 @@ describe('exceeding pipette max', () => {
         pipette: 'p300SingleId',
         volume: 150,
         well: 'A5'
-      }
+      },
+      blowoutSingleToDestPlateA1
     ])
   })
 
+  test('changeTip: "never" should fail with no initial tip', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'always',
+      volume: 150
+    }
+
+    const result = distributeWithErrors(distributeArgs)(robotInitialStatePipettesLackTips)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'INSUFFICIENT_TIPS'
+    })
+  })
+})
+
+describe('advanced settings: disposal volume, mix, pre-wet tip, tip touch', () => {
+  test('mix before aspirate, then aspirate disposal volume', () => {
+    // NOTE this also tests "uneven final chunk" eg A6 in [A2 A3 | A4 A5 | A6]
+    // which is especially relevant to disposal volume
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5', 'A6'],
+      changeTip: 'never',
+      volume: 120,
+
+      mixFirstAspirate: true,
+      disposalVolume: 12
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+    const aspirateVol = (120 * 2) + 12
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: aspirateVol,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 120,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 120,
+        well: 'A3'
+      },
+      blowoutSingleToDestPlateA1,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: aspirateVol,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 120,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 120,
+        well: 'A5'
+      },
+      blowoutSingleToDestPlateA1,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 120 + 12,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 120,
+        well: 'A6'
+      },
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test.skip('pre-wet tip', () => {
+    // TODO Ian 2018-05-04 pre-wet volume is TBD.
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
+      volume: 150,
+      preWetTip: true
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    const preWetVolume = 42 // TODO what is pre-wet volume?
+    const preWetTipCommands = [
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: preWetVolume,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: preWetVolume,
+        well: 'A1'
+      }
+    ]
+
+    expect(result.commands).toEqual([
+      ...preWetTipCommands,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      blowoutSingleToDestPlateA1,
+      ...preWetTipCommands,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      },
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test('touch tip after aspirate', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
+      volume: 150,
+      touchTipAfterAspirate: true
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+    const touchTipCommand = {
+      command: 'touch-tip',
+      labware: 'sourcePlateId',
+      pipette: 'p300SingleId',
+      well: 'A1'
+    }
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      touchTipCommand,
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      blowoutSingleToDestPlateA1,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      touchTipCommand,
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      },
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test('touch tip after dispense', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
+      volume: 150,
+      touchTipAfterDispense: true
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    function makeTouchTip (well: string) {
+      return {
+        command: 'touch-tip',
+        pipette: 'p300SingleId',
+        labware: 'destPlateId',
+        well
+      }
+    }
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      makeTouchTip('A2'),
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      makeTouchTip('A3'),
+      blowoutSingleToDestPlateA1,
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      makeTouchTip('A4'),
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      },
+      makeTouchTip('A5'),
+      blowoutSingleToDestPlateA1
+    ])
+  })
+
+  test('mix before aspirate') // TODO IMMEDIATELY
+})
+
+describe('weirdos TBD', () => {
   // TODO Ian 2018-05-03 is this a valid distribute?
   // It's gonna be equivalent to a transfer under the hood anyway, right?
   // SKIPPING for now
@@ -154,7 +638,8 @@ describe('exceeding pipette max', () => {
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
       changeTip: 'never', // TODO additional test with changeTip='always'
-      volume: 350
+      volume: 350,
+      blowout: null
     }
     const result = distribute(distributeArgs)(robotInitialState)
 
@@ -218,11 +703,4 @@ describe('exceeding pipette max', () => {
       }
     ])
   })
-
-  test('changeTip="always"')
-  test('changeTip="never"')
-})
-
-describe('changeTip=never with no initial tip returns error', () => {
-  // TODO
 })

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -8,6 +8,7 @@ const distribute = commandCreatorNoErrors(_distribute)
 
 let mixinArgs
 let robotInitialState
+let robotInitialStatePipettesLackTips
 
 beforeEach(() => {
   mixinArgs = {
@@ -37,10 +38,18 @@ beforeEach(() => {
     fillPipetteTips: true,
     fillTiprackTips: true
   })
+
+  robotInitialStatePipettesLackTips = createRobotState({
+    sourcePlateType: '96-flat',
+    destPlateType: '96-flat',
+    tipracks: [200],
+    fillPipetteTips: true,
+    fillTiprackTips: false
+  })
 })
 
 describe('distribute single-channel', () => {
-  test('minimal distribute: 60uL from A1 -> A2, A3', () => {
+  test('minimal distribute: 60uL from A1 -> A2, A3; no tip pickup', () => {
     // TODO Ian 2018-05-03 distributeArgs needs to be typed because the
     // commandCreatorNoErrors wrapper casts the arg type to any :(
     const distributeArgs: DistributeFormData = {
@@ -57,27 +66,163 @@ describe('distribute single-channel', () => {
         command: 'aspirate',
         labware: 'sourcePlateId',
         pipette: 'p300SingleId',
-        volume: 60,
+        volume: 120,
         well: 'A1'
       },
       {
         command: 'dispense',
         labware: 'destPlateId',
         pipette: 'p300SingleId',
-        volume: 30,
+        volume: 60,
         well: 'A2'
       },
       {
         command: 'dispense',
         labware: 'destPlateId',
         pipette: 'p300SingleId',
-        volume: 30,
+        volume: 60,
         well: 'A3'
       }
     ])
   })
 })
 
-describe('distribute exceeding pipette max', () => {
-  // TODO Ian 2018-05-03
+describe('exceeding pipette max', () => {
+  test('multiple asp-disp-disp chunks', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'once',
+      volume: 150
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A3'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A4'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 150,
+        well: 'A5'
+      }
+    ])
+  })
+
+  // TODO Ian 2018-05-03 is this a valid distribute?
+  // It's gonna be equivalent to a transfer under the hood anyway, right?
+  // SKIPPING for now
+  // I think this is also an issue with consolidate!
+  test.skip('each well exceeds pipette max vol', () => {
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3'],
+      changeTip: 'never', // TODO additional test with changeTip='always'
+      volume: 350
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A2'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A2'
+      },
+      // A2 done, move to A3
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 300,
+        well: 'A3'
+      },
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 50,
+        well: 'A3'
+      }
+    ])
+  })
+
+  test('changeTip="always"')
+  test('changeTip="never"')
+})
+
+describe('changeTip=never with no initial tip returns error', () => {
+  // TODO
 })

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -1,5 +1,83 @@
 // @flow
+import _distribute from '../distribute'
+// import merge from 'lodash/merge'
+import {createRobotState, commandCreatorNoErrors} from './fixtures' // getTipColumn, getTiprackTipstate, createEmptyLiquidState, commandCreatorHasErrors
+import type {DistributeFormData} from '../types'
+const distribute = commandCreatorNoErrors(_distribute)
+// const distributeWithErrors = commandCreatorHasErrors(_distribute)
 
-test('TODO', () => {
+let mixinArgs
+let robotInitialState
+
+beforeEach(() => {
+  mixinArgs = {
+    stepType: 'distribute',
+    name: 'distribute test',
+    description: 'test blah blah',
+    pipette: 'p300SingleId',
+
+    sourceLabware: 'sourcePlateId',
+    destLabware: 'destPlateId',
+
+    preWetTip: false,
+    touchTipAfterAspirate: false,
+    disposalVolume: null,
+    mixBeforeAspirate: null,
+
+    touchTipAfterDispense: false,
+    // mixInDestination: null, // SHOULD NOT BE IN FORM DATA
+    delayAfterDispense: null,
+    blowout: null
+  }
+
+  robotInitialState = createRobotState({
+    sourcePlateType: '96-flat',
+    destPlateType: '96-flat',
+    tipracks: [200],
+    fillPipetteTips: true,
+    fillTiprackTips: true
+  })
+})
+
+describe('distribute single-channel', () => {
+  test('minimal distribute: 60uL from A1 -> A2, A3', () => {
+    // TODO Ian 2018-05-03 distributeArgs needs to be typed because the
+    // commandCreatorNoErrors wrapper casts the arg type to any :(
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3'],
+      changeTip: 'once',
+      volume: 60
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      {
+        command: 'aspirate',
+        labware: 'sourcePlateId',
+        pipette: 'p300SingleId',
+        volume: 60,
+        well: 'A1'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 30,
+        well: 'A2'
+      },
+      {
+        command: 'dispense',
+        labware: 'destPlateId',
+        pipette: 'p300SingleId',
+        volume: 30,
+        well: 'A3'
+      }
+    ])
+  })
+})
+
+describe('distribute exceeding pipette max', () => {
   // TODO Ian 2018-05-03
 })

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -19,7 +19,7 @@ export type SharedFormDataFields = {|
 
 // ===== Processed form types. Used as args to call command creator fns =====
 
-export type TransferLikeFormDataFields = {|
+export type TransferLikeFormDataFields = {
   ...SharedFormDataFields,
 
   pipette: string, // PipetteId
@@ -40,19 +40,15 @@ export type TransferLikeFormDataFields = {|
   disposalVolume: ?number,
 
   // ===== DISPENSE SETTINGS =====
-  /** Mix in destination well after dispense */
-  mixInDestination: ?MixArgs,
   /** Touch tip in destination well after dispense */
   touchTipAfterDispense: boolean,
   /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
   delayAfterDispense: ?number,
   /** If given, blow out in the specified labware after dispense at the end of each asp-asp-dispense cycle */
   blowout: ?string // TODO LATER LabwareId export type here instead of string?
-|}
+}
 
 export type ConsolidateFormData = {
-  ...TransferLikeFormDataFields,
-
   stepType: 'consolidate',
 
   sourceWells: Array<string>,
@@ -60,10 +56,11 @@ export type ConsolidateFormData = {
 
   /** Mix in first well in chunk */
   mixFirstAspirate: ?MixArgs,
-}
+  /** Mix in destination well after dispense */
+  mixInDestination: ?MixArgs
+} & TransferLikeFormDataFields
 
 export type TransferFormData = {
-  ...TransferLikeFormDataFields,
   stepType: 'transfer',
 
   sourceWells: Array<string>,
@@ -71,18 +68,19 @@ export type TransferFormData = {
 
   /** Mix in first well in chunk */
   mixBeforeAspirate: ?MixArgs,
-}
+  /** Mix in destination well after dispense */
+  mixInDestination: ?MixArgs
+} & TransferLikeFormDataFields
 
 export type DistributeFormData = {
-  ...TransferLikeFormDataFields,
   stepType: 'distribute',
 
   sourceWell: string,
-  destWell: Array<string>,
+  destWells: Array<string>,
 
   /** Mix in first well in chunk */
   mixBeforeAspirate: ?MixArgs
-}
+} & TransferLikeFormDataFields
 
 export type PauseFormData = {|
   ...SharedFormDataFields,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -21,6 +21,7 @@ import type {StepIdType} from '../form-types'
 import type {
   PipetteData,
   ConsolidateFormData,
+  DistributeFormData,
   PauseFormData,
   TransferFormData
 } from '../step-generation/types'
@@ -190,6 +191,14 @@ function _consolidateSubsteps (
   }
 }
 
+function _distributeSubsteps (
+  form: DistributeFormData,
+  transferLikeFields: *
+): ?TransferLikeSubstepItem { // <-- TODO remove '?' type
+  console.log('Distribute substeps not yet implemented') // TODO Ian 2018-05-04
+  return null
+}
+
 // NOTE: This is the fn used by the `allSubsteps` selector
 export function generateSubsteps (
   validatedForms: {[StepIdType]: ValidFormAndErrors},
@@ -221,7 +230,8 @@ export function generateSubsteps (
     // Handle all TransferLike substeps
     if (
       validatedForm.stepType === 'transfer' ||
-      validatedForm.stepType === 'consolidate'
+      validatedForm.stepType === 'consolidate' ||
+      validatedForm.stepType === 'distribute'
     ) {
       const namedIngredsByLabware = namedIngredsByLabwareAllSteps[prevStepId]
 
@@ -277,10 +287,17 @@ export function generateSubsteps (
         )
       }
 
+      if (validatedForm.stepType === 'distribute') {
+        return _distributeSubsteps(
+          validatedForm,
+          transferLikeFields
+        )
+      }
+
       // unreachable here
     }
 
-    console.warn('allSubsteps doesnt support step type: ', validatedForm.stepType, stepId)
+    console.warn('allSubsteps doesn\'t support step type: ', validatedForm.stepType, stepId)
     return null
   })
 }

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,6 +1,6 @@
 // @flow
 import type {PauseFormData} from '../step-generation'
-import type {StepIdType, StepType} from '../form-types'
+import type {StepIdType, StepType, TransferLikeStepType} from '../form-types'
 
 // sections of the form that are expandable/collapsible
 export type FormSectionState = {aspirate: boolean, dispense: boolean}
@@ -37,7 +37,7 @@ export type StepItemSourceDestRowMulti = {|
 
 export type TransferLikeSubstepItemSingleChannel = {|
   multichannel: false,
-  stepType: 'transfer' | 'consolidate' | 'distribute',
+  stepType: TransferLikeStepType,
   parentStepId: StepIdType,
   rows: Array<{|
     ...StepItemSourceDestRow,


### PR DESCRIPTION
Closes #729 and closes #730

## overview

Implements Distribute step! User can create distribute steps, they'll update liquid + tip state, and user can save protocol and see that commands have been generated for Distribute.

## changelog

- `distribute` command and tests
- Some further cleanup to make "TransferLike" (transfer, consolidate, distribute) be treated more uniformly
- Hooked up Distribute form
- Distribute form blows out to trash by default (as opposed to not blowing out. This was not specified in the ticket but I think it makes sense)

## review requests

- Review tests, they should hopefully be straightforward (just long)
- Try it out in PD! The liquid tracking view as you scrub across the step list should be a good indicator of whether it's working right. Also, download the .json and make sure it generated the commands.

**Does not** implement distribute's substeps (the highlightable A1 -> A2 rows in the step list on the left) that's for another ticket.