### PR TITLE
fix(app): Tip probe clears labware calibration progress

### DIFF
--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -233,7 +233,8 @@ function handleProbeTipResponse (state: State, action: any) {
       error: error
         ? payload
         : null
-    }
+    },
+    confirmedBySlot: {}
   }
 }
 

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -413,7 +413,8 @@ describe('robot reducer - calibration', () => {
         mount: 'right',
         inProgress: false,
         error: null
-      }
+      },
+      confirmedBySlot: {}
     })
     expect(reducer(state, failure).calibration).toEqual({
       calibrationRequest: {
@@ -421,7 +422,8 @@ describe('robot reducer - calibration', () => {
         mount: 'right',
         inProgress: false,
         error: new Error('AH')
-      }
+      },
+      confirmedBySlot: {}
     })
   })
 


### PR DESCRIPTION
## overview

This PR closes #1620. Now, if a user calibrates any labware and then runs a tip probe, labware calibration progress will be reset. Why? So we always have a tip on the pipette when we calibrate labware.

## changelog

-fix(app): Tip probe response clears out `confirmedBySlot`

## review requests

- Load a protocol
- Calibrate all tipracks (disabled in side panel)
- Run a tip probe

- [ ] Labware calibration progress reset and tip racks can be calibrated again
- [ ] Calibrate all labware without any crashes/unexpected behavior
