### PR TITLE
fix(protocol-designer): fix whitescreen upon creating new file

### DIFF
--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -12,6 +12,32 @@ export function sortLabwareBySlot (robotState: RobotState) {
 
 // SELECTORS
 
+export function getPipetteChannels (pipetteId: string, robotState: RobotState): ?Channels {
+  const pipette = robotState.instruments[pipetteId]
+
+  if (!pipette) {
+    // TODO Ian 2018-06-04 use assert
+    console.warn(`no pipette id: "${pipetteId}"`)
+    return null
+  }
+
+  const pipetteChannels = pipette.channels
+  return pipetteChannels
+}
+
+export function getLabwareType (labwareId: string, robotState: RobotState): ?string {
+  const labware = robotState.labware[labwareId]
+
+  if (!labware) {
+    // TODO Ian 2018-06-04 use assert
+    console.warn(`no labware id: "${labwareId}"`)
+    return null
+  }
+
+  const labwareType = labware.type
+  return labwareType
+}
+
 export function _getNextTip (
   pipetteChannels: Channels,
   tiprackWellsState: {[wellName: string]: boolean

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -41,9 +41,12 @@ function _getSelectedWellsForStep (
   }
 
   const pipetteId = form.pipette
-  // TODO Ian 2018-04-02 use robotState selectors here
-  const pipetteChannels = robotState.instruments[pipetteId].channels
-  const labwareType = robotState.labware[labwareId].type
+  const pipetteChannels = StepGeneration.getPipetteChannels(pipetteId, robotState)
+  const labwareType = StepGeneration.getLabwareType(labwareId, robotState)
+
+  if (!pipetteChannels || !labwareType) {
+    return []
+  }
 
   const getWells = (wells: Array<string>) => _wellsForPipette(pipetteChannels, labwareType, wells)
 
@@ -70,10 +73,15 @@ function _getSelectedWellsForStep (
       wells.push(...getWells([form.destWell]))
     }
   }
-  // TODO Ian 2018-03-23 once distribute is supported
-  // if (form.stepType === 'distribute') {
-  //   ...
-  // }
+  if (form.stepType === 'distribute') {
+    if (form.sourceLabware === labwareId) {
+      wells.push(...getWells([form.sourceWell]))
+    }
+    if (form.destLabware === labwareId) {
+      wells.push(...getWells(form.destWells))
+    }
+  }
+
   return wells
 }
 


### PR DESCRIPTION
## overview

Before this, if the user created a protocol, added steps that use a pipette, and then click "New
File" and make a new pipette, PD would whitescreen if that new pipette was different than the old
one

## changelog

- safe to change pipettes in "New File" modal (no white screen, but bad UX right now)
- also fixed partially implemented distribute well highlighting - before it was highlighting just single wells, it didn't highlight all wells when mousing over a distribute step

## review requests

- Changing pipette types in "New File" modal after making steps that use that pipette no longer whitescreens (but PD does show a bunch of error banners)
- Mouseover distribute step highlights all wells