### PR TITLE
feat(app): Render update app modal if update available

### DIFF
--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -16,9 +16,9 @@ type Props = {
 const Spinner = () => (<Icon name='ot-spinner' height='1em' spin />)
 
 export default function AppUpdateModal (props: Props) {
-  const {close, update: {downloadInProgress}} = props
+  const {close, update: {error, downloadInProgress}} = props
   const {button, message} = mapPropsToButtonPropsAndMessage(props)
-  const closeButtonChildren = props.error || downloadInProgress
+  const closeButtonChildren = error || downloadInProgress
     ? 'close'
     : 'not now'
 

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -30,6 +30,7 @@ export default function AppUpdateModal (props: Props) {
         {onClick: close, children: closeButtonChildren},
         button
       ]}
+      alertOverlay
     >
       {message}
     </AlertModal>

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -1,7 +1,6 @@
 // @flow
 // app status panel with connect button
 import * as React from 'react'
-
 import type {ShellUpdate} from '../../shell'
 import AppInfoCard from './AppInfoCard'
 import AnalyticsSettingsCard from './AnalyticsSettingsCard'

--- a/app/src/pages/AppSettings.js
+++ b/app/src/pages/AppSettings.js
@@ -2,7 +2,7 @@
 // view info about the app and update
 import React from 'react'
 import {connect} from 'react-redux'
-import {Route, type ContextRouter} from 'react-router'
+import {Route, Switch, Redirect, type ContextRouter} from 'react-router'
 import {push} from 'react-router-redux'
 
 import type {State} from '../types'
@@ -11,7 +11,8 @@ import {
   getShellUpdate,
   checkForShellUpdates,
   downloadShellUpdate,
-  quitAndInstallShellUpdate
+  quitAndInstallShellUpdate,
+  setUpdateSeen
 } from '../shell'
 import {toggleAnalyticsOptedIn, getAnalyticsOptedIn} from '../analytics'
 
@@ -38,12 +39,23 @@ type Props = OP & SP & DP
 export default connect(mapStateToProps, mapDispatchToProps)(AppSettingsPage)
 
 function AppSettingsPage (props: Props) {
+  const {update, match: {path}} = props
+
   return (
     <Page>
       <AppSettings {...props} />
-      <Route path='/menu/app/update' render={() => (
-        <AppUpdateModal {...props} close={props.closeUpdateModal} />
-      )} />
+      <Switch>
+        <Route path={`${path}/update`} render={() => (
+          <AppUpdateModal {...props} close={props.closeUpdateModal} />
+        )} />
+        <Route render={() => {
+          if (update.available && !update.seen) {
+            return (<Redirect to='/menu/app/update' />)
+          }
+
+          return null
+        }} />
+      </Switch>
     </Page>
   )
 }
@@ -60,7 +72,10 @@ function mapDispatchToProps (dispatch: Dispatch): DP {
     checkForUpdates: () => dispatch(checkForShellUpdates()),
     downloadUpdate: () => dispatch(downloadShellUpdate()),
     quitAndInstall: () => quitAndInstallShellUpdate(),
-    closeUpdateModal: () => dispatch(push('/menu/app')),
+    closeUpdateModal: () => {
+      dispatch(push('/menu/app'))
+      dispatch(setUpdateSeen())
+    },
     toggleAnalyticsOptedIn: () => dispatch(toggleAnalyticsOptedIn())
   }
 }

--- a/app/src/pages/AppSettings.js
+++ b/app/src/pages/AppSettings.js
@@ -73,8 +73,8 @@ function mapDispatchToProps (dispatch: Dispatch): DP {
     downloadUpdate: () => dispatch(downloadShellUpdate()),
     quitAndInstall: () => quitAndInstallShellUpdate(),
     closeUpdateModal: () => {
-      dispatch(push('/menu/app'))
       dispatch(setUpdateSeen())
+      dispatch(push('/menu/app'))
     },
     toggleAnalyticsOptedIn: () => dispatch(toggleAnalyticsOptedIn())
   }

--- a/app/src/shell/__tests__/shell.test.js
+++ b/app/src/shell/__tests__/shell.test.js
@@ -41,7 +41,8 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: null,
           downloaded: false,
-          error: null
+          error: null,
+          seen: false
         }
       }
     }
@@ -171,7 +172,8 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: null,
           downloaded: false,
-          error: null
+          error: null,
+          seen: false
         }
       })
     })
@@ -191,7 +193,8 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: '42.0.0',
           downloaded: false,
-          error: null
+          error: null,
+          seen: false
         }
       })
     })
@@ -211,7 +214,8 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: '42.0.0',
           downloaded: false,
-          error: new Error('AH')
+          error: new Error('AH'),
+          seen: false
         }
       })
     })
@@ -227,7 +231,8 @@ describe('app shell module', () => {
           downloadInProgress: true,
           available: '42.0.0',
           downloaded: false,
-          error: null
+          error: null,
+          seen: true
         }
       })
     })
@@ -248,7 +253,8 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: '42.0.0',
           downloaded: true,
-          error: null
+          error: null,
+          seen: false
         }
       })
     })
@@ -268,7 +274,25 @@ describe('app shell module', () => {
           downloadInProgress: false,
           available: '42.0.0',
           downloaded: false,
-          error: new Error('AH')
+          error: new Error('AH'),
+          seen: false
+        }
+      })
+    })
+
+    test('handles SET_UPDATE_SEEN', () => {
+      state.update.available = '42.0.0'
+      const action = {
+        type: 'shell:SET_UPDATE_SEEN'
+      }
+      expect(shellReducer(state, action)).toEqual({
+        update: {
+          checkInProgress: false,
+          downloadInProgress: false,
+          available: '42.0.0',
+          downloaded: false,
+          error: null,
+          seen: true
         }
       })
     })

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -28,6 +28,7 @@ type ShellState = {
     available: ?string,
     downloaded: boolean,
     error: ?Error,
+    seen: boolean
   },
 }
 
@@ -37,7 +38,8 @@ const INITIAL_STATE: ShellState = {
     downloadInProgress: false,
     available: null,
     downloaded: false,
-    error: null
+    error: null,
+    seen: false
   }
 }
 
@@ -57,6 +59,10 @@ type StartDownloadAction = {|
   type: 'shell:START_DOWNLOAD'
 |}
 
+type SeenUpdateAction = {|
+  type: 'shell:SET_UPDATE_SEEN'
+|}
+
 type FinishDownloadAction = {|
   type: 'shell:FINISH_DOWNLOAD',
   payload: {|
@@ -69,6 +75,7 @@ export type ShellAction =
   | FinishUpdateCheckAction
   | StartDownloadAction
   | FinishDownloadAction
+  | SeenUpdateAction
 
 export function checkForShellUpdates (): ThunkPromiseAction {
   return (dispatch) => {
@@ -85,6 +92,10 @@ export function checkForShellUpdates (): ThunkPromiseAction {
         payload
       }))
   }
+}
+
+export function setUpdateSeen (): ShellAction {
+  return {type: 'shell:SET_UPDATE_SEEN'}
 }
 
 export function downloadShellUpdate (): ThunkPromiseAction {
@@ -119,7 +130,10 @@ export function shellReducer (
         update: {...state.update, ...action.payload, checkInProgress: false}}
 
     case 'shell:START_DOWNLOAD':
-      return {...state, update: {...state.update, downloadInProgress: true}}
+      return {...state, update: {...state.update, downloadInProgress: true, seen: true}}
+
+    case 'shell:SET_UPDATE_SEEN':
+      return {...state, update: {...state.update, seen: true}}
 
     case 'shell:FINISH_DOWNLOAD':
       return {


### PR DESCRIPTION
## overview
This PR closes #1154 by rendering the app update modal on app page load if 
- an update is available
- the update alert has not been marked seen

<img width="800" alt="screen shot 2018-05-30 at 4 57 42 pm" src="https://user-images.githubusercontent.com/3430313/40747543-9e51fa8c-642b-11e8-9a8e-8c9cafb42e09.png">

## changelog

- add `SET_UPDATE_SEEN` reducer to shell
- set `update: {... seen: true}` on `START_DOWNLOAD`
- redirect `/menu/app` to `menu/app/update` on app page view if update is available and seen=false
- update `START_DOWNLOAD` test and write `SET_UPDATE_SEEN` in shell
- add alertOverlay prop `AppUpdateModal`

## review requests

Please let me know if tests are missing.

To test UI (no robot neccessary):

1. Change `app-shell/package.json` version (line 4) from `"version": "3.0.1-beta.1"` to "version": "3.0.0"
2. Click 'more' nav button in main nav
- [x] app setting page renders app update modal on initial page view
- [x] in redux devtools shell.update.seen is false

3.  Click [Not now] button in Alert
- [x] modal closes
- [x] returning to app from another page (same session) does not render the modal again
- [x] in redux devtools shell.update.seen is now true