### PR TITLE
Pd commands match json schema

### DIFF
--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -30,10 +30,12 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
 
   const commands = [{
     command: 'aspirate',
-    pipette,
-    volume,
-    labware,
-    well
+    params: {
+      pipette,
+      volume,
+      labware,
+      well
+    }
   }]
 
   const robotState = {

--- a/protocol-designer/src/step-generation/blowout.js
+++ b/protocol-designer/src/step-generation/blowout.js
@@ -30,9 +30,11 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
 
   const commands = [{
     command: 'blowout',
-    pipette,
-    labware,
-    well
+    params: {
+      pipette,
+      labware,
+      well
+    }
   }]
 
   return {

--- a/protocol-designer/src/step-generation/delay.js
+++ b/protocol-designer/src/step-generation/delay.js
@@ -6,8 +6,10 @@ const pause = (data: PauseFormData): CommandCreator => (prevRobotState: RobotSta
     robotState: prevRobotState,
     commands: [{
       command: 'delay',
-      message: data.message,
-      wait: data.wait
+      params: {
+        message: data.message,
+        wait: data.wait
+      }
     }]
   }
 }

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -20,10 +20,12 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
 
   const commands = [{
     command: 'dispense',
-    pipette,
-    volume,
-    labware,
-    well
+    params: {
+      pipette,
+      volume,
+      labware,
+      well
+    }
   }]
 
   return {

--- a/protocol-designer/src/step-generation/dropTip.js
+++ b/protocol-designer/src/step-generation/dropTip.js
@@ -20,9 +20,11 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
   const commands = [
     {
       command: 'drop-tip',
-      pipette: pipetteId,
-      labware: FIXED_TRASH_ID,
-      well: 'A1' // TODO: Is 'A1' of the trash always the right place to drop tips?
+      params: {
+        pipette: pipetteId,
+        labware: FIXED_TRASH_ID,
+        well: 'A1' // TODO: Is 'A1' of the trash always the right place to drop tips?
+      }
     }
   ]
 

--- a/protocol-designer/src/step-generation/replaceTip.js
+++ b/protocol-designer/src/step-generation/replaceTip.js
@@ -35,9 +35,11 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
     // pick up tip command
     {
       command: 'pick-up-tip',
-      pipette: pipetteData.id,
-      labware: nextTiprack.tiprackId,
-      well: nextTiprack.well
+      params: {
+        pipette: pipetteData.id,
+        labware: nextTiprack.tiprackId,
+        well: nextTiprack.well
+      }
     }
   ]
 

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -53,10 +53,12 @@ describe('aspirate', () => {
 
     expect(result.commands).toEqual([{
       command: 'aspirate',
-      pipette: 'p300SingleId',
-      volume: 50,
-      labware: 'sourcePlateId',
-      well: 'A1'
+      params: {
+        pipette: 'p300SingleId',
+        volume: 50,
+        labware: 'sourcePlateId',
+        well: 'A1'
+      }
     }])
 
     expect(result.robotState).toMatchObject(robotStateWithTipNoLiquidState)

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -48,9 +48,11 @@ describe('blowout', () => {
 
     expect(result.commands).toEqual([{
       command: 'blowout',
-      pipette: 'p300SingleId',
-      labware: 'sourcePlateId',
-      well: 'A1'
+      params: {
+        pipette: 'p300SingleId',
+        labware: 'sourcePlateId',
+        well: 'A1'
+      }
     }])
 
     expect(result.robotState).toEqual(robotStateWithTip)

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -6,12 +6,29 @@ import {
   getTipColumn,
   getTiprackTipstate,
   commandCreatorNoErrors,
-  commandCreatorHasErrors
+  commandCreatorHasErrors,
+  commandFixtures as cmd
 } from './fixtures'
 import _consolidate from '../consolidate'
 
 const consolidate = commandCreatorNoErrors(_consolidate)
 const consolidateWithErrors = commandCreatorHasErrors(_consolidate)
+
+// shorthand
+const dispense = (well, volume) =>
+  cmd.dispense(well, volume, {labware: 'destPlateId'})
+
+function tripleMix (well: string, volume: number, labware: string) {
+  const params = {labware}
+  return [
+    cmd.aspirate(well, volume, params),
+    cmd.dispense(well, volume, params),
+    cmd.aspirate(well, volume, params),
+    cmd.dispense(well, volume, params),
+    cmd.aspirate(well, volume, params),
+    cmd.dispense(well, volume, params)
+  ]
+}
 
 const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
@@ -99,33 +116,10 @@ describe('consolidate single-channel', () => {
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTip)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 50),
+      cmd.aspirate('A2', 50),
+      dispense('B1', 100)
     ])
   })
 
@@ -140,54 +134,14 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+      dispense('B1', 300),
+
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+      dispense('B1', 300)
     ])
 
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
@@ -203,66 +157,16 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'drop-tip',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+      dispense('B1', 300),
+      cmd.dropTip('A1'),
+
+      cmd.pickUpTip('B1'),
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+      dispense('B1', 300)
     ])
 
     expect(result.robotState).toMatchObject({
@@ -290,54 +194,14 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+      dispense('B1', 300),
+
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+      dispense('B1', 300)
     ])
 
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
@@ -353,48 +217,13 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotStatePickedUpOneTip)
 
     expect(result.commands).toEqual([
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+      dispense('B1', 300),
+
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+      dispense('B1', 300)
     ])
 
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
@@ -411,68 +240,16 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150, // disposalVolume included
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 200,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150, // disposalVolume included
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 200,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 150), // disposalVolume included
+      cmd.aspirate('A2', 100),
+      dispense('B1', 200),
+      cmd.blowout(), // Trash the disposal volume
+
+      cmd.aspirate('A3', 150), // disposalVolume included
+      cmd.aspirate('A4', 100),
+      dispense('B1', 200),
+      cmd.blowout() // Trash the disposal volume
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -488,142 +265,19 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      // done mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      // done mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+
+      ...tripleMix('A1', 50, 'sourcePlateId'),
+
+      cmd.aspirate('A1', 100),
+      cmd.aspirate('A2', 100),
+      cmd.aspirate('A3', 100),
+      dispense('B1', 300),
+
+      ...tripleMix('A4', 50, 'sourcePlateId'),
+
+      cmd.aspirate('A4', 100),
+      dispense('B1', 100)
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -640,156 +294,36 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
+      cmd.pickUpTip('A1'),
       // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
+      cmd.aspirate('A1', 50),
+      cmd.dispense('A1', 50), // sourceLabwareId
+      cmd.aspirate('A1', 50),
+      cmd.dispense('A1', 50), // sourceLabwareId
+      cmd.aspirate('A1', 50),
+      cmd.dispense('A1', 50), // sourceLabwareId
       // done mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 155, // with disposal vol
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 125,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 250,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
+      cmd.aspirate('A1', 155), // with disposal vol
+      cmd.aspirate('A2', 125),
+      dispense('B1', 250),
+
+      // Trash the disposal volume
+      cmd.blowout(),
+
       // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
+      cmd.aspirate('A3', 50),
+      cmd.dispense('A3', 50), // sourceLabwareId
+      cmd.aspirate('A3', 50),
+      cmd.dispense('A3', 50), // sourceLabwareId
+      cmd.aspirate('A3', 50),
+      cmd.dispense('A3', 50), // sourceLabwareId
       // done mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 155, // with disposal volume
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 125,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 250,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      }
+
+      cmd.aspirate('A3', 155), // with disposal volume
+      cmd.aspirate('A4', 125),
+      dispense('B1', 250),
+      // Trash the disposal volume
+      cmd.blowout()
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -805,142 +339,18 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // done mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // Start mix 2
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 53,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
-      // done mix 2
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 100),
+      cmd.aspirate('A2', 100),
+      cmd.aspirate('A3', 100),
+      dispense('B1', 300),
+
+      ...tripleMix('B1', 53, 'destPlateId'),
+
+      cmd.aspirate('A4', 100),
+      dispense('B1', 100),
+
+      ...tripleMix('B1', 53, 'destPlateId')
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -956,154 +366,21 @@ describe('consolidate single-channel', () => {
 
     const result = consolidate(data)(robotInitialState)
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // Start mix
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // done mix
-      {
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // Start mix 2
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 54,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // done mix 2
-      {
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 100),
+      cmd.aspirate('A2', 100),
+      cmd.aspirate('A3', 100),
+      dispense('B1', 300),
+
+      ...tripleMix('B1', 54, 'destPlateId'),
+
+      cmd.blowout(),
+      cmd.aspirate('A4', 100),
+      dispense('B1', 100),
+
+      ...tripleMix('B1', 54, 'destPlateId'),
+
+      cmd.blowout()
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -1120,155 +397,24 @@ describe('consolidate single-channel', () => {
 
     const result = consolidate(data)(robotInitialState)
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 130, // includes disposal volume
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 200,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
-      // Now, mix in the dest well
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      // done mixing
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 130, // includes disposal volume
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 100,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 200,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        // Trash the disposal volume
-        command: 'blowout',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
-      },
-      // Now, mix in the dest well
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 52,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+      cmd.aspirate('A1', 130), // includes disposal volume
+      cmd.aspirate('A2', 100),
+      dispense('B1', 200),
+      // Trash the disposal volume
+      cmd.blowout(),
+
+      // Mix in the dest well
+      ...tripleMix('B1', 52, 'destPlateId'),
+
+      cmd.aspirate('A3', 130), // includes disposal volume
+      cmd.aspirate('A4', 100),
+      dispense('B1', 200),
+      // Trash the disposal volume
+      cmd.blowout(),
+
+      // Mix in the dest well
+      ...tripleMix('B1', 52, 'destPlateId')
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -1287,86 +433,25 @@ describe('consolidate single-channel', () => {
 
     const result = consolidate(data)(robotInitialState)
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
+      cmd.pickUpTip('A1'),
+
       // pre-wet tip
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: preWetVol,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: preWetVol,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
+      cmd.aspirate('A1', preWetVol),
+      cmd.dispense('A1', preWetVol),
       // done pre-wet
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
+
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+      dispense('B1', 300),
+
       // pre-wet tip, now with A3
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: preWetVol,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: preWetVol,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
+      cmd.aspirate('A3', preWetVol),
+      cmd.dispense('A3', preWetVol),
       // done pre-wet
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+      dispense('B1', 300)
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -1382,78 +467,23 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 150),
+      cmd.touchTip('A1'),
+
+      cmd.aspirate('A2', 150),
+      cmd.touchTip('A2'),
+
+      dispense('B1', 300),
+
+      cmd.aspirate('A3', 150),
+      cmd.touchTip('A3'),
+
+      cmd.aspirate('A4', 150),
+      cmd.touchTip('A4'),
+
+      dispense('B1', 300)
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -1469,66 +499,19 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300SingleId',
-        volume: 150,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 300,
-        labware: 'destPlateId',
-        well: 'B1'
-      },
-      {
-        command: 'touch-tip',
-        pipette: 'p300SingleId',
-        labware: 'destPlateId',
-        well: 'B1'
-      }
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 150),
+      cmd.aspirate('A2', 150),
+
+      dispense('B1', 300),
+      cmd.touchTip('B1', {labware: 'destPlateId'}),
+
+      cmd.aspirate('A3', 150),
+      cmd.aspirate('A4', 150),
+
+      dispense('B1', 300),
+      cmd.touchTip('B1', {labware: 'destPlateId'})
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpOneTipNoLiquidState)
   })
@@ -1553,6 +536,14 @@ describe('consolidate single-channel', () => {
 })
 
 describe('consolidate multi-channel', () => {
+  const multiParams = {pipette: 'p300MultiId'}
+  const multiDispense = (well: string, volume: number) =>
+    cmd.dispense(
+      well,
+      volume,
+      {labware: 'destPlateId', pipette: 'p300MultiId'}
+    )
+
   const baseData = {
     stepType: 'consolidate',
     name: 'Consolidate Test',
@@ -1586,54 +577,14 @@ describe('consolidate multi-channel', () => {
     const result = consolidate(data)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'pick-up-tip',
-        pipette: 'p300MultiId',
-        labware: 'tiprack1Id',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300MultiId',
-        volume: 140,
-        labware: 'sourcePlateId',
-        well: 'A1'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300MultiId',
-        volume: 140,
-        labware: 'sourcePlateId',
-        well: 'A2'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300MultiId',
-        volume: 280,
-        labware: 'destPlateId',
-        well: 'A12'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300MultiId',
-        volume: 140,
-        labware: 'sourcePlateId',
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        pipette: 'p300MultiId',
-        volume: 140,
-        labware: 'sourcePlateId',
-        well: 'A4'
-      },
-      {
-        command: 'dispense',
-        pipette: 'p300MultiId',
-        volume: 280,
-        labware: 'destPlateId',
-        well: 'A12'
-      }
+      cmd.pickUpTip('A1', multiParams),
+      cmd.aspirate('A1', 140, multiParams),
+      cmd.aspirate('A2', 140, multiParams),
+      multiDispense('A12', 280),
+
+      cmd.aspirate('A3', 140, multiParams),
+      cmd.aspirate('A4', 140, multiParams),
+      multiDispense('A12', 280)
     ])
     expect(result.robotState).toMatchObject(robotStatePickedUpMultiTipsNoLiquidState)
   })

--- a/protocol-designer/src/step-generation/test-with-flow/delay.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/delay.test.js
@@ -27,8 +27,10 @@ describe('delay indefinitely', () => {
     expect(result.commands).toEqual([
       {
         command: 'delay',
-        wait: true,
-        message
+        params: {
+          wait: true,
+          message
+        }
       }
     ])
   })
@@ -52,8 +54,10 @@ describe('delay for a given time', () => {
     expect(result.commands).toEqual([
       {
         command: 'delay',
-        wait: 95.5,
-        message
+        params: {
+          wait: 95.5,
+          message
+        }
       }
     ])
   })

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -53,10 +53,12 @@ describe('dispense', () => {
 
       expect(result.commands).toEqual([{
         command: 'dispense',
-        pipette: 'p300SingleId',
-        volume: 50,
-        labware: 'sourcePlateId',
-        well: 'A1'
+        params: {
+          pipette: 'p300SingleId',
+          volume: 50,
+          labware: 'sourcePlateId',
+          well: 'A1'
+        }
       }])
     })
 

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -67,9 +67,11 @@ describe('dropTip', () => {
 
       expect(result.commands).toEqual([{
         command: 'drop-tip',
-        pipette: 'p300SingleId',
-        labware: 'trashId',
-        well: 'A1'
+        params: {
+          pipette: 'p300SingleId',
+          labware: 'trashId',
+          well: 'A1'
+        }
       }])
       expect(result.robotState).toEqual(
         makeRobotState({singleHasTips: false, multiHasTips: true})
@@ -89,9 +91,11 @@ describe('dropTip', () => {
       const result = dropTip('p300MultiId')(makeRobotState({singleHasTips: true, multiHasTips: true}))
       expect(result.commands).toEqual([{
         command: 'drop-tip',
-        pipette: 'p300MultiId',
-        labware: 'trashId',
-        well: 'A1'
+        params: {
+          pipette: 'p300MultiId',
+          labware: 'trashId',
+          well: 'A1'
+        }
       }])
       expect(result.robotState).toEqual(
         makeRobotState({singleHasTips: true, multiHasTips: false})

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -35,45 +35,69 @@ export const pickUpTip = (
   params: {
     pipette: 'p300SingleId',
     labware: 'tiprack1Id',
-    well: (typeof tip === 'string') ? tip : tiprackWellNamesFlat[tip],
-    ...params
+    ...params,
+    well: (typeof tip === 'string') ? tip : tiprackWellNamesFlat[tip]
   }
 })
 
-export const touchTip = (well: string): Command => ({
+export const touchTip = (
+  well: string,
+  params?: {| labware?: string |}
+): Command => ({
   command: 'touch-tip',
   params: {
     labware: 'sourcePlateId',
     pipette: 'p300SingleId',
+    ...params,
     well
   }
 })
 
-export const aspirate = (well: string, volume: number): Command => ({
+export const aspirate = (
+  well: string,
+  volume: number,
+  params?: {|
+    pipette?: string,
+    labware?: string
+  |}
+): Command => ({
   command: 'aspirate',
   params: {
     pipette: 'p300SingleId',
     labware: 'sourcePlateId',
+    ...params,
     volume,
     well
   }
 })
 
-export const dispense = (well: string, volume: number): Command => ({
+export const dispense = (
+  well: string,
+  volume: number,
+  params?: {|
+    pipette?: string,
+    labware?: string
+  |}
+): Command => ({
   command: 'dispense',
   params: {
     pipette: 'p300SingleId',
     labware: 'sourcePlateId',
+    ...params,
     volume,
     well
   }
 })
 
-export const blowout = (labware: string): Command => ({
+export const blowout = (
+  labware: string,
+  params?: {| pipette?: string |}
+): Command => ({
   command: 'blowout',
   params: {
     pipette: 'p300SingleId',
     well: 'A1',
+    ...params,
     labware
   }
 })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -3,14 +3,7 @@ import {tiprackWellNamesFlat} from '../../data'
 import type {Command} from '../../types'
 
 export const replaceTipCommands = (tip: number | string): Array<Command> => [
-  {
-    command: 'drop-tip',
-    params: {
-      pipette: 'p300SingleId',
-      labware: 'trashId',
-      well: 'A1'
-    }
-  },
+  dropTip('A1'),
   pickUpTip(tip)
 ]
 

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -2,7 +2,7 @@
 import {tiprackWellNamesFlat} from '../../data'
 import type {Command} from '../../types'
 
-export const replaceTipCommands = (tiprackTipIdx: number): Array<Command> => [
+export const replaceTipCommands = (tip: number | string): Array<Command> => [
   {
     command: 'drop-tip',
     params: {
@@ -11,15 +11,34 @@ export const replaceTipCommands = (tiprackTipIdx: number): Array<Command> => [
       well: 'A1'
     }
   },
-  {
-    command: 'pick-up-tip',
-    params: {
-      pipette: 'p300SingleId',
-      labware: 'tiprack1Id',
-      well: tiprackWellNamesFlat[tiprackTipIdx]
-    }
-  }
+  pickUpTip(tip)
 ]
+
+export const dropTip = (
+  tip: number | string,
+  params?: {| pipette?: string, labware?: string |}
+): Command => ({
+  command: 'drop-tip',
+  params: {
+    pipette: 'p300SingleId',
+    labware: 'trashId',
+    well: (typeof tip === 'string') ? tip : tiprackWellNamesFlat[tip],
+    ...params
+  }
+})
+
+export const pickUpTip = (
+  tip: number | string,
+  params?: {| pipette?: string, labware?: string |}
+): Command => ({
+  command: 'pick-up-tip',
+  params: {
+    pipette: 'p300SingleId',
+    labware: 'tiprack1Id',
+    well: (typeof tip === 'string') ? tip : tiprackWellNamesFlat[tip],
+    ...params
+  }
+})
 
 export const touchTip = (well: string): Command => ({
   command: 'touch-tip',

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -1,0 +1,60 @@
+// @flow
+import {tiprackWellNamesFlat} from '../../data'
+import type {Command} from '../../types'
+
+export const replaceTipCommands = (tiprackTipIdx: number): Array<Command> => [
+  {
+    command: 'drop-tip',
+    params: {
+      pipette: 'p300SingleId',
+      labware: 'trashId',
+      well: 'A1'
+    }
+  },
+  {
+    command: 'pick-up-tip',
+    params: {
+      pipette: 'p300SingleId',
+      labware: 'tiprack1Id',
+      well: tiprackWellNamesFlat[tiprackTipIdx]
+    }
+  }
+]
+
+export const touchTip = (well: string): Command => ({
+  command: 'touch-tip',
+  params: {
+    labware: 'sourcePlateId',
+    pipette: 'p300SingleId',
+    well
+  }
+})
+
+export const aspirate = (well: string, volume: number): Command => ({
+  command: 'aspirate',
+  params: {
+    pipette: 'p300SingleId',
+    labware: 'sourcePlateId',
+    volume,
+    well
+  }
+})
+
+export const dispense = (well: string, volume: number): Command => ({
+  command: 'dispense',
+  params: {
+    pipette: 'p300SingleId',
+    labware: 'sourcePlateId',
+    volume,
+    well
+  }
+})
+
+export const blowout = (labware: string): Command => ({
+  command: 'blowout',
+  params: {
+    pipette: 'p300SingleId',
+    well: 'A1',
+    labware
+  }
+})

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -8,7 +8,7 @@ export const replaceTipCommands = (tip: number | string): Array<Command> => [
 ]
 
 export const dropTip = (
-  tip: number | string,
+  tip: number | string, // TODO IMMEDIATELY should this be well?: string & default to A1?
   params?: {| pipette?: string, labware?: string |}
 ): Command => ({
   command: 'drop-tip',
@@ -83,14 +83,14 @@ export const dispense = (
 })
 
 export const blowout = (
-  labware: string,
+  labware?: string,
   params?: {| pipette?: string |}
 ): Command => ({
   command: 'blowout',
   params: {
     pipette: 'p300SingleId',
     well: 'A1',
-    ...params,
-    labware
+    labware: labware || 'trashId',
+    ...params
   }
 })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/fixtures.js
@@ -4,9 +4,9 @@ import map from 'lodash/map'
 import mapValues from 'lodash/mapValues'
 import range from 'lodash/range'
 import reduce from 'lodash/reduce'
-import {tiprackWellNamesFlat} from '../'
-import type {RobotState, PipetteData, LabwareData} from '../'
-import type {CommandsAndRobotState, CommandCreatorErrorResponse} from '../types'
+import {tiprackWellNamesFlat} from '../../'
+import type {RobotState, PipetteData, LabwareData} from '../../'
+import type {CommandsAndRobotState, CommandCreatorErrorResponse} from '../../types'
 
 /** Used to wrap command creators in tests, effectively casting their results
  **  to normal response or error response

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/index.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/index.js
@@ -1,0 +1,6 @@
+import * as commandFixtures from './commandFixtures.js'
+export * from './fixtures.js'
+
+export {
+  commandFixtures
+}

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -1,60 +1,17 @@
 // @flow
 import _mix from '../mix'
-import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures'
-import {tiprackWellNamesFlat} from '../data'
+import {
+  createRobotState,
+  commandCreatorNoErrors,
+  commandCreatorHasErrors,
+  commandFixtures as cmd
+} from './fixtures'
 import type {MixFormData} from '../types'
 const mix = commandCreatorNoErrors(_mix)
 const mixWithErrors = commandCreatorHasErrors(_mix)
 
 let robotInitialState
 let mixinArgs
-
-// TODO Ian 2018-05-08 move these to fixtures, use to make other tests less verbose too.
-// You also need a factory to use different pipette id, etc
-const cmd = {
-  // NOTE: 'Commands' name in these fixture creators indicates
-  // it's an array & not a single command obj
-  replaceTipCommands: (tiprackTipIdx: number) => [
-    {
-      command: 'drop-tip',
-      pipette: 'p300SingleId',
-      labware: 'trashId',
-      well: 'A1'
-    },
-    {
-      command: 'pick-up-tip',
-      pipette: 'p300SingleId',
-      labware: 'tiprack1Id',
-      well: tiprackWellNamesFlat[tiprackTipIdx]
-    }
-  ],
-  touchTip: (well: string) => ({
-    command: 'touch-tip',
-    labware: 'sourcePlateId',
-    pipette: 'p300SingleId',
-    well
-  }),
-  aspirate: (well: string, volume: number) => ({
-    command: 'aspirate',
-    pipette: 'p300SingleId',
-    labware: 'sourcePlateId',
-    volume,
-    well
-  }),
-  dispense: (well: string, volume: number) => ({
-    command: 'dispense',
-    pipette: 'p300SingleId',
-    labware: 'sourcePlateId',
-    volume,
-    well
-  }),
-  blowout: (labware: string) => ({
-    command: 'blowout',
-    pipette: 'p300SingleId',
-    well: 'A1',
-    labware
-  })
-}
 
 beforeEach(() => {
   robotInitialState = createRobotState({

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -1,6 +1,12 @@
 // @flow
 import merge from 'lodash/merge'
-import {createRobotState, getTiprackTipstate, getTipColumn, commandCreatorNoErrors} from './fixtures'
+import {
+  createRobotState,
+  getTiprackTipstate,
+  getTipColumn,
+  commandCreatorNoErrors,
+  commandFixtures as cmd
+} from './fixtures'
 import _replaceTip from '../replaceTip'
 
 import updateLiquidState from '../dispenseUpdateLiquidState'
@@ -38,12 +44,9 @@ describe('replaceTip', () => {
     test('Single-channel: first tip', () => {
       const result = replaceTip('p300SingleId')(robotInitialState)
 
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: tiprack1Id,
-        well: 'A1'
-      }])
+      expect(result.commands).toEqual([
+        cmd.pickUpTip(0)
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -81,12 +84,9 @@ describe('replaceTip', () => {
         }
       ))
 
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: tiprack1Id,
-        well: 'B1'
-      }])
+      expect(result.commands).toEqual([
+        cmd.pickUpTip(1)
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -125,12 +125,9 @@ describe('replaceTip', () => {
 
       const result = replaceTip('p300SingleId')(initialTestRobotState)
 
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: tiprack1Id,
-        well: 'A2'
-      }])
+      expect(result.commands).toEqual([
+        cmd.pickUpTip('A2')
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -171,18 +168,8 @@ describe('replaceTip', () => {
       const result = replaceTip('p300SingleId')(initialTestRobotState)
 
       expect(result.commands).toEqual([
-        {
-          command: 'drop-tip',
-          pipette: 'p300SingleId',
-          labware: 'trashId',
-          well: 'A1'
-        },
-        {
-          command: 'pick-up-tip',
-          pipette: 'p300SingleId',
-          labware: tiprack1Id,
-          well: 'B1'
-        }
+        cmd.dropTip('A1'),
+        cmd.pickUpTip('B1')
       ])
 
       expect(result.robotState).toEqual(
@@ -220,12 +207,9 @@ describe('replaceTip', () => {
 
       const result = replaceTip('p300SingleId')(initialTestRobotState)
 
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300SingleId',
-        labware: tiprack2Id,
-        well: 'A1'
-      }])
+      expect(result.commands).toEqual([
+        cmd.pickUpTip('A1', {labware: tiprack2Id})
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -247,15 +231,13 @@ describe('replaceTip', () => {
   })
 
   describe('replaceTip: multi-channel', () => {
+    const p300MultiId = 'p300MultiId'
     test('multi-channel, all tipracks have tips', () => {
-      const result = replaceTip('p300MultiId')(robotInitialState)
+      const result = replaceTip(p300MultiId)(robotInitialState)
 
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300MultiId',
-        labware: tiprack1Id,
-        well: 'A1'
-      }])
+      expect(result.commands).toEqual([
+        cmd.pickUpTip('A1', {pipette: p300MultiId})
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -285,13 +267,11 @@ describe('replaceTip', () => {
         }
       }
 
-      const result = replaceTip('p300MultiId')(robotStateWithTipA1Missing)
-      expect(result.commands).toEqual([{
-        command: 'pick-up-tip',
-        pipette: 'p300MultiId',
-        labware: tiprack1Id,
-        well: 'A2' // get from next row
-      }])
+      const result = replaceTip(p300MultiId)(robotStateWithTipA1Missing)
+
+      expect(result.commands).toEqual([
+        cmd.pickUpTip('A2', {pipette: p300MultiId})
+      ])
 
       expect(result.robotState).toEqual(merge(
         {},
@@ -330,20 +310,10 @@ describe('replaceTip', () => {
           }
         }
       }
-      const result = replaceTip('p300MultiId')(robotStateWithTipsOnMulti)
+      const result = replaceTip(p300MultiId)(robotStateWithTipsOnMulti)
       expect(result.commands).toEqual([
-        {
-          command: 'drop-tip',
-          pipette: 'p300MultiId',
-          labware: 'trashId',
-          well: 'A1'
-        },
-        {
-          command: 'pick-up-tip',
-          pipette: 'p300MultiId',
-          labware: tiprack1Id,
-          well: 'A1' // get from next row
-        }
+        cmd.dropTip('A1', {pipette: p300MultiId}),
+        cmd.pickUpTip('A1', {pipette: p300MultiId})
       ])
 
       expect(result.robotState).toEqual(merge(

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -29,9 +29,11 @@ describe('touchTip', () => {
 
     expect(result.commands).toEqual([{
       command: 'touch-tip',
-      pipette: 'p300SingleId',
-      labware: 'sourcePlateId',
-      well: 'A1'
+      params: {
+        pipette: 'p300SingleId',
+        labware: 'sourcePlateId',
+        well: 'A1'
+      }
     }])
 
     expect(result.robotState).toEqual(robotStateWithTip)

--- a/protocol-designer/src/step-generation/touchTip.js
+++ b/protocol-designer/src/step-generation/touchTip.js
@@ -26,9 +26,11 @@ const touchTip = (args: PipetteLabwareFields): CommandCreator => (prevRobotState
 
   const commands = [{
     command: 'touch-tip',
-    pipette,
-    labware,
-    well
+    params: {
+      pipette,
+      labware,
+      well
+    }
   }]
 
   return {

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -180,20 +180,24 @@ export type AspirateDispenseArgs = {|
 
 export type Command = {|
   command: 'aspirate' | 'dispense',
-  ...AspirateDispenseArgs
+  params: AspirateDispenseArgs
 |} | {|
   command: 'pick-up-tip' | 'drop-tip' | 'blowout' | 'touch-tip',
-  ...PipetteLabwareFields
+  params: PipetteLabwareFields
 |} | {|
   command: 'delay',
   /** number of seconds to delay (fractional values OK),
     or `true` for delay until user input */
-  wait: number | true,
-  message: ?string
+  params: {|
+    wait: number | true,
+    message: ?string
+  |}
 |} | {|
   command: 'air-gap',
-  pipette: string,
-  volume: number
+  params: {|
+    pipette: string,
+    volume: number
+  |},
 |}
 
 export type ErrorType =


### PR DESCRIPTION
Closes #1435 

## overview

Deletes a :boat:load of lines of code to make `step-generation` tests much more succinct, without adding much complexity.

Also, modified low-level command objects (and their type definitions) to match our JSON schema v1.0.0

## changelog

- Factor out step-generation fixtures into `fixtures/` dir
- `commandFixtures` makes it easy to change commands in tests in ~one place, so updating the schema doesn't require editing ~2000 lines of code again
- All low-level commands updated to match JSON schema

## review requests

- Code review highlights: Glance at commandFixtures, and at how all the step-generation tests look now.
- PD should now save protocols fully consistent with JSON schema v1.0.0 https://github.com/IanLondon/opentrons-json-schema/blob/master/schema.json - you can make a protocol and validate it at https://www.jsonschemavalidator.net/