### PR TITLE
chore(*): add precommit-js make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ test-js:
 		--watch=$(watch) \
 		--updateSnapshot=$(updateSnapshot)
 
+# This is the same as `make lint-css lint-js test-js`
+# but uses flow serve instead of flow check to save a few minutes
+# Intended for developers, not for CI
+.PHONY: precommit-js
+precommit-js: lint-css
+	eslint '**/*.js'
+	flow
+	jest --verbose
+
 # lints and typechecks
 .PHONY: lint
 lint: lint-py lint-js lint-css


### PR DESCRIPTION
## overview

To make sure your JS-only changes won't fail in CI, you need to do `make lint-js lint-css test-js`.

1. It's easy to accidentally leave one of those out
2. `lint-js` takes several minutes because it uses `flow check` instead of `flow status` aka `flow` -- this is correct in CI for clean CI logs, but when developing locally it saves a lot of time to do `flow status`

So now if you do JS-only changes, you can be lazier and impatient and just do `make precommit-js` before pushing

## changelog

- add `precommit-js` make command to `Makefile`

## review requests

Good idea? Missing anything? If nobody else thinks this is useful I can just use a script outside of version control