### PR TITLE
feat(protocol-designer): pd & components: selected prop on NavButton

### DIFF
--- a/components/src/nav/NavButton.js
+++ b/components/src/nav/NavButton.js
@@ -24,15 +24,20 @@ type NavButtonProps= {
   iconName: IconName,
   /** Display a notification dot */
   notification?: boolean,
+  /** selected styling (can also use react-router & `activeClassName`) */
+  selected?: boolean
 }
 
 export default function NavButton (props: NavButtonProps) {
   const {url} = props
   const className = classnames(
+    props.className,
     styles.button,
-    {[styles.disabled]: props.disabled},
-    {[styles.bottom]: props.isBottom},
-    props.className
+    {
+      [styles.disabled]: props.disabled,
+      [styles.bottom]: props.isBottom,
+      [styles.active]: props.selected
+    }
   )
 
   let buttonProps = {

--- a/components/src/nav/NavButton.md
+++ b/components/src/nav/NavButton.md
@@ -27,7 +27,7 @@ Currently Selected:
   <NavButton
     onClick={() => alert('you clicked me')}
     iconName='ot-connect'
-    isCurrent={true}
+    selected
   />
 </div>
 ```

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -18,15 +18,14 @@ function Nav (props: Props) {
       <NavButton
         iconName='ot-file'
         title='FILE'
-        disabled={props.currentPage === 'file-splash'}
-        isCurrent={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
+        selected={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
         onClick={props.handleClick('file-detail')} />
 
       <NavButton
         iconName='ot-design'
         title='DESIGN'
         disabled={props.currentPage === 'file-splash'}
-        isCurrent={props.currentPage === 'steplist' || props.currentPage === 'ingredient-detail'}
+        selected={props.currentPage === 'steplist' || props.currentPage === 'ingredient-detail'}
         onClick={props.handleClick('steplist')} />
     </VerticalNavBar>
   )


### PR DESCRIPTION
## overview

Closes #1505

## changelog

- Add `selected` prop to NavButton, update complib NavButton.md

## review requests

There used to be `isCurrent` but it got removed?

Run App should be unaffected, PD should have selected styles on current page

Does not fix bug #1561 - I wanna map out all the page-like things, forms, modals, and modes before figuring out a cleaner way to handle out navigation. This is just a style PR