### PR TITLE
refactor(app): Update deck calibration error modal

### DIFF
--- a/app/src/components/CalibrateDeck/ErrorModal.js
+++ b/app/src/components/CalibrateDeck/ErrorModal.js
@@ -4,8 +4,6 @@ import {Link} from 'react-router-dom'
 import {AlertModal} from '@opentrons/components'
 import type {Error} from '../../types'
 
-import styles from './styles.css'
-
 type Props = {
   closeUrl: string,
   error: Error
@@ -19,12 +17,12 @@ export default function ErrorModal (props: Props) {
     <AlertModal
       heading={HEADING}
       buttons={[
-        {children: 'try again', Component: Link, to: closeUrl}
+        {children: 'close', Component: Link, to: closeUrl}
       ]}
       alertOverlay
     >
+      <p><em>{error.message}</em></p>
       <p>An unexpected error has cleared your deck calibration progress, please try again.</p>
-      <p className={styles.error}>{error.message}</p>
       <p>If you keep getting this message, try restarting your robot. If this does not resolve the issue please contact Opentrons Support.</p>
     </AlertModal>
   )

--- a/app/src/components/CalibrateDeck/ErrorModal.js
+++ b/app/src/components/CalibrateDeck/ErrorModal.js
@@ -4,12 +4,14 @@ import {Link} from 'react-router-dom'
 import {AlertModal} from '@opentrons/components'
 import type {Error} from '../../types'
 
+import styles from './styles.css'
+
 type Props = {
   closeUrl: string,
   error: Error
 }
 
-const HEADING = 'Error'
+const HEADING = 'Unexpected Error'
 export default function ErrorModal (props: Props) {
   const {error, closeUrl} = props
 
@@ -17,11 +19,13 @@ export default function ErrorModal (props: Props) {
     <AlertModal
       heading={HEADING}
       buttons={[
-        {children: 'close', Component: Link, to: closeUrl}
+        {children: 'try again', Component: Link, to: closeUrl}
       ]}
+      alertOverlay
     >
-      <p>Something went wrong</p>
-      {error.message}
+      <p>An unexpected error has cleared your deck calibration progress, please try again.</p>
+      <p className={styles.error}>{error.message}</p>
+      <p>If you keep getting this message, try restarting your robot. If this does not resolve the issue please contact Opentrons Support.</p>
     </AlertModal>
   )
 }

--- a/app/src/components/CalibrateDeck/styles.css
+++ b/app/src/components/CalibrateDeck/styles.css
@@ -30,3 +30,9 @@
     height: auto;
   }
 }
+
+.error {
+  padding-left: 1rem;
+  color: var(--c-red);
+  font-weight: var(--fw-semibold);
+}

--- a/app/src/components/CalibrateDeck/styles.css
+++ b/app/src/components/CalibrateDeck/styles.css
@@ -33,6 +33,4 @@
 
 .error {
   padding-left: 1rem;
-  color: var(--c-red);
-  font-weight: var(--fw-semibold);
 }


### PR DESCRIPTION
## overview

This PR addresses #1641 and updates the text and styling of the error modal in deck calibration. Currently, the error modal is just a fallback error modal during startRequest. The error modal close button directs users back to robot settings page.  Error modal is an alertOverlay to ensure it renders over calibrate deck modals. Implementation in deck calibration steps to come in follow up PR.

<img width="800" alt="screen shot 2018-06-08 at 12 00 37 pm" src="https://user-images.githubusercontent.com/3430313/41168341-a6bb1408-6b13-11e8-9314-6b3c1b8b43a1.png">

## changelog

- refactor ErrorAlertModal 

## review requests
This is just a text and style update. 

To view error modal in deck calibration comment out lines 
 57- 64 in `app/src/components/CalibrateDeck/index.js` and begin deck calibration from robot settings page.
