### PR TITLE
feat(protocol-designer): show a clear incompatible wells error

### DIFF
--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from 'react'
+import _ from 'lodash'
 import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {selectors} from '../file-data'
+import {selectors as steplistSelectors} from '../steplist'
 import {AlertItem} from '@opentrons/components'
 import type {BaseState} from '../types'
 import type {ErrorType, CommandCreatorError} from '../step-generation'
@@ -44,18 +46,24 @@ function Alerts (props: Props) {
   )
 }
 
+const VISIBLE_FORM_ERRORS = ['_mismatchedWells']
+
 function mapStateToProps (state: BaseState): SP {
   const timelineFull = selectors.robotStateTimeline(state)
-  const errors = timelineFull.timelineErrors
+  const timelineErrors = timelineFull.timelineErrors || []
 
+  // TODO: BC 2018-06-12 deal with all form errors uniformly elsewhere
+  const formErrors = steplistSelectors.currentFormErrors(state)
+  const visibleFormErrors = _.filter(formErrors, (key: string, value: string) => VISIBLE_FORM_ERRORS.includes(value)) || []
+  const formAlerts = visibleFormErrors.map(err => ({message: err, type: 'FORM_ERROR'}))
+
+  const errors = [...timelineErrors, ...formAlerts]
   if (!errors || errors.length === 0) {
-    return {
-      alerts: []
-    }
+    return { alerts: [] }
   }
 
   return {
-    alerts: errors.map(err => ({...err})) // NOTE Flow complains about exact obj types if you don't map & unpack here
+    alerts: [...errors.map(err => ({...err}))]// NOTE Flow complains about exact obj types if you don't map & unpack here
 
     // TODO LATER Ian 2018-05-01 generate warnings somewhere, and merge in here with dismissId's
   }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -211,6 +211,7 @@ export type ErrorType =
   | 'PIPETTE_DOES_NOT_EXIST'
   | 'NO_TIP_ON_PIPETTE'
   | 'PIPETTE_VOLUME_EXCEEDED'
+  | 'FORM_ERROR'
 
 export type CommandCreatorError = {|
   message: string,

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -167,7 +167,7 @@ function _vapTransferLike (
 
     if (stepType === 'transfer') {
       if (sourceWells.length !== destWells.length || sourceWells.length === 0) {
-        errors._mismatchedWells = 'Numbers of wells must match'
+        errors._mismatchedWells = 'In transfer actions the number of source and destination wells must match'
       }
 
       const validatedForm: TransferFormData = {
@@ -184,7 +184,7 @@ function _vapTransferLike (
 
     if (stepType === 'consolidate') {
       if (sourceWells.length <= 1 || destWells.length !== 1) {
-        errors._mismatchedWells = 'Multiple source wells and exactly one destination well is required.'
+        errors._mismatchedWells = 'In consolidate actions there must be multiple source wells and one destination well'
       }
 
       const validatedForm: ConsolidateFormData = {
@@ -201,7 +201,7 @@ function _vapTransferLike (
 
     if (stepType === 'distribute') {
       if (sourceWells.length !== 1 || destWells.length <= 1) {
-        errors._mismatchedWells = 'Single source well and multiple destination wells is required.'
+        errors._mismatchedWells = 'In distribute actions there must be one source well and multiple destination wells'
       }
 
       const validatedForm: DistributeFormData = {


### PR DESCRIPTION
## overview

Depending on the action in a step, certain source and destination well combinations should produce a validation error. Display those errors clearly to the user



## review requests

Add a new step and purposefully mismatch the number of source and destination wells and witness 
the error. Example error test cases:

 - transfer -> {source: A1, destination: [A2, A3]}
 - distribute -> {source: A1, destination: A2}
 - consolidate -> {source: A1, destination: [A2, A3]}

Closes #1594
