### PR TITLE
feat(app, comp): Display `SpinnerModal` while robot homes and reboots

### DIFF
--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -1,8 +1,11 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import styles from './styles.css'
+
+import {SpinnerModal} from '@opentrons/components'
 import SessionAlert from './SessionAlert'
+
+import styles from './styles.css'
 
 export default class CommandList extends Component {
   componentDidUpdate () {
@@ -10,7 +13,7 @@ export default class CommandList extends Component {
   }
 
   render () {
-    const {commands, sessionStatus} = this.props
+    const {commands, sessionStatus, cancelInProgress} = this.props
     const makeCommandToTemplateMapper = (depth) => (command) => {
       const {id, isCurrent, isLast, description, children, handledAt} = command
       const style = [styles[`indent-${depth}`]]
@@ -49,6 +52,9 @@ export default class CommandList extends Component {
     const showAlert = (sessionStatus !== 'running' && sessionStatus !== 'loaded' && sessionStatus !== 'error')
     return (
       <div className={styles.run_page}>
+      {cancelInProgress && (
+        <SpinnerModal />
+      )}
       <SessionAlert {...this.props} className={styles.alert}/>
       <section className={cx(styles.run_log_wrapper, {[styles.alert_visible]: showAlert})}>
         <ol className={styles.list}>

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -18,7 +18,8 @@ type Props = SP
 
 const mapStateToProps = (state: State): SP => ({
   commands: robotSelectors.getCommands(state),
-  sessionStatus: robotSelectors.getSessionStatus(state)
+  sessionStatus: robotSelectors.getSessionStatus(state),
+  cancelInProgress: robotSelectors.getCancelInProgress(state)
 })
 
 function RunLog (props: Props) {

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -11,6 +11,7 @@
   font-family: 'Open Sans';
   overflow-y: scroll;
   border: 1rem solid white;
+  height: calc(100vh - 3.5rem);
   max-height: calc(100vh - 3.5rem);
 }
 

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -11,7 +11,7 @@
   font-family: 'Open Sans';
   overflow-y: scroll;
   border: 1rem solid white;
-  max-height: 44rem;
+  max-height: calc(100vh - 3.5rem);
 }
 
 .alert_visible {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -29,6 +29,7 @@ const calibration = (state: State) => state[_NAME].calibration
 const connection = (state: State) => state[_NAME].connection
 const session = (state: State) => state[_NAME].session
 const sessionRequest = (state: State) => session(state).sessionRequest
+const cancelRequest = (state: State) => session(state).cancelRequest
 
 export function isMount (target: ?string): boolean {
   return INSTRUMENT_MOUNTS.indexOf(target) > -1
@@ -131,6 +132,10 @@ export function getIsRunning (state: State): boolean {
 
 export function getIsPaused (state: State): boolean {
   return getSessionStatus(state) === ('paused': SessionStatus)
+}
+
+export function getCancelInProgress (state: State) {
+  return cancelRequest(state).inProgress
 }
 
 export function getIsDone (state: State): boolean {

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -198,10 +198,6 @@ exports[`modals SpinnerModalPage renders correctly 1`] = `
 <div
   className="modal"
 >
-  <div
-    className="overlay"
-    onClick={undefined}
-  />
   <header
     className="title_bar title_bar"
   >
@@ -252,26 +248,34 @@ exports[`modals SpinnerModalPage renders correctly 1`] = `
     </div>
   </header>
   <div
-    className="spinner_modal_contents"
+    className="modal"
   >
-    <svg
-      aria-hidden="true"
-      className="spinner_modal_icon spin"
-      fill="currentColor"
-      height={undefined}
-      style={undefined}
-      version="1.1"
-      viewBox="0 0 512 512"
-      width={undefined}
-      x={undefined}
-      y={undefined}
+    <div
+      className="overlay"
+      onClick={undefined}
+    />
+    <div
+      className="spinner_modal_contents"
     >
-      <path
-        d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
-        fillRule="evenodd"
-      />
-    </svg>
-    <p />
+      <svg
+        aria-hidden="true"
+        className="spinner_modal_icon spin"
+        fill="currentColor"
+        height={undefined}
+        style={undefined}
+        version="1.1"
+        viewBox="0 0 512 512"
+        width={undefined}
+        x={undefined}
+        y={undefined}
+      >
+        <path
+          d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+          fillRule="evenodd"
+        />
+      </svg>
+      <p />
+    </div>
   </div>
 </div>
 `;

--- a/components/src/modals/SpinnerModal.js
+++ b/components/src/modals/SpinnerModal.js
@@ -1,0 +1,30 @@
+// @flow
+// titled modal page component
+import * as React from 'react'
+import cx from 'classnames'
+import {Overlay} from './'
+import {Icon} from '../icons'
+
+import styles from './modals.css'
+
+type Props = {
+  /** Additional/Override style */
+  contentsClassName?: string,
+  /** Optional message to display as italic text below spinner */
+  message?: string
+}
+
+/**
+ * Spinner Modal with no background and optional message
+ */
+export default function SpinnerModal (props: Props) {
+  return (
+    <div className={styles.modal}>
+      <Overlay />
+      <div className={cx(styles.spinner_modal_contents, props.contentsClassName)}>
+        <Icon name='ot-spinner' className={styles.spinner_modal_icon} spin/>
+        <p>{props.message}</p>
+      </div>
+    </div>
+  )
+}

--- a/components/src/modals/SpinnerModal.md
+++ b/components/src/modals/SpinnerModal.md
@@ -1,0 +1,7 @@
+Basic usage:
+
+```js
+<div style={{position: 'relative', width: '48em', height: '24rem'}}>
+  <SpinnerModal message='Robot is moving' />
+</div>
+```

--- a/components/src/modals/SpinnerModalPage.js
+++ b/components/src/modals/SpinnerModalPage.js
@@ -1,10 +1,8 @@
 // @flow
 // titled modal page component
 import * as React from 'react'
-import cx from 'classnames'
-import {Overlay} from './'
+import {SpinnerModal} from './'
 import {TitleBar, type TitleBarProps} from '../structure'
-import {Icon} from '../icons'
 
 import styles from './modals.css'
 
@@ -17,17 +15,16 @@ type Props = {
   message?: string
 }
 
+/**
+ * Spinner Modal variant with TitleBar
+ */
 export default function SpinnerModalPage (props: Props) {
   const {titleBar} = props
 
   return (
     <div className={styles.modal}>
-      <Overlay />
       <TitleBar {...titleBar} className={styles.title_bar} />
-      <div className={cx(styles.spinner_modal_contents, props.contentsClassName)}>
-        <Icon name='ot-spinner' className={styles.spinner_modal_icon} spin/>
-        <p>{props.message}</p>
-      </div>
+      <SpinnerModal {...props} />
     </div>
   )
 }

--- a/components/src/modals/index.js
+++ b/components/src/modals/index.js
@@ -4,8 +4,9 @@
 import Modal from './Modal'
 import AlertModal from './AlertModal'
 import ContinueModal from './ContinueModal'
+import SpinnerModal from './SpinnerModal'
 import ModalPage from './ModalPage'
 import SpinnerModalPage from './SpinnerModalPage'
 import Overlay from './Overlay'
 
-export {Modal, AlertModal, ContinueModal, ModalPage, SpinnerModalPage, Overlay}
+export {Modal, AlertModal, ContinueModal, SpinnerModal, ModalPage, SpinnerModalPage, Overlay}

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -29,6 +29,7 @@
   top: 0;
   left: 0;
   right: 0;
+  z-index: 3;
 }
 
 .modal_contents {


### PR DESCRIPTION
## overview
This PR closes #855 by displaying a spinner modal while a cancel request is in progress. *Note i updated to thicket to not include the reset run link as it is not implemented, is quite large, and is covered in several other tickets*

This ticket also breaks out `SpinnerModal` and implements it as a child of `SpinnerModalPage` in comp_lib to allow for spinner modals with optional message and no title bar.

<img width="800" alt="screen shot 2018-05-22 at 2 56 47 pm" src="https://user-images.githubusercontent.com/3430313/40424971-087243a8-5e65-11e8-9770-7647221dd0f9.png">
<img width="800" alt="screen shot 2018-05-22 at 2 57 08 pm" src="https://user-images.githubusercontent.com/3430313/40424972-087fc5fa-5e65-11e8-871e-cc9e38bc2157.png">


## changelog

- Add `SpinnerModal` to comp_lib
- Update `SpinnerModalPage` to use SpinnerModal
- getCancelInProgress selector for conditional rendering of `SpinnerModal` while robot homes and resets

## review requests
Standard code review.

https://s3-us-west-2.amazonaws.com/opentrons-components/app_cancel-confirmation/index.html

Run a protocol (if you're not on moon moon you may have to make push onto the testing robot).
Cancel the protocol.
- [ ] spinner modal displays while cancel is in progress
- [ ] run canceled banner displays once robot has fully homed over the canceled run log.