### PR TITLE
PD: well selection input gives correct number of wells with multichannel

### DIFF
--- a/protocol-designer/src/containers/WellSelectionInput.js
+++ b/protocol-designer/src/containers/WellSelectionInput.js
@@ -2,6 +2,12 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
+import flatten from 'lodash/flatten'
+import uniq from 'lodash/uniq'
+import {getWellSetForMultichannel} from '../well-selection/utils'
+import {selectors as fileDataSelectors} from '../file-data'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import type {BaseState} from '../types'
 
 import {openWellSelectionModal} from '../well-selection/actions'
 
@@ -14,25 +20,57 @@ type OP = {
   initialSelectedWells: ?Array<string>
 }
 
+type SP = {
+  numWells: ?number
+}
+
 type DP = {
   onClick?: (e: SyntheticMouseEvent<*>) => mixed
 }
 
-type Props = OP & DP
+type Props = OP & SP & DP
 
 function WellSelectorInput (props: Props) {
-  const {initialSelectedWells, labwareId, pipetteId, onClick} = props
+  const {labwareId, pipetteId, onClick, numWells} = props
   const disabled = !(labwareId && pipetteId)
 
   return (
     <FormGroup label='Wells:' disabled={disabled}>
       <InputField
         readOnly
-        value={initialSelectedWells && `${initialSelectedWells.length}`} // TODO Ian 2018-04-27 use selector to get num wells * 8 if multi-channel
+        value={numWells ? `${numWells}` : ''}
         onClick={onClick}
       />
     </FormGroup>
   )
+}
+
+function mapStateToProps (state: BaseState, ownProps: OP): SP {
+  const {pipetteId, labwareId, initialSelectedWells} = ownProps
+  const pipetteData = pipetteId
+    ? fileDataSelectors.equippedPipettes(state)[pipetteId]
+    : null
+
+  const labware = labwareId
+    ? labwareIngredSelectors.getLabware(state)[labwareId]
+    : null
+
+  if (
+    (pipetteData && pipetteData.channels === 1) ||
+    !labwareId || !initialSelectedWells || !labware
+  ) {
+    // single-channel or empty fields
+    return {
+      numWells: initialSelectedWells && initialSelectedWells.length
+    }
+  }
+
+  const wellSets = initialSelectedWells.map(well =>
+    getWellSetForMultichannel(labware.type, well))
+
+  return {
+    numWells: uniq(flatten(wellSets)).length
+  }
 }
 
 function mapDispatchToProps (dispatch: Dispatch<*>, ownProps: OP): DP {
@@ -51,6 +89,6 @@ function mapDispatchToProps (dispatch: Dispatch<*>, ownProps: OP): DP {
   return {...ownProps}
 }
 
-const ConnectedWellSelectorInput = connect(null, mapDispatchToProps)(WellSelectorInput)
+const ConnectedWellSelectorInput = connect(mapStateToProps, mapDispatchToProps)(WellSelectorInput)
 
 export default ConnectedWellSelectorInput


### PR DESCRIPTION
## overview

Closes #1297

## changelog

- For multichannel, `WellSelectionInput` shows number of wells selected, not number of columns

## review requests

- Multichannel steps show number of wells selected, not number of columns selected
- Should still work the same as before with single channel (trough, plate, etc)

-----

@howisthisnamenottakenyet - after playing with it, I realized that to me, this makes well mismatch error harder to understand. Eg when I'm doing a transfer, PD requires a matching number of source & dest wells. However, for multichannel, it's really a matching number of source & dest **columns**. That's how it should be I think, a single trough -> plate column isn't a distribute.

With the multichannel, I can transfer from 1x trough well to 8x destination wells in a 96-plate, because it's 1 source column and 2 dest column. But this now shows me `1` and `8` (wells), instead of `1` and `1` (columns).

But before, people were confused that they selected a column and it said only 8 wells were selected. So I dunno. As an alternative, would you want to do `Well Columns` as the label for the well selection field when multichannel pipette is selected, and have it count well columns so the numbers match up?

Or I could be totally off and it turns out that with a clear error message, people will easily understand the mismatched wells thing.