### PR TITLE
fix(app): Reset calibration state on reset run

### DIFF
--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -141,6 +141,9 @@ export default function calibrationReducer (
     case 'robot:SET_JOG_DISTANCE':
       return handleSetJogDistance(state, action)
 
+    case 'robot:REFRESH_SESSION':
+      return handleSession(state, action)
+
     // TODO(mc, 20187-01-26): caution - not covered by flow yet
     case SESSION: return handleSession(state, action)
     case SET_DECK_POPULATED: return handleSetDeckPopulated(state, action)

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -77,11 +77,34 @@ describe('robot reducer - session', () => {
   })
 
   test('handles robot:REFRESH_SESSION action', () => {
+    const INITIAL_CALIBRATION_STATE = {
+      deckPopulated: null,
+      jogDistance: 0.1,
+
+      // TODO(mc, 2018-01-22): combine these into subreducer
+      probedByMount: {},
+      tipOnByMount: {},
+
+      confirmedBySlot: {},
+
+      calibrationRequest: {type: '', inProgress: false, error: null}
+    }
+
     const state = {
       session: {
         sessionRequest: {inProgress: false, error: null},
         startTime: 40,
         runTime: 42
+      },
+      calibration: {
+        deckPopulated: true,
+        jogDistance: 1,
+        probedByMount: {
+          left: true
+        },
+        confirmedBySlot: {
+          9: true
+        }
       }
     }
     const action = {type: 'robot:REFRESH_SESSION'}
@@ -91,6 +114,7 @@ describe('robot reducer - session', () => {
       startTime: null,
       runTime: 0
     })
+    expect(reducer(state, action).calibration).toEqual(INITIAL_CALIBRATION_STATE)
   })
 
   test('handles SESSION_RESPONSE success', () => {


### PR DESCRIPTION
## overview
This PR fixes #1597 by resetting labware calibration on session refresh. Tipracks are re-enabled and other labware is disabled until tipracks are calibrated again.

## changelog

-fix(app): Reset calibration state on reset run

## review requests
- calibrate labware (tipracks in particular)
- run a protocol to completion or cancel
- click reset run
- navigate back to calibrate screen
    - [ ] tipracks are re-enabled
    - [ ] all other labware is disabled