### PR TITLE
refactor(app): Support mini session updates in RPC client/robot state

### DIFF
--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -10,7 +10,8 @@ import type {
   Direction,
   BaseRobot,
   RobotService,
-  ProtocolFile
+  ProtocolFile,
+  SessionUpdate
 } from './types'
 
 // TODO(mc, 2017-11-22): rename this function to actionType
@@ -155,6 +156,11 @@ export type CalibrationFailureAction = {|
   payload: Error
 |}
 
+export type SessionUpdateAction = {|
+  type: 'robot:SESSION_UPDATE',
+  payload: SessionUpdate,
+|}
+
 export type CalibrationResponseAction =
   | CalibrationSuccessAction
   | CalibrationFailureAction
@@ -209,6 +215,7 @@ export type Action =
   | CalibrationFailureAction
   | ReturnTipResponseAction
   | SetJogDistanceAction
+  | SessionUpdateAction
 
 export const actions = {
   discover (): DiscoverAction {
@@ -273,6 +280,13 @@ export const actions = {
       payload: !didError
         ? session
         : error
+    }
+  },
+
+  sessionUpdate (update: SessionUpdate): SessionUpdateAction {
+    return {
+      type: 'robot:SESSION_UPDATE',
+      payload: update
     }
   },
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -197,8 +197,8 @@ export default function client (dispatch) {
     // return setTimeout(() => dispatch(actions.return_tipResponse()), 1000)
 
     remote.calibration_manager.return_tip(instrument)
-    .then(() => dispatch(actions.returnTipResponse()))
-    .catch((error) => dispatch(actions.returnTipResponse(error)))
+      .then(() => dispatch(actions.returnTipResponse()))
+      .catch((error) => dispatch(actions.returnTipResponse(error)))
   }
 
   function moveTo (state, action) {
@@ -292,45 +292,51 @@ export default function client (dispatch) {
   }
 
   function handleApiSession (apiSession) {
-    const {
-      name,
-      protocol_text,
-      commands,
-      command_log,
-      state,
-      instruments,
-      containers
-    } = apiSession
-    const protocolCommands = []
-    const protocolCommandsById = {}
-    const instrumentsByMount = {}
-    const labwareBySlot = {}
+    const update = {state: apiSession.state, startTime: apiSession.startTime}
 
     // ensure run timer is running or stopped
-    if (state === constants.RUNNING) {
+    if (update.state === constants.RUNNING) {
       setRunTimerInterval()
     } else {
       clearRunTimerInterval()
     }
 
-    try {
-      // TODO(mc, 2017-08-30): Use a reduce
-      ;(commands || []).forEach(makeHandleCommand())
-      ;(instruments || []).forEach(apiInstrumentToInstrument)
-      ;(containers || []).forEach(apiContainerToContainer)
-
-      const payload = {
-        name,
-        state,
-        errors: [],
-        protocolText: protocol_text,
-        protocolCommands,
-        protocolCommandsById,
-        instrumentsByMount,
-        labwareBySlot
+    // if lastCommand key is present, we're dealing with a light update
+    if ('lastCommand' in apiSession) {
+      const lastCommand = apiSession.lastCommand && {
+        id: apiSession.lastCommand.id,
+        handledAt: apiSession.lastCommand.handledAt
       }
 
-      dispatch(actions.sessionResponse(null, payload))
+      return dispatch(actions.sessionUpdate({...update, lastCommand}))
+    }
+
+    // else we're doing a heavy full session deserialization
+    try {
+      // TODO(mc, 2017-08-30): Use a reduce
+      if (apiSession.commands) {
+        update.protocolCommands = []
+        update.protocolCommandsById = {}
+        apiSession.commands.forEach(makeHandleCommand())
+      }
+
+      if (apiSession.instruments) {
+        update.instrumentsByMount = {}
+        apiSession.instruments.forEach(apiInstrumentToInstrument)
+      }
+
+      if (apiSession.containers) {
+        update.labwareBySlot = {}
+        apiSession.containers.forEach(apiContainerToContainer)
+      }
+
+      if (apiSession.protocol_text) {
+        update.protocolText = apiSession.protocol_text
+      }
+
+      if (apiSession.name) update.name = apiSession.name
+
+      dispatch(actions.sessionResponse(null, update))
     } catch (error) {
       dispatch(actions.sessionResponse(error))
     }
@@ -338,16 +344,16 @@ export default function client (dispatch) {
     function makeHandleCommand (depth = 0) {
       return function handleCommand (command) {
         const {id, description} = command
-        const logEntry = command_log[id]
+        const logEntry = apiSession.command_log[id]
         const children = Array.from(command.children)
         let handledAt = null
 
-        if (logEntry) handledAt = logEntry.timestamp
-        if (depth === 0) protocolCommands.push(id)
+        if (logEntry != null) handledAt = logEntry
+        if (depth === 0) update.protocolCommands.push(id)
 
         children.forEach(makeHandleCommand(depth + 1))
 
-        protocolCommandsById[id] = {
+        update.protocolCommandsById[id] = {
           id,
           description,
           handledAt,
@@ -362,7 +368,7 @@ export default function client (dispatch) {
       //  interacts with
       const volume = Number(name.match(RE_VOLUME)[1])
 
-      instrumentsByMount[mount] = {_id, mount, name, channels, volume}
+      update.instrumentsByMount[mount] = {_id, mount, name, channels, volume}
     }
 
     function apiContainerToContainer (apiContainer) {
@@ -374,20 +380,20 @@ export default function client (dispatch) {
         labware.calibratorMount = apiContainer.instruments[0].mount
       }
 
-      labwareBySlot[slot] = labware
+      update.labwareBySlot[slot] = labware
     }
   }
 
   function handleRobotNotification (message) {
     const {topic, payload} = message
 
-    console.log(message)
+    console.log(`"${topic}" message:`, payload)
 
     switch (topic) {
       case 'session': return handleApiSession(payload)
     }
 
-    console.log('Unhandled message!')
+    console.warn(`"${topic}" message was unhandled`)
   }
 
   function handleClientError (error) {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -196,12 +196,9 @@ export const getRunProgress = createSelector(
 
 // TODO(mc, 2018-01-04): inferring start time from handledAt of first command
 // is inadequate; robot starts moving before this timestamp is set
-export const getStartTime = createSelector(
-  getCommands,
-  (commands): ?number => commands.length
-    ? commands[0].handledAt
-    : null
-)
+export function getStartTime (state: State) {
+  return session(state).startTime
+}
 
 export const getRunTime = createSelector(
   getStartTime,

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -120,6 +120,13 @@ describe('robot actions', () => {
     expect(actions.sessionResponse(error)).toEqual(failure)
   })
 
+  test('SESSION_UPDATE action', () => {
+    const update = {state: 'running', startTime: 1}
+    const expected = {type: 'robot:SESSION_UPDATE', payload: update}
+
+    expect(actions.sessionUpdate(update)).toEqual(expected)
+  })
+
   test('set deck populated action', () => {
     expect(actions.setDeckPopulated(false)).toEqual({
       type: actionTypes.SET_DECK_POPULATED,

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -203,6 +203,48 @@ describe('robot selectors', () => {
     })
   })
 
+  test('getStartTime', () => {
+    const state = makeState({session: {startTime: 42}})
+    expect(getStartTime(state)).toBe(42)
+  })
+
+  test('getRunTime with no startTime', () => {
+    const state = {
+      [NAME]: {
+        session: {
+          startTime: null,
+          runTime: 42
+        }
+      }
+    }
+
+    expect(getRunTime(state)).toEqual('00:00:00')
+  })
+
+  test('getRunTime', () => {
+    const testGetRunTime = (seconds, expected) => {
+      const stateWithRunTime = {
+        [NAME]: {
+          session: {
+            startTime: 42,
+            runTime: 42 + (1000 * seconds)
+          }
+        }
+      }
+
+      expect(getRunTime(stateWithRunTime)).toEqual(expected)
+    }
+
+    testGetRunTime(0, '00:00:00')
+    testGetRunTime(1, '00:00:01')
+    testGetRunTime(59, '00:00:59')
+    testGetRunTime(60, '00:01:00')
+    testGetRunTime(61, '00:01:01')
+    testGetRunTime(3599, '00:59:59')
+    testGetRunTime(3600, '01:00:00')
+    testGetRunTime(3601, '01:00:01')
+  })
+
   describe('command based', () => {
     const state = makeState({
       session: {
@@ -253,44 +295,6 @@ describe('robot selectors', () => {
       })
 
       expect(getRunProgress(state)).toEqual(0)
-    })
-
-    test('getStartTime', () => {
-      expect(getStartTime(state)).toEqual(42)
-    })
-
-    test('getStartTime without commands', () => {
-      expect(getStartTime(makeState({session: {protocolCommands: []}})))
-        .toEqual(null)
-    })
-
-    test('getRunTime', () => {
-      const testGetRunTime = (seconds, expected) => {
-        const stateWithRunTime = {
-          [NAME]: {
-            session: {
-              ...state[NAME].session,
-              runTime: 42 + (1000 * seconds)
-            }
-          }
-        }
-
-        expect(getRunTime(stateWithRunTime)).toEqual(expected)
-      }
-
-      testGetRunTime(0, '00:00:00')
-      testGetRunTime(1, '00:00:01')
-      testGetRunTime(59, '00:00:59')
-      testGetRunTime(60, '00:01:00')
-      testGetRunTime(61, '00:01:01')
-      testGetRunTime(3599, '00:59:59')
-      testGetRunTime(3600, '01:00:00')
-      testGetRunTime(3601, '01:00:01')
-    })
-
-    test('getRunTime without commands', () => {
-      expect(getRunTime(makeState({session: {protocolCommands: []}})))
-        .toEqual('00:00:00')
     })
 
     test('getCommands', () => {

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -31,6 +31,7 @@ describe('robot reducer - session', () => {
       pauseRequest: {inProgress: false, error: null},
       resumeRequest: {inProgress: false, error: null},
       cancelRequest: {inProgress: false, error: null},
+      startTime: null,
       runTime: 0
     })
   })
@@ -77,7 +78,6 @@ describe('robot reducer - session', () => {
         sessionRequest: {inProgress: true, error: null},
         name: '/path/to/foo.py'
       }
-
     }
     const action = {
       type: actionTypes.SESSION_RESPONSE,
@@ -118,6 +118,37 @@ describe('robot reducer - session', () => {
     expect(reducer(state, action).session).toEqual({
       sessionRequest: {inProgress: false, error: new Error('AH')},
       name: '/path/to/foo.py'
+    })
+  })
+
+  test('handles SESSION_UPDATE action', () => {
+    const state = {
+      session: {
+        state: 'loaded',
+        startTime: null,
+        protocolCommands: [0, 1, 2],
+        protocolCommandsById: {
+          0: {id: 0, handledAt: 2}
+        }
+      }
+    }
+    const action = {
+      type: 'robot:SESSION_UPDATE',
+      payload: {
+        state: 'running',
+        startTime: 1,
+        lastCommand: {id: 1, handledAt: 3}
+      }
+    }
+
+    expect(reducer(state, action).session).toEqual({
+      state: 'running',
+      startTime: 1,
+      protocolCommands: [0, 1, 2],
+      protocolCommandsById: {
+        0: {id: 0, handledAt: 2},
+        1: {id: 1, handledAt: 3}
+      }
     })
   })
 

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -140,3 +140,12 @@ export type SessionStatus =
   | 'error'
   | 'finished'
   | 'stopped'
+
+export type SessionUpdate = {
+  state: SessionStatus,
+  startTime: ?number,
+  lastCommand: ?{
+    id: number,
+    handledAt: number,
+  },
+}

--- a/app/src/rpc/client.js
+++ b/app/src/rpc/client.js
@@ -224,7 +224,7 @@ class RpcContext extends EventEmitter {
       case NOTIFICATION:
         this._cacheCallResultMetadata(data)
 
-        RemoteObject(this, data)
+        RemoteObject(this, data, {methods: false})
           .then((remote) => this.emit('notification', remote))
           // .catch((e) => log.error('Error creating notification remote', e))
 

--- a/app/src/rpc/test/client.test.js
+++ b/app/src/rpc/test/client.test.js
@@ -311,7 +311,8 @@ describe('rpc client', () => {
     Client(url)
       .then((client) => {
         addListener(client, 'notification', (message) => {
-          expect(RemoteObject).toHaveBeenCalledWith(client, INSTANCE)
+          expect(RemoteObject)
+            .toHaveBeenCalledWith(client, INSTANCE, {methods: false})
           expect(message).toEqual(mockRemote)
           done()
         })

--- a/app/src/rpc/test/remote-object.test.js
+++ b/app/src/rpc/test/remote-object.test.js
@@ -62,6 +62,16 @@ describe('rpc remote object factory', () => {
       })
   })
 
+  test('deserializes an object without methods if methods: false', () => {
+    const source = {i: 1, t: 2, v: {foo: 'bar'}}
+
+    return RemoteObject(context, source, {methods: false})
+      .then((remote) => {
+        expect(context.resolveTypeValues).not.toHaveBeenCalledWith(source)
+        expect(remote).toEqual({_id: 1, foo: 'bar'})
+      })
+  })
+
   test('deserializes object props as remote objects', () => {
     const child = {i: 2, t: 100, v: {baz: 'qux'}}
     const source = {i: 1, t: 100, v: {foo: 'bar', bar: child}}


### PR DESCRIPTION
## overview

This PR updates the app to support the minimal session state updates provided by #1426. It also disables remote method deserialization of notification objects (yes , the RPC server sends simple notifications over as crazy RPC objects, too) to further reduce worker / socket load for session update events.

## changelog

- refactor(app): Support mini session updates in RPC client/robot state 

BREAKING CHANGE: Run timer will not work with robot API software prior to #1426

## review requests

Will be testing on a robot that has been loaded with #1426. Virtual smoothie testing is also important / valid.

- Protocol runs still work
    - [x] Start time is accurate
    - [x] Run log updates correctly
- [x] 🤞 "long" protocols no longer crap out all the time (Sort of, see #1433)