### PR TITLE
PD file upload button initial steps

### DIFF
--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -7,17 +7,6 @@
   }
 }
 
-.download_button {
-  margin: 0 1rem;
-}
-
-.divider {
-  display: block;
-  width: 100%;
-  height: 2px;
-  background-color: var(--c-light-gray);
-}
-
 .bottom_buttons {
   margin: 1rem 2rem;
 
@@ -25,4 +14,36 @@
     /* Unlike PrimaryButton, OutlineButton isn't 100% width */
     width: 100%;
   }
+}
+
+.download_button {
+  margin: 2rem 1rem;
+}
+
+.upload_button {
+  /* File input is transparent and laid over the button */
+  position: relative;
+  height: 4.25rem;
+
+  & > * {
+    @apply --absolute-fill;
+  }
+
+  & input {
+    z-index: 5;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  &:hover button {
+    cursor: text;
+    background-color: color(var(--c-bg-light) shade(5%));
+  }
+}
+
+.divider {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background-color: var(--c-light-gray);
 }

--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -21,23 +21,12 @@
 }
 
 .upload_button {
-  /* File input is transparent and laid over the button */
-  position: relative;
-  height: 4.25rem;
-
-  & > * {
-    @apply --absolute-fill;
-  }
+  display: block;
+  width: 100%;
 
   & input {
-    z-index: 5;
-    opacity: 0;
-    cursor: pointer;
-  }
-
-  &:hover button {
-    cursor: text;
-    background-color: color(var(--c-bg-light) shade(5%));
+    position: fixed;
+    clip: rect(1px 1px 1px 1px);
   }
 }
 

--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -1,28 +1,16 @@
 @import '@opentrons/components';
 
-.download_button,
-.bottom_buttons {
-  & button {
-    margin: 1rem 0;
-  }
-}
-
-.bottom_buttons {
-  margin: 1rem 2rem;
-
-  & button {
-    /* Unlike PrimaryButton, OutlineButton isn't 100% width */
-    width: 100%;
-  }
+.bottom_button {
+  margin: 1.5rem 4rem 0;
+  width: calc(100% - 4rem * 2);
 }
 
 .download_button {
-  margin: 2rem 1rem;
+  margin: 1.5rem 2.5rem;
 }
 
 .upload_button {
   display: block;
-  width: 100%;
 
   & input {
     position: fixed;

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -27,10 +27,10 @@ export default function FileSidebar (props: Props) {
       }
 
       <div className={styles.bottom_buttons}>
-        <div className={styles.upload_button}>
+        <OutlineButton Component='label' className={styles.upload_button}>
+          UPLOAD
           <input type='file' onChange={props.onUpload} />
-          <OutlineButton type='submit'>UPLOAD</OutlineButton>
-        </div>
+        </OutlineButton>
         <OutlineButton onClick={props.onCreateNew}>Create New</OutlineButton>
       </div>
     </SidePanel>

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -4,7 +4,7 @@ import {PrimaryButton, OutlineButton, SidePanel} from '@opentrons/components'
 import styles from './FileSidebar.css'
 
 type Props = {
-  onUploadClick?: () => mixed,
+  onUpload: (SyntheticInputEvent<HTMLInputElement>) => mixed,
   onCreateNew?: () => mixed,
   downloadData: ?{
     fileContents: string,
@@ -27,7 +27,10 @@ export default function FileSidebar (props: Props) {
       }
 
       <div className={styles.bottom_buttons}>
-        <OutlineButton onClick={props.onUploadClick}>Upload</OutlineButton>
+        <div className={styles.upload_button}>
+          <input type='file' onChange={props.onUpload} />
+          <OutlineButton type='submit'>UPLOAD</OutlineButton>
+        </div>
         <OutlineButton onClick={props.onCreateNew}>Create New</OutlineButton>
       </div>
     </SidePanel>

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import {PrimaryButton, OutlineButton, SidePanel} from '@opentrons/components'
+import cx from 'classnames'
 import styles from './FileSidebar.css'
 
 type Props = {
@@ -25,14 +26,11 @@ export default function FileSidebar (props: Props) {
           <div className={styles.divider} />
         </div>
       }
-
-      <div className={styles.bottom_buttons}>
-        <OutlineButton Component='label' className={styles.upload_button}>
-          UPLOAD
-          <input type='file' onChange={props.onUpload} />
-        </OutlineButton>
-        <OutlineButton onClick={props.onCreateNew}>Create New</OutlineButton>
-      </div>
+      <OutlineButton Component='label' className={cx(styles.upload_button, styles.bottom_button)}>
+        UPLOAD
+        <input type='file' onChange={props.onUpload} />
+      </OutlineButton>
+      <OutlineButton onClick={props.onCreateNew} className={styles.bottom_button}>Create New</OutlineButton>
     </SidePanel>
   )
 }

--- a/protocol-designer/src/containers/ConnectedFileSidebar.js
+++ b/protocol-designer/src/containers/ConnectedFileSidebar.js
@@ -9,9 +9,17 @@ import type {BaseState} from '../types'
 
 type Props = React.ElementProps<typeof FileSidebar>
 
+type SP = {
+  downloadData: $PropertyType<Props, 'downloadData'>
+}
+
+type MP = {
+  _canCreateNew: ?boolean
+}
+
 export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
 
-function mapStateToProps (state: BaseState): * {
+function mapStateToProps (state: BaseState): SP & MP {
   const protocolName = fileDataSelectors.fileFormValues(state).name || 'untitled'
   const fileData = fileDataSelectors.createFile(state)
 
@@ -25,11 +33,39 @@ function mapStateToProps (state: BaseState): * {
   }
 }
 
-function mergeProps (stateProps: *, dispatchProps: {dispatch: Dispatch<*>}): Props {
+function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: Dispatch<*>}): Props {
   const {_canCreateNew, downloadData} = stateProps
   const {dispatch} = dispatchProps
   return {
     downloadData,
+    onUpload: (event) => {
+      const file = event.currentTarget.files[0]
+      const reader = new FileReader()
+
+      if (file.name.endsWith('.py')) {
+        // TODO LATER Ian 2018-05-18 use a real modal
+        window.alert('Protocol Designer does not support Python (*.py) protocol files.\n\nPlease use a text editor to edit Python protocol files.')
+      } else {
+        reader.onload = readEvent => {
+          const result = readEvent.currentTarget.result
+
+          try {
+            const parsedProtocol = JSON.parse(result)
+            // TODO LATER Ian 2018-05-18 validate file with JSON Schema here
+
+            // TODO IMMEDIATELY (next PR) dispatch a FILE_UPLOAD action
+            console.log({parsedProtocol})
+          } catch (error) {
+            // TODO LATER Ian 2018-05-18 use a real modal
+            window.alert(`Could not parse JSON protocol.\n\nError message: "${error.message}"`)
+          }
+        }
+        reader.readAsText(file)
+      }
+
+      // reset the state of the input to allow file re-uploads
+      event.currentTarget.value = ''
+    },
     onCreateNew: _canCreateNew
       ? () => dispatch(actions.toggleNewProtocolModal(true))
       : undefined


### PR DESCRIPTION
## overview

Closes #1500

This is just minimal setup for the Upload button in PD. It doesn't do anything with the protocol when you upload it (just logs parsed JSON to console). Doing the Redux hookup in a separate PR.

I tried adapting the `UploadInput` from Run App to re-use it, but the buttons are styled differently enough, and the presentational side is simple enough, that it seemed easier to just make a separate component. UploadInput is already kinda multiplexed to be a button or a file-drop-area, so making it an OutlineButton with a different label text and no icon seemed to be cramming too much into it.

![image](https://user-images.githubusercontent.com/11590381/40311508-fd775ade-5cdd-11e8-9126-fb26b90ac65c.png)

## changelog

* parses JSON (and just logs to console for now)
* gives error when `*.py` file is uploaded
* gives error if file cannot be parsed as JSON
* added top/bottom margin to DOWNLOAD button to match design

## review requests

* Code review
* Try out the button with .py vs valid .json (any json works right now) vs .txt or something