### PR TITLE
API: Pipette sets current with set_active_current()

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -180,7 +180,14 @@ class SmoothieDriver_3_0_0:
         self._config = config
 
         # motor current settings
-        self._saved_current_settings = config.low_current.copy()
+        self._active_current_settings = config.high_current.copy()
+        self._dwelling_current_settings = config.low_current.copy()
+
+        self._saved_active_current_settings = \
+            self._active_current_settings.copy()
+        self._saved_dwelling_current_settings = \
+            self._dwelling_current_settings.copy()
+        self._saved_current_settings = self._dwelling_current_settings.copy()
         self._current_settings = self._saved_current_settings.copy()
 
         # Active axes are axes that are in use. An axis might be disabled if
@@ -426,6 +433,72 @@ class SmoothieDriver_3_0_0:
     def pop_axis_max_speed(self):
         self.set_axis_max_speed(self._saved_max_speed_settings)
 
+    def set_active_current(self, settings):
+        '''
+        Sets the amperage of each motor for when it is activated by driver.
+        Values are initialized from the `robot_config.high_current` values,
+        and can then be changed through this method by other parts of the API.
+
+        For example, `Pipette` setting the active-current of it's pipette,
+        depending on what model pipette it is, and what action it is performing
+
+        settings
+            Dict with axes as valies (e.g.: 'X', 'Y', 'Z', 'A', 'B', or 'C')
+            and floating point number for current (generally between 0.1 and 2)
+        '''
+        self._active_current_settings.update(settings)
+
+        # if an axis specified in the `settings` is currently active,
+        # reset it's current to the new active-current value
+        active_axes_to_update = {
+            axis: amperage
+            for axis, amperage in self._active_current_settings.items()
+            if self._active_axes.get(axis) is True
+            if self.current[axis] != amperage
+        }
+        if active_axes_to_update:
+            self.set_current(active_axes_to_update, axes_active=True)
+
+    def push_active_current(self):
+        self._saved_active_current_settings.update(
+            self._active_current_settings)
+
+    def pop_active_current(self):
+        self.set_active_current(self._saved_active_current_settings)
+
+    def set_dwelling_current(self, settings):
+        '''
+        Sets the amperage of each motor for when it is dwelling.
+        Values are initialized from the `robot_config.log_current` values,
+        and can then be changed through this method by other parts of the API.
+
+        For example, `Pipette` setting the dwelling-current of it's pipette,
+        depending on what model pipette it is.
+
+        settings
+            Dict with axes as valies (e.g.: 'X', 'Y', 'Z', 'A', 'B', or 'C')
+            and floating point number for current (generally between 0.1 and 2)
+        '''
+        self._dwelling_current_settings.update(settings)
+
+        # if an axis specified in the `settings` is currently dwelling,
+        # reset it's current to the new dwelling-current value
+        dwelling_axes_to_update = {
+            axis: amperage
+            for axis, amperage in self._dwelling_current_settings.items()
+            if self._active_axes.get(axis) is False
+            if self.current[axis] != amperage
+        }
+        if dwelling_axes_to_update:
+            self.set_current(dwelling_axes_to_update, axes_active=False)
+
+    def push_dwelling_current(self):
+        self._saved_dwelling_current_settings.update(
+            self._dwelling_current_settings)
+
+    def pop_dwelling_current(self):
+        self.set_dwelling_current(self._dwelling_current_settings)
+
     def set_current(self, settings, axes_active=True):
         '''
         Sets the current in mA by axis.
@@ -491,7 +564,7 @@ class SmoothieDriver_3_0_0:
         '''
         axes = ''.join(set(axes) & set(AXES) - set(DISABLE_AXES))
         dwelling_currents = {
-            ax: self._config.low_current[ax]
+            ax: self._dwelling_current_settings[ax]
             for ax in axes
             if self._active_axes[ax] is True
         }
@@ -510,7 +583,7 @@ class SmoothieDriver_3_0_0:
         '''
         axes = ''.join(set(axes) & set(AXES) - set(DISABLE_AXES))
         active_currents = {
-            ax: self._config.high_current[ax]
+            ax: self._active_current_settings[ax]
             for ax in axes
             if self._active_axes[ax] is False
         }
@@ -640,7 +713,7 @@ class SmoothieDriver_3_0_0:
         self._send_command(self._config.acceleration)
         self._send_command(self._config.steps_per_mm)
         self._send_command(GCODES['ABSOLUTE_COORDS'])
-        self.set_current(self._config.low_current, axes_active=False)
+        self.set_current(self._dwelling_current_settings, axes_active=False)
         self.update_position(default=self.homed_position)
         self.pop_axis_max_speed()
         self.pop_speed()

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -929,15 +929,15 @@ class Pipette:
             for i in range(int(presses)):
                 # move nozzle down into the tip
                 self.instrument_mover.push_speed()
-                self.instrument_mover.push_current()
-                self.instrument_mover.set_current(self._pick_up_current)
+                self.instrument_mover.push_active_current()
+                self.instrument_mover.set_active_current(self._pick_up_current)
                 self.instrument_mover.set_speed(30)
                 dist = plunge_depth + (-1 * increment * i)
                 self.move_to(
                     self.current_tip().top(dist),
                     strategy='direct')
                 # move nozzle back up
-                self.instrument_mover.pop_current()
+                self.instrument_mover.pop_active_current()
                 self.instrument_mover.pop_speed()
                 self.move_to(
                     self.current_tip().top(0),

--- a/api/opentrons/robot/mover.py
+++ b/api/opentrons/robot/mover.py
@@ -88,6 +88,30 @@ class Mover:
                 for axis in self._axis_mapping.values()
             })
 
+    def set_active_current(self, power):
+        self._driver.set_active_current({
+                axis.upper(): power
+                for axis in self._axis_mapping.values()
+            })
+
+    def push_active_current(self):
+        self._driver.push_active_current()
+
+    def push_dwelling_current(self):
+        self._driver.push_dwelling_current()
+
+    def pop_active_current(self):
+        self._driver.pop_active_current()
+
+    def pop_dwelling_current(self):
+        self._driver.pop_dwelling_current()
+
+    def set_dwelling_current(self, power):
+        self._driver.set_dwelling_current({
+                axis.upper(): power
+                for axis in self._axis_mapping.values()
+            })
+
     def push_current(self):
         self._driver.push_current()
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -266,6 +266,53 @@ def test_plunger_commands(smoothie, monkeypatch):
     fuzzy_assert(result=command_log, expected=expected)
 
 
+def test_set_active_current(smoothie, monkeypatch):
+    from opentrons.drivers.smoothie_drivers import serial_communication
+    from opentrons.drivers.smoothie_drivers import driver_3_0
+    command_log = []
+    smoothie._setup()
+    smoothie.home()
+    smoothie.simulating = False
+
+    def write_with_log(command, ack, connection, timeout):
+        command_log.append(command.strip())
+        return driver_3_0.SMOOTHIE_ACK
+
+    def _parse_axis_values(arg):
+        return smoothie.position
+
+    monkeypatch.setattr(serial_communication, 'write_and_return',
+                        write_with_log)
+    monkeypatch.setattr(driver_3_0, '_parse_axis_values', _parse_axis_values)
+
+    smoothie.set_active_current(
+        {'X': 2, 'Y': 2, 'Z': 2, 'A': 2, 'B': 2, 'C': 2})
+    smoothie.set_dwelling_current(
+        {'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
+
+    smoothie.move({'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
+    smoothie.move({'B': 1, 'C': 1})
+    expected = [
+        ['M907 A0 B0 C0 X0 Y0 Z0 M400'],       # from call set_dwelling_current
+        ['G4P0.05 M400'],                      # Dwell
+        ['M907 A2 B2 C2 X2 Y2 Z2 M400'],       # Set all axes to high current
+        ['G4P0.05 M400'],                      # Dwell
+        ['G0.+[ABCXYZ].+ M400'],               # Move (including BC)
+        ['M907 B0 C0 M400'],                   # Set plunger current low
+        ['G4P0.05 M400'],                      # Dwell
+        ['M907 A0 X0 Y0 Z0 M400'],             # dwell the inactive axes
+        ['G4P0.05 M400'],                      # Dwell
+        ['M907 B2 C2 M400'],                   # Set plunger motors active
+        ['G4P0.05 M400'],                      # Dwell
+        ['G0.+[BC].+ M400'],                   # Move (including BC)
+        ['M907 B0 C0 M400'],                   # Set plunger current low
+        ['G4P0.05 M400']                       # Dwell
+    ]
+    from pprint import pprint
+    pprint(command_log)
+    fuzzy_assert(result=command_log, expected=expected)
+
+
 def test_functional(smoothie):
     assert smoothie.position == position(0, 0, 0, 0, 0, 0)
 


### PR DESCRIPTION
## overview

Fixes #1403 , this is a high-priority PR because of the severity of the bug

Instead of allowing `Pipette` to set the instantaneous current with `set_current()`, this PR creates the method `driver.set_active_current()`, which allows `Pipette` to set an axis' current for when it is moving.

Previously, using `driver.push_current()`, `driver.set_current()`, and `driver.pop_current()` is not safe, because the values that are popped/pushed could be "dwelling" currents.