### PR TITLE
PD: restyle step items & organize steplist comps

### DIFF
--- a/protocol-designer/src/components/StepList/StepItem.css
+++ b/protocol-designer/src/components/StepList/StepItem.css
@@ -8,6 +8,7 @@
     padding: 0.5rem;
     border-top: 2px solid var(--c-light-gray);
     text-align: center;
+    font-size: var(--fs-body-1);
   };
 
   --subitem_cell: {
@@ -35,9 +36,7 @@
   }
 
   & .volume_cell {
-    color: var(--c-med-gray);
     overflow: visible;
-    text-align: right;
   }
 }
 
@@ -84,9 +83,9 @@
 /* Aspirate / dispense headers */
 .aspirate_dispense {
   display: flex;
-  padding: 0.5rem;
-  font-size: var(--fs-body-1);
+  margin: 0.5rem;
   text-align: left;
+  font-size: var(--fs-body-1);
 
   & .spacer {
     flex: 1;

--- a/protocol-designer/src/components/StepList/StepItem.js
+++ b/protocol-designer/src/components/StepList/StepItem.js
@@ -3,10 +3,10 @@ import * as React from 'react'
 import cx from 'classnames'
 
 import {Icon, TitledList} from '@opentrons/components'
-import StepDescription from './StepDescription'
+import StepDescription from '../StepDescription'
 import styles from './StepItem.css'
 
-import {stepIconsByType, type StepType} from '../form-types'
+import {stepIconsByType, type StepType} from '../../form-types'
 
 type StepItemProps = {
   stepType: StepType,

--- a/protocol-designer/src/components/StepList/TransferLikeSubstep.js
+++ b/protocol-designer/src/components/StepList/TransferLikeSubstep.js
@@ -5,7 +5,7 @@ import last from 'lodash/last'
 import uniqBy from 'lodash/uniqBy'
 
 import {Icon} from '@opentrons/components'
-import IngredPill from './IngredPill'
+import IngredPill from '../IngredPill'
 
 import styles from './StepItem.css'
 
@@ -14,7 +14,7 @@ import type {
   StepItemSourceDestRowMulti,
   SubstepIdentifier,
   NamedIngred
-} from '../steplist/types'
+} from '../../steplist/types'
 
 export type StepSubItemProps = {|
   substeps: TransferLikeSubstepItem

--- a/protocol-designer/src/components/StepList/index.js
+++ b/protocol-designer/src/components/StepList/index.js
@@ -4,13 +4,13 @@ import isNil from 'lodash/isNil'
 import pick from 'lodash/pick'
 import {SidePanel, TitledList} from '@opentrons/components'
 
-import {END_STEP} from '../steplist/types'
-import type {StepItemsWithSubsteps, SubstepIdentifier} from '../steplist/types'
-import type {StepIdType} from '../form-types'
+import {END_STEP} from '../../steplist/types'
+import type {StepItemsWithSubsteps, SubstepIdentifier} from '../../steplist/types'
+import type {StepIdType} from '../../form-types'
 
-import StepItem from '../components/StepItem'
-import TransferLikeSubstep from '../components/TransferLikeSubstep'
-import StepCreationButton from '../containers/StepCreationButton'
+import StepItem from './StepItem'
+import TransferLikeSubstep from './TransferLikeSubstep'
+import StepCreationButton from '../../containers/StepCreationButton'
 import styles from './StepItem.css'
 
 type StepIdTypeWithEnd = StepIdType | typeof END_STEP


### PR DESCRIPTION
## overview

Closes #1331

![image](https://user-images.githubusercontent.com/11590381/39822281-289e6f78-5378-11e8-9eff-891a924f4b35.png)

## changelog
   
* move steplist components into their own dir
* body1 font size for step items
* volume left-aligned & normal font color

## review requests

- Should be a quick one, this is just reorganization and small style changes