### PR TITLE
feat(protocol-designer): elaborate on deck setup in title bar

### DIFF
--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -22,66 +22,41 @@ type StateProps = $Diff<Props, DispatchProps> & {_page: Page}
 
 function mapStateToProps (state: BaseState): StateProps {
   const _page = selectors.currentPage(state)
-  // TODO Ian 2018-02-22 fileName from file
+  // TODO: Ian 2018-02-22 fileName from file
   const fileName = 'Protocol Name'
 
   const selectedStep = steplistSelectors.selectedStep(state)
   const stepName = selectedStep && selectedStep.title
 
-  if (_page === 'file-splash') {
-    return {
-      _page,
-      title: 'Opentrons Protocol Designer'
+  switch (_page) {
+    case 'file-splash':
+      return { _page, title: 'Opentrons Protocol Designer' }
+    case 'file-detail':
+      return {_page, title: fileName, subtitle: 'FILE DETAILS'}
+    case 'steplist': {
+      // TODO: Ian 2018-02-22 add in icon, you need to make it inline and of the correct height
+      // <Icon name={stepIconsByType[selectedStep]} /> */
+      const subtitle = <span> {} {stepName} </span>
+      return { _page, title: fileName, subtitle }
     }
-  }
-
-  if (_page === 'file-detail') {
-    return {
-      _page,
-      title: fileName,
-      subtitle: 'FILE DETAILS'
+    case 'ingredient-detail': {
+      const labware = labwareIngredSelectors.getSelectedContainer(state)
+      const labwareNames = labwareIngredSelectors.getLabwareNames(state)
+      const labwareId = labware && labware.id
+      return {
+        _page,
+        title: labwareId && labwareNames[labwareId],
+        subtitle: labware && humanizeLabwareType(labware.type),
+        backButtonLabel: 'Deck'
+      }
     }
-  }
-
-  if (_page === 'steplist') {
-    return {
-      _page,
-      title: fileName,
-      subtitle: (
-        <span>
-          {/* TODO Ian 2018-02-22 add in icon, you need to make it inline and of the correct height */}
-          {/* <Icon name={stepIconsByType[selectedStep]} /> */}
-          {stepName}
-        </span>
-      )
-    }
-  }
-
-  if (_page === 'ingredient-detail') {
-    const labware = labwareIngredSelectors.getSelectedContainer(state)
-    const labwareNames = labwareIngredSelectors.getLabwareNames(state)
-    const labwareId = labware && labware.id
-    return {
-      _page,
-      title: labwareId && labwareNames[labwareId],
-      subtitle: labware && humanizeLabwareType(labware.type),
-      backButtonLabel: 'Deck'
-    }
-  }
-
-  if (_page === 'well-selection-modal') {
-    // TODO Ian 2018-02-23 well selection modal's title bar
-    return {
-      _page,
-      title: 'TODO: Well selection modal'
-    }
-  }
-
-  // NOTE: this return should never be reached, it's just to keep flow happy
-  console.error('ConnectedTitleBar got an unsupported page, returning steplist instead')
-  return {
-    _page: 'steplist',
-    title: '???'
+    case 'well-selection-modal':
+      // TODO Ian 2018-02-23 well selection modal's title bar
+      return { _page, title: 'TODO: Well selection modal' }
+    default:
+      // NOTE: this default case should never be reached, it's just to keep flow happy
+      console.error('ConnectedTitleBar got an unsupported page, returning steplist instead')
+      return { _page: 'steplist', title: '???' }
   }
 }
 
@@ -96,7 +71,7 @@ function mergeProps (stateProps: StateProps, dispatchProps: {dispatch: Dispatch<
   }
 
   if (_page === 'well-selection-modal') {
-    onBackClick = () => console.warn('TODO: leave well selection modal') // TODO LATER Ian 2018-02-22
+    onBackClick = () => console.warn('TODO: leave well selection modal') // TODO: LATER Ian 2018-02-22
   }
 
   return {

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -28,7 +28,6 @@ function mapStateToProps (state: BaseState): SP {
       return { _page, title: 'Opentrons Protocol Designer' }
     case 'file-detail':
       return {_page, title: fileName, subtitle: 'FILE DETAILS'}
-
     case 'ingredient-detail': {
       const labware = labwareIngredSelectors.getSelectedContainer(state)
       const labwareNames = labwareIngredSelectors.getLabwareNames(state)
@@ -45,7 +44,7 @@ function mapStateToProps (state: BaseState): SP {
       return { _page, title: 'TODO: Well selection modal' }
     case 'steplist':
     default: {
-      // NOTE: this default case console.error should never be reached, it's just a sanity check
+      // NOTE: this default case error should never be reached, it's just a sanity check
       if (_page !== 'steplist') console.error('ConnectedTitleBar got an unsupported page, returning steplist instead')
       const selectedStep = steplistSelectors.selectedStep(state)
       // TODO: Ian 2018-02-22 add in icon, you need to make it inline and of the correct height

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -14,31 +14,21 @@ import type {BaseState} from '../types'
 
 type Props = React.ElementProps<typeof TitleBar>
 
-type DispatchProps = {
-    onBackClick: $PropertyType<Props, 'onBackClick'>
-}
+type DP = { onBackClick: $PropertyType<Props, 'onBackClick'> }
 
-type StateProps = $Diff<Props, DispatchProps> & {_page: Page}
+type SP = $Diff<Props, DP> & {_page: Page}
 
-function mapStateToProps (state: BaseState): StateProps {
+function mapStateToProps (state: BaseState): SP {
   const _page = selectors.currentPage(state)
   // TODO: Ian 2018-02-22 fileName from file
   const fileName = 'Protocol Name'
-
-  const selectedStep = steplistSelectors.selectedStep(state)
-  const stepName = selectedStep && selectedStep.title
 
   switch (_page) {
     case 'file-splash':
       return { _page, title: 'Opentrons Protocol Designer' }
     case 'file-detail':
       return {_page, title: fileName, subtitle: 'FILE DETAILS'}
-    case 'steplist': {
-      // TODO: Ian 2018-02-22 add in icon, you need to make it inline and of the correct height
-      // <Icon name={stepIconsByType[selectedStep]} /> */
-      const subtitle = <span> {} {stepName} </span>
-      return { _page, title: fileName, subtitle }
-    }
+
     case 'ingredient-detail': {
       const labware = labwareIngredSelectors.getSelectedContainer(state)
       const labwareNames = labwareIngredSelectors.getLabwareNames(state)
@@ -51,16 +41,27 @@ function mapStateToProps (state: BaseState): StateProps {
       }
     }
     case 'well-selection-modal':
-      // TODO Ian 2018-02-23 well selection modal's title bar
+      // TODO: Ian 2018-02-23 well selection modal's title bar
       return { _page, title: 'TODO: Well selection modal' }
-    default:
-      // NOTE: this default case should never be reached, it's just to keep flow happy
-      console.error('ConnectedTitleBar got an unsupported page, returning steplist instead')
-      return { _page: 'steplist', title: '???' }
+    case 'steplist':
+    default: {
+      // NOTE: this default case console.error should never be reached, it's just a sanity check
+      if (_page !== 'steplist') console.error('ConnectedTitleBar got an unsupported page, returning steplist instead')
+      const selectedStep = steplistSelectors.selectedStep(state)
+      // TODO: Ian 2018-02-22 add in icon, you need to make it inline and of the correct height
+      // <Icon name={stepIconsByType[selectedStep]} /> */
+      let subtitle
+      if (selectedStep) {
+        subtitle = selectedStep.stepType === 'deck-setup'
+          ? `DECK SETUP - LABWARE & INGREDIENTS`
+          : selectedStep.title
+      }
+      return { _page: 'steplist', title: fileName, subtitle }
+    }
   }
 }
 
-function mergeProps (stateProps: StateProps, dispatchProps: {dispatch: Dispatch<*>}): Props {
+function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Props {
   const {_page, ...props} = stateProps
   const {dispatch} = dispatchProps
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This adds some explanatory text to the page title that shows when the desk setup step is selected. 
It also consolidates the logic in the `ConnectedTitleBar`'s complex mapping of state to props.

Closes #1339
