### PR TITLE
fix(app): Send session.resume before stop to cancel paused runs

### DIFF
--- a/app/__util__/mock-promise.js
+++ b/app/__util__/mock-promise.js
@@ -1,5 +1,6 @@
 // test utility functions
 
+// TODO(mc, 2018-05-12): upgrade jest to get builtin mock resolve and reject
 export function mockResolvedValue (mock, value) {
   mock.mockImplementation(() => new Promise((resolve) => {
     process.nextTick(() => resolve(value))

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -272,7 +272,10 @@ export default function client (dispatch) {
   }
 
   function cancel (state, action) {
-    remote.session_manager.session.stop()
+    // ensure session is unpaused before canceling to work around RPC API's
+    // inablity to cancel a paused protocol
+    remote.session_manager.session.resume()
+      .then(() => remote.session_manager.session.stop())
       .then(() => dispatch(actions.cancelResponse()))
       .catch((error) => dispatch(actions.cancelResponse(error)))
   }

--- a/app/src/robot/test/__mocks__/session.js
+++ b/app/src/robot/test/__mocks__/session.js
@@ -10,6 +10,9 @@ export default function MockSession () {
     instruments: [],
     containers: [],
 
-    run: jest.fn()
+    run: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    stop: jest.fn()
   }
 }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -1,6 +1,9 @@
 // tests for the api client
+import functions from 'lodash/functions'
+import omit from 'lodash/omit'
 import {push} from 'react-router-redux'
 
+import {mockResolvedValue, mockRejectedValue} from '../../../__util__/mock-promise'
 import {delay} from '../../util'
 import client from '../api-client/client'
 import RpcClient from '../../rpc/client'
@@ -53,7 +56,7 @@ describe('api client', () => {
     }
 
     dispatch = jest.fn()
-    RpcClient.mockReturnValue(Promise.resolve(rpcClient))
+    mockResolvedValue(RpcClient, rpcClient)
 
     const _receive = client(dispatch)
 
@@ -83,7 +86,7 @@ describe('api client', () => {
 
   const sendDisconnect = () => sendToClient(STATE, actions.disconnect())
 
-  const sendNotification = (notification) => {
+  const sendNotification = (topic, payload) => {
     expect(rpcClient.on)
       .toHaveBeenCalledWith('notification', expect.any(Function))
 
@@ -91,7 +94,8 @@ describe('api client', () => {
       return args[0] === 'notification'
     })[1]
 
-    handler(notification)
+    // only send properties, not methods
+    handler({topic, payload: omit(payload, functions(payload))})
   }
 
   describe('connect and disconnect', () => {
@@ -111,7 +115,7 @@ describe('api client', () => {
       const error = new Error('AHH get_root')
       const expectedResponse = actions.connectResponse(error)
 
-      RpcClient.mockReturnValueOnce(Promise.reject(error))
+      mockRejectedValue(RpcClient, error)
 
       return sendConnect()
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
@@ -152,8 +156,103 @@ describe('api client', () => {
   })
 
   describe('running', () => {
+    test('calls session.run and dispatches RUN_RESPONSE success', () => {
+      const expected = actions.runResponse()
+
+      mockResolvedValue(session.run)
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.run()))
+        .then(() => {
+          expect(session.run).toHaveBeenCalled()
+          expect(dispatch).toHaveBeenCalledWith(expected)
+        })
+    })
+
+    test('calls session.run and dispatches RUN_RESPONSE failure', () => {
+      const expected = actions.runResponse(new Error('AH'))
+
+      mockRejectedValue(session.run, new Error('AH'))
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.run()))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('calls session.pause and dispatches PAUSE_RESPONSE success', () => {
+      const expected = actions.pauseResponse()
+
+      mockResolvedValue(session.pause)
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.pause()))
+        .then(() => {
+          expect(session.pause).toHaveBeenCalled()
+          expect(dispatch).toHaveBeenCalledWith(expected)
+        })
+    })
+
+    test('calls session.stop and dispatches PAUSE_RESPONSE failure', () => {
+      const expected = actions.pauseResponse(new Error('AH'))
+
+      mockRejectedValue(session.pause, new Error('AH'))
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.pause()))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('calls session.resume and dispatches RESUME_RESPONSE success', () => {
+      const expected = actions.resumeResponse()
+
+      mockResolvedValue(session.resume)
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.resume()))
+        .then(() => {
+          expect(session.resume).toHaveBeenCalled()
+          expect(dispatch).toHaveBeenCalledWith(expected)
+        })
+    })
+
+    test('calls session.resume and dispatches RESUME_RESPONSE failure', () => {
+      const expected = actions.resumeResponse(new Error('AH'))
+
+      mockRejectedValue(session.resume, new Error('AH'))
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.resume()))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('calls session.resume + stop and dispatches CANCEL_RESPONSE', () => {
+      const expected = actions.cancelResponse()
+
+      mockResolvedValue(session.resume)
+      mockResolvedValue(session.stop)
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.cancel()))
+        .then(() => {
+          expect(session.resume).toHaveBeenCalled()
+          expect(session.stop).toHaveBeenCalled()
+          expect(dispatch).toHaveBeenCalledWith(expected)
+        })
+    })
+
+    test('calls session.stop and dispatches CANCEL_RESPONSE failure', () => {
+      const expected = actions.cancelResponse(new Error('AH'))
+
+      mockResolvedValue(session.resume)
+      mockRejectedValue(session.stop, new Error('AH'))
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.cancel()))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
     test('start a timer when the run starts', () => {
-      session.run.mockReturnValue(Promise.resolve())
+      mockResolvedValue(session.run)
 
       return sendConnect()
         .then(() => sendToClient({}, actions.run()))
@@ -185,7 +284,7 @@ describe('api client', () => {
       return sendConnect()
         .then(() => {
           dispatch.mockClear()
-          sendNotification({topic: 'session', payload: session})
+          sendNotification('session', session)
         })
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedInitial))
     })
@@ -302,7 +401,7 @@ describe('api client', () => {
       const expected = actions.sessionUpdate(update)
 
       return sendConnect()
-        .then(() => sendNotification({topic: 'session', payload: update}))
+        .then(() => sendNotification('session', update))
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
   })
@@ -347,7 +446,7 @@ describe('api client', () => {
       const action = actions.moveToFront('left')
       const expectedResponse = actions.moveToFrontResponse()
 
-      calibrationManager.move_to_front.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.move_to_front)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -362,8 +461,7 @@ describe('api client', () => {
       const action = actions.moveToFront('left')
       const expectedResponse = actions.moveToFrontResponse(new Error('AH'))
 
-      calibrationManager.move_to_front
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.move_to_front, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -374,7 +472,7 @@ describe('api client', () => {
       const action = actions.probeTip('right')
       const expectedResponse = actions.probeTipResponse()
 
-      calibrationManager.tip_probe.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.tip_probe)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -389,8 +487,7 @@ describe('api client', () => {
       const action = actions.probeTip('right')
       const expectedResponse = actions.probeTipResponse(new Error('AH'))
 
-      calibrationManager.tip_probe
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.tip_probe, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -401,7 +498,7 @@ describe('api client', () => {
       const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse()
 
-      calibrationManager.move_to.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.move_to)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -416,8 +513,7 @@ describe('api client', () => {
       const action = actions.moveTo('left', '5')
       const expectedResponse = actions.moveToResponse(new Error('AH'))
 
-      calibrationManager.move_to
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.move_to, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -428,10 +524,9 @@ describe('api client', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse()
 
-      calibrationManager.update_container_offset
-        .mockReturnValue(Promise.resolve())
-      calibrationManager.pick_up_tip.mockReturnValue(Promise.resolve())
-      calibrationManager.home.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.update_container_offset)
+      mockResolvedValue(calibrationManager.pick_up_tip)
+      mockResolvedValue(calibrationManager.home)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -446,8 +541,10 @@ describe('api client', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse(new Error('AH'))
 
-      calibrationManager.update_container_offset
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(
+        calibrationManager.update_container_offset,
+        new Error('AH')
+      )
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -458,10 +555,8 @@ describe('api client', () => {
       const action = actions.pickupAndHome('left', '5')
       const expectedResponse = actions.pickupAndHomeResponse(new Error('AH'))
 
-      calibrationManager.update_container_offset
-        .mockReturnValue(Promise.resolve())
-      calibrationManager.pick_up_tip
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockResolvedValue(calibrationManager.update_container_offset)
+      mockRejectedValue(calibrationManager.pick_up_tip, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -472,9 +567,9 @@ describe('api client', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse()
 
-      calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
-      calibrationManager.home.mockReturnValue(Promise.resolve())
-      calibrationManager.move_to.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.drop_tip)
+      mockResolvedValue(calibrationManager.home)
+      mockResolvedValue(calibrationManager.move_to)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -492,8 +587,7 @@ describe('api client', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
-      calibrationManager.drop_tip
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.drop_tip, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -504,8 +598,8 @@ describe('api client', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
-      calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
-      calibrationManager.home.mockReturnValue(Promise.reject(new Error('AH')))
+      mockResolvedValue(calibrationManager.drop_tip)
+      mockRejectedValue(calibrationManager.home, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -516,10 +610,9 @@ describe('api client', () => {
       const action = actions.dropTipAndHome('right', '9')
       const expectedResponse = actions.dropTipAndHomeResponse(new Error('AH'))
 
-      calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
-      calibrationManager.home.mockReturnValue(Promise.resolve())
-      calibrationManager.move_to
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockResolvedValue(calibrationManager.drop_tip)
+      mockResolvedValue(calibrationManager.home)
+      mockRejectedValue(calibrationManager.move_to, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -530,7 +623,7 @@ describe('api client', () => {
       const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse()
 
-      calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.drop_tip)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -547,7 +640,7 @@ describe('api client', () => {
       const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse(null, true)
 
-      calibrationManager.drop_tip.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.drop_tip)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -561,8 +654,7 @@ describe('api client', () => {
       const action = actions.confirmTiprack('left', '9')
       const expectedResponse = actions.confirmTiprackResponse(new Error('AH'))
 
-      calibrationManager.drop_tip
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.drop_tip, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -573,7 +665,7 @@ describe('api client', () => {
       const action = actions.jog('left', 'y', -1)
       const expectedResponse = actions.jogResponse()
 
-      calibrationManager.jog.mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.jog)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -591,7 +683,7 @@ describe('api client', () => {
       const action = actions.jog('left', 'x', 1)
       const expectedResponse = actions.jogResponse(new Error('AH'))
 
-      calibrationManager.jog.mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(calibrationManager.jog, new Error('AH'))
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -602,8 +694,7 @@ describe('api client', () => {
       const action = actions.updateOffset('left', 1)
       const expectedResponse = actions.updateOffsetResponse(null, false)
 
-      calibrationManager.update_container_offset
-        .mockReturnValue(Promise.resolve())
+      mockResolvedValue(calibrationManager.update_container_offset)
 
       return sendConnect()
         .then(() => sendToClient(state, action))
@@ -618,8 +709,10 @@ describe('api client', () => {
       const action = actions.updateOffset('left', 9)
       const expectedResponse = actions.updateOffsetResponse(new Error('AH'))
 
-      calibrationManager.update_container_offset
-        .mockReturnValue(Promise.reject(new Error('AH')))
+      mockRejectedValue(
+        calibrationManager.update_container_offset,
+        new Error('AH')
+      )
 
       return sendConnect()
         .then(() => sendToClient(state, action))


### PR DESCRIPTION
## overview

The RPC API is unable to handle a `session.stop` call if the protocol run is paused. This PR works around that issue by always calling `session.resume` right before `session.stop`.

Fixes #707

## changelog

- fix(app): Send session.resume before stop to cancel paused runs

## review requests

Needs real robot testing! This will be difficult / impossible to test using virtual smoothie.

- [x] Regular cancel still works (tested on Sunset and Moon Moon)
    1. Start protocol run
    2. Click "Cancel"
    3. Run should cancel and robot should home
    4. Robot page should show "Status: Cancelled"
- [x] Paused cancel works (tested on Moon Moon)
    1. Start protocol run
    2. Click "Pause" and wait for robot to stop
    3. Click "Cancel"
    4. Run should cancel and robot should home
    5. Robot page should show "Status: Cancelled"

This PR also adds a bunch of tests that were missing but test existing run, pause, resume, and cancel functionality. `'calls session.resume + stop and dispatches CANCEL_RESPONSE'` (line 228) is the only test that is for new functionality. The test updates also gets rid of those annoying "Promise rejection was handled asynchronously" warnings