### PR TITLE
feat(app): Wire jog buttons for Deck Calibration

### DIFF
--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -9,6 +9,7 @@ export default function InstructionsModal (props: CalibrateDeckProps) {
   const HEADING = props.calibrationStep === 'step-2'
    ? 'Calibrate the z-axis'
    : 'Calibrate the X-Y axis'
+
   return (
     <ModalPage
       titleBar={{

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -2,6 +2,7 @@
 import type {PipetteConfig} from '@opentrons/labware-definitions'
 import type {RobotService} from '../../robot'
 import type {RobotMove, DeckCalStartState} from '../../http-api-client'
+import type {JogControlsProps} from '../JogControls'
 
 export type CalibrationStep = 2 | 3 | 4 | 5
 
@@ -19,13 +20,13 @@ export type SP = {
   pipette: ?PipetteConfig,
   startRequest: DeckCalStartState,
   moveRequest: RobotMove,
-  currentJogDistance: number
+  step: $PropertyType<JogControlsProps, 'step'>,
 }
 
 export type DP = {
   forceStart: () => mixed,
-  makeJog: (axis: any, direction: any) => () => mixed,
-  onIncrementSelect: (event: SyntheticInputEvent<>) => mixed,
+  jog: $PropertyType<JogControlsProps, 'jog'>,
+  onStepSelect: $PropertyType<JogControlsProps, 'onStepSelect'>,
 }
 
 export type CalibrateDeckProps = OP & SP & DP

--- a/app/src/http-api-client/__tests__/calibration.test.js
+++ b/app/src/http-api-client/__tests__/calibration.test.js
@@ -7,8 +7,10 @@ import {
   reducer,
   startDeckCalibration,
   deckCalibrationCommand,
+  setCalibrationJogStep,
   makeGetDeckCalibrationStartState,
-  makeGetDeckCalibrationCommandState
+  makeGetDeckCalibrationCommandState,
+  getCalibrationJogStep
 } from '..'
 
 jest.mock('../client')
@@ -142,6 +144,15 @@ describe('/calibration/**', () => {
     })
   })
 
+  describe('non-API-call action creators', () => {
+    test('setCalibrationJogStep', () => {
+      const step = 4
+      const expected = {type: 'api:SET_CAL_JOG_STEP', payload: {step}}
+
+      expect(setCalibrationJogStep(step)).toEqual(expected)
+    })
+  })
+
   const REDUCER_REQUEST_RESPONSE_TESTS = [
     {
       path: 'deck/start',
@@ -236,6 +247,21 @@ describe('/calibration/**', () => {
     })
   })
 
+  describe('reducer with non-API-call actions', () => {
+    beforeEach(() => {
+      state = state.api
+    })
+
+    test('handles SET_CAL_JOG_STEP', () => {
+      const action = setCalibrationJogStep(5)
+
+      expect(reducer(state, action).calibration).toEqual({
+        ...state.calibration,
+        jogStep: 5
+      })
+    })
+  })
+
   describe('selectors', () => {
     beforeEach(() => {
       state.api.calibration[NAME] = {
@@ -270,6 +296,11 @@ describe('/calibration/**', () => {
         request: null,
         response: null
       })
+    })
+
+    test('getCalibrationJogStep', () => {
+      state.api.calibration.jogStep = 42
+      expect(getCalibrationJogStep(state)).toBe(42)
     })
   })
 })

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -11,6 +11,8 @@ export type JogAxis = 'x' | 'y' | 'z'
 
 export type JogDirection = -1 | 1
 
+export type JogStep = number
+
 export type DeckCalPoint = 1 | 2 | 3
 
 type DeckStartRequest = {
@@ -28,7 +30,7 @@ type DeckStartResponse = {
 type DeckCalRequest =
   | {| command: 'attach tip', tipLength: number |}
   | {| command: 'detach tip' |}
-  | {| command: 'jog', axis: JogAxis, direction: JogDirection, step: number |}
+  | {| command: 'jog', axis: JogAxis, direction: JogDirection, step: JogStep |}
   | {| command: 'save xy', point: DeckCalPoint |}
   | {| command: 'save z' |}
   | {| command: 'save transform' |}
@@ -52,7 +54,7 @@ type CalRequestAction = {|
     robot: RobotService,
     path: RequestPath,
     request: CalRequest,
-  |}
+  |},
 |}
 
 type CalSuccessAction = {|
@@ -61,7 +63,7 @@ type CalSuccessAction = {|
     robot: RobotService,
     path: RequestPath,
     response: CalResponse,
-  |}
+  |},
 |}
 
 type CalFailureAction = {|
@@ -70,13 +72,21 @@ type CalFailureAction = {|
     robot: RobotService,
     path: RequestPath,
     error: ApiRequestError,
-  |}
+  |},
+|}
+
+type SetCalJogStepAction = {|
+  type: 'api:SET_CAL_JOG_STEP',
+  payload: {|
+    step: JogStep,
+  |},
 |}
 
 export type CalibrationAction =
   | CalRequestAction
   | CalSuccessAction
   | CalFailureAction
+  | SetCalJogStepAction
 
 export type DeckCalStartState = ApiCall<DeckStartRequest, DeckStartResponse>
 
@@ -88,11 +98,14 @@ type RobotCalState = {
 }
 
 type CalState = {
-  [robotName: string]: ?RobotCalState
+  jogStep: JogStep,
+  [robotName: string]: ?RobotCalState,
 }
 
 const DECK: 'deck' = 'deck'
 const DECK_START: 'deck/start' = 'deck/start'
+
+const DEFAULT_JOG_STEP = 0.1
 
 export function startDeckCalibration (
   robot: RobotService,
@@ -128,11 +141,15 @@ export function deckCalibrationCommand (
   }
 }
 
+export function setCalibrationJogStep (step: JogStep): SetCalJogStepAction {
+  return {type: 'api:SET_CAL_JOG_STEP', payload: {step}}
+}
+
 export function calibrationReducer (
   state: ?CalState,
   action: Action
 ): CalState {
-  if (!state) return {}
+  if (!state) return {jogStep: DEFAULT_JOG_STEP}
 
   let name
   let path
@@ -186,6 +203,9 @@ export function calibrationReducer (
           }
         }
       }
+
+    case 'api:SET_CAL_JOG_STEP':
+      return {...state, jogStep: action.payload.step}
   }
 
   return state
@@ -207,6 +227,10 @@ export function makeGetDeckCalibrationCommandState () {
   )
 
   return sel
+}
+
+export function getCalibrationJogStep (state: State): JogStep {
+  return state.api.calibration.jogStep
 }
 
 function getRobotCalState (state: State, props: BaseRobot): RobotCalState {

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -28,6 +28,7 @@ export type {
   DeckCalCommandState,
   JogAxis,
   JogDirection,
+  JogStep,
   DeckCalPoint
 } from './calibration'
 
@@ -77,8 +78,10 @@ export type Action =
 export {
   startDeckCalibration,
   deckCalibrationCommand,
+  setCalibrationJogStep,
   makeGetDeckCalibrationStartState,
-  makeGetDeckCalibrationCommandState
+  makeGetDeckCalibrationCommandState,
+  getCalibrationJogStep
 } from './calibration'
 
 export {

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -102,6 +102,11 @@ export type PipetteCalibrationAction = {|
   |}
 |}
 
+export type SetJogDistanceAction = {|
+  type: 'robot:SET_JOG_DISTANCE',
+  payload: number,
+|}
+
 export type LabwareCalibrationAction = {|
   type: (
     | 'robot:MOVE_TO'
@@ -171,7 +176,6 @@ export const actionTypes = {
 
   RETURN_TIP: makeRobotActionName('RETURN_TIP'),
   RETURN_TIP_RESPONSE: makeRobotActionName('RETURN_TIP_RESPONSE'),
-  SET_JOG_DISTANCE: makeRobotActionName('SET_JOG_DISTANCE'),
   CONFIRM_LABWARE: makeRobotActionName('CONFIRM_LABWARE'),
 
   // protocol run controls
@@ -204,6 +208,7 @@ export type Action =
   | CalibrationResponseAction
   | CalibrationFailureAction
   | ReturnTipResponseAction
+  | SetJogDistanceAction
 
 export const actions = {
   discover (): DiscoverAction {
@@ -423,7 +428,7 @@ export const actions = {
     return {type: 'robot:MOVE_TO_SUCCESS', payload: {}}
   },
 
-  setJogDistance (step: number) {
+  setJogDistance (step: number): SetJogDistanceAction {
     return {type: 'robot:SET_JOG_DISTANCE', payload: step}
   },
 

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -25,15 +25,9 @@ export type Slot =
   | '11'
 
 // jog axes and directions
+// TODO(mc, 2018-05-04): deprecate in favor of types in HTTP API module
 export type Axis = 'x' | 'y' | 'z'
 export type Direction = -1 | 1
-export type JogButtonName =
-  | 'left'
-  | 'right'
-  | 'back'
-  | 'forward'
-  | 'up'
-  | 'down'
 
 // minimum robot for actions/reducers/middleware to work
 export type BaseRobot = {


### PR DESCRIPTION
## overview

This PR wires up the `jog` deck calibration command to @Kadee80's new jog controls component and refactors the labware calibration usage of this component to make sure everything keeps working.

Closes #1246 

## changelog

- feat(app): Add action and state for setting HTTP jog step size
- feat(app): Wire HTTP jog to CalibrateDeck jog controls
- refactor(app): Cleanup labware cal jog to support changes for deck cal
 
## review requests

I've tested this on Sunset. Please at least test that labware calibration jog still works on a robot. For testing deck calibration, getting to a state where you have a valid token and end up on the jog controls is a little tricky and relies on some hot-reload trickery, so it may be easier to wait until more of the API is wired up before actual testing. Otherwise follow the code modification instructions in #1367.

Also please check out the [TODO I put in the JogButton component](https://github.com/Opentrons/opentrons/pull/1381/files#diff-721193666e2647ff19b2a3b00bb78425R87). Has anyone every seen anything like this happen?
