### PR TITLE
feat(protocol-designer): show nickname or humanized labware name with…

### DIFF
--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -104,6 +104,7 @@ type LabwareOnDeckProps = {
   containerId: string,
   containerType: string,
   containerName: ?string,
+  showNameOverlay: ?boolean,
 
   // canAdd: boolean,
 
@@ -141,6 +142,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     containerId,
     containerType,
     containerName,
+    showNameOverlay,
 
     // canAdd,
 
@@ -165,10 +167,9 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     deckSetupMode
   } = props
 
-  const hasName = containerName !== null
   const slotIsOccupied = !!containerType
 
-  const canAddIngreds = hasName && !nonFillableContainers.includes(containerType)
+  const canAddIngreds = !showNameOverlay && !nonFillableContainers.includes(containerType)
 
   return (
     <LabwareContainer {...{height, width, slot}} highlighted={highlighted}>
@@ -197,7 +198,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
         )
       }
 
-      {deckSetupMode && slotIsOccupied && hasName &&
+      {deckSetupMode && slotIsOccupied && !showNameOverlay &&
         <OccupiedDeckSlotOverlay {...{
           canAddIngreds,
           containerId,
@@ -209,7 +210,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
           deleteContainer
         }} />}
 
-      {deckSetupMode && !hasName && <NameThisLabwareOverlay {...{
+      {deckSetupMode && showNameOverlay && <NameThisLabwareOverlay {...{
         containerType,
         containerId,
         slot,

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import {humanizeLabwareType} from '@opentrons/components'
 import ForeignDiv from '../../components/ForeignDiv.js'
 import ClickableText from './ClickableText'
 import styles from './labware.css'
@@ -45,7 +44,7 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
 
   onSubmit = () => {
     const { containerId, modifyContainer } = this.props
-    const containerName = this.state.inputValue || humanizeLabwareType(this.props.containerType)
+    const containerName = this.state.inputValue || null
 
     modifyContainer({
       containerId,

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -8,7 +8,7 @@ import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../s
 import * as substepSelectors from '../top-selectors/substeps'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import {selectors as fileDataSelectors} from '../file-data'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+// import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 why is importing StepItem from index.js not working?
 
 type Props = React.ElementProps<typeof StepItem>
@@ -33,7 +33,7 @@ type DP = $Diff<$Diff<Props, SP>, OP>
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {stepId} = ownProps
   const allSteps = steplistSelectors.allSteps(state)
-  const allLabware = labwareIngredSelectors.getLabware(state)
+  // const allLabware = labwareIngredSelectors.getLabware(state) // TODO
 
   // TODO Ian 2018-05-10 is there a way to avoid these ternaries and still have flow pass?
   // Also if you can, use END_STEP const instead of hard-coded '__end__',
@@ -72,8 +72,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
     error: fileDataSelectors.robotStateTimeline(state).errorStepId === stepId, // TODO make mini selector
 
-    getLabwareName: (labwareId: ?string): ?string =>
-      labwareId && allLabware[labwareId] && allLabware[labwareId].name // TODO make mini selector
+    getLabwareName: (labwareId: ?string) => 'todo labware name' // (labwareId: ?string): ?string =>
+      // labwareId && allLabware[labwareId] && allLabware[labwareId].name // TODO IMMEDIATELY make selector
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -8,7 +8,7 @@ import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../s
 import * as substepSelectors from '../top-selectors/substeps'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import {selectors as fileDataSelectors} from '../file-data'
-// import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 why is importing StepItem from index.js not working?
 
 type Props = React.ElementProps<typeof StepItem>
@@ -33,7 +33,6 @@ type DP = $Diff<$Diff<Props, SP>, OP>
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {stepId} = ownProps
   const allSteps = steplistSelectors.allSteps(state)
-  // const allLabware = labwareIngredSelectors.getLabware(state) // TODO
 
   // TODO Ian 2018-05-10 is there a way to avoid these ternaries and still have flow pass?
   // Also if you can, use END_STEP const instead of hard-coded '__end__',
@@ -72,8 +71,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
     error: fileDataSelectors.robotStateTimeline(state).errorStepId === stepId, // TODO make mini selector
 
-    getLabwareName: (labwareId: ?string) => 'todo labware name' // (labwareId: ?string): ?string =>
-      // labwareId && allLabware[labwareId] && allLabware[labwareId].name // TODO IMMEDIATELY make selector
+    getLabwareName: (labwareId: ?string) => labwareId && labwareIngredSelectors.getLabwareNames(state)[labwareId]
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 
-import {TitleBar} from '@opentrons/components'
+import {TitleBar, humanizeLabwareType} from '@opentrons/components'
 
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
@@ -59,10 +59,12 @@ function mapStateToProps (state: BaseState): StateProps {
 
   if (_page === 'ingredient-detail') {
     const labware = labwareIngredSelectors.getSelectedContainer(state)
+    const labwareNames = labwareIngredSelectors.getLabwareNames(state)
+    const labwareId = labware && labware.id
     return {
       _page,
-      title: labware && labware.name,
-      subtitle: labware && labware.type,
+      title: labwareId && labwareNames[labwareId],
+      subtitle: labware && humanizeLabwareType(labware.type),
       backButtonLabel: 'Deck'
     }
   }

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -58,7 +58,7 @@ function mapStateToProps (state: BaseState): StateProps {
   }
 
   if (_page === 'ingredient-detail') {
-    const labware = labwareIngredSelectors.selectedContainer(state)
+    const labware = labwareIngredSelectors.getSelectedContainer(state)
     return {
       _page,
       title: labware && labware.name,

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -16,10 +16,10 @@ type PropsWithoutActions = {
 function mapStateToProps (state: BaseState): PropsWithoutActions {
   // TODO Ian 2018-02-21 put these selectors in Header
   // const activeModals = selectors.activeModals(state)
-  const container = selectors.selectedContainer(state)
+  const container = selectors.getSelectedContainer(state)
   const selectedIngredientGroup = selectors.selectedIngredientGroup(state)
   return {
-    ingredients: container ? selectors.ingredientsByLabware(state)[container.containerId] : {},
+    ingredients: container ? selectors.ingredientsByLabware(state)[container.id] : {},
     selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,
     selected: false
   }

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -48,8 +48,11 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   const {slot} = ownProps
   const container = selectors.containersBySlot(state)[ownProps.slot]
   const containerInfo = (container)
-    ? { containerType: container.type, containerId: container.containerId, containerName: container.name }
+    ? {containerType: container.type, containerId: container.id, containerName: container.name}
     : {}
+
+  const selectedContainer = selectors.getSelectedContainer(state)
+  const isSelectedSlot = !!(selectedContainer && selectedContainer.slot === slot)
 
   const deckSetupMode = steplistSelectors.deckSetupMode(state)
   return {
@@ -61,10 +64,9 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     highlighted: (deckSetupMode)
       // in deckSetupMode, labware is highlighted when selected (currently editing ingredients)
       // or when targeted by an open "Add Labware" modal
-      ? (selectors.selectedContainerSlot(state) === slot ||
-      selectors.canAdd(state) === slot)
+      ? (isSelectedSlot || selectors.canAdd(state) === slot)
       // outside of deckSetupMode, labware is highlighted when step/substep is hovered
-      : steplistSelectors.hoveredStepLabware(state).includes(container && container.containerId),
+      : steplistSelectors.hoveredStepLabware(state).includes(container && container.id),
     deckSetupMode
   }
 }

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -47,8 +47,9 @@ type StateProps = $Diff<Props, DispatchProps>
 function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   const {slot} = ownProps
   const container = selectors.containersBySlot(state)[ownProps.slot]
+  const labwareNames = selectors.getLabwareNames(state)
   const containerInfo = (container)
-    ? {containerType: container.type, containerId: container.id, containerName: container.name}
+    ? {containerType: container.type, containerId: container.id, containerName: labwareNames[container.id]}
     : {}
 
   const selectedContainer = selectors.getSelectedContainer(state)
@@ -58,6 +59,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   return {
     ...containerInfo,
     slot,
+    showNameOverlay: (container && !selectors.getSavedLabware(state)[container.id]),
     canAdd: selectors.canAdd(state),
     activeModals: selectors.activeModals(state),
     labwareToCopy: selectors.labwareToCopy(state),

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -50,8 +50,7 @@ type MP = {
 type SP = $Diff<Props, MP>
 
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
-  const selectedContainer = selectors.selectedContainer(state)
-  const selectedContainerId = selectedContainer && selectedContainer.containerId
+  const selectedContainerId = selectors.getSelectedContainerId(state)
   const containerId = ownProps.containerId || selectedContainerId
 
   if (containerId === null) {

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -125,8 +125,8 @@ export type DeleteIngredient = {|
 |}
 
 export const deleteIngredient = (payload: DeleteIngredientPrepayload) => (dispatch: Dispatch<DeleteIngredient>, getState: GetState) => {
-  const container = selectors.selectedContainer(getState())
-  if (!container || !container.containerId) {
+  const container = selectors.getSelectedContainer(getState())
+  if (!container || !container.id) {
     console.warn('Tried to delete ingredient with no selected container')
     return null
   }
@@ -135,7 +135,7 @@ export const deleteIngredient = (payload: DeleteIngredientPrepayload) => (dispat
     type: 'DELETE_INGREDIENT',
     payload: {
       ...payload,
-      containerId: container.containerId
+      containerId: container.id
     }
   })
 }
@@ -159,7 +159,7 @@ export const editIngredient = (payload: {|
   copyGroupId: string | null
 |}) => (dispatch: Dispatch<EditIngredient>, getState: GetState) => {
   const state = getState()
-  const container = selectors.selectedContainer(state)
+  const container = selectors.getSelectedContainer(state)
   const allIngredients = selectors.getIngredientGroups(state)
 
   const {groupId, copyGroupId, ...inputFields} = payload
@@ -175,7 +175,7 @@ export const editIngredient = (payload: {|
       payload: {
         ...inputFields,
         groupId: groupId,
-        containerId: container.containerId,
+        containerId: container.id,
         wells: wellSelectionSelectors.selectedWellNames(state),
         isUnchangedClone: true
       }
@@ -205,7 +205,7 @@ export const editIngredient = (payload: {|
       ...inputFields,
       // if it matches the name of the clone parent, append "copy" to that name
       name,
-      containerId: container && container.containerId,
+      containerId: container.id,
       groupId: (isUnchangedClone && copyGroupId) ? copyGroupId : nextGroupId,
       wells: wellSelectionSelectors.selectedWellNames(state), // TODO use locations: [slot]: [selected wells]
       isUnchangedClone

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -60,12 +60,13 @@ const copyLabwareMode = handleActions({
   COPY_LABWARE: (state, action: CopyLabware) => false // leave copy mode after performing a copy action
 }, false)
 
-const selectedContainer = handleActions({
-  OPEN_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.openIngredientSelector>) => action.payload,
-  CLOSE_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.closeIngredientSelector>) => null,
+type SelectedContainerId = string | null
+const selectedContainerId = handleActions({
+  OPEN_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.openIngredientSelector>): SelectedContainerId => action.payload,
+  CLOSE_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.closeIngredientSelector>): SelectedContainerId => null,
 
-  OPEN_WELL_SELECTION_MODAL: (state, action: ActionType<openWellSelectionModal>) => action.payload.labwareId,
-  CLOSE_WELL_SELECTION_MODAL: () => null
+  OPEN_WELL_SELECTION_MODAL: (state, action: ActionType<openWellSelectionModal>): SelectedContainerId => action.payload.labwareId,
+  CLOSE_WELL_SELECTION_MODAL: (): SelectedContainerId => null
 }, null)
 
 type SelectedIngredientGroupState = {|
@@ -88,24 +89,37 @@ type ContainersState = {
   [id: string]: Labware
 }
 
-const initialLabwareState = {
+const initialLabwareState: ContainersState = {
   [FIXED_TRASH_ID]: {
     id: FIXED_TRASH_ID,
     type: 'fixed-trash',
+    disambiguationNumber: 1,
     name: 'Trash',
     slot: '12'
   }
 }
 
+function getNextDisambiguationNumber (allContainers: ContainersState, labwareType: string): number {
+  const allIds = Object.keys(allContainers)
+  const sameTypeLabware = allIds.filter(containerId => allContainers[containerId].type === labwareType)
+  const disambigNumbers = sameTypeLabware.map(containerId => allContainers[containerId].disambiguationNumber)
+  return Math.max(...disambigNumbers)
+}
+
 export const containers = handleActions({
-  CREATE_CONTAINER: (state: ContainersState, action: ActionType<typeof actions.createContainer>) => ({
-    ...state,
-    [uuid() + ':' + action.payload.containerType]: {
-      slot: action.payload.slot || nextEmptySlot(_loadedContainersBySlot(state)),
-      type: action.payload.containerType,
-      name: null // create with null name, so we force explicit naming.
+  CREATE_CONTAINER: (state: ContainersState, action: ActionType<typeof actions.createContainer>) => {
+    const id = uuid() + ':' + action.payload.containerType
+    return {
+      ...state,
+      [id]: {
+        slot: action.payload.slot || nextEmptySlot(_loadedContainersBySlot(state)),
+        type: action.payload.containerType,
+        disambiguationNumber: getNextDisambiguationNumber(state, action.payload.containerType),
+        id,
+        name: null // create with null name, so we force explicit naming.
+      }
     }
-  }),
+  },
   DELETE_CONTAINER: (state: ContainersState, action: ActionType<typeof actions.deleteContainer>) => pickBy(
     state,
     (value: Labware, key: string) => key !== action.payload.containerId
@@ -234,7 +248,7 @@ export const ingredLocations = handleActions({
 export type RootState = {|
   modeLabwareSelection: string | false, // TODO use null, not false
   copyLabwareMode: string | false,
-  selectedContainer: string | null,
+  selectedContainerId: SelectedContainerId,
   selectedIngredientGroup: SelectedIngredientGroupState,
   containers: ContainersState,
   ingredients: IngredientsState,
@@ -245,7 +259,7 @@ export type RootState = {|
 const rootReducer = combineReducers({
   modeLabwareSelection,
   copyLabwareMode,
-  selectedContainer,
+  selectedContainerId,
   selectedIngredientGroup,
   containers,
   ingredients,
@@ -255,13 +269,11 @@ const rootReducer = combineReducers({
 // SELECTORS
 const rootSelector = (state: BaseState): RootState => state.labwareIngred
 
-// TODO Ian 2018-03-02 when you do selector cleanup, use this one more widely instead of .containers
-const getLabware: Selector<ContainersState> = createSelector(
+const getLabware: Selector<{[labwareId: string]: Labware}> = createSelector(
   rootSelector,
   rootState => rootState.containers
 )
 
-// TODO Ian 2018-03-08 use these instead of direct access in other selectors
 const getIngredientGroups = (state: BaseState) => rootSelector(state).ingredients
 const getIngredientLocations = (state: BaseState) => rootSelector(state).ingredLocations
 
@@ -296,23 +308,15 @@ const labwareOptions: (state: BaseState) => Array<{value: string, name: string}>
 
 const canAdd = (state: BaseState) => rootSelector(state).modeLabwareSelection // false or selected slot to add labware to, eg 'A2'
 
-// TODO: containerId should be intrinsic to container reducer?
-// Or should this selector just return the ID?
-const getSelectedContainer = createSelector(
+const getSelectedContainerId: Selector<SelectedContainerId> = createSelector(
   rootSelector,
-  state => (state.selectedContainer === null)
-    ? null
-    : {
-      ...state.containers[state.selectedContainer],
-      containerId: state.selectedContainer
-    }
+  rootState => rootState.selectedContainerId
 )
 
-// Currently selected container's slot
-// TODO flow type container so this doesn't need its own selector
-const selectedContainerSlot = createSelector(
-  getSelectedContainer,
-  container => container && container.slot
+const getSelectedContainer: Selector<?Labware> = createSelector(
+  getSelectedContainerId,
+  getLabware,
+  (_selectedId, _labware) => (_selectedId && _labware[_selectedId]) || null
 )
 
 type ContainersBySlot = { [DeckSlot]: {...Labware, containerId: string} }
@@ -327,13 +331,6 @@ const containersBySlot: Selector<ContainersBySlot> = createSelector(
       [containerObj.slot]: {...containerObj, containerId}
     }),
     {})
-)
-
-// Uses selectedSlot to determine container type
-const selectedContainerType = createSelector(
-  selectedContainerSlot,
-  loadedContainersBySlot,
-  (slot, allContainers) => slot && allContainers[slot]
 )
 
 const ingredFields = [...editableIngredFields, 'groupId']
@@ -397,16 +394,25 @@ const allIngredientNamesIds: BaseState => Array<{ingredientId: string, name: ?st
 
 // TODO: just use the individual selectors separately, no need to combine it into 'activeModals'
 // -- so you'd have to refactor the props of the containers that use this selector too
-const activeModals = createSelector(
+type ActiveModals = {
+  labwareSelection: boolean,
+  ingredientSelection: ?{
+    slot: ?string,
+    containerName: ?string
+  }
+}
+
+const activeModals: Selector<ActiveModals> = createSelector(
   rootSelector,
-  selectedContainerSlot,
-  selectedContainerType,
-  (state, slot, containerType) => {
+  getLabware,
+  getSelectedContainerId,
+  (state, _allLabware, _selectedContainerId) => {
+    const selectedContainer = _selectedContainerId && _allLabware[_selectedContainerId]
     return ({
       labwareSelection: state.modeLabwareSelection !== false,
       ingredientSelection: {
-        slot,
-        containerName: containerType
+        slot: selectedContainer && selectedContainer.slot,
+        containerName: selectedContainer && selectedContainer.type
       }
     })
   }
@@ -424,6 +430,7 @@ export const selectors = {
   getIngredientLocations,
   getLabware,
   getSelectedContainer,
+  getSelectedContainerId,
 
   activeModals,
   allIngredientGroupFields,
@@ -432,10 +439,7 @@ export const selectors = {
   containersBySlot,
   labwareToCopy,
   canAdd,
-  selectedContainerType,
   selectedIngredientGroup: getSelectedIngredientGroup,
-  selectedContainerSlot,
-  selectedContainer: getSelectedContainer,
   ingredientsByLabware,
   labwareOptions
 }

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -4,7 +4,13 @@ import type {LabwareData} from '../step-generation'
 
 //  ===== LABWARE ===========
 
-export type Labware = LabwareData // TODO Ian 2018-03-01 use same name, ("Labware"?)
+// NOTE: In labware-ingred, labware objects have a `disambiguationNumber` field
+// so that UI can render "96 Flat (2)"
+export type Labware = {|
+  ...LabwareData,
+  id: string,
+  disambiguationNumber: number
+|}
 
 // ==== WELLS ==========
 

--- a/protocol-designer/src/navigation/selectors.js
+++ b/protocol-designer/src/navigation/selectors.js
@@ -14,7 +14,7 @@ export const newProtocolModal = (state: BaseState) =>
 
 export const currentPage: Selector<Page> = (state: BaseState) => {
   // If we're in ingredient detail mode, override the nav button page state
-  const ingredDetailMode = labwareIngredSelectors.selectedContainer(state) &&
+  const ingredDetailMode = labwareIngredSelectors.getSelectedContainer(state) &&
     !wellSelectionSelectors.wellSelectionModalData(state)
   const page = navigationRootSelector(state).page
 

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -121,11 +121,11 @@ export type PipetteData = {| // TODO refactor all 'pipette fields', split Pipett
   channels: Channels
 |}
 
-export type LabwareData = {
+export type LabwareData = {|
   type: string, // TODO Ian 2018-04-17 keys from JSON. Also, rename 'type' to 'model' (or something??)
   name: ?string, // user-defined nickname
   slot: DeckSlot
-}
+|}
 
 /** tips are numbered 0-7. 0 is the furthest to the back of the robot.
   * For an 8-channel, on a 96-flat, Tip 0 is in row A, Tip 7 is in row H.

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/wellContentsAllLabware.test.js
@@ -58,7 +58,7 @@ describe('wellContentsAllLabware', () => {
   const singleIngredResult = wellContentsAllLabware.resultFunc(
     containerState, // all labware
     ingredsByLabwareXXSingleIngred,
-    {containerId: 'container1Id'}, // selected labware
+    {id: 'container1Id'}, // selected labware
     {A1: 'A1', B1: 'B1'}, // selected
     {A3: 'A3'} // highlighted
   )

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -122,9 +122,10 @@ export const namedIngredsByLabware: Selector<NamedIngredsByLabwareAllSteps> = cr
 
 export const selectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
-  labwareIngredSelectors.selectedContainerType,
-  (selectedWells, selectedContainerType) => {
+  labwareIngredSelectors.getSelectedContainer,
+  (selectedWells, selectedContainer) => {
     const selectedWellNames = Object.keys(selectedWells)
+    const selectedContainerType = selectedContainer && selectedContainer.type
     if (!selectedContainerType) {
       console.warn('No container type selected, cannot get max volume')
       return Infinity

--- a/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
@@ -8,7 +8,6 @@ import wellSelectionSelectors from '../../well-selection/selectors'
 
 import type {Selector, JsonWellData, VolumeJson} from '../../types'
 import type {Wells, AllWellContents, IngredsForLabware} from '../../labware-ingred/types'
-import type {LabwareData} from '../../step-generation'
 import {defaultContainers} from '../../constants.js'
 
 const _getWellContents = (
@@ -62,12 +61,12 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
   labwareIngredSelectors.getSelectedContainer,
   wellSelectionSelectors.getSelectedWells,
   wellSelectionSelectors.getHighlightedWells,
-  (_labware: {[id: string]: LabwareData}, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
-    const allLabwareIds = Object.keys(_labware)
+  (_labware, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
+    const allLabwareIds: Array<string> = Object.keys(_labware) // TODO Ian 2018-05-29 weird flow error w/o annotation
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: AllWellContents | null}, labwareId: string) => {
       const ingredsForLabware = _ingredsByLabware[labwareId]
-      const isSelectedLabware = _selectedLabware && (_selectedLabware.containerId === labwareId)
+      const isSelectedLabware = _selectedLabware && (_selectedLabware.id === labwareId)
       // Skip labware ids with no ingreds
       return {
         ...acc,


### PR DESCRIPTION
## overview

Closes Part 2 of #1281:

> If a 96 Well Flat is being placed but a 96 Well Flat is already on the deck, this second plate's name defaults to "96 Well Flat (2)". Even if that first labware has a nickname. That way if the nickname is erased we never have instances where labware has identical names.

Step Item labware names:

![image](https://user-images.githubusercontent.com/11590381/40691456-ecb5e0b0-6379-11e8-924e-238e07b9ea88.png)

Ingred edit mode's header

![image](https://user-images.githubusercontent.com/11590381/40691472-04c6fb4e-637a-11e8-9619-ba6acff1663a.png)

Step edit form labware selection

![image](https://user-images.githubusercontent.com/11590381/40691515-3536d268-637a-11e8-96de-6733cf56d998.png)

## changelog
    * in Ingred Selection header, Step Items, and labware dropdown in step forms, show nickname or
    humanized labware name with disambiguating number (eg "96 Flat (2)")
     * Keep track of whether
    labware has saved name or not in a new reducer


## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_labware-type-or-nickname-exclusive-1281-part-2-b/index.html

* Code review: also see #1563 which this PR is based off of

* UI review: try to find anything broken around creating/copying/deleting labware. Labware name shows up in header during ingredient editing mode, in labware dropdown in step forms, and in step items (see screenshots).