### PR TITLE
fix(api): Modify touch tip defaults

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -72,6 +72,10 @@ def log_init():
                 'handlers': ['debug'],
                 'level': level_value
             },
+            'opentrons.instruments': {
+                'handlers': ['debug'],
+                'level': level_value
+            },
             'opentrons.robot.robot_configs': {
                 'handlers': ['debug'],
                 'level': level_value

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -873,7 +873,7 @@ class PipetteTest(unittest.TestCase):
         self.p200.pick_up_tip()
         self.p200.robot.move_to = mock.Mock()
         self.p200.touch_tip(self.plate[0])
-        self.p200.touch_tip(-3)
+        self.p200.touch_tip(v_offset=-3)
         self.p200.touch_tip(self.plate[1], radius=0.5)
 
         expected = [
@@ -882,19 +882,19 @@ class PipetteTest(unittest.TestCase):
                       strategy='arc'),
 
             mock.call(
-                (self.plate[0], (6.40, 3.20, 10.50)),
+                (self.plate[0], (6.40, 3.20, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[0], (0.00, 3.20, 10.50)),
+                (self.plate[0], (0.00, 3.20, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[0], (3.20, 6.40, 10.50)),
+                (self.plate[0], (3.20, 6.40, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[0], (3.20, 0.00, 10.50)),
+                (self.plate[0], (3.20, 0.00, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
@@ -917,19 +917,19 @@ class PipetteTest(unittest.TestCase):
                       instrument=self.p200,
                       strategy='arc'),
             mock.call(
-                (self.plate[1], (4.80, 3.20, 10.50)),
+                (self.plate[1], (4.80, 3.20, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[1], (1.60, 3.20, 10.50)),
+                (self.plate[1], (1.60, 3.20, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[1], (3.20, 4.80, 10.50)),
+                (self.plate[1], (3.20, 4.80, 9.50)),
                 instrument=self.p200,
                 strategy='direct'),
             mock.call(
-                (self.plate[1], (3.20, 1.60, 10.50)),
+                (self.plate[1], (3.20, 1.60, 9.50)),
                 instrument=self.p200,
                 strategy='direct')
         ]


### PR DESCRIPTION
## overview

fix(api): Modify touch tip defaults to reduce speed and touch 1mm below edge of well, and add parameters to allow users to modify these values.

Closes #1448

## changelog

- fix(api): Modify touch tip defaults to 60mm/s and 1mm below edge of well

## review requests

Tested on 🌔 🌔 and demo'ed to Kristin and Kinnari
