### PR TITLE
feat(app): Initiate and confirm run cancel

### DIFF
--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -1,0 +1,48 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+import {AlertModal} from '@opentrons/components'
+
+import {
+  actions as robotActions
+} from '../../robot'
+
+type Props = {
+  back: () => mixed,
+  cancel: () => mixed,
+}
+
+const HEADING = 'Are you sure you want to cancel this run?'
+const CANCEL_TEXT = 'cancel run'
+const BACK_TEXT = 'go back'
+
+const mapDispatchToProps = (dispatch) => ({
+  back: () => {
+    dispatch(robotActions.resume())
+    dispatch(push('/run'))
+  },
+  cancel: () => {
+    dispatch(robotActions.cancel())
+    dispatch(push('/run'))
+  }
+})
+
+function ExitAlertModal (props: Props) {
+  const {back, cancel} = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {children: BACK_TEXT, onClick: back},
+        {children: CANCEL_TEXT, onClick: cancel}
+      ]}
+      alertOverlay
+    >
+      <p>Doing so will terminate this run and home your robot.</p>
+    </AlertModal>
+  )
+}
+
+export default connect(null, mapDispatchToProps)(ExitAlertModal)

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -8,6 +8,7 @@ import {
 } from '../../robot'
 
 import CommandList from './CommandList'
+import ConfirmCancelModal from './ConfirmCancelModal'
 
 type SP = {
   commands: Array<any>,
@@ -29,3 +30,5 @@ function RunLog (props: Props) {
 }
 
 export default connect(mapStateToProps)(RunLog)
+
+export {ConfirmCancelModal}

--- a/app/src/components/RunPanel/RunControls.js
+++ b/app/src/components/RunPanel/RunControls.js
@@ -1,6 +1,7 @@
 // @flow
 // play pause run buttons for sidepanel
 import * as React from 'react'
+import {Link} from 'react-router-dom'
 import {OutlineButton} from '@opentrons/components'
 
 import styles from './styles.css'
@@ -12,10 +13,9 @@ type RunProps = {
   onRunClick: () => void,
   onPauseClick: () => void,
   onResumeClick: () => void,
-  onCancelClick: () => void
 }
 export default function (props: RunProps) {
-  const {isReadyToRun, isPaused, isRunning, onRunClick, onPauseClick, onResumeClick, onCancelClick} = props
+  const {isReadyToRun, isPaused, isRunning, onRunClick, onPauseClick, onResumeClick} = props
   const onPauseResumeClick = isPaused
     ? onResumeClick
     : onPauseClick
@@ -49,7 +49,9 @@ export default function (props: RunProps) {
     )
     cancelButton = (
       <OutlineButton
-        onClick={onCancelClick}
+        Component={Link}
+        to={'/run/cancel'}
+        onClick={onPauseClick}
         className={styles.run_button}
         disabled={!isRunning}
       >

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -25,8 +25,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   onRunClick: () => dispatch(robotActions.run()),
   onPauseClick: () => dispatch(robotActions.pause()),
-  onResumeClick: () => dispatch(robotActions.resume()),
-  onCancelClick: () => dispatch(robotActions.cancel())
+  onResumeClick: () => dispatch(robotActions.resume())
 })
 
 function RunPanel (props) {

--- a/app/src/pages/Run.js
+++ b/app/src/pages/Run.js
@@ -4,17 +4,14 @@ import React from 'react'
 import {Route} from 'react-router'
 import Page from '../components/Page'
 import SessionHeader from '../components/SessionHeader'
-import RunLog from '../components/RunLog'
-import ConfirmCancelModal from '../components/RunLog/ConfirmCancelModal'
+import RunLog, {ConfirmCancelModal} from '../components/RunLog'
 
 export default function RunPage () {
   return (
     <Page>
       <SessionHeader />
       <RunLog />
-      <Route path='/run/cancel' render={() => (
-        <ConfirmCancelModal />
-      )} />
+      <Route path='/run/cancel' component={ConfirmCancelModal} />
     </Page>
   )
 }

--- a/app/src/pages/Run.js
+++ b/app/src/pages/Run.js
@@ -1,15 +1,20 @@
+// @flow
 // run task component
 import React from 'react'
-
+import {Route} from 'react-router'
 import Page from '../components/Page'
 import SessionHeader from '../components/SessionHeader'
 import RunLog from '../components/RunLog'
+import ConfirmCancelModal from '../components/RunLog/ConfirmCancelModal'
 
 export default function RunPage () {
   return (
     <Page>
       <SessionHeader />
       <RunLog />
+      <Route path='/run/cancel' render={() => (
+        <ConfirmCancelModal />
+      )} />
     </Page>
   )
 }


### PR DESCRIPTION
## overview

This PR closes #1271. Clicking cancel now pauses run and links to `/run/cancel`. Modal provides option to go back (resume) or cancel run. Both actions redirect to `/run`

## changelog

- change cancel button to `Link` component, trigger onPauseClick
- `/run/cancel` renders new component `ConfirmCancelModal`
- go back action resumes protocol and returns to RunLog
- cancel action cancels protocol and returns to RunLog

## review requests
Please test on a robot. 

- [x] Cancel Button (in side panel) pauses protocol and opens CancelConfirmModal
- [x] Go Back button resumes protocol and returns to RunLog
- [x] Cancel Run button cancels protocol, renders spinner modal, then RunLog with run canceled banner.
