### PR TITLE
feat(app): Add file/console log module to app's main and renderer

### DIFF
--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -3,14 +3,10 @@
 // api updater
 'use strict'
 
-const fs = require('fs')
+const fse = require('fs-extra')
 const path = require('path')
-const {promisify} = require('util')
 
 const {version: AVAILABLE_UPDATE} = require('../package.json')
-
-const readDir = promisify(fs.readdir)
-const readFile = promisify(fs.readFile)
 
 /*::
 import type {RobotService} from '../../app/src/robot'
@@ -28,7 +24,7 @@ module.exports = {
 }
 
 function initialize () /*: Promise<void> */ {
-  return readDir(UPDATE_DIR)
+  return fse.readdir(UPDATE_DIR)
     .then((files) => {
       const wheels = files.filter((file) => file.endsWith(UPDATE_EXT))
 
@@ -45,6 +41,6 @@ function initialize () /*: Promise<void> */ {
 function getUpdateFile () /*: Promise<string> */ {
   if (!updateFile) return Promise.reject(new Error('No update file available'))
 
-  return readFile(path.join(UPDATE_DIR, updateFile))
+  return fse.readFile(path.join(UPDATE_DIR, updateFile))
     .then((contents) => ({name: updateFile, contents}))
 }

--- a/app-shell/lib/config.js
+++ b/app-shell/lib/config.js
@@ -1,0 +1,32 @@
+// app configuration and settings
+// TODO(mc, 2018-05-15): implement this module properly
+'use strict'
+
+const path = require('path')
+const url = require('url')
+
+// TODO(mc, 2018-05-15): "properly" means features, not DEV_MODE / DEBUG
+const DEV_MODE = process.env.NODE_ENV === 'development'
+const DEBUG_MODE = process.env.DEBUG
+
+module.exports = {
+  DEV_MODE,
+  DEBUG_MODE,
+
+  // logging config
+  log: {
+    level: {
+      file: 'debug',
+      console: 'info'
+    }
+  },
+
+  // ui config
+  ui: {
+    width: 1024,
+    height: 768,
+    url: DEV_MODE
+      ? `http://localhost:${process.env.PORT}`
+      : url.resolve('file://', path.join(__dirname, '../ui/index.html'))
+  }
+}

--- a/app-shell/lib/log.js
+++ b/app-shell/lib/log.js
@@ -1,0 +1,112 @@
+// create logger function
+const {app} = require('electron')
+const {inspect} = require('util')
+const fse = require('fs-extra')
+const path = require('path')
+const dateFormat = require('dateformat')
+const winston = require('winston')
+
+const {log: config} = require('./config')
+
+const LOG_DIR = path.join(app.getPath('userData'), 'logs')
+const ERROR_LOG = path.join(LOG_DIR, 'error.log')
+const COMBINED_LOG = path.join(LOG_DIR, 'combined.log')
+const FILE_OPTIONS = {
+  // JSON logs
+  format: winston.format.json(),
+  // 1 MB max log file size (to ensure emailablity)
+  maxsize: 1024 * 1024,
+  // keep 10 backups at most
+  maxFiles: 10,
+  // roll filenames in accending order (larger the number, older the log)
+  tailable: true
+}
+
+let transports
+let log
+
+module.exports = function getLogger (filename) {
+  if (!transports) initializeTransports()
+
+  return createLogger(filename)
+}
+
+function initializeTransports () {
+  let error = null
+
+  // sync is ok here because this only happens once
+  try {
+    fse.ensureDirSync(LOG_DIR)
+  } catch (e) {
+    error = e
+  }
+
+  transports = createTransports()
+  log = createLogger(__filename)
+
+  if (error) log.error('Could not create log directory', {error})
+  log.info(`Level "error" and higher logging to ${ERROR_LOG}`)
+  log.info(`Level "${config.level.file}" and higher logging to ${COMBINED_LOG}`)
+  log.info(`Level "${config.level.console}" and higher logging to console`)
+}
+
+function createTransports () {
+  const timeFromStamp = ts => dateFormat(new Date(ts), 'HH:MM:ss.l')
+
+  return [
+    // error file log
+    new winston.transports.File(Object.assign({
+      level: 'error',
+      filename: ERROR_LOG
+    }, FILE_OPTIONS)),
+
+    // regular combined file log
+    new winston.transports.File(Object.assign({
+      level: config.level.file,
+      filename: COMBINED_LOG
+    }, FILE_OPTIONS)),
+
+    // console log
+    new winston.transports.Console({
+      level: config.level.console,
+      format: winston.format.combine(
+        winston.format.printf(info => {
+          const {level, message, timestamp, label} = info
+          const time = timeFromStamp(timestamp)
+          const print = `${time} [${label}] ${level}: ${message}`
+          const meta = inspect(info.meta, {depth: 6})
+
+          if (meta !== '{}') return `${print} ${meta}`
+
+          return print
+        })
+      )
+    })
+  ]
+}
+
+function createLogger (filename) {
+  log && log.debug(`Creating logger for ${filename}`)
+
+  const formats = [
+    winston.format.timestamp(),
+    winston.format.metadata({
+      key: 'meta',
+      fillExcept: ['level', 'message', 'timestamp', 'label']
+    })
+  ]
+
+  if (filename) {
+    const label = path.relative(
+      path.join(__dirname, '../..'),
+      filename
+    )
+
+    formats.unshift(winston.format.label({label}))
+  }
+
+  return winston.createLogger({
+    transports,
+    format: winston.format.combine(...formats)
+  })
+}

--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -1,76 +1,51 @@
 // electron main entry point
 'use strict'
 
-const path = require('path')
-const url = require('url')
-const {app, dialog, Menu, BrowserWindow} = require('electron')
-const log = require('electron-log')
+const {app, dialog, ipcMain, Menu} = require('electron')
 
+const {DEV_MODE, DEBUG_MODE} = require('./config')
+const createUi = require('./ui')
 const initializeMenu = require('./menu')
 const {initialize: initializeApiUpdate} = require('./api-update')
-
-// TODO(mc, 2018-01-06): replace dev and debug vars with feature vars
-const DEV_MODE = process.env.NODE_ENV === 'development'
-const DEBUG_MODE = process.env.DEBUG
+const createLogger = require('./log')
+const log = createLogger(__filename)
 
 if (DEV_MODE || DEBUG_MODE) {
   require('electron-debug')({showDevTools: true})
 }
 
-const appUrl = DEV_MODE
-  ? `http://localhost:${process.env.PORT}`
-  : url.resolve('file://', path.join(__dirname, '../ui/index.html'))
-
-// hold on to a reference to ensure mainWindow isn't GC'd
+// hold on to references so they don't get garbage collected
 let mainWindow
+let rendererLogger
 
 app.on('ready', startUp)
 
 function startUp () {
   log.info('Starting App')
-  process.on('uncaughtException', (error) => log.info('Uncaught: ', error))
+  process.on('uncaughtException', (error) => log.error('Uncaught: ', {error}))
 
-  createWindow()
+  mainWindow = createUi()
+  rendererLogger = createRendererLogger()
+
   initializeMenu()
   initializeApiUpdate()
-    .catch((e) => console.error('Initialze API update module error', e))
-
-  load()
+    .catch((error) => log.error('Initialize API update module error', error))
 
   if (DEV_MODE || DEBUG_MODE) {
     installAndOpenExtensions()
       .catch((error) => dialog.showErrorBox('Error opening dev tools', error))
   }
+
+  log.silly('Global references', {mainWindow, rendererLogger})
 }
 
-function createWindow () {
-  mainWindow = new BrowserWindow({
-    show: false,
-    useContentSize: true,
-    width: 1024,
-    height: 768,
-    webPreferences: {
-      experimentalFeatures: true,
-      devTools: DEV_MODE || DEBUG_MODE,
+function createRendererLogger () {
+  log.info('Creating renderer logger')
 
-      // node integration needed for mdns robot discovery in webworker
-      nodeIntegrationInWorker: true,
+  const logger = createLogger()
+  ipcMain.on('log', (_, info) => logger.log(info))
 
-      // TODO(mc, 2018-02-12): this works around CORS restrictions
-      //   while in dev mode; evaluate whether this is acceptable
-      webSecurity: !DEV_MODE
-    }
-  })
-
-  mainWindow.once('ready-to-show', () => mainWindow.show())
-
-  return mainWindow
-}
-
-function load () {
-  log.info('Loading App UI at ' + appUrl)
-  mainWindow.loadURL(appUrl, {'extraHeaders': 'pragma: no-cache\n'})
-  log.info('App UI loaded')
+  return logger
 }
 
 function installAndOpenExtensions () {

--- a/app-shell/lib/ui.js
+++ b/app-shell/lib/ui.js
@@ -1,0 +1,42 @@
+// sets up the main window ui
+'use strict'
+
+const {BrowserWindow} = require('electron')
+const {DEV_MODE, DEBUG_MODE, ui: config} = require('./config')
+const log = require('./log')(__filename)
+
+const WINDOW_OPTS = {
+  show: false,
+  useContentSize: true,
+  width: config.width,
+  height: config.height,
+  webPreferences: {
+    // TODO(mc, 2018-05-15): turn off experimentalFeatures?
+    experimentalFeatures: true,
+    devTools: DEV_MODE || DEBUG_MODE,
+
+    // TODO(mc, 2018-05-15): disable nodeIntegration in renderer thread
+    nodeIntegration: true,
+    // node integration needed for mdns robot discovery in webworker
+    nodeIntegrationInWorker: true,
+
+    // TODO(mc, 2018-02-12): this works around CORS restrictions
+    //   while in dev mode; evaluate whether this is acceptable
+    webSecurity: !DEV_MODE
+  }
+}
+
+module.exports = function createUi () {
+  log.debug('Creating main window', {options: WINDOW_OPTS})
+
+  const mainWindow = new BrowserWindow(WINDOW_OPTS)
+    .once('ready-to-show', () => {
+      log.debug('Main window ready to show')
+      mainWindow.show()
+    })
+
+  log.info(`Loading ${config.url}`)
+  mainWindow.loadURL(config.url, {'extraHeaders': 'pragma: no-cache\n'})
+
+  return mainWindow
+}

--- a/app-shell/lib/update.js
+++ b/app-shell/lib/update.js
@@ -1,8 +1,8 @@
 // app updater
 'use strict'
 
-const log = require('electron-log')
 const {autoUpdater: updater} = require('electron-updater')
+const log = require('./log')(__filename)
 
 updater.logger = log
 updater.autoDownload = false

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -28,10 +28,12 @@
     "shx": "^0.2.2"
   },
   "dependencies": {
+    "dateformat": "^3.0.3",
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.2.0",
-    "electron-log": "^2.2.9",
     "electron-updater": "2.21.3",
-    "semver": "^5.5.0"
+    "fs-extra": "^6.0.1",
+    "semver": "^5.5.0",
+    "winston": "^3.0.0-rc5"
   }
 }

--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -2,6 +2,8 @@
 'use strict'
 
 const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
 jest.mock('electron-updater', () => ({autoUpdater: {}}))
 
@@ -18,6 +20,8 @@ const __clearMock = () => {
   })
 }
 
+const __tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ot-'))
+
 module.exports = {
   __mockRemotes,
   __clearMock,
@@ -33,5 +37,9 @@ module.exports = {
       __mockRemotes[name] = remote
       return remote
     })
+  },
+
+  app: {
+    getPath: () => __tempDir
   }
 }

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -8,6 +8,7 @@ import thunk from 'redux-thunk'
 import createHistory from 'history/createBrowserHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
+import createLogger from './logger'
 import {checkForShellUpdates} from './shell'
 import {healthCheckMiddleware} from './http-api-client'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
@@ -20,6 +21,8 @@ import reducer from './reducer'
 
 // components
 import App from './components/App'
+
+const log = createLogger(__filename)
 
 const history = createHistory()
 
@@ -65,6 +68,7 @@ if (process.env.NODE_ENV === 'development') {
 // kickoff an initial update check at launch
 store.dispatch(checkForShellUpdates())
 
+log.info('Rendering app UI')
 renderApp()
 
 initializeAnalytics({

--- a/app/src/logger.js
+++ b/app/src/logger.js
@@ -1,0 +1,43 @@
+// logger
+import {ipcRenderer} from 'electron'
+
+const LEVELS = [
+  'error',
+  'warn',
+  'info',
+  'http',
+  'verbose',
+  'debug',
+  'silly'
+]
+
+export default function createLogger (filename) {
+  const label = `app/${filename}`
+
+  return LEVELS.reduce((result, level) => ({
+    ...result,
+    [level]: (message, meta) => log(level, message, label, meta)
+  }), {})
+}
+
+function log (level, message, label, meta) {
+  const print = `[${label}] ${level}: ${message}`
+
+  // log to web console, too
+  if (level === 'error') {
+    console.error(print)
+  } else if (level === 'warn') {
+    console.warn(print)
+  } else if (level === 'info') {
+    console.info(print)
+  } else {
+    console.log(print)
+  }
+
+  if (meta && Object.getOwnPropertyNames(meta).length !== 0) {
+    console.dir(meta)
+  }
+
+  // send to main process for logfile collection
+  ipcRenderer.send('log', {level, message, label, meta})
+}

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -107,5 +107,8 @@ module.exports = {
   target,
   plugins,
   devtool,
-  devServer
+  devServer,
+  node: {
+    __filename: true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,7 +426,7 @@ async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1:
+async@^2.1.2, async@^2.1.4, async@^2.4.1, async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -1953,15 +1953,15 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
+color-convert@^0.5.0, color-convert@~0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+
 color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
-
-color-convert@~0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
 
 color-name@^1.0.0, color-name@^1.1.1:
   version "1.1.3"
@@ -1979,6 +1979,13 @@ color-string@^1.4.0, color-string@^1.5.2:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color@0.8.x:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/color/-/color-0.8.0.tgz#890c07c3fd4e649537638911cf691e5458b6fca5"
+  dependencies:
+    color-convert "^0.5.0"
+    color-string "^0.3.0"
 
 color@^0.11.0:
   version "0.11.4"
@@ -2010,6 +2017,10 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
+colornames@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz#d811fd6c84f59029499a8ac4436202935b92be31"
+
 colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -2018,9 +2029,20 @@ colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
+colors@^1.2.1:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+
 colors@~0.6.0-1:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
+
+colorspace@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz#c99c796ed31128b9876a52e1ee5ee03a4a719749"
+  dependencies:
+    color "0.8.x"
+    text-hex "0.0.x"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -2488,6 +2510,10 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
+dateformat@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
+
 debug@2.6.9, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2639,6 +2665,14 @@ detect-port-alt@1.1.3:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diagnostics@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz#e1090900b49523e8527be20f081275205f2ae36a"
+  dependencies:
+    colorspace "1.0.x"
+    enabled "1.0.x"
+    kuler "0.0.x"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -2956,10 +2990,6 @@ electron-localshortcut@^3.0.0:
     keyboardevent-from-electron-accelerator "^1.1.0"
     keyboardevents-areequal "^0.2.1"
 
-electron-log@^2.2.9:
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-2.2.13.tgz#15571ca695484fec39ddb9b3a9ff6e83e2a0d980"
-
 electron-osx-sign@0.4.10:
   version "0.4.10"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.10.tgz#be4f3b89b2a75a1dc5f1e7249081ab2929ca3a26"
@@ -3070,6 +3100,12 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
+enabled@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
+  dependencies:
+    env-variable "0.0.x"
+
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -3102,6 +3138,10 @@ entities@^1.1.1, entities@~1.1.1:
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+
+env-variable@0.0.x:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz#0d6280cf507d84242befe35a512b5ae4be77c54e"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.6"
@@ -3666,6 +3706,10 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+fecha@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3920,6 +3964,14 @@ fs-extra@^4.0.1:
 fs-extra@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -5621,6 +5673,12 @@ known-css-properties@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.5.0.tgz#6ff66943ed4a5b55657ee095779a91f4536f8084"
 
+kuler@0.0.x:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz#b66bb46b934e550f59d818848e0abba4f7f5553c"
+  dependencies:
+    colornames "0.0.2"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -5803,6 +5861,15 @@ log-symbols@^2.0.0:
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
   dependencies:
     chalk "^2.0.1"
+
+logform@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/logform/-/logform-1.6.0.tgz#1104c93af10269864f2d98e7661abbea3690d83f"
+  dependencies:
+    colors "^1.2.1"
+    fecha "^2.3.3"
+    ms "^2.1.1"
+    triple-beam "^1.2.0"
 
 loglevel@^1.4.1:
   version "1.6.1"
@@ -6200,6 +6267,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -6504,6 +6575,10 @@ once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+one-time@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
 
 onecolor@^3.0.4:
   version "3.0.5"
@@ -9395,6 +9470,10 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-hex@0.0.x:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz#578fbc85a6a92636e42dd17b41d0218cce9eb2b3"
+
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -9545,6 +9624,10 @@ trim-trailing-lines@^1.0.0:
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+triple-beam@^1.0.1, triple-beam@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/triple-beam/-/triple-beam-1.2.0.tgz#8b5c1f3d491229bf6ddcf721c0ba84cef5ab51fa"
 
 trough@^1.0.0:
   version "1.0.1"
@@ -10187,6 +10270,10 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
+winston-transport@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/winston-transport/-/winston-transport-3.2.1.tgz#5b79b294096b1a18bfe502e769491553a2cb1042"
+
 winston@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.0.tgz#808050b93d52661ed9fb6c26b3f0c826708b0aee"
@@ -10197,6 +10284,19 @@ winston@^2.2.0:
     eyes "0.1.x"
     isstream "0.1.x"
     stack-trace "0.0.x"
+
+winston@^3.0.0-rc5:
+  version "3.0.0-rc5"
+  resolved "https://registry.npmjs.org/winston/-/winston-3.0.0-rc5.tgz#bc383d32b0e774d387a66e77290fe78766468f34"
+  dependencies:
+    async "^2.6.0"
+    diagnostics "^1.0.1"
+    is-stream "^1.1.0"
+    logform "^1.4.1"
+    one-time "0.0.4"
+    stack-trace "0.0.x"
+    triple-beam "^1.0.1"
+    winston-transport "^3.1.0"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
## overview

This PR is also serving as a ticket because I forgot to write the ticket first. My bad.

Lays groundwork for #1329 

## changelog

- feat(app): Add file/console log module to app's main and renderer 

## review requests

App only change so no need for robot testing. Please note that this PR _does not_ replace all instances of `console.xyz` in the app. Instead, it adds a single `log.info` to `app/src/index.js` for verification.

Checks:

- New dependencies, so do a `make install`
- Logs from `app-shell` go to log files (`combined.log` and `error.log` at levels `debug` and `error`)
    - [x] Windows: `%APPDATA%\Opentrons\logs`
    - [x] Linux: `~/.config/Opentrons/logs` (or `$XDG_CONFIG_HOME`, whatever that means)
    - [x] Mac: `~/Library/Application Support/Opentrons/logs`
- [x] Logs from `app-shell` go to terminal at level `info`
- [x] Logs from `app` go to log files as described above
- [x] Logs from `app` go to terminal as described above
- [x] Logs from `app` go to web console
