### PR TITLE
feat(protocol-designer): allow user to rename labware in ingred edit mode

### DIFF
--- a/protocol-designer/src/components/Form.css
+++ b/protocol-designer/src/components/Form.css
@@ -54,6 +54,16 @@
   }
 }
 
+.simple_button_row {
+  lost-utility: clearfix;
+  lost-align: right flex;
+
+  & > * {
+    lost-column: 1/6;
+  }
+}
+
+/* TODO Ian 2018-05-30 clean up .button_row so it's more reusable, merge with .simple_button_row */
 .button_row {
   lost-utility: clearfix;
   margin-top: 2rem;

--- a/protocol-designer/src/components/IngredientSelectionModal.js
+++ b/protocol-designer/src/components/IngredientSelectionModal.js
@@ -4,23 +4,19 @@ import * as React from 'react'
 import SingleLabware from './SingleLabware'
 import styles from './IngredientSelectionModal.css'
 
-import SelectablePlate from '../containers/SelectablePlate.js'
-// import IngredientsList from '../containers/IngredientsList.js'
-import IngredientPropertiesForm from '../containers/IngredientPropertiesForm.js'
+import SelectablePlate from '../containers/SelectablePlate'
+import IngredientPropertiesForm from '../containers/IngredientPropertiesForm'
+import LabwareNameEditForm from '../containers/LabwareNameEditForm'
 import WellSelectionInstructions from './WellSelectionInstructions'
 
-type Props = {
-  visible: boolean
-}
+type Props = {}
 
 export default function IngredientSelectionModal (props: Props) {
-  const {visible} = props
-  if (!visible) return null
-
   return (
     <div className={styles.ingredient_modal}>
 
       <IngredientPropertiesForm />
+      <LabwareNameEditForm />
 
       <SingleLabware>
         <SelectablePlate showLabels selectable />

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -2,6 +2,7 @@
 import React from 'react'
 
 import {IconButton, SidePanel, TitledList} from '@opentrons/components'
+import stepItemStyles from './steplist/StepItem.css'
 import StepDescription from './StepDescription'
 import {swatchColors} from '../constants.js'
 import styles from './IngredientsList.css'
@@ -132,6 +133,12 @@ export default function IngredientsList (props: Props) {
 
   return (
     <SidePanel title='Ingredients'>
+        <TitledList
+          className={stepItemStyles.step_item}
+          title='labware name'
+          iconName='flask-outline'
+          selected
+        />
 
         {ingredients && Object.keys(ingredients).map((i) =>
           <IngredGroupCard key={i}

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -8,8 +8,8 @@ import {swatchColors} from '../constants.js'
 import styles from './IngredientsList.css'
 import type {IngredGroupForLabware, IngredsForLabware} from '../labware-ingred/types'
 
-type DeleteIngredient = (args: {wellName: string, groupId: string}) => void // TODO get from action type?
-type EditModeIngredientGroup = (args: {groupId: string}) => void
+type DeleteIngredient = (args: {|groupId: string, wellName?: string|}) => mixed
+type EditModeIngredientGroup = (args: {|groupId: string, wellName: ?string|}) => mixed
 
 // Props used by both IngredientsList and IngredGroupCard // TODO
 type CommonProps = {|
@@ -49,7 +49,7 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
         onCollapseToggle={() => this.toggleAccordion()}
         collapsed={!isExpanded}
         selected={selected}
-        onClick={() => editModeIngredientGroup({groupId})}
+        onClick={() => editModeIngredientGroup({groupId, wellName: null})}
         description={<StepDescription description={description} header='Description:' />}
       >
         <div className={styles.ingredient_row_header}>
@@ -117,10 +117,12 @@ function IngredIndividual (props: IndividProps) {
   )
 }
 
-export type Props = {
+type Props = {
+  ...CommonProps,
   ingredients: IngredsForLabware,
   selectedIngredientGroupId: string | null,
-  ...CommonProps
+  renameLabwareFormMode: boolean,
+  openRenameLabwareForm: () => mixed
 }
 
 export default function IngredientsList (props: Props) {
@@ -128,16 +130,20 @@ export default function IngredientsList (props: Props) {
     ingredients,
     editModeIngredientGroup,
     deleteIngredient,
-    selectedIngredientGroupId
+    selectedIngredientGroupId,
+    renameLabwareFormMode,
+    openRenameLabwareForm
   } = props
 
   return (
     <SidePanel title='Ingredients'>
+        {/* Labware Name "button" to open LabwareNameEditForm */}
         <TitledList
           className={stepItemStyles.step_item}
           title='labware name'
           iconName='flask-outline'
-          selected
+          selected={renameLabwareFormMode}
+          onClick={openRenameLabwareForm}
         />
 
         {ingredients && Object.keys(ingredients).map((i) =>

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -57,7 +57,6 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
       containerType,
       containerId,
       slot,
-      // modifyContainer, // TODO do propTypes, include this
       deleteContainer
     } = this.props
 
@@ -65,27 +64,21 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
       <g className={styles.slot_overlay}>
         <rect className={styles.overlay_panel} />
         <g transform='translate(5, 0)'>
-          <text className={styles.clickable} x='0' y='0'>Name this labware:</text>
           <ForeignDiv x='0' y='15%' width='90%'>
             <input
+              className={styles.name_input}
               onChange={this.handleChange}
               onKeyUp={this.handleKeyUp}
               placeholder={NICKNAME_PROMPT}
               value={this.state.inputValue}
             />
           </ForeignDiv>
-          {/* <text className={styles.clickable} x='0' y='60%' onClick={this.onSubmit}>
-            Save
-          </text> */}
+
           <ClickableText onClick={this.onSubmit}
-            iconName='plus' y='60%' text='Save Labware' />
+            iconName='check' y='60%' text='Save' />
+
           <ClickableText onClick={() => deleteContainer({containerId, slot, containerType})}
             iconName='close' y='80%' text='Cancel' />
-          {/* <text className={styles.clickable} x='0' y='80%'
-            onClick={() => deleteContainer({containerId, slot, containerType})}
-          >
-              Delete
-          </text> */}
         </g>
       </g>
     )

--- a/protocol-designer/src/components/labware/labware.css
+++ b/protocol-designer/src/components/labware/labware.css
@@ -54,3 +54,13 @@
     fill: currentColor;
   }
 }
+
+.name_input {
+  width: 100%;
+  border: none;
+  border-radius: var(--bd-radius-default);
+  padding-left: 0.25rem;
+  background-color: var(--c-light-gray);
+  color: var(--c-font-dark);
+  font-size: var(--fs-body-1);
+}

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -8,28 +8,22 @@ import IngredientSelectionModal from '../components/IngredientSelectionModal.js'
 import LabwareContainer from '../containers/LabwareContainer.js'
 import LabwareDropdown from '../containers/LabwareDropdown.js'
 
-import {closeIngredientSelector} from '../labware-ingred/actions'
 import {selectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist/reducers'
 import type {BaseState} from '../types'
 
 const ingredSelModIsVisible = activeModals => activeModals.ingredientSelection && activeModals.ingredientSelection.slot
 
-// TODO Ian 2017-12-04 make proper component
-const ConnectedIngredSelModal = connect(
-  (state: BaseState) => ({
-    visible: ingredSelModIsVisible(selectors.activeModals(state)) // TODO Ian 2018-02-16 does `visible` prop do anything?
-  }),
-  {
-    onClose: closeIngredientSelector
-  }
-)(IngredientSelectionModal)
-
-type DeckSetupProps = {deckSetupMode: boolean}
+type DeckSetupProps = {
+  deckSetupMode: boolean,
+  ingredSelectionMode: boolean
+}
 
 function mapStateToProps (state: BaseState): DeckSetupProps {
   return {
-    deckSetupMode: steplistSelectors.deckSetupMode(state)
+    deckSetupMode: steplistSelectors.deckSetupMode(state),
+    // TODO SOON remove all uses of the `activeModals` selector
+    ingredSelectionMode: !!ingredSelModIsVisible(selectors.activeModals(state))
   }
 }
 
@@ -38,12 +32,20 @@ function DeckSetup (props: DeckSetupProps) {
   if (!props.deckSetupMode) {
     // Temporary quickfix: if we're not in deck setup mode,
     // hide the labware dropdown and ingredient selection modal
+    // and just show the deck.
+    // TODO Ian 2018-05-30 this shouldn't be a responsibility of DeckSetup
     return <Deck LabwareComponent={LabwareContainer} />
   }
+
+  // NOTE: besides `Deck`, these are all modal-like components that show up
+  // only when user is on deck setup / ingred selection "page".
+  // Once DeckSetup is broken apart and moved into ProtocolEditor,
+  // this will go away
   return (
     <div>
       <LabwareDropdown />
-      <ConnectedIngredSelModal />
+      {props.ingredSelectionMode && <IngredientSelectionModal />}
+
       <Deck LabwareComponent={LabwareContainer} />
     </div>
   )

--- a/protocol-designer/src/containers/IngredientPropertiesForm.js
+++ b/protocol-designer/src/containers/IngredientPropertiesForm.js
@@ -19,7 +19,7 @@ type DispatchProps = {
 type StateProps = $Diff<Props, DispatchProps>
 
 function mapStateToProps (state: BaseState): StateProps {
-  const selectedIngredGroup = selectors.selectedIngredientGroup(state)
+  const selectedIngredGroup = selectors.getSelectedIngredientGroup(state)
   return {
     editingIngredGroupId: selectedIngredGroup && selectedIngredGroup.groupId,
     numWellsSelected: wellSelectionSelectors.numWellsSelected(state),

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -17,7 +17,7 @@ function mapStateToProps (state: BaseState): PropsWithoutActions {
   // TODO Ian 2018-02-21 put these selectors in Header
   // const activeModals = selectors.activeModals(state)
   const container = selectors.getSelectedContainer(state)
-  const selectedIngredientGroup = selectors.selectedIngredientGroup(state)
+  const selectedIngredientGroup = selectors.getSelectedIngredientGroup(state)
   return {
     ingredients: container ? selectors.ingredientsByLabware(state)[container.id] : {},
     selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -1,35 +1,39 @@
 // @flow
+import * as React from 'react'
 import {connect} from 'react-redux'
 import {selectors} from '../labware-ingred/reducers'
-import {editModeIngredientGroup, deleteIngredient} from '../labware-ingred/actions'
+import {editModeIngredientGroup, deleteIngredient, openRenameLabwareForm} from '../labware-ingred/actions'
 import type {BaseState, ThunkDispatch} from '../types'
 
-import IngredientsList, {type Props} from '../components/IngredientsList.js'
+import IngredientsList from '../components/IngredientsList'
 
-// TODO Ian 2018-02-21 Is there a nicer way to strip out keys from an object type?
-type PropsWithoutActions = {
-  ...Props,
-  editModeIngredientGroup?: *,
-  deleteIngredient?: *
+type Props = React.ElementProps<typeof IngredientsList>
+
+type DP = {
+  editModeIngredientGroup: $ElementType<Props, 'editModeIngredientGroup'>,
+  deleteIngredient: $ElementType<Props, 'deleteIngredient'>,
+  openRenameLabwareForm: $ElementType<Props, 'openRenameLabwareForm'>
 }
 
-function mapStateToProps (state: BaseState): PropsWithoutActions {
+type SP = $Diff<Props, DP>
+
+function mapStateToProps (state: BaseState): SP {
   // TODO Ian 2018-02-21 put these selectors in Header
-  // const activeModals = selectors.activeModals(state)
   const container = selectors.getSelectedContainer(state)
   const selectedIngredientGroup = selectors.getSelectedIngredientGroup(state)
   return {
+    renameLabwareFormMode: selectors.getRenameLabwareFormMode(state),
     ingredients: container ? selectors.ingredientsByLabware(state)[container.id] : {},
     selectedIngredientGroupId: selectedIngredientGroup && selectedIngredientGroup.groupId,
     selected: false
   }
 }
 
-function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
   return {
-    // TODO Ian 2018-02-23 How to type action creators so that arg types follow along?
     editModeIngredientGroup: (args) => dispatch(editModeIngredientGroup(args)),
-    deleteIngredient: (args) => dispatch(deleteIngredient(args))
+    deleteIngredient: (args) => dispatch(deleteIngredient(args)),
+    openRenameLabwareForm: () => dispatch(openRenameLabwareForm())
   }
 }
 

--- a/protocol-designer/src/containers/LabwareNameEditForm.js
+++ b/protocol-designer/src/containers/LabwareNameEditForm.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import type {Dispatch} from 'redux'
+import type {BaseState} from '../types'
+
+import {FormGroup, InputField, PrimaryButton} from '@opentrons/components'
+import formStyles from '../components/Form.css'
+
+type Props = {
+  labwareName: string,
+  onCancel: (event: SyntheticMouseEvent<*>) => mixed,
+  onSaveName: (name: string) => (event: SyntheticMouseEvent<*>) => mixed
+}
+
+type SP = {
+  labwareName: $ElementType<Props, 'labwareName'>
+}
+
+type DP = $Diff<Props, SP>
+
+type State = {
+  name: string
+}
+
+class LabwareNameEditForm extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {name: props.labwareName}
+  }
+
+  handleChangeName = (e: SyntheticInputEvent<*>) => {
+    this.setState({name: e.currentTarget.value})
+  }
+
+  render () {
+    const {onCancel, onSaveName} = this.props
+
+    return (
+      <div className={formStyles.form}>
+        <div className={formStyles.field_row}>
+          <FormGroup label='Labware Name'>
+            <InputField value={this.state.name} onChange={this.handleChangeName} />
+          </FormGroup>
+        </div>
+
+        <div className={formStyles.simple_button_row}>
+          <PrimaryButton onClick={onCancel}>Close</PrimaryButton>
+          <PrimaryButton onClick={onSaveName && onSaveName(this.state.name)}>Save</PrimaryButton>
+        </div>
+      </div>
+    )
+  }
+}
+
+function mapStateToProps (state: BaseState): SP {
+  return {
+    labwareName: 'todo name here'
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch<*>): DP {
+  return {
+    onCancel: () => console.log('cancel'),
+    onSaveName: (name) => () => console.log(name)
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LabwareNameEditForm)

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -47,7 +47,7 @@ export const editModeIngredientGroup = createAction(
   'EDIT_MODE_INGREDIENT_GROUP',
   (args: (
     | null // null here means "deselect ingredient group"
-    | {| wellName: string, groupId: string |}
+    | {| wellName: ?string, groupId: string |}
   )) => args
 )
 
@@ -81,6 +81,16 @@ export const modifyContainer = createAction(
   |}) => args
 )
 
+export const openRenameLabwareForm = createAction(
+  'OPEN_RENAME_LABWARE_FORM',
+  () => {}
+)
+
+export const closeRenameLabwareForm = createAction(
+  'CLOSE_RENAME_LABWARE_FORM',
+  () => {}
+)
+
 // ===========
 
 export type CopyLabware = {
@@ -111,17 +121,16 @@ export const copyLabware = (slot: DeckSlot) => (dispatch: Dispatch<CopyLabware>,
   })
 }
 
-type DeleteIngredientPrepayload = {|
+type DeleteIngredientPrepayload = {
   wellName?: string,
   groupId: string
-|}
+}
 
 export type DeleteIngredient = {|
   type: 'DELETE_INGREDIENT',
   payload: {
-    ...DeleteIngredientPrepayload,
     containerId: string
-  }
+  } & DeleteIngredientPrepayload
 |}
 
 export const deleteIngredient = (payload: DeleteIngredientPrepayload) => (dispatch: Dispatch<DeleteIngredient>, getState: GetState) => {

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -84,8 +84,18 @@ const selectedIngredientGroup = handleActions({
   OPEN_INGREDIENT_SELECTOR: () => null,
   EDIT_INGREDIENT: () => null, // unselect ingredient group when edited.
   DELETE_INGREDIENT: () => null, // unselect ingredient group when deleted.
-  CLOSE_INGREDIENT_SELECTOR: () => null
+  CLOSE_INGREDIENT_SELECTOR: () => null,
+  OPEN_RENAME_LABWARE_FORM: () => null
 }, null)
+
+type RenameLabwareFormModeState = boolean
+const renameLabwareFormMode = handleActions({
+  OPEN_RENAME_LABWARE_FORM: () => true,
+
+  CLOSE_RENAME_LABWARE_FORM: () => false,
+  CLOSE_INGREDIENT_SELECTOR: () => false,
+  EDIT_MODE_INGREDIENT_GROUP: () => false
+}, false)
 
 type ContainersState = {
   [id: string]: Labware
@@ -271,7 +281,8 @@ export type RootState = {|
   containers: ContainersState,
   savedLabware: SavedLabwareState,
   ingredients: IngredientsState,
-  ingredLocations: LocationsState
+  ingredLocations: LocationsState,
+  renameLabwareFormMode: RenameLabwareFormModeState
 |}
 
 // TODO Ian 2018-01-15 factor into separate files
@@ -283,7 +294,8 @@ const rootReducer = combineReducers({
   containers,
   savedLabware,
   ingredients,
-  ingredLocations
+  ingredLocations,
+  renameLabwareFormMode
 })
 
 // SELECTORS
@@ -449,6 +461,8 @@ const activeModals: Selector<ActiveModals> = createSelector(
   }
 )
 
+const getRenameLabwareFormMode = (state: BaseState) => rootSelector(state).renameLabwareFormMode
+
 const labwareToCopy = (state: BaseState) => rootSelector(state).copyLabwareMode
 
 const getSelectedIngredientGroup = (state: BaseState) => rootSelector(state).selectedIngredientGroup
@@ -466,11 +480,14 @@ export const selectors = {
   getSelectedContainerId,
 
   activeModals,
+  getRenameLabwareFormMode,
+
+  labwareToCopy,
+
   allIngredientGroupFields,
   allIngredientNamesIds,
   loadedContainersBySlot,
   containersBySlot,
-  labwareToCopy,
   canAdd,
   getSelectedIngredientGroup,
   ingredientsByLabware,

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -472,7 +472,7 @@ export const selectors = {
   containersBySlot,
   labwareToCopy,
   canAdd,
-  selectedIngredientGroup: getSelectedIngredientGroup,
+  getSelectedIngredientGroup,
   ingredientsByLabware,
   labwareOptions
 }

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -41,7 +41,8 @@ const selectedWells = handleActions({
   EDIT_MODE_INGREDIENT_GROUP: () => selectedWellsInitialState,
   CLOSE_INGREDIENT_SELECTOR: () => selectedWellsInitialState,
   EDIT_INGREDIENT: () => selectedWellsInitialState,
-  CLOSE_WELL_SELECTION_MODAL: () => selectedWellsInitialState
+  CLOSE_WELL_SELECTION_MODAL: () => selectedWellsInitialState,
+  OPEN_RENAME_LABWARE_FORM: () => selectedWellsInitialState
 }, selectedWellsInitialState)
 
 type WellSelectionModalState = OpenWellSelectionModalPayload | null


### PR DESCRIPTION
## overview

Closes #1281

## changelog

* show "Labware Name" TitledList "button" in IngredientsList
* LabwareNameEditForm connected component - labware edit form appears when the button is clicked and closes when the form is saved or canceled

## review requests

* Make sure you can't get into funky state by flipping around btw diff labware, diff modals, clicking the labware, etc - but keep in mind standing bug #1561
* This is the oldest part of PD and the code needs a broader cleanup, I tried to balance not having a huge diff vs not making the mess worse