### PR TITLE
feat(app): Add resources page to more section

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -5,7 +5,7 @@ import NavBar from './nav-bar'
 
 import SidePanel from '../pages/SidePanel'
 import Robots from '../pages/Robots'
-import AppSettingsPage from '../pages/AppSettings'
+import More from '../pages/More'
 import Upload from '../pages/Upload'
 import Calibrate from '../pages/Calibrate'
 import Run from '../pages/Run'
@@ -22,7 +22,7 @@ export default function App () {
         <Redirect from='(.*)/index.html' to='/' />
         <Redirect exact from='/' to='/robots' />
         <Route path='/robots/:name?' component={Robots} />
-        <Route path='/menu/app' component={AppSettingsPage} />
+        <Route path='/menu' component={More} />
         <Route path='/upload' component={Upload} />
         <Route path='/calibrate' component={Calibrate} />
         <Route path='/run' component={Run} />

--- a/app/src/components/MenuPanel/index.js
+++ b/app/src/components/MenuPanel/index.js
@@ -9,9 +9,13 @@ export default function MenuPanel () {
   return (
     <SidePanel title='Menu'>
       <div className={styles.menu_panel}>
-        <ol>
+        <ol className={styles.menu_list}>
           <ListItem className={styles.menu_item} url={'/menu/app'} activeClassName={styles.active}>
             <span>App</span>
+            <Icon name={'chevron-right'} className={styles.menu_icon}/>
+          </ListItem>
+          <ListItem className={styles.menu_item} url={'/menu/resources'} activeClassName={styles.active}>
+            <span>Resources</span>
             <Icon name={'chevron-right'} className={styles.menu_icon}/>
           </ListItem>
         </ol>

--- a/app/src/components/MenuPanel/styles.css
+++ b/app/src/components/MenuPanel/styles.css
@@ -8,13 +8,14 @@
 
 .menu_list {
   list-style: none;
-  margin-left: 0;
+  margin: 1rem 0 0;
 }
 
 .menu_item {
-  margin-bottom: 0.5rem;
   text-transform: uppercase;
   font-size: var(--fs-body-2);
+  margin-bottom: 0.25rem;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
 
   & > span {
     width: 100%;

--- a/app/src/components/Resources/KnowledgeCard.js
+++ b/app/src/components/Resources/KnowledgeCard.js
@@ -1,0 +1,23 @@
+// @flow
+// resources page layout
+import * as React from 'react'
+import {Card, OutlineButton} from '@opentrons/components'
+
+const TITLE = 'Knowledge Base'
+
+export default function KnowledgeCard () {
+  return (
+    <Card
+      title={TITLE}
+    >
+      <p>Visit our walkthroughs and FAQs</p>
+      <OutlineButton
+        Component="a"
+        href="https://support.opentrons.com"
+        target="_blank"
+      >
+        View in Browser
+      </OutlineButton>
+    </Card>
+  )
+}

--- a/app/src/components/Resources/LibraryCard.js
+++ b/app/src/components/Resources/LibraryCard.js
@@ -1,0 +1,23 @@
+// @flow
+// resources page layout
+import * as React from 'react'
+import {Card, OutlineButton} from '@opentrons/components'
+
+const TITLE = 'Protocol Library'
+
+export default function LibraryCard () {
+  return (
+    <Card
+      title={TITLE}
+    >
+      <p>Download a protocol to run on your robot</p>
+      <OutlineButton
+        Component="a"
+        href="http://protocols.opentrons.com/"
+        target="_blank"
+      >
+        View in Browser
+      </OutlineButton>
+    </Card>
+  )
+}

--- a/app/src/components/Resources/index.js
+++ b/app/src/components/Resources/index.js
@@ -1,0 +1,21 @@
+// @flow
+// resources page layout
+import * as React from 'react'
+
+import KnowledgeCard from './KnowledgeCard'
+import LibraryCard from './LibraryCard'
+
+import styles from './styles.css'
+
+export default function Resources () {
+  return (
+    <div className={styles.resources_page}>
+      <div className={styles.row}>
+        <KnowledgeCard />
+      </div>
+      <div className={styles.row}>
+        <LibraryCard />
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/Resources/styles.css
+++ b/app/src/components/Resources/styles.css
@@ -1,0 +1,16 @@
+/* stylesheet for Resources page components */
+@import '@opentrons/components';
+
+:root {
+  --resources_card_spacing: 0.75rem;
+}
+
+.resources_page {
+  padding: 1.5rem;
+  font-size: var(--fs-body-1);
+}
+
+.row {
+  width: 100%;
+  margin-bottom: var(--resources_card_spacing);
+}

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -67,7 +67,7 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
       iconName: 'dots-horizontal',
       isBottom: true,
       title: 'more',
-      url: '/menu/app',
+      url: '/menu',
       notification: moreNotification
     }
   }

--- a/app/src/pages/More/AppSettings.js
+++ b/app/src/pages/More/AppSettings.js
@@ -1,0 +1,76 @@
+// @flow
+// view info about the app and update
+import React from 'react'
+import {connect} from 'react-redux'
+import {Route, Switch, Redirect, type ContextRouter} from 'react-router'
+import {push} from 'react-router-redux'
+
+import type {State} from '../../types'
+import type {ShellUpdate} from '../../shell'
+import {
+  getShellUpdate,
+  checkForShellUpdates,
+  downloadShellUpdate,
+  quitAndInstallShellUpdate,
+  setUpdateSeen
+} from '../../shell'
+
+import Page from '../../components/Page'
+import AppSettings, {AppUpdateModal} from '../../components/AppSettings'
+
+type OP = ContextRouter
+
+type SP = {
+  update: ShellUpdate,
+}
+
+type DP = {
+  checkForUpdates: () => mixed,
+  downloadUpdate: () => mixed,
+  quitAndInstall: () => mixed,
+  closeUpdateModal: () => mixed,
+}
+
+type Props = OP & SP & DP
+
+export default connect(mapStateToProps, mapDispatchToProps)(AppSettingsPage)
+
+function AppSettingsPage (props: Props) {
+  const {update, match: {path}} = props
+
+  return (
+    <Page>
+      <AppSettings {...props} />
+      <Switch>
+        <Route path={`${path}/update`} render={() => (
+          <AppUpdateModal {...props} close={props.closeUpdateModal} />
+        )} />
+        <Route render={() => {
+          if (update.available && !update.seen) {
+            return (<Redirect to='/menu/app/update' />)
+          }
+
+          return null
+        }} />
+      </Switch>
+    </Page>
+  )
+}
+
+function mapStateToProps (state: State): SP {
+  return {
+    update: getShellUpdate(state)
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch): DP {
+  return {
+    checkForUpdates: () => dispatch(checkForShellUpdates()),
+    downloadUpdate: () => dispatch(downloadShellUpdate()),
+    quitAndInstall: () => quitAndInstallShellUpdate(),
+    closeUpdateModal: () => {
+      dispatch(setUpdateSeen())
+      dispatch(push('/menu/app'))
+    }
+  }
+}

--- a/app/src/pages/More/Resources.js
+++ b/app/src/pages/More/Resources.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import Page from '../../components/Page'
+import Resources from '../../components/Resources'
+export default function ResourcesPage () {
+  return (
+    <Page>
+      <Resources />
+    </Page>
+  )
+}

--- a/app/src/pages/More/index.js
+++ b/app/src/pages/More/index.js
@@ -1,0 +1,28 @@
+// @flow
+// more nav button routes
+import * as React from 'react'
+import {Switch, Route, Redirect, type Match} from 'react-router'
+
+import AppSettings from './AppSettings'
+import Resources from './Resources'
+
+type Props = {
+  match: Match
+}
+
+export default function More (props: Props) {
+  const {match: {path}} = props
+  return (
+    <Switch>
+      <Redirect exact from={path} to={'/menu/app'} />
+      <Route
+        path={'/menu/app'}
+        component={AppSettings}
+      />
+      <Route
+        path={'/menu/resources'}
+        component={Resources}
+      />
+    </Switch>
+  )
+}


### PR DESCRIPTION
## overview
This PR closes #1607 -  adds resources page to more section of the app. 

<img width="800" alt="screen shot 2018-06-06 at 11 44 25 am" src="https://user-images.githubusercontent.com/3430313/41053343-443ef92e-6989-11e8-9200-e57e44327479.png">

## changelog

- group `AppSettings` and `Resources` pages in `/More`, refactor routes
- add `KnowledgeCard` and `LibraryCard` to resources page

## review requests
Standards review. Please click around and make sure [more] NavButton is correctly highlighted. and nothing whitescreens.
