### PR TITLE
feat(app): Add app analytics card UI to app page

### DIFF
--- a/app/src/components/AppSettings/AnalyticsSettingsCard.js
+++ b/app/src/components/AppSettings/AnalyticsSettingsCard.js
@@ -13,11 +13,12 @@ export default function AnalyticsSettingsCard () {
         <p className={styles.analytics_label}>Share Robot & App analytics with Opentrons</p>
         <ToggleButton
           className={styles.analytics_icon}
-          toggledOn onClick={() => console.log('opting in or out')}
+          toggledOn={false}
+          disabled
         />
       </div>
       <div className={styles.analytics_info}>
-        <p>Help Opentrons improve its products and services by automatically sending diagnostic and usage data.</p>
+        <p>Help Opentrons improve its products and services by automatically sending anonymous diagnostic and usage data.</p>
         <p>This will allow us to learn things such as which features get used the most, which parts of the process are taking longest to complete, and how errors are generated.</p>
       </div>
     </Card>

--- a/app/src/components/AppSettings/AnalyticsSettingsCard.js
+++ b/app/src/components/AppSettings/AnalyticsSettingsCard.js
@@ -1,0 +1,25 @@
+// @flow
+// info on analytic data collected and toggle to opt in/out
+import * as React from 'react'
+import ToggleButton from '../ToggleButton'
+import {Card} from '@opentrons/components'
+import styles from './styles.css'
+
+const TITLE = 'Privacy Settings'
+export default function AnalyticsSettingsCard () {
+  return (
+    <Card title={TITLE} column>
+      <div className={styles.analytics_toggle}>
+        <p className={styles.analytics_label}>Share Robot & App analytics with Opentrons</p>
+        <ToggleButton
+          className={styles.analytics_icon}
+          toggledOn onClick={() => console.log('opting in or out')}
+        />
+      </div>
+      <div className={styles.analytics_info}>
+        <p>Help Opentrons improve its products and services by automatically sending diagnostic and usage data.</p>
+        <p>This will allow us to learn things such as which features get used the most, which parts of the process are taking longest to complete, and how errors are generated.</p>
+      </div>
+    </Card>
+  )
+}

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 
 import type {ShellUpdate} from '../../shell'
 import AppInfoCard from './AppInfoCard'
+import AnalyticsSettingsCard from './AnalyticsSettingsCard'
 import AppUpdateModal from './AppUpdateModal'
 
 import styles from './styles.css'
@@ -15,7 +16,12 @@ type Props = ShellUpdate & {
 export default function AppSettings (props: Props) {
   return (
     <div className={styles.app_settings}>
-      <AppInfoCard {...props} />
+      <div className={styles.row}>
+        <AppInfoCard {...props}/>
+      </div>
+      <div className={styles.row}>
+        <AnalyticsSettingsCard {...props} />
+      </div>
     </div>
   )
 }

--- a/app/src/components/AppSettings/styles.css
+++ b/app/src/components/AppSettings/styles.css
@@ -1,6 +1,48 @@
 /* stylesheet for AppSettings components */
 @import '@opentrons/components';
 
+:root {
+  --app_settings_card_spacing: 0.75rem;
+}
+
 .app_settings {
   padding: 1.5rem;
+}
+
+.row {
+  width: 100%;
+  margin-bottom: var(--app_settings_card_spacing);
+}
+
+.analytics_toggle {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.analytics_label {
+  @apply --font-body-1-dark;
+
+  font-weight: 600;
+  line-height: 2rem;
+}
+
+.analytics_icon {
+  width: 4rem;
+  flex: 0 0 auto;
+  padding: 0 2rem 0 0;
+
+  &:hover {
+    background-color: transparent;
+  }
+}
+
+.analytics_info {
+  max-width: 25rem;
+
+  & > p {
+    @apply --font-body-1-dark;
+
+    margin: 1rem 0;
+  }
 }

--- a/app/src/components/ConnectPanel/RobotList.js
+++ b/app/src/components/ConnectPanel/RobotList.js
@@ -1,15 +1,14 @@
 // @flow
 // list of robots
 import * as React from 'react'
-import cx from 'classnames'
 
 import {
   ListItem,
-  IconButton,
   NotificationIcon
 } from '@opentrons/components'
 
 import type {Robot} from '../../robot'
+import ToggleButton from '../ToggleButton'
 import styles from './connect-panel.css'
 
 type ListProps = {
@@ -36,19 +35,6 @@ export function RobotListItem (props: ItemProps) {
     ? disconnect
     : connect
 
-  const connectButtonClassName = cx(styles.robot_item_icon, {
-    [styles.connected]: isConnected,
-    [styles.disconnected]: !isConnected
-  })
-
-  /* TODO (ka 2018-2-13):
-  Toggle Button Class based on connectivity,
-  NavLink gets ActiveClassName in ListItem
-  */
-  const toggleIcon = isConnected
-    ? 'ot-toggle-switch-on'
-    : 'ot-toggle-switch-off'
-
   return (
     <ListItem
       url={`/robots/${name}`}
@@ -66,10 +52,10 @@ export function RobotListItem (props: ItemProps) {
         {name}
       </p>
 
-      <IconButton
-        name={toggleIcon}
-        className={connectButtonClassName}
+      <ToggleButton
+        toggledOn={isConnected}
         onClick={onClick}
+        className={styles.robot_item_icon}
       />
     </ListItem>
   )

--- a/app/src/components/ConnectPanel/connect-panel.css
+++ b/app/src/components/ConnectPanel/connect-panel.css
@@ -30,18 +30,9 @@
   text-overflow: ellipsis;
 }
 
-.disconnected {
-  fill: var(--c-dark-gray);
-}
-
 .active {
   color: #0ec9eb;
   background-color: #f0f3ff;
-}
-
-.connected {
-  fill: #0ec9eb;
-  color: #0ec9eb;
 }
 
 .scan_status {

--- a/app/src/components/ToggleButton/index.js
+++ b/app/src/components/ToggleButton/index.js
@@ -1,0 +1,32 @@
+// @flow
+// reusuable toggle button with on off styling for connect to robot and opt in/out
+import * as React from 'react'
+import cx from 'classnames'
+import {IconButton} from '@opentrons/components'
+import styles from './styles.css'
+
+type ToggleProps = {
+  toggledOn: boolean,
+  onClick: () => mixed,
+  className?: string
+}
+
+export default function ToggleButton (props: ToggleProps) {
+  const {toggledOn, onClick} = props
+  const className = cx(styles.robot_item_icon, props.className, {
+    [styles.toggled_on]: toggledOn,
+    [styles.toggled_off]: !toggledOn
+  })
+
+  const toggleIcon = toggledOn
+    ? 'ot-toggle-switch-on'
+    : 'ot-toggle-switch-off'
+
+  return (
+    <IconButton
+      name={toggleIcon}
+      className={className}
+      onClick={onClick}
+    />
+  )
+}

--- a/app/src/components/ToggleButton/index.js
+++ b/app/src/components/ToggleButton/index.js
@@ -2,17 +2,15 @@
 // reusuable toggle button with on off styling for connect to robot and opt in/out
 import * as React from 'react'
 import cx from 'classnames'
-import {IconButton} from '@opentrons/components'
+import {IconButton, type ButtonProps} from '@opentrons/components'
 import styles from './styles.css'
 
-type ToggleProps = {
-  toggledOn: boolean,
-  onClick: () => mixed,
-  className?: string
+type ToggleProps = ButtonProps & {
+  toggledOn: boolean
 }
 
 export default function ToggleButton (props: ToggleProps) {
-  const {toggledOn, onClick} = props
+  const {toggledOn} = props
   const className = cx(styles.robot_item_icon, props.className, {
     [styles.toggled_on]: toggledOn,
     [styles.toggled_off]: !toggledOn
@@ -24,9 +22,9 @@ export default function ToggleButton (props: ToggleProps) {
 
   return (
     <IconButton
+      {...props}
       name={toggleIcon}
       className={className}
-      onClick={onClick}
     />
   )
 }

--- a/app/src/components/ToggleButton/styles.css
+++ b/app/src/components/ToggleButton/styles.css
@@ -1,0 +1,10 @@
+@import '@opentrons/components';
+
+.toggled_on {
+  fill: #0ec9eb;
+  color: #0ec9eb;
+}
+
+.toggled_off {
+  fill: var(--c-dark-gray);
+}


### PR DESCRIPTION
## overview
This PR adds an analytics settings card UI to the app (more) section of the app. Toggle behavior is out of scope and covered in #1330.

- closes #1173

<img width="800" alt="screen shot 2018-05-16 at 11 38 57 am" src="https://user-images.githubusercontent.com/3430313/40127632-d296c482-58fd-11e8-8d5f-b13c3578acda.png">

## changelog

- Create reusable `ToggleButton` component for app, implement in RobotList and AnalyticsSettingsCard
- Implement UI only for analytics settings card

## review requests
Standard review, nothing in state. Just UI and code review. 

Also, I was eyeballing off a screenshot for this ticket so any spelling/grammar callouts much appreciated!