### PR TITLE
API: removes characters before the P in the pipette barcode

### DIFF
--- a/api/opentrons/tools/write_pipette_memory.py
+++ b/api/opentrons/tools/write_pipette_memory.py
@@ -76,6 +76,9 @@ def _user_submitted_barcode(max_length):
     barcode = input('BUTTON + SCAN: ').strip()
     if len(barcode) > max_length:
         raise Exception(BAD_BARCODE_MESSAGE.format(barcode))
+    # remove all characters before the letter P
+    # for example, remove ASCII selector code "\x1b(B" on chinese keyboards
+    barcode = barcode[barcode.index('P'):]
     return barcode
 
 


### PR DESCRIPTION
## overview

Small PR, to help the SZ team avoid sending unneeded characters when scanning barcodes (like the ASCII select character in XTerm `"\x1b(B"` they are seeing over there)