### PR TITLE
fix(app-shell): Remove Reload from View menu unless devtools are active

### DIFF
--- a/app-shell/lib/menu.js
+++ b/app-shell/lib/menu.js
@@ -4,6 +4,7 @@
 const {app, Menu} = require('electron')
 
 const pkg = require('../package.json')
+const config = require('./config').getConfig()
 
 // file or application menu
 const firstMenu = {
@@ -25,8 +26,9 @@ if (process.platform === 'darwin') {
       {role: 'hide'},
       {role: 'hideothers'},
       {role: 'unhide'},
-      {type: 'separator'}
-    ].concat(firstMenu.submenu)
+      {type: 'separator'},
+      ...firstMenu.submenu
+    ]
   })
 }
 
@@ -43,11 +45,19 @@ const editMenu = {
 const viewMenu = {
   label: 'View',
   submenu: [
-    {role: 'reload'},
-    {role: 'forcereload'},
-    {type: 'separator'},
     {role: 'togglefullscreen'}
   ]
+}
+
+if (config.devtools) {
+  Object.assign(viewMenu, {
+    submenu: [
+      {role: 'reload'},
+      {role: 'forcereload'},
+      {type: 'separator'},
+      ...viewMenu.submenu
+    ]
+  })
 }
 
 const windowMenu = {


### PR DESCRIPTION
## overview

This PR removes the Reload option from the View menu if devtools are not active. Given that we still have improper `throw`s in render paths that will break reloads, this is a more appropriate solution than #1640.

Fixes #1618

## changelog

- fix(app-shell): Remove Reload from View menu unless devtools are active

## review requests

- [x] View > Reload still shows up in dev build
- [x] View > Reload does **not** show up in prod build
