### PR TITLE
Pd clear well selection after pipette switch

### DIFF
--- a/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
+++ b/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
@@ -30,7 +30,7 @@ function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
 
     handleChange: (accessor: string) => (e: SyntheticInputEvent<*>) => {
       // NOTE this is similar to ConnectedStepEdit form, is it possible to make a more general reusable fn?
-      dispatch(changeMoreOptionsModalInput({accessor, value: e.target.value}))
+      dispatch(changeMoreOptionsModalInput({update: {[accessor]: e.target.value}}))
     },
 
     onClickAway: () => dispatch(cancelMoreOptionsModal())

--- a/protocol-designer/src/containers/ConnectedStepEditForm.js
+++ b/protocol-designer/src/containers/ConnectedStepEditForm.js
@@ -49,7 +49,7 @@ function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
     onToggleFormSection: (section) => () => dispatch(collapseFormSection(section)),
     handleChange: (accessor: string) => (e: SyntheticEvent<HTMLInputElement> | SyntheticEvent<HTMLSelectElement>) => {
       // TODO Ian 2018-01-26 factor this nasty type handling out
-      const dispatchEvent = value => dispatch(changeFormInput({accessor, value}))
+      const dispatchEvent = value => dispatch(changeFormInput({update: {[accessor]: value}}))
 
       if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {
         dispatchEvent(e.target.checked)

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -1,107 +1,19 @@
 // @flow
 import type {Dispatch} from 'redux'
 
-import {selectors} from './reducers'
-import {END_STEP} from './types'
-import type {SubstepIdentifier, FormSectionNames} from './types'
-import type {StepType, StepIdType, FormModalFields, FormData} from '../form-types'
-import type {GetState, ThunkAction, ThunkDispatch} from '../types'
-import {getWellSetForMultichannel} from '../well-selection/utils'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors} from '../reducers'
+import {END_STEP} from '../types'
+import type {StepType, StepIdType, FormModalFields, FormData} from '../../form-types'
+import type {ChangeFormPayload} from './types'
+import type {SubstepIdentifier, FormSectionNames} from '../types'
+import type {GetState, ThunkAction, ThunkDispatch} from '../../types'
+import handleFormChange from './handleFormChange'
 
 type EndStepId = typeof END_STEP
-
-// Update Form input (onChange on inputs)
-type ChangeFormPayload = {
-  // TODO Ian 2018-05-04 use StepType + FormData type to properly type this payload.
-  // Accessor strings and values depend on StepType
-  stepType?: string,
-  update: {
-    [accessor: string]: string | boolean | Array<string>,
-  }
-}
 
 export type ChangeFormInputAction = {
   type: 'CHANGE_FORM_INPUT',
   payload: ChangeFormPayload
-}
-
-function _getAllWells (
-  primaryWells: ?Array<string>,
-  labwareType: ?string
-): Array<string> {
-  if (!labwareType || !primaryWells) {
-    return []
-  }
-
-  const _labwareType = labwareType // TODO Ian 2018-05-04 remove this weird flow workaround
-
-  const allWells = primaryWells.reduce((acc: Array<string>, well: string) => {
-    const nextWellSet = getWellSetForMultichannel(_labwareType, well)
-    // filter out any nulls (but you shouldn't get any)
-    return (nextWellSet) ? [...acc, ...nextWellSet] : acc
-  }, [])
-
-  return allWells
-}
-
-function handleFormChange (payload: ChangeFormPayload, getState: GetState): ChangeFormPayload {
-  const baseState = getState()
-  const unsavedForm = selectors.formData(baseState)
-
-  // Changing pipette from multi-channel to single-channel (and visa versa) modifies well selection
-  if (
-    unsavedForm !== null &&
-    unsavedForm.pipette &&
-    'pipette' in payload.update
-  ) {
-    const prevPipette = unsavedForm.pipette
-    const nextPipette = payload.update.pipette
-
-    const getChannels = (pipetteId: string): 1 | 8 => {
-      // TODO HACK Ian 2018-05-04 use pipette definitions for this;
-      // you'd also need a way to grab pipette model from a given pipetteId here
-      return pipetteId.endsWith('8-Channel') ? 8 : 1
-    }
-
-    if (nextPipette === 'string' && // TODO Ian 2018-05-04 this type check can probably be removed when changeFormInput is typed
-      getChannels(nextPipette) === 8 &&
-      getChannels(prevPipette) === 1
-    ) {
-      // multi-channel to single-channel: clear all selected wells
-      // to avoid carrying over inaccessible wells
-      return {
-        update: {
-          pipette: nextPipette,
-          'aspirate--wells': [],
-          'dispense--wells': []
-        }
-      }
-    }
-
-    if (typeof nextPipette === 'string' &&
-      getChannels(nextPipette) === 1 &&
-      getChannels(prevPipette) === 8
-    ) {
-      // single-channel to multi-channel: convert primary wells to all wells
-      const sourceLabwareId = unsavedForm['aspirate--labware']
-      const destLabwareId = unsavedForm['dispense--labware']
-
-      const sourceLabwareType = sourceLabwareId && labwareIngredSelectors.getLabware(baseState)[sourceLabwareId].type
-      const destLabwareType = destLabwareId && labwareIngredSelectors.getLabware(baseState)[destLabwareId].type
-
-      return {
-        update: {
-          pipette: nextPipette,
-          'aspirate--wells': _getAllWells(unsavedForm['aspirate--wells'], sourceLabwareType),
-          'dispense--wells': _getAllWells(unsavedForm['dispense--wells'], destLabwareType)
-        }
-      }
-    }
-  }
-
-  // fallback, untransformed
-  return payload
 }
 
 export const changeFormInput = (payload: ChangeFormPayload) =>

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -1,0 +1,89 @@
+// @flow
+import {getWellSetForMultichannel} from '../../well-selection/utils'
+
+import {selectors} from '../reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import type {GetState} from '../../types'
+
+import type {ChangeFormPayload} from './types'
+
+function _getAllWells (
+  primaryWells: ?Array<string>,
+  labwareType: ?string
+): Array<string> {
+  if (!labwareType || !primaryWells) {
+    return []
+  }
+
+  const _labwareType = labwareType // TODO Ian 2018-05-04 remove this weird flow workaround
+
+  const allWells = primaryWells.reduce((acc: Array<string>, well: string) => {
+    const nextWellSet = getWellSetForMultichannel(_labwareType, well)
+    // filter out any nulls (but you shouldn't get any)
+    return (nextWellSet) ? [...acc, ...nextWellSet] : acc
+  }, [])
+
+  return allWells
+}
+
+function handleFormChange (payload: ChangeFormPayload, getState: GetState): ChangeFormPayload {
+  // Use state to handle form changes
+  const baseState = getState()
+  const unsavedForm = selectors.formData(baseState)
+
+  // Changing pipette from multi-channel to single-channel (and visa versa) modifies well selection
+  if (
+    unsavedForm !== null &&
+    unsavedForm.pipette &&
+    'pipette' in payload.update
+  ) {
+    const prevPipette = unsavedForm.pipette
+    const nextPipette = payload.update.pipette
+
+    const getChannels = (pipetteId: string): 1 | 8 => {
+      // TODO HACK Ian 2018-05-04 use pipette definitions for this;
+      // you'd also need a way to grab pipette model from a given pipetteId here
+      return pipetteId.endsWith('8-Channel') ? 8 : 1
+    }
+
+    if (nextPipette === 'string' && // TODO Ian 2018-05-04 this type check can probably be removed when changeFormInput is typed
+      getChannels(nextPipette) === 8 &&
+      getChannels(prevPipette) === 1
+    ) {
+      // multi-channel to single-channel: clear all selected wells
+      // to avoid carrying over inaccessible wells
+      return {
+        update: {
+          pipette: nextPipette,
+          'aspirate--wells': [],
+          'dispense--wells': []
+        }
+      }
+    }
+
+    if (typeof nextPipette === 'string' &&
+      getChannels(nextPipette) === 1 &&
+      getChannels(prevPipette) === 8
+    ) {
+      // single-channel to multi-channel: convert primary wells to all wells
+      const sourceLabwareId = unsavedForm['aspirate--labware']
+      const destLabwareId = unsavedForm['dispense--labware']
+
+      const sourceLabwareType = sourceLabwareId && labwareIngredSelectors.getLabware(baseState)[sourceLabwareId].type
+      const destLabwareType = destLabwareId && labwareIngredSelectors.getLabware(baseState)[destLabwareId].type
+
+      return {
+        update: {
+          pipette: nextPipette,
+          'aspirate--wells': _getAllWells(unsavedForm['aspirate--wells'], sourceLabwareType),
+          'dispense--wells': _getAllWells(unsavedForm['dispense--wells'], destLabwareType)
+        }
+      }
+    }
+  }
+
+  // fallback, untransformed
+  return payload
+}
+
+export default handleFormChange

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -46,11 +46,11 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
       return pipetteId.endsWith('8-Channel') ? 8 : 1
     }
 
-    if (nextPipette === 'string' && // TODO Ian 2018-05-04 this type check can probably be removed when changeFormInput is typed
-      getChannels(nextPipette) === 8 &&
-      getChannels(prevPipette) === 1
+    if (typeof nextPipette === 'string' && // TODO Ian 2018-05-04 this type check can probably be removed when changeFormInput is typed
+      getChannels(prevPipette) === 1 &&
+      getChannels(nextPipette) === 8
     ) {
-      // multi-channel to single-channel: clear all selected wells
+      // single-channel to multi-channel: clear all selected wells
       // to avoid carrying over inaccessible wells
       return {
         update: {
@@ -62,10 +62,10 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
     }
 
     if (typeof nextPipette === 'string' &&
-      getChannels(nextPipette) === 1 &&
-      getChannels(prevPipette) === 8
+      getChannels(prevPipette) === 8 &&
+      getChannels(nextPipette) === 1
     ) {
-      // single-channel to multi-channel: convert primary wells to all wells
+      // multi-channel to single-channel: convert primary wells to all wells
       const sourceLabwareId = unsavedForm['aspirate--labware']
       const destLabwareId = unsavedForm['dispense--labware']
 

--- a/protocol-designer/src/steplist/actions/index.js
+++ b/protocol-designer/src/steplist/actions/index.js
@@ -1,0 +1,9 @@
+// @flow
+import handleFormChange from './handleFormChange'
+
+export * from './actions'
+export * from './types'
+
+export {
+  handleFormChange
+}

--- a/protocol-designer/src/steplist/actions/types.js
+++ b/protocol-designer/src/steplist/actions/types.js
@@ -6,6 +6,6 @@ export type ChangeFormPayload = {
   // Accessor strings and values depend on StepType
   stepType?: string,
   update: {
-    [accessor: string]: string | boolean | Array<string>,
+    [accessor: string]: string | boolean | Array<string> | null,
   }
 }

--- a/protocol-designer/src/steplist/actions/types.js
+++ b/protocol-designer/src/steplist/actions/types.js
@@ -1,0 +1,11 @@
+// @flow
+
+// Update Form input (onChange on inputs)
+export type ChangeFormPayload = {
+  // TODO Ian 2018-05-04 use StepType + FormData type to properly type this payload.
+  // Accessor strings and values depend on StepType
+  stepType?: string,
+  update: {
+    [accessor: string]: string | boolean | Array<string>,
+  }
+}

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -36,6 +36,7 @@ import {
 
 import type {
   AddStepAction,
+  ChangeFormInputAction,
   DeleteStepAction,
   SaveStepFormAction,
   SelectStepAction,
@@ -52,7 +53,6 @@ import {
   cancelStepForm, // TODO try collapsing them all into a single Action type
   saveStepForm,
   hoverOnSubstep,
-  changeFormInput,
   expandAddStepButton,
   hoverOnStep,
   toggleStepCollapsed
@@ -60,13 +60,15 @@ import {
 
 type FormState = FormData | null
 
-// the `form` state holds temporary form info that is saved or thrown away with "cancel".
-// TODO: rename to make that more clear. 'unsavedForm'?
+// the `unsavedForm` state holds temporary form info that is saved or thrown away with "cancel".
 const unsavedForm = handleActions({
-  CHANGE_FORM_INPUT: (state, action: ActionType<typeof changeFormInput>) => ({
-    ...state,
-    [action.payload.accessor]: action.payload.value
-  }),
+  CHANGE_FORM_INPUT: (state: FormState, action: ChangeFormInputAction) => {
+    // $FlowFixMe TODO IMMEDIATELY
+    return {
+      ...state,
+      ...action.payload.update
+    }
+  },
   POPULATE_FORM: (state, action: PopulateFormAction) => action.payload,
   CANCEL_STEP_FORM: (state, action: ActionType<typeof cancelStepForm>) => null,
   SAVE_STEP_FORM: (state, action: ActionType<typeof saveStepForm>) => null,
@@ -101,7 +103,7 @@ function createDefaultStep (action: AddStepAction) {
 const unsavedFormModal = handleActions({
   OPEN_MORE_OPTIONS_MODAL: (state, action: OpenMoreOptionsModal) => action.payload,
   CHANGE_MORE_OPTIONS_MODAL_INPUT: (state, action: ChangeMoreOptionsModalInputAction) =>
-    ({...state, [action.payload.accessor]: action.payload.value}),
+    ({...state, ...action.payload.update}),
   CANCEL_MORE_OPTIONS_MODAL: () => null,
   SAVE_MORE_OPTIONS_MODAL: () => null,
   DELETE_STEP: () => null

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -89,8 +89,9 @@ export const saveWellSelectionModal = () =>
     // this if-else is mostly for Flow
     if (wellSelectionModalData) {
       dispatch(changeFormInput({
-        accessor: wellSelectionModalData.formFieldAccessor,
-        value: selectors.selectedWellNames(state)
+        update: {
+          [wellSelectionModalData.formFieldAccessor]: selectors.selectedWellNames(state)
+        }
       }))
     } else {
       console.warn('No well selection modal data in state')


### PR DESCRIPTION
## overview

Closes #1298 - this prevents the last white screen error I know of (I'd bet there's a few I don't know of still!) that you could previously cause by selecting wells with a single channel then switching to multi-channel and saving a step.

Also BONUS: changing labware in labware dropdown should clear the well selection for that labware, preventing a similar well-carry-over problem.

#1380 will follow-up this PR (addresses cleaning up pipette data)

## changelog

* ChangeFormPayload allows multiple form field changes with one action
* changeFormInput action is a thunk, uses access to state to handle form change events differently
* Factored out steplist/actions.js into a directory

## review requests

- In a Step Form (eg Transfer), select an 8-channel pipette, then select source and/or dest wells. Switching to a single-channel should keep the same well selection (the number in the well field will go up x8, that's b/c it wasn't initially multiplied by 8, another ticket.)
- Select a single-channel pipette, then select wells. Switching to an 8-channel pipette should clear the well selection.
- This should work when you have just source wells selected, just dest wells selected, or both source & dest.
- Works with 96, 384, trough, etc all labware formats.
