### PR TITLE
fix(app): Add reset run link to run canceled/complete banners

### DIFF
--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -5,22 +5,23 @@ import type {SessionStatus} from '../../robot'
 
 type Props = {
   sessionStatus: SessionStatus,
-  className?: string
+  className?: string,
+  onResetClick: () => mixed
 }
 
-// TODO (ka 2018-5-21): only adding text without call to action until redux work in place
-const COMPLETE_MESSAGE = 'Run complete'
-const PAUSE_MESSAGE = 'Run paused'
-const CANCEL_MESSAGE = 'Run canceled'
-
 export default function SessionAlert (props: Props) {
-  const {sessionStatus, className} = props
+  const {sessionStatus, className, onResetClick} = props
+
+  const completeMessage = (<p>Run  complete! <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+  const pauseMessage = 'Run paused'
+  const cancelMessage = (<p>Run  canceled. <a onClick={onResetClick}>Reset run</a> to run protocol again.</p>)
+
   switch (sessionStatus) {
     case 'finished':
       return (
         <AlertItem
           type='success'
-          title={COMPLETE_MESSAGE}
+          title={completeMessage}
           className={className}
         />
       )
@@ -28,7 +29,7 @@ export default function SessionAlert (props: Props) {
       return (
         <AlertItem
           type='info'
-          title={PAUSE_MESSAGE}
+          title={pauseMessage}
           className={className}
           icon={{name: 'pause-circle'}}
         />
@@ -37,7 +38,7 @@ export default function SessionAlert (props: Props) {
       return (
         <AlertItem
         type='warning'
-        title={CANCEL_MESSAGE}
+        title={cancelMessage}
         className={className}
       />)
     default:

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -2,6 +2,7 @@
 import {connect} from 'react-redux'
 import type {State} from '../../types'
 import {
+  actions as robotActions,
   selectors as robotSelectors,
   type SessionStatus
 } from '../../robot'
@@ -15,10 +16,6 @@ type SP = {
   showSpinner: boolean,
 }
 
-export default connect(mapStateToProps)(CommandList)
-
-export {ConfirmCancelModal}
-
 function mapStateToProps (state: State): SP {
   return {
     commands: robotSelectors.getCommands(state),
@@ -29,3 +26,11 @@ function mapStateToProps (state: State): SP {
     )
   }
 }
+
+const mapDispatchToProps = (dispatch) => ({
+  onResetClick: () => dispatch(robotActions.refreshSession())
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(CommandList)
+
+export {ConfirmCancelModal}

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -59,4 +59,10 @@ li.last_current {
   top: 0;
   left: 0;
   right: 0;
+
+  & a {
+    text-decoration: underline;
+    cursor: pointer;
+    font-weight: var(--fw-semibold);
+  }
 }

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -9,7 +9,7 @@ export type AlertProps = {
   /** name constant of the icon to display */
   type: 'success' | 'warning' | 'info',
   /** title/main message of colored alert bar */
-  title: string,
+  title: string | React.Node,
   /** Alert message body contents */
   children?: React.Node,
   /** Additional class name */


### PR DESCRIPTION
## overview

This is the new PR to replace the once previously dirtied by a rebase and a merge. 

This PR doesn't have an issue attached but [reset run] link was not present in the Run Complete and Run Canceled banners but was shown in design. This adds the reset functionality and text to those banners.

<img width="800" alt="screen shot 2018-06-01 at 4 01 27 pm" src="https://user-images.githubusercontent.com/3430313/40860933-1eb17218-65b5-11e8-9aae-669a9262717d.png">
<img width="800" alt="screen shot 2018-06-01 at 4 01 42 pm" src="https://user-images.githubusercontent.com/3430313/40860934-1ec55652-65b5-11e8-9711-55a28c462b70.png">

## changelog

- fix(app): Add reset run link to run canceled/complete banners

## review requests
Testing on Virtual Smoothie is fine. 

Upload and run a protocol to completion
- [x] Confirm clicking 'reset run' link in Run Complete banner resets run
Run protocol again and cancel
- [x] Confirm clicking 'reset run' link in Run Canceled banner resets run