### PR TITLE
API: adds endpoint to detect if trash-bin has been removed

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -500,6 +500,11 @@ class SmoothieDriver_3_0_0:
     @property
     def switch_state(self):
         '''Returns the state of all SmoothieBoard limit switches'''
+        if self.simulating:
+            return {
+                key: False
+                for key in ['X', 'Y', 'Z', 'A', 'B', 'C', 'Probe']
+            }
         res = self._send_command(GCODES['LIMIT_SWITCH_STATUS'])
         return _parse_switch_values(res)
 

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -48,6 +48,27 @@ async def get_attached_pipettes(request):
     return web.json_response(robot.get_attached_pipettes())
 
 
+async def get_trash_lid_attached(request):
+    """
+    Query driver for engaged state by the tip-probe switches. Response key will
+    be trash_bin, and value will be True for if the trash_bin is attached, and
+    False if the trash_bin is removed.
+
+    The tip-probe switches are engaged if the trash_bin is still placed on top
+    of it, due to a small piece of plastic pressing down on the Z switch. It
+    will be fully disengaged when the lid is removed by the user.
+
+    Response shape example:
+        {"trash_bin": {"attached": true}}
+    """
+    return web.json_response({
+        'trash_bin': {
+            'attached': robot._driver.switch_state.get('Probe')
+            }
+        }
+    )
+
+
 async def get_engaged_axes(request):
     """
     Query driver for engaged state by axis. Response keys will be axes XYZABC

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -48,21 +48,21 @@ async def get_attached_pipettes(request):
     return web.json_response(robot.get_attached_pipettes())
 
 
-async def get_trash_lid_attached(request):
+async def get_trash_attached(request):
     """
     Query driver for engaged state by the tip-probe switches. Response key will
-    be trash_bin, and value will be True for if the trash_bin is attached, and
-    False if the trash_bin is removed.
+    be trash, and value will be True for if the trash is attached, and
+    False if the trash is removed.
 
-    The tip-probe switches are engaged if the trash_bin is still placed on top
+    The tip-probe switches are engaged if the trash is still placed on top
     of it, due to a small piece of plastic pressing down on the Z switch. It
     will be fully disengaged when the lid is removed by the user.
 
     Response shape example:
-        {"trash_bin": {"attached": true}}
+        {"trash": {"attached": true}}
     """
     return web.json_response({
-        'trash_bin': {
+        'trash': {
             'attached': robot._driver.switch_state.get('Probe')
             }
         }

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -155,7 +155,7 @@ def init(loop=None):
     server.app.router.add_post(
         '/camera/picture', control.take_picture)
     server.app.router.add_get(
-        '/trash/attached', control.get_trash_attached)
+        '/trash', control.get_trash_attached)
     server.app.router.add_post(
         '/server/update', endpoints.update_api)
     server.app.router.add_post(

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -154,6 +154,8 @@ def init(loop=None):
         '/lights/off', control.turn_off_rail_lights)
     server.app.router.add_post(
         '/camera/picture', control.take_picture)
+    server.app.router.add_get(
+        '/trash/attached', control.get_trash_attached)
     server.app.router.add_post(
         '/server/update', endpoints.update_api)
     server.app.router.add_post(

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -532,6 +532,7 @@ def test_homing_flags(model):
 def test_switch_state(model):
     import types
     driver = model.robot._driver
+    driver.simulating = False
 
     def send_mock(self, target):
         smoothie_switch_res = 'X_max:0 Y_max:0 Z_max:0 A_max:0 B_max:0 C_max:0'

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -202,7 +202,7 @@ async def test_trash_attached(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    res = await cli.get('/trash/attached')
+    res = await cli.get('/trash')
     assert res.status == 200
 
     text = await res.text()
@@ -220,7 +220,7 @@ async def test_trash_attached(
     monkeypatch.setattr(robot._driver, '_send_command', _send_command_mock)
     robot._driver.simulating = False
 
-    res = await cli.get('/trash/attached')
+    res = await cli.get('/trash')
     assert res.status == 200
 
     text = await res.text()


### PR DESCRIPTION
## overview

Adds endpoint `"/trash/attached"`, which returns true if the bin is still there, and false if the bin has been removed. This could be queried by the FE both before a tip-probe, or before starting a run.

The trash-bin has a small piece of plastic that presses down onto the tip-probe's Z switch, allowing us to detect the bin's presence.