### PR TITLE
Api disconnect before connect

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1290,7 +1290,6 @@ class SmoothieDriver_3_0_0:
         if self.simulating:
             pass
         else:
-            self.disconnect()
             gpio.set_low(gpio.OUTPUT_PINS['RESET'])
             gpio.set_low(gpio.OUTPUT_PINS['ISP'])
             sleep(0.25)

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1276,14 +1276,11 @@ class SmoothieDriver_3_0_0:
         if self.simulating:
             pass
         else:
-            old_port = self.port
-            self.disconnect()
             gpio.set_low(gpio.OUTPUT_PINS['RESET'])
             gpio.set_high(gpio.OUTPUT_PINS['ISP'])
             sleep(0.25)
             gpio.set_high(gpio.OUTPUT_PINS['RESET'])
             sleep(0.25)
-            self._connect_to_port(old_port)
             self._wait_for_ack()
             self._reset_from_error()
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -84,6 +84,19 @@ def test_remove_serial_echo(smoothie, monkeypatch):
         driver_3_0.SMOOTHIE_ACK)
     assert res == 'TESTS-RULE'
 
+    def return_echo_response(command, ack, connection, timeout):
+        if 'some-data' in command:
+            return command.strip() + '\r\nT\r\nESTS-RULE'
+        return command
+
+    monkeypatch.setattr(serial_communication, 'write_and_return',
+                        return_echo_response)
+
+    res = smoothie._send_command(
+        '\r\n' + cmd + '\r\n\r\nsome-data\r\nok\r\n',
+        driver_3_0.SMOOTHIE_ACK)
+    assert res == 'TESTS-RULE'
+
 
 def test_parse_position_response(smoothie):
     from opentrons.drivers.smoothie_drivers import driver_3_0 as drv


### PR DESCRIPTION
## overview

This PR adds an explicit call to `disconnect()` before the driver attempts to `connect()` to the port. In the event that the responses from a machine's uart port show an echo, it is occuring immediately after the port has been re-connected to, like after simulating, or swapping between processes and calling robot.connect(). This PR attempts to avoid the source of that error, whether it's source is from Smoothieware or the OS.

In addition, this PR adds a private driver method `_remove_unwanted_characters()`, which refactors how the above mentioned echo was previously being removed from a uart response. The refactor adds some logging messages to help debug, it searches for each gcode-command individually, and it removes newline and return characters, which have been found to appear within the response data itself.

An example of an echo that combines the sent command and the response. Notice the `X` in the response:
```
-> G28.6 M400\r\n\r\n
<- G0 X10 M400\r\nX\r\n:0 Y:0 Z:0 A:0 B:0 C:0

# after _remove_unwanted_characters()...
<- X:0 Y:0 Z:0 A:0 B:0 C:0
```

Note that removing the newline and return characters does not affect any of the data we expect from smoothieware, since the datas are all contained within the first line of any response we would get.