### PR TITLE
API: dwell axis if not included in movement

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -745,12 +745,20 @@ class SmoothieDriver_3_0_0:
         target_coords = create_coords_list(target)
         backlash_coords = create_coords_list(backlash_target)
 
+        non_moving_axes = ''.join([
+            ax
+            for ax in AXES
+            if ax not in target.keys()
+        ])
+
         if target_coords:
             command = ''
             if backlash_coords != target_coords:
                 command += GCODES['MOVE'] + ''.join(backlash_coords) + ' '
             command += GCODES['MOVE'] + ''.join(target_coords)
             try:
+                if non_moving_axes:
+                    self.dwell_axes(non_moving_axes)
                 self.activate_axes(target.keys())
                 for axis in target.keys():
                     self.engaged_axes[axis] = True
@@ -792,6 +800,14 @@ class SmoothieDriver_3_0_0:
                 ''.join(set(group) & set(axis) - set(disabled))
                 for group in HOME_SEQUENCE
             ]))
+
+        non_moving_axes = ''.join([
+            ax
+            for ax in AXES
+            if ax not in home_sequence
+        ])
+        if non_moving_axes:
+            self.dwell_axes(non_moving_axes)
 
         for axes in home_sequence:
             if 'X' in axes:

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -184,6 +184,8 @@ def test_plunger_commands(smoothie, monkeypatch):
 
     smoothie.move({'B': 2})
     expected = [
+        ['M907 A0.1 X0.3 Y0.3 Z0.1 M400'],
+        ['G4P0.05 M400'],
         ['M907 B0.5 M400'],
         ['G4P0.05 M400'],
         ['G0B2 M400'],
@@ -203,7 +205,7 @@ def test_plunger_commands(smoothie, monkeypatch):
         'B': 4,
         'C': 5})
     expected = [
-        ['M907 B0.5 C0.5 M400'],               # Set plunger current high
+        ['M907 A1.0 B0.5 C0.5 X1.5 Y1.75 Z1.0 M400'],  # Set active axes high
         ['G4P0.05 M400'],                      # Dwell
         ['G0.+[BC].+ M400'],                   # Move (including BC)
         ['M907 B0.1 C0.1 M400'],               # Set plunger current low
@@ -259,7 +261,10 @@ def test_set_current(model):
         {'C': 0.5},
         {'C': 0.1},
         {'A': 1.0},
+        {'A': 0.1},
         {'X': 1.5, 'Y': 1.75},
+        {'X': 0.3, 'Y': 0.3},
+        {'A': 1.0},
         {'A': 0.1},
         {'A': 1.0},
         {'A': 0.1}


### PR DESCRIPTION
## overview

This PR includes a check inside both `driver.move()` and `driver.home()` to automatically dwell all axes that are not being moved/homed.

The `driver.dwell_axes()` method will not send a current update if the axis is already at a low current, so this will not create redundant current-setting GCodes.

This has the wonderful side effect of helping to avoiding unnecessary current draw through the motor-driving IC's, which can overheat and enter a thermal-shutdown state if too hot. This is especially true for the Y axis, which if not in a low current when holding, will draw 1.75 amperes, which is very close to the IC's maximum 2.0 amperes, so it can get pretty darn hot.