### PR TITLE
feat(protocol-designer): rename upload & download buttons

### DIFF
--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -1,12 +1,9 @@
 @import '@opentrons/components';
 
-.bottom_button {
-  margin: 1.5rem 4rem 0;
-  width: calc(100% - 4rem * 2);
-}
-
+.bottom_button,
 .download_button {
-  margin: 1.5rem 2.5rem;
+  margin: 1rem 3rem;
+  width: calc(100% - 3rem * 2);
 }
 
 .upload_button {

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -21,16 +21,20 @@ export default function FileSidebar (props: Props) {
           <div className={styles.download_button}>
             <PrimaryButton Component='a' download={props.downloadData.fileName}
               href={'data:application/json;charset=utf-8,' + encodeURIComponent(props.downloadData.fileContents)}
-            >Download</PrimaryButton>
+            >Export</PrimaryButton>
           </div>
           <div className={styles.divider} />
         </div>
       }
+
       <OutlineButton Component='label' className={cx(styles.upload_button, styles.bottom_button)}>
-        UPLOAD
+        Import JSON
         <input type='file' onChange={props.onUpload} />
       </OutlineButton>
-      <OutlineButton onClick={props.onCreateNew} className={styles.bottom_button}>Create New</OutlineButton>
+
+      <OutlineButton onClick={props.onCreateNew} className={styles.bottom_button}>
+        Create New
+      </OutlineButton>
     </SidePanel>
   )
 }


### PR DESCRIPTION
## overview

Closes #1534

![image](https://user-images.githubusercontent.com/35570080/40504223-b1cfeeec-5f5e-11e8-9dd2-06233be480ef.png)

## changelog

Rename upload to "Import JSON" and download to "Export"

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_rename-buttons-1534/index.html

:bread: 