### PR TITLE
feat(protocol-designer): make new labware dismiss nickname overlay when user clicks away

### DIFF
--- a/components/src/interaction-enhancers/index.js
+++ b/components/src/interaction-enhancers/index.js
@@ -1,6 +1,11 @@
 // @flow
 import clickOutside from './clickOutside'
+import type {ClickOutsideInterface} from './clickOutside'
 
 export {
   clickOutside
+}
+
+export type {
+  ClickOutsideInterface
 }

--- a/components/src/interaction-enhancers/index.js
+++ b/components/src/interaction-enhancers/index.js
@@ -1,11 +1,7 @@
 // @flow
 import clickOutside from './clickOutside'
-import type {ClickOutsideInterface} from './clickOutside'
+export type {ClickOutsideInterface} from './clickOutside'
 
 export {
   clickOutside
-}
-
-export type {
-  ClickOutsideInterface
 }

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -17,7 +17,8 @@ import {
   EmptyDeckSlot,
   SLOT_WIDTH,
   SLOT_HEIGHT,
-  humanizeLabwareType
+  humanizeLabwareType,
+  clickOutside
 } from '@opentrons/components'
 
 import {nonFillableContainers} from '../../constants'
@@ -26,6 +27,8 @@ import styles from './labware.css'
 import ClickableText from './ClickableText'
 import SelectablePlate from '../../containers/SelectablePlate.js'
 import NameThisLabwareOverlay from './NameThisLabwareOverlay.js'
+
+const EnhancedNameThisLabwareOverlay = clickOutside(NameThisLabwareOverlay)
 
 function OccupiedDeckSlotOverlay ({
   canAddIngreds,
@@ -171,6 +174,11 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
 
   const canAddIngreds = !showNameOverlay && !nonFillableContainers.includes(containerType)
 
+  const setDefaultLabwareName = () => modifyContainer({
+    containerId,
+    modify: {name: null}
+  })
+
   return (
     <LabwareContainer {...{height, width, slot}} highlighted={highlighted}>
       {/* The actual deck slot container: rendering of container, or rendering of empty slot */}
@@ -210,13 +218,14 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
           deleteContainer
         }} />}
 
-      {deckSetupMode && showNameOverlay && <NameThisLabwareOverlay {...{
+      {deckSetupMode && showNameOverlay && <EnhancedNameThisLabwareOverlay {...{
         containerType,
         containerId,
         slot,
         modifyContainer,
         deleteContainer
-      }} />}
+      }}
+      onClickOutside={setDefaultLabwareName} />}
     </LabwareContainer>
   )
 }

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import ForeignDiv from '../../components/ForeignDiv.js'
 import ClickableText from './ClickableText'
 import styles from './labware.css'
+import type {ClickOutsideInterface} from '@opentrons/components'
 
 type Props = {
   containerType: string,
@@ -11,7 +12,7 @@ type Props = {
   // TODO Ian 2018-02-16 type these fns elsewhere and import the type
   modifyContainer: (args: {containerId: string, modify: {[field: string]: mixed}}) => void,
   deleteContainer: (args: {containerId: string, slot: string, containerType: string}) => void
-}
+} & ClickOutsideInterface
 
 type State = {
   pristine: boolean,
@@ -57,11 +58,12 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
       containerType,
       containerId,
       slot,
-      deleteContainer
+      deleteContainer,
+      passRef
     } = this.props
 
     return (
-      <g className={styles.slot_overlay}>
+      <g className={styles.slot_overlay} ref={passRef}>
         <rect className={styles.overlay_panel} />
         <g transform='translate(5, 0)'>
           <ForeignDiv x='0' y='15%' width='90%'>


### PR DESCRIPTION
## overview

Closes #1282

## changelog

- During deck setup, new labware "saves" when you click outside the "name this labware" overlay

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_deck-setup-name-labware-on-click-away-1282/index.html