### PR TITLE
fix(api): Fix RPC reporting wrong models for v1.3 pipettes

### DIFF
--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -234,18 +234,15 @@ class InstrumentsWrapper(object):
         return p
 
     def _retrieve_version_number(self, mount, expected_model_substring):
-        # pass a default pipette model-version, for when robot is simulating
-        # this allows any pipette to be simulated, regardless of what is
-        # actually attached/cached on the robot's mounts
-        default_model = expected_model_substring + '_v1'  # default to v1
-        if robot.is_simulating():
-            return default_model
-
         attached_model = robot.get_attached_pipettes()[mount]['model']
+
         if attached_model and expected_model_substring in attached_model:
             return attached_model
         else:
-            return default_model
+            # pass a default pipette model-version for when robot is simulating
+            # this allows any pipette to be simulated, regardless of what is
+            # actually attached/cached on the robot's mounts
+            return expected_model_substring + '_v1'  # default to v1
 
 
 instruments = InstrumentsWrapper(robot)

--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -117,6 +117,9 @@ class Session(object):
         unsubscribe = subscribe(types.COMMAND, on_command)
 
         try:
+            # ensure actual pipettes are cached before driver is disconnected
+            robot.cache_instrument_models()
+
             # TODO (artyom, 20171005): this will go away
             # once robot / driver simulation flow is fixed
             robot.disconnect()

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -19,6 +19,7 @@ def labware_setup():
     plates = \
         [containers.load('96-PCR-flat', slot, slot) for slot in ['2', '5']]
 
+    # TODO(mc, 2018-06-13): use standard pipette factories
     p100 = instruments.Pipette(
         name='p100', mount='right', channels=8, tip_racks=tip_racks)
 


### PR DESCRIPTION
## overview

This PR also serving as the bug ticket.

As reported by @HenryOpentrons, the app was reporting that an incorrect pipette was attached in the Tip Probe screen even if the correct pipette was attached. Upon further investigation, this was only happening with `v1.3` pipettes, and was due to the fact that the RPC API was _always_ reporting pipettes used in the protocol as `v1` pipettes, regardless of what was attached to the robot.

## changelog

- fix(api): Fix RPC reporting wrong models for v1.3 pipettes
    - Removed redundant `is_simulating` check for retrieving correct model string of pipettes created from config
    - Added attached pipette caching call prior to RPC protocol simulation to ensure proper pipette models were picked up

## review requests

I've tested this on Sunset with a `v1.3` P50. We need to ensure:

- [ ] Virtual smoothie doesn't crap out completely with these changes
- [ ] Real robot with `v1` pipette does not show "incorrect pipette attached" warning
- [ ] Real robot with `v1.3` pipette does not show "incorrect pipette attached" warning
