### PR TITLE
explicitly return after recursively calling update_position; adds test

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -232,11 +232,12 @@ class SmoothieDriver_3_0_0:
                 updated_position = \
                     _parse_axis_values(position_response)
                 # TODO jmg 10/27: log warning rather than an exception
-            except (TypeError, ParseError) as e:
+            except (TypeError, ParseError, ValueError) as e:
                 if is_retry:
                     raise e
                 else:
                     self.update_position(default=default, is_retry=True)
+                    return  # avoid calling `_update_position` after recursion
 
         self._update_position(updated_position)
 

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -236,8 +236,7 @@ class SmoothieDriver_3_0_0:
                 if is_retry:
                     raise e
                 else:
-                    self.update_position(default=default, is_retry=True)
-                    return  # avoid calling `_update_position` after recursion
+                    return self.update_position(default=default, is_retry=True)
 
         self._update_position(updated_position)
 


### PR DESCRIPTION
## overview

Bug fix. Explicitly return from `driver.update_position` after calling itself recursively, to avoid referencing variable before assignment (variable is `updated_position`)