### PR TITLE
refactor(api): Separate endpoints into a library to be shared with update server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ After your Pull Request is merged (or otherwise closed), you’ll want to make s
 
 ### Deciding What to Work On
 
-If you're looking for something to work on, especially for a first contribution, check out [our list of easy issues][easyfix]. Be sure to drop a comment in the thread before starting work to make sure nobody else has picked it up.
+If you're looking for something to work on, especially for a first contribution, check out [our list of easy issues][easyfix]. Be sure to drop a comment in the thread before starting work to make sure nobody else has picked it up. Also, to understand a bit more of the plans developed by the Opentrons software engineering team, see the [documentation on software architecture and plans](https://github.com/Opentrons/opentrons/tree/edge/architecture-and-planning).
 
 ## Commit Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SHELL := /bin/bash
 PATH := $(shell yarn bin):$(PATH)
 
 API_DIR := api
+API_LIB_DIR := api-server-lib
 COMPONENTS_DIR := components
 APP_DIR := app
 APP_SHELL_DIR := app-shell
@@ -27,6 +28,7 @@ endif
 .PHONY: install
 install:
 	pip install pipenv==11.6.8
+	$(MAKE) -C $(API_LIB_DIR) install
 	$(MAKE) -C $(API_DIR) install
 	yarn
 	$(MAKE) -C $(LABWARE_DEFINITIONS_DIR) build
@@ -45,6 +47,12 @@ install-types:
 	flow-mono install-types --overwrite --flowVersion=0.61.0
 	flow-typed install --overwrite --flowVersion=0.61.0
 
+.PHONY: push-api
+push-api:
+	$(MAKE) -C $(API_LIB_DIR) push
+	$(MAKE) -C $(API_DIR) push
+	$(MAKE) -C $(API_DIR) restart
+
 # all tests
 .PHONY: test
 test: test-api test-js
@@ -52,6 +60,7 @@ test: test-api test-js
 .PHONY: test-api
 test-api:
 	$(MAKE) -C $(API_DIR) test
+	$(MAKE) -C $(API_LIB_DIR) test
 
 .PHONY: test-js
 test-js:
@@ -68,6 +77,7 @@ lint: lint-py lint-js lint-css
 .PHONY: lint-py
 lint-py:
 	$(MAKE) -C $(API_DIR) lint
+	$(MAKE) -C $(API_LIB_DIR) lint
 
 .PHONY: lint-js
 lint-js:

--- a/api-server-lib/MANIFEST.in
+++ b/api-server-lib/MANIFEST.in
@@ -1,0 +1,1 @@
+include ot2serverlib/package.json

--- a/api-server-lib/Makefile
+++ b/api-server-lib/Makefile
@@ -1,0 +1,59 @@
+SHELL := /bin/bash
+
+# add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
+PATH := $(shell cd .. && yarn bin):$(PATH)
+
+# make push host
+host ?= \[fd00:0:cafe:fefe::1\]
+# make push wheel file (= rather than := to expand at every use)
+wheel = $(wildcard dist/*.whl)
+firmware = $(wildcard smoothie/*.hex)
+
+# python and pipenv config
+python := pipenv run python
+pipenv_opts := --dev
+pipenv_opts += $(and $(CI),--ignore-pipfile)
+
+.PHONY: install
+install:
+	pipenv install $(pipenv_opts)
+
+.PHONY: clean
+clean:
+	shx rm -rf \
+		build \
+		dist \
+		.coverage \
+		coverage.xml \
+		'*.egg-info' \
+		'**/__pycache__' \
+		'**/*.pyc'
+
+.PHONY: test
+test:
+	$(python) -m pytest \
+		--cov=opentrons \
+		--cov-report term-missing:skip-covered \
+		--cov-report xml:coverage.xml \
+		tests
+
+.PHONY: lint
+lint:
+	$(python) -m pylama ot2serverlib tests
+
+.PHONY: wheel
+wheel: clean
+	$(python) setup.py bdist_wheel
+	shx rm -rf build
+	shx ls dist
+
+.PHONY: push
+push: wheel
+	curl -X POST \
+		-H "Content-Type: multipart/form-data" \
+		-F "whl=@$(wheel)" \
+		http://$(host):31950/server/update
+
+.PHONY: restart
+restart:
+	curl -X POST http://$(host):31950/server/restart

--- a/api-server-lib/Makefile
+++ b/api-server-lib/Makefile
@@ -29,13 +29,16 @@ clean:
 		'**/__pycache__' \
 		'**/*.pyc'
 
+# TODO(mc, 2018-06-07): add api-server-lib tests
 .PHONY: test
 test:
-	$(python) -m pytest \
-		--cov=opentrons \
-		--cov-report term-missing:skip-covered \
-		--cov-report xml:coverage.xml \
-		tests
+	@echo "TODO: add api-server-lib tests"
+# test:
+# 	$(python) -m pytest \
+# 		--cov=opentrons \
+# 		--cov-report term-missing:skip-covered \
+# 		--cov-report xml:coverage.xml \
+# 		tests
 
 .PHONY: lint
 lint:

--- a/api-server-lib/Pipfile
+++ b/api-server-lib/Pipfile
@@ -1,0 +1,25 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+"e1839a8" = {path = ".", editable = true}
+pyserial = "*"
+
+
+[dev-packages]
+
+pylama = "==7.4.3"
+pytest = "==3.4.2"
+pytest-aiohttp = "==0.2.0"
+wheel = "==0.30.0"
+coverage = "==4.4.2"
+
+
+[requires]
+
+python_version = "3.6"

--- a/api-server-lib/Pipfile.lock
+++ b/api-server-lib/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00f9dc456f75b907583d292626208efe39fc99ce93c00287d85cd4fc220cbcc6"
+            "sha256": "66ab602984e678923d2bdf57187c7fedcc06961900940594324effdf80c468f7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -62,10 +62,6 @@
             "editable": true,
             "path": "."
         },
-        "f7933a7": {
-            "editable": true,
-            "path": "../api-server-lib"
-        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
@@ -97,60 +93,27 @@
             ],
             "version": "==4.3.1"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:130105bfc0b03245115da67b441c48597bf1ed7f5385f8388ce4f75cdf2f91d2",
-                "sha256:3b21dc40fa1e2450dee8cf54991b0f95c415ac508d5db1227338efcf03c162cd",
-                "sha256:405ce136edb18c6f1f8c5acc75d7d8fbb875cc8b5015562251b93435099233d3",
-                "sha256:43ccfed0092def52b924e004780517c762f8fce3ececbd3f8e2580ac0538bb5e",
-                "sha256:47b4c4da2fe0618b65fd70987a414fdc24c09e1ffdff77f7147a3c6627b07596",
-                "sha256:4c64d9c389827f310c7f4e7887b741c34c6b2c337ff63a12f66ef0197fdf5366",
-                "sha256:4eac5f2f624c5e7eecbdb51395ff39a099c48cab607a158f16f288c6fe39a2b3",
-                "sha256:56e68de63ae738f40669b6a5f0601f9453940a0470a1e9bea16448e5b53f5f28",
-                "sha256:5cb6341fc885b101978328d3c8d51a069a97a00699a30891106ef7dda56a0d30",
-                "sha256:5dd60892710df0ef654bbf4d1e3cb53ac79845e55a96e4a26dd47218e06d819a",
-                "sha256:727d6373355b00b96d9320254a676b878d6cd43ae409186bec27eec3e5e4e6e7",
-                "sha256:7e9015bc5de54c8bd73ca750ccedfda25d34a25a767caf802740d35a692ec3ab",
-                "sha256:818d5a1d5752d09929ce1ba1735366d5acc769a1839386dc91f3ac30cf9faf19",
-                "sha256:92dce120e385767cbe433719b5e3fdb1ac81907140d3984b3187208f79aff19f",
-                "sha256:95e52d1077abeead6d205c1fc644f075228813859bb625960c1ae1248c4189ba",
-                "sha256:9cd16915a815c2f04633d14e7640083c1b72e82b325439c91370adfd376c9975",
-                "sha256:9ce673bb7b6240b94b60b52186f5c0825f4b31e8191c8bc7412a7d0348fca2cd",
-                "sha256:a65266a4ad6ec8936a1bc85ce51f8600634a31a258b722c9274a80ff189d9542",
-                "sha256:bcbce5ef18dc826ef67756a0d3669baca815c8d44b26867c6865f714a23d9262",
-                "sha256:ca917155b35b3bcc68ef1ad82570a29414f5088495ea8f68c65b071c50e64340",
-                "sha256:cd7892f7d644d1b4ed2ead254d4851616c07ecf82618e3203e2a81747ffb6069",
-                "sha256:d8dbd7e35e4819e059a044c7545d5602937d6b666dbd9b6eb8ff40037ab0980c",
-                "sha256:e97cecd783e8e7e70d18a42f6df7f18be14cbcc82fb9b837b03d072d1401ae53"
-            ],
-            "version": "==1.12.1"
-        },
         "pyserial": {
             "hashes": [
-                "sha256:1eecfe4022240f2eab5af8d414f0504e072ee68377ba63d3b6fe6e66c26f66d1",
-                "sha256:b05fa0d2f5cc5a9584bed5d695441f6dba127c5b593dfa6e671a0db2de0d959a"
+                "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627",
+                "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8"
             ],
-            "version": "==3.2.1"
-        },
-        "urwid": {
-            "hashes": [
-                "sha256:cfcec03e36de25a1073e2e35c2c7b0cc6969b85745715c3a025a31d9786896a1"
-            ],
-            "version": "==1.3.1"
+            "index": "pypi",
+            "version": "==3.4"
         },
         "yarl": {
             "hashes": [
-                "sha256:135f8cc72e4f46bbdca229e1fbc9960e984a16488dd3367431ddb7501f9cc507",
-                "sha256:3dc28e1d2a0a8bcc44715d284c816725e310c178626692073ecdc4eb11a853d0",
-                "sha256:40632b38f355cec13c3760bbc5943075997c4592bbc765c3b83df1df0a7eca08",
-                "sha256:7e03ce8595522aa1c234a2b42d643be55f796e546d0f36700a1cb02dbe24e147",
-                "sha256:83ee1bbb20c96fdf5e3a5d9681624cdcde2abe3bb985361140c29dfb3788b008",
-                "sha256:ae20db1fbc7fff7d7dffd38ab1a2b83dd76157b138b80b813931a8e302cd4d7e",
-                "sha256:cead78320aaa21601435cfc04ed0eff14df39800e93b79d7374562cafa9be2fa",
-                "sha256:cfccc464e1502028d225f694b05b70053d9872a2b81f872fd79b0d0a399e87e8",
-                "sha256:dd5da4150a882f5cd26aeec7939f38e4b08b790717b9d696409dba9e18ff3ab6"
+                "sha256:397d150e1352ccd5c8e8c996be80d3c58b2cd80699e49821bebed2d761f90c6d",
+                "sha256:437c51e7e31d9fa462ad99f829fb8282eccba836d67868ab61a513d20ec467b7",
+                "sha256:4a5e0183c505e0f62023489d138af5d54d4dcc41a51a0797f43287c74651ea65",
+                "sha256:59a6973f796487f4616018b96b31f70b48f96d8c2d6ce8c0bb2eb88918127f7c",
+                "sha256:5c5c21414f37bed5da3f9f90c6aa50b4b6302fd8c723747e65e07b894a9483cc",
+                "sha256:5cbe712703050e63d86b4199a7f3f2d080bbd539cea786591766e6e33bfdf5f1",
+                "sha256:7df2ec23eab1adf243f351d36236063a95f348a0206f2cf5637e4aeb179f90a7",
+                "sha256:887add43096d991d2ada336e150c20eae0a355d176f657f61e49676fdef4da60",
+                "sha256:95a564541e115088f8aa89a8fee607ba1b2ce4fecf43a9b0e84b51079286f9fb"
             ],
-            "version": "==1.2.5"
+            "version": "==1.2.4"
         }
     },
     "develop": {
@@ -175,13 +138,6 @@
             ],
             "version": "==2.3.8"
         },
-        "alabaster": {
-            "hashes": [
-                "sha256:2eef172f44e8d301d25aff8068fddd65f767a3f04b5f15b0f4922f113aa1c732",
-                "sha256:37cdcb9e9954ed60912ebc1ca12a9d12178c26637abdf124e3cde2341c257fe0"
-            ],
-            "version": "==0.7.10"
-        },
         "async-timeout": {
             "hashes": [
                 "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
@@ -202,20 +158,6 @@
                 "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
             "version": "==18.1.0"
-        },
-        "babel": {
-            "hashes": [
-                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
-                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
-            ],
-            "version": "==2.6.0"
-        },
-        "certifi": {
-            "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
-            ],
-            "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
@@ -278,21 +220,6 @@
             "index": "pypi",
             "version": "==4.4.2"
         },
-        "dill": {
-            "hashes": [
-                "sha256:97fd758f5fe742d42b11ec8318ecfcff8776bccacbfcec05dfd6276f5d450f73"
-            ],
-            "index": "pypi",
-            "version": "==0.2.7.1"
-        },
-        "docutils": {
-            "hashes": [
-                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
-            ],
-            "version": "==0.14"
-        },
         "idna": {
             "hashes": [
                 "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
@@ -305,26 +232,6 @@
                 "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
             ],
             "version": "==1.0.1"
-        },
-        "imagesize": {
-            "hashes": [
-                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
-                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
-            ],
-            "version": "==1.0.0"
-        },
-        "jinja2": {
-            "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
-            ],
-            "version": "==2.10"
-        },
-        "markupsafe": {
-            "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
-            ],
-            "version": "==1.0"
         },
         "mccabe": {
             "hashes": [
@@ -358,28 +265,6 @@
                 "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
             ],
             "version": "==4.3.1"
-        },
-        "numpydoc": {
-            "hashes": [
-                "sha256:1ec573e91f6d868a9940d90a6599f3e834a2d6c064030fbe078d922ee21dcfa1",
-                "sha256:974584a8293182ae995113ee2dce9f4be939c3f40c6c2daf11f9df33f961b5cb"
-            ],
-            "index": "pypi",
-            "version": "==0.6.0"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
-                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
-            ],
-            "version": "==17.1"
-        },
-        "pkginfo": {
-            "hashes": [
-                "sha256:5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474",
-                "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
-            ],
-            "version": "==1.4.2"
         },
         "pluggy": {
             "hashes": [
@@ -419,13 +304,6 @@
             ],
             "version": "==2.0.0"
         },
-        "pygments": {
-            "hashes": [
-                "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
-                "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
-            ],
-            "version": "==2.2.0"
-        },
         "pylama": {
             "hashes": [
                 "sha256:390c1dab1daebdf3d6acc923e551b035c3faa77d8b96b98530c230493f9ec712",
@@ -433,26 +311,6 @@
             ],
             "index": "pypi",
             "version": "==7.4.3"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
-                "sha256:281683241b25fe9b80ec9d66017485f6deff1af5cde372469134b56ca8447a07",
-                "sha256:8f1e18d3fd36c6795bb7e02a39fd05c611ffc2596c1e0d995d34d67630426c18",
-                "sha256:9e8143a3e15c13713506886badd96ca4b579a87fbdf49e550dbfc057d6cb218e",
-                "sha256:b8b3117ed9bdf45e14dcc89345ce638ec7e0e29b2b579fa1ecf32ce45ebac8a5",
-                "sha256:e4d45427c6e20a59bf4f88c639dcc03ce30d193112047f94012102f235853a58",
-                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
-            ],
-            "version": "==2.2.0"
-        },
-        "pyreadline": {
-            "hashes": [
-                "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1",
-                "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e",
-                "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"
-            ],
-            "version": "==2.1"
         },
         "pytest": {
             "hashes": [
@@ -470,35 +328,6 @@
             "index": "pypi",
             "version": "==0.2.0"
         },
-        "pytest-cov": {
-            "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
-            ],
-            "index": "pypi",
-            "version": "==2.5.1"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
-                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
-            ],
-            "version": "==2018.4"
-        },
-        "requests": {
-            "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
-            ],
-            "version": "==2.18.4"
-        },
-        "requests-toolbelt": {
-            "hashes": [
-                "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
-                "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
-            ],
-            "version": "==0.8.0"
-        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
@@ -513,43 +342,6 @@
             ],
             "version": "==1.2.1"
         },
-        "sphinx": {
-            "hashes": [
-                "sha256:41af978f653ef862eb4bb3776dabd8ff13afed17e431907310fe990a3947707f",
-                "sha256:c715b714228bd135a41b33ff91e5f41ac434ceb6e98a86447687a2177e7486b9"
-            ],
-            "index": "pypi",
-            "version": "==1.4.8"
-        },
-        "sphinxcontrib-websupport": {
-            "hashes": [
-                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
-                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
-            ],
-            "version": "==1.1.0"
-        },
-        "tqdm": {
-            "hashes": [
-                "sha256:224291ee0d8c52d91b037fd90806f48c79bcd9994d3b0abc9e44b946a908fccd",
-                "sha256:77b8424d41b31e68f437c6dd9cd567aebc9a860507cb42fbd880a5f822d966fe"
-            ],
-            "version": "==4.23.4"
-        },
-        "twine": {
-            "hashes": [
-                "sha256:3202d943a144962a821d9c5e92e07f9442dbbe6d6f18eae74e2a725b9980c559",
-                "sha256:68b663691a947b844f92853c992d42bb68b6333bffc9ab7f661346b001c1da82"
-            ],
-            "index": "pypi",
-            "version": "==1.8.1"
-        },
-        "urllib3": {
-            "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
-            ],
-            "version": "==1.22"
-        },
         "wheel": {
             "hashes": [
                 "sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8",
@@ -560,17 +352,17 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:135f8cc72e4f46bbdca229e1fbc9960e984a16488dd3367431ddb7501f9cc507",
-                "sha256:3dc28e1d2a0a8bcc44715d284c816725e310c178626692073ecdc4eb11a853d0",
-                "sha256:40632b38f355cec13c3760bbc5943075997c4592bbc765c3b83df1df0a7eca08",
-                "sha256:7e03ce8595522aa1c234a2b42d643be55f796e546d0f36700a1cb02dbe24e147",
-                "sha256:83ee1bbb20c96fdf5e3a5d9681624cdcde2abe3bb985361140c29dfb3788b008",
-                "sha256:ae20db1fbc7fff7d7dffd38ab1a2b83dd76157b138b80b813931a8e302cd4d7e",
-                "sha256:cead78320aaa21601435cfc04ed0eff14df39800e93b79d7374562cafa9be2fa",
-                "sha256:cfccc464e1502028d225f694b05b70053d9872a2b81f872fd79b0d0a399e87e8",
-                "sha256:dd5da4150a882f5cd26aeec7939f38e4b08b790717b9d696409dba9e18ff3ab6"
+                "sha256:397d150e1352ccd5c8e8c996be80d3c58b2cd80699e49821bebed2d761f90c6d",
+                "sha256:437c51e7e31d9fa462ad99f829fb8282eccba836d67868ab61a513d20ec467b7",
+                "sha256:4a5e0183c505e0f62023489d138af5d54d4dcc41a51a0797f43287c74651ea65",
+                "sha256:59a6973f796487f4616018b96b31f70b48f96d8c2d6ce8c0bb2eb88918127f7c",
+                "sha256:5c5c21414f37bed5da3f9f90c6aa50b4b6302fd8c723747e65e07b894a9483cc",
+                "sha256:5cbe712703050e63d86b4199a7f3f2d080bbd539cea786591766e6e33bfdf5f1",
+                "sha256:7df2ec23eab1adf243f351d36236063a95f348a0206f2cf5637e4aeb179f90a7",
+                "sha256:887add43096d991d2ada336e150c20eae0a355d176f657f61e49676fdef4da60",
+                "sha256:95a564541e115088f8aa89a8fee607ba1b2ce4fecf43a9b0e84b51079286f9fb"
             ],
-            "version": "==1.2.5"
+            "version": "==1.2.4"
         }
     }
 }

--- a/api-server-lib/README.md
+++ b/api-server-lib/README.md
@@ -1,0 +1,22 @@
+# ot2serverlib
+
+A library of shared functionality for server applications running on
+Opentrons robots
+
+## Install
+
+This package is a dependency of `opentrons` and provides functionality
+used by the Opentrons API server. In the near future, this package will
+also be a dependency of the Opentrons update server, and house other
+shared functionality between those applications.
+
+For development (to be able to run commands from this module directly,
+rather than through another app, and to run make tasks), run `make install`
+in the root level of the repo, which will run the `make install` task in
+this project.
+
+## Test
+
+Currently, `ot2updateserver` is imported and tested under tests in the
+API server project (in particular, the
+[server test suite](https://github.com/Opentrons/opentrons/tree/edge/api/tests/opentrons/server))

--- a/api-server-lib/ot2serverlib/__init__.py
+++ b/api-server-lib/ot2serverlib/__init__.py
@@ -1,0 +1,58 @@
+import os
+import logging
+import asyncio
+
+log = logging.getLogger(__name__)
+
+
+async def _install(filename, loop):
+    proc = await asyncio.create_subprocess_shell(
+        'pip install --upgrade --force-reinstall --no-deps {}'.format(
+            filename),
+        stdout=asyncio.subprocess.PIPE,
+        loop=loop)
+
+    rd = await proc.stdout.read()
+    res = rd.decode().strip()
+    print(res)
+    await proc.wait()
+    return res
+
+
+async def install_api(data, loop):
+    filename = data['whl'].filename
+    log.info('Preparing to install: {}'.format(filename))
+    content = data['whl'].file.read()
+
+    with open(filename, 'wb') as wf:
+        wf.write(content)
+
+    msg = await _install(filename, loop)
+    log.debug('Install complete')
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
+    log.debug("Result: {}".format(msg))
+    return {'message': msg, 'filename': filename}
+
+
+async def install_smoothie_firmware(data, loop):
+    from opentrons.server.endpoints.update import _update_firmware
+
+    filename = data['hex'].filename
+    log.info('Flashing image "{}", this will take about 1 minute'.format(
+        filename))
+    content = data['hex'].file.read()
+
+    with open(filename, 'wb') as wf:
+        wf.write(content)
+
+    msg = await _update_firmware(filename, loop)
+    log.debug('Firmware Update complete')
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
+    log.debug("Result: {}".format(msg))
+    return {'message': msg, 'filename': filename}

--- a/api-server-lib/ot2serverlib/endpoints.py
+++ b/api-server-lib/ot2serverlib/endpoints.py
@@ -1,0 +1,59 @@
+import os
+import logging
+from time import sleep
+from aiohttp import web
+from threading import Thread
+import ot2serverlib
+
+log = logging.getLogger(__name__)
+
+
+async def update_api(request: web.Request) -> web.Response:
+    """
+    This handler accepts a POST request with Content-Type: multipart/form-data
+    and a file field in the body named "whl". The file should be a valid Python
+    wheel to be installed. The received file is install using pip, and then
+    deleted and a success code is returned.
+    """
+    log.debug('Update request received')
+    data = await request.post()
+    try:
+        res = await ot2serverlib.install_api(data, request.loop)
+        status = 200
+    except Exception as e:
+        res = {'error': 'Exception {} raised by update of {}: {}'.format(
+                type(e), data, e.__traceback__)}
+        status = 500
+    return web.json_response(res, status=status)
+
+
+async def update_firmware(request):
+    """
+    This handler accepts a POST request with Content-Type: multipart/form-data
+    and a file field in the body named "hex". The file should be a valid HEX
+    image to be flashed to the LPC1769. The received file is flashed using
+    lpc21isp, and then deleted and a success code is returned.
+    """
+    log.debug('Update Firmware request received')
+    data = await request.post()
+    try:
+        res = await ot2serverlib.install_smoothie_firmware(data, request.loop)
+        status = 200
+    except Exception as e:
+        log.exception("Exception during firmware update:")
+        res = {'error': 'Exception {} raised by update of {}: {}'.format(
+                type(e), data, e.__traceback__)}
+        status = 500
+    return web.json_response(res, status=status)
+
+
+async def restart(request):
+    """
+    Returns OK, then waits approximately 3 seconds and restarts container
+    """
+    def wait_and_restart():
+        log.info('Restarting server')
+        sleep(3)
+        os.system('kill 1')
+    Thread(target=wait_and_restart).start()
+    return web.json_response({"message": "restarting"})

--- a/api-server-lib/ot2serverlib/package.json
+++ b/api-server-lib/ot2serverlib/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@opentrons/ot2serverlib",
+  "version": "3.1.2",
+  "description": "Opentrons server library",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Opentrons/opentrons.git"
+  },
+  "author": {
+    "name": "Opentrons Labworks",
+    "email": "engineering@opentrons.com"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Opentrons/opentrons/issues"
+  },
+  "homepage": "https://github.com/Opentrons/opentrons"
+}

--- a/api-server-lib/setup.cfg
+++ b/api-server-lib/setup.cfg
@@ -1,0 +1,11 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = ../LICENSE
+
+[pep8]
+ignore = E221,E222
+
+[aliases]
+test=pytest

--- a/api-server-lib/setup.py
+++ b/api-server-lib/setup.py
@@ -1,0 +1,73 @@
+# Inspired by:
+# https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+import codecs
+import os
+from setuptools import setup, find_packages
+import json
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version():
+    with open(os.path.join(HERE, 'ot2serverlib', 'package.json')) as pkg:
+        package_json = json.load(pkg)
+        return package_json.get('version')
+
+
+VERSION = get_version()
+
+DISTNAME = 'ot2serverlib'
+LICENSE = 'Apache 2.0'
+AUTHOR = "Opentrons"
+EMAIL = "engineering@opentrons.com"
+URL = "https://github.com/OpenTrons/opentrons"
+DOWNLOAD_URL = ''
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Operating System :: OS Independent',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Topic :: Scientific/Engineering',
+]
+KEYWORDS = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
+DESCRIPTION = (
+    "A library of shared server functions for servers running on Opentrons "
+    "robots.")
+PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
+INSTALL_REQUIRES = ['aiohttp==2.3.8']
+
+
+def read(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
+
+
+if __name__ == "__main__":
+    setup(
+        python_requires='>=3.6',
+        name=DISTNAME,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        version=VERSION,
+        author=AUTHOR,
+        author_email=EMAIL,
+        maintainer=AUTHOR,
+        maintainer_email=EMAIL,
+        keywords=KEYWORDS,
+        long_description=read("README.md"),
+        packages=PACKAGES,
+        zip_safe=False,
+        classifiers=CLASSIFIERS,
+        install_requires=INSTALL_REQUIRES,
+        setup_requires=['pytest-runner'],
+        tests_require=['pytest'],
+        include_package_data=True
+    )

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -4,9 +4,11 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
+
 [requires]
 
 python_version = "3.6"
+
 
 [dev-packages]
 
@@ -21,6 +23,8 @@ twine = "==1.8.1"
 wheel = "==0.30.0"
 coverage = "==4.4.2"
 
+
 [packages]
 
 "e1839a8" = {path = ".", editable = true}
+"f7933a7" = {path = "../api-server-lib", editable = true}

--- a/api/opentrons/broker/broker.py
+++ b/api/opentrons/broker/broker.py
@@ -25,7 +25,7 @@ class Notifications(object):
         def thread_has_event_loop():
             try:
                 asyncio.get_event_loop()
-            except RuntimeError as e:
+            except RuntimeError:
                 return False
             else:
                 return True

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -107,7 +107,7 @@ def _parse_number_from_substring(smoothie_substring):
             float(smoothie_substring.split(':')[1]),
             GCODE_ROUNDING_PRECISION
         )
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected argument to _parse_number_from_substring:')
         raise ParseError(
             'Unexpected argument to _parse_number_from_substring: {}'.format(
@@ -121,7 +121,7 @@ def _parse_axis_from_substring(smoothie_substring):
     '''
     try:
         return smoothie_substring.split(':')[0].title()  # upper 1st letter
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected argument to _parse_axis_from_substring:')
         raise ParseError(
             'Unexpected argument to _parse_axis_from_substring: {}'.format(
@@ -150,7 +150,7 @@ def _parse_instrument_data(smoothie_response):
         # data received from Smoothieware is stringified HEX values
         # because of how Smoothieware handles GCODE messages
         data = bytearray.fromhex(items[1])
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected argument to _parse_instrument_data:')
         raise ParseError(
             'Unexpected argument to _parse_instrument_data: {}'.format(
@@ -165,7 +165,7 @@ def _byte_array_to_ascii_string(byte_array):
             if c in byte_array:
                 byte_array = byte_array[:byte_array.index(c)]
         res = byte_array.decode()
-    except (ValueError, TypeError, AttributeError) as e:
+    except (ValueError, TypeError, AttributeError):
         log.exception('Unexpected argument to _byte_array_to_ascii_string:')
         raise ParseError(
             'Unexpected argument to _byte_array_to_ascii_string: {}'.format(
@@ -178,7 +178,7 @@ def _byte_array_to_hex_string(byte_array):
     # because of how Smoothieware parses GCODE messages
     try:
         res = ''.join('%02x' % b for b in byte_array)
-    except TypeError as e:
+    except TypeError:
         log.exception('Unexpected argument to _byte_array_to_hex_string:')
         raise ParseError(
             'Unexpected argument to _byte_array_to_hex_string: {}'.format(

--- a/api/opentrons/drivers/temp_deck/driver.py
+++ b/api/opentrons/drivers/temp_deck/driver.py
@@ -57,7 +57,7 @@ def _parse_string_value_from_substring(substring) -> str:
     try:
         value = substring.split(':')[1]
         return str(value)
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected arg to _parse_string_value_from_substring:')
         raise ParseError(
             'Unexpected arg to _parse_string_value_from_substring: {}'.format(
@@ -77,7 +77,7 @@ def _parse_number_from_substring(substring) -> int:
         if value.strip().lower() == 'none':
             return None
         return int(value)
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected argument to _parse_number_from_substring:')
         raise ParseError(
             'Unexpected argument to _parse_number_from_substring: {}'.format(
@@ -91,7 +91,7 @@ def _parse_key_from_substring(substring) -> str:
     '''
     try:
         return substring.split(':')[0]
-    except (ValueError, IndexError, TypeError, AttributeError) as e:
+    except (ValueError, IndexError, TypeError, AttributeError):
         log.exception('Unexpected argument to _parse_key_from_substring:')
         raise ParseError(
             'Unexpected argument to _parse_key_from_substring: {}'.format(

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -250,7 +250,7 @@ class Pipette:
         if self.has_tip_rack():
             try:
                 next_tip = next(self.tip_rack_iter)
-            except StopIteration as e:
+            except StopIteration:
                 raise RuntimeWarning(
                     '{0} has run out of tips'.format(self.name))
         else:

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import json
 import logging
-from time import sleep
 from aiohttp import web
 from threading import Thread
 from opentrons import robot, instruments
@@ -320,15 +319,3 @@ async def take_picture(request):
         return web.json_response({'message': 'picture not saved'}, status=500)
 
     return web.FileResponse(filename)
-
-
-async def restart(request):
-    """
-    Returns OK, then waits approximately 3 seconds and restarts container
-    """
-    def wait_and_restart():
-        log.info('Restarting server')
-        sleep(3)
-        os.system('kill 1')
-    Thread(target=wait_and_restart).start()
-    return web.json_response({"message": "restarting"})

--- a/api/opentrons/server/endpoints/update.py
+++ b/api/opentrons/server/endpoints/update.py
@@ -2,28 +2,19 @@ import os
 import logging
 import asyncio
 from aiohttp import web
-
-from opentrons import robot
 from opentrons.config import feature_flags as ff
+from opentrons import robot
 
 log = logging.getLogger(__name__)
 
 
-async def _install(filename, loop):
-    proc = await asyncio.create_subprocess_shell(
-        'pip install --upgrade --force-reinstall --no-deps {}'.format(
-            filename),
-        stdout=asyncio.subprocess.PIPE,
-        loop=loop)
-
-    rd = await proc.stdout.read()
-    res = rd.decode().strip()
-    print(res)
-    await proc.wait()
-    return res
-
-
 async def _update_firmware(filename, loop):
+    """
+    This method remains in the API currently because of its use of the robot
+    singleton's copy of the driver. This should move to the server lib project
+    eventually and use its own driver object (preferably involving moving the
+    drivers themselves to the serverlib)
+    """
     # ensure there is a reference to the port
     if not robot.is_connected():
         robot.connect()
@@ -53,77 +44,6 @@ async def _update_firmware(filename, loop):
     # run setup gcodes
     robot._driver._setup()
 
-    return res
-
-
-async def install_api(request):
-    """
-    This handler accepts a POST request with Content-Type: multipart/form-data
-    and a file field in the body named "whl". The file should be a valid Python
-    wheel to be installed. The received file is install using pip, and then
-    deleted and a success code is returned.
-    """
-    log.debug('Update request received')
-    data = await request.post()
-    try:
-        filename = data['whl'].filename
-        log.info('Preparing to install: {}'.format(filename))
-        content = data['whl'].file.read()
-
-        with open(filename, 'wb') as wf:
-            wf.write(content)
-
-        msg = await _install(filename, request.loop)
-        log.debug('Install complete')
-        try:
-            os.remove(filename)
-        except OSError:
-            pass
-        log.debug("Result: {}".format(msg))
-        res = web.json_response({
-            'message': msg,
-            'filename': filename})
-    except Exception as e:
-        res = web.json_response(
-            {'error': 'Exception {} raised by update of {}. Trace: {}'.format(
-                type(e), data, e.__traceback__)},
-            status=500)
-    return res
-
-
-async def update_firmware(request):
-    """
-    This handler accepts a POST request with Content-Type: multipart/form-data
-    and a file field in the body named "hex". The file should be a valid HEX
-    image to be flashed to the LPC1769. The received file is flashed using
-    lpc21isp, and then deleted and a success code is returned.
-    """
-    log.debug('Update Firmware request received')
-    data = await request.post()
-    try:
-        filename = data['hex'].filename
-        log.info('Flashing image "{}", this will take about 1 minute'.format(
-            filename))
-        content = data['hex'].file.read()
-
-        with open(filename, 'wb') as wf:
-            wf.write(content)
-
-        msg = await _update_firmware(filename, request.loop)
-        log.debug('Firmware Update complete')
-        try:
-            os.remove(filename)
-        except OSError:
-            pass
-        log.debug("Result: {}".format(msg))
-        res = web.json_response({
-            'message': msg,
-            'filename': filename})
-    except Exception as e:
-        res = web.json_response(
-            {'error': 'Exception {} raised by update of {}. Trace: {}'.format(
-                type(e), data, e.__traceback__)},
-            status=500)
     return res
 
 

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -15,6 +15,7 @@ from opentrons.config import feature_flags as ff
 from opentrons.util import environment
 from opentrons.deck_calibration import endpoints as dc_endp
 from logging.config import dictConfig
+from ot2serverlib import endpoints
 
 from argparse import ArgumentParser
 
@@ -154,11 +155,11 @@ def init(loop=None):
     server.app.router.add_post(
         '/camera/picture', control.take_picture)
     server.app.router.add_post(
-        '/server/update', update.install_api)
+        '/server/update', endpoints.update_api)
     server.app.router.add_post(
-        '/server/update/firmware', update.update_firmware)
+        '/server/update/firmware', endpoints.update_firmware)
     server.app.router.add_post(
-        '/server/restart', control.restart)
+        '/server/restart', endpoints.restart)
     server.app.router.add_post(
         '/calibration/deck/start', dc_endp.start)
     server.app.router.add_post(

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 from aiohttp import web
 from opentrons.server.main import init
-from opentrons.server.endpoints import (control, update)
+import ot2serverlib
 
 
 async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
@@ -11,7 +11,7 @@ async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
 
     async def mock_restart(request):
         return web.json_response(test_data)
-    monkeypatch.setattr(control, 'restart', mock_restart)
+    monkeypatch.setattr(ot2serverlib.endpoints, 'restart', mock_restart)
 
     app = init(loop)
     cli = await loop.create_task(test_client(app))
@@ -32,13 +32,15 @@ async def test_update(virtual_smoothie_env, monkeypatch, loop, test_client):
 
     async def mock_install(filename, loop):
         return msg
-    monkeypatch.setattr(update, '_install', mock_install)
+    monkeypatch.setattr(ot2serverlib, '_install', mock_install)
 
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
     data = {'whl': open(os.path.join(tmpdir, filename))}
 
+    # Note: hits API server update endpoint--this test covers backward
+    # compatibility until the update server is universally available
     resp = await cli.post(
         '/server/update',
         data=data)

--- a/architecture-and-planning/backend-architecture.md
+++ b/architecture-and-planning/backend-architecture.md
@@ -1,0 +1,95 @@
+# Opentrons backend architecture
+
+This document provides a high-level overview of current and planned
+architecture for backend applications and libraries for Opentrons robots.
+
+## Current design
+
+### Runtime environment
+
+The OT-2 robot has two primary computing systems: a
+[Raspberry Pi](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/)
+and a modified [SmoothieBoard](http://smoothieware.org/smoothieboard). The
+SmoothieBoard acts as a motor-controller and receives
+[G-code](http://smoothieware.org/supported-g-codes) commands from
+Opentrons server applications. All other software on the OT-2 runs on the
+Raspberry Pi.
+
+The Raspberry Pi runs [ResinOS](https://resin.io/), which allows Opentrons
+support staff to connect to an OT-2 if needed to help with troubleshooting
+and support. On top of ResinOS, we run [Alpine Linux](https://alpinelinux.org/about/)
+inside of a [Docker](https://www.docker.com/community-edition) container.
+From this point forward, "software running on the OT-2" is assumed to mean
+running on Alpine Linux in Docker on top of ResinOS.
+
+There are three notable processes running on the OT-2: 1) an [nginx](http://nginx.org/en/)
+reverse-proxy server, 2) the Opentrons API server, and 3) a
+[Jupyter Notebook]() server.
+
+### API Server architecture
+
+The API Server has an interface layer composed of an RPC system and a set
+of HTTP endpoints. The RPC system is used for performing labware calibration
+and running protocols, and allowing the server to communicate status back
+to the Opentrons App (or other clients) as needed. The HTTP endpoints
+provide for setting WiFi credentials, feature flags, changing pipettes,
+updating software and firmware, etc. (everything other than labware
+calibration and protocol execution).
+
+## Planned changes
+
+Currently, all Opentrons backend software is part of the same codebase,
+and changes to the server application runtime have the potential to affect
+protocols written by/for users. Also, the API server takes on concerns other
+than running protocols, such as updating software and configurations.
+
+In the future, we plan to separate the backend software into multiple
+applications with more narrow concerns, and also make a separation between
+libraries and applications. Apps in this model should generally be very
+little more than a `main` and the objects and methods needed to maintain
+application state, and libraries should be stateless on import.
+
+Specifically, the OT-2 should run two applications: the API Server and the
+Update Server.
+
+### API Server
+
+The API Server is in charge of maintaining the state of the robot, such
+as what pipettes are attached, the current position of the gantry, what
+labware and modules have been loaded on the deck, and other configuration
+of the robot (both in terms of physical arrangement and software config).
+
+It serves endpoints that enable running protocols, calibrating the robot
+and labware, homing the gantry motors, etc. Over time, we plan to deprecate
+as much as possible the RPC interface to the server, and prefer HTTP
+connections. This server will serve both Python and JSON protocols.
+
+Once the API Server App is separated from the protocollib project, this
+app will no longer use `opentrons` as the name of its base module. That
+module will live in protocollib.
+
+### Update Server
+
+The Update Server is in charge of managing software, firmware, and allowing
+users to modify configuration such as feature flags.
+
+### ot2serverlib
+
+Shared functionality across server applications, and complex state management
+apparatus should move to the ot2serverlib, and then applications can depend
+on this library. This enables, for instance, the API Server to continue
+serving a software update endpoint for backward-compatibility, even after
+that functionality is moved to the Update Server.
+
+### protocollib
+
+This library project should contain the modules, classes, and functions that users
+import to write an Opentrons Python protocol. Because of the way that user-
+facing classes are currently coupled with robot state management, this will
+probably actually be a re-implementation of the current syntax, backed
+by asynchronous calls to HTTP endpoints designed to support JSON protocols.
+
+The base module of this library will be the `opentrons` package, and may
+be imported by the API Server. Once separated from the API Server App,
+this will be the only portion of the backend codebase installed and imported
+by users.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "shared-data",
     "protocol-designer",
     "webpack-config",
-    "api/opentrons"
+    "api/opentrons",
+    "api-server-lib/ot2serverlib"
   ],
   "config": {
     "commitizen": {


### PR DESCRIPTION
## overview

Separate update endpoints into a library that can be imported by both the Update Server and the API Server, to ensure they stay the same. Fixes #1642 

## changelog

- refactor(api): Separate endpoints into a library to be shared with update server

## review requests

Tested on 🌔 🌔 , update to this version works and runs protocols as normal, and API accepts successive updates. This PR is a little long, but there are actually *no* changes in functionality. Code moves to new files, unused variables are removed to fix lint errors [that I'm not sure why they passed before], and added a bunch of documentation and install boilerplate. The only new thing that is really of note is the `push-api` task in the repo-level Makefile.