### PR TITLE
PD & Complib: Update styles for TitledList & behavior for StepItems

### DIFF
--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -260,7 +260,7 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
         y={undefined}
       >
         <path
-          d="M8.571 7.839l4.242 4.59-4.242 4.59 1.312 1.41 5.545-6-5.545-6z"
+          d="M7.41 15.857L12 11.615l4.59 4.242L18 14.545 12 9l-6 5.545z"
           fillRule="evenodd"
         />
       </svg>

--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -205,7 +205,7 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
       className="title"
     />
     <div
-      className="title_bar_carat"
+      className="title_bar_carat hoverable_carat"
       onClick={[Function]}
     >
       <svg
@@ -244,7 +244,7 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
       className="title"
     />
     <div
-      className="title_bar_carat"
+      className="title_bar_carat hoverable_carat"
       onClick={[Function]}
     >
       <svg

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -30,7 +30,7 @@ type ListProps = {
   onCollapseToggle?: (event: SyntheticMouseEvent<>) => mixed,
   /** collapse the list if true (false by default) */
   collapsed?: boolean,
-  /** highlights the whole TitledList if true */
+  /** set to true when TitledList is selected (eg, user clicked it) */
   selected?: boolean,
   /** disables the whole TitledList if true */
   disabled?: boolean
@@ -68,7 +68,7 @@ export default function TitledList (props: ListProps) {
     [styles.clickable]: props.onClick
   })
 
-  const iconClass = cx(styles.title_bar_icon, iconProps && iconProps.className)
+  const iconClass = cx(styles.title_bar_icon, styles.icon_left_of_title, iconProps && iconProps.className)
 
   return (
     <div className={className} {...{onMouseEnter, onMouseLeave}}>
@@ -86,7 +86,9 @@ export default function TitledList (props: ListProps) {
           >
             <Icon
               className={styles.title_bar_icon}
-              name={props.collapsed ? 'chevron-down' : 'chevron-right'}
+              name={props.selected
+                  ? 'chevron-right'
+                  : (props.collapsed ? 'chevron-down' : 'chevron-up')}
             />
           </div>
         )}

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -32,8 +32,8 @@ type ListProps = {
   collapsed?: boolean,
   /** set to true when TitledList is selected (eg, user clicked it) */
   selected?: boolean,
-  /** enable :hover styling (show border on hover) */
-  hoverable?: boolean,
+  /** set to true when TitledList is hovered (but not when its contents are hovered) */
+  hovered?: boolean,
   /** disables the whole TitledList if true */
   disabled?: boolean
 }
@@ -64,7 +64,7 @@ export default function TitledList (props: ListProps) {
   const className = cx(styles.titled_list, props.className, {
     [styles.disabled]: disabled,
     [styles.titled_list_selected]: !disabled && props.selected,
-    [styles.hoverable_titled_list]: !disabled && props.hoverable
+    [styles.hovered]: !disabled && props.hovered
   })
 
   const titleBarClass = cx(styles.title_bar, {

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -32,6 +32,8 @@ type ListProps = {
   collapsed?: boolean,
   /** set to true when TitledList is selected (eg, user clicked it) */
   selected?: boolean,
+  /** enable :hover styling (show border on hover) */
+  hoverable?: boolean,
   /** disables the whole TitledList if true */
   disabled?: boolean
 }
@@ -61,7 +63,8 @@ export default function TitledList (props: ListProps) {
 
   const className = cx(styles.titled_list, props.className, {
     [styles.disabled]: disabled,
-    [styles.titled_list_selected]: !disabled && props.selected
+    [styles.titled_list_selected]: !disabled && props.selected,
+    [styles.hoverable_titled_list]: !disabled && props.hoverable
   })
 
   const titleBarClass = cx(styles.title_bar, {

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -85,7 +85,7 @@ export default function TitledList (props: ListProps) {
         {collapsible && (
           <div
             onClick={handleCollapseToggle}
-            className={styles.title_bar_carat}
+            className={cx(styles.title_bar_carat, {[styles.hoverable_carat]: !props.selected})}
           >
             <Icon
               className={styles.title_bar_icon}

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -64,7 +64,7 @@ export default function TitledList (props: ListProps) {
   const className = cx(styles.titled_list, props.className, {
     [styles.disabled]: disabled,
     [styles.titled_list_selected]: !disabled && props.selected,
-    [styles.hovered]: !disabled && props.hovered
+    [styles.hover_border]: !disabled && props.hovered
   })
 
   const titleBarClass = cx(styles.title_bar, {

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -24,18 +24,31 @@
 
 .titled_list {
   border: var(--bd-width-default) solid transparent;
-}
 
-.titled_list_selected {
-  border-color: var(--c-highlight);
+  &:hover {
+    /* "highlighted" appearance */
+    border-color: var(--c-highlight);
+  }
 }
 
 .title_bar {
+  position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
   text-decoration: none;
   padding: var(--list-padding-large) var(--list-padding-small);
+}
+
+.titled_list_selected {
+  & .title_bar {
+    background-color: var(--c-bg-selected);
+
+    & * {
+      color: var(--c-highlight);
+      font-weight: var(--fw-semibold);
+    }
+  }
 }
 
 .title {
@@ -48,12 +61,22 @@
 .title_bar_icon {
   color: var(--c-font-dark);
   height: 1.5rem;
+}
+
+.icon_left_of_title {
   margin-right: 0.5rem;
 }
 
 .title_bar_carat {
-  margin-left: auto;
-  margin-right: 0;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  padding: calc(var(--list-padding-small) - var(--bd-width-default));
+
+  &:hover {
+    background-color: var(--c-bg-hover);
+  }
 }
 
 .list {

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -16,6 +16,15 @@
   @apply --clickable;
 }
 
+.disabled {
+  pointer-events: none;
+  background-color: transparent;
+
+  & * {
+    @apply --list-disabled;
+  }
+}
+
 .panel_group,
 .titled_list,
 .list_item {
@@ -24,11 +33,11 @@
 
 .titled_list {
   border: var(--bd-width-default) solid transparent;
+}
 
-  &:hover {
-    /* "highlighted" appearance */
-    border-color: var(--c-highlight);
-  }
+.hoverable_titled_list:hover {
+  /* "highlighted" appearance */
+  border-color: var(--c-highlight);
 }
 
 .title_bar {
@@ -122,13 +131,4 @@ a.list_item {
   flex: none;
   height: calc(1.25 * var(--fs-body-1));
   margin-right: 0.5rem;
-}
-
-.disabled {
-  pointer-events: none;
-  background-color: transparent;
-
-  & * {
-    @apply --list-disabled;
-  }
 }

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -6,7 +6,7 @@
 
   --list-disabled: {
     color: var(--c-font-disabled);
-    border-color: #eee;
+    outline-color: #eee;
     fill: var(--c-font-disabled);
     background-color: transparent;
   }
@@ -32,12 +32,12 @@
 }
 
 .titled_list {
-  border: var(--bd-width-default) solid transparent;
+  outline: var(--bd-width-default) solid transparent;
 }
 
 .hoverable_titled_list:hover {
   /* "highlighted" appearance */
-  border-color: var(--c-highlight);
+  outline-color: var(--c-highlight);
 }
 
 .title_bar {

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -54,7 +54,7 @@
     background-color: var(--c-bg-selected);
 
     & * {
-      color: var(--c-highlight);
+      color: var(--c-selected-dark);
       font-weight: var(--fw-semibold);
     }
   }

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -84,7 +84,7 @@
   padding: calc(var(--list-padding-small) - var(--bd-width-default));
   padding-top: 1rem;
 
-  &:hover {
+  &.hoverable_carat:hover {
     background-color: var(--c-bg-hover);
   }
 }

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -35,7 +35,7 @@
   outline: var(--bd-width-default) solid transparent;
 }
 
-.hoverable_titled_list:hover {
+.hovered {
   /* "highlighted" appearance */
   outline-color: var(--c-highlight);
 }
@@ -82,6 +82,7 @@
   bottom: 0;
   right: 0;
   padding: calc(var(--list-padding-small) - var(--bd-width-default));
+  padding-top: 1rem;
 
   &:hover {
     background-color: var(--c-bg-hover);

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -31,13 +31,8 @@
   background-color: white;
 }
 
-.titled_list {
-  outline: var(--bd-width-default) solid transparent;
-}
-
-.hovered {
-  /* "highlighted" appearance */
-  outline-color: var(--c-highlight);
+.hover_border {
+  outline: var(--bd-width-default) solid var(--c-highlight);
 }
 
 .title_bar {

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -19,6 +19,7 @@
 
   /* general UI */
   --c-highlight: #5fd8ee;
+  --c-selected-dark: #00c3e6;
   --c-warning: #e28200;
   --c-success: #60b120;
 

--- a/protocol-designer/src/components/StepCreationButton.css
+++ b/protocol-designer/src/components/StepCreationButton.css
@@ -1,4 +1,5 @@
 .step_creation_button {
+  z-index: 5;
   position: relative;
   padding: 1rem 2rem 1.25rem 2rem;
 }

--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.js
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.js
@@ -48,11 +48,11 @@ export default class MultiChannelSubstep extends React.Component<MultiChannelSub
       <ol
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}
-        className={cx(styles.substep, {[styles.highlighted]: highlighted})}
+        className={cx({[styles.highlighted]: highlighted})}
       >
         {/* Header row */}
         <SubstepRow
-          className={styles.step_subitem}
+          className={cx(styles.step_subitem, {[styles.clear_border]: highlighted})}
           sourceIngredients={uniqBy(
             rowGroup.reduce((acc, row) => (row.sourceIngredients)
               ? [...acc, ...row.sourceIngredients]

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -6,7 +6,6 @@
     flex-direction: row;
     align-items: center;
     padding: 0.5rem;
-    border-top: 2px solid var(--c-light-gray);
     text-align: center;
     font-size: var(--fs-body-1);
   };
@@ -21,6 +20,8 @@
 
 .step_subitem {
   @apply --step_subitem;
+
+  border-top: 2px solid var(--c-light-gray);
 
   & > * {
     @apply --subitem_cell;
@@ -63,8 +64,6 @@
 
 .step_subitem_column_header {
   @apply --step_subitem;
-
-  border: none;
 
   & svg {
     /* Source labware -> Dest Labware arrow icon */
@@ -114,14 +113,14 @@
   @apply --clickable;
 }
 
-.substep {
-  /* Invisible border for padding */
-  border: 2px solid transparent;
+.highlighted {
+  border-color: transparent;
+  outline: 2px solid var(--c-highlight);
+  outline-width: 2px 0;
 }
 
-.highlighted {
-  border: 2px solid var(--c-highlight);
-  border-width: 2px 0;
+.clear_border {
+  border-color: transparent;
 }
 
 .error_icon {

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -121,6 +121,7 @@
 
 .highlighted {
   border: 2px solid var(--c-highlight);
+  border-width: 2px 0;
 }
 
 .error_icon {

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -71,6 +71,7 @@ export default function StepItem (props: StepItemProps) {
       onMouseEnter={onStepHover}
       onMouseLeave={onStepMouseLeave}
       onCollapseToggle={onStepItemCollapseToggle}
+      hoverable
       {...{selected, collapsed}}
     >
       {getStepItemContents(props)}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -25,6 +25,7 @@ type StepItemProps = {
   collapsed?: boolean,
   error?: ?boolean,
   selected?: boolean,
+  hovered?: boolean,
   hoveredSubstep: ?SubstepIdentifier,
 
   getLabwareName: (labwareId: ?string) => ?string,
@@ -43,6 +44,7 @@ export default function StepItem (props: StepItemProps) {
     collapsed,
     error,
     selected,
+    hovered,
 
     onStepMouseLeave,
     onStepClick,
@@ -71,8 +73,7 @@ export default function StepItem (props: StepItemProps) {
       onMouseEnter={onStepHover}
       onMouseLeave={onStepMouseLeave}
       onCollapseToggle={onStepItemCollapseToggle}
-      hoverable
-      {...{selected, collapsed}}
+      {...{selected, collapsed, hovered}}
     >
       {getStepItemContents(props)}
     </TitledList>

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -53,7 +53,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
       ? undefined
       : steplistSelectors.getCollapsedSteps(state)[stepId],
 
-    selected: steplistSelectors.hoveredOrSelectedStepId(state) === stepId,
+    selected: steplistSelectors.selectedStepId(state) === stepId,
     hovered: steplistSelectors.getHoveredSubstep(state) === stepId,
     error: fileDataSelectors.robotStateTimeline(state).errorStepId === stepId, // TODO make mini selector
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -38,9 +38,20 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   // TODO Ian 2018-05-10 is there a way to avoid these ternaries and still have flow pass?
   // Also if you can, use END_STEP const instead of hard-coded '__end__',
   // but flow doesn't like that :(
+  // Same issue with repeating `stepId === '__end__' || stepId === 0` 2x
 
   const hoveredSubstep = steplistSelectors.getHoveredSubstep(state)
   const hoveredStep = steplistSelectors.hoveredStepId(state)
+  const selected = steplistSelectors.selectedStepId(state) === stepId
+
+  let collapsed
+
+  if (!(stepId === '__end__' || stepId === 0)) {
+    // Leave collapsed undefined for special steps
+    collapsed = (selected)
+      ? false // selected steps never collapsed
+      : steplistSelectors.getCollapsedSteps(state)[stepId]
+  }
 
   return {
     step: (stepId === '__end__')
@@ -52,12 +63,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
       : substepSelectors.allSubsteps(state)[stepId],
 
     hoveredSubstep,
-
-    collapsed: (stepId === '__end__' || stepId === 0)
-      ? undefined
-      : steplistSelectors.getCollapsedSteps(state)[stepId],
-
-    selected: steplistSelectors.selectedStepId(state) === stepId,
+    collapsed,
+    selected,
 
     // no double-highlighting: whole step is only "hovered" when
     // user is not hovering on substep.

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -17,15 +17,16 @@ type OP = {
   stepId: $PropertyType<Props, 'stepId'>
 }
 
-type SP = {
+type SP = {|
   step: $PropertyType<Props, 'step'>,
   substeps: $PropertyType<Props, 'substeps'>,
   collapsed: $PropertyType<Props, 'collapsed'>,
   error: $PropertyType<Props, 'error'>,
   selected: $PropertyType<Props, 'selected'>,
+  hovered: $PropertyType<Props, 'hovered'>,
   hoveredSubstep: $PropertyType<Props, 'hoveredSubstep'>,
   getLabwareName: $PropertyType<Props, 'getLabwareName'>
-}
+|}
 
 type DP = $Diff<$Diff<Props, SP>, OP>
 
@@ -38,6 +39,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   // Also if you can, use END_STEP const instead of hard-coded '__end__',
   // but flow doesn't like that :(
 
+  const hoveredSubstep = steplistSelectors.getHoveredSubstep(state)
+  const hoveredStep = steplistSelectors.hoveredStepId(state)
+
   return {
     step: (stepId === '__end__')
       ? null
@@ -47,14 +51,18 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
       ? null
       : substepSelectors.allSubsteps(state)[stepId],
 
-    hoveredSubstep: steplistSelectors.getHoveredSubstep(state),
+    hoveredSubstep,
 
     collapsed: (stepId === '__end__' || stepId === 0)
       ? undefined
       : steplistSelectors.getCollapsedSteps(state)[stepId],
 
     selected: steplistSelectors.selectedStepId(state) === stepId,
-    hovered: steplistSelectors.getHoveredSubstep(state) === stepId,
+
+    // no double-highlighting: whole step is only "hovered" when
+    // user is not hovering on substep.
+    hovered: hoveredStep === stepId && !hoveredSubstep,
+
     error: fileDataSelectors.robotStateTimeline(state).errorStepId === stepId, // TODO make mini selector
 
     getLabwareName: (labwareId: ?string): ?string =>

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -87,10 +87,18 @@ type ToggleStepCollapsedAction = {
   payload: StepIdType
 }
 
-export const toggleStepCollapsed = (payload: StepIdType): ToggleStepCollapsedAction => ({
-  type: 'TOGGLE_STEP_COLLAPSED',
-  payload
-})
+export const toggleStepCollapsed = (stepId: StepIdType): ThunkAction<?ToggleStepCollapsedAction> =>
+  (dispatch: ThunkDispatch<*>, getState: GetState) => {
+    if (stepId === selectors.selectedStepId(getState())) {
+      // User cannot collapse the currently selected step
+      return
+    }
+
+    dispatch({
+      type: 'TOGGLE_STEP_COLLAPSED',
+      payload: stepId
+    })
+  }
 
 export type SelectStepAction = {
   type: 'SELECT_STEP',

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -148,16 +148,6 @@ const collapsedSteps = handleActions({
     ...state,
     [action.payload.id]: false
   }),
-  SELECT_STEP: (state: CollapsedStepsState, action: SelectStepAction) => {
-    if (action.payload === '__end__') {
-      return state
-    }
-
-    return {
-      ...state,
-      [action.payload]: false
-    }
-  },
   DELETE_STEP: (state: CollapsedStepsState, action: DeleteStepAction) =>
     omit(state, action.payload.toString()),
   TOGGLE_STEP_COLLAPSED: (state: CollapsedStepsState, {payload}: ActionType<typeof toggleStepCollapsed>) => ({

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -517,7 +517,7 @@ export const selectors = {
 
   stepCreationButtonExpanded: stepCreationButtonExpandedSelector,
   orderedSteps: orderedStepsSelector,
-  selectedStepId, // TODO replace with selectedStep: selectedStepSelector
+  selectedStepId, // TODO ??? replace with selectedStep: selectedStepSelector ???
   hoveredStepId,
   hoveredOrSelectedStepId,
   getHoveredSubstep,

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -148,6 +148,16 @@ const collapsedSteps = handleActions({
     ...state,
     [action.payload.id]: false
   }),
+  SELECT_STEP: (state: CollapsedStepsState, action: SelectStepAction) => {
+    if (action.payload === '__end__') {
+      return state
+    }
+
+    return {
+      ...state,
+      [action.payload]: false
+    }
+  },
   DELETE_STEP: (state: CollapsedStepsState, action: DeleteStepAction) =>
     omit(state, action.payload.toString()),
   TOGGLE_STEP_COLLAPSED: (state: CollapsedStepsState, {payload}: ActionType<typeof toggleStepCollapsed>) => ({


### PR DESCRIPTION
## overview

Closes #1171 

## changelog

- complib: `TitledList` takes `hoverable` prop that toggles `:hover` style to show border
- complib: `TitledList` style updated to match design (see #1171)
- complib: `TitledList` uses `outline` not `border`
- pd: user cannot collapse selected step; steps *temporarily* expand when selected and return to their previous collapse state when de-selected
- pd: hovered steps are not "selected"; hovered steps show border
- pd: StepCreationButton gets z-height so it is above TitledList header
-complib: remove carat hover state for selected step

## review requests

Run App should look the same as before, and interaction with TitledList items in Run App should be unchanged.

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_update-styles-for-step-items-2018-05-22/index.html

PD should fulfill behavioral & design requirements of 1171