### PR TITLE
API: fallback to pipette_config when json config values fail to load

### DIFF
--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -35,16 +35,25 @@ pipette_config = namedtuple(
 def _load_config_from_file(pipette_model: str, fallback) -> pipette_config:
 
     def _json_key_to_config_attribute(key) -> str:
+        '''
+        Converts the JSON key syntax (eg: "plungerPositions"), to the format
+        used in the namedtuple `plunger_config` (eg: "plunger_positions")
+        '''
         return ''.join([
                 '_{}'.format(c.lower()) if c.isupper() else c
                 for c in key
             ])
 
-    def _load_config_value(config, key) -> pipette_config:
+    def _load_config_value(config_json, key) -> pipette_config:
+        '''
+        Retrieves a given key from the loaded JSON config dict. If that key is
+        not present in the dictionary, it falls back to the value from
+        the namedtuple `plunger_config`, named "fallback"
+        '''
         nonlocal fallback
         fallback_key = _json_key_to_config_attribute(key)
         fallback_value = getattr(fallback, fallback_key)
-        return config.get(key, fallback_value)
+        return config_json.get(key, fallback_value)
 
     config_file = pipette_config_path()
     res = None

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -196,3 +196,20 @@ def test_drop_tip_in_trash(virtual_smoothie_env, monkeypatch):
     y_offset = movelog[0][1][1]
     assert base_obj == robot.fixed_trash[0]
     assert y_offset == 108
+
+
+def test_fallback_config_file(monkeypatch):
+    from opentrons.instruments.pipette_config import _create_config_from_dict
+
+    pipette_dict = {
+        'ulPerMm': 123,
+        'tipLength': 321,
+        'channels': 4
+    }
+
+    config = _create_config_from_dict(pipette_dict, 'p300_single_v1')
+    assert config.ul_per_mm == 123
+    assert config.tip_length == 321
+    assert config.channels == 4
+    assert config.name == 'p300_single_v1'  # loaded from fallback
+    assert config.pick_up_current == 0.1    # loaded from fallback

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -199,7 +199,8 @@ def test_drop_tip_in_trash(virtual_smoothie_env, monkeypatch):
 
 
 def test_fallback_config_file(monkeypatch):
-    from opentrons.instruments.pipette_config import _create_config_from_dict
+    from opentrons.instruments.pipette_config import \
+        _create_config_from_dict, fallback_configs
 
     pipette_dict = {
         'ulPerMm': 123,
@@ -207,9 +208,11 @@ def test_fallback_config_file(monkeypatch):
         'channels': 4
     }
 
-    config = _create_config_from_dict(pipette_dict, 'p300_single_v1')
-    assert config.ul_per_mm == 123
-    assert config.tip_length == 321
-    assert config.channels == 4
-    assert config.name == 'p300_single_v1'  # loaded from fallback
-    assert config.pick_up_current == 0.1    # loaded from fallback
+    for model, config in fallback_configs.items():
+        new_config = _create_config_from_dict(pipette_dict, model)
+        assert new_config.ul_per_mm == 123
+        assert new_config.tip_length == 321
+        assert new_config.channels == 4
+        assert new_config.name == config.name
+        assert new_config.pick_up_current == config.pick_up_current
+        assert new_config.plunger_positions == config.plunger_positions


### PR DESCRIPTION
## overview

This PR allows pipette configs loaded from JSON to not completely fail if a single value fails to load. For each value expected to find in the loaded JSON, if it is not there, it will be loaded from the `pipette_config` namedtuple.