### PR TITLE
Add alertOverlay prop to Modal

### DIFF
--- a/app/src/components/CalibrateDeck/ExitAlertModal.js
+++ b/app/src/components/CalibrateDeck/ExitAlertModal.js
@@ -21,6 +21,7 @@ export default function ExitAlertModal (props: Props) {
         {children: CANCEL_TEXT, onClick: back},
         {children: EXIT_TEXT, onClick: exit}
       ]}
+      alertOverlay
     >
       <p>Doing so will home the robot and revert to using previously saved calibration settings.</p>
     </AlertModal>

--- a/app/src/components/ChangePipette/ExitAlertModal.js
+++ b/app/src/components/ChangePipette/ExitAlertModal.js
@@ -22,6 +22,7 @@ export default function ExitAlertModal (props: Props) {
         {children: CANCEL_TEXT, onClick: back},
         {children: EXIT_TEXT, onClick: exit}
       ]}
+      alertOverlay
     >
       <p>Doing so will exit pipette setup and home your robot.</p>
     </AlertModal>

--- a/app/src/components/LostConnectionAlert/ModalCopy.js
+++ b/app/src/components/LostConnectionAlert/ModalCopy.js
@@ -16,7 +16,7 @@ export default function DefaultCopy () {
             "If you've uploaded a protocol to your robot, it should re-open when you reconnect."
           )} />
           <Route path='/calibrate' render={() => (
-            'Calibration progress has been lost, so please redo it after you reconnect.'
+            'Calibration progress has been lost.'
           )} />
           <Route path='/run' render={() => (
             'If your robot is still running, it will complete the protocol, and you may track its progress once you reconnect.'

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -42,6 +42,7 @@ function LostConnectionAlert (props: Props) {
       buttons={[
         {onClick: disconnect, children: 'close'}
       ]}
+      alertOverlay
     >
       <ModalCopy />
     </AlertModal>

--- a/app/src/components/TipProbe/AttachTipPanel.js
+++ b/app/src/components/TipProbe/AttachTipPanel.js
@@ -32,9 +32,9 @@ function AttachTipPanel (props: OwnProps & DispatchProps) {
   const leftChildren = (
     <div>
       <p>
-        Place a previously used or otherwise discarded
+        Place a spare
         <em>{` ${volume} μL `}</em>
-        tip on the pipette before continuing
+        tip on pipette before continuing
       </p>
       <PrimaryButton onClick={onProbeTipClick}>
         Confirm Tip Attached

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -17,20 +17,27 @@ type Props = {
   /** modal contents */
   children: React.Node,
   /** optional classes to apply */
-  className?: string
+  className?: string,
+  /** lightens overlay (alert modal over existing modal)**/
+  alertOverlay?: boolean
 }
 
 /**
  * Generic alert modal with a heading and a set of buttons at the bottom
  */
 export default function AlertModal (props: Props) {
-  const {heading, buttons, className, onCloseClick} = props
+  const {heading, buttons, className, onCloseClick, alertOverlay} = props
   const wrapperStyle = heading
     ? styles.alert_modal_wrapper
     : cx(styles.alert_modal_wrapper, styles.no_alert_header)
 
   return (
-    <Modal className={className} contentsClassName={wrapperStyle} onCloseClick={onCloseClick}>
+    <Modal
+      className={className}
+      contentsClassName={wrapperStyle}
+      onCloseClick={onCloseClick}
+      alertOverlay={alertOverlay}
+    >
       {heading && (
         <div className={styles.alert_modal_heading}>
           <Icon name='alert' className={styles.alert_modal_icon} />

--- a/components/src/modals/AlertModal.md
+++ b/components/src/modals/AlertModal.md
@@ -28,6 +28,37 @@ const alertContents = {
 </div>
 ```
 
+Optional alertOverlay prop to lighten background
+
+```js
+initialState = {alert: 'foo'}
+
+const alertContents = {
+  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+}
+
+;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>
+    Alert foo
+  </FlatButton>
+  {state.alert && (
+    <AlertModal
+      heading={state.alert}
+      onCloseClick={() => setState({alert: ''})}
+      buttons={[
+        {children: 'foo', onClick: () => setState({alert: 'foo'})},
+        {children: 'bar', onClick: () => setState({alert: 'bar'})},
+        {children: 'close', onClick: () => setState({alert: ''})}
+      ]}
+      alertOverlay
+    >
+      {alertContents[state.alert]}
+    </AlertModal>
+  )}
+</div>
+```
+
 Alert modal without heading prop:
 
 ```js

--- a/components/src/modals/Modal.js
+++ b/components/src/modals/Modal.js
@@ -12,7 +12,9 @@ type ModalProps = {
   /** classes to apply */
   className?: string,
   /** classes to apply to the contents box */
-  contentsClassName?: string
+  contentsClassName?: string,
+  /** lightens overlay (alert modal over existing modal)**/
+  alertOverlay?: boolean
 }
 
 /**
@@ -20,10 +22,11 @@ type ModalProps = {
  * with a dark overlay and displays `children` as its contents in a white box
  */
 export default function Modal (props: ModalProps) {
+  const {contentsClassName, alertOverlay, onCloseClick} = props
   return (
-    <div className={cx(styles.modal, props.className)}>
-      <Overlay onClick={props.onCloseClick} />
-      <div className={cx(styles.modal_contents, props.contentsClassName)}>
+    <div className={cx(styles.modal, props.className, {[styles.alert_modal]: alertOverlay})} >
+      <Overlay onClick={onCloseClick} alertOverlay={alertOverlay}/>
+       <div className={cx(styles.modal_contents, contentsClassName)}>
         {props.children}
       </div>
     </div>

--- a/components/src/modals/Overlay.js
+++ b/components/src/modals/Overlay.js
@@ -6,7 +6,8 @@ import styles from './modals.css'
 
 type OverlayProps = {
   /** optional onClick handler */
-  onClick?: (event: SyntheticEvent<>) => mixed
+  onClick?: (event: SyntheticEvent<>) => mixed,
+  alertOverlay?: boolean
 }
 
 /**
@@ -15,9 +16,10 @@ type OverlayProps = {
  * just want to use `<Modal>`
  */
 export default function Overlay (props: OverlayProps) {
-  const className = cx(styles.overlay, {
-    [styles.clickable]: props.onClick
-  })
+  const className = cx(
+    styles.overlay,
+    {[styles.clickable]: props.onClick, [styles.alert_modal_overlay]: props.alertOverlay}
+  )
 
   return (
     <div className={className} onClick={props.onClick} />

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -85,6 +85,14 @@
   @apply --clickable;
 }
 
+.alert_modal {
+  z-index: 10;
+}
+
+.alert_modal_overlay {
+  background-color: rgba(115, 115, 115, 0.9);
+}
+
 .alert_modal_contents {
   @apply --font-body-2-dark;
 


### PR DESCRIPTION
## overview
This PR allows for lighter overlay (modal over modal) in ExitAlertModal(s) and LostConnectionModal by introducing an optional alertOverlay boolean in Modal, AlertModal in components Library. 

Also addresses a few usability issues copy changes:
- closes #1315 
- closes #1313

<img width="600" alt="screen shot 2018-05-08 at 4 04 35 pm" src="https://user-images.githubusercontent.com/3430313/39781972-b58d5b00-52de-11e8-8eef-71d91df55e49.png">
<img width="600" alt="screen shot 2018-05-08 at 4 49 30 pm" src="https://user-images.githubusercontent.com/3430313/39782323-d33185ea-52df-11e8-8501-52b6e26b82c2.png">
<img width="600" alt="screen shot 2018-05-08 at 4 08 47 pm" src="https://user-images.githubusercontent.com/3430313/39781973-b59960bc-52de-11e8-9ccb-5cc6a3c41a0b.png">
<img width="600" alt="screen shot 2018-05-08 at 4 14 58 pm" src="https://user-images.githubusercontent.com/3430313/39781975-b5a7cc88-52de-11e8-856e-0614eacc060f.png">


## changelog

- chore(comp): Add alertOverlay prop to Modal
- style(app): Implement new alertOverlay in LostConnectionModal, and ExitAlertModal
- chore(app): copy change in TipProbe (attach tip)
- chore(app): closes #1313 copy change in LostConnectionModal

## review requests

