### PR TITLE
feat(protocol-designer): specify left|right pipette label

### DIFF
--- a/components/src/instrument-diagram/InstrumentGroup.js
+++ b/components/src/instrument-diagram/InstrumentGroup.js
@@ -6,6 +6,7 @@ import InstrumentInfo, {type InstrumentInfoProps} from './InstrumentInfo'
 import styles from './instrument.css'
 
 type Props = {
+  showMountLabel?: ?boolean,
   left?: InstrumentInfoProps,
   right?: InstrumentInfoProps
 }
@@ -15,12 +16,12 @@ type Props = {
  * Takes an array of `InstrumentInfo` props.
  */
 export default function InstrumentGroup (props: Props) {
-  const {left, right} = props
+  const {left, right, showMountLabel} = props
 
   return (
     <section className={styles.pipette_group}>
-      {left && <InstrumentInfo {...left} />}
-      {right && <InstrumentInfo {...right} />}
+      {left && <InstrumentInfo {...left} showMountLabel={showMountLabel} />}
+      {right && <InstrumentInfo {...right} showMountLabel={showMountLabel} />}
     </section>
   )
 }

--- a/components/src/instrument-diagram/InstrumentInfo.js
+++ b/components/src/instrument-diagram/InstrumentInfo.js
@@ -11,6 +11,8 @@ import styles from './instrument.css'
 export type InstrumentInfoProps = {
   /** 'left' or 'right' */
   mount: Mount,
+  /** if true, show labels 'LEFT PIPETTE' / 'RIGHT PIPETTE' */
+  showMountLabel?: ?boolean,
   /** human-readable description, eg 'p300 Single-channel' */
   description: string,
   /** recommended tip type */
@@ -38,7 +40,10 @@ export default function InstrumentInfo (props: InstrumentInfoProps) {
   return (
     <div className={className}>
       <div className={cx(styles.pipette_info, props.infoClassName)}>
-        <InfoItem title={'pipette'} value={props.description} />
+        <InfoItem
+          title={props.showMountLabel ? `${props.mount} pipette` : 'pipette'}
+          value={props.description}
+        />
         <InfoItem title={'suggested tip type'} value={props.tipType} />
         {props.children}
       </div>

--- a/components/src/instrument-diagram/instrument.css
+++ b/components/src/instrument-diagram/instrument.css
@@ -2,7 +2,6 @@
 
 .pipette_group {
   margin: 0 auto;
-  min-width: 40rem;
   max-width: 45rem;
   padding-bottom: 2rem;
   display: grid;

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -40,7 +40,7 @@ export default function FilePage (props: Props) {
         <h2>
           Pipettes
         </h2>
-        <InstrumentGroup {...instruments} />
+        <InstrumentGroup {...instruments} showMountLabel />
       </section>
     </div>
   )


### PR DESCRIPTION
## overview

Closes #1535

## changelog

* `showMountLabel` prop on `InstrumentGroup` + `InstrumentLabel` shows "Left Pipette" | "Right
Pipette" when true
* Remove `min-width` from `InstrumentGroup` b/c it makes PD file page too wide on small screens

## review requests

* Should not affect run app - double check!
* PD matches image in #1535 