### PR TITLE
Changes mm movement by only rounding in final location

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1685,10 +1685,10 @@ class Pipette:
         """
         if aspirate:
             self.set_speed(
-                aspirate=round(self._ul_to_mm(aspirate), 3))
+                aspirate=round(self._ul_to_mm(aspirate), 6))
         if dispense:
             self.set_speed(
-                dispense=round(self._ul_to_mm(dispense), 3))
+                dispense=round(self._ul_to_mm(dispense), 6))
         return self
 
     def set_pick_up_current(self, amperes):

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1457,7 +1457,7 @@ class Pipette:
         """
 
         millimeters = ul / self.ul_per_mm
-        return round(millimeters, 3)
+        return millimeters
 
     def _ul_to_plunger_position(self, ul):
         """Calculate axis position for a given liquid volume.
@@ -1470,7 +1470,7 @@ class Pipette:
 
         millimeters = self._ul_to_mm(ul)
         destination_mm = self._get_plunger_position('bottom') + millimeters
-        return round(destination_mm, 3)
+        return round(destination_mm, 6)
 
     def _volume_percentage(self, volume):
         """Returns the plunger percentage for a given volume.
@@ -1685,10 +1685,10 @@ class Pipette:
         """
         if aspirate:
             self.set_speed(
-                aspirate=self._ul_to_mm(aspirate))
+                aspirate=round(self._ul_to_mm(aspirate), 3))
         if dispense:
             self.set_speed(
-                dispense=self._ul_to_mm(dispense))
+                dispense=round(self._ul_to_mm(dispense), 3))
         return self
 
     def set_pick_up_current(self, amperes):

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -92,7 +92,8 @@ def test_aspirate_move_to():
     current_pos = pose_tracker.absolute(
         robot.poses,
         p300.instrument_actuator)
-    assert (current_pos == (7.848, 0.0, 0.0)).all()
+
+    assert (current_pos == (7.847594, 0.0, 0.0)).all()
 
     current_pos = pose_tracker.absolute(robot.poses, p300)
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()


### PR DESCRIPTION
## overview

Attempt to minimize amount of times a number is rounded in intermediate calculations. Fixes #1409 .

## changelog

- Remove rounding from def _ul_per_mm
- Adds rounding in flow rate calculation speed

## review requests

