### PR TITLE
fix(app): Hide last calibrated labeled value

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -7,6 +7,8 @@ import {push} from 'react-router-redux'
 import type {Robot} from '../../robot'
 import {startDeckCalibration} from '../../http-api-client'
 import {Card, LabeledValue, OutlineButton} from '@opentrons/components'
+// TODO (ka 2018-5-14): temporariliy hide last calibrated labeled value without affecting card layout
+import styles from './styles.css'
 
 type OP = Robot
 
@@ -24,12 +26,12 @@ export default connect(null, mapDispatchToProps)(CalibrationCard)
 
 function CalibrationCard (props: Props) {
   const {start} = props
-
   return (
     <Card title={TITLE} description={CALIBRATION_MESSAGE}>
     <LabeledValue
       label={LAST_RUN_LABEL}
       value='Never'
+      className={styles.hidden_value}
     />
     <OutlineButton onClick={start}>
       Calibrate

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -99,3 +99,8 @@
     order: 3;
   }
 }
+
+/* TODO (ka 2018-5-14): temporariliy hide last calibrated labeled value without affecting card layout */
+.hidden_value {
+  visibility: hidden;
+}


### PR DESCRIPTION
## overview

Since this feature is not implemented yet, hide the last calibrated text using `visibility: hidden;` so that layout remains consistent.

## changelog

- temporarily import styles to calibration card to hide LabeledValue containing last calibrated text

## review requests
 
I know this breaks our rule of no styled containers, but its a temp fix until last calibrated date it returned accurately. Deleting/commenting out the `LabeledValue` will result in a misaligned button which also would need to be fixed with a temporary className.

