### PR TITLE
pd, complib, run app: standardize highlight color

### DIFF
--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -1,3 +1,5 @@
+@import '@opentrons/components';
+
 /* TODO(mc, 2018-02-09): fix lint errors and remove this ignore */
 /* stylelint-disable selector-class-pattern, font-family-no-missing-generic-family-keyword  */
 .run_log_wrapper {
@@ -40,5 +42,5 @@ li.current {
 }
 
 li.last_current {
-  color: #006fff;
+  color: var(--c-highlight);
 }

--- a/components/src/deck/LabwareContainer.css
+++ b/components/src/deck/LabwareContainer.css
@@ -19,7 +19,7 @@ NOTE: available defs are:
 
 .highlighted {
   fill: none;
-  stroke: var(--c-blue);
+  stroke: var(--c-highlight);
   stroke-width: 2.5;
 }
 

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -27,7 +27,7 @@
 }
 
 .titled_list_selected {
-  border-color: var(--c-blue);
+  border-color: var(--c-highlight);
 }
 
 .title_bar {

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -3,7 +3,6 @@
   --c-mustard: #ffd252;
   --c-blue: #006fff;
   --c-light-blue: color(var(--c-blue) lightness(85%));
-  --c-teal: #05c1b3;
 
   /* grays */
   --c-dark-gray: #4a4a4a;

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -120,8 +120,7 @@
 }
 
 .highlighted {
-  /* TODO Ian 2018-04-09 this border for highlight is also in lists.css in complib. Export from complib as class? */
-  border: 2px solid var(--c-blue);
+  border: 2px solid var(--c-highlight);
 }
 
 .error_icon {


### PR DESCRIPTION
## overview

Closes #1328 - we're trying to standardize the highlight color across PD + Run App

## changelog

* Use `--c-highlight` for highlight border of LabwareContainer, TitledList, and StepItem
* Use `--c-highlight` for active text color in RunList
* Delete now-unused `--c-teal` definition

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_components-standardize-highlight-color/index.html

* Look at changes in PD and Run App to components listed above
* `--c-teal` should be removed here, right? Wherever we need it, I think it's really `--c-highlight` (a slightly different shade of teal)