### PR TITLE
WellSeries now displays its slot when running robot.commands()

### DIFF
--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -745,8 +745,9 @@ class WellSeries(Container):
         return str(self)
 
     def __str__(self):
-        return '<{0}: {1}>'.format(
+        return '<{0} in slot {1}: {2}>'.format(
             self.__class__.__name__,
+            self.get_path()[0],
             ''.join([str(well) for well in self.values]))
 
     def __getattr__(self, name):

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -745,9 +745,9 @@ class WellSeries(Container):
         return str(self)
 
     def __str__(self):
-        return '<{0} in slot {1}: {2}>'.format(
+        return '<{0} in {1}: {2}>'.format(
             self.__class__.__name__,
-            self.get_path()[0],
+            self.parent.parent,
             ''.join([str(well) for well in self.values]))
 
     def __getattr__(self, name):


### PR DESCRIPTION
## overview

Using `robot.commands()` gives you a lot of information about the actions being performed on individual wells, like which slot on the deck is the container on. I put together this quick hack because the output from `WellSeries` was lacking the originating slot and found it really useful for debugging my protocol.

## changelog

  - added `self.get_path()[0]` to the `__str__` method in `WellSeries`

## review requests

  * Maybe not the best way to access slot information?