### PR TITLE
fix(api): Reduce size of rpc session packet

### DIFF
--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -68,7 +68,6 @@ MAIN_TESTER_DB = str(os.path.join(
 def state(topic, state):
     def _match(item):
         return \
-            item['name'] == 'state' and \
             item['topic'] == topic and \
             item['payload'].state == state
 

--- a/api/tests/opentrons/integration/test_server.py
+++ b/api/tests/opentrons/integration/test_server.py
@@ -55,12 +55,6 @@ async def test_notifications(session, session_manager, protocol, root, connect):
     res = await socket.receive_json()
 
     assert len(res['data']['v']['command_log']['v']) == 76
-    responses = [
-        res for res in responses
-        if res['data']['v']['name'] == 'state']
-    # TODO (artyom 20171030): travis breaks with off by one len == 107
-    # passes locally.
-    # assert len(responses) == 106
 
     states = [
         response['data']['v']['payload']['v']['state']


### PR DESCRIPTION
## overview

Rpc session was sending entire state of object on every state update, which was overwhelming the webworker and causing it to crash. This modifies the data such that the whole state is sent on first connect, and then on update only the data for the most recent command is sent. Fixes #1021 

This includes a breaking change for the app, as the shape of the data sent back during an rpc session has changed. The shape specified in this change was coordinated with @mcous, who is going to open a PR to fix the break. This will make upcoming releases non-backwards-compatible with prior servers, but they will still be able to update servers as that process does not use rpc.

## changelog

- (fix) Reduce the size of the data packet sent on state update in the rpc session

## review requests

Run a long protocol and see the webworker not tank
