### PR TITLE
feat(api): Add endpoints to handle API update ignores

### DIFF
--- a/api-server-lib/ot2serverlib/ignore_update.py
+++ b/api-server-lib/ot2serverlib/ignore_update.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+PATH = os.path.abspath(os.path.dirname(__file__))
+filepath = os.path.join(PATH, 'ignore.json')
+
+
+def _set_ignored_version(version):
+    """
+    Private helper function that writes the most updated
+    API version that was ignored by a user in the app
+    :param version: Most recent ignored API update
+    """
+    data = {'version': version}
+    with open(filepath, 'w') as data_file:
+        json.dump(data, data_file)
+
+
+def _get_ignored_version():
+    """
+    :return: Most recently ignored API version
+    """
+    if os.path.exists(filepath):
+        with open(filepath) as data_file:
+            data = json.load(data_file)
+            version = data.get('version')
+    else:
+        version = None
+    return version

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -162,6 +162,10 @@ def init(loop=None):
         '/server/update', endpoints.update_api)
     server.app.router.add_post(
         '/server/update/firmware', endpoints.update_firmware)
+    server.app.router.add_get(
+        '/server/update/ignore', endpoints.get_ignore_version)
+    server.app.router.add_post(
+        '/server/update/ignore', endpoints.set_ignore_version)
     server.app.router.add_post(
         '/server/restart', endpoints.restart)
     server.app.router.add_post(

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -5,6 +5,7 @@ from aiohttp import web
 from opentrons.server.main import init
 from opentrons.server.endpoints import update
 import ot2serverlib
+from ot2serverlib import ignore_update
 
 
 async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
@@ -82,3 +83,33 @@ async def test_feature_flags(
     r2body = await r2.text()
     expected = {flag_name: flag_value}
     assert json.loads(r2body) == expected
+
+
+async def test_ignore_updates(
+        virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    # Test no ignore file found
+    r0 = await cli.get('/server/update/ignore')
+    r0body = await r0.text()
+    assert json.loads(r0body) == {'version': None}
+
+    # Test that values are set correctly
+    ignore_name = "testy_ignore.json"
+    tmpdir = tempfile.mkdtemp("files")
+    ignore_update.filepath = os.path.join(tmpdir, ignore_name)
+
+    ignore = {'version': '3.1.3'}
+    r1 = await cli.post('server/update/ignore', json=ignore)
+    assert r1.status == 200
+
+    # Test that you cannot pass an empty version
+    ignore2 = {'version': ''}
+    r2 = await cli.post('server/update/ignore', json=ignore2)
+    assert r2.status == 400
+
+    # Test that version in the temporary directory is still '3.1.3'
+    r3 = await cli.get('/server/update/ignore')
+    r3body = await r3.text()
+    assert json.loads(r3body) == {'version': '3.1.3'}


### PR DESCRIPTION
## overview
Closes #1624. Provides two endpoints, a getter and setter, to handle returning the currently ignored update. Tested on young- 🌔 

## changelog

- Adds GET request under /server/update/ignore
- Adds POST request under /server/update/ignore which is formatted as:
{'IgnoreStatus': 'True or False', 'IgnoredVersion': 'Version String'}

## review requests

@Kadee80 does this implementation make sense? Any other use cases to return something other than status 200?