### PR TITLE
feat(app): Pass server-lib and firmware to /server/update

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,8 +8,9 @@ PATH := $(shell yarn bin):$(PATH)
 # ui directory for production build
 ui_dir := ../app
 
-# api directory for robot API update bundled in production build
+# directories for robot API update bundled in production build
 api_dir := ../api
+api_lib_dir := ../api-server-lib
 
 # set NODE_ENV for a command with $(env)=environment
 env := cross-env NODE_ENV
@@ -61,8 +62,12 @@ ui:
 api:
 	$(MAKE) -C $(api_dir) wheel
 
+.PHONY: api-lib
+api-lib:
+	$(MAKE) -C $(api_lib_dir) wheel
+
 .PHONY: package-deps
-package-deps: clean ui api
+package-deps: clean ui api api-lib
 
 .PHONY: package
 package: package-deps

--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -15,6 +15,16 @@
       "from": "../api/dist",
       "to": "./api/dist",
       "filter": ["**/*"]
+    },
+    {
+      "from": "../api-server-lib/dist",
+      "to": "./api-server-lib/dist",
+      "filter": ["**/*"]
+    },
+    {
+      "from": "../api/smoothie",
+      "to": "./api/smoothie",
+      "filter": ["**/*.hex"]
     }
   ],
   "artifactName": "${productName}-v${version}-${os}-${env.BUILD_ID}.${ext}",

--- a/app-shell/lib/api-update.js
+++ b/app-shell/lib/api-update.js
@@ -1,46 +1,79 @@
-// @flow
-// TODO(mc, 2018-03-15): use babel with flow preset instead of comments
+// TODO(mc, 2018-03-15): use babel with flow preset
 // api updater
 'use strict'
 
+const assert = require('assert')
 const fse = require('fs-extra')
 const path = require('path')
 
 const {version: AVAILABLE_UPDATE} = require('../package.json')
+const log = require('./log')(__filename)
 
-/*::
-import type {RobotService} from '../../app/src/robot'
-import type {RobotHealth} from '../../app/src/http-api-client'
-*/
-
-const UPDATE_EXT = '.whl'
-const UPDATE_DIR = path.join(__dirname, '../../api/dist')
-let updateFile
+let updateFiles = []
 
 module.exports = {
   AVAILABLE_UPDATE,
   initialize,
-  getUpdateFile
+  getUpdateFiles
 }
 
-function initialize () /*: Promise<void> */ {
-  return fse.readdir(UPDATE_DIR)
-    .then((files) => {
-      const wheels = files.filter((file) => file.endsWith(UPDATE_EXT))
+function initialize () {
+  updateFiles = [
+    // API update
+    {
+      id: 'whl',
+      directory: path.join(__dirname, '../../api/dist'),
+      ext: '.whl'
+    },
 
-      if (wheels.length !== 1) {
-        return Promise.reject(new Error(
-          `Expected 1 wheel, got ${wheels.length} of ${files.length} files`
-        ))
-      }
+    // API server lib update
+    {
+      id: 'serverlib',
+      directory: path.join(__dirname, '../../api-server-lib/dist'),
+      ext: '.whl'
+    },
 
-      updateFile = wheels[0]
-    })
+    // firmware update
+    {
+      id: 'fw',
+      directory: path.join(__dirname, '../../api/smoothie'),
+      ext: '.hex'
+    }
+  ].map(findUpdateFile)
 }
 
-function getUpdateFile () /*: Promise<string> */ {
-  if (!updateFile) return Promise.reject(new Error('No update file available'))
+function getUpdateFiles () {
+  if (!updateFiles.length || !updateFiles.every(Boolean)) {
+    return Promise.reject(new Error('Update files were not all found'))
+  }
 
-  return fse.readFile(path.join(UPDATE_DIR, updateFile))
-    .then((contents) => ({name: updateFile, contents}))
+  return Promise.all(updateFiles.map(readUpdateFile))
+}
+
+function findUpdateFile (file) {
+  const {directory, ext} = file
+
+  try {
+    const results = fse.readdirSync(directory)
+    const files = results.filter(f => f.endsWith(ext))
+
+    assert(
+      files.length === 1,
+      `Expected 1 ${ext} file in ${directory}, found ${results.join(' ')}`
+    )
+
+    const updateFile = Object.assign({name: files[0]}, file)
+    log.info(`Found update file`, updateFile)
+
+    return updateFile
+  } catch (error) {
+    log.error('Unable to load API update files', {error})
+  }
+
+  return null
+}
+
+function readUpdateFile (file) {
+  return fse.readFile(path.join(file.directory, file.name))
+    .then(contents => Object.assign({contents}, file))
 }

--- a/app-shell/lib/main.js
+++ b/app-shell/lib/main.js
@@ -36,9 +36,7 @@ function startUp () {
   rendererLogger = createRendererLogger()
 
   initializeMenu()
-
   initializeApiUpdate()
-    .catch((error) => log.error('Initialize API update module error', error))
 
   // wire modules to UI dispatches
   const dispatch = (action) => {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -10,7 +10,7 @@ import type {ApiCall} from './types'
 import client, {FetchError, type ApiRequestError} from './client'
 
 // remote module paths relative to app-shell/lib/main.js
-const {AVAILABLE_UPDATE, getUpdateFile} = remote.require('./api-update')
+const {AVAILABLE_UPDATE, getUpdateFiles} = remote.require('./api-update')
 
 type RequestPath = 'update' | 'restart'
 
@@ -223,10 +223,10 @@ function selectRobotServerState (state: State, props: RobotService) {
 }
 
 function getUpdateRequestBody () {
-  return getUpdateFile()
-    .then((file) => {
+  return getUpdateFiles()
+    .then(files => {
       const formData = new FormData()
-      formData.append('whl', new Blob([file.contents]), file.name)
+      files.forEach(f => formData.append(f.id, new Blob([f.contents]), f.name))
       return formData
     })
     .catch((error) => Promise.reject(FetchError(error)))


### PR DESCRIPTION
## overview

This PR adds additional files to the payload of the `POST /server/update` call:

- API server lib wheel (to update the server lib)
- Smoothie firmware hex (to update smoothie)

After merging, clicking "Update" in the app for a robot will update the API, the API support library, and Smoothie, so this PR closes #1115

## changelog

- feat(app): Pass server-lib and firmware to /server/update 

## review requests

Tested on Sunset. Does not work with Virtual Smoothie (endpoint `500`s on Smoothie firmware update, which makes sense).

1. Check out an older: `git checkout v3.1.1`
2. Downgrade a robot: `make -C api push flash restart`
3. `git checkout app-shell_bundle-updates `
4. `make -C app-shell` (Ensure all wheels are built)
3. Open app, go to robot settings page, click Update
    - [ ] Update successfully completes
    - After restart (and possibly an info card refresh) robot reports new version
        - [ ] API: `3.1.2`
        - [ ] Smoothie: `edge-6168d32`
