### PR TITLE
Switch from testcode -> codeblock in Sphinx

### DIFF
--- a/api/docs/source/atomic commands.rst
+++ b/api/docs/source/atomic commands.rst
@@ -15,7 +15,7 @@ When we handle liquids with a pipette, we are constantly exchanging old, used ti
 
 This section demonstrates the options available for controlling tips
 
-.. testcode:: tips
+.. code-block:: python
 
     '''
     Examples in this section expect the following
@@ -32,7 +32,7 @@ Pick Up Tip
 
 Before any liquid handling can be done, your pipette must have a tip on it. The command ``pick_up_tip()`` will move the pipette over to the specified tip, the press down into it to create a vacuum seal. The below example picks up the tip at location ``'A1'``.
 
-.. testcode:: tips
+.. code-block:: python
 
     pipette.pick_up_tip(tiprack.wells('A1'))
 
@@ -41,13 +41,13 @@ Drop Tip
 
 Once finished with a tip, the pipette will autonomously remove the tip when we call ``drop_tip()``. We can specify where to drop the tip by passing in a location. The below example drops the tip back at its originating location on the tip rack.
 If no location is specified, it will go to the fixed trash location on the deck.
-.. testcode:: tips
+.. code-block:: python
 
     pipette.drop_tip(tiprack.wells('A1'))
 
 Instead of returning a tip to the tip rack, we can also drop it in an alternative trash container besides the fixed trash on the deck.
 
-.. testcode:: tips
+.. code-block:: python
 
     trash = labware.load('trash-box', '1')
     pipette.pick_up_tip(tiprack.wells('A2'))
@@ -58,16 +58,10 @@ Return Tip
 
 When we need to return the tip to its originating location on the tip rack, we can simply call ``return_tip()``. The example below will automatically return the tip to ``'A3'`` on the tip rack.
 
-.. testcode:: tips
+.. code-block:: python
 
     pipette.pick_up_tip(tiprack.wells('A3'))
     pipette.return_tip()
-
-.. testcleanup:: tips
-
-    from opentrons import robot
-
-    robot.reset()
 
 
 **********************
@@ -78,7 +72,7 @@ Tips Iterating
 Automatically iterate through tips and drop tip in trash by attaching containers to a pipette.
 If no location is specified, the pipette will move to the next available tip by iterating through the tiprack that is associated with it.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     '''
     Examples in this section expect the following
@@ -98,7 +92,7 @@ Trash containers can be attached with the option ``trash_container=TRASH_CONTAIN
 
 Multiple tip racks are can be attached with the option ``tip_racks=[RACK_1, RACK_2, etc... ]``.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     pipette = instruments.P300_Single(mount='left',
                                       tip_racks=[tip_rack_1, tip_rack_2],
@@ -116,7 +110,7 @@ Iterating Through Tips
 
 Now that we have two tip racks attached to the pipette, we can automatically step through each tip whenever we call ``pick_up_tip()``. We then have the option to either ``return_tip()`` to the tip rack, or we can ``drop_tip()`` to remove the tip in the attached trash container.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     pipette.pick_up_tip()  # picks up tip_rack_1:A1
     pipette.return_tip()
@@ -135,7 +129,7 @@ If we try to ``pick_up_tip()`` again when all the tips have been used, the Opent
 
     If you run the cell above, and then uncomment and run the cell below, you will get an error because the pipette is out of tips.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     # this will raise an exception if run after the previous code block
     # pipette.pick_up_tip()
@@ -144,7 +138,7 @@ Reseting Tip Tracking
 ---------------------
 If you plan to change out tipracks during the protocol run, you must reset tip tracking to prevent any errors. This is done through ``pipette.reset()`` which resets the tipracks and sets the current volume back to 0 ul.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     pipette.reset()
 
@@ -154,7 +148,7 @@ Select Starting Tip
 
 Calls to ``pick_up_tip()`` will by default start at the attached tip rack's ``'A1'`` location in order of tipracks listed. If you however want to start automatic tip iterating at a different tip, you can use ``start_at_tip()``.
 
-.. testcode:: tipsiterating
+.. code-block:: python
 
     pipette.start_at_tip(tip_rack_1['C3'])
     pipette.pick_up_tip()  # pick up C3 from "tip_rack_1"
@@ -165,7 +159,7 @@ Get Current Tip
 
 Get the source location of the pipette's current tip by calling ``current_tip()``. If the tip was from the ``'A1'`` position on our tip rack, ``current_tip()`` will return that position.
 
-.. testoutput:: tipsinterating
+.. code-block:: python
 
     print(pipette.current_tip())  # is holding no tip
 
@@ -178,9 +172,6 @@ Get the source location of the pipette's current tip by calling ``current_tip()`
 will print out...
 
 
-.. testcleanup:: tipsinterating
-    robot.reset()
-
 **********************
 
 ****************
@@ -192,7 +183,7 @@ Please note that the default now for pipette aspirate and dispense location is a
 
 **********************
 
-.. testcode:: liquid
+.. code-block:: python
 
     from opentrons import labware, instruments, robot
 
@@ -209,7 +200,7 @@ Aspirate
 
 To aspirate is to pull liquid up into the pipette's tip. When calling aspirate on a pipette, we can specify how many micoliters, and at which location, to draw liquid from:
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.aspirate(50, plate.wells('A1'))  # aspirate 50uL from plate:A1
 
@@ -217,7 +208,7 @@ Now our pipette's tip is holding 50uL.
 
 We can also simply specify how many microliters to aspirate, and not mention a location. The pipette in this circumstance will aspirate from it's current location (which we previously set as ``plate.wells('A1'))``.
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.aspirate(50)                     # aspirate 50uL from current position
 
@@ -225,7 +216,7 @@ Now our pipette's tip is holding 100uL.
 
 We can also specify only the location to aspirate from. If we do not tell the pipette how many micoliters to aspirate, it will by default fill up the remaining volume in it's tip. In this example, since we already have 100uL in the tip, the pipette will aspirate another 200uL
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.aspirate(plate.wells('A2'))      # aspirate until pipette fills from plate:A2
 
@@ -235,7 +226,7 @@ Dispense
 
 To dispense is to push out liquid from the pipette's tip. It's usage in the Opentrons API is nearly identical to ``aspirate()``, in that you can specify microliters and location, only microliters, or only a location:
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.dispense(50, plate.wells('B1')) # dispense 50uL to plate:B1
     pipette.dispense(50)                    # dispense 50uL to current position
@@ -250,7 +241,7 @@ To blow out is to push an extra amount of air through the pipette's tip, so as t
 
 When calling ``blow_out()`` on a pipette, we have the option to specify a location to blow out the remaining liquid. If no location is specified, the pipette will blow out from it's current position.
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.blow_out()                  # blow out in current location
     pipette.blow_out(plate.wells('B3')) # blow out in current plate:B3
@@ -263,7 +254,7 @@ To touch tip is to move the pipette's currently attached tip to four opposite ed
 
 When calling ``touch_tip()`` on a pipette, we have the option to specify a location where the tip will touch the inner walls. If no location is specified, the pipette will touch tip inside it's current location.
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.touch_tip()                  # touch tip within current location
     pipette.touch_tip(-2)                # touch tip 2mm below the top of the current location
@@ -277,7 +268,7 @@ Mixing is simply performing a series of ``aspirate()`` and ``dispense()`` comman
 
 The mix command takes three arguments: ``mix(repetitions, volume, location)``
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.mix(4, 100, plate.wells('A2'))   # mix 4 times, 100uL, in plate:A2
     pipette.mix(3, 50)                       # mix 3 times, 50uL, in current location
@@ -289,18 +280,16 @@ Air Gap
 
 Some liquids need an extra amount of air in the pipette's tip to prevent it from sliding out. A call to ``air_gap()`` with a microliter amount will aspirate that much air into the tip.
 
-.. testcode:: liquid
+.. code-block:: python
 
     pipette.aspirate(100, plate.wells('B4'))
     pipette.air_gap(20)
     pipette.drop_tip()
 
-.. testcleanup:: liquid
-    robot.reset()
 
 **********************
 
-.. testcode:: moving
+.. code-block:: python
 
     from opentrons import labware, instruments, robot
 
@@ -323,13 +312,13 @@ Pipette's are able to ``move_to()`` any location on the deck.
 
 For example, we can move to the first tip in our tip rack:
 
-.. testcode:: moving
+.. code-block:: python
 
     pipette.move_to(tiprack.wells('A1'))
 
 You can also specify at what height you would like the robot to move to inside of a location using ``top()`` and ``bottom()`` methods on that location.
 
-.. testcode:: moving
+.. code-block:: python
 
     pipette.move_to(plate.wells('A1').bottom())  # move to the bottom of well A1
     pipette.move_to(plate.wells('A1').top())     # move to the top of well A1
@@ -338,7 +327,7 @@ You can also specify at what height you would like the robot to move to inside o
 
 The above commands will cause the robot's head to first move upwards, then over to above the target location, then finally downwards until the target location is reached. If instead you would like the robot to mive in a straight line to the target location, you can set the movement strategy to ``'direct'``.
 
-.. testcode:: moving
+.. code-block:: python
 
     pipette.move_to(plate.wells('A1'), strategy='direct')
 
@@ -348,7 +337,7 @@ The above commands will cause the robot's head to first move upwards, then over 
 
 Usually the ``strategy='direct'`` option is useful when moving inside of a well. Take a look at the below sequence of movements, which first move the head to a well, and use 'direct' movements inside that well, then finally move on to a different well.
 
-.. testcode:: moving
+.. code-block:: python
 
     pipette.move_to(plate.wells('A1'))
     pipette.move_to(plate.wells('A1').bottom(1), strategy='direct')
@@ -360,11 +349,9 @@ Delay
 
 To have your protocol pause for any given number of minutes or seconds, simply call ``delay()`` on your pipette. The value passed into ``delay()`` is the number of minutes or seconds the robot will wait until moving on to the next commands.
 
-.. testcode:: moving
+.. code-block:: python
 
     pipette.delay(seconds=2)             # pause for 2 seconds
     pipette.delay(minutes=5)             # pause for 5 minutes
     pipette.delay(minutes=5, seconds=2)  # pause for 5 minutes and 2 seconds
 
-.. testcleanup:: moving
-    robot.reset()

--- a/api/docs/source/complex commands.rst
+++ b/api/docs/source/complex commands.rst
@@ -1,6 +1,12 @@
 .. _complex commands:
 
-.. testsetup:: *
+#######################
+Complex Liquid Handling
+#######################
+
+The examples below will use the following set-up:
+
+.. code-block:: python
 
     from opentrons import robot, labware, instruments
 
@@ -14,11 +20,6 @@
         mount='left',
         tip_racks=[tiprack])
 
-#######################
-Complex Liquid Handling
-#######################
-
-
 **********************
 
 Transfer
@@ -31,7 +32,7 @@ Basic
 
 The example below will transfer 100 uL from well ``'A1'`` to well ``'B1'``, automatically picking up a new tip and then disposing it when finished.
 
-.. testcode:: transfer
+.. code-block:: python
 
     pipette.transfer(100, plate.wells('A1'), plate.wells('B1'))
 
@@ -43,7 +44,7 @@ Large Volumes
 
 Volumes larger than the pipette's ``max_volume`` will automatically divide into smaller transfers.
 
-.. testcode:: transfer_1
+.. code-block:: python
 
     pipette.transfer(700, plate.wells('A2'), plate.wells('B2'))
 
@@ -52,8 +53,7 @@ Volumes larger than the pipette's ``max_volume`` will automatically divide into 
 
 will print out...
 
-.. testoutput:: transfer_1
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 700 from <Well A2> to <Well B2>
     Picking up tip <Well A1>
@@ -72,7 +72,7 @@ Multiple Wells
 
 Transfer commands are most useful when moving liquid between multiple wells.
 
-.. testcode:: transfer_2
+.. code-block:: python
 
     pipette.transfer(100, plate.cols('1'), plate.cols('2'))
 
@@ -81,8 +81,7 @@ Transfer commands are most useful when moving liquid between multiple wells.
 
 will print out...
 
-.. testoutput:: transfer_2
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3><Well A4><Well A5><Well A6><Well A7><Well A8><Well A9><Well A10><Well A11><Well A12>> to <WellSeries: <Well B1><Well B2><Well B3><Well B4><Well B5><Well B6><Well B7><Well B8><Well B9><Well B10><Well B11><Well B12>>
     Picking up tip <Well A1>
@@ -117,7 +116,7 @@ One to Many
 
 You can transfer from a single source to multiple destinations, and the other way around (many sources to one destination).
 
-.. testcode:: transfer_3
+.. code-block:: python
 
     pipette.transfer(100, plate.wells('A1'), plate.rows('2'))
 
@@ -126,8 +125,7 @@ You can transfer from a single source to multiple destinations, and the other wa
 
 will print out...
 
-.. testoutput:: transfer_3
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Picking up tip <Well A1>
@@ -154,7 +152,7 @@ Few to Many
 
 What happens if, for example, you tell your pipette to transfer from 4 source wells to 2 destination wells? The transfer command will attempt to divide the wells evenly, or raise an error if the number of wells aren't divisible.
 
-.. testcode:: transfer_4
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -166,8 +164,7 @@ What happens if, for example, you tell your pipette to transfer from 4 source we
 
 will print out...
 
-.. testoutput:: transfer_4
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3><Well A4>> to <WellSeries: <Well B1><Well B2>>
     Picking up tip <Well A1>
@@ -186,7 +183,7 @@ List of Volumes
 
 Instead of applying a single volume amount to all source/destination wells, you can instead pass a list of volumes.
 
-.. testcode:: transfer_5
+.. code-block:: python
 
     pipette.transfer(
         [20, 40, 60],
@@ -198,8 +195,7 @@ Instead of applying a single volume amount to all source/destination wells, you 
 
 will print out...
 
-.. testoutput:: transfer_5
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring [20, 40, 60] from <Well A1> to <WellSeries: <Well B1><Well B2><Well B3>>
     Picking up tip <Well A1>
@@ -216,7 +212,7 @@ Volume Gradient
 
 Create a linear gradient between a start and ending volume (uL). The start and ending volumes must be the first and second elements of a tuple.
 
-.. testcode:: transfer_6
+.. code-block:: python
 
     pipette.transfer(
         (100, 30),
@@ -228,8 +224,7 @@ Create a linear gradient between a start and ending volume (uL). The start and e
 
 will print out...
 
-.. testoutput:: transfer_6
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring (100, 30) from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Picking up tip <Well A1>
@@ -263,7 +258,7 @@ Consolidate
 
 Volumes going to the same destination well are combined within the same tip, so that multiple aspirates can be combined to a single dispense.
 
-.. testcode:: distributeconsolidate_1
+.. code-block:: python
 
     pipette.consolidate(30, plate.rows('2'), plate.wells('A1'))
 
@@ -272,8 +267,7 @@ Volumes going to the same destination well are combined within the same tip, so 
 
 will print out...
 
-.. testoutput:: distributeconsolidate_1
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Consolidating 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <Well A1>
     Transferring 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <Well A1>
@@ -292,7 +286,7 @@ will print out...
 
 If there are multiple destination wells, the pipette will never combine their volumes into the same tip.
 
-.. testcode:: distributeconsolidate_2
+.. code-block:: python
 
     pipette.consolidate(30, plate.rows('2'), plate.wells('A1', 'A2'))
 
@@ -301,8 +295,7 @@ If there are multiple destination wells, the pipette will never combine their vo
 
 will print out...
 
-.. testoutput:: distributeconsolidate_2
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Consolidating 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <WellSeries: <Well A1><Well A2>>
     Transferring 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <WellSeries: <Well A1><Well A2>>
@@ -324,7 +317,7 @@ Distribute
 
 Volumes from the same source well are combined within the same tip, so that one aspirate can provide for multiple dispenses.
 
-.. testcode:: distributeconsolidate_3
+.. code-block:: python
 
     pipette.distribute(55, plate.wells('A1'), plate.rows('2'))
 
@@ -333,8 +326,7 @@ Volumes from the same source well are combined within the same tip, so that one 
 
 will print out...
 
-.. testoutput:: distributeconsolidate_3
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Distributing 55 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Transferring 55 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
@@ -355,7 +347,7 @@ will print out...
 
 If there are multiple source wells, the pipette will never combine their volumes into the same tip.
 
-.. testcode:: distributeconsolidate_4
+.. code-block:: python
 
     pipette.distribute(30, plate.wells('A1', 'A2'), plate.rows('2'))
 
@@ -364,8 +356,7 @@ If there are multiple source wells, the pipette will never combine their volumes
 
 will print out...
 
-.. testoutput:: distributeconsolidate_4
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
@@ -387,7 +378,7 @@ Disposal Volume
 
 When dispensing multiple times from the same tip, it is recommended to aspirate an extra amount of liquid to be disposed of after distributing. This added ``disposal_vol`` can be set as an optional argument.
 
-.. testcode:: distributeconsolidate_5
+.. code-block:: python
 
     pipette.distribute(
         30,
@@ -400,8 +391,7 @@ When dispensing multiple times from the same tip, it is recommended to aspirate 
 
 will print out...
 
-.. testoutput:: distributeconsolidate_5
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
@@ -424,7 +414,7 @@ will print out...
 
     If you do not specify a ``disposal_vol``, the pipette will by default use a ``disposal_vol`` equal to it's ``min_volume``. This tutorial has not given the pipette any ``min_volume``, so below is an example of allowing the pipette's ``min_volume`` to be used as a default for ``disposal_vol``.
 
-.. testcode:: distributeconsolidate_6
+.. code-block:: python
 
     pipette.min_volume = 20  # `min_volume` is used as default to `disposal_vol`
 
@@ -438,8 +428,7 @@ will print out...
 
 will print out...
 
-.. testoutput:: distributeconsolidate_6
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
@@ -472,7 +461,7 @@ Transfer commands will by default use the same one tip for each well, then final
 
 The pipette can optionally get a new tip at the beginning of each aspirate, to help avoid cross contamination.
 
-.. testcode:: options_1
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -485,8 +474,7 @@ The pipette can optionally get a new tip at the beginning of each aspirate, to h
 
 will print out...
 
-.. testoutput:: options_1
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3>> to <WellSeries: <Well B1><Well B2><Well B3>>
     Picking up tip <Well A1>
@@ -507,7 +495,7 @@ Never Get a New Tip
 
 For scenarios where you instead are calling ``pick_up_tip()`` and ``drop_tip()`` elsewhere in your protocol, the transfer command can ignore picking up or dropping tips.
 
-.. testcode:: options_2
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -520,8 +508,7 @@ For scenarios where you instead are calling ``pick_up_tip()`` and ``drop_tip()``
 
 will print out...
 
-.. testoutput:: options_2
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3>> to <WellSeries: <Well B1><Well B2><Well B3>>
     Aspirating 100.0 uL from <Well A1> at 1 speed
@@ -536,7 +523,7 @@ Trash or Return Tip
 
 By default, the transfer command will drop the pipette's tips in the trash container. However, if you wish to instead return the tip to it's tip rack, you can set ``trash=False``.
 
-.. testcode:: options_3
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -549,8 +536,7 @@ By default, the transfer command will drop the pipette's tips in the trash conta
 
 will print out...
 
-.. testoutput:: options_3
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <Well B1>
     Picking up tip <Well A1>
@@ -564,7 +550,7 @@ Touch Tip
 
 A touch-tip can be performed after every aspirate and dispense by setting ``touch_tip=True``.
 
-.. testcode:: options_4
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -577,8 +563,7 @@ A touch-tip can be performed after every aspirate and dispense by setting ``touc
 
 will print out...
 
-.. testoutput:: options_4
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <Well A2>
     Picking up tip <Well A1>
@@ -593,7 +578,7 @@ Blow Out
 
 A blow-out can be performed after every dispense that leaves the tip empty by setting ``blow_out=True``.
 
-.. testcode:: options_5
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -606,8 +591,7 @@ A blow-out can be performed after every dispense that leaves the tip empty by se
 
 will print out...
 
-.. testoutput:: options_5
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <Well A2>
     Picking up tip <Well A1>
@@ -621,7 +605,7 @@ Mix Before/After
 
 A mix can be performed before every aspirate by setting ``mix_before=``. The value of ``mix_before=`` must be a tuple, the 1st value is the number of repetitions, the 2nd value is the amount of liquid to mix.
 
-.. testcode:: options_6
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -635,8 +619,7 @@ A mix can be performed before every aspirate by setting ``mix_before=``. The val
 
 will print out...
 
-.. testoutput:: options_6
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <Well A2>
     Picking up tip <Well A1>
@@ -661,7 +644,7 @@ Air Gap
 
 An air gap can be performed after every aspirate by setting ``air_gap=int``, where the value is the volume of air in microliters to aspirate after aspirating the liquid.
 
-.. testcode:: options_7
+.. code-block:: python
 
     pipette.transfer(
         100,
@@ -674,8 +657,7 @@ An air gap can be performed after every aspirate by setting ``air_gap=int``, whe
 
 will print out...
 
-.. testoutput:: options_7
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Transferring 100 from <Well A1> to <Well A2>
     Picking up tip <Well A1>

--- a/api/docs/source/examples.rst
+++ b/api/docs/source/examples.rst
@@ -6,7 +6,7 @@ Examples
 
 All examples on this page assume the following labware and pipette:
 
-.. testcode:: examples
+.. code-block:: python
 
   from opentrons import robot, labware, instruments
 
@@ -28,13 +28,13 @@ Basic Transfer
 
 Moving 100uL from one well to another:
 
-.. testcode:: examples
+.. code-block:: python
 
   p300.transfer(100, plate.wells('A1'), plate.wells('B1'))
 
 If you prefer to not use the ``.transfer()`` command, the following pipette commands will create the some results:
 
-.. testcode:: examples
+.. code-block:: python
 
   p300.pick_up_tip()
   p300.aspirate(100, plate.wells('A1'))
@@ -49,7 +49,7 @@ Loops
 
 Loops in Python allows your protocol to perform many actions, or act upon many wells, all within just a few lines. The below example loops through the numbers ``0`` to ``11``, and uses that loop's current value to transfer from all wells in a trough to each row of a plate:
 
-.. testcode:: examples
+.. code-block:: python
 
   # distribute 20uL from trough:A1 -> plate:row:1
   # distribute 20uL from trough:A2 -> plate:row:2
@@ -67,7 +67,7 @@ Multiple Air Gaps
 
 The Opentrons liquid handler can do some things that a human cannot do with a pipette, like accurately alternate between aspirating and creating air gaps within the same tip. The below example will aspirate from five wells in the trough, while creating a air gap between each sample.
 
-.. testcode:: examples
+.. code-block:: python
 
   p300.pick_up_tip()
 
@@ -86,7 +86,7 @@ Dilution
 
 This example first spreads a dilutent to all wells of a plate. It then dilutes 8 samples from the trough across the 8 columns of the plate.
 
-.. testcode:: examples
+.. code-block:: python
 
   p300.distribute(50, trough.wells('A12'), plate.wells())  # dilutent
 
@@ -113,7 +113,7 @@ Plate Mapping
 
 Deposit various volumes of liquids into the same plate of wells, and automatically refill the tip volume when it runs out.
 
-.. testcode:: examples
+.. code-block:: python
 
   # these uL values were created randomly for this example
   water_volumes = [
@@ -179,7 +179,7 @@ Precision Pipetting
 
 This example shows how to deposit liquid around the edge of a well.
 
-.. testcode:: examples
+.. code-block:: python
 
   p300.pick_up_tip()
   p300.aspirate(200, trough.wells('A1'))

--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. testsetup:: *
+.. code-block:: python
 
   from opentrons import robot, containers, instruments
 
@@ -40,7 +40,7 @@ The design goal of the Opentrons API is to make code readable and easy to unders
 
 If we were to rewrite this with the Opentrons API, it would look like the following:
 
-.. testcode:: helloworld
+.. code-block:: python
 
     # imports
     from opentrons import containers, instruments
@@ -74,7 +74,7 @@ When writing in Python, you must always include the Opentrons API within your fi
 
 From the example above, the "imports" section looked like:
 
-.. testcode:: imports
+.. code-block:: python
 
     from opentrons import containers, instruments
 
@@ -88,7 +88,7 @@ Each container is given a type (ex: ``'96-flat'``), and the slot on the robot it
 
 From the example above, the "containers" section looked like:
 
-.. testcode:: imports
+.. code-block:: python
 
     plate = containers.load('96-flat', 'B1')
     tiprack = containers.load('tiprack-200ul', 'A1')
@@ -102,7 +102,7 @@ There are other parameters for pipettes, but the most important are the ``max_vo
 
 From the example above, the "pipettes" section looked like:
 
-.. testcode:: imports
+.. code-block:: python
 
     pipette = instruments.Pipette(axis='b', max_volume=200, tip_racks=[tiprack])
 
@@ -115,7 +115,7 @@ This section can tend to get long, relative to the complexity of your protocol. 
 
 From the example above, the "commands" section looked like:
 
-.. testcode:: imports
+.. code-block:: python
 
     pipette.transfer(100, plate.wells('A1'), plate.wells('B1'))
 

--- a/api/docs/source/labware.rst
+++ b/api/docs/source/labware.rst
@@ -1,9 +1,5 @@
 .. _containers:
 
-.. testsetup:: *
-
-    from opentrons import containers, robot
-    robot.reset()
 
 ######################
 Containers
@@ -279,7 +275,7 @@ The containers module allows you to load common labware into your protocol. `Go 
 
 __ https://andysigler.github.io/ot-api-containerviz/
 
-.. testcode:: containers
+.. code-block:: python
 
     '''
     Examples in this section require the following
@@ -291,7 +287,7 @@ List
 
 Once the container module is loaded, you can see a list of all containers currently inside the API by calling ``containers.list()``
 
-.. testcode:: containers
+.. code-block:: python
 
     containers.list()
 
@@ -300,13 +296,13 @@ Load
 
 Labware is loaded with two arguments: 1) the container type, and 2) the deck slot it will be placed in on the robot.
 
-.. testcode:: containers
+.. code-block:: python
 
     p = containers.load('96-flat', 'B1')
 
 A third optional argument can be used to give a container a unique name.
 
-.. testcode:: containers_2
+.. code-block:: python
 
     p = containers.load('96-flat', 'B1', 'any-name-you-want')
 
@@ -320,7 +316,7 @@ __ https://opentrons.com/getting-started/calibrate-deck
 
 Names can also be used to place multiple containers in the same slot all at once, using the `share=True` argument. For example, the flasks below are all placed in slot D1. So in order for the Opentrons API to tell them apart, we have given them each a unique name.
 
-.. testcode:: containers
+.. code-block:: python
 
     fa = containers.load('T25-flask', 'D1', 'flask_a')
     fb = containers.load('T25-flask', 'D1', 'flask_b', share=True)
@@ -333,7 +329,7 @@ In addition to the default containers that come with the Opentrons API, you can 
 
 Through the API's call containers.create(), you can create simple grid containers, which consist of circular wells arranged in columns and rows.
 
-.. testcode:: containers_custom
+.. code-block:: python
 
     custom_plate = containers.create(
         '3x6_plate',                    # name of you container
@@ -345,15 +341,14 @@ Through the API's call containers.create(), you can create simple grid container
 
 When you create your custom container it will return the custom plate. If you would like to save this container to the robot's containers library you can pass save=True and it will be saved for later use under the name you've given it. This means you can use containers.load() to use the custom container you've created in this and any future protocol.
 
-.. testcode:: containers_custom
+.. code-block:: python
 
     for well in custom_plate.wells():
         print(well)
 
 will print out...
 
-.. testoutput:: containers_custom
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well B1>
@@ -374,18 +369,13 @@ will print out...
     <Well B6>
     <Well C6>
 
-.. testsetup:: pipettes
-
-    from opentrons import instruments, robot
-    robot.reset()
 
 **********************
 
-.. testsetup:: individualwells
+.. code-block:: python
 
     from opentrons import containers, robot
 
-    robot.reset()
     plate = containers.load('96-flat', 'A1')
 
 ******************
@@ -401,7 +391,7 @@ The OT-One deck and containers are all set up with the same coordinate system - 
 
 .. image:: img/well_iteration/Well_Iteration.png
 
-.. testcode:: individualwells
+.. code-block:: python
 
     '''
     Examples in this section expect the following
@@ -415,7 +405,7 @@ Wells by Name
 
 Once a container is loaded into your protocol, you can easily access the many wells within it using ``wells()`` method. ``wells()`` takes the name of the well as an argument, and will return the well at that location.
 
-.. testcode:: individualwells
+.. code-block:: python
 
     plate.wells('A1')
     plate.wells('H12')
@@ -425,7 +415,7 @@ Wells by Index
 
 Wells can be referenced by their "string" name, as demonstrated above. However, they can also be referenced with zero-indexing, with the first well in a container being at position 0.
 
-.. testcode:: individualwells
+.. code-block:: python
 
     plate.wells(0)   # well A1
     plate.wells(95)  # well H12
@@ -437,7 +427,7 @@ Columns and Rows
 A container's wells are organized within a series of columns and rows, which are also labelled on standard labware. In the API, columns are given letter names (``'A'`` through ``'H'`` for example) and go left to right, while rows are given numbered names (``'1'`` through ``'8'`` for example) and go from front to back.
 You can access a specific row or column by using the ``rows()`` and ``cols()`` methods on a container. These will return all wells within that row or column.
 
-.. testcode:: individualwells
+.. code-block:: python
 
     column = plate.cols('A')
     row = plate.rows('1')
@@ -447,26 +437,24 @@ You can access a specific row or column by using the ``rows()`` and ``cols()`` m
 
 will print out...
 
-.. testoutput:: individualwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Column "A" has 12 wells
     Row "1" has 8 wells
 
 The ``rows()`` or ``cols()`` methods can be used in combination with the ``wells()`` method to access wells within that row or column. In the example below, both lines refer to well ``'A1'``.
 
-.. testcode:: individualwells
+.. code-block:: python
 
     plate.cols('A').wells('1')
     plate.rows('1').wells('A')
 
 **********************
 
-.. testsetup:: multiwells
+.. code-block:: python
 
     from opentrons import containers, robot
 
-    robot.reset()
     plate = containers.load('96-flat', 'A1')
 
 
@@ -477,7 +465,7 @@ If we had to reference each well one at a time, our protocols could get very ver
 
 When describing a liquid transfer, we can point to groups of wells for the liquid's source and/or destination. Or, we can get a group of wells that we want to loop through.
 
-.. testcode:: multiwells
+.. code-block:: python
 
     '''
     Examples in this section expect the following
@@ -493,7 +481,7 @@ The ``wells()`` method can return a single well, or it can return a list of well
 
 Here is an example or accessing a list of wells, each specified by name:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     w = plate.wells('A1', 'B2', 'C3', 'H12')
 
@@ -501,22 +489,20 @@ Here is an example or accessing a list of wells, each specified by name:
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <WellSeries: <Well A1><Well B2><Well C3><Well H12>>
 
 Multiple wells can be treated just like a normal Python list, and can be iterated through:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('A1', 'B2', 'C3', 'H12'):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well B2>
@@ -528,15 +514,14 @@ Wells To
 
 Instead of having to list the name of every well, we can also create a range of wells with a start and end point. The first argument is the starting well, and the ``to=`` argument is the last well.
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('A1', to='H1'):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well B1>
@@ -549,15 +534,14 @@ will print out...
 
 Not only can we get every well between the start and end positions, but we can also set the ``step=`` size. The example below will access every 2nd well between ``'A1'`` and ``'H'``:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('A1', to='H1', step=2):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well C1>
@@ -566,15 +550,14 @@ will print out...
 
 These lists of wells can also move in the reverse direction along your container. For example, setting the ``to=`` argument to a well that comes before the starting position is allowed:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('H1', to='A1', step=2):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well H1>
     <Well F1>
@@ -586,15 +569,14 @@ Wells Length
 
 Another way you can create a list of wells is by specifying the length= of the well list you need, in addition to the starting point. The example below will return eight wells, starting at well ``'A1'``:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('A1', length=8):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well B1>
@@ -607,15 +589,14 @@ will print out...
 
 And just like before, we can also set the ``step=`` argument. Except this time the example will be accessing every 3rd well, until a total of eight wells have been found:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('A1', length=8, step=3):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well D1>
@@ -628,15 +609,14 @@ will print out...
 
 You can set the step= value to a negative number to move in the reverse direction along the container:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.wells('H11', length=8, step=-1):
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well H11>
     <Well G11>
@@ -655,15 +635,14 @@ The same arguments described above can be used with ``rows()`` and ``cols()`` to
 
 Here is an example of iterating through rows:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for r in plate.rows('2', length=3, step=-2):
         print(r)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
     <WellSeries: <Well A12><Well B12><Well C12><Well D12><Well E12><Well F12><Well G12><Well H12>>
@@ -671,15 +650,14 @@ will print out...
 
 And here is an example of iterating through columns:
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for c in plate.cols('B', to='F', step=2):
         print(c)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <WellSeries: <Well B1><Well B2><Well B3><Well B4><Well B5><Well B6><Well B7><Well B8><Well B9><Well B10><Well B11><Well B12>>
     <WellSeries: <Well D1><Well D2><Well D3><Well D4><Well D5><Well D6><Well D7><Well D8><Well D9><Well D10><Well D11><Well D12>>
@@ -691,15 +669,14 @@ Slices
 
 Containers can also be treating similarly to Python lists, and can therefore handle slices.
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate[0:8:2]:
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well C1>
@@ -708,30 +685,28 @@ will print out...
 
 The API's containers are also prepared to take string values for the slice's ``start`` and ``stop`` positions.
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate['A1':'A2':2]:
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well A1>
     <Well C1>
     <Well E1>
     <Well G1>
 
-.. testcode:: multiwells
+.. code-block:: python
 
     for w in plate.cols['B']['1'::2]:
         print(w)
 
 will print out...
 
-.. testoutput:: multiwells
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     <Well B1>
     <Well B3>

--- a/api/docs/source/pipettes.rst
+++ b/api/docs/source/pipettes.rst
@@ -8,7 +8,7 @@ The ``instruments`` module gives your protocol access to the ``Pipette``, which 
 Creating a Pipette
 ******************
 
-.. testcode:: pipettes
+.. code-block:: python
 
     '''
     Examples in this section require the following:
@@ -19,6 +19,8 @@ Creating a Pipette
 Pipette Model(s)
 ===================
 Currently in our API there are 7 pipette models to correspond with the offered pipette models on our website.
+
+.. note::
 
 They are as follows:
 ``P10_Single`` (1 - 10 ul)
@@ -38,7 +40,7 @@ Mount
 To create a ``Pipette``, you must give it a mount. The mount can be either ``'left'`` or ``'right'``.
 In this example, we are using a Single-Channel 300uL pipette.
 
-.. testcode:: pipettes
+.. code-block:: python
 
     pipette = instruments.P300_Single(mount='left')
 
@@ -49,15 +51,11 @@ Plunger Flow Rates
 The speeds at which the pipette will aspirate and dispense can be set through ``aspirate_speed`` and ``dispense_speed``.
 The values are in microliters/seconds, and have varying defaults depending on the model.
 
-default to ``aspirate_flow_rate=300`` and ``dispense_flow_rate=500``.
 
-.. testcode:: pipettes
+.. code-block:: python
 
     pipette = instruments.P300_Single(
         mount='right',
         aspirate_flow_rate=200,
         dispense_flow_rate=600)
 
-.. testcleanup:: pipettes
-
-    robot.reset()

--- a/api/docs/source/robot.rst
+++ b/api/docs/source/robot.rst
@@ -1,6 +1,6 @@
 .. _robot:
 
-.. testsetup:: robot
+.. code-block:: python
 
     from opentrons import robot
     robot.reset()
@@ -15,7 +15,7 @@ Advanced Control
 
 The robot module can be thought of as the parent for all aspects of the Opentrons API. All containers, instruments, and protocol commands are added to and controlled by robot.
 
-.. testcode:: robot
+.. code-block:: python
 
     '''
     Examples in this section require the following
@@ -33,7 +33,7 @@ User-Specified Pause
 
 This will pause your protocol at a specific step. You can resume by pressing 'resume' in your OT App.
 
-.. testcode:: robot
+.. code-block:: python
 
 robot.pause()
 
@@ -42,7 +42,7 @@ Head Speed
 
 The maximum speed of the robot's head can be set using ``robot.head_speed()``. The value we set the speed to is in millimeters-per-second (mm/sec).
 
-.. testcode:: robot
+.. code-block:: python
 
     robot.head_speed(5000)
 
@@ -55,7 +55,7 @@ Homing
 
 You can `home` the robot by calling ``home()``. You can also specify axes. The robot will home immdediately when this call is made.
 
-.. testcode:: robot
+.. code-block:: python
 
     robot.home()           # home the robot on all axis
     robot.home('z')        # home the Z axis only
@@ -67,7 +67,7 @@ When commands are called on a pipette, they are recorded on the ``robot`` in the
 
 __ https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists
 
-.. testcode:: robot
+.. code-block:: python
 
     pipette.pick_up_tip(tiprack.wells('A1'))
     pipette.drop_tip(tiprack.wells('A1'))
@@ -77,8 +77,7 @@ __ https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Picking up tip <Well A1>
     Dropping tip <Well A1>
@@ -88,7 +87,7 @@ Clear Commands
 
 We can erase the robot command history by calling ``robot.clear_commands()``. Any previously created instruments and containers will still be inside robot, but the commands history is erased.
 
-.. testcode:: robot
+.. code-block:: python
 
     robot.clear_commands()
     pipette.pick_up_tip(tiprack['A1'])
@@ -99,8 +98,7 @@ We can erase the robot command history by calling ``robot.clear_commands()``. An
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     There is 1 command
     There are now 0 commands
@@ -110,7 +108,7 @@ Comment
 
 You can add a custom message to the list of command descriptions you see when running ``robot.commands()``. This command is ``robot.comment()``, and it allows you to print out any information you want at the point in your protocol
 
-.. testcode:: robot
+.. code-block:: python
 
     robot.clear_commands()
 
@@ -125,8 +123,7 @@ You can add a custom message to the list of command descriptions you see when ru
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     Picking up tip <Well A1>
     Hello, just picked up tip A1
@@ -140,15 +137,14 @@ When containers are loaded, they are automatically added to the ``robot``. You c
 
 __ https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists
 
-.. testcode:: robot
+.. code-block:: python
 
     for container in robot.get_containers():
         print(container.get_name(), container.get_type())
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     my-rack tiprack-200ul
     my-plate 96-flat
@@ -160,15 +156,14 @@ When instruments are created, they are automatically added to the ``robot``. You
 
 __ https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists
 
-.. testcode:: robot
+.. code-block:: python
 
     for axis, pipette in robot.get_instruments():
         print(pipette.name, axis)
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     my-pipette B
 
@@ -177,7 +172,7 @@ Reset
 
 Calling ``robot.reset()`` will remove everything from the robot. Any previously added containers, pipettes, or commands will be erased.
 
-.. testcode:: robot
+.. code-block:: python
 
     robot.reset()
     print(robot.get_containers())
@@ -186,8 +181,7 @@ Calling ``robot.reset()`` will remove everything from the robot. Any previously 
 
 will print out...
 
-.. testoutput:: robot
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+.. code-block:: python
 
     []
     []


### PR DESCRIPTION
## overview

Above says it all. Got tired of trying to make code run correctly with Sphinx testing modules so switch the docs to a code-block.

Will attempt to fix the api source code tests next. Tune in next time

## changelog
- All docs pages were affected, but only change is switching from 'testCode' call out to 'code-block' 

## review requests
