### PR TITLE
feat(app): Capture and display errors during deck calibration

### DIFF
--- a/app/src/__tests__/util.test.js
+++ b/app/src/__tests__/util.test.js
@@ -1,0 +1,166 @@
+// utility function tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import {chainActions} from '../util'
+
+jest.mock('../logger')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('chainActions utility', () => {
+  let state
+  let store
+
+  beforeEach(() => {
+    state = {}
+    store = mockStore(state)
+  })
+
+  test('dispatches a chain of plain actions', () => {
+    const actions = [
+      {type: 'foo'},
+      {type: 'bar'},
+      {type: 'baz'}
+    ]
+
+    const result = store.dispatch(chainActions(...actions))
+    expect(result).toEqual(actions[2])
+    expect(store.getActions()).toEqual(actions)
+  })
+
+  test('dispatches a chain of thunk actions', () => {
+    const actions = [
+      {type: 'foo'},
+      {type: 'bar'},
+      {type: 'baz'}
+    ]
+    const thunks = actions.map(a => dispatch => dispatch(a))
+
+    const result = store.dispatch(chainActions(...thunks))
+    expect(result).toEqual(actions[2])
+    expect(store.getActions()).toEqual(actions)
+  })
+
+  test('dispatches a chain of thunk promise actions', () => {
+    const actions = [
+      {type: 'foo'},
+      {type: 'bar'},
+      {type: 'baz'}
+    ]
+    const thunks = actions.map(a => dispatch => Promise.resolve(dispatch(a)))
+
+    return store.dispatch(chainActions(...thunks))
+      .then(result => {
+        expect(result).toEqual(actions[2])
+        expect(store.getActions()).toEqual(actions)
+      })
+  })
+
+  test('dispatches a combination of action types', () => {
+    const actions = [
+      {type: 'foo'},
+      {type: 'bar'},
+      {type: 'baz'}
+    ]
+    const thunks = [
+      (dispatch) => dispatch(actions[0]),
+      (dispatch) => Promise.resolve(dispatch(actions[1])),
+      actions[2]
+    ]
+
+    return store.dispatch(chainActions(...thunks))
+      .then(result => {
+        expect(result).toEqual(actions[2])
+        expect(store.getActions()).toEqual(actions)
+      })
+  })
+
+  test('bails out early if a plain action has an error', () => {
+    const actions = [
+      {type: 'foo', error: new Error('AH')},
+      {type: 'bar'}
+    ]
+
+    const result = store.dispatch(chainActions(...actions))
+    expect(result).toEqual(actions[0])
+    expect(store.getActions()).toEqual(actions.slice(0, 1))
+  })
+
+  test('bails out early if a thunk action has an error', () => {
+    const errorAction = {type: 'foo', error: new Error('AH')}
+    const actions = [
+      (dispatch) => dispatch(errorAction),
+      {type: 'bar'}
+    ]
+
+    const result = store.dispatch(chainActions(...actions))
+    expect(result).toEqual(errorAction)
+    expect(store.getActions()).toEqual([errorAction])
+  })
+
+  test('bails out early if a thunk promise has an error', () => {
+    const errorAction = {type: 'foo', error: new Error('AH')}
+    const actions = [
+      (dispatch) => Promise.resolve(dispatch(errorAction)),
+      {type: 'bar'}
+    ]
+
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(errorAction)
+        expect(store.getActions()).toEqual([errorAction])
+      })
+  })
+
+  test('bails out early if a plain action has an error in the payload', () => {
+    const actions = [
+      {type: 'foo', payload: {error: new Error('AH')}},
+      {type: 'bar'}
+    ]
+
+    const result = store.dispatch(chainActions(...actions))
+    expect(result).toEqual(actions[0])
+    expect(store.getActions()).toEqual(actions.slice(0, 1))
+  })
+
+  test('bails out early if a thunk action has an error in the payload', () => {
+    const errorAction = {type: 'foo', payload: {error: new Error('AH')}}
+    const actions = [
+      (dispatch) => dispatch(errorAction),
+      {type: 'bar'}
+    ]
+
+    const result = store.dispatch(chainActions(...actions))
+    expect(result).toEqual(errorAction)
+    expect(store.getActions()).toEqual([errorAction])
+  })
+
+  test('bails out early if a thunk promise has an error in the payload', () => {
+    const errorAction = {type: 'foo', payload: {error: new Error('AH')}}
+    const actions = [
+      (dispatch) => Promise.resolve(dispatch(errorAction)),
+      {type: 'bar'}
+    ]
+
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(errorAction)
+        expect(store.getActions()).toEqual([errorAction])
+      })
+  })
+
+  test('bails out early if a thunk promise rejects', () => {
+    const actions = [
+      (dispatch) => Promise.reject(new Error('AH')),
+      {type: 'bar'}
+    ]
+
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(null)
+        expect(store.getActions()).toEqual([])
+      })
+  })
+})

--- a/app/src/components/CalibrateDeck/ErrorModal.js
+++ b/app/src/components/CalibrateDeck/ErrorModal.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {Link} from 'react-router-dom'
 import {AlertModal} from '@opentrons/components'
+
 import type {Error} from '../../types'
 
 type Props = {
@@ -10,6 +11,7 @@ type Props = {
 }
 
 const HEADING = 'Unexpected Error'
+
 export default function ErrorModal (props: Props) {
   const {error, closeUrl} = props
 

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -12,6 +12,7 @@ import {
   deckCalibrationCommand as dcCommand
 } from '../../http-api-client'
 
+import {chainActions} from '../../util'
 import {ModalPage, SpinnerModalPage} from '@opentrons/components'
 import AttachTip from './AttachTip'
 import ConfirmPosition from './ConfirmPosition'
@@ -106,46 +107,46 @@ function getMovementDescription (props: Props): string {
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {robot, pipette, calibrationStep: step, match: {url}} = ownProps
-  const goToNext = () => dispatch(push(`${url}/step-${Number(step) + 1}`))
-  let proceed
+  const goToNext = push(`${url}/step-${Number(step) + 1}`)
+  let actions
 
   if (step === '1') {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'attach tip', tipLength: pipette.tipLength})
-    ).then(() => dispatch(
-      dcCommand(robot, {command: 'move', point: 'safeZ'})
-    )).then(goToNext)
+    actions = [
+      dcCommand(robot, {command: 'attach tip', tipLength: pipette.tipLength}),
+      dcCommand(robot, {command: 'move', point: 'safeZ'}),
+      goToNext
+    ]
   } else if (step === '2') {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'save z'})
-    ).then(() => dispatch(
-      dcCommand(robot, {command: 'move', point: '1'})
-    )).then(goToNext)
+    actions = [
+      dcCommand(robot, {command: 'save z'}),
+      dcCommand(robot, {command: 'move', point: '1'}),
+      goToNext
+    ]
   } else if (step === '3') {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'save xy', point: '1'})
-    ).then(() => dispatch(
-      dcCommand(robot, {command: 'move', point: '2'})
-    )).then(goToNext)
+    actions = [
+      dcCommand(robot, {command: 'save xy', point: '1'}),
+      dcCommand(robot, {command: 'move', point: '2'}),
+      goToNext
+    ]
   } else if (step === '4') {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'save xy', point: '2'})
-    ).then(() => dispatch(
-      dcCommand(robot, {command: 'move', point: '3'})
-    )).then(goToNext)
+    actions = [
+      dcCommand(robot, {command: 'save xy', point: '2'}),
+      dcCommand(robot, {command: 'move', point: '3'}),
+      goToNext
+    ]
   } else if (step === '5') {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'save xy', point: '3'})
-    ).then(() => dispatch(
-      dcCommand(robot, {command: 'move', point: 'attachTip'})
-    )).then(goToNext)
+    actions = [
+      dcCommand(robot, {command: 'save xy', point: '3'}),
+      dcCommand(robot, {command: 'move', point: 'attachTip'}),
+      goToNext
+    ]
   } else {
-    proceed = () => dispatch(
-      dcCommand(robot, {command: 'save transform'})
-    ).then(() => dispatch(
-      restartRobotServer(robot))
-    ).then(() => dispatch(push(ownProps.parentUrl)))
+    actions = [
+      dcCommand(robot, {command: 'save transform'}),
+      restartRobotServer(robot),
+      push(ownProps.parentUrl)
+    ]
   }
 
-  return {proceed}
+  return {proceed: () => dispatch(chainActions(...actions))}
 }

--- a/app/src/components/CalibrateDeck/styles.css
+++ b/app/src/components/CalibrateDeck/styles.css
@@ -30,7 +30,3 @@
     height: auto;
   }
 }
-
-.error {
-  padding-left: 1rem;
-}

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -1,7 +1,5 @@
 // @flow
 // robot actions and action types
-// action helpers
-import {makeActionName} from '../util'
 import {_NAME as NAME} from './constants'
 import type {
   Mount,
@@ -15,7 +13,7 @@ import type {
 } from './types'
 
 // TODO(mc, 2017-11-22): rename this function to actionType
-const makeRobotActionName = (action) => makeActionName(NAME, action)
+const makeRobotActionName = (action) => `${NAME}:${action}`
 const tagForRobotApi = (action) => ({...action, meta: {robotCommand: true}})
 
 type Error = {message: string}

--- a/app/src/util.js
+++ b/app/src/util.js
@@ -1,9 +1,60 @@
+// @flow
 // utility functions
+import type {Dispatch, GetState, Action, ThunkAction, ThunkPromiseAction} from './types'
+import createLogger from './logger'
 
-export function makeActionName (moduleName, actionName) {
-  return `${moduleName}:${actionName}`
+type Chainable = Action | ThunkAction | ThunkPromiseAction
+
+type ChainAction = ?Action | Promise<?Action>
+
+type ThunkChain = (Dispatch, GetState) => ChainAction
+
+const log = createLogger(__filename)
+
+export function delay (ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export function delay (ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+// dispatch a chain of actions or thunk actions until an error occurs
+// error means: error in action, error in payload, or promise rejection
+// TODO(mc, 2018-06-11): This is a little too bespoke for my tastes. Explore
+//   npm for available ecosystem solutions soon
+export function chainActions (...actions: Array<Chainable>): ThunkChain {
+  let i = 0
+  let result: ?Action = null
+
+  return (dispatch) => {
+    return next()
+
+    function next (): ChainAction {
+      const current = actions[i]
+
+      if (!current) return result
+
+      i++
+      // TODO(mc, 2018-06-11): Should we debounce plain actions with RAF?
+      result = dispatch(current)
+
+      if (result.then) return result.then(handleAction, handleError)
+      return handleAction(result)
+    }
+
+    function handleAction (action: ?Action): ChainAction {
+      if (
+        action &&
+        // $FlowFixMe: Flow complains about accessing `error` on payload
+        (action.error || (action.payload && action.payload.error))
+      ) {
+        log.debug('Early return from action chain', {action})
+        return result
+      }
+
+      return next()
+    }
+
+    function handleError (error) {
+      log.error('ThunkPromiseAction in chain rejected', {error})
+      return null
+    }
+  }
 }


### PR DESCRIPTION
## overview

This PR adds some chaining logic to the API calls in deck calibration to ensure that if a given API call errors, deck calibration is stopped.

Closes #1641

## changelog

- feat(app): Capture and display errors during deck calibration 

## review requests

First off, don't be scared by the diff count. It's mostly a unit test file. Second off:

1. Start deck calibration with a robot
    - This doesn't work well with Virtual Smoothie without `driver_3_0.py` modifications
2. Induce some sort of failure (e.g. turn the robot off)
- [x] Clicking whatever proceed button results in an error modal

### implementation details

I've written a fairly straightforward chainer (implemented as a thunk action) for the types of actions we use in the app:

1. Plain actions
2. Thunk actions (that return a maybe action)
    - e.g. a thunk that needs to put something from state into a payload
3. Thunk actions that return a Promise (that resolves to a maybe action)
    - e.g. a thunk that calls `fetch` and dispatches something when it resolves/rejects

Option (3) is the most important, because all our API calls are thunk actions that:

1. Dispatch `api:SOME_REQUEST`
2. Call `fetch`
3. Dispatch / resolve the finish action
    - If success: `api:SOME_REQUEST_SUCCESS`
    - If failure (i.e. rejects or resolves a non-`2xx` response): `api:SOME_REQUEST_FAILURE` with an `error` field in the payload

The logic for the chainer is (roughly):

1. Dispatch next action
2. Grab the return value of `dispatch`
    - If plain action, `dispatch` returns the action
    - If thunk, `dispatch` returns whatever the thunk returns (in the case of our API calls, the thunk returns a Promise that resolves the finish action described above
    - If return value is `then`-able, wait for the Promise to resolve (and exit chain if it rejects)
3. Check the return value (which is a maybe action), and
    - If `action.error` exists, exit the chain
    - If `action.payload.error` exists, exit the chain
    - If no more actions in the chain, return the last action dispatched
    - Else, increment the chain index and go back to (1)

So, to run a chain of actions, bailing out at the first sign of trouble:

```js
dispatch(chainActions(action1, action2, action3))
```

Cool? Cool. All this being said, I don't like introducing this sort of bespoke work for what is almost certainly a solved problem, so I'd like to rip this out as soon as possible with something from `npm`. This could coincide nicely with a boilerplate reduction refactor of the API client. For now, though, this is easier than trying to reconfigure everything to use some library solution right now, especially considering we're currently swallowing deck calibration errors.