### PR TITLE
feat(app): Remove confirm exit modal from change pipette screens

### DIFF
--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -166,9 +166,12 @@ function ExitButton (props: ChangePipetteProps) {
     ? EXIT_BUTTON_MESSAGE_WRONG
     : EXIT_BUTTON_MESSAGE
 
-  let exitButtonProps = {children, className: styles.confirm_button, onClick: exit}
-
   return (
-    <PrimaryButton {...exitButtonProps} />
+    <PrimaryButton
+      className={styles.confirm_button}
+      onClick={exit}
+    >
+      {children}
+    </PrimaryButton >
   )
 }

--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -161,16 +161,12 @@ function TryAgainButton (props: ChangePipetteProps) {
 }
 
 function ExitButton (props: ChangePipetteProps) {
-  const {exit, exitUrl, success, attachedWrong} = props
+  const {exit, attachedWrong} = props
   const children = attachedWrong
     ? EXIT_BUTTON_MESSAGE_WRONG
     : EXIT_BUTTON_MESSAGE
 
-  let exitButtonProps = {children, className: styles.confirm_button}
-
-  exitButtonProps = success
-    ? {...exitButtonProps, onClick: exit}
-    : {...exitButtonProps, Component: Link, to: exitUrl}
+  let exitButtonProps = {children, className: styles.confirm_button, onClick: exit}
 
   return (
     <PrimaryButton {...exitButtonProps} />


### PR DESCRIPTION
## overview

This PR closes #1453
Modal popup after user clicks the exit button within confirm pipette attached screen,
particularly in a detach pipette use case was redundant. Exit button in title bar still displays the confirm cancel modal.

## changelog

- remove conditional exitButtonProps. Exit button in confirm pipette screen never hits exit confirmation url.

## review requests
Please test on actual robot if possible! Virtual smoothie is fine as well.
Go through change pipette in RobotSettings. Click [exit pipette setup] and confirm no confirm cancel modal renders.
