### PR TITLE
fix(app): Hide modal title in pick up tip spinner

### DIFF
--- a/app/src/components/LabwareCalibration/styles.css
+++ b/app/src/components/LabwareCalibration/styles.css
@@ -25,6 +25,10 @@
 
 .in_progress_contents {
   background-color: transparent;
+
+  & h3 {
+    display: none;
+  }
 }
 
 .position_diagram,


### PR DESCRIPTION
## overview

This PR implements a CSS only fix to hide the previous modal's title in pick up tip spinner. 

closes #1630

## changelog

- don't display `h3` (modal titles) in `.in_progress_contents`

## review requests
Should probably be reviewed on a robot so that the spinner is visible for more than a split second.

Calibrate a tiprack. 

- [ ] ghosted previous modal title does not appear on pick up tip spinner
- [ ] ghosted previous modal title does not appear on spinner after confirming tips picked up
