### PR TITLE
fix(api): Fix movement strategy and values for deck calibration

### DIFF
--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -89,6 +89,11 @@ Z_OFFSET_P1000 = 20  # shortest single-channel pipette
 DEFAULT_ASPIRATE_SECONDS = 2
 DEFAULT_DISPENSE_SECONDS = 1
 
+# TODO (ben 20180511): should we read these values from
+# TODO                 /shared-data/robot-data/pipette-config.json ? Unclear,
+# TODO                 because this is the backup in case that behavior fails,
+# TODO                 but we could make it more reliable if we start bundling
+# TODO                 config data into the wheel file perhaps. Needs research.
 p10_single = pipette_config(
     plunger_positions={
         'top': 19,
@@ -105,7 +110,7 @@ p10_single = pipette_config(
     model_offset=(0.0, 0.0, Z_OFFSET_P10),
     plunger_current=0.3,
     drop_tip_current=0.5,
-    tip_length=40
+    tip_length=33
 )
 
 p10_multi = pipette_config(
@@ -124,7 +129,7 @@ p10_multi = pipette_config(
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
     plunger_current=0.5,
     drop_tip_current=0.5,
-    tip_length=40
+    tip_length=33
 )
 
 p50_single = pipette_config(
@@ -143,7 +148,7 @@ p50_single = pipette_config(
     model_offset=(0.0, 0.0, Z_OFFSET_P50),
     plunger_current=0.3,
     drop_tip_current=0.5,
-    tip_length=60
+    tip_length=51.7
 )
 
 p50_multi = pipette_config(
@@ -162,7 +167,7 @@ p50_multi = pipette_config(
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
     plunger_current=0.5,
     drop_tip_current=0.5,
-    tip_length=60
+    tip_length=51.7
 )
 
 p300_single = pipette_config(
@@ -181,7 +186,7 @@ p300_single = pipette_config(
     model_offset=(0.0, 0.0, Z_OFFSET_P300),
     plunger_current=0.3,
     drop_tip_current=0.5,
-    tip_length=60
+    tip_length=51.7
 )
 
 p300_multi = pipette_config(
@@ -200,7 +205,7 @@ p300_multi = pipette_config(
     model_offset=(0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI),
     plunger_current=0.5,
     drop_tip_current=0.5,
-    tip_length=60
+    tip_length=51.7
 )
 
 p1000_single = pipette_config(
@@ -219,7 +224,7 @@ p1000_single = pipette_config(
     model_offset=(0.0, 0.0, Z_OFFSET_P1000),
     plunger_current=0.5,
     drop_tip_current=0.5,
-    tip_length=60
+    tip_length=76.7
 )
 
 fallback_configs = {

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -191,7 +191,7 @@ async def move(request):
             message = _move_mount(mount, point)
         elif target == 'pipette':
             pipette = _fetch_or_create_pipette(mount, model)
-            pipette.move_to((robot.deck, point))
+            pipette.move_to((robot.deck, point), strategy='arc')
             new_position = tuple(
                 pose_tracker.absolute(pipette.robot.poses, pipette))
             message = "Move complete. New position: {}".format(new_position)

--- a/shared-data/robot-data/pipette-config.json
+++ b/shared-data/robot-data/pipette-config.json
@@ -16,7 +16,7 @@
     "modelOffset": [0.0, 0.0, -13],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
-    "tipLength": 40
+    "tipLength": 33
   },
   "p10_multi_v1": {
     "displayName": "P10 8-Channel",
@@ -35,7 +35,7 @@
     "modelOffset": [0.0, 28.0, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
-    "tipLength": 40
+    "tipLength": 33
   },
   "p50_single_v1": {
     "displayName": "P50 Single-Channel",
@@ -54,7 +54,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
-    "tipLength": 60
+    "tipLength": 51.7
   },
   "p50_multi_v1": {
     "displayName": "P50 8-Channel",
@@ -73,7 +73,7 @@
     "modelOffset": [0.0, 28.0, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
-    "tipLength": 60
+    "tipLength": 51.7
   },
   "p300_single_v1": {
     "displayName": "P300 Single-Channel",
@@ -92,7 +92,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
-    "tipLength": 60
+    "tipLength": 51.7
   },
   "p300_multi_v1": {
     "displayName": "P300 8-Channel",
@@ -111,7 +111,7 @@
     "modelOffset": [0.0, 28.0, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
-    "tipLength": 60
+    "tipLength": 51.7
   },
   "p1000_single_v1": {
     "displayName": "P1000 Single-channel",
@@ -130,6 +130,6 @@
     "modelOffset": [0.0, 0.0, 20.0],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
-    "tipLength": 60
+    "tipLength": 76.7
   }
 }


### PR DESCRIPTION
## overview

Explicitly use 'arc' movement strategy in control move endpoint, and update tip length values to account for overlap between nozzle and tip. Fixes #1402 

## changelog: 

- (fix) Explicitly use 'arc' movement strategy in control move endpoint
- (fix) Update tip length values to account for overlap between nozzle and tip

## review requests

- [ ] Delete your `pipetteSettings.json` file from the config directory
- Do deck calibration flow
  - [ ] Pipette should move up before moving in xy
  - [ ] Resulting calibration matrix should have a z value near -26
- Do labware calibration
  - [ ] Nozzle should be just clear of top of trash box during tip probe
  - [ ] Pipette should go to correct position for previously calibrated labware