### PR TITLE
fix(app-shell): Manually specify deb package name

### DIFF
--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -35,6 +35,9 @@
       }
     ]
   },
+  "deb": {
+    "fpm": ["--name=Opentrons"]
+  },
   "mac": {
     "target": [
       "zip"


### PR DESCRIPTION
## overview

Workaround for electron-userland/electron-builder#2963, where `electron-builder` uses `name` from `package.json` instead of `productName` for the `deb` file's package name, resulting in an illegal name (because `name` starts with an `@`).

## changelog

- fix(app-shell): Manually specify deb package name

## review requests

Please verify the travis linux deb is actually installable