### PR TITLE
fix(app): Switch to hash routes to enable reload in prod

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -5,7 +5,7 @@ import {Provider} from 'react-redux'
 import {AppContainer} from 'react-hot-loader'
 import {createStore, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
-import createHistory from 'history/createBrowserHistory'
+import createHistory from 'history/createHashHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
 import createLogger from './logger'


### PR DESCRIPTION
## overview

Window reload in the prod app was broken because in prod we use `file:` URLs, which confuses Electron once the client-side routing takes over. This PR switches to hash URLs which are less featureful than regular HTML5 urls, but get us everything we need and don't break reload in prod.

Fixes #1618 

## changelog

- fix(app): Switch to hash routes to enable reload in prod

## review requests

Please test both the dev app and the prod app (check #builds for builds on the `app_fix-reload` branch). Make sure you can't break navigation, including auto-redirects from stuff like connecting to a running robot, etc.

Also see if you can break the app with a reload anywhere. I think we're pretty good these days about redirecting if the state's no good for a given page, but we may have corner-cases in the calibration flows.