### PR TITLE
feat(app): Make tip probe completely optional

### DIFF
--- a/app/src/components/SetupPanel/DeckCalibrationGroup.js
+++ b/app/src/components/SetupPanel/DeckCalibrationGroup.js
@@ -17,9 +17,8 @@ type StateProps = {
 export default connect(mapStateToProps)(SidePanelGroup)
 
 function mapStateToProps (state): StateProps {
-  const instrumentsCalibrated = robotSelectors.getInstrumentsCalibrated(state)
   const isRunning = robotSelectors.getIsRunning(state)
-  const disabled = isRunning || !instrumentsCalibrated
+  const disabled = isRunning
 
   return {
     title: TITLE,

--- a/app/src/components/TipProbe/UnprobedPanel.js
+++ b/app/src/components/TipProbe/UnprobedPanel.js
@@ -62,8 +62,10 @@ function UnprobedPanel (props: Props) {
 }
 
 function mapStateToProps (state, ownProps: OwnProps): StateProps {
+  const deckPopulated = robotSelectors.getDeckPopulated(state)
+
   return {
-    _showContinueModal: robotSelectors.getDeckPopulated(state)
+    _showContinueModal: deckPopulated || deckPopulated == null
   }
 }
 

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -36,7 +36,6 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
   const nextLabware = robotSelectors.getNextLabware(state)
   const isTipsProbed = robotSelectors.getInstrumentsCalibrated(state)
   const isRunning = robotSelectors.getIsRunning(state)
-  const isDone = robotSelectors.getIsDone(state)
   const isConnected = (
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
   )
@@ -85,7 +84,7 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
       url: calibrateUrl
     },
     run: {
-      disabled: !isTipsProbed && !(isRunning || isDone),
+      disabled: !isSessionLoaded,
       iconName: 'ot-run',
       title: 'run',
       url: '/run'

--- a/app/src/pages/SetupDeck.js
+++ b/app/src/pages/SetupDeck.js
@@ -34,6 +34,6 @@ function SetupDeckPage (props: Props) {
 
 function mapStateToProps (state): StateProps {
   return {
-    deckPopulated: robotSelectors.getDeckPopulated(state)
+    deckPopulated: !!robotSelectors.getDeckPopulated(state)
   }
 }

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -38,7 +38,7 @@ type CalibrationRequest = {
 }
 
 export type State = {
-  +deckPopulated: boolean,
+  +deckPopulated: ?boolean,
   +jogDistance: number,
 
   +probedByMount: {[Mount]: boolean},
@@ -61,7 +61,7 @@ const {
 } = actionTypes
 
 const INITIAL_STATE: State = {
-  deckPopulated: true,
+  deckPopulated: null,
   jogDistance: 0.1,
 
   // TODO(mc, 2018-01-22): combine these into subreducer

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -6,7 +6,7 @@ describe('robot reducer - calibration', () => {
     const state = reducer(undefined, {}).calibration
 
     expect(state).toEqual({
-      deckPopulated: true,
+      deckPopulated: null,
       jogDistance: 0.1,
 
       // intrument probed + basic tip-tracking flags


### PR DESCRIPTION
## overview

This PR makes tip probe completely optional for both protocol run and labware calibration

Closes #1496

## changelog

- feat(app): Make tip probe completely optional

## review requests

Virtual smoothie is fine. Making tip probe optional messes a little with the existing logic for when to display the various clear / populate deck modals, so should test that still works:

- [x] Can run a protocol without first doing tip probe
- [x] Can calibrate labware without first doing tip probe
- Ensure "clear deck" alert modal still pops up before tip probe on:
    - [x] First tip probe
    - [x] First tip probe after doing some labware calibration
- Ensure populate deck alert modal pops up before labware calibration on:
    - [x] First labware calibration
    - [x] First labware calibration after doing a tip probe
