### PR TITLE
feat(app): Order tipracks calibrated by 8-channel first in list

### DIFF
--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -325,8 +325,18 @@ describe('api client', () => {
             },
             labwareBySlot: {
               1: {_id: 'lab-1', type: '96-flat'},
-              5: {_id: 'lab-2', type: 'tiprack-200ul', isTiprack: true},
-              9: {_id: 'lab-3', type: 'tiprack-200ul', isTiprack: true}
+              5: {
+                _id: 'lab-2',
+                type: 'tiprack-200ul',
+                isTiprack: true,
+                calibratorMount: 'left'
+              },
+              9: {
+                _id: 'lab-3',
+                type: 'tiprack-200ul',
+                isTiprack: true,
+                calibratorMount: 'right'
+              }
             }
           }
         }

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -524,13 +524,22 @@ describe('robot selectors', () => {
           labwareBySlot: {
             1: {
               slot: '1',
-              name: 'a1',
-              type: 'a',
+              type: 's',
+              isTiprack: true,
+              calibratorMount: 'right'
+            },
+            2: {
+              slot: '2',
+              type: 'm',
               isTiprack: true,
               calibratorMount: 'left'
             },
-            5: {slot: '5', name: 'b2', type: 'b', isTiprack: false},
-            9: {slot: '9', name: 'c3', type: 'c', isTiprack: false}
+            5: {slot: '5', type: 'a', isTiprack: false},
+            9: {slot: '9', type: 'b', isTiprack: false}
+          },
+          instrumentsByMount: {
+            left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
+            right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
           }
         },
         calibration: {
@@ -541,10 +550,6 @@ describe('robot selectors', () => {
           confirmedBySlot: {
             1: false,
             5: true
-          },
-          instrumentsByMount: {
-            left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
-            right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
           },
           calibrationRequest: {
             type: 'MOVE_TO',
@@ -560,20 +565,30 @@ describe('robot selectors', () => {
 
     test('get labware', () => {
       expect(getLabware(state)).toEqual([
+        // multi channel tiprack should be first
+        {
+          slot: '2',
+          type: 'm',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left'
+        },
+        // then single channel tiprack
         {
           slot: '1',
-          name: 'a1',
-          type: 'a',
+          type: 's',
           isTiprack: true,
           isMoving: true,
           calibration: 'moving-to-slot',
           confirmed: false,
-          calibratorMount: 'left'
+          calibratorMount: 'right'
         },
+        // then other labware by slot
         {
           slot: '5',
-          name: 'b2',
-          type: 'b',
+          type: 'a',
           isTiprack: false,
           isMoving: false,
           calibration: 'unconfirmed',
@@ -581,8 +596,7 @@ describe('robot selectors', () => {
         },
         {
           slot: '9',
-          name: 'c3',
-          type: 'c',
+          type: 'b',
           isTiprack: false,
           isMoving: false,
           calibration: 'unconfirmed',
@@ -594,14 +608,22 @@ describe('robot selectors', () => {
     test('get unconfirmed tipracks', () => {
       expect(getUnconfirmedTipracks(state)).toEqual([
         {
+          slot: '2',
+          type: 'm',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left'
+        },
+        {
           slot: '1',
-          name: 'a1',
-          type: 'a',
+          type: 's',
           isTiprack: true,
           isMoving: true,
           calibration: 'moving-to-slot',
           confirmed: false,
-          calibratorMount: 'left'
+          calibratorMount: 'right'
         }
       ])
     })
@@ -609,19 +631,26 @@ describe('robot selectors', () => {
     test('get unconfirmed labware', () => {
       expect(getUnconfirmedLabware(state)).toEqual([
         {
-          slot: '1',
-          name: 'a1',
-          type: 'a',
+          slot: '2',
+          type: 'm',
           isTiprack: true,
-          isMoving: true,
-          calibration: 'moving-to-slot',
+          isMoving: false,
+          calibration: 'unconfirmed',
           confirmed: false,
           calibratorMount: 'left'
         },
         {
+          slot: '1',
+          type: 's',
+          isTiprack: true,
+          isMoving: true,
+          calibration: 'moving-to-slot',
+          confirmed: false,
+          calibratorMount: 'right'
+        },
+        {
           slot: '9',
-          name: 'c3',
-          type: 'c',
+          type: 'b',
           isTiprack: false,
           isMoving: false,
           calibration: 'unconfirmed',
@@ -632,12 +661,11 @@ describe('robot selectors', () => {
 
     test('get next labware', () => {
       expect(getNextLabware(state)).toEqual({
-        slot: '1',
-        name: 'a1',
-        type: 'a',
+        slot: '2',
+        type: 'm',
         isTiprack: true,
-        isMoving: true,
-        calibration: 'moving-to-slot',
+        isMoving: false,
+        calibration: 'unconfirmed',
         confirmed: false,
         calibratorMount: 'left'
       })
@@ -649,7 +677,8 @@ describe('robot selectors', () => {
             ...state[NAME].calibration,
             confirmedBySlot: {
               ...state[NAME].calibration.confirmedBySlot,
-              1: true
+              1: true,
+              2: true
             }
           }
         }
@@ -657,8 +686,7 @@ describe('robot selectors', () => {
 
       expect(getNextLabware(nextState)).toEqual({
         slot: '9',
-        name: 'c3',
-        type: 'c',
+        type: 'b',
         isTiprack: false,
         isMoving: false,
         calibration: 'unconfirmed',


### PR DESCRIPTION
## overview

This PR changes the order of the internal labware list to sort tip racks according to their associated calibrator pipette. Tipracks calibrated by the multi-channel are placed first in the list. This ensures that by the time the user gets to non-tiprack calibration, they will probably be using a single-channel pipette.

Fixes #1128

## changelog

- feat(app): Order tipracks calibrated by 8-channel first in list

## review requests

- Load a protocol with a single and a multi (like `calibration-validation.py`)
- [ ] Tipracks calibrated by the multi-channel should appear first in tiprack list
- [ ] Clicking "continue to next tiprack" calibrates tipracks in the same order as the correct list