### PR TITLE
add box shadow & more margin to StepItems

### DIFF
--- a/protocol-designer/src/components/StepItem.css
+++ b/protocol-designer/src/components/StepItem.css
@@ -42,8 +42,9 @@
 }
 
 .step_item {
-  margin: 0.25rem 0;
+  margin: 0.4rem 0.125rem;
   color: var(--c-dark-gray);
+  box-shadow: 0 0.125rem 0.5rem color(var(--c-black) alpha(0.25));
 }
 
 .step_item ol {

--- a/protocol-designer/src/components/StepList.js
+++ b/protocol-designer/src/components/StepList.js
@@ -11,6 +11,7 @@ import type {StepIdType} from '../form-types'
 import StepItem from '../components/StepItem'
 import TransferLikeSubstep from '../components/TransferLikeSubstep'
 import StepCreationButton from '../containers/StepCreationButton'
+import styles from './StepItem.css'
 
 type StepIdTypeWithEnd = StepIdType | typeof END_STEP
 
@@ -99,6 +100,7 @@ export default function StepList (props: StepListProps) {
 
       <StepCreationButton />
       <TitledList title='END' iconName='check'
+        className={styles.step_item}
         onClick={props.handleStepItemClickById && props.handleStepItemClickById(END_STEP)}
         onMouseEnter={props.handleStepHoverById && props.handleStepHoverById(END_STEP)}
         selected={props.selectedStepId === END_STEP}


### PR DESCRIPTION
## overview

Closes #1293 

![image](https://user-images.githubusercontent.com/11590381/39646990-3f1163d0-4fab-11e8-93f6-c8d36222882e.png)

## changelog

- MORE BOX SHADOW
- "END" step is styled like the rest

## review requests

- :eye: 