### PR TITLE
docs(docs): Update header and footer navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Opentrons Platform
 
-[![Travis CI][travis-badge]][travis]
+<!-- [![Travis CI][travis-badge]][travis]
 [![AppVeyor][appveyor-badge]][appveyor]
-[![Codecov][codecov-badge]][codecov]
+[![Codecov][codecov-badge]][codecov] -->
 
 *   [Overview](#overview)
 *   [Opentrons API](#opentrons-api)
@@ -30,16 +30,16 @@ pipette.aspirate(tube_1).dispense(tube_2)
 That is how you tell the Opentrons robot to pipette its max volume from one tube to another. Learn more here:
 
 *   [Documentation](http://docs.opentrons.com)
-*   [Source code](https://github.com/Opentrons/opentrons/tree/v3a/api)
+*   [Source code](https://github.com/Opentrons/opentrons/tree/edge/api)
 
 ## Opentrons App
 
 Easily upload a protocol, calibrate positions, and run your experiment from your computer.
 
 *   [Documentation](https://support.opentrons.com/)
-*   [Source code](https://github.com/Opentrons/opentrons/tree/v3a/app)
+*   [Source code](https://github.com/Opentrons/opentrons/tree/edge/app)
 
-![ot-app](https://lh3.googleusercontent.com/hz80NB3yiMB6r50aKg9DgSuqmwNAEKFz7aC3qQS56YregCGygg1oc3ldn9FAanqTt7REUXikkSuHDX69JODaLWgegDwO_JnDf30j3NuZ05mWOq16nMTxQBAFW6cZqqEsLaDU-uRW)
+![ot-app](https://s3.amazonaws.com/opentrons-images/standalone/ot-2-app.png)
 
 ## Contributing
 
@@ -54,9 +54,9 @@ For more information and development setup instructions, please read [the contri
 Enjoy!
 
 [travis]: https://travis-ci.org/Opentrons/opentrons/branches
-[travis-badge]: https://img.shields.io/travis/Opentrons/opentrons/v3a.svg?style=flat-square&maxAge=3600&label=*nix%20build
+[travis-badge]: https://img.shields.io/travis/Opentrons/opentrons/edge.svg?style=flat-square&maxAge=3600&label=*nix%20build
 [appveyor]: https://ci.appveyor.com/project/Opentrons/opentrons
-[appveyor-badge]: https://img.shields.io/appveyor/ci/Opentrons/opentrons/v3a.svg?style=flat-square&maxAge=3600&label=windows%20build
+[appveyor-badge]: https://img.shields.io/appveyor/ci/Opentrons/opentrons/edge.svg?style=flat-square&maxAge=3600&label=windows%20build
 [codecov]: https://codecov.io/gh/Opentrons/opentrons/branches
-[codecov-badge]: https://img.shields.io/codecov/c/github/Opentrons/opentrons/v3a.svg?style=flat-square&maxAge=3600
+[codecov-badge]: https://img.shields.io/codecov/c/github/Opentrons/opentrons/edge.svg?style=flat-square&maxAge=3600
 [contributing]: ./CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Opentrons Platform
 
-<!-- [![Travis CI][travis-badge]][travis]
+[![Travis CI][travis-badge]][travis]
 [![AppVeyor][appveyor-badge]][appveyor]
-[![Codecov][codecov-badge]][codecov] -->
+[![Codecov][codecov-badge]][codecov]
 
 *   [Overview](#overview)
 *   [Opentrons API](#opentrons-api)
@@ -30,14 +30,14 @@ pipette.aspirate(tube_1).dispense(tube_2)
 That is how you tell the Opentrons robot to pipette its max volume from one tube to another. Learn more here:
 
 *   [Documentation](http://docs.opentrons.com)
-*   [Source code](https://github.com/Opentrons/opentrons/tree/edge/api)
+*   [Source code](./api)
 
 ## Opentrons App
 
 Easily upload a protocol, calibrate positions, and run your experiment from your computer.
 
 *   [Documentation](https://support.opentrons.com/)
-*   [Source code](https://github.com/Opentrons/opentrons/tree/edge/app)
+*   [Source code](./app)
 
 ![ot-app](https://s3.amazonaws.com/opentrons-images/standalone/ot-2-app.png)
 

--- a/api/docs/source/static/nav.css
+++ b/api/docs/source/static/nav.css
@@ -57,12 +57,12 @@ nav.main-menu a.brand img {
 }
 
 nav.main-menu:hover {
-    height: 160px;
+    height: 190px;
     overflow: hidden;
 }
 
 nav.main-menu:hover a.brand img {
-    margin-top: 52.8px;
+    margin-top: 77px;
 }
 
 nav.main-menu ul {

--- a/api/docs/source/templates/layout.html
+++ b/api/docs/source/templates/layout.html
@@ -71,9 +71,11 @@ window.intercomSettings = {
          Products
         </a>
         <ul>
-          <li><a href="https://opentrons.com/robots" >Robots</a></li>
+          <li><a href="https://opentrons.com/robots" >OT-One</a></li>
+          <li><a href="https://opentrons.com/ot-2" >OT-2</a></li>
+          <li><a href="https://opentrons.com/pipettes" >OT-2 Pipettes</a></li>
           <li><a href="https://opentrons.com/modules" >Modules</a></li>
-          <li><a href="https://opentrons.com/ot-app" >OT App</a></li>
+          <li><a href="https://opentrons.com/ot-app" >OT Run App</a></li>
           <li><a href="https://protocols.opentrons.com/" target="_blank">Protocol Library</a></li>
         </ul>
 
@@ -96,7 +98,6 @@ window.intercomSettings = {
         </a>
         <ul>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
-          <li><a href="https://support.opentrons.com/getting-started"target="_blank" >Getting Started</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
           <li><a href="https://github.com/OpenTrons/otone_docs/blob/master/Open_Source.md" target="_blank">Open Source</a></li>
         </ul>
@@ -173,9 +174,11 @@ window.intercomSettings = {
     <section class="footer-menu">
       <ul>
         <li>Products</li>
-        <li><a href="https://opentrons.com/robots" >Robots</a></li>
+        <li><a href="https://opentrons.com/robots" >OT-One</a></li>
+        <li><a href="https://opentrons.com/ot-2" >OT-2</a></li>
+        <li><a href="https://opentrons.com/pipettes" >OT-2 Pipettes</a></li>
         <li><a href="https://opentrons.com/modules" >Modules</a></li>
-        <li><a href="https://opentrons.com/ot-app" >OT App</a></li>
+        <li><a href="https://opentrons.com/ot-app" >OT Run App</a></li>
         <li><a href="https://protocols.opentrons.com/" target="_blank">Protocol Library</a></li>
       </ul>
       <ul>
@@ -189,7 +192,6 @@ window.intercomSettings = {
       <ul>
         <li>Resources</li>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
-        <li><a href="https://support.opentrons.com/getting-started" target="_blank">Getting Started</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
           <li><a href="https://github.com/OpenTrons/otone_docs/blob/master/Open_Source.md" target="_blank">Open Source</a></li>
       </ul>

--- a/api/docs/source/templates/layout.html
+++ b/api/docs/source/templates/layout.html
@@ -99,7 +99,7 @@ window.intercomSettings = {
         <ul>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
-          <li><a href="https://github.com/OpenTrons/otone_docs/blob/master/Open_Source.md" target="_blank">Open Source</a></li>
+          <li><a href="https://github.com/OpenTrons/opentrons" target="_blank">Open Source</a></li>
         </ul>
       </li>
       <li>
@@ -193,7 +193,7 @@ window.intercomSettings = {
         <li>Resources</li>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
-          <li><a href="https://github.com/OpenTrons/otone_docs/blob/master/Open_Source.md" target="_blank">Open Source</a></li>
+          <li><a href="https://github.com/OpenTrons/opentrons" target="_blank">Open Source</a></li>
       </ul>
       <ul>
         <li><a href="https://shop.opentrons.com/" class="buy">Buy</a></li>

--- a/api/docs/source/templates/layout.html
+++ b/api/docs/source/templates/layout.html
@@ -99,7 +99,7 @@ window.intercomSettings = {
         <ul>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
-          <li><a href="https://github.com/OpenTrons/opentrons" target="_blank">Open Source</a></li>
+          <li><a href="https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md" target="_blank">Open Source</a></li>
         </ul>
       </li>
       <li>
@@ -193,7 +193,7 @@ window.intercomSettings = {
         <li>Resources</li>
         <li><a href="https://support.opentrons.com" target="_blank">Support</a></li>
           <li><a href="http://docs.opentrons.com/" target="_blank">Opentrons API</a></li>
-          <li><a href="https://github.com/OpenTrons/opentrons" target="_blank">Open Source</a></li>
+          <li><a href="https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md" target="_blank">Open Source</a></li>
       </ul>
       <ul>
         <li><a href="https://shop.opentrons.com/" class="buy">Buy</a></li>

--- a/api/docs/source/templates/layout.html
+++ b/api/docs/source/templates/layout.html
@@ -75,7 +75,7 @@ window.intercomSettings = {
           <li><a href="https://opentrons.com/ot-2" >OT-2</a></li>
           <li><a href="https://opentrons.com/pipettes" >OT-2 Pipettes</a></li>
           <li><a href="https://opentrons.com/modules" >Modules</a></li>
-          <li><a href="https://opentrons.com/ot-app" >OT Run App</a></li>
+          <li><a href="https://opentrons.com/ot-app" >OT App</a></li>
           <li><a href="https://protocols.opentrons.com/" target="_blank">Protocol Library</a></li>
         </ul>
 
@@ -178,7 +178,7 @@ window.intercomSettings = {
         <li><a href="https://opentrons.com/ot-2" >OT-2</a></li>
         <li><a href="https://opentrons.com/pipettes" >OT-2 Pipettes</a></li>
         <li><a href="https://opentrons.com/modules" >Modules</a></li>
-        <li><a href="https://opentrons.com/ot-app" >OT Run App</a></li>
+        <li><a href="https://opentrons.com/ot-app" >OT App</a></li>
         <li><a href="https://protocols.opentrons.com/" target="_blank">Protocol Library</a></li>
       </ul>
       <ul>


### PR DESCRIPTION
## overview

This PR ensures online documentation navigation header and footer match opentrons.com

## changelog

- remove dead links from resources tab in nav
- update layout template css, js, and navigation

## review requests
1- Checkout this branch
2- `cd api/docs`
3- `make clean html`
4- go to build folder and open any html file 
- [ ] `getting started` and `faq` are removed from resources tab
- [ ] css looks like opentrons.com

go to blog.opentrons.com
- [ ] navigation + css matches opentrons.com