### PR TITLE
API: toggle uart port closed/open if no response

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -849,6 +849,9 @@ class SmoothieDriver_3_0_0:
                 raise e
             if not self.simulating:
                 sleep(DEFAULT_STABILIZE_DELAY)
+            if self._connection:
+                self._connection.close()
+                self._connection.open()
             return self._recursive_write_and_return(
                 cmd, timeout, retries)
 

--- a/api/opentrons/drivers/smoothie_drivers/serial_communication.py
+++ b/api/opentrons/drivers/smoothie_drivers/serial_communication.py
@@ -58,8 +58,10 @@ def _write_to_device_and_return(cmd, ack, device_connection):
     - Formats command
     - Wait for ack return
     - return parsed response'''
+    log.debug('Write -> {}'.format(cmd.encode()))
     device_connection.write(cmd.encode())
     response = device_connection.read_until(ack.encode())
+    log.debug('Read <- {}'.format(response))
     if ack.encode() not in response:
         raise SerialNoResponse(
             'No response from serial port after {} second(s)'.format(
@@ -96,12 +98,10 @@ def _attempt_command_recovery(command, ack, serial_conn):
 def write_and_return(
         command, ack, serial_connection, timeout=DEFAULT_WRITE_TIMEOUT):
     '''Write a command and return the response'''
-    log.debug('Write -> {}'.format(command.encode()))
     clear_buffer(serial_connection)
     with serial_with_temp_timeout(
             serial_connection, timeout) as device_connection:
         response = _write_to_device_and_return(command, ack, device_connection)
-    log.debug('Read <- {}'.format(response.encode()))
     return response
 
 


### PR DESCRIPTION
## overview

This small PR toggle the UART port close/open if there is no response from the port.

In addition, the logging messages for gcodes sent and received were moved to show the exact contents of the response, to help debuggin.