### PR TITLE
PD: delete labware gracefully

### DIFF
--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -24,6 +24,10 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.pipetteVolumeExceeded({actionName, volume, maxVolume: pipetteData.maxVolume}))
   }
 
+  if (!labware || !prevRobotState.labware[labware]) {
+    errors.push(errorCreators.labwareDoesNotExist({actionName, labware}))
+  }
+
   if (errors.length > 0) {
     return {errors}
   }

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -14,6 +14,10 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
   }
 
+  if (!labware || !prevRobotState.labware[labware]) {
+    errors.push(errorCreators.labwareDoesNotExist({actionName, labware}))
+  }
+
   if (errors.length > 0) {
     return {errors}
   }

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -32,8 +32,9 @@ export function pipetteDoesNotExist (args: {actionName: string, pipette: string}
 
 export function labwareDoesNotExist (args: {actionName: string, labware: string}): CommandCreatorError {
   const {actionName, labware} = args
+  console.warn(`Attempted to ${actionName} with labware id "${labware}", this labware was not found under "labware"`)
   return {
-    message: `Attempted to ${actionName} with labware id "${labware}", this labware was not found under "labware"`,
+    message: 'This step involves labware that has been deleted',
     type: 'LABWARE_DOES_NOT_EXIST'
   }
 }
@@ -44,9 +45,8 @@ export function pipetteVolumeExceeded (args: {
   maxVolume: string | number
 }): CommandCreatorError {
   const {actionName, volume, maxVolume} = args
-  console.warn(`Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`)
   return {
-    message: 'This step involves labware that has been deleted',
+    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
     type: 'PIPETTE_VOLUME_EXCEEDED'
   }
 }

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -44,8 +44,9 @@ export function pipetteVolumeExceeded (args: {
   maxVolume: string | number
 }): CommandCreatorError {
   const {actionName, volume, maxVolume} = args
+  console.warn(`Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`)
   return {
-    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
+    message: 'This step involves labware that has been deleted',
     type: 'PIPETTE_VOLUME_EXCEEDED'
   }
 }

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -106,6 +106,20 @@ describe('aspirate', () => {
     })
   })
 
+  test('aspirate from nonexistent labware should return error', () => {
+    const result = aspirateWithErrors({
+      pipette: 'p300SingleId',
+      volume: 50,
+      labware: 'problematicLabwareId',
+      well: 'A1'
+    })(robotStateWithTip)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'LABWARE_DOES_NOT_EXIST'
+    })
+  })
+
   describe('liquid tracking', () => {
     const mockLiquidReturnValue = 'expected liquid state'
     beforeEach(() => {

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -76,6 +76,20 @@ describe('dispense', () => {
       })
     })
 
+    test('dispense to nonexistent labware should throw error', () => {
+      const result = dispenseWithErrors({
+        pipette: 'p300SingleId',
+        volume: 50,
+        labware: 'someBadLabwareId',
+        well: 'A1'
+      })(robotStateWithTip)
+
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toMatchObject({
+        type: 'LABWARE_DOES_NOT_EXIST'
+      })
+    })
+
     // TODO Ian 2018-02-12... what is excessive volume?
     // Is it OK to dispense vol > pipette max vol?
     // LATER: shouldn't dispense > volume of liquid in pipette


### PR DESCRIPTION
## overview

Closes #1406

## changelog

- Aspirate & dispense command creators return "labware does not exist" error object instead of raising an exception, when labware id does not exist in RobotState

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_delete-labware-gracefully/index.html

- Create labware X
- Set up steps
- Go back to Deck Setup, delete labware X, you should see an error banner 'This step involves labware that has been deleted'
- Fix the step by selecting another labware Y, the error will go away

And for multiple steps all using the same labware, same thing should happen.