### PR TITLE
api(feature): Home Z axes on boot and home after run instead of before

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -192,12 +192,12 @@ class Session(object):
 
         try:
             self.resume()
-            robot.home()
             if self._is_json_protocol:
                 execute_protocol(self._protocol)
             else:
                 exec(self._protocol, {})
             self.set_state('finished')
+            robot.home()
         except Exception as e:
             log.exception("Exception during run:")
             self.error_append(e)

--- a/api/opentrons/config/feature_flags.py
+++ b/api/opentrons/config/feature_flags.py
@@ -55,3 +55,9 @@ def calibrate_to_bottom(): return get_feature_flag('calibrate-to-bottom')
 # - True: The deck layout has etched "dots"
 # - False: The deck layout has etched "crosses"
 def dots_deck_type(): return get_feature_flag('dots-deck-type')
+
+
+# disable_home_on_boot
+# - True: The robot should not home the carriages on boot
+# - False: The robot should home the carriages on boot
+def disable_home_on_boot(): return get_feature_flag('disable-home-on-boot')

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -294,8 +294,10 @@ class Robot(object):
         return self
 
     def cache_instrument_models(self):
+        log.debug("Updating instrument model cache")
         for mount in self.model_by_mount.keys():
             self.model_by_mount[mount] = self._driver.read_pipette_model(mount)
+            log.debug("{}: {}".format(mount, self.model_by_mount[mount]))
 
     def turn_on_button_light(self):
         self._driver.turn_on_blue_button_light()
@@ -508,20 +510,6 @@ class Robot(object):
     def home(self, *args, **kwargs):
         """
         Home robot's head and plunger motors.
-
-        Parameters
-        ----------
-        *args :
-            A string with axes to home. For example ``'xyz'`` or ``'ab'``.
-
-            If no arguments provided home Z-axis then X, Y, B, A
-
-        Notes
-        -----
-        Sometimes while executing a long protocol,
-        a robot might accumulate precision
-        error and it is recommended to home it. In this scenario, add
-        ``robot.home('xyzab')`` into your script.
         """
 
         # Home gantry first to avoid colliding with labware
@@ -541,6 +529,10 @@ class Robot(object):
         # because their Mover.home() commands aren't used here
         for a in self._actuators.values():
             self.poses = a['carriage'].update_pose_from_driver(self.poses)
+
+    def home_z(self):
+        for mount in ['left', 'right']:
+            self.poses = self._actuators[mount]['carriage'].home(self.poses)
 
     def move_head(self, *args, **kwargs):
         self.poses = self.gantry.move(self.poses, **kwargs)


### PR DESCRIPTION
## overview

Home after a successful protocol run, rather than before, and home Z axes only on boot (can be disabled via feature flag). Fixes #1497 

## changelog

- (feature) Home after protocol rather than before
- (feature) Home Z axes on boot (can be disabled via feature flag)

## review requests

Tested on 🌔 🌔 