### PR TITLE
fix(api): Improve pipette model caching

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -8,7 +8,6 @@ from serial.serialutil import SerialException
 
 from opentrons.drivers import serial_communication
 from opentrons.drivers.rpi_drivers import gpio
-from opentrons.instruments.pipette_config import configs
 '''
 - Driver is responsible for providing an interface for motion control
 - Driver is the only system component that knows about GCODES or how smoothie
@@ -369,10 +368,10 @@ class SmoothieDriver_3_0_0:
         Reads an attached pipette's MODEL
         The MODEL is a unique string for this model of pipette
 
-        :return :dict with key 'model' and model string as value, or None
+        :return model string, or None
         '''
         if self.simulating:
-            res = list(configs.values())[0].name
+            res = None
         else:
             res = self._read_from_pipette(
                 GCODES['READ_INSTRUMENT_MODEL'], mount)

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -2,7 +2,6 @@ import numpy as np
 from opentrons import robot
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
-from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons.trackers.pose_tracker import absolute
 from opentrons.instruments.pipette_config import Y_OFFSET_MULTI
 
@@ -21,14 +20,14 @@ async def test_transform_from_moves(async_client, monkeypatch):
     test_mount, test_model = ('left', 'p300_multi_v1')
     # test_mount, test_model = ('right', 'p300_single_v1')
 
-    def dummy_read_model(self, mount):
+    def dummy_read_model(mount):
         if mount == test_mount:
             return test_model
         else:
             return None
 
     monkeypatch.setattr(
-        SmoothieDriver_3_0_0, 'read_pipette_model', dummy_read_model)
+        robot._driver, 'read_pipette_model', dummy_read_model)
 
     robot.reset()
     robot.home()

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -40,10 +40,18 @@ async def test_get_pipettes_uncommissioned(
 
 async def test_get_pipettes(
         virtual_smoothie_env, loop, test_client, monkeypatch):
+    test_model = 'p300_multi_v1'
+
+    def dummy_read_model(mount):
+        return test_model
+
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', dummy_read_model)
+    robot.reset()
+
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = list(configs.values())[0]
+    model = configs[test_model]
     expected = {
         'left': {
             'model': model.name,
@@ -67,10 +75,18 @@ async def test_get_pipettes(
 
 async def test_get_cached_pipettes(
         virtual_smoothie_env, loop, test_client, monkeypatch):
+    test_model = 'p300_multi_v1'
+
+    def dummy_read_model(mount):
+        return test_model
+
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', dummy_read_model)
+    robot.reset()
+
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = list(configs.values())[0]
+    model = configs[test_model]
     expected = {
         'left': {
             'model': model.name,


### PR DESCRIPTION
## overview

Driver simulation will no longer falsely report 'p10_single_v1', and pipette model cache will not be overwritten when driver is in simulation.

## changelog

- fix(api): Improve pipette model caching

## review requests

- [ ] Connect to robot
- [ ] Begin protocol upload and close app before upload completes
- [ ] Re-open app and go to robot settings page, see correct pipette models reported (prior behavior: both models 'p10_single_v1')
