### PR TITLE
pd: fix tip removed from one tip affects other tipracks bug

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -61,10 +61,13 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
     const tipracks: TiprackTipState = reduce(
       labware,
       (acc: TiprackTipState, labwareData: StepGeneration.LabwareData, labwareId: string) => {
-        if (labwareData.type.startsWith('tiprack')) {
+        // TODO Ian 2018-05-18 have a more robust way of designating labware types
+        // as tiprack or not
+        if (labwareData.type && labwareData.type.startsWith('tiprack')) {
           return {
             ...acc,
-            [labwareId]: all96Tips
+            // TODO LATER Ian 2018-05-18 use shared-data wells instead of assuming 96 tips?
+            [labwareId]: {...all96Tips}
           }
         }
         return acc

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -498,7 +498,7 @@ export function generateSubsteps (
 
       if (!namedIngredsByLabware) {
         // TODO Ian 2018-05-02 another assert candidate here
-        console.warn(`No namedIngredsByLabware for previous step id ${prevStepId}`)
+        console.warn(`No namedIngredsByLabware for previous step id ${prevStepId}`, namedIngredsByLabwareAllSteps)
         return null
       }
 


### PR DESCRIPTION
## overview

@howisthisnamenottakenyet discovered that adding tip racks didn't dismiss the "Insufficient Tips" error. This turned out to be because all tipracks' tip tracking states were accidentally using the same object, so when a tip (eg tip B3) was removed from one well, it simultaneously got removed from all tipracks.

## changelog

- tipracks don't share tip state
- comments for later TODOs

## review requests

- You should be able to use more than 96 tips
- The "Insufficient tips" error should go away when you add a new tiprack