### PR TITLE
PD: saved file matches JSON schema 1.0.0 (commands still not matching)

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -2,7 +2,7 @@
 import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
 import type {BaseState} from '../../types'
-import type {ProtocolFile} from '../types'
+import type {ProtocolFile, FilePipette} from '../types'
 import type {LabwareData, PipetteData} from '../../step-generation'
 import {fileFormValues} from './fileFields'
 import {getInitialRobotState, robotStateTimeline} from './commands'
@@ -26,11 +26,10 @@ export const createFile: BaseState => ?ProtocolFile = createSelector(
 
     const instruments = mapValues(
       initialRobotState.instruments,
-      (pipette: PipetteData) => ({
-        type: 'pipette',
+      (pipette: PipetteData): FilePipette => ({
         mount: pipette.mount,
-        channels: pipette.channels,
-        model: pipette.maxVolume
+        // TODO HACK Ian 2018-05-11 use pipette definitions in labware-definitions
+        model: `p${pipette.maxVolume}_${pipette.channels === 1 ? 'single' : 'multi'}_v1` // eg p10_single_v1
       })
     )
 
@@ -38,8 +37,8 @@ export const createFile: BaseState => ?ProtocolFile = createSelector(
       initialRobotState.labware,
       (l: LabwareData) => ({
         slot: l.slot,
-        name: l.name || l.type, // TODO "humanize" it, or force naming of labware
-        type: l.type
+        displayName: l.name || l.type, // TODO Ian 2018-05-11 "humanize" type when no name?
+        model: l.type
       })
     )
 
@@ -67,15 +66,15 @@ export const createFile: BaseState => ?ProtocolFile = createSelector(
         model: 'OT-2 Standard'
       },
 
-      instruments,
+      pipettes: instruments,
       labware,
 
-      commands: timeline.map((timelineItem, i) => ({
+      procedure: timeline.map((timelineItem, i) => ({
         annotation: {
           name: `TODO Name ${i}`,
           description: 'todo description'
         },
-        commands: timelineItem.commands.reduce((acc, c) => [...acc, c], [])
+        subprocedure: timelineItem.commands.reduce((acc, c) => [...acc, c], [])
       }))
     }
   }

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {DeckSlot, Mount, Channels} from '@opentrons/components'
+import type {DeckSlot, Mount} from '@opentrons/components'
 import type {Command} from '../step-generation/types'
 
 export type FilePageFields = {
@@ -12,6 +12,11 @@ export type FilePageFieldAccessors = $Keys<FilePageFields>
 
 type MsSinceEpoch = number
 type VersionString = string // eg '1.0.0'
+
+export type FilePipette = {
+  mount: Mount,
+  model: string // TODO Ian 2018-05-11 use pipette-definitions model types
+}
 
 // A JSON protocol
 export type ProtocolFile = {
@@ -41,28 +46,23 @@ export type ProtocolFile = {
     model: 'OT-2 Standard' // TODO LATER support additional models
   },
 
-  instruments: {
-    [instrumentId: string]: {
-      type: 'pipette',
-      mount: Mount,
-      model: string, // Eg '10' for p10
-      channels: Channels
-    }
+  pipettes: {
+    [instrumentId: string]: FilePipette
   },
 
   labware: {
     [labwareId: string]: {
       slot: DeckSlot,
-      type: string,
-      name: string
+      model: string,
+      displayName: string
     }
   },
 
-  commands: Array<{
+  procedure: Array<{
     annotation: {
       name: string,
       description: string
     },
-    commands: Array<Command>
+    subprocedure: Array<Command>
   }>
 }


### PR DESCRIPTION
## overview

Some updates have been made to JSON schema in response to #1139 discussions. This PR updates Protocol Designer's saved file format to better match the schema at https://github.com/IanLondon/opentrons-json-schema (soon we'll move this into the monorepo where it belongs)

## changelog

* changed fields in `CreateFile` selector and in `ProtocolFile` type definition

## review requests

If you want you can create a protocol and run it through https://www.jsonschemavalidator.net/ -- the commands themselves have been changed, but metadata/pipettes/labware should pass JSON schema validation. The schema is at https://github.com/IanLondon/opentrons-json-schema/blob/master/schema.json right now

But since there's still more work to do on the commands, which is gonna be a big ugly diff b/c the tests aren't using fixtures, a quick code review is OK with me!

Also an important "to do later" not addressed here is to use pipette models from `labware-definitions`, but the hack to generate the model string should allow that to be punted. It's important to do but it's a big change to PD that affects most everywhere pipettes are used and out of scope of the schema change IMO.