### PR TITLE
API: increase serial retries to 3; add small delay between retries

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -927,11 +927,12 @@ class SmoothieDriver_3_0_0:
             self.delay(CURRENT_CHANGE_DELAY)
             # request from Smoothieware the information from that pipette
             res = self._send_command(gcode + mount)
-            res = _parse_instrument_data(res)
-            assert mount in res
-            # data is read/written as strings of HEX characters
-            # to avoid firmware weirdness in how it parses GCode arguments
-            return _byte_array_to_ascii_string(res[mount])
+            if res:
+                res = _parse_instrument_data(res)
+                assert mount in res
+                # data is read/written as strings of HEX characters
+                # to avoid firmware weirdness in how it parses GCode arguments
+                return _byte_array_to_ascii_string(res[mount])
         except (ParseError, AssertionError, SmoothieError):
             pass
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -760,7 +760,3 @@ def test_send_command_with_retry(model, monkeypatch):
     count = -1
     with pytest.raises(serial_communication.SerialNoResponse):
         robot._driver._send_command('test')
-
-    count = -1
-    res = robot._driver._send_command('test', retries=4)
-    assert res == 'ok'

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -744,7 +744,7 @@ def test_send_command_with_retry(model, monkeypatch):
     def _no_response(command, ack, connection, timeout):
         nonlocal count
         count += 1
-        if count < 2:
+        if count < 3:
             raise serial_communication.SerialNoResponse('No response')
         else:
             return 'ok'
@@ -760,3 +760,7 @@ def test_send_command_with_retry(model, monkeypatch):
     count = -1
     with pytest.raises(serial_communication.SerialNoResponse):
         robot._driver._send_command('test')
+
+    count = -1
+    res = robot._driver._send_command('test', retries=4)
+    assert res == 'ok'


### PR DESCRIPTION
## overview

When a `ParseError` or `SerialNoResponse` error is raised within the driver, this PR increases the number of command retries from 2 to 3, and also adds a small delay (100ms) between each retry.