### PR TITLE
chore(github): update github issue template headers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
   Thanks for taking the time to file an issue! Please make sure you've read the
   "Opening Issues" section of our Contributing Guide:
 
-  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-issues
+  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-issues
 
   To ensure your issue can be addressed quickly, please fill out the sections
   below to the best of your ability!
@@ -16,11 +16,11 @@
   find that may be related.
 -->
 
-## behavior
+## current behavior
 
 <!--
   Describe how the software currently behaves and how that differs from how you
-  think the software should behave
+  think the software should behave.
 -->
 
 ## steps to reproduce
@@ -28,5 +28,11 @@
 <!--
   If this is a bug report and there are specific steps we can take to reproduce
   the bug, please list them here. This is a good place to put things like
-  software version, hardware version, and operating system
+  software version, hardware version, and operating system.
+-->
+
+## expected behavior
+
+<!--
+  Describe how you think the software should behave.
 -->


### PR DESCRIPTION
## overview

The "behavior" header in our issues template trips me up every time.


## changelog

- Update GH issue template: current behavor / expected behavior instead of 'behavior'
- Also update link to CONTRIBUTING.md (`edge` not `v3a`)

## review requests

Clearer?