### PR TITLE
Skip database migration if split labware def feature flag is set

### DIFF
--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -5,6 +5,7 @@ from opentrons.instruments import pipette_config
 from opentrons import instruments as inst, containers as cnt
 from opentrons.data_storage import database_migration
 from opentrons._version import __version__
+from opentrons.config import feature_flags as ff
 
 version = sys.version_info[0:2]
 if version < (3, 5):
@@ -12,7 +13,8 @@ if version < (3, 5):
         'opentrons requires Python 3.5 or above, this is {0}.{1}'.format(
             version[0], version[1]))
 
-database_migration.check_version_and_perform_necessary_migrations()
+if not ff.split_labware_definitions():
+    database_migration.check_version_and_perform_necessary_migrations()
 robot = Robot()
 
 


### PR DESCRIPTION
## overview

If the database is not present when the robot boots, it tries to create the database from the default-containers.json file. If the split labware def flag is set, it tries to use the "ordering" field which does not exist in default-containers.json. This PR modifies boot behavior so it does not try to migrate the database if the split labware def flag is set.

## changelog

- (fix) Don't create the sql database if the split labware definition feature flag is set

## review requests

- [x] Delete `/data/user_storage/opentrons_data/opentrons.db`
- [x] Set the "split-labware-def" feature flag to true
- [x] Reboot the robot - the server should boot normally and not run database migration
- [x] Set the "split-labware-def" feature flag to false
- [x] Reboot the robot - the server should do database migration and then boot normally