### PR TITLE
feat(app-shell): Add configuration file with CLI and env overrides

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -103,4 +103,9 @@ _dist-collect-artifacts:
 
 .PHONY: dev
 dev:
-	$(env)=development PORT=$(port) electron .
+	$(env)=development electron . \
+		--devtools \
+		--log.level.console="debug" \
+		--disable_ui.webPreferences.webSecurity \
+		--ui.url.protocol="http:" \
+		--ui.url.path="localhost:$(port)"

--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -8,11 +8,132 @@
 
 This directory contains the code for the [Electron main process][electron-main] that runs the Opentrons application.
 
+### configuration
+
+The app uses [`electron-store`][electron-store] to store its configuration in a JSON file located at:
+
+* `%APPDATA%\Opentrons\config.json` on Windows
+* `~/.config/Opentrons/config.json` on Linux
+* `~/Library/Application Support/Opentrons/config.json` on macOS
+
+Configuration values will be determined by:
+
+1.  Checking for a CLI argument
+2.  If no CLI argument, checking for an environment variable
+3.  If no environment variable, checking the `config.json` file
+4.  If no value in `config.json`, default value from code will be used
+    * Default value will also be written to `config.json`
+
+**If overriding boolean values**:
+
+* For CLI arguments, use `--value` for true, and `--disable_value` for false
+* For environment variables, use `OT_APP_VALUE=1` for true, and `OT_APP_VALUE=0` for false
+
+<!-- TODO(mc, 2018-05-16): generate this section from lib/config.js -->
+
+#### settings
+
+##### devtools
+
+* CLI argument: `--devtools` or `--disable_devtools`
+* Environment variable: `OT_APP_DEVTOOLS`
+* JSON path: `devtools`
+* Default: `false`
+
+Enables and opens the Chrome devtools.
+
+##### log.level.file
+
+* CLI argument: `--log.level.file`
+* Environment variable: `OT_APP_LOG__LEVEL__FILE`
+* JSON path: `log.level.file`
+* Default: `"debug"`
+
+Default log level of the `combined.log` log file. See logging section below.
+
+##### log.level.console
+
+* CLI argument: `--log.level.console`
+* Environment variable: `OT_APP_LOG__LEVEL__CONSOLE`
+* JSON path: `log.level.console`
+* Default: `"info"`
+
+Default log level of the console log. See logging section below.
+
+##### ui.webPreferences.webSecurity
+
+* CLI argument: `--ui.webPreferences.webSecurity` or `--disable_ui.webPreferences.webSecurity`
+* Environment variable: `OT_APP_UI__WEB_PREFERENCES__WEB_SECURITY`
+* JSON path: `ui.webPreferences.webSecurity`
+* Default: `true`
+
+Sets the `webPreferences.webSecurity` option of the Electron [BrowserWindow][electron-docs-browser-window] created for the UI. When disabled, the browsers same-origin policy will be disabled. This should only be disabled in development / testing environments.
+
+##### ui.width
+
+* CLI argument: `--ui.width`
+* Environment variable: `OT_APP_UI__WIDTH`
+* JSON path: `ui.width`
+* Default: `1024`
+
+[BrowserWindow][electron-docs-browser-window] width at launch.
+
+##### ui.height
+
+* CLI argument: `--ui.height`
+* Environment variable: `OT_APP_UI__HEIGHT`
+* JSON path: `ui.height`
+* Default: `768`
+
+[BrowserWindow][electron-docs-browser-window] height at launch.
+
+##### ui.url.protocol
+
+* CLI argument: `--ui.url.protocol`
+* Environment variable: `OT_APP_UI__URL__PROTOCOL`
+* JSON path: `ui.url.protocol`
+* Default: `"file:"`
+
+Protocol used to fetch the UI's `index.html`. If you want to fetch the UI from the dev server in [`app`](../app), set this to `http:`.
+
+##### ui.url.path
+
+* CLI argument: `--ui.url.path`
+* Environment variable: `OT_APP_UI__URL__PATH`
+* JSON path: `ui.url.path`
+* Default: `"ui/index.html"`
+
+Path to `index.html`. If `ui.url.protocol` is `file:`, this path is relative to the [application directory][electron-docs-get-app-path]. This path will be combined with the protocol to get the full path to `index.html`. If you want to fetch the UI from the dev server in [`app`](../app), set this to `localhost:8090`.
+
+### logging
+
+Logs from both the main and renderer processes are logged to rolling files as well as the terminal by [winston][winston]. The logs are stored in a `logs` directory at:
+
+* `%APPDATA%\Opentrons\logs` on Windows
+* `~/.config/Opentrons/logs` on Linux
+* `~/Library/Application Support/Opentrons/logs` on macOS
+
+#### available log levels
+
+* error
+* warn
+* info
+* http
+* verbose
+* debug
+* silly
+
+#### logs written
+
+* `logs/combined.log` - JSON logs at level `log.level.file` and above
+* `logs/error.log` - JSON logs at level `error` and above
+* Console - Human-readable logs at level `log.level.console` and above
+
 ## developing
 
 To get started: clone the Opentrons/opentrons repository, set up your computer for development as specified in the [project readme][project-readme-setup], and then:
 
-``` shell
+```shell
 # prerequisite: install dependencies as specified in project setup
 make install
 # change into the app-shell directory
@@ -25,14 +146,14 @@ make dev
 
 You probably want to be developing from the [app directory](../app) instead. Its `make dev` task will automatically call `make dev` here in `app-shell`.
 
-## stack and structure
+### stack and structure
 
 The desktop application shell uses:
 
-*   [Electron][]
-*   [Electron Builder][electron-builder]
+* [Electron][]
+* [Electron Builder][electron-builder]
 
-## testing
+### testing
 
 The desktop shell has no tests at this time.
 
@@ -44,27 +165,27 @@ This section details production build instructions for the desktop application.
 
 `electron-builder` requires some native dependencies to build and package the app (see [the electron-builder docs][electron-builder-platforms]).
 
-*   macOS - None
-*   Windows - None
-*   Linux - icnsutils, graphicsmagick, and xz-utils
+* macOS - None
+* Windows - None
+* Linux - icnsutils, graphicsmagick, and xz-utils
 
-    ```shell
-    sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils
-    ```
+  ```shell
+  sudo apt-get install --no-install-recommends -y icnsutils graphicsmagick xz-utils
+  ```
 
 ### build tasks
 
-*   `make` - Default target is "clean package"
-*   `make clean` - Delete the dist folder
-*   `make package` - Creates a production package of the app for running and inspection (does not create a distributable)
+* `make` - Default target is "clean package"
+* `make clean` - Delete the dist folder
+* `make package` - Creates a production package of the app for running and inspection (does not create a distributable)
 
 #### production builds
 
 All packages and/or distributables will be placed in `app-shell/dist`. After running `make package`, you can launch the production app with:
 
-*   macOS: `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons`
-*   Linux: `./dist/linux-unpacked/opentrons`
-*   Windows: `./dist/win-unpacked/Opentrons.exe`
+* macOS: `./dist/mac/Opentrons.app/Contents/MacOS/Opentrons`
+* Linux: `./dist/linux-unpacked/opentrons`
+* Windows: `./dist/win-unpacked/Opentrons.exe`
 
 To run the production app in debug mode, set the `DEBUG` environment variable. For example, on macOS:
 
@@ -92,28 +213,31 @@ make dist-win OT_BUCKET_APP=opentrons-app OT_FOLDER_APP=builds
 
 These tasks use the following environment variables defined:
 
- name          | description   | required | description
--------------- | ------------- | -------- | -----------------------------
- OT_BUCKET_APP | AWS S3 bucket | yes      | Artifact deploy bucket
- OT_FOLDER_APP | AWS S3 folder | yes      | Artifact deploy folder in bucket
- OT_BRANCH     | Branch name   | no       | Sometimes added to the artifact name
- OT_BUILD      | Build number  | no       | Appended to the artifact name
- OT_TAG        | Tag name      | no       | Flags autoupdate files to be published
+<!-- TODO(mc, 2018-05-16): update bucket / folder vars to use config prefix -->
+| name          | description   | required | description                            |
+| ------------- | ------------- | -------- | -------------------------------------- |
+| OT_BUCKET_APP | AWS S3 bucket | yes      | Artifact deploy bucket                 |
+| OT_FOLDER_APP | AWS S3 folder | yes      | Artifact deploy folder in bucket       |
+| OT_BRANCH     | Branch name   | no       | Sometimes added to the artifact name   |
+| OT_BUILD      | Build number  | no       | Appended to the artifact name          |
+| OT_TAG        | Tag name      | no       | Flags autoupdate files to be published |
 
 The release channel is set according to the version string:
 
--   `vM.m.p-alpha.x` - "alpha" channel
--   `vM.m.p-beta.x` - "beta" channel
--   `vM.m.p` - "latest" channel
+* `vM.m.p-alpha.x` - "alpha" channel
+* `vM.m.p-beta.x` - "beta" channel
+* `vM.m.p` - "latest" channel
 
 The `electron-updater` autoupdate files (e.g. `beta-mac.yml`) will only be copied to the publish directory if `OT_TAG` is set.
 
 [style-guide]: https://standardjs.com
 [style-guide-badge]: https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square&maxAge=3600
-
 [project-readme-setup]: ../README.md#set-up-your-development-environment
-
 [electron]: https://electron.atom.io/
 [electron-main]: https://electronjs.org/docs/tutorial/quick-start#main-process
 [electron-builder]: https://www.electron.build/
 [electron-builder-platforms]: https://www.electron.build/multi-platform-build
+[electron-store]: https://github.com/sindresorhus/electron-store
+[electron-docs-browser-window]: https://electronjs.org/docs/api/browser-window#new-browserwindowoptions
+[electron-docs-get-app-path]: https://electronjs.org/docs/api/app#appgetapppath
+[winston]: https://github.com/winstonjs/winston

--- a/app-shell/lib/config.js
+++ b/app-shell/lib/config.js
@@ -6,6 +6,11 @@ const dotProp = require('dot-prop')
 const mergeOptions = require('merge-options')
 const yargsParser = require('yargs-parser')
 
+// make sure all arguments are included in production
+const argv = process.defaultApp
+  ? process.argv.slice(2)
+  : process.argv.slice(1)
+
 const ENV_PREFIX = 'OT_APP'
 
 const DEFAULTS = {
@@ -33,7 +38,7 @@ const DEFAULTS = {
   }
 }
 
-const overrides = yargsParser(process.argv.slice(2), {
+const overrides = yargsParser(argv, {
   envPrefix: ENV_PREFIX,
   configuration: {
     'negation-prefix': 'disable_'

--- a/app-shell/lib/log.js
+++ b/app-shell/lib/log.js
@@ -6,7 +6,7 @@ const path = require('path')
 const dateFormat = require('dateformat')
 const winston = require('winston')
 
-const {log: config} = require('./config')
+const config = require('./config').get('log')
 
 const LOG_DIR = path.join(app.getPath('userData'), 'logs')
 const ERROR_LOG = path.join(LOG_DIR, 'error.log')

--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -3,14 +3,22 @@
 
 const {app, dialog, ipcMain, Menu} = require('electron')
 
-const {DEV_MODE, DEBUG_MODE} = require('./config')
 const createUi = require('./ui')
 const initializeMenu = require('./menu')
 const {initialize: initializeApiUpdate} = require('./api-update')
 const createLogger = require('./log')
+const {get: getConfig, getStore, getOverrides} = require('./config')
+
+const config = getConfig()
 const log = createLogger(__filename)
 
-if (DEV_MODE || DEBUG_MODE) {
+log.debug('App config', {
+  config,
+  store: getStore(),
+  overrides: getOverrides()
+})
+
+if (config.devtools) {
   require('electron-debug')({showDevTools: true})
 }
 
@@ -31,7 +39,7 @@ function startUp () {
   initializeApiUpdate()
     .catch((error) => log.error('Initialize API update module error', error))
 
-  if (DEV_MODE || DEBUG_MODE) {
+  if (config.devtools) {
     installAndOpenExtensions()
       .catch((error) => dialog.showErrorBox('Error opening dev tools', error))
   }

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -29,11 +29,15 @@
   },
   "dependencies": {
     "dateformat": "^3.0.3",
+    "dot-prop": "^4.2.0",
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.2.0",
+    "electron-store": "^1.3.0",
     "electron-updater": "2.21.3",
     "fs-extra": "^6.0.1",
+    "merge-options": "^1.0.1",
     "semver": "^5.5.0",
-    "winston": "^3.0.0-rc5"
+    "winston": "^3.0.0-rc5",
+    "yargs-parser": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,6 +2135,16 @@ concurrently@^3.5.0:
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
 
+conf@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz#1ea66c9d7a9b601674a5bb9d2b8dc3c726625e67"
+  dependencies:
+    dot-prop "^4.1.0"
+    env-paths "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-up "^2.0.0"
+    write-file-atomic "^2.3.0"
+
 configstore@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.1.tgz#094ee662ab83fad9917678de114faaea8fcdca90"
@@ -2807,6 +2817,12 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  dependencies:
+    is-obj "^1.0.0"
+
 dotenv-expand@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.0.1.tgz#68fddc1561814e0a10964111057ff138ced7d7a8"
@@ -3051,6 +3067,12 @@ electron-publisher-s3@20.7.0:
 electron-releases@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
+
+electron-store@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/electron-store/-/electron-store-1.3.0.tgz#ee488a28a61fb982fd35b658fb9cb6331eb201f8"
+  dependencies:
+    conf "^1.3.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.30"
@@ -5013,7 +5035,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -6062,6 +6084,12 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
+  dependencies:
+    is-plain-obj "^1.1"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -6931,6 +6959,12 @@ pkg-dir@^1.0.0:
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
     find-up "^2.1.0"
 
@@ -10335,7 +10369,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@^2.0.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
   dependencies:
@@ -10422,6 +10456,12 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yargs-parser@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz#c737c93de2567657750cb1f2c00be639fd19c994"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2811,15 +2811,9 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^4.1.0, dot-prop@^4.1.1:
+dot-prop@^4.1.0, dot-prop@^4.1.1, dot-prop@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
 


### PR DESCRIPTION
## overview

This PR implements the electron side of app configuration as described in #1463 in order to support #1329.

## changelog

- feat(app-shell): Add configuration file with CLI and env overrides

## review requests

There's +182 of README diff in this one and +50 of package.json + lockfile, so the actual code diff isn't that large.

For testing this, I've been using `ui.width` and `ui.height` because it's readily apparent if they work. But also, the `make dev` task in `app-shell` has been updated to use the CLI args so there's some testing built in.

 - [x] Config from file is read (test by modifying `config.json`, location described in `app-shell/README.md`)
- [x] Config from env var overrides file
    - e.g. `make dev OT_APP_UI__WIDTH=768`
- [x] Config from CLI overrides file
    - Makefile overrides console log level in `make dev` to `debug` (default is `info`)
- [x] Config from CLI overrides env var
    - e.g. Verify that `make dev OT_APP_LOG__LEVEL__CONSOLE=error` has no effect because of the CLI arg in the Makefile

Also please double check my documentation in `README.md` (thanks @IanLondon for reminding me to do this).