### PR TITLE
feat(app): Toggle devtools feature flag in app settings

### DIFF
--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -19,7 +19,7 @@ log.debug('App config', {
 })
 
 if (config.devtools) {
-  require('electron-debug')({showDevTools: true})
+  require('electron-debug')({enabled: true, showDevTools: true})
 }
 
 // hold on to references so they don't get garbage collected

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -1,0 +1,49 @@
+// @flow
+// app info card with version and updated
+import * as React from 'react'
+import {connect} from 'react-redux'
+
+import type {State, Dispatch} from '../../types'
+import {getDevToolsOn, toggleDevTools} from '../../config'
+import {Card} from '@opentrons/components'
+import {LabeledToggle, ToggleInfo} from '../toggles'
+
+type SP = {
+  devToolsOn: boolean,
+}
+
+type DP = {
+  toggleDevTools: () => mixed
+}
+type Props = SP & DP
+
+const TITLE = 'Advanced Settings'
+
+export default connect(mapStateToProps, mapDispatchToProps)(AdvancedSettingsCard)
+
+function AdvancedSettingsCard (props: Props) {
+  return (
+    <Card title={TITLE} column>
+      <LabeledToggle
+        label='Enable Developer Tools'
+        toggledOn={props.devToolsOn}
+        onClick={props.toggleDevTools}
+      />
+      <ToggleInfo>
+        <p>Requires restart. Turns on the app&#39;s developer tools, which provide access to the inner workings of the app and additional logging.</p>
+      </ToggleInfo>
+    </Card>
+  )
+}
+
+function mapStateToProps (state: State): SP {
+  return {
+    devToolsOn: getDevToolsOn(state)
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch) {
+  return {
+    toggleDevTools: () => dispatch(toggleDevTools())
+  }
+}

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import type {ShellUpdate} from '../../shell'
 import {AnalyticsSettingsCard} from '../analytics-settings'
+import AdvancedSettingsCard from './AdvancedSettingsCard'
 import AppInfoCard from './AppInfoCard'
 import AppUpdateModal from './AppUpdateModal'
 
@@ -21,6 +22,9 @@ export default function AppSettings (props: Props) {
       </div>
       <div className={styles.row}>
         <AnalyticsSettingsCard {...props} />
+      </div>
+      <div className={styles.row}>
+        <AdvancedSettingsCard />
       </div>
     </div>
   )

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -85,3 +85,14 @@ export function configReducer (
 export function getConfig (state: State): Config {
   return state.config
 }
+
+export function getDevToolsOn (state: State): boolean {
+  return state.config.devtools
+}
+
+export function toggleDevTools (): Action {
+  return (dispatch, getState) => {
+    const devToolsOn = getDevToolsOn(getState())
+    return dispatch(updateConfig('devtools', !devToolsOn))
+  }
+}


### PR DESCRIPTION
## overview

This PR addresses #1632 (last checkbox) User can toggle app-level feature flags in the App 'Advanced Settings' section.

<img width="800" alt="screen shot 2018-06-11 at 4 24 36 pm" src="https://user-images.githubusercontent.com/3430313/41255279-002126fe-6d94-11e8-9296-33252b05c09f.png">

## changelog

- Add advanced settings to app settings page
- Enable toggling devtools in app

## review requests
- Run `make -C app-shell` in root
- Open app build from `./app-shell/dist/YOUR_OS/Opentrons`
- [x] Advanced settings in AppSettings toggles devtools on - Toggle on, quit app, relaunch confirm devtools opens view > reload is enabled in app toolbar
- [x] Advanced settings in AppSettings toggles devtools off - Toggle on, quit app, relaunch confirm devtools does not open, and view > reload is no longer accessible
