### PR TITLE
feat(protocol-designer): make default trash labware 'fixed-trash' not 'trash-box'

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -91,7 +91,7 @@ type ContainersState = {
 const initialLabwareState = {
   [FIXED_TRASH_ID]: {
     id: FIXED_TRASH_ID,
-    type: 'trash-box', // TODO Ian 2018-03-23 Change to 'fixed-trash' using new defs
+    type: 'fixed-trash',
     name: 'Trash',
     slot: '12'
   }


### PR DESCRIPTION
## overview

Previous behavior used 'trash-box' which causes misalignment with actual trash on deck! D'oh

## changelog

* Fixed trash in slot 12 was `trash-box`, now is `fixed-trash` labware type

## review requests

Test on a robot, if you'd like