### PR TITLE
fix(app): Render jog increments to left of jog buttons

### DIFF
--- a/app/src/components/JogControls/styles.css
+++ b/app/src/components/JogControls/styles.css
@@ -19,44 +19,46 @@
   justify-self: center;
 
   &.back {
-    grid-column: 2;
+    grid-column: 6;
     grid-row: 2;
   }
 
   &.forward {
-    grid-column: 2;
+    grid-column: 6;
     grid-row: 3;
   }
 
   &.left {
-    grid-column: 1;
+    grid-column: 5;
     grid-row: 3;
   }
 
   &.right {
-    grid-column: 3;
+    grid-column: 7;
     grid-row: 3;
   }
 
   &.up {
-    grid-column: 6;
+    grid-column: 10;
     grid-row: 2;
   }
 
   &.down {
-    grid-column: 6;
+    grid-column: 10;
     grid-row: 3;
   }
 }
 
 .jog_increment {
   grid-row: 1;
-  grid-column: 9/11;
+  grid-column: 1/4;
+  padding-left: 1rem;
 }
 
 .increment_group {
   grid-row: 2;
-  grid-column: 9/11;
+  grid-column: 1/4;
+  padding-left: 1rem;
 }
 
 .increment_item {
@@ -70,12 +72,13 @@
 }
 
 .jog_label_xy {
-  grid-column: 1 / 4;
+  grid-column: 4/9;
   grid-row: 1;
+  text-align: center;
 }
 
 .jog_label_z {
-  grid-column: 5/8;
+  grid-column: 9/12;
   grid-row: 1;
   text-align: center;
 }


### PR DESCRIPTION
## overview
This PR closes #1567. Jog increment selection is now to the left of the jog buttons. Since jog hot keys are not implemented yet, that text is not included in this ticket.

<img width="1027" alt="screen shot 2018-05-31 at 1 53 28 pm" src="https://user-images.githubusercontent.com/3430313/40798938-4abe0e60-64da-11e8-9461-df6a942b8a88.png">


## changelog

- Update css grid placement of jog buttons, increments, and labels

## review requests
Quick CSS only fix. Please check the layout in deck calibration and/or labware calibration jog controls implementation