### PR TITLE
fix(app): add reset run to banners

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -8,7 +8,6 @@ from serial.serialutil import SerialException
 
 from opentrons.drivers import serial_communication
 from opentrons.drivers.rpi_drivers import gpio
-from opentrons.instruments.pipette_config import configs
 '''
 - Driver is responsible for providing an interface for motion control
 - Driver is the only system component that knows about GCODES or how smoothie
@@ -369,10 +368,10 @@ class SmoothieDriver_3_0_0:
         Reads an attached pipette's MODEL
         The MODEL is a unique string for this model of pipette
 
-        :return :dict with key 'model' and model string as value, or None
+        :return model string, or None
         '''
         if self.simulating:
-            res = list(configs.values())[0].name
+            res = None
         else:
             res = self._read_from_pipette(
                 GCODES['READ_INSTRUMENT_MODEL'], mount)

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -2,7 +2,6 @@ import numpy as np
 from opentrons import robot
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
-from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons.trackers.pose_tracker import absolute
 from opentrons.instruments.pipette_config import Y_OFFSET_MULTI
 
@@ -21,14 +20,14 @@ async def test_transform_from_moves(async_client, monkeypatch):
     test_mount, test_model = ('left', 'p300_multi_v1')
     # test_mount, test_model = ('right', 'p300_single_v1')
 
-    def dummy_read_model(self, mount):
+    def dummy_read_model(mount):
         if mount == test_mount:
             return test_model
         else:
             return None
 
     monkeypatch.setattr(
-        SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
+        robot._driver, 'read_pipette_model', dummy_read_model)
 
     robot.reset()
     robot.home()

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -40,10 +40,18 @@ async def test_get_pipettes_uncommissioned(
 
 async def test_get_pipettes(
         virtual_smoothie_env, loop, test_client, monkeypatch):
+    test_model = 'p300_multi_v1'
+
+    def dummy_read_model(mount):
+        return test_model
+
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', dummy_read_model)
+    robot.reset()
+
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = list(configs.values())[0]
+    model = configs[test_model]
     expected = {
         'left': {
             'model': model.name,
@@ -67,10 +75,18 @@ async def test_get_pipettes(
 
 async def test_get_cached_pipettes(
         virtual_smoothie_env, loop, test_client, monkeypatch):
+    test_model = 'p300_multi_v1'
+
+    def dummy_read_model(mount):
+        return test_model
+
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', dummy_read_model)
+    robot.reset()
+
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = list(configs.values())[0]
+    model = configs[test_model]
     expected = {
         'left': {
             'model': model.name,

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -12,16 +12,16 @@ type Props = {
 export default function SessionAlert (props: Props) {
   const {sessionStatus, className, onResetClick} = props
 
-  const COMPLETE_MESSAGE = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
-  const PAUSE_MESSAGE = 'Run paused'
-  const CANCEL_MESSAGE = (<p>Run  canceled. <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+  const completeMesage = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+  const pauseMessage = 'Run paused'
+  const cancelMessage = (<p>Run  canceled. <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
 
   switch (sessionStatus) {
     case 'finished':
       return (
         <AlertItem
           type='success'
-          title={COMPLETE_MESSAGE}
+          title={completeMesage}
           className={className}
         />
       )
@@ -29,7 +29,7 @@ export default function SessionAlert (props: Props) {
       return (
         <AlertItem
           type='info'
-          title={PAUSE_MESSAGE}
+          title={pauseMessage}
           className={className}
           icon={{name: 'pause-circle'}}
         />
@@ -38,7 +38,7 @@ export default function SessionAlert (props: Props) {
       return (
         <AlertItem
         type='warning'
-        title={CANCEL_MESSAGE}
+        title={cancelMessage}
         className={className}
       />)
     default:

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -12,7 +12,7 @@ type Props = {
 export default function SessionAlert (props: Props) {
   const {sessionStatus, className, onResetClick} = props
 
-  const completeMesage = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+  const completeMessage = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
   const pauseMessage = 'Run paused'
   const cancelMessage = (<p>Run  canceled. <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
 
@@ -21,7 +21,7 @@ export default function SessionAlert (props: Props) {
       return (
         <AlertItem
           type='success'
-          title={completeMesage}
+          title={completeMessage}
           className={className}
         />
       )

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -5,16 +5,17 @@ import type {SessionStatus} from '../../robot'
 
 type Props = {
   sessionStatus: SessionStatus,
-  className?: string
+  className?: string,
+  onResetClick: () => mixed
 }
 
-// TODO (ka 2018-5-21): only adding text without call to action until redux work in place
-const COMPLETE_MESSAGE = 'Run complete'
-const PAUSE_MESSAGE = 'Run paused'
-const CANCEL_MESSAGE = 'Run canceled'
-
 export default function SessionAlert (props: Props) {
-  const {sessionStatus, className} = props
+  const {sessionStatus, className, onResetClick} = props
+
+  const COMPLETE_MESSAGE = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+  const PAUSE_MESSAGE = 'Run paused'
+  const CANCEL_MESSAGE = (<p>Run  canceled. <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+
   switch (sessionStatus) {
     case 'finished':
       return (

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import type {State} from '../../types'
 import {
   selectors as robotSelectors,
+  actions as robotActions,
   type SessionStatus
 } from '../../robot'
 
@@ -15,10 +16,6 @@ type SP = {
   showSpinner: boolean,
 }
 
-export default connect(mapStateToProps)(CommandList)
-
-export {ConfirmCancelModal}
-
 function mapStateToProps (state: State): SP {
   return {
     commands: robotSelectors.getCommands(state),
@@ -29,3 +26,11 @@ function mapStateToProps (state: State): SP {
     )
   }
 }
+
+const mapDispatchToProps = (dispatch) => ({
+  onResetClick: () => dispatch(robotActions.refreshSession())
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CommandList)
+
+export {ConfirmCancelModal}

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -59,4 +59,10 @@ li.last_current {
   top: 0;
   left: 0;
   right: 0;
+
+  & a {
+    text-decoration: underline;
+    cursor: pointer;
+    font-weight: var(--fw-semibold);
+  }
 }

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -9,7 +9,7 @@ export type AlertProps = {
   /** name constant of the icon to display */
   type: 'success' | 'warning' | 'info',
   /** title/main message of colored alert bar */
-  title: string,
+  title: string | React.Node,
   /** Alert message body contents */
   children?: React.Node,
   /** Additional class name */

--- a/protocol-designer/src/components/FileSidebar.css
+++ b/protocol-designer/src/components/FileSidebar.css
@@ -1,12 +1,9 @@
 @import '@opentrons/components';
 
-.bottom_button {
-  margin: 1.5rem 4rem 0;
-  width: calc(100% - 4rem * 2);
-}
-
+.bottom_button,
 .download_button {
-  margin: 1.5rem 2.5rem;
+  margin: 1rem 3rem;
+  width: calc(100% - 3rem * 2);
 }
 
 .upload_button {

--- a/protocol-designer/src/components/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar.js
@@ -21,16 +21,20 @@ export default function FileSidebar (props: Props) {
           <div className={styles.download_button}>
             <PrimaryButton Component='a' download={props.downloadData.fileName}
               href={'data:application/json;charset=utf-8,' + encodeURIComponent(props.downloadData.fileContents)}
-            >Download</PrimaryButton>
+            >Export</PrimaryButton>
           </div>
           <div className={styles.divider} />
         </div>
       }
+
       <OutlineButton Component='label' className={cx(styles.upload_button, styles.bottom_button)}>
-        UPLOAD
+        Import JSON
         <input type='file' onChange={props.onUpload} />
       </OutlineButton>
-      <OutlineButton onClick={props.onCreateNew} className={styles.bottom_button}>Create New</OutlineButton>
+
+      <OutlineButton onClick={props.onCreateNew} className={styles.bottom_button}>
+        Create New
+      </OutlineButton>
     </SidePanel>
   )
 }


### PR DESCRIPTION
## overview

This PR doesn't have an issue attached but i noticed the reset run link was present in the Run Complete and Run Canceled banners. This adds the reset functionality and text to those banners.

<img width="800" alt="screen shot 2018-06-01 at 4 01 27 pm" src="https://user-images.githubusercontent.com/3430313/40860933-1eb17218-65b5-11e8-9aae-669a9262717d.png">
<img width="800" alt="screen shot 2018-06-01 at 4 01 42 pm" src="https://user-images.githubusercontent.com/3430313/40860934-1ec55652-65b5-11e8-9711-55a28c462b70.png">

## changelog

- fix(app): add reset run to banners

## review requests
Testing on Virtual Smoothie is fine. 

Upload and run a protocol to completion
- [ ] Confirm clicking 'reset run' link in Run Complete banner resets run
Run protocol again and cancel
- [ ] Confirm clicking 'reset run' link in Run Canceled banner resets run