### PR TITLE
add api configs in tests to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ target/
 /Pipfile
 
 # Testing
+api/tests/opentrons/data/configs/
 sample_protocol.py
 
 # Local Calibration Data


### PR DESCRIPTION
Whenever I run virtual smoothie I get a new file `api/tests/opentrons/data/configs/robotSettings.json` that I shouldn't commit. This PR adds `api/tests/opentrons/data/configs/` to `.gitignore`