### PR TITLE
feat(app): Add refresh to GET /pipette calls in ChangePipette

### DIFF
--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -189,7 +189,7 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {confirmUrl, parentUrl, baseUrl, robot, mount} = ownProps
   const disengage = () => dispatch(disengagePipetteMotors(robot, mount))
   const checkPipette = () => disengage()
-    .then(() => dispatch(fetchPipettes(robot)))
+    .then(() => dispatch(fetchPipettes(robot, true)))
 
   return {
     checkPipette,

--- a/app/src/http-api-client/__tests__/pipettes.test.js
+++ b/app/src/http-api-client/__tests__/pipettes.test.js
@@ -40,6 +40,14 @@ describe('pipettes', () => {
           .toHaveBeenCalledWith(robot, 'GET', 'pipettes'))
     })
 
+    test('fetchPipettes with refresh calls GET /pipettes?refresh=true', () => {
+      client.__setMockResponse(pipettes)
+
+      return store.dispatch(fetchPipettes(robot, true))
+        .then(() => expect(client)
+          .toHaveBeenCalledWith(robot, 'GET', 'pipettes?refresh=true'))
+    })
+
     test('fetchPipettes dispatches PIPETTES_REQUEST + SUCCESS', () => {
       const expectedActions = [
         {type: 'api:PIPETTES_REQUEST', payload: {robot}},

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -55,11 +55,17 @@ type PipettesState = {
   [robotName: string]: ?RobotPipettes
 }
 
-export function fetchPipettes (robot: RobotService): ThunkPromiseAction {
+export function fetchPipettes (
+  robot: RobotService,
+  refresh: boolean = false
+): ThunkPromiseAction {
+  let path = 'pipettes'
+  if (refresh) path += '?refresh=true'
+
   return (dispatch) => {
     dispatch({type: 'api:PIPETTES_REQUEST', payload: {robot}})
 
-    return client(robot, 'GET', 'pipettes')
+    return client(robot, 'GET', path)
       .then((pipettes) => (
         {type: 'api:PIPETTES_SUCCESS', payload: {robot, pipettes}}
       )).catch((error) => (


### PR DESCRIPTION
## overview

This PR adds app support for the `GET /pipettes` changes made in  #1414

## changelog

- feat(app): Add `?refresh=true` to `GET /pipettes` calls in ChangePipette 

## review requests

Put #1414 on a robot, test that app on this branch is able to make it through Change Pipette
