### PR TITLE
fix(api): Move to and use correct calibration point for troughs

### DIFF
--- a/api/opentrons/api/calibration.py
+++ b/api/opentrons/api/calibration.py
@@ -110,7 +110,9 @@ class CalibrationManager:
         log.info('Moving {} to {} in {}'.format(
             instrument.name, container.name, container.slot))
         self._set_state('moving')
+
         inst.move_to(target)
+
         self._set_state('ready')
 
     def jog(self, instrument, distance, axis):

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -317,6 +317,7 @@ class Pipette:
                 strategy = 'direct'
 
         self._associate_placeable(placeable)
+
         self.robot.move_to(
             location,
             instrument=self,

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -15,6 +15,7 @@ from opentrons.robot.mover import Mover
 from opentrons.robot.robot_configs import load
 from opentrons.trackers import pose_tracker
 from opentrons.config import feature_flags as fflags
+from opentrons.instruments.pipette_config import Y_OFFSET_MULTI
 
 log = logging.getLogger(__name__)
 
@@ -646,6 +647,15 @@ class Robot(object):
         # because the top position is what is tracked,
         # this checks if coordinates doesn't equal top
         offset = subtract(coordinates, placeable.top()[1])
+
+        if 'trough' in repr(placeable):
+            # Move the pipette so that a multi-channel pipette is centered in
+            # the trough well to prevent crashing into the side, which would
+            # happen if you send the "A1" tip to the center of the well. See
+            # `robot.calibrate_container_with_instrument` for corresponding
+            # offset and comment.
+            offset = offset + (0, Y_OFFSET_MULTI, 0)
+
         if isinstance(placeable, containers.WellSeries):
             placeable = placeable[0]
 
@@ -1022,6 +1032,20 @@ class Robot(object):
             delta_x = delta[0]
             delta_y = delta[1]
             delta_z = delta[2]
+
+        if 'trough' in container.get_type():
+            # Rather than calibrating troughs to the center of the well, we
+            # calibrate such that a multi-channel would be centered in the
+            # well. We don't differentiate between single- and multi-channel
+            # pipettes here, and we track the tip of a multi-channel pipette
+            # that would go into well A1 of an 8xN plate rather than the axial
+            # center, but the axial center of a well is what we track for
+            # calibration, so we add Y_OFFSET_MULTI in the calibration `move`
+            # command, and then back that value off of the pipette position
+            # here (Y_OFFSET_MULTI is the y-distance from the axial center of
+            # the pipette to the A1 tip).
+            delta_y = delta_y - Y_OFFSET_MULTI
+
         self.poses = calib.calibrate_container_with_delta(
             self.poses,
             container,

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -159,8 +159,8 @@ async def test_move_to_top(main_router, model):
         main_router.calibration_manager.move_to(
             model.instrument,
             model.container)
-
-        move_to.assert_called_with(model.container._container[0])
+        target = model.container._container[0]
+        move_to.assert_called_with(target)
 
         await main_router.wait_until(state('moving'))
         await main_router.wait_until(state('ready'))

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -339,6 +339,24 @@ def model(robot):
 
 
 @pytest.fixture
+def model_with_trough(robot):
+    from opentrons.containers import load
+    from opentrons.instruments.pipette import Pipette
+
+    pipette = Pipette(robot, mount='right')
+    plate = load(robot, 'trough-12row', '1')
+
+    instrument = models.Instrument(pipette)
+    container = models.Container(plate)
+
+    return namedtuple('model', 'robot instrument container')(
+            robot=robot,
+            instrument=instrument,
+            container=container
+        )
+
+
+@pytest.fixture
 def smoothie(monkeypatch):
     from opentrons.drivers.smoothie_drivers.driver_3_0 import \
          SmoothieDriver_3_0_0 as SmoothieDriver

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -126,6 +126,22 @@ def test_dispense_move_to():
     assert isclose(current_pos, (175.34,  127.94,   10.5)).all()
 
 
+def test_trough_move_to():
+    from opentrons.instruments.pipette_config import Y_OFFSET_MULTI
+    robot.reset()
+    tip_rack = containers_load(robot, 'tiprack-200ul', '3')
+    p300 = instruments.P300_Single(
+                   mount='left',
+                   tip_racks=[tip_rack])
+
+    trough = containers_load(robot, 'trough-12row', '1')
+    p300.pick_up_tip()
+    p300.move_to(trough)
+    current_pos = pose_tracker.absolute(robot.poses, p300)
+
+    assert isclose(current_pos, (14.34, 7.75 + 35 + Y_OFFSET_MULTI, 40)).all()
+
+
 def test_delay_calls(monkeypatch):
     from opentrons import robot
     from opentrons.instruments import pipette


### PR DESCRIPTION
## overview

During labware calibration, the pipette moves to the center of the first well in a labware. For multi-channel pipettes, it specifically places the rear-most tip in the center of that well (the "A1" tip), as this would position the pipette correctly in an 8xN well plate or tiprack. This is a problem with troughs, where the whole multi-channel pipette should be centered in the trough well. As a solution, this PR would make the calibration endpoints check if the word 'trough' is in the name of the labware, and add the multi-channel y-offset value to the position during move, and subtract the y-offset value from the calibration delta when it updates the labware data. The result of this is that both single- and multi-channel pipettes move such that the "A1" tip is near the +Y edge of the trough well, but the calibration value saved will correspond to the axial center of the well.

## changelog

- (fix) Pipettes move and calibrate trough with multi-channel pipettes centered in the well, and single-channel pipettes at the position corresponding to the "A1" tip of a multi-channel

## review requests

- [x] Upload a protocol that uses a multi-channel only and a trough, and go through the calibration flow. The pipette should correctly move to the center of the trough well
- [x] Upload a protocol that uses a single-channel only and a trough, and go through the calibration flow. The pipette should move to near the +Y edge of the well