### PR TITLE
Removes functions that are no longer used in OT 2

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1297,37 +1297,6 @@ class Pipette:
 
         return self
 
-    def calibrate(self, position):
-        """
-        Calibrate a saved plunger position to the robot's current position
-        Notes
-        -----
-        This will only work if the API is connected to a robot
-        Parameters
-        ----------
-        position : str
-            Either "top", "bottom", "blow_out", or "drop_tip"
-        Returns
-        -------
-        This instance of :class:`Pipette`.
-        Examples
-        --------
-        ..
-        >>> robot = Robot()
-        >>> p200 = instruments.Pipette(name='p200', mount='left')
-        >>> robot.move_plunger(**{'a': 10})
-        >>> # save plunger 'top' to coordinate 10
-        >>> p200.calibrate('top') # doctest: +ELLIPSIS
-        <opentrons.instruments.pipette.Pipette object at ...>
-        """
-        current_position = self.robot._driver.get_plunger_positions()
-        current_position = current_position['target'][self.axis]
-        kwargs = {}
-        kwargs[position] = current_position
-        self.calibrate_plunger(**kwargs)
-
-        return self
-
     def calibrate_plunger(
             self,
             top=None,
@@ -1365,31 +1334,6 @@ class Pipette:
             self.plunger_positions['blow_out'] = blow_out
         if drop_tip is not None:
             self.plunger_positions['drop_tip'] = drop_tip
-
-        return self
-
-    def set_max_volume(self, max_volume):
-        """
-        Set this pipette's maximum volume, equal to the number of
-        microliters drawn when aspirating with the plunger's full range
-        Parameters
-        ----------
-        max_volume: int or float
-            The maximum number of microliters this :any:`Pipette` can hold.
-            Must be calculated and set after plunger calibrations to ensure
-            accuracy
-        """
-        # self.max_volume = max_volume
-
-        # if self.max_volume <= self.min_volume:
-        #     raise RuntimeError(
-        #         'Pipette max volume is less than '
-        #         'min volume ({0} < {1})'.format(
-        #             self.max_volume, self.min_volume))
-
-        warnings.warn(
-            "'max_volume' is deprecated, use `ul_per_mm` in constructor"
-        )
 
         return self
 

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -68,14 +68,6 @@ class PipetteTest(unittest.TestCase):
         self.assertRaises(
             RuntimeError, self.p200._get_plunger_position, 'roll_out')
 
-    def test_set_max_volume(self):
-        import warnings
-        warnings.filterwarnings('error')
-        self.assertRaises(UserWarning, self.p200.set_max_volume, 200)
-        self.assertRaises(
-            UserWarning, Pipette, self.robot, mount='right', max_volume=200)
-        warnings.filterwarnings('default')
-
     def test_deprecated_axis_call(self):
         import warnings
 


### PR DESCRIPTION
## overview

Quick PR to remove some functions that are no longer relevant to our code-base.

## changelog

- Removes the 'calibrate' function as that is no longer how we handle calibrating containers
- Removes 'set_max_volume' function as that will be calculated using the pre-set ul-per-mm value

## review requests
