### PR TITLE
Pd mix command

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -175,10 +175,12 @@ export const robotStateTimelineFull: Selector<RobotStateTimelineAcc> = createSel
         nextCommandsAndState = StepGeneration.delay(validatedForm)(acc.robotState)
       }
       if (validatedForm.stepType === 'mix') {
-        console.warn('Mix step not yet implemented') // TODO Ian 2018-05-08 next PR!
+        nextCommandsAndState = StepGeneration.mix(validatedForm)(acc.robotState)
       }
 
       if (!nextCommandsAndState) {
+        // TODO Ian 2018-05-08 use assert
+        console.warn(`StepType "${validatedForm.stepType}" not yet implemented`)
         return {
           ...acc,
           formErrors: {

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -3,6 +3,7 @@ import type {IconName} from '@opentrons/components'
 import type {
   ChangeTipOptions,
   ConsolidateFormData,
+  DistributeFormData,
   TransferFormData,
   MixFormData,
   PauseFormData
@@ -123,6 +124,7 @@ export type BlankForm = {
 // TODO gradually create & use definitions from step-generation/types.js
 export type ProcessedFormData =
   | ConsolidateFormData
+  | DistributeFormData
   | MixFormData
   | PauseFormData
   | TransferFormData

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -3,7 +3,7 @@ import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators} from './'
-import mix from './mix'
+import {mixUtil} from './mix'
 import * as errorCreators from './errorCreators'
 import type {ConsolidateFormData, RobotState, CommandCreator} from './'
 
@@ -97,7 +97,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         : []
 
       const mixBeforeCommands = (data.mixFirstAspirate)
-        ? mix(
+        ? mixUtil(
           data.pipette,
           data.sourceLabware,
           sourceWellChunk[0],
@@ -108,7 +108,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
 
       const preWetTipCommands = (data.preWetTip)
         // Pre-wet tip is equivalent to a single mix, with volume equal to the consolidate volume.
-        ? mix(
+        ? mixUtil(
           data.pipette,
           data.sourceLabware,
           sourceWellChunk[0],
@@ -118,7 +118,7 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
         : []
 
       const mixAfterCommands = (data.mixInDestination)
-        ? mix(
+        ? mixUtil(
           data.pipette,
           data.destLabware,
           data.destWell,

--- a/protocol-designer/src/step-generation/distribute.js
+++ b/protocol-designer/src/step-generation/distribute.js
@@ -4,7 +4,7 @@ import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 // import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators} from './'
-import mix from './mix'
+import {mixUtil} from './mix'
 import * as errorCreators from './errorCreators'
 import type {DistributeFormData, RobotState, CommandCreator} from './'
 
@@ -101,7 +101,7 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
         : []
 
       const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
-        ? mix(
+        ? mixUtil(
           data.pipette,
           data.sourceLabware,
           data.sourceWell,

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -30,6 +30,14 @@ export function pipetteDoesNotExist (args: {actionName: string, pipette: string}
   }
 }
 
+export function labwareDoesNotExist (args: {actionName: string, labware: string}): CommandCreatorError {
+  const {actionName, labware} = args
+  return {
+    message: `Attempted to ${actionName} with labware id "${labware}", this labware was not found under "labware"`,
+    type: 'LABWARE_DOES_NOT_EXIST'
+  }
+}
+
 export function pipetteVolumeExceeded (args: {
   actionName: string,
   volume: string | number,

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -6,6 +6,7 @@ import distribute from './distribute'
 import delay from './delay'
 import dispense from './dispense'
 import dropTip from './dropTip'
+import mix from './mix'
 import replaceTip from './replaceTip'
 import touchTip from './touchTip'
 import transfer from './transfer'
@@ -22,6 +23,7 @@ export {
   delay,
   dispense,
   dropTip,
+  mix,
   replaceTip,
   touchTip,
   transfer

--- a/protocol-designer/src/step-generation/mix.js
+++ b/protocol-designer/src/step-generation/mix.js
@@ -1,21 +1,94 @@
 // @flow
+import flatMap from 'lodash/flatMap'
 import aspirate from './aspirate'
+import blowout from './blowout'
 import dispense from './dispense'
-import {repeatArray} from './utils'
+import replaceTip from './replaceTip'
+import touchTip from './touchTip'
+import {repeatArray, reduceCommandCreators} from './utils'
+import * as errorCreators from './errorCreators'
+import type {MixFormData, RobotState, CommandCreator} from './'
 
-export default function mix (pipette: string, labware: string, well: string, volume: number, times: number) {
+/** Helper fn to make mix command creators w/ minimal arguments */
+export function mixUtil (
+  pipette: string,
+  labware: string,
+  well: string,
+  volume: number,
+  times: number
+): Array<CommandCreator> {
   return repeatArray([
-    aspirate({
-      pipette,
-      volume,
-      labware,
-      well
-    }),
-    dispense({
-      pipette,
-      volume,
-      labware,
-      well
-    })
+    aspirate({pipette, volume, labware, well}),
+    dispense({pipette, volume, labware, well})
   ], times)
 }
+
+const mix = (data: MixFormData): CommandCreator => (prevRobotState: RobotState) => {
+  /**
+    Mix will aspirate and dispense a uniform volume some amount of times from a set of wells
+    in a single labware.
+
+    =====
+
+    For mix, changeTip means:
+    * 'always': before the first aspirate in each well, get a fresh tip
+    * 'once': get a new tip at the beginning of the overall mix step, and use it throughout for all wells
+    * 'never': reuse the tip from the last step
+  */
+  const actionName = 'mix'
+  const {pipette, labware, wells, volume, times, changeTip} = data
+
+  // Errors
+  if (!prevRobotState.instruments[pipette]) {
+    // bail out before doing anything else
+    return {
+      errors: [errorCreators.pipetteDoesNotExist({actionName, pipette})]
+    }
+  }
+
+  if (!prevRobotState.labware[labware]) {
+    return {
+      errors: [errorCreators.labwareDoesNotExist({actionName, labware})]
+    }
+  }
+
+  // Command generation
+  const commandCreators = flatMap(
+    wells,
+    (well: string, wellIndex: number): Array<CommandCreator> => {
+      let tipCommands: Array<CommandCreator> = []
+
+      if (
+        changeTip === 'always' ||
+        (changeTip === 'once' && wellIndex === 0)
+      ) {
+        tipCommands = [replaceTip(pipette)]
+      }
+
+      const touchTipCommands = data.touchTip
+      ? [touchTip({pipette, labware, well})]
+      : []
+
+      const blowoutCommands = data.blowout
+      ? [blowout({
+        pipette,
+        labware: data.blowout,
+        well: 'A1'
+      })]
+      : []
+
+      const mixCommands = mixUtil(pipette, labware, well, volume, times)
+
+      return [
+        ...tipCommands,
+        ...mixCommands,
+        ...blowoutCommands,
+        ...touchTipCommands
+      ]
+    }
+  )
+
+  return reduceCommandCreators(commandCreators)(prevRobotState)
+}
+
+export default mix

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -1,0 +1,338 @@
+// @flow
+import _mix from '../mix'
+import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures'
+import {tiprackWellNamesFlat} from '../data'
+import type {MixFormData} from '../types'
+const mix = commandCreatorNoErrors(_mix)
+const mixWithErrors = commandCreatorHasErrors(_mix)
+
+let robotInitialState
+let mixinArgs
+
+// TODO Ian 2018-05-08 move these to fixtures, use to make other tests less verbose too.
+// You also need a factory to use different pipette id, etc
+const cmd = {
+  // NOTE: 'Commands' name in these fixture creators indicates
+  // it's an array & not a single command obj
+  replaceTipCommands: (tiprackTipIdx: number) => [
+    {
+      command: 'drop-tip',
+      pipette: 'p300SingleId',
+      labware: 'trashId',
+      well: 'A1'
+    },
+    {
+      command: 'pick-up-tip',
+      pipette: 'p300SingleId',
+      labware: 'tiprack1Id',
+      well: tiprackWellNamesFlat[tiprackTipIdx]
+    }
+  ],
+  touchTip: (well: string) => ({
+    command: 'touch-tip',
+    labware: 'sourcePlateId',
+    pipette: 'p300SingleId',
+    well
+  }),
+  aspirate: (well: string, volume: number) => ({
+    command: 'aspirate',
+    pipette: 'p300SingleId',
+    labware: 'sourcePlateId',
+    volume,
+    well
+  }),
+  dispense: (well: string, volume: number) => ({
+    command: 'dispense',
+    pipette: 'p300SingleId',
+    labware: 'sourcePlateId',
+    volume,
+    well
+  }),
+  blowout: (labware: string) => ({
+    command: 'blowout',
+    pipette: 'p300SingleId',
+    well: 'A1',
+    labware
+  })
+}
+
+beforeEach(() => {
+  robotInitialState = createRobotState({
+    sourcePlateType: '96-flat',
+    destPlateType: '96-flat',
+    tipracks: [200],
+    fillPipetteTips: true,
+    fillTiprackTips: true
+  })
+
+  mixinArgs = {
+    stepType: 'mix',
+    name: 'mix test',
+    description: 'test blah blah',
+
+    pipette: 'p300SingleId',
+    labware: 'sourcePlateId',
+
+    delay: null,
+    touchTip: false
+  }
+})
+
+describe('mix: change tip', () => {
+  const volume = 5
+  const times = 2
+  const makeArgs = (changeTip): MixFormData => ({
+    ...mixinArgs,
+    volume,
+    times,
+    wells: ['A1', 'B1', 'C1'],
+    changeTip
+  })
+  test('changeTip="always"', () => {
+    const args = makeArgs('always')
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      ...cmd.replaceTipCommands(1),
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      ...cmd.replaceTipCommands(2),
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume)
+    ])
+  })
+
+  test('changeTip="once"', () => {
+    const args = makeArgs('once')
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume)
+    ])
+  })
+
+  test('changeTip="never"', () => {
+    const args = makeArgs('never')
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume)
+    ])
+  })
+})
+
+describe('mix: advanced options', () => {
+  const volume = 8
+  const times = 2
+  const blowoutLabwareId = 'destPlateId'
+
+  test('touch tip (after each dispense)', () => {
+    const args: MixFormData = {
+      ...mixinArgs,
+      volume,
+      times,
+      changeTip: 'always',
+      touchTip: true,
+      wells: ['A1', 'B1', 'C1']
+    }
+
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+      cmd.touchTip('A1'),
+
+      ...cmd.replaceTipCommands(1),
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+      cmd.touchTip('B1'),
+
+      ...cmd.replaceTipCommands(2),
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+      cmd.touchTip('C1')
+    ])
+  })
+
+  test('blowout', () => {
+    const args: MixFormData = {
+      ...mixinArgs,
+      volume,
+      times,
+      changeTip: 'always',
+      blowout: blowoutLabwareId,
+      wells: ['A1', 'B1', 'C1']
+    }
+
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+      cmd.blowout(blowoutLabwareId),
+
+      ...cmd.replaceTipCommands(1),
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+      cmd.blowout(blowoutLabwareId),
+
+      ...cmd.replaceTipCommands(2),
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+      cmd.blowout(blowoutLabwareId)
+    ])
+  })
+
+  test('touch tip after blowout', () => {
+    const args: MixFormData = {
+      ...mixinArgs,
+      volume,
+      times,
+      changeTip: 'always',
+      touchTip: true,
+      blowout: blowoutLabwareId,
+      wells: ['A1', 'B1', 'C1']
+    }
+
+    const result = mix(args)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+
+      cmd.aspirate('A1', volume),
+      cmd.dispense('A1', volume),
+      cmd.blowout(blowoutLabwareId),
+      cmd.touchTip('A1'),
+
+      ...cmd.replaceTipCommands(1),
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+
+      cmd.aspirate('B1', volume),
+      cmd.dispense('B1', volume),
+      cmd.blowout(blowoutLabwareId),
+      cmd.touchTip('B1'),
+
+      ...cmd.replaceTipCommands(2),
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+
+      cmd.aspirate('C1', volume),
+      cmd.dispense('C1', volume),
+      cmd.blowout(blowoutLabwareId),
+      cmd.touchTip('C1')
+    ])
+  })
+
+  test.skip('delay') // TODO Ian 2018-05-08 implement when behavior is decided
+})
+
+describe('mix: errors', () => {
+  let errorArgs = {}
+  beforeEach(() => {
+    errorArgs = {
+      ...mixinArgs,
+      volume: 8,
+      times: 2,
+      changeTip: 'once',
+      wells: ['A1', 'A2']
+    }
+  })
+  test('invalid labware', () => {
+    const args: MixFormData = {
+      ...errorArgs,
+      labware: 'invalidLabwareId'
+    }
+    const result = mixWithErrors(args)(robotInitialState)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'LABWARE_DOES_NOT_EXIST'
+    })
+  })
+
+  test('invalid pipette', () => {
+    const args: MixFormData = {
+      ...errorArgs,
+      pipette: 'invalidPipetteId'
+    }
+    const result = mixWithErrors(args)(robotInitialState)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'PIPETTE_DOES_NOT_EXIST'
+    })
+  })
+
+  // TODO Ian 2018-05-08
+  test('"times" arg non-integer')
+  test('"times" arg negative')
+})

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -1,9 +1,9 @@
 // @flow
 import flatMap from 'lodash/flatMap'
 import zip from 'lodash/zip'
-import mix from './mix'
 import aspirate from './aspirate'
 import dispense from './dispense'
+import {mixUtil} from './mix'
 import replaceTip from './replaceTip'
 import {reduceCommandCreators} from './utils'
 import touchTip from './touchTip'
@@ -75,11 +75,11 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
               : []
 
           const preWetTipCommands = (data.preWetTip && chunkIdx === 0)
-            ? mix(data.pipette, data.sourceLabware, sourceWell, Math.max(subTransferVol), 1)
+            ? mixUtil(data.pipette, data.sourceLabware, sourceWell, Math.max(subTransferVol), 1)
             : []
 
           const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
-            ? mix(
+            ? mixUtil(
               data.pipette,
               data.sourceLabware,
               sourceWell,
@@ -105,7 +105,7 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
             : []
 
           const mixInDestinationCommands = (data.mixInDestination)
-            ? mix(
+            ? mixUtil(
               data.pipette,
               data.destLabware,
               destWell,

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -96,11 +96,7 @@ export type MixFormData = {
   touchTip: boolean,
   /** Delay in seconds */
   delay: ?number,
-  /** change tip:
-    * 'never' keeps tip from prev step
-    * 'once' gets fresh tip for the mix step and uses it across all wells
-    * 'always' uses fresh tip for each mix well
-   **/
+  /** change tip: see comments in step-generation/mix.js */
   changeTip: ChangeTipOptions,
   /** If given, blow out in the specified labware after mixing each well */
   blowout?: string

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -11,7 +11,6 @@ export function repeatArray<T> (array: Array<T>, repeats: number): Array<T> {
   return flatMap(range(repeats), (i: number): Array<T> => array)
 }
 
-// TODO Ian 2018-02-13: how should errors that happen in CommandCreators (eg, invalid previous state: no more tips) be handled?
 /**
  * Take an array of CommandCreators, streaming robotState through them in order,
  * and adding each CommandCreator's commands to a single commands array.


### PR DESCRIPTION
## overview

Mix form does stuff now! Closes #723 

## changelog

- Implemented mix command generator & hooked it up to the Mix step form

## review requests

- Tried to use some shorthand fns to make the tests a bit more compact -- more readable, or less readable this way?

- Mix form should save commands when you download the JSON

- Substeps for mix aren't implemented yet