### PR TITLE
feat(app): Show connect alert banner on successful connection

### DIFF
--- a/app/src/components/RobotSettings/ConnectBanner.js
+++ b/app/src/components/RobotSettings/ConnectBanner.js
@@ -20,15 +20,14 @@ export default class ConnectBanner extends React.Component <Robot, State> {
     const {isConnected, name} = this.props
     const isVisible = isConnected && !this.state.dismissed
     const TITLE = `${name} successfully connected`
+    if (!isVisible) {
+      return null
+    }
     return (
-      <div>
-        {isVisible && (
-          <AlertItem
-            type='success'
-            onCloseClick={() => this.setState({dismissed: true})}
-            title={TITLE} />
-        )}
-      </div>
+      <AlertItem
+        type='success'
+        onCloseClick={() => this.setState({dismissed: true})}
+        title={TITLE} />
     )
   }
 }

--- a/app/src/components/RobotSettings/ConnectBanner.js
+++ b/app/src/components/RobotSettings/ConnectBanner.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import {type Robot} from '../../robot'
+import {AlertItem} from '@opentrons/components'
+
+type State = {
+  dismissed: boolean
+}
+
+export default class ConnectBanner extends React.Component <Robot, State> {
+  constructor (props: Robot) {
+    super(props)
+
+    this.state = {
+      dismissed: false
+    }
+  }
+
+  render () {
+    const {isConnected, name} = this.props
+    const isVisible = isConnected && !this.state.dismissed
+    const TITLE = `${name} successfully connected`
+    return (
+      <div>
+        {isVisible && (
+          <AlertItem
+            type='success'
+            onCloseClick={() => this.setState({dismissed: true})}
+            title={TITLE} />
+        )}
+      </div>
+    )
+  }
+}

--- a/app/src/pages/Robots.js
+++ b/app/src/pages/Robots.js
@@ -14,6 +14,7 @@ import Page from '../components/Page'
 import RobotSettings, {ConnectAlertModal} from '../components/RobotSettings'
 import ChangePipette from '../components/ChangePipette'
 import CalibrateDeck from '../components/CalibrateDeck'
+import ConnectBanner from '../components/RobotSettings/ConnectBanner'
 
 type StateProps = {
   robot: ?Robot,
@@ -58,6 +59,7 @@ function RobotSettingsPage (props: Props) {
   return (
     <Page>
       <TitleBar title={robot.name} />
+      <ConnectBanner {...robot} key={Number(robot.isConnected)}/>
       <RobotSettings {...robot} />
 
       <Route path={`${path}/pipettes`} render={(props) => (


### PR DESCRIPTION
## overview
This PR closes #1314. Will open a separate issue for connectRequest error banner.

<img width="800" alt="screen shot 2018-06-14 at 2 19 32 pm" src="https://user-images.githubusercontent.com/3430313/41431940-86542f82-6fe2-11e8-9398-452071be7c7b.png">

## changelog

- feat(app): Show connect alert banner on successful connection

## review requests
- [x] connection banner displays on successful robot connect
- [x] connection banner is dismissible 
- [x] dismissed banner reappears on disconnect and reconnect