### PR TITLE
API: fix bug in Pipette.max_volume

### DIFF
--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -199,9 +199,9 @@ class InstrumentsWrapper(object):
             ul_per_mm=config.ul_per_mm,
             aspirate_flow_rate=config.aspirate_flow_rate,
             dispense_flow_rate=config.dispense_flow_rate,
+            plunger_positions=config.plunger_positions.copy(),
             fallback_tip_length=config.tip_length)  # TODO move to labware
 
-        p.plunger_positions = config.plunger_positions.copy()
         p.set_pick_up_current(config.pick_up_current)
         return p
 

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -123,6 +123,7 @@ class Pipette:
             dispense_speed=DEFAULT_DISPENSE_SPEED,
             aspirate_flow_rate=None,
             dispense_flow_rate=None,
+            plunger_positions=PLUNGER_POSITIONS,
             fallback_tip_length=51.7):  # TODO (andy): move to tip-rack
 
         self.robot = robot
@@ -170,18 +171,17 @@ class Pipette:
         self.previous_placeable = None
         self.current_volume = 0
 
-        self.plunger_positions = PLUNGER_POSITIONS.copy()
+        self.plunger_positions = plunger_positions
 
         if max_volume:
             warnings.warn(
                 "'max_volume' is deprecated, use `ul_per_mm` in constructor"
             )
 
-        self.ul_per_mm = ul_per_mm
+        self.max_volume = None
         self.min_volume = min_volume
-        t = self._get_plunger_position('top')
-        b = self._get_plunger_position('bottom')
-        self.max_volume = (t - b) * self.ul_per_mm
+        self.ul_per_mm = None
+        self.set_ul_per_mm(ul_per_mm)
 
         self._pick_up_current = None
         self.set_pick_up_current(DEFAULT_PLUNGE_CURRENT)
@@ -1424,6 +1424,12 @@ class Pipette:
         )
 
         return self
+
+    def set_ul_per_mm(self, ul_per_mm):
+        self.ul_per_mm = ul_per_mm
+        t = self._get_plunger_position('top')
+        b = self._get_plunger_position('bottom')
+        self.max_volume = (t - b) * self.ul_per_mm
 
     def _get_plunger_position(self, position):
         """

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -82,7 +82,7 @@ DEFAULT_DISPENSE_SECONDS = 1
 
 p10_single = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 3,
         'blow_out': 1,
         'drop_tip': -5
@@ -90,7 +90,7 @@ p10_single = pipette_config(
     pick_up_current=0.1,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
+    ul_per_mm=0.77,
     channels=1,
     name='p10_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P10),
@@ -99,7 +99,7 @@ p10_single = pipette_config(
 
 p10_multi = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 3,
         'blow_out': 1,
         'drop_tip': -5
@@ -107,7 +107,7 @@ p10_multi = pipette_config(
     pick_up_current=0.2,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
+    ul_per_mm=0.77,
     channels=8,
     name='p10_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -116,7 +116,7 @@ p10_multi = pipette_config(
 
 p50_single = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 4,
         'blow_out': 2,
         'drop_tip': -2.5
@@ -124,7 +124,7 @@ p50_single = pipette_config(
     pick_up_current=0.1,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
+    ul_per_mm=3.35,
     channels=1,
     name='p50_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P50),
@@ -133,7 +133,7 @@ p50_single = pipette_config(
 
 p50_multi = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 4,
         'blow_out': 2,
         'drop_tip': -4
@@ -141,7 +141,7 @@ p50_multi = pipette_config(
     pick_up_current=0.3,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
+    ul_per_mm=3.35,
     channels=8,
     name='p50_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -150,15 +150,15 @@ p50_multi = pipette_config(
 
 p300_single = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
+        'top': 19,
+        'bottom': 2.5,
         'blow_out': 1,
         'drop_tip': -2.5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
+    ul_per_mm=18.7,
     channels=1,
     name='p300_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P300),
@@ -167,7 +167,7 @@ p300_single = pipette_config(
 
 p300_multi = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 3,
         'blow_out': 1,
         'drop_tip': -4
@@ -175,7 +175,7 @@ p300_multi = pipette_config(
     pick_up_current=0.3,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
+    ul_per_mm=19,
     channels=8,
     name='p300_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -184,7 +184,7 @@ p300_multi = pipette_config(
 
 p1000_single = pipette_config(
     plunger_positions={
-        'top': 18,
+        'top': 19,
         'bottom': 3,
         'blow_out': 1,
         'drop_tip': -2.5
@@ -192,7 +192,7 @@ p1000_single = pipette_config(
     pick_up_current=0.1,
     aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=61.69,
+    ul_per_mm=65,
     channels=1,
     name='p1000_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P1000),

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -82,15 +82,15 @@ DEFAULT_DISPENSE_SECONDS = 1
 
 p10_single = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 2.5,
-        'blow_out': -0.5,
-        'drop_tip': -4
+        'top': 18,
+        'bottom': 3,
+        'blow_out': 1,
+        'drop_tip': -5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.77,
+    ul_per_mm=0.617,
     channels=1,
     name='p10_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P10),
@@ -99,15 +99,15 @@ p10_single = pipette_config(
 
 p10_multi = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 4,
+        'top': 18,
+        'bottom': 3,
         'blow_out': 1,
-        'drop_tip': -4
+        'drop_tip': -5
     },
     pick_up_current=0.2,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.77,
+    ul_per_mm=0.617,
     channels=8,
     name='p10_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -116,15 +116,15 @@ p10_multi = pipette_config(
 
 p50_single = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 5,
+        'top': 18,
+        'bottom': 4,
         'blow_out': 2,
-        'drop_tip': -3
+        'drop_tip': -2.5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3,
+    ul_per_mm=3.08,
     channels=1,
     name='p50_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P50),
@@ -133,15 +133,15 @@ p50_single = pipette_config(
 
 p50_multi = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 5,
+        'top': 18,
+        'bottom': 4,
         'blow_out': 2,
-        'drop_tip': -2.5
+        'drop_tip': -4
     },
     pick_up_current=0.3,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3,
+    ul_per_mm=3.08,
     channels=8,
     name='p50_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -150,15 +150,15 @@ p50_multi = pipette_config(
 
 p300_single = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 4,
+        'top': 18,
+        'bottom': 3,
         'blow_out': 1,
-        'drop_tip': -4.5
+        'drop_tip': -2.5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.7,
+    ul_per_mm=18.51,
     channels=1,
     name='p300_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P300),
@@ -167,15 +167,15 @@ p300_single = pipette_config(
 
 p300_multi = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 4,
+        'top': 18,
+        'bottom': 3,
         'blow_out': 1,
-        'drop_tip': -3.5
+        'drop_tip': -4
     },
     pick_up_current=0.3,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=19,
+    ul_per_mm=18.51,
     channels=8,
     name='p300_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -184,8 +184,8 @@ p300_multi = pipette_config(
 
 p1000_single = pipette_config(
     plunger_positions={
-        'top': 19,
-        'bottom': 4,
+        'top': 18,
+        'bottom': 3,
         'blow_out': 1,
         'drop_tip': -2.5
     },

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -82,15 +82,15 @@ DEFAULT_DISPENSE_SECONDS = 1
 
 p10_single = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -5
+        'top': 19,
+        'bottom': 2.5,
+        'blow_out': -0.5,
+        'drop_tip': -4
     },
     pick_up_current=0.1,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
+    ul_per_mm=0.77,
     channels=1,
     name='p10_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P10),
@@ -99,15 +99,15 @@ p10_single = pipette_config(
 
 p10_multi = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
+        'top': 19,
+        'bottom': 4,
         'blow_out': 1,
-        'drop_tip': -5
+        'drop_tip': -4
     },
     pick_up_current=0.2,
     aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=0.617,
+    ul_per_mm=0.77,
     channels=8,
     name='p10_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -116,15 +116,15 @@ p10_multi = pipette_config(
 
 p50_single = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 4,
+        'top': 19,
+        'bottom': 5,
         'blow_out': 2,
-        'drop_tip': -2.5
+        'drop_tip': -3
     },
     pick_up_current=0.1,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
+    ul_per_mm=3,
     channels=1,
     name='p50_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P50),
@@ -133,15 +133,15 @@ p50_single = pipette_config(
 
 p50_multi = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 4,
+        'top': 19,
+        'bottom': 5,
         'blow_out': 2,
-        'drop_tip': -4
+        'drop_tip': -2.5
     },
     pick_up_current=0.3,
     aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=3.08,
+    ul_per_mm=3,
     channels=8,
     name='p50_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -150,15 +150,15 @@ p50_multi = pipette_config(
 
 p300_single = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
+        'top': 19,
+        'bottom': 4,
         'blow_out': 1,
-        'drop_tip': -2.5
+        'drop_tip': -4.5
     },
     pick_up_current=0.1,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
+    ul_per_mm=18.7,
     channels=1,
     name='p300_single_v1',
     model_offset=(0.0, 0.0, Z_OFFSET_P300),
@@ -167,15 +167,15 @@ p300_single = pipette_config(
 
 p300_multi = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
+        'top': 19,
+        'bottom': 4,
         'blow_out': 1,
-        'drop_tip': -4
+        'drop_tip': -3.5
     },
     pick_up_current=0.3,
     aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
     dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    ul_per_mm=18.51,
+    ul_per_mm=19,
     channels=8,
     name='p300_multi_v1',
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
@@ -184,8 +184,8 @@ p300_multi = pipette_config(
 
 p1000_single = pipette_config(
     plunger_positions={
-        'top': 18,
-        'bottom': 3,
+        'top': 19,
+        'bottom': 4,
         'blow_out': 1,
         'drop_tip': -2.5
     },

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -54,7 +54,7 @@ async def test_load_from_text(session_manager, protocol):
             traverse(command['children'])
     traverse(session.commands)
     # Less commands now that trash is built in
-    assert len(acc) == 69
+    assert len(acc) == 75
 
 
 async def test_async_notifications(main_router):

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -246,7 +246,8 @@ async def test_session_model_functional(session_manager, protocol):
     session = session_manager.create(name='<blank>', text=protocol.text)
     assert [container.name for container in session.containers] == \
            ['tiprack', 'trough', 'plate', 'tall-fixed-trash']
-    assert [instrument.name for instrument in session.instruments] == ['p200']
+    names = [instrument.name for instrument in session.instruments]
+    assert names == ['p300_single_v1']
 
 
 # TODO(artyom 20171018): design a small protocol specifically for the test

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -9,12 +9,7 @@ plate = containers.load('96-PCR-flat', '1', 'plate')
 p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
 
 # create a p200 pipette on robot axis B
-p200 = instruments.Pipette(
-    name="p200",
-    mount="left",
-    min_volume=20,
-    tip_racks=[p200rack]
-)
+p200 = instruments.P300_Single(mount="left",tip_racks=[p200rack])
 
 # simple, atomic commands to control fine details
 p200.pick_up_tip()

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -9,7 +9,7 @@ plate = containers.load('96-PCR-flat', '1', 'plate')
 p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
 
 # create a p200 pipette on robot axis B
-p200 = instruments.P300_Single(mount="left",tip_racks=[p200rack])
+p200 = instruments.P300_Single(mount="left", tip_racks=[p200rack])
 
 # simple, atomic commands to control fine details
 p200.pick_up_tip()

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -9,18 +9,8 @@ tiprack = containers.load('tiprack-200ul', '8')
 trough = containers.load('trough-12row', '9')
 plate = containers.load('96-flat', '5')
 
-single = instruments.Pipette(
-    mount='right',
-    min_volume=10,
-    name="p200",
-    tip_racks=[tiprack])
-
-multi = instruments.Pipette(
-    mount='left',
-    min_volume=10,
-    name="p200S",
-    tip_racks=[tiprack],
-    channels=8)
+single = instruments.P300_Single(mount='right', tip_racks=[tiprack])
+multi = instruments.P300_Multi(mount='left', tip_racks=[tiprack])
 
 
 for tip in [tiprack[0], tiprack[-1]]:

--- a/api/tests/opentrons/integration/test_server.py
+++ b/api/tests/opentrons/integration/test_server.py
@@ -54,7 +54,7 @@ async def test_notifications(session, session_manager, protocol, root, connect):
     await socket.receive_json()  # Skip ack
     res = await socket.receive_json()
 
-    assert len(res['data']['v']['command_log']['v']) == 70
+    assert len(res['data']['v']['command_log']['v']) == 76
     responses = [
         res for res in responses
         if res['data']['v']['name'] == 'state']

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -10,31 +10,31 @@ def test_pipette_models():
     robot.reset()
     p = instruments.P10_Single(mount='left')
     assert p.channels == 1
-    assert p.max_volume > 10
+    assert round(p.max_volume, 2) == 12.71
     p = instruments.P10_Multi(mount='right')
     assert p.channels == 8
-    assert p.max_volume > 10
+    assert round(p.max_volume, 2) == 11.55
 
     robot.reset()
     p = instruments.P50_Single(mount='left')
     assert p.channels == 1
-    assert p.max_volume > 50
+    assert round(p.max_volume, 2) == 42         # too low b/c of hardware
     p = instruments.P50_Multi(mount='right')
     assert p.channels == 8
-    assert p.max_volume > 50
+    assert round(p.max_volume, 2) == 42         # too low b/c of hardware
 
     robot.reset()
     p = instruments.P300_Single(mount='left')
     assert p.channels == 1
-    assert p.max_volume > 300
+    assert round(p.max_volume, 2) == 280.5      # too low b/c of hardware
     p = instruments.P300_Multi(mount='right')
     assert p.channels == 8
-    assert p.max_volume > 300
+    assert round(p.max_volume, 2) == 285        # too low b/c of hardware
 
     robot.reset()
     p = instruments.P1000_Single(mount='left')
     assert p.channels == 1
-    assert p.max_volume > 1000
+    assert round(p.max_volume, 2) == 925.35      # too low b/c of hardware
 
 
 def test_pipette_max_deck_height():
@@ -92,7 +92,7 @@ def test_aspirate_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (8.402, 0.0, 0.0)).all()
+    assert (current_pos == (9.348, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()
@@ -120,7 +120,7 @@ def test_dispense_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (3.0, 0.0, 0.0)).all()
+    assert (current_pos == (4.0, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -10,31 +10,31 @@ def test_pipette_models():
     robot.reset()
     p = instruments.P10_Single(mount='left')
     assert p.channels == 1
-    assert round(p.max_volume, 2) == 12.71
+    assert p.max_volume > 10
     p = instruments.P10_Multi(mount='right')
     assert p.channels == 8
-    assert round(p.max_volume, 2) == 11.55
+    assert p.max_volume > 10
 
     robot.reset()
     p = instruments.P50_Single(mount='left')
     assert p.channels == 1
-    assert round(p.max_volume, 2) == 42         # too low b/c of hardware
+    assert p.max_volume > 50
     p = instruments.P50_Multi(mount='right')
     assert p.channels == 8
-    assert round(p.max_volume, 2) == 42         # too low b/c of hardware
+    assert p.max_volume > 50
 
     robot.reset()
     p = instruments.P300_Single(mount='left')
     assert p.channels == 1
-    assert round(p.max_volume, 2) == 280.5      # too low b/c of hardware
+    assert p.max_volume > 300
     p = instruments.P300_Multi(mount='right')
     assert p.channels == 8
-    assert round(p.max_volume, 2) == 285        # too low b/c of hardware
+    assert p.max_volume > 300
 
     robot.reset()
     p = instruments.P1000_Single(mount='left')
     assert p.channels == 1
-    assert round(p.max_volume, 2) == 925.35      # too low b/c of hardware
+    assert p.max_volume > 1000
 
 
 def test_pipette_max_deck_height():
@@ -92,7 +92,7 @@ def test_aspirate_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (9.348, 0.0, 0.0)).all()
+    assert (current_pos == (8.402, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()
@@ -120,7 +120,7 @@ def test_dispense_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (4.0, 0.0, 0.0)).all()
+    assert (current_pos == (3.0, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -92,7 +92,7 @@ def test_aspirate_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (8.402, 0.0, 0.0)).all()
+    assert (current_pos == (7.848, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()
@@ -120,7 +120,7 @@ def test_dispense_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (3.0, 0.0, 0.0)).all()
+    assert (current_pos == (2.5, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()

--- a/labware-definitions/robot-data/pipette-config.json
+++ b/labware-definitions/robot-data/pipette-config.json
@@ -3,7 +3,7 @@
     "displayName": "P10 Single-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 3,
       "blowOut": 1,
       "dropTip": -5
@@ -11,7 +11,7 @@
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.617,
+    "ulPerMm": 0.77,
     "channels": 1,
     "modelOffset": [0.0, 0.0, -13],
     "tipLength": 40
@@ -20,7 +20,7 @@
     "displayName": "P10 8-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 3,
       "blowOut": 1,
       "dropTip": -5
@@ -28,7 +28,7 @@
     "pickUpCurrent": 0.2,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.617,
+    "ulPerMm": 0.77,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 40
@@ -37,7 +37,7 @@
     "displayName": "P50 Single-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 4,
       "blowOut": 2,
       "dropTip": -2.5
@@ -45,7 +45,7 @@
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3.08,
+    "ulPerMm": 3.35,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -54,7 +54,7 @@
     "displayName": "P50 8-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 4,
       "blowOut": 2,
       "dropTip": -4
@@ -62,7 +62,7 @@
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3.08,
+    "ulPerMm": 3.35,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -71,15 +71,15 @@
     "displayName": "P300 Single-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
+      "top": 19,
+      "bottom": 2.5,
       "blowOut": 1,
       "dropTip": -2.5
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 18.51,
+    "ulPerMm": 18.7,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -88,7 +88,7 @@
     "displayName": "P300 8-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 3,
       "blowOut": 1,
       "dropTip": -4
@@ -96,7 +96,7 @@
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 18.51,
+    "ulPerMm": 19,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -105,7 +105,7 @@
     "displayName": "P1000 Single-channel",
     "nominalMaxVolumeUl": 1000,
     "plungerPositions": {
-      "top": 18,
+      "top": 19,
       "bottom": 3,
       "blowOut": 1,
       "dropTip": -2.5
@@ -113,7 +113,7 @@
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 500,
     "dispenseFlowRate": 1000,
-    "ulPerMm": 61.69,
+    "ulPerMm": 65,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 20.0],
     "tipLength": 60

--- a/labware-definitions/robot-data/pipette-config.json
+++ b/labware-definitions/robot-data/pipette-config.json
@@ -3,15 +3,15 @@
     "displayName": "P10 Single-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 2.5,
-      "blowOut": -0.5,
-      "dropTip": -4
+      "top": 18,
+      "bottom": 3,
+      "blowOut": 1,
+      "dropTip": -5
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.77,
+    "ulPerMm": 0.617,
     "channels": 1,
     "modelOffset": [0.0, 0.0, -13],
     "tipLength": 40
@@ -20,15 +20,15 @@
     "displayName": "P10 8-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 4,
+      "top": 18,
+      "bottom": 3,
       "blowOut": 1,
-      "dropTip": -4
+      "dropTip": -5
     },
     "pickUpCurrent": 0.2,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.77,
+    "ulPerMm": 0.617,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 40
@@ -37,15 +37,15 @@
     "displayName": "P50 Single-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 5,
+      "top": 18,
+      "bottom": 4,
       "blowOut": 2,
-      "dropTip": -3
+      "dropTip": -2.5
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3,
+    "ulPerMm": 3.08,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -54,15 +54,15 @@
     "displayName": "P50 8-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 5,
+      "top": 18,
+      "bottom": 4,
       "blowOut": 2,
-      "dropTip": -2.5
+      "dropTip": -4
     },
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3,
+    "ulPerMm": 3.08,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -71,15 +71,15 @@
     "displayName": "P300 Single-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 4,
+      "top": 18,
+      "bottom": 3,
       "blowOut": 1,
-      "dropTip": -4.5
+      "dropTip": -2.5
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 18.7,
+    "ulPerMm": 18.51,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -88,15 +88,15 @@
     "displayName": "P300 8-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 4,
+      "top": 18,
+      "bottom": 3,
       "blowOut": 1,
-      "dropTip": -3.5
+      "dropTip": -4
     },
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 19,
+    "ulPerMm": 18.51,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -105,8 +105,8 @@
     "displayName": "P1000 Single-channel",
     "nominalMaxVolumeUl": 1000,
     "plungerPositions": {
-      "top": 19,
-      "bottom": 4,
+      "top": 18,
+      "bottom": 3,
       "blowOut": 1,
       "dropTip": -2.5
     },

--- a/labware-definitions/robot-data/pipette-config.json
+++ b/labware-definitions/robot-data/pipette-config.json
@@ -3,15 +3,15 @@
     "displayName": "P10 Single-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
-      "blowOut": 1,
-      "dropTip": -5
+      "top": 19,
+      "bottom": 2.5,
+      "blowOut": -0.5,
+      "dropTip": -4
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.617,
+    "ulPerMm": 0.77,
     "channels": 1,
     "modelOffset": [0.0, 0.0, -13],
     "tipLength": 40
@@ -20,15 +20,15 @@
     "displayName": "P10 8-Channel",
     "nominalMaxVolumeUl": 10,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
+      "top": 19,
+      "bottom": 4,
       "blowOut": 1,
-      "dropTip": -5
+      "dropTip": -4
     },
     "pickUpCurrent": 0.2,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
-    "ulPerMm": 0.617,
+    "ulPerMm": 0.77,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 40
@@ -37,15 +37,15 @@
     "displayName": "P50 Single-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 4,
+      "top": 19,
+      "bottom": 5,
       "blowOut": 2,
-      "dropTip": -2.5
+      "dropTip": -3
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3.08,
+    "ulPerMm": 3,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -54,15 +54,15 @@
     "displayName": "P50 8-Channel",
     "nominalMaxVolumeUl": 50,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 4,
+      "top": 19,
+      "bottom": 5,
       "blowOut": 2,
-      "dropTip": -4
+      "dropTip": -2.5
     },
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
-    "ulPerMm": 3.08,
+    "ulPerMm": 3,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -71,15 +71,15 @@
     "displayName": "P300 Single-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
+      "top": 19,
+      "bottom": 4,
       "blowOut": 1,
-      "dropTip": -2.5
+      "dropTip": -4.5
     },
     "pickUpCurrent": 0.1,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 18.51,
+    "ulPerMm": 18.7,
     "channels": 1,
     "modelOffset": [0.0, 0.0, 0.0],
     "tipLength": 60
@@ -88,15 +88,15 @@
     "displayName": "P300 8-Channel",
     "nominalMaxVolumeUl": 300,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
+      "top": 19,
+      "bottom": 4,
       "blowOut": 1,
-      "dropTip": -4
+      "dropTip": -3.5
     },
     "pickUpCurrent": 0.3,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
-    "ulPerMm": 18.51,
+    "ulPerMm": 19,
     "channels": 8,
     "modelOffset": [0.0, 28.0, -25.8],
     "tipLength": 60
@@ -105,8 +105,8 @@
     "displayName": "P1000 Single-channel",
     "nominalMaxVolumeUl": 1000,
     "plungerPositions": {
-      "top": 18,
-      "bottom": 3,
+      "top": 19,
+      "bottom": 4,
       "blowOut": 1,
       "dropTip": -2.5
     },


### PR DESCRIPTION
## overview

This PR passes plunger-positions as an argument to the `Pipette` constructor, as well as adds the method `Pipette.set_ul_per_mm()`, which saved the new ul/mm value, as well as re-calculates the max-volume of that pipette.

This PR also adjusts the pipette-configs so that each pipette can physically hold it's advertised max-volume.

This PR fixes a bug with max-volume:

`Pipette.max_volume` was not accurate previously. It was using the default-plunger positions to determine it's max-volume, and then after being constructed the pipette then had its plunger positions mutated from outside itself. This left every pipette with an inaccurate max-volume, most of them reporting being larger than what the pipette could physically hold.