### PR TITLE
fix(api): Reset startTime when session.refresh is called

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -154,6 +154,7 @@ class Session(object):
 
         self.containers = self.get_containers()
         self.instruments = self.get_instruments()
+        self.startTime = None
 
         self.set_state('loaded')
 


### PR DESCRIPTION
## overview

This is a little PR to address the API portion of #1270

## changelog

- fix(api): Reset startTime when session.refresh is called

## review requests

Changes are self-explanatory. Please let me know if you feel like the assignment should live in a different method (e.g. `self._reset`)