### PR TITLE
add well selection instructional text

### DIFF
--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -61,4 +61,11 @@
     font-weight: var(--fw-regular);
     color: var(--c-font-light);
   };
+
+  --unselectable: {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  };
 }

--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -61,11 +61,4 @@
     font-weight: var(--fw-regular);
     color: var(--c-font-light);
   };
-
-  --unselectable: {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-  };
 }

--- a/protocol-designer/src/components/IngredientSelectionModal.js
+++ b/protocol-designer/src/components/IngredientSelectionModal.js
@@ -7,6 +7,7 @@ import styles from './IngredientSelectionModal.css'
 import SelectablePlate from '../containers/SelectablePlate.js'
 // import IngredientsList from '../containers/IngredientsList.js'
 import IngredientPropertiesForm from '../containers/IngredientPropertiesForm.js'
+import WellSelectionInstructions from './WellSelectionInstructions'
 
 type Props = {
   visible: boolean
@@ -24,6 +25,8 @@ export default function IngredientSelectionModal (props: Props) {
       <SingleLabware>
         <SelectablePlate showLabels selectable />
       </SingleLabware>
+
+      <WellSelectionInstructions />
     </div>
   )
 }

--- a/protocol-designer/src/components/WellSelectionInstructions.css
+++ b/protocol-designer/src/components/WellSelectionInstructions.css
@@ -1,0 +1,10 @@
+@import '@opentrons/components';
+
+.instructional_text {
+  @apply --unselectable;
+
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: var(--fw-semibold);
+  color: var(--c-white);
+}

--- a/protocol-designer/src/components/WellSelectionInstructions.css
+++ b/protocol-designer/src/components/WellSelectionInstructions.css
@@ -1,8 +1,7 @@
 @import '@opentrons/components';
 
 .instructional_text {
-  @apply --unselectable;
-
+  user-select: none;
   text-align: center;
   font-size: 1.5rem;
   font-weight: var(--fw-semibold);

--- a/protocol-designer/src/components/WellSelectionInstructions.js
+++ b/protocol-designer/src/components/WellSelectionInstructions.js
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import styles from './WellSelectionInstructions.css'
+
+export default function WellSelectionInstructions () {
+  return <div className={styles.instructional_text}>
+    De-select: Shift + Click
+  </div>
+}

--- a/protocol-designer/src/components/WellSelectionModal.js
+++ b/protocol-designer/src/components/WellSelectionModal.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 
 import SelectablePlate from '../containers/SelectablePlate'
 import SingleLabwareWrapper from '../components/SingleLabware'
+import WellSelectionInstructions from './WellSelectionInstructions'
 
 import {Modal, OutlineButton, LabeledValue} from '@opentrons/components'
 
@@ -44,9 +45,7 @@ export default function WellSelectionModal (props: Props) {
         />
       </SingleLabwareWrapper>
 
-      <div className={styles.bottom_row}>
-        De-select: Shift + Click (NOT IMPLEMENTED TODO)
-      </div>
+      <WellSelectionInstructions />
     </Modal>
   )
 }


### PR DESCRIPTION
## overview

Closes #1324 

> Add the text "De-select: Shift + Click" as in this illustration:

![instructional text](https://user-images.githubusercontent.com/35570080/38695657-e4a6270c-3e5a-11e8-8e34-589cf366004a.png)

## changelog

* complib: 'unselectable' custom prop set in typography.css
* pd: WellSelectionInstructions component

## review requests

- quick UI review: this text should show up as in the image for ingred selection modal & for well selection modal
- CSS review: `--unselectable` in `typography.css`