### PR TITLE
feat(app): Default robot setting page to connected robot

### DIFF
--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -39,9 +39,17 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
   const isConnected = (
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
   )
+  const connectedRobotName = robotSelectors.getConnectedRobotName(state)
   const robotNotification = getAnyRobotUpdateAvailable(state)
   const moreNotification = getShellUpdate(state).available != null
 
+  // TODO(ka 2018-5-11): quick workaround to show connected robot on return to robot setting page
+  let robotUrl
+  if (connectedRobotName) {
+    robotUrl = `/robots/${connectedRobotName}`
+  } else {
+    robotUrl = '/robots'
+  }
   // TODO(mc, 2018-03-08): move this logic to the Calibrate page
   let calibrateUrl
   if (isSessionLoaded) {
@@ -60,7 +68,7 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
     connect: {
       iconName: 'ot-connect',
       title: 'robot',
-      url: '/robots',
+      url: robotUrl,
       notification: robotNotification
     },
     upload: {


### PR DESCRIPTION
## overview
This PR is an easy usability quick win. If a robot is connected and the user returns to robot settings, the connect robot will appear selected, connected, and show the connected robots settings.

closes #1312

## changelog

- NavButton url mapping takes connectedRobotName if it exists for robot settings page

## review requests

Followed existing pattern for calibrateUrl in NavButton. 

To test UI:
- Connect to a robot
- Navigate away from robot settings page (upload/calibrate) 
- Navigate back to robot page
- Confirm connected robot is highlighted(blue) and that robot's settings show up in right page panel.