### PR TITLE
PD: fix liquid tracking bug on aspirating from trough

### DIFF
--- a/protocol-designer/src/step-generation/test-with-flow/aspirateUpdateLiquidState.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirateUpdateLiquidState.test.js
@@ -271,15 +271,18 @@ describe('...8-channel pipette', () => {
   test('aspirate from single-ingredient common well (trough-12row)', () => {
     let initialLiquidState = getBlankLiquidState('trough-12row')
 
+    const initialSourceVolume = 300
+    const aspirateVolume = 20
+
     initialLiquidState.labware.sourcePlateId = {
       ...initialLiquidState.labware.sourcePlateId,
-      A1: {ingred1: {volume: 300}}
+      A1: {ingred1: {volume: initialSourceVolume}}
     }
 
     const args = {
       ...aspirate8Ch50FromA1Args,
       labwareType: 'trough-12row',
-      volume: 100
+      volume: aspirateVolume
     }
 
     const result = updateLiquidState(args, initialLiquidState)
@@ -288,12 +291,12 @@ describe('...8-channel pipette', () => {
       pipettes: {
         p300MultiId: {
           // aspirate volume divided among the 8 tips
-          ...createTipLiquidState(8, {ingred1: {volume: 100 / 8}})
+          ...createTipLiquidState(8, {ingred1: {volume: aspirateVolume}})
         }
       },
       labware: {
         sourcePlateId: {
-          A1: {ingred1: {volume: 200}}
+          A1: {ingred1: {volume: initialSourceVolume - (aspirateVolume * 8)}}
         }
       }
     })

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -134,6 +134,8 @@ type TipId = string
 
 export type LocationLiquidState = {[ingredGroup: string]: {volume: number}}
 
+export type SingleLabwareLiquidState = {[well: string]: LocationLiquidState}
+
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
   instruments: {

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -13,8 +13,6 @@ import type {Selector} from '../types'
 import type {StepSubItemData} from '../steplist/types'
 import type {ProcessedFormData} from '../form-types'
 
-type SingleLabwareLiquidState = {[well: string]: StepGeneration.LocationLiquidState}
-
 type AllWellHighlights = {[wellName: string]: true} // NOTE: all keys are true
 type AllWellHighlightsAllLabware = {[labwareId: string]: AllWellHighlights}
 
@@ -134,7 +132,7 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
   allSubsteps,
   (_robotStateTimeline, _forms, _hoveredStepId, _hoveredSubstep, _allSubsteps) => {
     function highlightedWellsForLabwareAtStep (
-      labwareLiquids: SingleLabwareLiquidState,
+      labwareLiquids: StepGeneration.SingleLabwareLiquidState,
       labwareId: string,
       robotState: StepGeneration.RobotState,
       form: ProcessedFormData,
@@ -169,7 +167,7 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
       // replace value of each labware with highlighted wells info
       return mapValues(
         liquidState,
-        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => (form)
+        (labwareLiquids: StepGeneration.SingleLabwareLiquidState, labwareId: string) => (form)
           ? highlightedWellsForLabwareAtStep(
             labwareLiquids,
             labwareId,

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -22,8 +22,6 @@ import type {NamedIngredsByLabwareAllSteps} from '../../steplist/types'
 import wellContentsAllLabwareExport from './wellContentsAllLabware'
 export const wellContentsAllLabware = wellContentsAllLabwareExport
 
-type SingleLabwareLiquidState = {[well: string]: StepGeneration.LocationLiquidState}
-
 function _wellContentsForWell (
   liquidVolState: StepGeneration.LocationLiquidState,
   well: string
@@ -45,7 +43,7 @@ function _wellContentsForWell (
 }
 
 export function _wellContentsForLabware (
-  labwareLiquids: SingleLabwareLiquidState,
+  labwareLiquids: StepGeneration.SingleLabwareLiquidState,
   labwareId: string,
   labwareType: string
 ): AllWellContents {
@@ -70,7 +68,7 @@ export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWe
     return liquidStateTimeline.map(
       (liquidState, timelineIdx) => mapValues(
         liquidState,
-        (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => {
+        (labwareLiquids: StepGeneration.SingleLabwareLiquidState, labwareId: string) => {
           const robotState = _robotStateTimeline[timelineIdx].robotState
           const labwareType = robotState.labware[labwareId].type
 
@@ -90,7 +88,7 @@ export const lastValidWellContents: Selector<{[labwareId: string]: AllWellConten
   (timelineFull) => {
     return mapValues(
       timelineFull.robotState.labware,
-      (labwareLiquids: SingleLabwareLiquidState, labwareId: string) => {
+      (labwareLiquids: StepGeneration.SingleLabwareLiquidState, labwareId: string) => {
         return _wellContentsForLabware(
           timelineFull.robotState.liquidState.labware[labwareId],
           labwareId,


### PR DESCRIPTION
## overview

Closes #1479 

Turns out I'd written the test for "aspirate from trough with 8-channel pipette" with the wrong logic - the specified aspirate `volume` should be per tip, not "total volume aspirated from source". So before, when aspirating 10uL from a trough with a multi-channel, liquid tracking would move 10/8 uL (instead of 10 uL) from the trough to each pipette tip, then on dispensing 10 it would dispense `__air__`, thus making the destination wells gray.

## changelog

- update aspirateUpdateLiquidState test for common well (trough) with multichannel pipette
- fix aspirateUpdateLiquidState for common wells with multichannel pipette
- type cleanup with the repeated `SingleLabwareLiquidState` type

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_fix-aspirate-from-trough-liq-tracking-bug/index.html


Transfers from trough and 96 plates (and visa-versa) should work correctly, and wells should only show gray contents when there truly are multiple ingredients in a well.