### PR TITLE
refactor robotTimeline selector to support drop tips at end

### DIFF
--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -138,7 +138,7 @@ export type SingleLabwareLiquidState = {[well: string]: LocationLiquidState}
 
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
-  instruments: {
+  instruments: { // TODO Ian 2018-05-23 rename this 'pipettes' to match tipState (& to disambiguate from future 'modules')
     [instrumentId: string]: PipetteData
   },
   labware: {


### PR DESCRIPTION
## overview

Closes #969 

## changelog

- refactor `robotStateTimeline` selector to be able to compose command creators
- drop tips from all pipettes at end of protocol

## review requests

All cases should drop tips only if there are tips on pipette: 2 pipettes with tips, 1 with 1 without, and no tips on either pipette. Test on robot please if you can.

### NOTE
The multi-channel has been doing something weird with the position of the trash when it goes to drop tips. It does this even when I ssh in and `from opentrons import protocols; import json; protocols.execute_protocol(json.loads("""{ protocol JSON here }"""))` so it's a backend problem out of scope of this PR.