### PR TITLE
feat(app): Wireup analytics opt-in button

### DIFF
--- a/app/src/components/AppSettings/AnalyticsSettingsCard.js
+++ b/app/src/components/AppSettings/AnalyticsSettingsCard.js
@@ -5,16 +5,25 @@ import ToggleButton from '../ToggleButton'
 import {Card} from '@opentrons/components'
 import styles from './styles.css'
 
+type Props = {
+  analyticsOptedIn: boolean,
+  toggleAnalyticsOptedIn: () => mixed,
+}
+
 const TITLE = 'Privacy Settings'
-export default function AnalyticsSettingsCard () {
+
+export default function AnalyticsSettingsCard (props: Props) {
+  const {analyticsOptedIn, toggleAnalyticsOptedIn} = props
+
   return (
     <Card title={TITLE} column>
       <div className={styles.analytics_toggle}>
         <p className={styles.analytics_label}>Share Robot & App analytics with Opentrons</p>
+
         <ToggleButton
           className={styles.analytics_icon}
-          toggledOn={false}
-          disabled
+          toggledOn={analyticsOptedIn}
+          onClick={toggleAnalyticsOptedIn}
         />
       </div>
       <div className={styles.analytics_info}>

--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -6,7 +6,8 @@ import {Link} from 'react-router-dom'
 import type {ShellUpdate} from '../../shell'
 import {RefreshCard, LabeledValue, OutlineButton} from '@opentrons/components'
 
-type Props = ShellUpdate & {
+type Props = {
+  update: ShellUpdate,
   checkForUpdates: () => mixed
 }
 
@@ -15,10 +16,8 @@ const VERSION_LABEL = 'Software Version'
 
 export default function AppInfoCard (props: Props) {
   const {
-    current,
     checkForUpdates,
-    checkInProgress,
-    available
+    update: {current, available, checkInProgress}
   } = props
 
   return (

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -5,7 +5,8 @@ import * as React from 'react'
 import type {ShellUpdate} from '../../shell'
 import {Icon, AlertModal, type ButtonProps} from '@opentrons/components'
 
-type Props = ShellUpdate & {
+type Props = {
+  update: ShellUpdate,
   downloadUpdate: () => mixed,
   quitAndInstall: () => mixed,
   close: () => mixed
@@ -15,7 +16,7 @@ type Props = ShellUpdate & {
 const Spinner = () => (<Icon name='ot-spinner' height='1em' spin />)
 
 export default function AppUpdateModal (props: Props) {
-  const {close, downloadInProgress} = props
+  const {close, update: {downloadInProgress}} = props
   const {button, message} = mapPropsToButtonPropsAndMessage(props)
   const closeButtonChildren = props.error || downloadInProgress
     ? 'close'
@@ -23,7 +24,7 @@ export default function AppUpdateModal (props: Props) {
 
   return (
     <AlertModal
-      heading={`App Version ${props.available || ''} Available`}
+      heading={`App Version ${props.update.available || ''} Available`}
       onCloseClick={close}
       buttons={[
         {onClick: close, children: closeButtonChildren},
@@ -36,7 +37,7 @@ export default function AppUpdateModal (props: Props) {
 }
 
 function mapPropsToButtonPropsAndMessage (props: Props) {
-  const {error, downloaded, checkInProgress, downloadInProgress} = props
+  const {error, downloaded, checkInProgress, downloadInProgress} = props.update
 
   if (error) {
     return {

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -9,8 +9,11 @@ import AppUpdateModal from './AppUpdateModal'
 
 import styles from './styles.css'
 
-type Props = ShellUpdate & {
-  checkForUpdates: () => mixed
+type Props = {
+  update: ShellUpdate,
+  analyticsOptedIn: boolean,
+  checkForUpdates: () => mixed,
+  toggleAnalyticsOptedIn: () => mixed,
 }
 
 export default function AppSettings (props: Props) {

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -51,7 +51,7 @@ type UpdateConfigAction = {|
 |}
 
 type SetConfigAction = {|
-  type: 'config:UPDATE',
+  type: 'config:SET',
   payload: {|
     path: string,
     value: any

--- a/app/src/pages/AppSettings.js
+++ b/app/src/pages/AppSettings.js
@@ -13,19 +13,24 @@ import {
   downloadShellUpdate,
   quitAndInstallShellUpdate
 } from '../shell'
+import {toggleAnalyticsOptedIn, getAnalyticsOptedIn} from '../analytics'
 
 import Page from '../components/Page'
 import AppSettings, {AppUpdateModal} from '../components/AppSettings'
 
 type OP = ContextRouter
 
-type SP = ShellUpdate
+type SP = {
+  update: ShellUpdate,
+  analyticsOptedIn: boolean,
+}
 
 type DP = {
   checkForUpdates: () => mixed,
   downloadUpdate: () => mixed,
   quitAndInstall: () => mixed,
-  closeUpdateModal: () => mixed
+  closeUpdateModal: () => mixed,
+  toggleAnalyticsOptedIn: () => mixed,
 }
 
 type Props = OP & SP & DP
@@ -44,7 +49,10 @@ function AppSettingsPage (props: Props) {
 }
 
 function mapStateToProps (state: State): SP {
-  return getShellUpdate(state)
+  return {
+    update: getShellUpdate(state),
+    analyticsOptedIn: getAnalyticsOptedIn(state)
+  }
 }
 
 function mapDispatchToProps (dispatch: Dispatch): DP {
@@ -52,6 +60,7 @@ function mapDispatchToProps (dispatch: Dispatch): DP {
     checkForUpdates: () => dispatch(checkForShellUpdates()),
     downloadUpdate: () => dispatch(downloadShellUpdate()),
     quitAndInstall: () => quitAndInstallShellUpdate(),
-    closeUpdateModal: () => dispatch(push('/menu/app'))
+    closeUpdateModal: () => dispatch(push('/menu/app')),
+    toggleAnalyticsOptedIn: () => dispatch(toggleAnalyticsOptedIn())
   }
 }

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -12,6 +12,7 @@ import typeof reducer from './reducer'
 import type {Action as RobotAction} from './robot'
 import type {Action as HttpApiAction} from './http-api-client'
 import type {ShellAction} from './shell'
+import type {ConfigAction} from './config'
 
 export type State = $Call<reducer>
 
@@ -21,6 +22,7 @@ export type Action =
   | RobotAction
   | HttpApiAction
   | ShellAction
+  | ConfigAction
   | RouterAction
 
 export type ActionType = $PropertyType<Action, 'type'>


### PR DESCRIPTION
## overview

This PR wires up the analytics card in the app settings.

Closes #1330

## changelog

- feat(app): Wireup analytics opt-in button

## review requests

Remember to pass in the mixpanel ID when running:

```js
make -C app dev OT_APP_MIXPANEL_ID=replace_with_real_id
```

- [ ] Clicking toggle off writes `optedIn: false` to JSON config file
- [ ] Clicking toggle on writes `optedIn: true` to JSON config file
- [ ] Clicking toggle off disables analytics without app restart
- [ ] Clicking toggle off enables analytics without app restart
