### PR TITLE
feat(app): Add app-shell config to app state

### DIFF
--- a/app-shell/lib/log.js
+++ b/app-shell/lib/log.js
@@ -6,7 +6,7 @@ const path = require('path')
 const dateFormat = require('dateformat')
 const winston = require('winston')
 
-const config = require('./config').get('log')
+const config = require('./config').getConfig('log')
 
 const LOG_DIR = path.join(app.getPath('userData'), 'logs')
 const ERROR_LOG = path.join(LOG_DIR, 'error.log')

--- a/app-shell/lib/ui.js
+++ b/app-shell/lib/ui.js
@@ -3,7 +3,7 @@
 
 const {app, BrowserWindow} = require('electron')
 const path = require('path')
-const config = require('./config').get('ui')
+const config = require('./config').getConfig('ui')
 const log = require('./log')(__filename)
 
 const urlPath = config.url.protocol === 'file:'

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -28,8 +28,8 @@
     "shx": "^0.2.2"
   },
   "dependencies": {
+    "@thi.ng/paths": "^1.3.8",
     "dateformat": "^3.0.3",
-    "dot-prop": "^4.2.0",
     "electron-debug": "^1.1.0",
     "electron-devtools-installer": "^2.2.0",
     "electron-store": "^1.3.0",

--- a/app/__mocks__/electron.js
+++ b/app/__mocks__/electron.js
@@ -2,10 +2,13 @@
 'use strict'
 
 const path = require('path')
-const fs = require('fs')
-const os = require('os')
 
 jest.mock('electron-updater', () => ({autoUpdater: {}}))
+
+jest.mock(
+  '../../app-shell/lib/log',
+  () => require('../src/__mocks__/logger').default
+)
 
 const __mockRemotes = {}
 
@@ -19,8 +22,6 @@ const __clearMock = () => {
     })
   })
 }
-
-const __tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ot-'))
 
 module.exports = {
   __mockRemotes,
@@ -40,6 +41,11 @@ module.exports = {
   },
 
   app: {
-    getPath: () => __tempDir
+    getPath: () => '__mock-app-path__'
+  },
+
+  ipcRenderer: {
+    on: jest.fn(),
+    send: jest.fn()
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@opentrons/components": "3.0.0",
     "@opentrons/shared-data": "3.0.0",
+    "@thi.ng/paths": "^1.3.8",
     "bonjour": "^3.5.0",
     "classnames": "^2.2.5",
     "electron": "1.8.3",

--- a/app/src/__mocks__/logger.js
+++ b/app/src/__mocks__/logger.js
@@ -1,0 +1,13 @@
+// mock logger for tests
+import path from 'path'
+
+export default function createLogger (filename) {
+  const label = path.relative(path.join(__dirname, '../../..'), filename)
+
+  return new Proxy({}, {
+    get (_, level) {
+      return (message, meta) =>
+        console.log(`[${label}] ${level}: ${message} %j`, meta)
+    }
+  })
+}

--- a/app/src/config/__tests__/config.test.js
+++ b/app/src/config/__tests__/config.test.js
@@ -1,0 +1,66 @@
+// config tests
+import {
+  updateConfig,
+  configReducer,
+  getConfig
+} from '..'
+
+import * as mockShell from '../../shell'
+
+jest.mock('../../shell', () => ({getShellConfig: jest.fn()}))
+
+describe('config', () => {
+  let state
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    state = {
+      config: {
+        foo: {bar: 'baz'},
+        qux: 'fizzbuzz'
+      }
+    }
+  })
+
+  describe('actions', () => {
+    // updateConfig triggers an update call to app-shell
+    test('config:UPDATE', () => {
+      expect(updateConfig('foo.bar', false)).toEqual({
+        type: 'config:UPDATE',
+        payload: {path: 'foo.bar', value: false},
+        meta: {shell: true}
+      })
+    })
+  })
+
+  describe('reducer', () => {
+    beforeEach(() => {
+      state = state.config
+    })
+
+    test('gets store and overrides from remote for initial state', () => {
+      mockShell.getShellConfig.mockReturnValue({isConfig: true})
+
+      expect(configReducer(null, {})).toEqual({isConfig: true})
+    })
+
+    test('handles config:SET', () => {
+      const action = {
+        type: 'config:SET',
+        payload: {path: 'foo.bar', value: 'xyz'}
+      }
+
+      expect(configReducer(state, action)).toEqual({
+        foo: {bar: 'xyz'},
+        qux: 'fizzbuzz'
+      })
+    })
+  })
+
+  describe('selectors', () => {
+    test('getConfig', () => {
+      expect(getConfig(state)).toEqual(state.config)
+    })
+  })
+})

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -1,0 +1,81 @@
+// @flow
+// config redux module
+import {setIn} from '@thi.ng/paths'
+import {getShellConfig} from '../shell'
+import type {State, Action} from '../types'
+import type {LogLevel} from '../logger'
+
+type UrlProtocol = 'file:' | 'http:'
+
+// TODO(mc, 2018-05-17): put this type somewhere common to app and app-shell
+export type Config = {
+  devtools: boolean,
+
+  // logging config
+  log: {
+    level: {
+      file: LogLevel,
+      console: LogLevel
+    }
+  },
+
+  // ui and browser config
+  ui: {
+    width: number,
+    height: number,
+    url: {
+      protocol: UrlProtocol,
+      path: string
+    },
+    webPreferences: {
+      webSecurity: boolean
+    }
+  }
+}
+
+type UpdateConfigAction = {|
+  type: 'config:UPDATE',
+  payload: {|
+    path: string,
+    value: any
+  |},
+  meta: {|
+    shell: true
+  |}
+|}
+
+type SetConfigAction = {|
+  type: 'config:UPDATE',
+  payload: {|
+    path: string,
+    value: any
+  |}
+|}
+
+export type ConfigAction = UpdateConfigAction | SetConfigAction
+
+// trigger a config value update to the app-shell via shell middleware
+export function updateConfig (path: string, value: any): UpdateConfigAction {
+  return {type: 'config:UPDATE', payload: {path, value}, meta: {shell: true}}
+}
+
+// config reducer
+export function configReducer (
+  state: ?Config,
+  action: Action
+): Config {
+  // initial state
+  // getShellConfig makes a sync RPC call, so use sparingly
+  if (!state) return getShellConfig()
+
+  switch (action.type) {
+    case 'config:SET':
+      return setIn(state, action.payload.path, action.payload.value)
+  }
+
+  return state
+}
+
+export function getConfig (state: State): Config {
+  return state.config
+}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -9,7 +9,8 @@ import createHistory from 'history/createBrowserHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
 import createLogger from './logger'
-import {checkForShellUpdates} from './shell'
+import {checkForShellUpdates, shellMiddleware} from './shell'
+
 import {healthCheckMiddleware} from './http-api-client'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {
@@ -29,6 +30,7 @@ const history = createHistory()
 const middleware = applyMiddleware(
   thunk,
   robotApiMiddleware(),
+  shellMiddleware,
   healthCheckMiddleware,
   analyticsMiddleware,
   routerMiddleware(history)

--- a/app/src/logger.js
+++ b/app/src/logger.js
@@ -1,7 +1,20 @@
+// @flow
 // logger
 import {ipcRenderer} from 'electron'
 
-const LEVELS = [
+// TODO(mc, 2018-05-17): put this type somewhere common to app and app-shell
+export type LogLevel =
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'http'
+  | 'verbose'
+  | 'debug'
+  | 'silly'
+
+type Logger = {[level: LogLevel]: (message: string, meta: {}) => void}
+
+const LEVELS: Array<LogLevel> = [
   'error',
   'warn',
   'info',
@@ -11,7 +24,7 @@ const LEVELS = [
   'silly'
 ]
 
-export default function createLogger (filename) {
+export default function createLogger (filename: string): Logger {
   const label = `app/${filename}`
 
   return LEVELS.reduce((result, level) => ({
@@ -20,7 +33,7 @@ export default function createLogger (filename) {
   }), {})
 }
 
-function log (level, message, label, meta) {
+function log (level: LogLevel, message: string, label: string, meta: {}) {
   const print = `[${label}] ${level}: ${message}`
 
   // log to web console, too
@@ -39,5 +52,5 @@ function log (level, message, label, meta) {
   }
 
   // send to main process for logfile collection
-  ipcRenderer.send('log', {level, message, label, meta})
+  ipcRenderer.send('log', {level, message, label, ...meta})
 }

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -15,10 +15,14 @@ import {shellReducer} from './shell'
 // analytics state
 import {NAME as ANALYTICS_NAME, reducer as analyticsReducer} from './analytics'
 
+// config state
+import {configReducer} from './config'
+
 export default combineReducers({
   [ROBOT_NAME]: robotReducer,
   [ANALYTICS_NAME]: analyticsReducer,
   api: httpApiReducer,
+  config: configReducer,
   shell: shellReducer,
   router: routerReducer
 })

--- a/app/src/shell/__tests__/shell.test.js
+++ b/app/src/shell/__tests__/shell.test.js
@@ -13,20 +13,26 @@ import {
   downloadShellUpdate,
   quitAndInstallShellUpdate,
   shellReducer,
-  getShellUpdate
+  shellMiddleware,
+  getShellUpdate,
+  getShellConfig
 } from '..'
 
+jest.mock('../../logger')
 jest.mock('electron')
 
-const middlewares = [thunk]
+const middlewares = [thunk, shellMiddleware]
 const mockStore = configureMockStore(middlewares)
-const mockUpdate = electron.__mockRemotes['./update']
+const {
+  './update': mockUpdate,
+  './config': mockConfig
+} = electron.__mockRemotes
 
 describe('app shell module', () => {
   let state
 
   beforeEach(() => {
-    electron.__clearMock()
+    jest.clearAllMocks()
 
     state = {
       shell: {
@@ -268,6 +274,31 @@ describe('app shell module', () => {
     })
   })
 
+  describe('shell middleware', () => {
+    test('"dispatches" actions to the app shell if meta.shell', () => {
+      const store = mockStore({})
+      const action = {type: 'foo', meta: {shell: true}}
+
+      store.dispatch(action)
+      expect(electron.ipcRenderer.send).toHaveBeenCalledWith('dispatch', action)
+    })
+
+    test('catches actions from main and dispatches them to redux', () => {
+      const store = mockStore({})
+      const action = {type: 'foo'}
+
+      expect(electron.ipcRenderer.on)
+        .toHaveBeenCalledWith('dispatch', expect.any(Function))
+
+      const dispatchHandler = electron.ipcRenderer.on.mock.calls.find(call => {
+        return call[0] === 'dispatch' && typeof call[1] === 'function'
+      })[1]
+
+      dispatchHandler({}, action)
+      expect(store.getActions()).toEqual([action])
+    })
+  })
+
   describe('shell selectors', () => {
     // TODO(mc, 2018-05-11): mockUpdate.CURRENT_VERSION is undefined so this
     //  test isn't really doing anything anymore
@@ -276,6 +307,13 @@ describe('app shell module', () => {
         ...state.shell.update,
         current: mockUpdate.CURRENT_VERSION
       })
+    })
+  })
+
+  describe('config remote', () => {
+    test('getShellConfig', () => {
+      mockConfig.getConfig.mockReturnValue({isConfig: true})
+      expect(getShellConfig()).toEqual({isConfig: true})
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,21 @@
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.19.1.tgz#8bdf8ed0e759eea1c7010d22fb9789e462ec0a9b"
 
+"@thi.ng/checks@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/@thi.ng/checks/-/checks-1.5.3.tgz#566df9d173f4ee7a928406f56fafa0c263c5a73a"
+
+"@thi.ng/errors@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@thi.ng/errors/-/errors-0.1.3.tgz#42d5382b174fc21320f42ddbc0edcc8bfeea96e6"
+
+"@thi.ng/paths@^1.3.8":
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/@thi.ng/paths/-/paths-1.3.8.tgz#815ad89aebdf1bd2b9013ef874fddb97fcc67f47"
+  dependencies:
+    "@thi.ng/checks" "^1.5.3"
+    "@thi.ng/errors" "^0.1.3"
+
 "@types/node@^8.0.24":
   version "8.9.5"
   resolved "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz#162b864bc70be077e6db212b322754917929e976"
@@ -2811,7 +2826,7 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^4.1.0, dot-prop@^4.1.1, dot-prop@^4.2.0:
+dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:


### PR DESCRIPTION
## overview

Larger PR than I intended; I ended up implementing just a little more functionality than we strictly needed for config (but that we do need for future work). My apologies.

Closes #1329

## changelog

- feat(app): Add app-shell config to app state
    - Added config remote to `app/src/shell` module to grab initial state
    - Added an async IPC channel so the main and renderer threads can dispatch actions to each other
        - Handled in `app-shell/lib/main` and `app/src/shell` (middleware)
    - Added config actions:
        - `config:UPDATE` gets sent from renderer to main to trigger the file write
        - `config:SET` gets sent from main to renderer on write success to be reduced into state
    - Cleaned up some mocking related to config and logging so every test run doesn't need to create temp files

## review requests

Test procedure:

1. Launch app and open redux devtools
2. Dispatch a `config:UPDATE` action
    ```js
    {
      type: 'config:UPDATE',
      payload: {path: 'ui.width', value: 512},
      meta: {shell: true}
    }
    ```
    - [x] Main process dispatches a `config:SET` in response
    - [x] Redux config state is updated
    - [x] `config.json` is updated (can test by relaunching app and observing the width)

3. Dispatch a `config:UPDATE` action for overriden value
    ```js
    {
      type: 'config:UPDATE',
      payload: {path: 'devtools', value: false},
      meta: {shell: true}
    }
    ```
    - [x] Main process does not dispatch a `config:SET`
    - [x] Redux config state does not change
    - [x] `config.json` does not change