### PR TITLE
fix(app): Fix change pipette with v1.3 pipette models

### DIFF
--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import {Link} from 'react-router-dom'
 
 import {Icon, PrimaryButton, ModalPage} from '@opentrons/components'
+import {getPipetteChannelsByName} from '@opentrons/shared-data'
 
 import type {ChangePipetteProps} from './types'
 import {getDiagramSrc} from './InstructionStep'
@@ -13,7 +14,7 @@ const EXIT_BUTTON_MESSAGE = 'exit pipette setup'
 const EXIT_BUTTON_MESSAGE_WRONG = 'keep pipette and exit setup'
 
 // note: direction prop is not valid inside this component
-// display messages based on presence of wantedPipette and actualPipette
+// display messages based on presence of wantedPipetteName and actualPipette
 export default function ConfirmPipette (props: ChangePipetteProps) {
   const {success, attachedWrong, actualPipette} = props
 
@@ -42,7 +43,7 @@ export default function ConfirmPipette (props: ChangePipetteProps) {
 }
 
 function Status (props: ChangePipetteProps) {
-  const {displayName, wantedPipette, attachedWrong, success} = props
+  const {displayName, wantedPipetteName, attachedWrong, success} = props
   const iconName = success ? 'check-circle' : 'close-circle'
   const iconClass = cx(styles.confirm_icon, {
     [styles.success]: success,
@@ -51,12 +52,12 @@ function Status (props: ChangePipetteProps) {
 
   let message
 
-  if (wantedPipette && success) {
+  if (wantedPipetteName && success) {
     message = `${displayName} successfully attached.`
-  } else if (wantedPipette) {
+  } else if (wantedPipetteName) {
     message = attachedWrong
       ? `Incorrect pipette attached (${displayName})`
-      : `Unable to detect ${wantedPipette.displayName || ''}.`
+      : `Unable to detect ${wantedPipetteName || ''}.`
   } else {
     message = success
       ? 'Pipette is detached'
@@ -72,25 +73,25 @@ function Status (props: ChangePipetteProps) {
 }
 
 function StatusDetails (props: ChangePipetteProps) {
-  const {success, attachedWrong, wantedPipette, actualPipette} = props
+  const {success, attachedWrong, wantedPipetteName, actualPipette} = props
 
   if (!success) {
-    if (wantedPipette && attachedWrong) {
+    if (wantedPipetteName && attachedWrong) {
       return (
         <p className={styles.confirm_failure_instructions}>
-          The attached pipette does not match the {wantedPipette.displayName} pipette you had originally selected.
+          The attached pipette does not match the {wantedPipetteName} pipette you had originally selected.
         </p>
       )
     }
 
-    if (wantedPipette) {
+    if (wantedPipetteName) {
       return (
         <div>
           <img
             className={styles.confirm_diagram}
             src={getDiagramSrc({
               ...props,
-              ...wantedPipette,
+              channels: getPipetteChannelsByName(wantedPipetteName),
               diagram: 'tab',
               direction: 'attach'
             })}
@@ -131,16 +132,16 @@ function TryAgainButton (props: ChangePipetteProps) {
     baseUrl,
     checkPipette,
     attachedWrong,
-    wantedPipette,
+    wantedPipetteName,
     actualPipette
   } = props
 
   let buttonProps
 
-  if (wantedPipette && attachedWrong) {
+  if (wantedPipetteName && attachedWrong) {
     buttonProps = {
       Component: Link,
-      to: baseUrl.replace(`/${wantedPipette.model}`, ''),
+      to: baseUrl.replace(`/${wantedPipetteName}`, ''),
       children: 'detach and try again'
     }
   } else if (actualPipette) {

--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -5,6 +5,7 @@ import capitalize from 'lodash/capitalize'
 
 import type {ChangePipetteProps} from './types'
 
+import {getPipetteChannelsByName} from '@opentrons/shared-data'
 import {ModalPage, PrimaryButton, type ButtonProps} from '@opentrons/components'
 import PipetteSelection from './PipetteSelection'
 import InstructionStep from './InstructionStep'
@@ -14,11 +15,11 @@ const ATTACH_CONFIRM = 'have robot check connection'
 const DETACH_CONFIRM = 'confirm pipette is detached'
 
 export default function Instructions (props: ChangePipetteProps) {
-  const {wantedPipette, actualPipette} = props
+  const {wantedPipetteName, actualPipette} = props
 
   const titleBar = {
     ...props,
-    back: wantedPipette
+    back: wantedPipetteName
       ? {onClick: props.back}
       : {Component: Link, to: props.exitUrl, children: 'exit'}
   }
@@ -27,11 +28,11 @@ export default function Instructions (props: ChangePipetteProps) {
     <ModalPage titleBar={titleBar} contentsClassName={styles.modal_contents}>
       <Title {...props} />
 
-      {!actualPipette && !wantedPipette && (
+      {!actualPipette && !wantedPipetteName && (
         <PipetteSelection onChange={props.onPipetteSelect} />
       )}
 
-      {(actualPipette || wantedPipette) && (
+      {(actualPipette || wantedPipetteName) && (
         <div>
           <Steps {...props} />
           <CheckButton onClick={props.confirmPipette}>
@@ -56,7 +57,10 @@ function Title (props: ChangePipetteProps) {
 
 function Steps (props: ChangePipetteProps) {
   const {direction} = props
-  const pipette = props.actualPipette || props.wantedPipette
+  const channels = props.actualPipette
+    ? props.actualPipette.channels
+    : getPipetteChannelsByName(props.wantedPipetteName)
+
   let stepOne
   let stepTwo
 
@@ -86,16 +90,16 @@ function Steps (props: ChangePipetteProps) {
       <InstructionStep
         step='one'
         diagram='screws'
+        channels={channels}
         {...props}
-        {...pipette}
       >
         {stepOne}
       </InstructionStep>
       <InstructionStep
         step='two'
         diagram='tab'
+        channels={channels}
         {...props}
-        {...pipette}
       >
         {stepTwo}
       </InstructionStep>

--- a/app/src/components/ChangePipette/PipetteSelection.js
+++ b/app/src/components/ChangePipette/PipetteSelection.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 
-import {getPipette, getPipetteModels} from '@opentrons/shared-data'
+import {getPipetteNames} from '@opentrons/shared-data'
 import {DropdownField} from '@opentrons/components'
 import styles from './styles.css'
 
@@ -11,10 +11,7 @@ export type PipetteSelectionProps = {
   onChange: $PropertyType<React.ElementProps<typeof DropdownField>, 'onChange'>
 }
 
-const OPTIONS = getPipetteModels().map(m => {
-  const pipette = getPipette(m) || {model: '', displayName: ''}
-  return {value: pipette.model, name: pipette.displayName}
-})
+const OPTIONS = getPipetteNames().map(name => ({name, value: name}))
 
 export default function PipetteSelection (props: PipetteSelectionProps) {
   return (

--- a/app/src/components/ChangePipette/types.js
+++ b/app/src/components/ChangePipette/types.js
@@ -21,7 +21,7 @@ export type ChangePipetteProps = {
   title: string,
   subtitle: string,
   mount: Mount,
-  wantedPipette: ?PipetteConfig,
+  wantedPipetteName: ?string,
   actualPipette: ?PipetteConfig,
   displayName: string,
   direction: Direction,

--- a/shared-data/js/pipettes.js
+++ b/shared-data/js/pipettes.js
@@ -31,18 +31,51 @@ const ALL_MODELS: Array<string> = Object
   .keys(pipetteConfigByModel)
   .sort(comparePipettes(['channels', 'nominalMaxVolumeUl']))
 
+const ALL_PIPETTES: Array<PipetteConfig> = ALL_MODELS
+  .map(getPipette)
+  .filter(Boolean)
+
 export function getPipette (model: string): ?PipetteConfig {
   const config = pipetteConfigByModel[model]
 
   return config && {...config, model: model}
 }
 
-export function getPipetteModels (...sortBy: Array<SortableProps>) {
+export function getPipetteModels (
+  ...sortBy: Array<SortableProps>
+): Array<string> {
   const models = [...ALL_MODELS]
 
   if (sortBy.length) models.sort(comparePipettes(sortBy))
 
   return models
+}
+
+export function getPipetteNames (
+  ...sortBy: Array<SortableProps>
+): Array<string> {
+  return getPipetteModels(...sortBy)
+    .reduce((result, model) => {
+      const {seen, names} = result
+      const {displayName} = getPipette(model) || {displayName: ''}
+
+      if (displayName && !seen[displayName]) {
+        seen[displayName] = true
+        names.push(displayName)
+      }
+
+      return {seen, names}
+    }, {seen: {}, names: []})
+    .names
+}
+
+// note: this function assumes all pipettes with the same display name have
+// the same number of channels. This feels like a sane assumption
+export function getPipetteChannelsByName (name: ?string): PipetteChannels {
+  const match = ALL_PIPETTES.find(p => p.displayName === name)
+
+  // default to single-channel if name doesn't match
+  return match ? match.channels : 1
 }
 
 function comparePipettes (sortBy: Array<SortableProps>) {


### PR DESCRIPTION
## overview

This PR is also serving as the bug ticket for this regression.

#1474 introduced changes to `shared-data` that were incompatible with the app's change pipette wizard. This PR updates the app's usage of pipettes from `shared-data` to fix change pipette.

## changelog

- fix(app): Fix change pipette with v1.3 pipette models

## review requests

Please test change pipette with a real robot. If at all possible (I'm not sure if there are any in the office) please try with a `v1.3` pipette (@andySigler has informed me that P50's should be `1.3`)

Previously, the change pipette route for a given pipette would be:

```
.../:mount/:model
```

But because more than one model may match a given selection (e.g. "P300 Single-channel"), we've switched it to:

```
.../:mount/:name
```

And the app now checks the attached pipette against `pipette.displayName` instead of `pipette.model`