### PR TITLE
fix(api): Fallback for update endpoints

### DIFF
--- a/api-server-lib/Makefile
+++ b/api-server-lib/Makefile
@@ -35,7 +35,7 @@ test:
 	@echo "TODO: add api-server-lib tests"
 # test:
 # 	$(python) -m pytest \
-# 		--cov=opentrons \
+# 		--cov=ot2serverlib \
 # 		--cov-report term-missing:skip-covered \
 # 		--cov-report xml:coverage.xml \
 # 		tests

--- a/api-server-lib/ot2serverlib/__init__.py
+++ b/api-server-lib/ot2serverlib/__init__.py
@@ -19,10 +19,10 @@ async def _install(filename, loop):
     return res
 
 
-async def install_api(data, loop):
-    filename = data['whl'].filename
+async def install_py(data, loop):
+    filename = data.filename
     log.info('Preparing to install: {}'.format(filename))
-    content = data['whl'].file.read()
+    content = data.file.read()
 
     with open(filename, 'wb') as wf:
         wf.write(content)
@@ -40,10 +40,10 @@ async def install_api(data, loop):
 async def install_smoothie_firmware(data, loop):
     from opentrons.server.endpoints.update import _update_firmware
 
-    filename = data['hex'].filename
+    filename = data.filename
     log.info('Flashing image "{}", this will take about 1 minute'.format(
         filename))
-    content = data['hex'].file.read()
+    content = data.file.read()
 
     with open(filename, 'wb') as wf:
         wf.write(content)

--- a/api-server-lib/ot2serverlib/endpoints.py
+++ b/api-server-lib/ot2serverlib/endpoints.py
@@ -11,14 +11,32 @@ log = logging.getLogger(__name__)
 async def update_api(request: web.Request) -> web.Response:
     """
     This handler accepts a POST request with Content-Type: multipart/form-data
-    and a file field in the body named "whl". The file should be a valid Python
-    wheel to be installed. The received file is install using pip, and then
-    deleted and a success code is returned.
+    and file fields in the body named "whl", "serverlib", and "fw". The "whl"
+    and "serverlib" files should be valid Python wheels to be installed ("whl"
+    is expected generally to be the API server wheel, and "serverlib" is
+    expected to be the ot2serverlib wheel. The "fw" file is expected to be a
+    Smoothie firmware hex file. The Python files are install using pip, and the
+    firmware file is flashed to the Smoothie board, then the files are deleted
+    and a success code is returned.
     """
     log.debug('Update request received')
     data = await request.post()
     try:
-        res = await ot2serverlib.install_api(data, request.loop)
+        res0 = await ot2serverlib.install_py(
+            data['whl'], request.loop)
+        reslist = [res0]
+        if 'serverlib' in data.keys():
+            res1 = await ot2serverlib.install_py(
+                data['serverlib'], request.loop)
+            reslist.append(res1)
+        if 'fw' in data.keys():
+            res2 = await ot2serverlib.install_smoothie_firmware(
+                data['fw'], request.loop)
+            reslist.append(res2)
+        res = {
+            'message': [r['message'] for r in reslist],
+            'filename': [r['filename'] for r in reslist]
+        }
         status = 200
     except Exception as e:
         res = {'error': 'Exception {} raised by update of {}: {}'.format(
@@ -37,7 +55,8 @@ async def update_firmware(request):
     log.debug('Update Firmware request received')
     data = await request.post()
     try:
-        res = await ot2serverlib.install_smoothie_firmware(data, request.loop)
+        res = await ot2serverlib.install_smoothie_firmware(
+            data['hex'], request.loop)
         status = 200
     except Exception as e:
         log.exception("Exception during firmware update:")

--- a/api/opentrons/server/endpoints/serverlib_fallback.py
+++ b/api/opentrons/server/endpoints/serverlib_fallback.py
@@ -1,0 +1,112 @@
+import os
+import asyncio
+import logging
+from time import sleep
+from aiohttp import web
+from threading import Thread
+
+log = logging.getLogger(__name__)
+
+
+async def _install(filename, loop):
+    proc = await asyncio.create_subprocess_shell(
+        'pip install --upgrade --force-reinstall --no-deps {}'.format(
+            filename),
+        stdout=asyncio.subprocess.PIPE,
+        loop=loop)
+
+    rd = await proc.stdout.read()
+    res = rd.decode().strip()
+    print(res)
+    await proc.wait()
+    return res
+
+
+async def install_api(data, loop):
+    filename = data['whl'].filename
+    log.info('Preparing to install: {}'.format(filename))
+    content = data['whl'].file.read()
+
+    with open(filename, 'wb') as wf:
+        wf.write(content)
+
+    msg = await _install(filename, loop)
+    log.debug('Install complete')
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
+    log.debug("Result: {}".format(msg))
+    return {'message': msg, 'filename': filename}
+
+
+async def install_smoothie_firmware(data, loop):
+    from opentrons.server.endpoints.update import _update_firmware
+
+    filename = data['hex'].filename
+    log.info('Flashing image "{}", this will take about 1 minute'.format(
+        filename))
+    content = data['hex'].file.read()
+
+    with open(filename, 'wb') as wf:
+        wf.write(content)
+
+    msg = await _update_firmware(filename, loop)
+    log.debug('Firmware Update complete')
+    try:
+        os.remove(filename)
+    except OSError:
+        pass
+    log.debug("Result: {}".format(msg))
+    return {'message': msg, 'filename': filename}
+
+
+async def update_api(request: web.Request) -> web.Response:
+    """
+    This handler accepts a POST request with Content-Type: multipart/form-data
+    and a file field in the body named "whl". The file should be a valid Python
+    wheel to be installed. The received file is install using pip, and then
+    deleted and a success code is returned.
+    """
+    log.debug('Update request received')
+    data = await request.post()
+    try:
+        res = await install_api(data, request.loop)
+        status = 200
+    except Exception as e:
+        res = {'error': 'Exception {} raised by update of {}: {}'.format(
+                type(e), data, e.__traceback__)}
+        status = 500
+    return web.json_response(res, status=status)
+
+
+async def update_firmware(request):
+    """
+    This handler accepts a POST request with Content-Type: multipart/form-data
+    and a file field in the body named "hex". The file should be a valid HEX
+    image to be flashed to the LPC1769. The received file is flashed using
+    lpc21isp, and then deleted and a success code is returned.
+    """
+    log.debug('Update Firmware request received')
+    data = await request.post()
+    try:
+        res = await install_smoothie_firmware(data, request.loop)
+        status = 200
+    except Exception as e:
+        log.exception("Exception during firmware update:")
+        res = {'error': 'Exception {} raised by update of {}: {}'.format(
+                type(e), data, e.__traceback__)}
+        status = 500
+    return web.json_response(res, status=status)
+
+
+async def restart(request):
+    """
+    Returns OK, then waits approximately 3 seconds and restarts container
+    """
+    def wait_and_restart():
+        log.info('Restarting server')
+        sleep(3)
+        os.system('kill 1')
+    Thread(target=wait_and_restart).start()
+    return web.json_response({"message": "restarting"})

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -15,7 +15,11 @@ from opentrons.config import feature_flags as ff
 from opentrons.util import environment
 from opentrons.deck_calibration import endpoints as dc_endp
 from logging.config import dictConfig
-from ot2serverlib import endpoints
+try:
+    from ot2serverlib import endpoints
+except ModuleNotFoundError:
+    print("Module ot2serverlib not found--using fallback implementation")
+    from opentrons.server.endpoints import serverlib_fallback as endpoints
 
 from argparse import ArgumentParser
 


### PR DESCRIPTION
## overview

Add fallback code for update endpoints, in case `ot2serverlib` is not installed. Make endpoints able to install "whl", "serverlib", and "fw" (see updated endpoint documentation).

## changelog

- fix(api): Add fallback code for update endpoints, in case `ot2serverlib` is not installed

## review requests

Tested on 🌔 🌔 for backward compatibility (multiple updates without `ot2serverlib` installed)
