### PR TITLE
Add deck calibration move endpoint with offset logic for multi-channel

### DIFF
--- a/api/opentrons/deck_calibration/__init__.py
+++ b/api/opentrons/deck_calibration/__init__.py
@@ -24,10 +24,12 @@ def dots_set():
     :return:  List of calibration coordinates
     """
     if ff.dots_deck_type():
+        # Etched dots
         slot_1_lower_left = (12.13, 6.0)
         slot_3_lower_right = (380.87, 6.0)
         slot_7_upper_left = (12.13, 261.0)
     else:
+        # Etched crosses
         slot_1_lower_left = (12.13, 9.0)
         slot_3_lower_right = (380.87, 9.0)
         slot_7_upper_left = (12.13, 258.0)
@@ -72,7 +74,6 @@ def position(axis: str):
 
 
 def jog(axis, direction, step):
-
     robot._driver.move(
         {axis: robot._driver.position[axis] + direction * step})
 

--- a/api/opentrons/deck_calibration/linal.py
+++ b/api/opentrons/deck_calibration/linal.py
@@ -111,7 +111,7 @@ def add_z(xy: np.ndarray, z: float) -> np.ndarray:
     # [ 0  0  1  z ]
     # [ 0  0  0  1 ]
 
-    return xyz
+    return xyz.round(11)
 
 
 def apply_transform(

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -249,7 +249,10 @@ class SmoothieDriver_3_0_0:
 
         self._position = HOMED_POSITION.copy()
         self.log = []
+
+        # why do we do this after copying the HOMED_POSITION?
         self._update_position({axis: 0 for axis in AXES})
+
         self.simulating = True
         self._connection = None
         self._config = config

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -231,7 +231,7 @@ def _load_json(filename) -> dict:
 
 
 def _save_json(data, filename):
-    print("Saving json file at {}".format(filename))
+    # print("Saving json file at {}".format(filename))
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, 'w') as file:
         json.dump(data, file, sort_keys=True, indent=4)

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -8,8 +8,6 @@ from threading import Thread
 from opentrons import robot, instruments
 from opentrons.instruments import pipette_config
 from opentrons.trackers import pose_tracker
-from opentrons.deck_calibration.endpoints import safe_points
-from opentrons.deck_calibration import z_pos
 
 log = logging.getLogger(__name__)
 
@@ -94,7 +92,6 @@ async def position_info(request):
     can easily access the pipette mount screws with a screwdriver. Attach tip
     position places either pipette roughly in the front-center of the deck area
     """
-    safe_pos1, safe_pos2, safe_pos3 = safe_points().values()
     return web.json_response({
         'positions': {
             'change_pipette': {
@@ -105,23 +102,6 @@ async def position_info(request):
             'attach_tip': {
                 'target': 'pipette',
                 'point': (200, 90, 150)
-            },
-            'initial_calibration_1': {
-                'target': 'pipette',
-                'point': safe_pos1
-            },
-            'initial_calibration_2': {
-                'target': 'pipette',
-                'point': safe_pos2
-            },
-            'initial_calibration_3': {
-                'target': 'pipette',
-                'point': safe_pos3
-            },
-            'z_calibration': {
-                'target': 'pipette',
-                'point': z_pos
-
             }
         }
     })

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -1,0 +1,204 @@
+import numpy as np
+from opentrons import robot
+from opentrons import deck_calibration as dc
+from opentrons.deck_calibration import endpoints
+from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
+from opentrons.trackers.pose_tracker import absolute
+from opentrons.instruments.pipette_config import Y_OFFSET_MULTI
+
+
+# Note that several values in this file have target/expected values that do not
+# accurately reflect robot operation, because of differences between return
+# values from the driver during simulating vs. non-simulating modes. In
+# particular, during simulating mode the driver's `position` method returns
+# the xyz position of the tip of the pipette, but during non-simulating mode
+# it returns a position that correponds roughly to the gantry (e.g.: where the
+# Smoothie board sees the position of itself--after a fashion). Simulating mode
+# should be replaced with something that accurately reflects actual robot
+# operation, and then these tests should be revised to match expected reality.
+
+async def test_transform_from_moves(async_client, monkeypatch):
+    test_mount, test_model = ('left', 'p300_multi_v1')
+    # test_mount, test_model = ('right', 'p300_single_v1')
+
+    def dummy_read_model(self, mount):
+        if mount == test_mount:
+            return test_model
+        else:
+            return None
+
+    monkeypatch.setattr(
+        SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
+
+    robot.reset()
+    robot.cache_instrument_models()
+    robot.home()
+
+    # This is difficult to test without the `async_client` because it has to
+    # take an `aiohttp.web.Request` object as a parameter instead of a dict
+    resp = await async_client.post('/calibration/deck/start')
+    start_res = await resp.json()
+    token = start_res.get('token')
+
+    assert start_res.get('pipette', {}).get('mount') == test_mount
+    assert start_res.get('pipette', {}).get('model') == test_model
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'attach tip', 'tipLength': 51.7})
+    assert res.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'move', 'point': 'safeZ'})
+    assert res.status == 200
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'z',
+        'direction': -1,
+        'step': 4.5})
+    assert jogres.status == 200
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'save z'})
+    assert res.status == 200
+
+    pipette = endpoints.session.pipettes[test_mount]
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'move', 'point': '1'})
+    assert res.status == 200
+    pt1 = endpoints.safe_points().get('1')
+    if 'multi' in test_model:
+        expected1 = (
+            pt1[0],
+            pt1[1] + 2 * Y_OFFSET_MULTI,
+            pt1[2])
+    else:
+        expected1 = pt1
+    assert np.isclose(absolute(robot.poses, pipette), expected1).all()
+
+    # Jog to calculated position for transform
+    x_delta1 = 13.16824337 - dc.endpoints.safe_points()['1'][0]
+    y_delta1 = 8.30855312 - dc.endpoints.safe_points()['1'][1]
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'x',
+        'direction': 1,
+        'step': x_delta1})
+    assert jogres.status == 200
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'y',
+        'direction': 1,
+        'step': y_delta1})
+    assert jogres.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'save xy', 'point': '1'})
+    assert res.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'move', 'point': '2'})
+    assert res.status == 200
+    pt2 = endpoints.safe_points().get('2')
+    if 'multi' in test_model:
+        expected2 = (
+            pt2[0],
+            pt2[1] + 2 * Y_OFFSET_MULTI,
+            pt2[2])
+    else:
+        expected2 = pt2
+    assert np.isclose(absolute(robot.poses, pipette), expected2).all()
+
+    # Jog to calculated position for transform
+    x_delta2 = 380.50507635 - dc.endpoints.safe_points()['2'][0]
+    y_delta2 = -23.82925545 - dc.endpoints.safe_points()['2'][1]
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'x',
+        'direction': 1,
+        'step': x_delta2})
+    assert jogres.status == 200
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'y',
+        'direction': 1,
+        'step': y_delta2})
+    assert jogres.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'save xy', 'point': '2'})
+    assert res.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'move', 'point': '3'})
+    assert res.status == 200
+    pt3 = endpoints.safe_points().get('3')
+    if 'multi' in test_model:
+        expected3 = (
+            pt3[0],
+            pt3[1] + 2 * Y_OFFSET_MULTI,
+            pt3[2])
+    else:
+        expected3 = pt3
+    assert np.isclose(absolute(robot.poses, pipette), expected3).all()
+
+    # Jog to calculated position for transform
+    x_delta3 = 34.87002331 - dc.endpoints.safe_points()['3'][0]
+    y_delta3 = 256.36103295 - dc.endpoints.safe_points()['3'][1]
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'x',
+        'direction': 1,
+        'step': x_delta3})
+    assert jogres.status == 200
+    jogres = await async_client.post('/calibration/deck', json={
+        'token': token,
+        'command': 'jog',
+        'axis': 'y',
+        'direction': 1,
+        'step': y_delta3})
+    assert jogres.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'save xy', 'point': '3'})
+    assert res.status == 200
+
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'save transform'})
+    assert res.status == 200
+    res = await async_client.post('/calibration/deck', json={
+        'token': token, 'command': 'release'})
+    assert res.status == 200
+
+    # This transform represents a 5 degree rotation, with a shift in x, y, & z.
+    # Values for the points and expected transform come from a hand-crafted
+    # transformation matrix and the points that would generate that matrix.
+    cos_5deg_p = 0.99619469809
+    sin_5deg_p = 0.08715574274
+    sin_5deg_n = -sin_5deg_p
+    const_zero = 0.0
+    const_one_ = 1.0
+    delta_x___ = 0.3
+    delta_y___ = 0.4
+    delta_z___ = 0.5
+    expected_transform = [
+        [cos_5deg_p, sin_5deg_p, const_zero, delta_x___],
+        [sin_5deg_n, cos_5deg_p, const_zero, delta_y___],
+        [const_zero, const_zero, const_one_, delta_z___],
+        [const_zero, const_zero, const_zero, const_one_]]
+
+    actual_transform = robot.config.gantry_calibration
+    from pprint import pprint
+    print()
+    print("Expected transform [type: {}]:".format(type(expected_transform)))
+    pprint(expected_transform)
+
+    print()
+    print("Actual transform [type: {}]:".format(type(actual_transform)))
+    pprint(actual_transform)
+    assert np.allclose(actual_transform, expected_transform)

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -1,10 +1,21 @@
 import json
+import numpy as np
 from opentrons import robot, instruments
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
-from opentrons.instruments import pipette_config
 from opentrons.robot import robot_configs
+from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 
+
+# Note that several tests in this file have target/expected values that do not
+# accurately reflect robot operation, because of differences between return
+# values from the driver during simulating vs. non-simulating modes. In
+# particular, during simulating mode the driver's `position` method returns
+# the xyz position of the tip of the pipette, but during non-simulating mode
+# it returns a position that correponds roughly to the gantry (e.g.: where the
+# Smoothie board sees the position of itself--after a fashion). Simulating mode
+# should be replaced with something that accurately reflects actual robot
+# operation, and then these tests should be revised to match expected reality.
 
 # ------------ Function tests (unit) ----------------------
 async def test_add_and_remove_tip(dc_session):
@@ -48,6 +59,7 @@ async def test_add_and_remove_tip(dc_session):
 
 async def test_save_xy(dc_session):
     robot.reset()
+    robot.cache_instrument_models()
     mount = 'left'
     pip = instruments.P10_Single(mount=mount)
     dc_session.pipettes = {mount: pip}
@@ -67,16 +79,22 @@ async def test_save_xy(dc_session):
     await endpoints.save_xy(data)
 
     actual = dc_session.points[point]
-    expected = (robot._driver.position['X'], robot._driver.position['Y'])
+    expected = (
+        robot._driver.position['X'] + robot.config.mount_offset[0],
+        robot._driver.position['Y']
+    )
     assert actual == expected
 
 
 async def test_save_z(dc_session):
     robot.reset()
+    robot.cache_instrument_models()
     mount = 'left'
+    model = 'p10_single_v1'
     pip = instruments.P10_Single(mount=mount)
     dc_session.pipettes = {mount: pip}
     dc_session.current_mount = 'Z'
+    dc_session.current_model = model
     dc_session.tip_length = 25
     dc_session.pipettes.get(mount)._add_tip(dc_session.tip_length)
 
@@ -88,8 +106,7 @@ async def test_save_z(dc_session):
     await endpoints.save_z({})
 
     new_z = dc_session.z_value
-    pipette_z_offset = pipette_config.configs['p10_single_v1'].model_offset[-1]
-    expected_z = z_target - pipette_z_offset
+    expected_z = z_target
     assert new_z == expected_z
 
 
@@ -111,19 +128,54 @@ async def test_save_calibration_file(dc_session, monkeypatch):
 
     await endpoints.save_transform({})
 
-    expected = robot.config.gantry_calibration
+    in_memory = robot.config.gantry_calibration
     assert len(persisted_data) == 2
-    assert persisted_data[0][0].gantry_calibration == expected
-    assert persisted_data[1][0].gantry_calibration == expected
+    assert persisted_data[0][0].gantry_calibration == in_memory
+    assert persisted_data[1][0].gantry_calibration == in_memory
     assert persisted_data[1][-1] is not None
+
+    expected = [[1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.3],
+                [0.0, 0.0, 1.0, 0.2],
+                [0.0, 0.0, 0.0, 1.0]]
+    assert np.allclose(in_memory, expected)
+
+
+async def test_transform_calculation(dc_session):
+    # This transform represents a 5 degree rotation, with a shift in x, y, & z.
+    # Values for the points and expected transform come from a hand-crafted
+    # transformation matrix and the points that would generate that matrix.
+    cos_5deg_p = 0.99619469809
+    sin_5deg_p = 0.08715574274
+    sin_5deg_n = -sin_5deg_p
+    const_zero = 0.0
+    const_one_ = 1.0
+    delta_x___ = 0.3
+    delta_y___ = 0.4
+    delta_z___ = 0.5
+    expected_transform = [
+        [cos_5deg_p, sin_5deg_p, const_zero, delta_x___],
+        [sin_5deg_n, cos_5deg_p, const_zero, delta_y___],
+        [const_zero, const_zero, const_one_, delta_z___],
+        [const_zero, const_zero, const_zero, const_one_]]
+
+    dc_session.z_value = 0.5
+    dc_session.points = {
+        '1': [13.16824337, 8.30855312],
+        '2': [380.50507635, -23.82925545],
+        '3': [34.87002331, 256.36103295]
+    }
+
+    await endpoints.save_transform({})
+
+    assert np.allclose(robot.config.gantry_calibration, expected_transform)
 
 
 # ------------ Session and token tests ----------------------
-# TODO(mc, 2018-05-02): this does not adequately pipette selection logic
 async def test_create_session(async_client, monkeypatch):
     """
     Tests that the POST request to initiate a session manager for factory
-    calibration returns a good token.
+    calibration returns a good token, along with the correct preferred pipette
     """
     dummy_token = 'Test Token'
 
@@ -132,14 +184,36 @@ async def test_create_session(async_client, monkeypatch):
 
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
-    expected = {
-        'token': dummy_token,
-        'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
-    resp = await async_client.post('/calibration/deck/start')
-    text = await resp.text()
+    # each tuple in this list is (left-mount, right-mount, correct-choice)
+    pipette_combinations = [
+        ('p300_multi_v1', 'p10_single_v1', 'p10_single_v1'),
+        ('p300_single_v1', 'p10_single_v1', 'p10_single_v1'),
+        ('p10_multi_v1', 'p300_multi_v1', 'p300_multi_v1'),
+        (None, 'p10_single_v1', 'p10_single_v1'),
+        ('p300_multi_v1', None, 'p300_multi_v1'),
+        ('p10_single_v1', 'p300_multi_v1', 'p10_single_v1')]
 
-    assert json.loads(text) == expected
-    assert resp.status == 201
+    for left_model, right_model, preferred in pipette_combinations:
+        def dummy_read_model(self, mount):
+            if mount == 'left':
+                res = left_model
+            else:
+                res = right_model
+            return res
+
+        monkeypatch.setattr(
+            SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
+
+        robot.reset()
+        robot.cache_instrument_models()
+
+        resp = await async_client.post('/calibration/deck/start')
+        start_result = await resp.json()
+        endpoints.session = None
+
+        assert start_result.get('token') == dummy_token
+        assert start_result.get('pipette', {}).get('model') == preferred
+        assert resp.status == 201
 
 
 async def test_create_session_fail(async_client, monkeypatch):
@@ -173,7 +247,6 @@ async def test_create_session_fail(async_client, monkeypatch):
 
     resp = await async_client.post('/calibration/deck/start')
     text = await resp.text()
-    print(text)
     assert json.loads(text) == {'message': 'Error, pipette not recognized'}
     assert resp.status == 403
     assert endpoints.session is None
@@ -216,6 +289,8 @@ async def test_forcing_new_session(async_client, monkeypatch):
     overridden.
     """
     robot.reset()
+    robot.cache_instrument_models()
+
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -230,7 +305,7 @@ async def test_forcing_new_session(async_client, monkeypatch):
 
     assert resp.status == 201
     expected = {'token': dummy_token,
-                'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
+                'pipette': {'mount': 'right', 'model': 'p10_single_v1'}}
     assert text == expected
 
     resp1 = await async_client.post('/calibration/deck/start')
@@ -241,7 +316,7 @@ async def test_forcing_new_session(async_client, monkeypatch):
     text2 = await resp2.json()
     assert resp2.status == 201
     expected2 = {'token': dummy_token,
-                 'pipette': {'mount': 'left', 'model': 'p10_single_v1'}}
+                 'pipette': {'mount': 'right', 'model': 'p10_single_v1'}}
     assert text2 == expected2
 
 
@@ -284,6 +359,7 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     Then jog requests will work as expected.
     """
     robot.reset()
+    robot.cache_instrument_models()
     dummy_token = 'Test Token'
 
     def uuid_mock():
@@ -298,8 +374,9 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     axis = 'z'
     direction = 1
     step = 3
-    # left pipette z carriage motor is smoothie axis "Z"
-    smoothie_axis = 'Z'
+    # left pipette z carriage motor is smoothie axis "Z", right is "A"
+    sess = dc.endpoints.session
+    smoothie_axis = 'Z' if sess.current_mount == 'left' else 'A'
 
     robot.reset()
     prior_x, prior_y, prior_z = dc.position(smoothie_axis)
@@ -316,4 +393,4 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     body = await resp.json()
     msg = body.get('message')
 
-    assert '{}'.format((prior_x, prior_y, prior_z + float(step))) in msg
+    assert '{}'.format((prior_x, prior_y, prior_z + step)) in msg

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -179,14 +179,6 @@ async def test_robot_info(virtual_smoothie_env, loop, test_client):
     assert len(body['positions']['change_pipette']['right']) == 3
     assert body['positions']['attach_tip']['target'] == 'pipette'
     assert len(body['positions']['attach_tip']['point']) == 3
-    assert body['positions']['initial_calibration_1']['target'] == 'pipette'
-    assert len(body['positions']['initial_calibration_1']['point']) == 3
-    assert body['positions']['initial_calibration_2']['target'] == 'pipette'
-    assert len(body['positions']['initial_calibration_2']['point']) == 3
-    assert body['positions']['initial_calibration_3']['target'] == 'pipette'
-    assert len(body['positions']['initial_calibration_3']['point']) == 3
-    assert body['positions']['z_calibration']['target'] == 'pipette'
-    assert len(body['positions']['z_calibration']['point']) == 3
 
 
 async def test_home_pipette(virtual_smoothie_env, loop, test_client):

--- a/app/src/components/CalibrateDeck/ClearDeckAlert.js
+++ b/app/src/components/CalibrateDeck/ClearDeckAlert.js
@@ -7,10 +7,7 @@ import type {PipetteConfig} from '@opentrons/shared-data'
 import type {Mount} from '../../robot'
 import type {CalibrateDeckProps} from './types'
 
-import {
-  moveRobotTo,
-  deckCalibrationCommand as dcCommand
-} from '../../http-api-client'
+import {deckCalibrationCommand as dcCommand} from '../../http-api-client'
 
 import ClearDeckAlertModal from '../ClearDeckAlertModal'
 
@@ -41,12 +38,12 @@ function ClearDeckAlert (props: Props) {
 }
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
-  const {robot, mount, pipette, match: {url}} = ownProps
+  const {robot, match: {url}} = ownProps
 
   return {
     onContinue: () => {
+      dispatch(dcCommand(robot, {command: 'move', point: 'attachTip'}))
       dispatch(push(`${url}/step-1`))
-      dispatch(moveRobotTo(robot, {position: 'attach_tip', mount, pipette}))
     },
     onCancel: () => dispatch(dcCommand(robot, {command: 'release'}))
   }

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -9,7 +9,6 @@ import type {CalibrateDeckStartedProps} from './types'
 
 import {
   restartRobotServer,
-  moveRobotTo,
   deckCalibrationCommand as dcCommand
 } from '../../http-api-client'
 
@@ -30,12 +29,16 @@ const TITLE = 'Deck Calibration'
 export default connect(null, mapDispatchToProps)(InstructionsModal)
 
 function InstructionsModal (props: Props) {
-  const {calibrationStep, exitUrl, moveRequest} = props
+  const {calibrationStep, exitUrl, commandRequest} = props
   const subtitle = `Step ${calibrationStep} of 6`
   const titleBarBase = {title: TITLE, subtitle}
   const backButtonBase = {children: 'exit'}
 
-  if (moveRequest.inProgress) {
+  if (
+    commandRequest.inProgress &&
+    commandRequest.request &&
+    commandRequest.request.command === 'move'
+  ) {
     return (
       <SpinnerModalPage
         titleBar={{
@@ -83,22 +86,26 @@ function getHeading (props: Props): string {
 }
 
 function getMovementDescription (props: Props): string {
-  const {moveRequest} = props
+  const {commandRequest} = props
   const mount = capitalize(props.mount)
 
-  switch (moveRequest.request && moveRequest.request.position) {
-    case 'attach_tip': return `${mount} pipette moving to the front and down.`
-    case 'z_calibration': return `${mount} pipette moving to slot 5.`
-    case 'initial_calibration_1': return `${mount} pipette moving to slot 1.`
-    case 'initial_calibration_2': return `${mount} pipette moving to slot 3.`
-    case 'initial_calibration_3': return `${mount} pipette moving to slot 7.`
+  switch (
+    commandRequest.request &&
+    commandRequest.request.command === 'move' &&
+    commandRequest.request.point
+  ) {
+    case 'attachTip': return `${mount} pipette moving to the front and down.`
+    case 'safeZ': return `${mount} pipette moving to slot 5.`
+    case '1': return `${mount} pipette moving to slot 1.`
+    case '2': return `${mount} pipette moving to slot 3.`
+    case '3': return `${mount} pipette moving to slot 7.`
   }
 
   return ''
 }
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
-  const {robot, mount, pipette, calibrationStep: step, match: {url}} = ownProps
+  const {robot, pipette, calibrationStep: step, match: {url}} = ownProps
   const goToNext = () => dispatch(push(`${url}/step-${Number(step) + 1}`))
   let proceed
 
@@ -106,31 +113,31 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
     proceed = () => dispatch(
       dcCommand(robot, {command: 'attach tip', tipLength: pipette.tipLength})
     ).then(() => dispatch(
-      moveRobotTo(robot, {position: 'z_calibration', mount, pipette})
+      dcCommand(robot, {command: 'move', point: 'safeZ'})
     )).then(goToNext)
   } else if (step === '2') {
     proceed = () => dispatch(
       dcCommand(robot, {command: 'save z'})
     ).then(() => dispatch(
-      moveRobotTo(robot, {position: 'initial_calibration_1', mount, pipette})
+      dcCommand(robot, {command: 'move', point: '1'})
     )).then(goToNext)
   } else if (step === '3') {
     proceed = () => dispatch(
       dcCommand(robot, {command: 'save xy', point: '1'})
     ).then(() => dispatch(
-      moveRobotTo(robot, {position: 'initial_calibration_2', mount, pipette})
+      dcCommand(robot, {command: 'move', point: '2'})
     )).then(goToNext)
   } else if (step === '4') {
     proceed = () => dispatch(
       dcCommand(robot, {command: 'save xy', point: '2'})
     ).then(() => dispatch(
-      moveRobotTo(robot, {position: 'initial_calibration_3', mount, pipette})
+      dcCommand(robot, {command: 'move', point: '3'})
     )).then(goToNext)
   } else if (step === '5') {
     proceed = () => dispatch(
       dcCommand(robot, {command: 'save xy', point: '3'})
     ).then(() => dispatch(
-      moveRobotTo(robot, {position: 'attach_tip', mount, pipette})
+      dcCommand(robot, {command: 'move', point: 'attachTip'})
     )).then(goToNext)
   } else {
     proceed = () => dispatch(

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -15,7 +15,7 @@ import {
   deckCalibrationCommand,
   setCalibrationJogStep,
   getCalibrationJogStep,
-  makeGetRobotMove,
+  makeGetDeckCalibrationCommandState,
   makeGetDeckCalibrationStartState
 } from '../../http-api-client'
 
@@ -102,7 +102,7 @@ function CalibrateDeck (props: CalibrateDeckProps) {
 }
 
 function makeMapStateToProps () {
-  const getRobotMove = makeGetRobotMove()
+  const getDeckCalCommand = makeGetDeckCalibrationCommandState()
   const getDeckCalStartState = makeGetDeckCalibrationStartState()
 
   return (state: State, ownProps: OP): SP => {
@@ -120,7 +120,7 @@ function makeMapStateToProps () {
     return {
       startRequest,
       pipetteProps,
-      moveRequest: getRobotMove(state, robot),
+      commandRequest: getDeckCalCommand(state, robot),
       jogStep: getCalibrationJogStep(state)
     }
   }

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -2,7 +2,7 @@
 import type {Match} from 'react-router'
 import type {PipetteConfig} from '@opentrons/shared-data'
 import type {RobotService, Mount} from '../../robot'
-import type {RobotMove, DeckCalStartState} from '../../http-api-client'
+import type {DeckCalCommandState, DeckCalStartState} from '../../http-api-client'
 import type {JogControlsProps} from '../JogControls'
 
 export type CalibrationStep = '1' | '2' | '3' | '4' | '5' | '6'
@@ -15,7 +15,7 @@ export type OP = {
 
 export type SP = {
   startRequest: DeckCalStartState,
-  moveRequest: RobotMove,
+  commandRequest: DeckCalCommandState,
   jogStep: $PropertyType<JogControlsProps, 'step'>,
   pipetteProps: ?{
     mount: Mount,

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -15,6 +15,8 @@ export type JogStep = number
 
 export type DeckCalPoint = '1' | '2' | '3'
 
+export type DeckCalMovePoint = 'attachTip' | 'safeZ' | DeckCalPoint
+
 type DeckStartRequest = {
   force?: boolean
 }
@@ -35,6 +37,7 @@ type DeckCalRequest =
   | {| command: 'save z' |}
   | {| command: 'save transform' |}
   | {| command: 'release' |}
+  | {| command: 'move', point: DeckCalMovePoint |}
 
 type DeckCalResponse = {
   message: string,

--- a/app/src/http-api-client/robot.js
+++ b/app/src/http-api-client/robot.js
@@ -26,10 +26,6 @@ type Position = {|
 type Positions = {|
   change_pipette: MountPosition,
   attach_tip: Position,
-  z_calibration: Position,
-  initial_calibration_1: Position,
-  initial_calibration_2: Position,
-  initial_calibration_3: Position,
 |}
 
 type RobotPositionsResponse = {
@@ -40,10 +36,6 @@ type RobotPositionsResponse = {
 type RobotMoveRequest =
   | {| position: 'change_pipette', mount: Mount |}
   | {| position: 'attach_tip', mount: Mount, pipette: PipetteConfig |}
-  | {| position: 'z_calibration', mount: Mount, pipette: PipetteConfig |}
-  | {| position: 'initial_calibration_1', mount: Mount, pipette: PipetteConfig |}
-  | {| position: 'initial_calibration_2', mount: Mount, pipette: PipetteConfig |}
-  | {| position: 'initial_calibration_3', mount: Mount, pipette: PipetteConfig |}
 
 type RobotMoveResponse = {
   message: string,


### PR DESCRIPTION
## overview

Accounts for multi-channel y offset and left mount x offset. Fixes #1400 and fixes #1450 

## changelog

- (fix) Deck calibration endpoints work correctly with single and multi-channel pipettes and both mounts

## review requests

Tested on 🌔 🌔 , creates functionally idential transform files with multi on left and single on right, and same as CLI