### PR TITLE
fix(app): Highlight active calibration step in subnav

### DIFF
--- a/app/src/components/SetupPanel/InstrumentListItem.js
+++ b/app/src/components/SetupPanel/InstrumentListItem.js
@@ -42,6 +42,7 @@ export default function InstrumentListItem (props: Props) {
       url={url}
       confirmed={confirmed}
       iconName={iconName}
+      activeClassName={styles.active}
     >
       <div className={styles.item_info}>
         <span>{capitalize(mount)}</span>

--- a/app/src/components/SetupPanel/LabwareListItem.js
+++ b/app/src/components/SetupPanel/LabwareListItem.js
@@ -35,6 +35,7 @@ export default function LabwareListItem (props: Props) {
       url={url}
       onClick={onClick}
       iconName={iconName}
+      activeClassName={styles.active}
     >
       <div className={styles.item_info}>
         <span>Slot {slot}</span>

--- a/app/src/components/SetupPanel/styles.css
+++ b/app/src/components/SetupPanel/styles.css
@@ -16,3 +16,9 @@
   display: flex;
   justify-content: space-between;
 }
+
+.active {
+  color: #0ec9eb;
+  background-color: #f0f3ff;
+  fill: #0ec9eb;
+}


### PR DESCRIPTION
## overview

This PR closes #1317 by adding an active state to selected labware or instrument item.

<img width="600" alt="screen shot 2018-05-10 at 9 51 41 am" src="https://user-images.githubusercontent.com/3430313/39875057-85e4ace0-543d-11e8-9526-633290a24f7c.png">

## changelog

- Implement active state style from connection panel in setup panel

## review requests

Another tiny PR. Just confirm selected labware or pipette matches screenshot for active list item.
