### PR TITLE
feat(protocol-designer): Darken font in labware selection modal

### DIFF
--- a/protocol-designer/src/components/LabwareDropdown.css
+++ b/protocol-designer/src/components/LabwareDropdown.css
@@ -1,3 +1,5 @@
+@import '@opentrons/components';
+
 @value disable_select, close from '../css/mixins.css';
 
 .labware_dropdown {
@@ -11,7 +13,7 @@
   background-color: lightgray;
   border: 3px solid darkgray;
   z-index: 500;
-  color: darkgray;
+  color: var(--c-font-dark);
   composes: disable_select;
 }
 


### PR DESCRIPTION
## overview

Make font color, in the labware selection modal, standard font-dark.

Closes #1341

<img width="251" alt="screen shot 2018-06-07 at 2 54 36 pm" src="https://user-images.githubusercontent.com/4731953/41120611-0142a8ba-6a64-11e8-8126-35f7ff62e6da.png">
