### PR TITLE
feat(app, comp): Add run complete, paused, and canceled AlertItems

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -15,7 +15,7 @@ from .models import Container, Instrument
 
 log = logging.getLogger(__name__)
 
-VALID_STATES = {'loaded', 'running', 'finished', 'stopped', 'paused'}
+VALID_STATES = {'loaded', 'running', 'finished', 'stopped', 'paused', 'error'}
 
 
 class SessionManager(object):
@@ -197,13 +197,14 @@ class Session(object):
                 execute_protocol(self._protocol)
             else:
                 exec(self._protocol, {})
+            self.set_state('finished')
         except Exception as e:
             log.exception("Exception during run:")
             self.error_append(e)
+            self.set_state('error')
             raise e
         finally:
             _unsubscribe()
-            self.set_state('finished')
 
         return self
 

--- a/app/src/components/ConnectPanel/connect-panel.css
+++ b/app/src/components/ConnectPanel/connect-panel.css
@@ -31,8 +31,8 @@
 }
 
 .active {
-  color: #0ec9eb;
-  background-color: #f0f3ff;
+  color: var(--c-highlight);
+  background-color: var(--c-bg-selected);
 }
 
 .scan_status {

--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
+import cx from 'classnames'
 import styles from './styles.css'
+import SessionAlert from './SessionAlert'
 
 export default class CommandList extends Component {
   componentDidUpdate () {
@@ -9,7 +10,7 @@ export default class CommandList extends Component {
   }
 
   render () {
-    const {commands} = this.props
+    const {commands, sessionStatus} = this.props
     const makeCommandToTemplateMapper = (depth) => (command) => {
       const {id, isCurrent, isLast, description, children, handledAt} = command
       const style = [styles[`indent-${depth}`]]
@@ -25,7 +26,7 @@ export default class CommandList extends Component {
 
       const liProps = {
         key: id,
-        className: classnames(style, {
+        className: cx(style, {
           [styles.executed]: handledAt,
           [styles.current]: isCurrent,
           [styles.last_current]: isLast
@@ -43,13 +44,18 @@ export default class CommandList extends Component {
     }
 
     const commandItems = commands.map(makeCommandToTemplateMapper(0))
-
+    // TODO (ka 2018-5-21): Temporarily hiding error to avoid showing smoothie error on halt,
+    // error AlertItem would be useful for future errors
+    const showAlert = (sessionStatus !== 'running' && sessionStatus !== 'loaded' && sessionStatus !== 'error')
     return (
-      <section className={styles.run_log_wrapper}>
+      <div className={styles.run_page}>
+      <SessionAlert {...this.props} className={styles.alert}/>
+      <section className={cx(styles.run_log_wrapper, {[styles.alert_visible]: showAlert})}>
         <ol className={styles.list}>
           {commandItems}
         </ol>
       </section>
+      </div>
     )
   }
 }

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -1,0 +1,46 @@
+// @flow
+import * as React from 'react'
+import {AlertItem} from '@opentrons/components'
+import type {SessionStatus} from '../../robot'
+
+type Props = {
+  sessionStatus: SessionStatus,
+  className?: string
+}
+
+// TODO (ka 2018-5-21): only adding text without call to action until redux work in place
+const COMPLETE_MESSAGE = 'Run complete'
+const PAUSE_MESSAGE = 'Run paused'
+const CANCEL_MESSAGE = 'Run canceled'
+
+export default function SessionAlert (props: Props) {
+  const {sessionStatus, className} = props
+  switch (sessionStatus) {
+    case 'finished':
+      return (
+        <AlertItem
+          type='success'
+          title={COMPLETE_MESSAGE}
+          className={className}
+        />
+      )
+    case 'paused':
+      return (
+        <AlertItem
+          type='info'
+          title={PAUSE_MESSAGE}
+          className={className}
+          icon={{name: 'pause-circle'}}
+        />
+      )
+    case 'stopped':
+      return (
+        <AlertItem
+        type='warning'
+        title={CANCEL_MESSAGE}
+        className={className}
+      />)
+    default:
+      return null
+  }
+}

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -1,18 +1,30 @@
+// @flow
 import React from 'react'
 import {connect} from 'react-redux'
-
-import {selectors as robotSelectors} from '../../robot'
+import type {State} from '../../types'
+import {
+  selectors as robotSelectors,
+  type SessionStatus
+} from '../../robot'
 
 import CommandList from './CommandList'
 
-const mapStateToProps = (state) => ({
-  commands: robotSelectors.getCommands(state)
+type SP = {
+  commands: Array<any>,
+  sessionStatus: SessionStatus
+}
+
+type Props = SP
+
+const mapStateToProps = (state: State): SP => ({
+  commands: robotSelectors.getCommands(state),
+  sessionStatus: robotSelectors.getSessionStatus(state)
 })
 
-function ConnectedRunLog (props) {
+function RunLog (props: Props) {
   return (
     <CommandList {...props} />
   )
 }
 
-export default connect(mapStateToProps)(ConnectedRunLog)
+export default connect(mapStateToProps)(RunLog)

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -1,11 +1,21 @@
 /* TODO(mc, 2018-02-09): fix lint errors and remove this ignore */
 /* stylelint-disable selector-class-pattern, font-family-no-missing-generic-family-keyword  */
+@import '@opentrons/components';
+
+.run_page {
+  position: relative;
+}
+
 .run_log_wrapper {
   box-sizing: border-box;
   font-family: 'Open Sans';
   overflow-y: scroll;
   border: 1rem solid white;
   max-height: 44rem;
+}
+
+.alert_visible {
+  border-top-width: 3rem;
 }
 
 .list {
@@ -36,9 +46,16 @@ li.executed {
 }
 
 li.current {
-  background-color: rgba(150, 150, 150, 0.1);
+  background-color: var(--c-bg-selected);
 }
 
 li.last_current {
-  color: #006fff;
+  color: var(--c-highlight);
+}
+
+.alert {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
 }

--- a/app/src/components/SetupPanel/styles.css
+++ b/app/src/components/SetupPanel/styles.css
@@ -18,7 +18,6 @@
 }
 
 .active {
-  color: #0ec9eb;
-  background-color: #f0f3ff;
-  fill: #0ec9eb;
+  color: var(--c-highlight);
+  background-color: var(--c-bg-selected);
 }

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -215,7 +215,6 @@ function handleCancel (state: State, action: any): State {
 
 function handleCancelResponse (state: State, action: any): State {
   const {error, payload} = action
-
   if (error) {
     return {...state, cancelRequest: {inProgress: false, error: payload}}
   }

--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -417,7 +417,7 @@ exports[`icons flask-outline renders correctly 1`] = `
 </svg>
 `;
 
-exports[`icons info-circle renders correctly 1`] = `
+exports[`icons information renders correctly 1`] = `
 <svg
   aria-hidden="true"
   className="foo"

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -35,7 +35,7 @@ const ALERT_PROPS_BY_TYPE = {
     className: styles.warning
   },
   info: {
-    icon: {name: 'info-circle'},
+    icon: {name: 'information'},
     className: styles.info
   }
 }

--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -22,27 +22,27 @@
 }
 
 .success {
-  border: 1px solid #60b120;
+  border: 1px solid var(--c-success);
 
   & > .title_bar {
-    background-color: #b6febc;
-    color: #60b120;
+    background-color: var(--c-bg-success);
+    color: var(--c-success);
 
     & svg {
-      fill: #60b120;
+      color: var(--c-success);
     }
   }
 }
 
 .info {
-  border: 1px solid #0ec9eb;
+  border: 1px solid var(--c-highlight);
 
   & > .title_bar {
-    background-color: #f0f3ff;
-    color: #0ec9eb;
+    background-color: var(--c-bg-selected);
+    color: var(--c-highlight);
 
     & svg {
-      fill: #0ec9eb;
+      color: var(--c-highlight);
     }
   }
 }
@@ -51,8 +51,8 @@
   border: 1px solid var(--c-warning);
 
   & > .title_bar {
-    background-color: #ffd58f;
-    color: #7c4d00;
+    background-color: var(--c-bg-warning);
+    color: var(--c-warning);
 
     & svg {
       fill: var(--c-warning);

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -189,7 +189,7 @@ const ICON_DATA_BY_NAME = {
     viewBox: '0 0 24 24',
     path: 'M12 20l8-8-8-8v4H4v8h8z'
   },
-  'info-circle': {
+  'information': {
     viewBox: '0 0 24 24',
     path: 'M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'
   }

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -73,9 +73,12 @@
   margin: 0;
   padding: var(--list-padding-small);
 
-  &:hover,
+  &:hover {
+    background-color: var(--c-bg-hover);
+  }
+
   &.active {
-    background-color: var(--c-bg-selected-light);
+    background-color: var(--c-bg-selected);
   }
 }
 

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -13,12 +13,15 @@
   /* background colors */
   --c-bg-dark: #4a4a4a;
   --c-bg-light: #fafafa;
-  --c-bg-selected: #d1d1d1;
-  --c-bg-selected-light: #f1f1f1;
+  --c-bg-selected: #f0f3ff;
+  --c-bg-hover: #f1f1f1;
+  --c-bg-success: #b6febc;
+  --c-bg-warning: #ffd58f;
 
   /* general UI */
   --c-highlight: #5fd8ee;
   --c-warning: #e28200;
+  --c-success: #60b120;
 
   /* Misc */
   --c-overlay: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
## overview
This PR closes #1269 addresses #855 by conditionally displaying 'RunComplete' 'Run Paused' and 'Run Canceled' `AlertItem` banners to the run screen. 

*Note:* the designs show links to run again after run complete or run canceled. This is hidden since this is not functional yet and thats a rather large ticket.

While I was in there I refactored some of the comp_lib colors to standardize highlighted/active/info states of `AlertItem` in comp_lib and active calibration steps in the app. We started having 3+ versions of the selected blue colors. @IanLondon and I sat down and standardized a few things to avoid this moving forward. There is a little bit of styling in RunLog CSS to allow for proper positioning of the AlertItems without screwing up the scrollable run log styles.

This PR also updates api/opentrons/api/session.py to not set the robot state to 'finished' when a smoothie error is thrown before homing when calling the halt command. This had resulted in the 'Run Complete' `AlertItem` rendering while the cancelRequest was in progress.

*Not* in this PR:
- Spinner modal while cancel is in progree
- Confirm cancel modal 

Complete

<img width="800" alt="screen shot 2018-05-21 at 4 28 59 pm" src="https://user-images.githubusercontent.com/3430313/40328378-230786da-5d14-11e8-8e07-b567301156f2.png">

Paused

<img width="800" alt="screen shot 2018-05-21 at 1 52 10 pm" src="https://user-images.githubusercontent.com/3430313/40328288-dd005324-5d13-11e8-87c2-f26d666005ba.png">

Canceled

<img width="800" alt="screen shot 2018-05-21 at 1 53 44 pm" src="https://user-images.githubusercontent.com/3430313/40328301-e7d60f5a-5d13-11e8-8dba-c198e90cc809.png">


## changelog

- feat(app):Conditionally display and style `AlertItem` banners based on `sessionStatus`
- refactor(comp): Address highlight and color inconsistencies in App and CompLib, update `info-circle` icon name to `information` to match material design naming
- fix(api): Update `session.py` error handling to not set session state to 'finished' on smoothie halt error

## review requests
Standard code review. 
Try it on a robot! Virtual smoothie wont work for pause and cancel since the protocols run so quickly.

NOTE: you need to `make push` this on to a robot b/c it affects the API.

- [ ] Click Run on Run Screen after uploading and tip probing etc. Confirm Run Complete banner renders on completion of a successful run
- [ ] Pause a run. Confirm Run Paused banner renders while robot is pause and disappears once you click resume
- [ ] Cancel a run. Confirm no banner renders until robot is done homing and sessionState is 'stopped'
