### PR TITLE
feat(app): Add priority 2 analytics events

### DIFF
--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -53,6 +53,22 @@ describe('analytics events map', () => {
     })
   })
 
+  test('robot:SESSION_RESPONSE error -> protocolUpload event', () => {
+    const state = {}
+    const success = {type: 'robot:SESSION_RESPONSE'}
+    const failure = {type: 'robot:SESSION_RESPONSE', error: new Error('AH')}
+
+    expect(makeEvent(state, success)).toEqual({
+      name: 'protocolUpload',
+      properties: {success: true, error: ''}
+    })
+
+    expect(makeEvent(state, failure)).toEqual({
+      name: 'protocolUpload',
+      properties: {success: false, error: 'AH'}
+    })
+  })
+
   test('robot:RUN -> runStart event', () => {
     const state = {}
     const action = {type: 'robot:RUN'}
@@ -60,6 +76,33 @@ describe('analytics events map', () => {
     expect(makeEvent(state, action)).toEqual({
       name: 'runStart',
       properties: {}
+    })
+  })
+
+  test('robot:PAUSE -> runPause event', () => {
+    const state = {}
+    const action = {type: 'robot:PAUSE'}
+
+    expect(makeEvent(state, action)).toEqual({
+      name: 'runPause',
+      properties: {}
+    })
+  })
+
+  test('robot:CANCEL -> runCancel event', () => {
+    const state = {
+      robot: {
+        session: {
+          startTime: 1000,
+          runTime: 5000
+        }
+      }
+    }
+    const action = {type: 'robot:CANCEL'}
+
+    expect(makeEvent(state, action)).toEqual({
+      name: 'runCancel',
+      properties: {runTime: 4}
     })
   })
 
@@ -77,6 +120,16 @@ describe('analytics events map', () => {
     expect(makeEvent(state, action)).toEqual({
       name: 'runFinish',
       properties: {runTime: 4}
+    })
+  })
+
+  test('robot:RUN_RESPONSE error -> runError event', () => {
+    const state = {}
+    const action = {type: 'robot:RUN_RESPONSE', error: new Error('AH')}
+
+    expect(makeEvent(state, action)).toEqual({
+      name: 'runError',
+      properties: {error: 'AH'}
     })
   })
 })

--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -79,17 +79,29 @@ describe('analytics events map', () => {
     })
   })
 
-  test('robot:PAUSE -> runPause event', () => {
+  test('robot:PAUSE_RESPONSE -> runPause event', () => {
     const state = {}
-    const action = {type: 'robot:PAUSE'}
+    const success = {type: 'robot:PAUSE_RESPONSE'}
+    const failure = {type: 'robot:PAUSE_RESPONSE', error: new Error('AH')}
 
-    expect(makeEvent(state, action)).toEqual({
+    expect(makeEvent(state, success)).toEqual({
       name: 'runPause',
-      properties: {}
+      properties: {
+        success: true,
+        error: ''
+      }
+    })
+
+    expect(makeEvent(state, failure)).toEqual({
+      name: 'runPause',
+      properties: {
+        success: false,
+        error: 'AH'
+      }
     })
   })
 
-  test('robot:CANCEL -> runCancel event', () => {
+  test('robot:CANCEL_REPSONSE -> runCancel event', () => {
     const state = {
       robot: {
         session: {
@@ -98,11 +110,25 @@ describe('analytics events map', () => {
         }
       }
     }
-    const action = {type: 'robot:CANCEL'}
+    const success = {type: 'robot:CANCEL_RESPONSE'}
+    const failure = {type: 'robot:CANCEL_RESPONSE', error: new Error('AH')}
 
-    expect(makeEvent(state, action)).toEqual({
+    expect(makeEvent(state, success)).toEqual({
       name: 'runCancel',
-      properties: {runTime: 4}
+      properties: {
+        runTime: 4,
+        success: true,
+        error: ''
+      }
+    })
+
+    expect(makeEvent(state, failure)).toEqual({
+      name: 'runCancel',
+      properties: {
+        runTime: 4,
+        success: false,
+        error: 'AH'
+      }
     })
   })
 

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -37,6 +37,7 @@ export default function makeEvent (state: State, action: Action): ?Event {
 
     // $FlowFixMe(ka, 2018-06-5): flow type robot:SESSION_RESPONSE
     case 'robot:SESSION_RESPONSE':
+      // TODO (ka, 2018-6-6): add file open type 'button' | 'drag-n-drop' (work required in action meta)
       return {
         name: 'protocolUpload',
         properties: {

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -35,6 +35,16 @@ export default function makeEvent (state: State, action: Action): ?Event {
         }
       }
 
+    // $FlowFixMe(ka, 2018-06-5): flow type robot:SESSION_RESPONSE
+    case 'robot:SESSION_RESPONSE':
+      return {
+        name: 'protocolUpload',
+        properties: {
+          success: !action.error,
+          error: (action.error && action.error.message) || ''
+        }
+      }
+
     // $FlowFixMe(mc, 2018-05-28): flow type robot:RUN
     case 'robot:RUN':
       return {name: 'runStart', properties: {}}
@@ -45,8 +55,21 @@ export default function makeEvent (state: State, action: Action): ?Event {
         const runTime = robotSelectors.getRunSeconds(state)
         return {name: 'runFinish', properties: {runTime}}
       } else {
-        // TODO(mc, 2018-05-28): runError event
-        return null
+        return {name: 'runError',
+          properties: {
+            error: action.error.message
+          }
+        }
+      }
+    // $FlowFixMe(ka, 2018-06-5): flow type robot:PAUSE
+    case 'robot:PAUSE':
+      return {name: 'runPause', properties: {}}
+
+    // $FlowFixMe(ka, 2018-06-5): flow type robot:CANCEL
+    case 'robot:CANCEL':
+      if (!action.error) {
+        const runTime = robotSelectors.getRunSeconds(state)
+        return {name: 'runCancel', properties: {runTime}}
       }
   }
 

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -55,21 +55,33 @@ export default function makeEvent (state: State, action: Action): ?Event {
         const runTime = robotSelectors.getRunSeconds(state)
         return {name: 'runFinish', properties: {runTime}}
       } else {
-        return {name: 'runError',
+        return {
+          name: 'runError',
           properties: {
             error: action.error.message
           }
         }
       }
-    // $FlowFixMe(ka, 2018-06-5): flow type robot:PAUSE
-    case 'robot:PAUSE':
-      return {name: 'runPause', properties: {}}
+    // $FlowFixMe(ka, 2018-06-5): flow type robot:PAUSE_RESPONSE
+    case 'robot:PAUSE_RESPONSE':
+      return {
+        name: 'runPause',
+        properties: {
+          success: !action.error,
+          error: (action.error && action.error.message) || ''
+        }
+      }
 
     // $FlowFixMe(ka, 2018-06-5): flow type robot:CANCEL
-    case 'robot:CANCEL':
-      if (!action.error) {
-        const runTime = robotSelectors.getRunSeconds(state)
-        return {name: 'runCancel', properties: {runTime}}
+    case 'robot:CANCEL_RESPONSE':
+      const runTime = robotSelectors.getRunSeconds(state)
+      return {
+        name: 'runCancel',
+        properties: {
+          runTime,
+          success: !action.error,
+          error: (action.error && action.error.message) || ''
+        }
       }
   }
 


### PR DESCRIPTION
## overview

This PR closes #1553 by adding level 2 priority tracking events and tests to the app.

## changelog

- add protocolUpload, runPause, runError, runCancel events and tests

## review requests

- Get Mixpanel user ID from debug logs or config file, or Alfie. replace `correct_mixpanel_id` in following command to run the app.
- `make dev OT_APP_MIXPANEL_ID=correct_mixpanel_id OT_APP_ANALYTICS__OPTED_IN=1`
- watch console for logged events!

**Upload Event:**

Upload a protocol without errors (upload successful)
- [x] protocolUpload event includes {success:true, error:''}
Upload a protocol errors (upload errors)
- [x] protocolUpload event includes {success:false, error: 'some error message'}

**Run Events:**

- [x] runPause event when protocol run is paused
- [x] runCanceled event when protocol run is canceled
- [x] runError event when protocol run errors (not sure how to produce this) returns {error: 'message text'}

