### PR TITLE
Fix bug with multichannel substep display

### DIFF
--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -239,7 +239,7 @@ function commandToMultiRows (
 
   return range(channels).map(channel => {
     const well = wellsForTips[channel]
-    const ingreds = getIngreds(labwareId, command.params.well)
+    const ingreds = getIngreds(labwareId, well)
     const volume = command.params.volume
 
     if (command.command === 'aspirate') {
@@ -287,6 +287,7 @@ export function generateSubsteps (
   orderedSteps: Array<StepIdType>,
   robotStateTimeline: RobotStateTimeline
 ): SubSteps {
+  console.log('generateSubsteps', namedIngredsByLabwareAllSteps)
   return mapValues(validatedForms, (valForm: ValidFormAndErrors, stepId: StepIdType) => {
     const validatedForm = valForm.validatedForm
     const prevStepId = steplistUtils.getPrevStepId(orderedSteps, stepId)
@@ -315,7 +316,7 @@ export function generateSubsteps (
     ) {
       const getIngreds = getIngredsFactory(namedIngredsByLabwareAllSteps, prevStepId)
       const getLabwareType = getLabwareTypeFactory(allLabwareTypes)
-      // TODO SOON Ian 2018-05-17 all transferlikes will use this fn in next PR
+
       return transferLikeSubsteps({
         validatedForm,
         allPipetteData,

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -106,6 +106,7 @@ export const lastValidWellContents: Selector<{[labwareId: string]: AllWellConten
 )
 
 /** NamedIngred-formatted contents of wells, across all steps on the timeline */
+// TODO: Ian 2018-06-08 do not used NamedIngreds. Stay close to 'native' liquid state shape.
 export const namedIngredsByLabware: Selector<NamedIngredsByLabwareAllSteps> = createSelector(
   allWellContentsForSteps,
   labwareIngredSelectors.getIngredientGroups,


### PR DESCRIPTION
## overview

Fix a bug where **multi-channel** transfer/distribute/consolidate substeps were always showing only the ingredients in the "first" tip of the multichannel (eg A-row in 96 plate).

Now each tip should show the correct ingredients for the well that tip accesses.

## changelog

- fix bug with multi-channel substep ingredients only showing ingredients for first tip

## review requests

- All variants of 8-channel access should render substeps correctly for 8-channel pipette transfer-like steps: 96 flat, 384 plate, trough