### PR TITLE
fix(api): json protocol upload does not time.sleep when simulating

### DIFF
--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -5,7 +5,8 @@ from opentrons.instruments import pipette_config
 
 
 def _sleep(seconds):
-    time.sleep(seconds)
+    if not robot.is_simulating():
+        time.sleep(seconds)
 
 
 def load_pipettes(protocol_data):
@@ -81,7 +82,7 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):
 
         if command_type == 'delay':
             wait = params.get('wait', 0)
-            if type(wait) is str:
+            if wait is True:
                 # TODO Ian 2018-05-14 pass message
                 robot.pause()
             else:


### PR DESCRIPTION
## overview

When uploading a protocol with a long delay (or a lot of short delays) the protocol takes a long time to upload because it's calling `time.sleep` as it simulates the protocol upon upload.

Also I realized that I had the implementation of "delay until user input" wrong - `wait: True` not `wait: String` should call `robot.pause()`

## changelog

- Don't `time.sleep` when uploading a JSON protocol
- Fix delay until user input `wait: True` implementation

## review requests

I tested on Sunset (upload a protocol that has long delays, see it doesn't take too long) - virtual smoothie is probably OK.

Are there any cases where this would cause a problem? `robot.is_simulating` is safe to use here, right?

---

## TEST PROTOCOL

```json
{
    "protocol-schema": "1.0.0",
    "metadata": {
        "protocol-name": "DNA-test",
        "author": "Kinnari",
        "description": "test with DNA isolation protocol (250 uL of saliva)",
        "created": 1527780108459,
        "last-modified": null,
        "category": null,
        "subcategory": null,
        "tags": []
    },
    "designer-application": {
        "application-name": "opentrons/protocol-designer",
        "application-version": "1.0.0",
        "data": {}
    },
    "robot": {
        "model": "OT-2 Standard"
    },
    "pipettes": {
        "left:P50 Single-Channel": {
            "mount": "left",
            "model": "p300_single_v1"
        },
        "right:P1000 Single-Channel": {
            "mount": "right",
            "model": "p300_multi_v1"
        }
    },
    "labware": {
        "trashId": {
            "slot": "12",
            "display-name": "Trash",
            "model": "fixed-trash"
        },
        "1527775131432.0.3768981732186625:96-deep-well": {
            "slot": "1",
            "display-name": "magrack",
            "model": "96-deep-well"
        },
        "1527775141813.0.7086222929508061:tube-rack-2ml": {
            "slot": "5",
            "display-name": "reagents",
            "model": "tube-rack-2ml"
        },
        "1527775261191.0.2402537052696916:tiprack-1000ul": {
            "slot": "3",
            "display-name": "p1000rack",
            "model": "tiprack-1000ul"
        },
        "1527775278489.0.9710298257908359:tiprack-200ul": {
            "slot": "6",
            "display-name": "p50rack",
            "model": "tiprack-200ul"
        },
        "1527775296860.0.442660831729319:tube-rack-.75ml": {
            "slot": "4",
            "display-name": "outrack",
            "model": "tube-rack-.75ml"
        },
        "1527775639467.0.4536018232318608:trough-12row": {
            "slot": "11",
            "display-name": "liquid_trash",
            "model": "trough-12row"
        }
    },
    "procedure": [
        {
            "annotation": {
                "name": "TODO Name 0",
                "description": "todo description"
            },
            "subprocedure": []
        },
        {
            "annotation": {
                "name": "TODO Name 1",
                "description": "todo description"
            },
            "subprocedure": [
                {
                    "command": "pick-up-tip",
                    "params": {
                        "pipette": "left:P50 Single-Channel",
                        "labware": "1527775261191.0.2402537052696916:tiprack-1000ul",
                        "well": "A1"
                    }
                },
                {
                    "command": "aspirate",
                    "params": {
                        "pipette": "left:P50 Single-Channel",
                        "volume": 20,
                        "labware": "1527775141813.0.7086222929508061:tube-rack-2ml",
                        "well": "A1"
                    }
                },
                {
                    "command": "delay",
                    "params": {
                        "message": "Engage the MagDeck",
                        "wait": 60
                    }
                },
                {
                    "command": "dispense",
                    "params": {
                        "pipette": "left:P50 Single-Channel",
                        "volume": 20,
                        "labware": "1527775296860.0.442660831729319:tube-rack-.75ml",
                        "well": "A1"
                    }
                }
            ]
        },
        {
            "annotation": {
                "name": "TODO Name 4",
                "description": "todo description"
            },
            "subprocedure": [
                {
                    "command": "delay",
                    "params": {
                        "message": "Engage the MagDeck",
                        "wait": true
                    }
                }
            ]
        },
        {
            "annotation": {
                "name": "TODO Name 5",
                "description": "todo description"
            },
            "subprocedure": [
                {
                    "command": "drop-tip",
                    "params": {
                        "pipette": "left:P50 Single-Channel",
                        "labware": "trashId",
                        "well": "A1"
                    }
                }
            ]
        }
    ]
}
```