### PR TITLE
docs(api): Fix docs copy task to include dotfiles (like .nojekyll)

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -48,7 +48,7 @@ docs:
 	pipenv run sphinx-build -b html -d docs/build/doctrees docs/source docs/build/html
 	pipenv run sphinx-build -b doctest -d docs/build/doctrees docs/source docs/build/doctest
 	shx mkdir -p docs/dist
-	shx cp -R docs/build/html/* docs/public/* docs/dist
+	shx cp -R docs/build/html/. docs/public/. docs/dist
 
 .PHONY: publish
 publish:


### PR DESCRIPTION
## overview

Thanks to @heyoni for reporting this!

`cp -R docs/public/*` will not copy dotfiles because globs do not include dotfiles with `*`

`cp -R docs/public/.` [will include dotfiles](https://superuser.com/a/367303)

## changelog

- docs(api): Fix docs copy task to include dotfiles (like .nojekyll)

## review requests

Run `make -C api docs` on your machine, ensure all necessary dotfiles are copied