### PR TITLE
chore(repo): Add commitizen to repo and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,15 +59,45 @@ If you're looking for something to work on, especially for a first contribution,
 
 ## Commit Guidelines
 
-Good commit messages are essential to keeping an organized and readable Git history. A readable Git history makes our lives easier when doing necessary work like writing changelogs or tracking down regressions. Please read [How to Write a Git Commit Message][commit-message-how-to] by Chris Beams and then come back here. The following seven rules (copied and pasted from that article) are a very good starting point to think about when writing your commit message:
+Good commit messages are essential to keeping an organized and readable Git history. A readable Git history makes our lives easier when doing necessary work like writing changelogs or tracking down regressions. Please read [How to Write a Git Commit Message][commit-message-how-to] by Chris Beams and then come back here. These selected guidelines (copied and pasted from that article) are a very good starting point to think about when writing your commit message:
 
 1.  Separate subject from body with a blank line
-2.  Limit the subject line to 50 characters
-3.  Capitalize the subject line
-4.  Do not end the subject line with a period
-5.  Use the imperative mood in the subject line
-6.  Wrap the body at 72 characters
-7.  Use the body to explain what and why vs. how
+2.  Capitalize the subject line
+3.  Do not end the subject line with a period
+4.  Use the imperative mood in the subject line
+5.  Use the body to explain what and why vs. how
+
+When committing, we use [commitizen][] to format our commit messages according to the [Conventional Commits][conventional-commits] specification. This allows us to automatically generate CHANGELOGs based on commit messages. To commit files, first install `commitizen`, then:
+
+```shell
+git add path/to/files
+git cz
+```
+
+This will launch the commitizen wizard, which will ask you to:
+
+1.  Select a commit type, which will be one of:
+    1.  `feat` - A new feature
+    2.  `fix` - A bug fix
+    3.  `docs` - Documentation only changes
+    4.  `style` - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc
+    5.  `refactor` - A code change that neither fixes a bug nor adds a feature
+    6.  `perf` - A code change that improves performance
+    7.  `test` - Adding missing tests or correcting existing tests
+    8.  `build` - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+    9.  `ci` - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+    10. `chore` - Other changes that don't modify src or test files
+2.  Select a scope
+    * For `feat`, `fix`, `refactor`, and `perf`, this should a top-level project, e.g. `app` or `api`
+    * For other commit types, use your best judgement or omit
+3.  Write a short commit title
+    * Written according to the guidelines above
+4.  Write a longer description if necessary
+    * Also written according to the guidelines above
+5.  Mention any tickets addressed by the commit
+    * e.g. `Closes #xyz`
+
+![commitizen](https://user-images.githubusercontent.com/2963448/40452320-776de7e0-5eaf-11e8-9aa7-ad706713b197.gif)
 
 ## Project and Repository Structure
 
@@ -98,23 +128,23 @@ Your computer will need the following tools installed to be able to develop with
 *   macOS 10.11+, Linux, or Windows 10
 *   Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux)
 
-    ``` shell
-    # pyenv on macOS: install with shared framework option
-    env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.6.4
-
-    # pyenv on Linux: install with shared library option
-    env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.6.4
+    ```shell
+    pyenv install 3.6.4
     ```
 
 *   Node v8 LTS (Carbon) - [nvm][] is optional, but recommended
 
     ```shell
-    # nvm on macOS and Linux
-    # installs version from .nvmrc ("8")
-    nvm install && nvm use
+    nvm install lts/carbon
     ```
 
 *   [yarn][yarn-install] - JavaScript package manager
+
+*   [commitizen][] - Commit message formatter
+
+    ```shell
+    yarn global add commitizen
+    ```
 
 *   GNU Make - we use [Makefiles][] to manage our builds
 
@@ -160,19 +190,13 @@ make lint-css
 Be sure to check out the [API `README`][api-readme] for additional instructions. To run the Opentrons API in development mode:
 
 ```shell
-# change into the API directory
-$ cd api
-
-# verify API is working by printing the version
-python -c 'import opentrons; print(opentrons.__version__)'
-
 # run API with virtual robot
-ENABLE_VIRTUAL_SMOOTHIE=true make dev
+make -C api dev ENABLE_VIRTUAL_SMOOTHIE=true
 # run API with robot's motor driver connected via USB to UART cable
-make dev
+make -C api dev
 
 # push the current contents of the api directory to robot for testing
-make push
+make -C api push
 ```
 
 ### Releasing (for Opentrons developers)
@@ -182,14 +206,17 @@ Our release process is still a work-in-progress. All projects are currently vers
 1.  Manually bump the `version` field in repo-level `package.json`
     *   The rest of these steps will refer to the bump as `${version}`
 2.  `python scripts/bump_version.py --sync && make install`
-3.  `git commit -am 'release: ${version}'`
-4.  Open a PR into `edge`
-5.  Merge the PR once approved
-6.  Verify that CI is green on `edge` and test the build artifacts
-7.  Pull latest `edge` to your machine
-8.  `git tag -a v${version} -m 'release: ${version}'`
-9.  `git push --tags`
-
+3.  `git add --all`
+4.  `git cz`
+    - Type: `chore`
+    - Scope: `release`
+    - Message: `${version}`
+5.  Open a PR into `edge`
+6.  Squash merge the PR once approved
+7.  Verify that CI is green on `edge` and test the build artifacts
+8.  Pull latest `edge` to your machine
+9.  `git tag -a v${version} -m 'chore(release): ${version}'`
+10. `git push --tags`
 
 ## Prior Art
 
@@ -201,7 +228,6 @@ This Contributing Guide was influenced by a lot of work done on existing Contrib
 
 [repo]: https://github.com/Opentrons/opentrons
 [api-readme]: ./api/README.rst
-
 [easyfix]: https://github.com/Opentrons/opentrons/issues?q=is%3Aopen+is%3Aissue+label%3Aeasyfix
 [support]: https://support.opentrons.com/
 [fork-and-pull]: https://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/
@@ -215,3 +241,5 @@ This Contributing Guide was influenced by a lot of work done on existing Contrib
 [makefiles]: https://en.wikipedia.org/wiki/Makefile
 [nvm]: https://github.com/creationix/nvm
 [yarn-install]: https://yarnpkg.com/en/docs/install
+[commitizen]: https://github.com/commitizen/cz-cli
+[conventional-commits]: https://conventionalcommits.org/

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "protocol-designer",
     "webpack-config"
   ],
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
+  },
   "jest": {
     "moduleNameMapper": {
       "\\.(css)$": "identity-obj-proxy"
@@ -58,6 +63,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "css-loader": "^0.28.4",
+    "cz-conventional-changelog": "2.1.0",
     "eslint": "3.19.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-flowtype": "^2.41.0",
@@ -88,10 +94,10 @@
     "react-test-renderer": "^16.2.0",
     "redux-mock-store": "^1.5.1",
     "script-ext-html-webpack-plugin": "^1.8.5",
-    "superagent": "^3.8.1",
     "style-loader": "^0.18.2",
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^18.0.0",
+    "superagent": "^3.8.1",
     "url-loader": "^0.6.2",
     "webpack": "^3.1.0",
     "webpack-bundle-analyzer": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,6 +2169,10 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
+conventional-commit-types@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz#5db95739d6c212acbe7b6f656a11b940baa68946"
+
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -2478,6 +2482,16 @@ cycle@1.0.x:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
+cz-conventional-changelog@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz#2f4bc7390e3244e4df293e6ba351e4c740a7c764"
+  dependencies:
+    conventional-commit-types "^2.0.0"
+    lodash.map "^4.5.1"
+    longest "^1.0.1"
+    right-pad "^1.0.1"
+    word-wrap "^1.0.3"
 
 d@1:
   version "1.0.0"
@@ -5807,6 +5821,10 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
+lodash.map@^4.5.1:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8557,6 +8575,10 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
+right-pad@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
+
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -10282,6 +10304,10 @@ winston@^3.0.0-rc5:
     stack-trace "0.0.x"
     triple-beam "^1.0.1"
     winston-transport "^3.1.0"
+
+word-wrap@^1.0.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
## overview

As discussed in various meetings, we need a way to keep track of the various changes that we make to this codebase. One way to do this is to add this information into our commit messages and format them in such a way that we could generate a changelog from them...

...and that's what we're going to do with [commitizen](https://commitizen.github.io/cz-cli/) and [Conventional Changelog](https://github.com/conventional-changelog/conventional-changelog)!

Ensuring your commit messages are properly formatted is a pain, so this PR adds commitizen to format our messages for us. Commitizen is a little CLI wizard that will ask a few questions and then commit your changes with the proper message:

```
<type>[optional scope]: <description>

[optional body]

[optional footer]
```

![commitizen](https://user-images.githubusercontent.com/2963448/40452320-776de7e0-5eaf-11e8-9aa7-ad706713b197.gif)

Closes #1523

## changelog

- chore(repo): Add commitizen to repo and docs 

## review requests

Give this a read-through and install `commitizen` globally on your machine according to the new instructions in `CONTRIBUTING.md`. We'll be doing a lunch-and-learn tomorrow to get us all up to speed before merging.
