### PR TITLE
refactor(api): Cache pipette models on reset and connect

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -291,6 +291,7 @@ class Robot(object):
         for mount in self._actuators.values():
             for mover in mount.values():
                 self.poses = mover.update_pose_from_driver(self.poses)
+        self.cache_instrument_models()
         return self
 
     def cache_instrument_models(self):
@@ -500,6 +501,7 @@ class Robot(object):
         for module in self.modules:
             module.connect()
         self.fw_version = self._driver.get_fw_version()
+        self.cache_instrument_models()
 
     def _update_axis_homed(self, *args):
         for a in args:

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -199,7 +199,6 @@ def main():
 
     try:
         robot.connect()
-        robot.cache_instrument_models()
     except Exception as e:
         log.exception("Error while connecting to motor-driver: {}".format(e))
 

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -31,7 +31,6 @@ async def test_transform_from_moves(async_client, monkeypatch):
         SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
 
     robot.reset()
-    robot.cache_instrument_models()
     robot.home()
 
     # This is difficult to test without the `async_client` because it has to

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -59,7 +59,6 @@ async def test_add_and_remove_tip(dc_session):
 
 async def test_save_xy(dc_session):
     robot.reset()
-    robot.cache_instrument_models()
     mount = 'left'
     pip = instruments.P10_Single(mount=mount)
     dc_session.pipettes = {mount: pip}
@@ -88,7 +87,6 @@ async def test_save_xy(dc_session):
 
 async def test_save_z(dc_session):
     robot.reset()
-    robot.cache_instrument_models()
     mount = 'left'
     model = 'p10_single_v1'
     pip = instruments.P10_Single(mount=mount)
@@ -205,7 +203,6 @@ async def test_create_session(async_client, monkeypatch):
             SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
 
         robot.reset()
-        robot.cache_instrument_models()
 
         resp = await async_client.post('/calibration/deck/start')
         start_result = await resp.json()
@@ -289,7 +286,6 @@ async def test_forcing_new_session(async_client, monkeypatch):
     overridden.
     """
     robot.reset()
-    robot.cache_instrument_models()
 
     dummy_token = 'Test Token'
 
@@ -359,7 +355,6 @@ async def test_set_and_jog_integration(async_client, monkeypatch):
     Then jog requests will work as expected.
     """
     robot.reset()
-    robot.cache_instrument_models()
     dummy_token = 'Test Token'
 
     def uuid_mock():


### PR DESCRIPTION
## overview

Cache pipette models on robot reset and connect, for better consistency

## changelog

- refactor(api): Cache pipette models on reset and connect

## review requests

Tested on 🌔 🌔 , resulted in slightly better consistency in detecting installed pipette models in corner cases, such as after cancelling a protocol.