### PR TITLE
Api retry send command

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -728,15 +728,10 @@ class SmoothieDriver_3_0_0:
                     self._connection,
                     timeout=timeout)
             except serial_communication.SerialNoResponse as e:
-                if not is_retry:
-                    # try again, falling back to a shorter timeout so
-                    # an error doesn't cause a very long hangup
-                    return self._send_command(
-                        command,
-                        timeout=DEFAULT_SMOOTHIE_TIMEOUT,
-                        is_retry=True)
-                else:
+                if is_retry:
                     raise e
+                return self._send_command(
+                    command, timeout=timeout, is_retry=True)
 
             # smoothieware can enter a weird state, where it repeats back
             # the sent command at the beginning of its response.


### PR DESCRIPTION
## overview

Adds a simple retry mechanism to `driver._send_command`, where if a `SerialNoResponse` exception is raised, the driver will attempt a single retry of the command. If that second retry fails, the exception will be raised.