### PR TITLE
API: check for ACK characters in serial response

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -60,7 +60,7 @@ def _write_to_device_and_return(cmd, ack, device_connection):
     - return parsed response'''
     device_connection.write(cmd.encode())
     response = device_connection.read_until(ack.encode())
-    if not response:
+    if ack.encode() not in response:
         raise SerialNoResponse(
             'No response from serial port after {} second(s)'.format(
                 device_connection.timeout))

--- a/api/opentrons/tools/factory_test.py
+++ b/api/opentrons/tools/factory_test.py
@@ -146,15 +146,11 @@ def test_smoothie_gpio():
 
     print('ISP')
     # drop the ISP line to LOW, and make sure it is dead
-    gpio.set_low(gpio.OUTPUT_PINS['ISP'])
-    sleep(0.25)
-    gpio.set_high(gpio.OUTPUT_PINS['ISP'])
-    sleep(0.25)
-
-    r = _write_and_return('M999')
-    if len(r):
+    d._smoothie_programming_mode()
+    try:
+        _write_and_return('M999')
         print(RESULT_SPACE.format(FAIL))
-    else:
+    except Exception:
         print(RESULT_SPACE.format(PASS))
 
     print('RESET')

--- a/api/opentrons/tools/factory_test.py
+++ b/api/opentrons/tools/factory_test.py
@@ -91,8 +91,6 @@ def run_quiet_process(command):
 
 
 def test_smoothie_gpio():
-    from time import sleep
-    from opentrons.drivers.rpi_drivers import gpio
     from opentrons.drivers.smoothie_drivers import serial_communication
     from opentrons.drivers.smoothie_drivers.driver_3_0 import SMOOTHIE_ACK
 
@@ -124,22 +122,15 @@ def test_smoothie_gpio():
     print('HALT')
     d._connection.reset_input_buffer()
     # drop the HALT line LOW, and make sure there is an error state
-    gpio.set_low(gpio.OUTPUT_PINS['HALT'])
-    sleep(0.25)
-    gpio.set_high(gpio.OUTPUT_PINS['HALT'])
-    sleep(0.25)
+    d._smoothie_hard_halt()
 
     old_timeout = int(d._connection.timeout)
     d._connection.timeout = 1  # 1 second
-    cycles = 5
-    for i in range(cycles):
-        r = d._connection.readline().decode()
-        if 'ALARM' in r:
-            print(RESULT_SPACE.format(PASS))
-            _write_and_return('M999')
-            break
-        elif i >= cycles - 1:
-            print(RESULT_SPACE.format(FAIL))
+    r = d._connection.readline().decode()
+    if 'ALARM' in r:
+        print(RESULT_SPACE.format(PASS))
+    else:
+        print(RESULT_SPACE.format(FAIL))
 
     d._reset_from_error()
     d._connection.timeout = old_timeout
@@ -147,11 +138,11 @@ def test_smoothie_gpio():
     print('ISP')
     # drop the ISP line to LOW, and make sure it is dead
     d._smoothie_programming_mode()
-    try:
-        _write_and_return('M999')
-        print(RESULT_SPACE.format(FAIL))
-    except Exception:
-        print(RESULT_SPACE.format(PASS))
+    try:                                        # NOQA
+        _write_and_return('M999')               # NOQA
+        print(RESULT_SPACE.format(FAIL))        # NOQA
+    except Exception:                           # NOQA
+        print(RESULT_SPACE.format(PASS))        # NOQA
 
     print('RESET')
     # toggle the RESET line to LOW, and make sure it is NOT dead


### PR DESCRIPTION
## overview

Fixes bug where if a response from the serial port did NOT contain the specified ack characters, then no exception was raised when there should be.

In this PR, if the ACK characters are not in the serial port's response, then a `SerialNoResponse` exception is raised.

If the ACK is an empty byte string (`""`), then an empty response from the serial port will not raise an exception