### PR TITLE
feat(app): Add ability to reset a run after it ends

### DIFF
--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -13,7 +13,7 @@ export default class CommandList extends Component {
   }
 
   render () {
-    const {commands, sessionStatus, cancelInProgress} = this.props
+    const {commands, sessionStatus, showSpinner} = this.props
     const makeCommandToTemplateMapper = (depth) => (command) => {
       const {id, isCurrent, isLast, description, children, handledAt} = command
       const style = [styles[`indent-${depth}`]]
@@ -47,16 +47,28 @@ export default class CommandList extends Component {
     }
 
     const commandItems = commands.map(makeCommandToTemplateMapper(0))
-    // TODO (ka 2018-5-21): Temporarily hiding error to avoid showing smoothie error on halt,
-    // error AlertItem would be useful for future errors
-    const showAlert = (sessionStatus !== 'running' && sessionStatus !== 'loaded' && sessionStatus !== 'error')
+
+    // TODO (ka 2018-5-21): Temporarily hiding error to avoid showing smoothie
+    //  error on halt, error AlertItem would be useful for future errors
+    const showAlert = (
+      sessionStatus !== 'running' &&
+      sessionStatus !== 'loaded' &&
+      sessionStatus !== 'error'
+    )
+
+    const wrapperStyle = cx(styles.run_log_wrapper, {
+      [styles.alert_visible]: showAlert
+    })
+
     return (
       <div className={styles.run_page}>
-      {cancelInProgress && (
+      {showSpinner && (
         <SpinnerModal />
       )}
-      <SessionAlert {...this.props} className={styles.alert}/>
-      <section className={cx(styles.run_log_wrapper, {[styles.alert_visible]: showAlert})}>
+      {!showSpinner && (
+        <SessionAlert {...this.props} className={styles.alert} />
+      )}
+      <section className={wrapperStyle}>
         <ol className={styles.list}>
           {commandItems}
         </ol>

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -1,5 +1,4 @@
 // @flow
-import React from 'react'
 import {connect} from 'react-redux'
 import type {State} from '../../types'
 import {
@@ -12,23 +11,21 @@ import ConfirmCancelModal from './ConfirmCancelModal'
 
 type SP = {
   commands: Array<any>,
-  sessionStatus: SessionStatus
+  sessionStatus: SessionStatus,
+  showSpinner: boolean,
 }
 
-type Props = SP
-
-const mapStateToProps = (state: State): SP => ({
-  commands: robotSelectors.getCommands(state),
-  sessionStatus: robotSelectors.getSessionStatus(state),
-  cancelInProgress: robotSelectors.getCancelInProgress(state)
-})
-
-function RunLog (props: Props) {
-  return (
-    <CommandList {...props} />
-  )
-}
-
-export default connect(mapStateToProps)(RunLog)
+export default connect(mapStateToProps)(CommandList)
 
 export {ConfirmCancelModal}
+
+function mapStateToProps (state: State): SP {
+  return {
+    commands: robotSelectors.getCommands(state),
+    sessionStatus: robotSelectors.getSessionStatus(state),
+    showSpinner: (
+      robotSelectors.getCancelInProgress(state) ||
+      robotSelectors.getUploadInProgress(state)
+    )
+  }
+}

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -25,7 +25,7 @@ function mapStateToProps (state: State): SP {
     sessionStatus: robotSelectors.getSessionStatus(state),
     showSpinner: (
       robotSelectors.getCancelInProgress(state) ||
-      robotSelectors.getUploadInProgress(state)
+      robotSelectors.getSessionLoadInProgress(state)
     )
   }
 }

--- a/app/src/components/RunPanel/RunControls.js
+++ b/app/src/components/RunPanel/RunControls.js
@@ -7,15 +7,27 @@ import {OutlineButton} from '@opentrons/components'
 import styles from './styles.css'
 
 type RunProps = {
+  disabled: boolean,
   isReadyToRun: boolean,
   isPaused: boolean,
   isRunning: boolean,
-  onRunClick: () => void,
-  onPauseClick: () => void,
-  onResumeClick: () => void,
+  onRunClick: () => mixed,
+  onPauseClick: () => mixed,
+  onResumeClick: () => mixed,
+  onResetClick: () => mixed,
 }
 export default function (props: RunProps) {
-  const {isReadyToRun, isPaused, isRunning, onRunClick, onPauseClick, onResumeClick} = props
+  const {
+    disabled,
+    isReadyToRun,
+    isPaused,
+    isRunning,
+    onRunClick,
+    onPauseClick,
+    onResumeClick,
+    onResetClick
+  } = props
+
   const onPauseResumeClick = isPaused
     ? onResumeClick
     : onPauseClick
@@ -27,22 +39,24 @@ export default function (props: RunProps) {
   let runButton
   let pauseResumeButton
   let cancelButton
-  if (!isRunning) {
+  let resetButton
+
+  if (isReadyToRun && !isRunning) {
     runButton = (
       <OutlineButton
         onClick={onRunClick}
         className={styles.run_button}
-        disabled={!isReadyToRun}
+        disabled={disabled}
       >
         Start Run
       </OutlineButton>
     )
-  } else {
+  } else if (isRunning) {
     pauseResumeButton = (
       <OutlineButton
         onClick={onPauseResumeClick}
         className={styles.run_button}
-        disabled={!isRunning}
+        disabled={disabled}
       >
         {pauseResumeText}
       </OutlineButton>
@@ -53,17 +67,29 @@ export default function (props: RunProps) {
         to={'/run/cancel'}
         onClick={onPauseClick}
         className={styles.run_button}
-        disabled={!isRunning}
+        disabled={disabled}
       >
         Cancel Job
       </OutlineButton>
     )
+  } else {
+    resetButton = (
+      <OutlineButton
+        onClick={onResetClick}
+        className={styles.run_button}
+        disabled={disabled}
+      >
+        Reset Run
+      </OutlineButton>
+    )
   }
+
   return (
     <div>
       {runButton}
       {pauseResumeButton}
       {cancelButton}
+      {resetButton}
     </div>
   )
 }

--- a/app/src/components/RunPanel/RunTimer.js
+++ b/app/src/components/RunPanel/RunTimer.js
@@ -5,7 +5,7 @@ import moment from 'moment'
 import styles from './styles.css'
 
 type TimeProps = {
-  startTime?: string,
+  startTime: ?number,
   runTime: string
 }
 

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state) => ({
   disabled: (
     !robotSelectors.getSessionIsLoaded(state) ||
     robotSelectors.getCancelInProgress(state) ||
-    robotSelectors.getUploadInProgress(state)
+    robotSelectors.getSessionLoadInProgress(state)
   )
 })
 

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -1,3 +1,4 @@
+// @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
 
@@ -13,19 +14,21 @@ import RunControls from './RunControls'
 const mapStateToProps = (state) => ({
   isRunning: robotSelectors.getIsRunning(state),
   isPaused: robotSelectors.getIsPaused(state),
-  sessionName: robotSelectors.getSessionName(state),
   startTime: robotSelectors.getStartTime(state),
   isReadyToRun: robotSelectors.getIsReadyToRun(state),
-  runTime: robotSelectors.getRunTime(state) || '00:00:00',
-  runProgress: robotSelectors.getRunProgress(state),
-  // TODO(mc, 2017-09-26): remove development hardcoded values for errors
-  errors: []
+  runTime: robotSelectors.getRunTime(state),
+  disabled: (
+    !robotSelectors.getSessionIsLoaded(state) ||
+    robotSelectors.getCancelInProgress(state) ||
+    robotSelectors.getUploadInProgress(state)
+  )
 })
 
 const mapDispatchToProps = (dispatch) => ({
   onRunClick: () => dispatch(robotActions.run()),
   onPauseClick: () => dispatch(robotActions.pause()),
-  onResumeClick: () => dispatch(robotActions.resume())
+  onResumeClick: () => dispatch(robotActions.resume()),
+  onResetClick: () => dispatch(robotActions.refreshSession())
 })
 
 function RunPanel (props) {

--- a/app/src/containers/UploadStatus.js
+++ b/app/src/containers/UploadStatus.js
@@ -6,7 +6,7 @@ import Upload from '../components/Upload'
 
 const mapStateToProps = (state) => ({
   name: robotSelectors.getSessionName(state),
-  inProgress: robotSelectors.getUploadInProgress(state),
+  inProgress: robotSelectors.getSessionLoadInProgress(state),
   error: robotSelectors.getUploadError(state)
 })
 

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -158,6 +158,13 @@ export type SessionUpdateAction = {|
   payload: SessionUpdate,
 |}
 
+export type RefreshSessionAction = {|
+  type: 'robot:REFRESH_SESSION',
+  meta: {|
+    robotCommand: true
+  |},
+|}
+
 export type CalibrationResponseAction =
   | CalibrationSuccessAction
   | CalibrationFailureAction
@@ -213,6 +220,7 @@ export type Action =
   | ReturnTipResponseAction
   | SetJogDistanceAction
   | SessionUpdateAction
+  | RefreshSessionAction
 
 export const actions = {
   discover (): DiscoverAction {
@@ -549,6 +557,10 @@ export const actions = {
     if (error) action.payload = error
 
     return action
+  },
+
+  refreshSession (): RefreshSessionAction {
+    return {type: 'robot:REFRESH_SESSION', meta: {robotCommand: true}}
   },
 
   tickRunTime () {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -48,6 +48,7 @@ export default function client (dispatch) {
       case actionTypes.PAUSE: return pause(state, action)
       case actionTypes.RESUME: return resume(state, action)
       case actionTypes.CANCEL: return cancel(state, action)
+      case 'robot:REFRESH_SESSION': return refreshSession(state, action)
     }
   }
 
@@ -278,6 +279,11 @@ export default function client (dispatch) {
       .then(() => remote.session_manager.session.stop())
       .then(() => dispatch(actions.cancelResponse()))
       .catch((error) => dispatch(actions.cancelResponse(error)))
+  }
+
+  function refreshSession (state, action) {
+    remote.session_manager.session.refresh()
+      .catch((error) => dispatch(actions.sessionResponse(error)))
   }
 
   function setRunTimerInterval () {

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -96,7 +96,10 @@ export default function sessionReducer (
     case 'robot:SESSION_UPDATE':
       return handleSessionUpdate(state, action)
 
-    case SESSION: return handleSession(state, action)
+    case SESSION:
+    case 'robot:REFRESH_SESSION':
+      return handleSession(state, action)
+
     case SESSION_RESPONSE: return handleSessionResponse(state, action)
     case RUN: return handleRun(state, action)
     case RUN_RESPONSE: return handleRunResponse(state, action)
@@ -143,12 +146,18 @@ function handleSessionUpdate (
 }
 
 function handleSession (state: State, action: any): State {
-  if (!action.payload || !action.payload.file) return state
+  let nextState = {
+    ...state,
+    runTime: 0,
+    startTime: null,
+    sessionRequest: {inProgress: true, error: null}
+  }
 
-  const {payload: {file: {name}}} = action
-  const sessionRequest = {inProgress: true, error: null}
+  if (action.payload && action.payload.file && action.payload.file.name) {
+    return {...nextState, name: action.payload.file.name}
+  }
 
-  return {...state, name, sessionRequest}
+  return nextState
 }
 
 function handleSessionResponse (state: State, action: any): State {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -97,7 +97,7 @@ export const getConnectionStatus = createSelector(
   }
 )
 
-export function getUploadInProgress (state: State) {
+export function getSessionLoadInProgress (state: State) {
   return sessionRequest(state).inProgress
 }
 

--- a/app/src/robot/test/__mocks__/session.js
+++ b/app/src/robot/test/__mocks__/session.js
@@ -13,6 +13,7 @@ export default function MockSession () {
     run: jest.fn(),
     pause: jest.fn(),
     resume: jest.fn(),
-    stop: jest.fn()
+    stop: jest.fn(),
+    refresh: jest.fn()
   }
 }

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -446,6 +446,13 @@ describe('robot actions', () => {
     expect(actions.cancelResponse(new Error('AHHH'))).toEqual(failure)
   })
 
+  test('robot:REFRESH_SESSION action', () => {
+    expect(actions.refreshSession()).toEqual({
+      type: 'robot:REFRESH_SESSION',
+      meta: {robotCommand: true}
+    })
+  })
+
   test('tick run time action', () => {
     const expected = {type: actionTypes.TICK_RUN_TIME}
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -251,6 +251,14 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
+    test('calls session.refresh with REFRESH_SESSION', () => {
+      mockResolvedValue(session.refresh)
+
+      return sendConnect()
+        .then(() => sendToClient({}, actions.refreshSession()))
+        .then(() => expect(session.refresh).toHaveBeenCalled())
+    })
+
     test('start a timer when the run starts', () => {
       mockResolvedValue(session.run)
 

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -7,7 +7,7 @@ const {
   getIsScanning,
   getDiscovered,
   getConnectionStatus,
-  getUploadInProgress,
+  getSessionLoadInProgress,
   getUploadError,
   getSessionName,
   getSessionIsLoaded,
@@ -104,12 +104,12 @@ describe('robot selectors', () => {
     expect(getConnectionStatus(makeState(state))).toBe(constants.DISCONNECTING)
   })
 
-  test('getUploadInProgress', () => {
+  test('getSessionLoadInProgress', () => {
     let state = makeState({session: {sessionRequest: {inProgress: true}}})
-    expect(getUploadInProgress(state)).toBe(true)
+    expect(getSessionLoadInProgress(state)).toBe(true)
 
     state = makeState({session: {sessionRequest: {inProgress: false}}})
-    expect(getUploadInProgress(state)).toBe(false)
+    expect(getSessionLoadInProgress(state)).toBe(false)
   })
 
   test('getUploadError', () => {

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -58,7 +58,9 @@ describe('robot reducer - session', () => {
     const state = {
       session: {
         sessionRequest: {inProgress: false, error: new Error('AH')},
-        name: ''
+        name: '',
+        startTime: 40,
+        runTime: 42
       }
     }
     const action = {
@@ -68,7 +70,26 @@ describe('robot reducer - session', () => {
 
     expect(reducer(state, action).session).toEqual({
       sessionRequest: {inProgress: true, error: null},
-      name: '/path/to/foo.py'
+      name: '/path/to/foo.py',
+      startTime: null,
+      runTime: 0
+    })
+  })
+
+  test('handles robot:REFRESH_SESSION action', () => {
+    const state = {
+      session: {
+        sessionRequest: {inProgress: false, error: null},
+        startTime: 40,
+        runTime: 42
+      }
+    }
+    const action = {type: 'robot:REFRESH_SESSION'}
+
+    expect(reducer(state, action).session).toEqual({
+      sessionRequest: {inProgress: true, error: null},
+      startTime: null,
+      runTime: 0
     })
   })
 


### PR DESCRIPTION
## overview

Addresses app requirements of #1270. This PR adds a reset run button that calls `session.refresh` to reset the run log. It also adds a spinner because `session.refresh` takes about the same amount of time as a session upload.

## changelog

- feat(app): Add ability to reset a run after it ends

## review requests

Please try this out with both a real robot as well as with Virtual Smoothie. If possible, run the API with #1576 or else "Start Time" will do weird stuff (i.e. it will clear out and then go back to the start time of the previous run when `session.refresh` completes. This is an API bug addressed in 1576).
