### PR TITLE
chore(protocol-designer): support ultra-minimal feature flags

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -7,6 +7,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const {rules} = require('@opentrons/webpack-config')
 
 const DEV = process.env.NODE_ENV !== 'production'
+const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 
 module.exports = {
   entry: [
@@ -33,10 +34,11 @@ module.exports = {
   devtool: DEV ? 'eval-source-map' : 'source-map',
 
   plugins: [
-    new webpack.EnvironmentPlugin({
-      NODE_ENV: 'development',
-      DEBUG: false
-    }),
+    new webpack.EnvironmentPlugin(
+      Object.keys(process.env).filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX)).concat([
+        'NODE_ENV'
+      ])
+    ),
 
     new ExtractTextPlugin({
       filename: 'bundle.css',


### PR DESCRIPTION
## overview

This is a super basic fast path to hiding the warnings we're going to make from showing production until they're ready. Copied small part of the pattern from app's config.

## changelog

- basic env var plugging in
- Clean out old README and add section for keeping track of env vars

## review requests

If you go to something like `protocol-designer/src/components/App.js` and do `console.log('env var test', process.env.OT_PD_SOMETHING)` then do ` OT_PD_SOMETHING=spam make dev`, you should see `'env var test', 'spam'` in the console