### PR TITLE
Api: fix instrument offset load bug

### DIFF
--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -124,9 +124,10 @@ def _default_probe_dimensions():
 def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
     inst_offs = {'right': {}, 'left': {}}
     pip_types = ['single', 'multi']
+    prev_instrument_offset = robot_settings.get('instrument_offset', {})
     for mount in inst_offs.keys():
+        mount_dict = prev_instrument_offset.get(mount, {})
         for typ in pip_types:
-            mount_dict = robot_settings.get(mount, {})
             inst_offs[mount][typ] = mount_dict.get(typ, DEFAULT_INST_OFFSET)
     cfg = robot_config(
         name=robot_settings.get('name', 'Ada Lovelace'),

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -134,7 +134,7 @@ def _build_fallback_instrument_offset(robot_settings: dict) -> dict:
     return inst_offs
 
 
-def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
+def _build_config(deck_cal: list, robot_settings: dict) -> robot_config:
     cfg = robot_config(
         name=robot_settings.get('name', 'Ada Lovelace'),
         version=int(robot_settings.get('version', ROBOT_CONFIG_VERSION)),

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -121,7 +121,9 @@ def _default_probe_dimensions():
     return [35.0, 40.0, probe_height + 5.0]
 
 
-def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
+def _build_fallback_instrument_offset(robot_settings: dict) -> dict:
+    # because `instrument_offset` is a dict of dicts, we must loop through it
+    # and replace empty values with the default offset
     inst_offs = {'right': {}, 'left': {}}
     pip_types = ['single', 'multi']
     prev_instrument_offset = robot_settings.get('instrument_offset', {})
@@ -129,6 +131,10 @@ def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
         mount_dict = prev_instrument_offset.get(mount, {})
         for typ in pip_types:
             inst_offs[mount][typ] = mount_dict.get(typ, DEFAULT_INST_OFFSET)
+    return inst_offs
+
+
+def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
     cfg = robot_config(
         name=robot_settings.get('name', 'Ada Lovelace'),
         version=int(robot_settings.get('version', ROBOT_CONFIG_VERSION)),
@@ -139,7 +145,7 @@ def _build_config(deck_cal: dict, robot_settings: dict) -> robot_config:
         probe_dimensions=robot_settings.get(
             'probe_dimensions', _default_probe_dimensions()),
         gantry_calibration=deck_cal or DEFAULT_DECK_CALIBRATION,
-        instrument_offset=inst_offs,
+        instrument_offset=_build_fallback_instrument_offset(robot_settings),
         tip_length=robot_settings.get('tip_length', DEFAULT_TIP_LENGTH_DICT),
         mount_offset=robot_settings.get('mount_offset', DEFAULT_MOUNT_OFFSET),
         serial_speed=robot_settings.get('serial_speed', SERIAL_SPEED),

--- a/api/tests/opentrons/robot/test_robots_config.py
+++ b/api/tests/opentrons/robot/test_robots_config.py
@@ -24,3 +24,61 @@ def test_load_corrupt_json():
     c = robot_configs.load(filename)
     assert c.version == 2
     os.remove(filename)
+
+
+def test_build_config():
+    from opentrons.robot import robot_configs
+
+    deck_cal = [
+        [1.23, 1.23, 1.23,  1.23],
+        [1.23, 1.23, 1.23,  1.23],
+        [1.23, 1.23, 1.23,  1.23],
+        [1.23, 1.23, 1.23,  1.23]
+    ]
+    robot_settings = {
+        'name': 'Andy',
+        'version': 42,
+        'steps_per_mm': 'steps_rulz',
+        'acceleration': 'acceleration_rulz',
+        'probe_center': [1, 2, 3],
+        'probe_dimensions': [4, 5, 6],
+        'instrument_offset': {
+            'left': {
+                'single': [1, 2, 3],
+                'multi': [4, 5, 6]
+            },
+            'right': {
+                'single': [7, 8, 9],
+                'multi': [10, 11, 12]
+            }
+        },
+        'tip_length': 999,
+        'mount_offset': [-3, -2, -1],
+        'serial_speed': 888,
+        'default_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+        'low_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+        'high_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+        'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+        'log_level': 'NADA'
+    }
+
+    built_config = robot_configs._build_config(deck_cal, robot_settings)
+
+    assert built_config.gantry_calibration == deck_cal
+    for key in robot_settings.keys():
+        assert getattr(built_config, key) == robot_settings[key]
+
+    robot_settings['instrument_offset'].update({'right': {}})
+
+    built_config = robot_configs._build_config(deck_cal, robot_settings)
+    expected = {
+            'left': {
+                'single': [1, 2, 3],
+                'multi': [4, 5, 6]
+            },
+            'right': {
+                'single': [0, 0, 0],
+                'multi': [0, 0, 0]
+            }
+        }
+    assert built_config.instrument_offset == expected


### PR DESCRIPTION
## overview

This PR fixes a bug in how the save tip-probe data (aka `robot.config.instrument_offset`) was being loaded. The bug was that it wasn't ever being loaded, so the only tip-probe data that was being used was data generated in the same session as the protocol run.