### PR TITLE
fix(app): Change carriage to mount in change pipette instructions

### DIFF
--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -75,7 +75,7 @@ function Steps (props: ChangePipetteProps) {
   } else {
     stepOne = (
       <p>
-        Attach pipette to carriage, <strong>starting with screw 1</strong>.
+        Attach pipette to mount, <strong>starting with screw 1</strong>.
       </p>
     )
     stepTwo = 'Connect the pipette to robot by pushing in the white connector tab.'

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -60,7 +60,7 @@ export default function ChangePipette (props: Props) {
           <ConnectedChangePipetteRouter
             robot={robot}
             title={TITLE}
-            subtitle={`${mount} carriage`}
+            subtitle={`${mount} mount`}
             mount={mount}
             wantedPipette={wantedPipette}
             parentUrl={parentUrl}


### PR DESCRIPTION
## overview

Title bar and instructions now read mount instead of carriage to keep consistent with API/documentation naming conventions.

closes #1452

<img width="800" alt="screen shot 2018-05-15 at 1 29 32 pm" src="https://user-images.githubusercontent.com/3430313/40073258-5a504d0e-5844-11e8-9a73-67c13c92b1c5.png">


## changelog
- change title bar subtitle and attach pipette instructions to use `mount` instead of `carriage`

## review requests
Pretty straight forward. You can only see detach pipette title and instructions on VS. I think a code review good enough.
