### PR TITLE
feat(update-server): Add basic update server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@
 !/shared-data/**
 !/audio/**
 !/compute/**
+!/api-server-lib/**
+!/update-server/**
 !/api/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ before_install:
 install:
   - make install
 
+before_script:
+  # Get all branches to allow comparison for mono-repo management tools
+  - git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  - git fetch
+
 script:
   - make test
   - if [[ $LINT = true ]]; then make lint; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,41 @@ This Contributing Guide was influenced by a lot of work done on existing Contrib
 *   [Node.js Contributing Guide][node-contributing]
 *   [Kibana Contributing Guide][kibana-contributing]
 
+## Developer "Gotchas"
+
+This section contains general information about problems we've encountered before so we don't have to keep researching the same issue over and over (and instead of keeping the info in the heads of individual developers)
+
+### Docker issues
+
+#### COPY
+
+If you get an error in Docker build like this:
+
+```
+Step 24/45 : COPY ./api-server-lib /tmp/api-server-lib
+COPY failed: stat /var/lib/docker/tmp/docker-builder657112660/api-server-lib: no such file or directory
+```
+
+You need to add an exception the directory to the ".dockerignore" file. In this case, the exception is `!/api-server-lib/**`
+
+#### Architecture
+
+If you run a Docker image on your computer and get:
+
+```
+Unknown target IFA type: 6
+```
+
+You probably built against the wrong CPU architecture (ARM instead of x86_64). The top of the Dockerfile has two `FROM` lines, with one of them commented out. Comment out the one that contains "raspberrypi3" and uncomment the one that contains "amd64", and then re-build your image.
+
+If you get:
+
+```
+panic: standard_init_linux.go:175: exec user process caused "exec format error"
+```
+
+You probably built against x86_64 and tried to run it on a Raspberry Pi. Switch to the "raspberrypi" `FROM` line.
+
 [repo]: https://github.com/Opentrons/opentrons
 [api-readme]: ./api/README.rst
 [easyfix]: https://github.com/Opentrons/opentrons/issues?q=is%3Aopen+is%3Aissue+label%3Aeasyfix

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV PATH=$PATH:/data/packages/usr/local/bin
 # Port name for connecting to smoothie over serial, i.e. /dev/ttyAMA0
 ENV OT_SMOOTHIE_ID=AMA
 ENV OT_SERVER_PORT=31950
+ENV OT_UPDATE_PORT=34000
 # File path to unix socket API server is listening
 ENV OT_SERVER_UNIX_SOCKET_PATH=/tmp/aiohttp.sock
 
@@ -66,14 +67,20 @@ COPY ./compute/conf/jupyter_notebook_config.py /root/.jupyter/
 COPY ./shared-data/definitions /etc/labware
 COPY ./audio/ /etc/audio
 COPY ./api /tmp/api
+COPY ./api-server-lib /tmp/api-server-lib
+COPY ./update-server /tmp/update-server
 COPY ./compute/avahi_tools /tmp/avahi_tools
 
 # When adding more python packages make sure to use setuptools to keep
 # packaging consistent across environments
 ENV PIPENV_VENV_IN_PROJECT=true
-RUN pipenv install /tmp/api --system && \
+RUN pipenv install /tmp/api-server-lib --system && \
+    pipenv install /tmp/api --system && \
+    pipenv install /tmp/update-server --system && \
     pip install /tmp/avahi_tools && \
     rm -rf /tmp/api && \
+    rm -rf /tmp/api-server-lib && \
+    rm -rf /tmp/update-server && \
     rm -rf /tmp/avahi_tools
 
 # Redirect nginx logs to stdout and stderr

--- a/compute/conf/nginx.conf
+++ b/compute/conf/nginx.conf
@@ -23,12 +23,22 @@ http {
 
         access_log /data/nginx-access.log;
 
+        # If nginx matches multiple location paths, it uses the one with the
+        # longest prefix, so order shouldn't matter but length of path does
         location / {
             proxy_http_version       1.1;
             proxy_set_header         Upgrade $http_upgrade;
             proxy_set_header         Connection "upgrade";
             proxy_read_timeout       1h;
             proxy_pass               http://unix:{OT_SERVER_UNIX_SOCKET_PATH};
+        }
+
+        location /server {
+            proxy_http_version       1.1;
+            proxy_set_header         Upgrade $http_upgrade;
+            proxy_set_header         Connection "upgrade";
+            proxy_read_timeout       1h;
+            proxy_pass               http://127.0.0.1:34000;
         }
     }
 

--- a/compute/scripts/setup.sh
+++ b/compute/scripts/setup.sh
@@ -32,8 +32,10 @@ touch /data/id
 previous_id=$(cat /data/id)
 current_id=$CONTAINER_ID
 if [ "$previous_id" != "$current_id" ] ; then
-  echo 'First start of a new container. Deleting local Opentrons API installation'
+  echo 'First start of a new container. Deleting local Opentrons installation'
   rm -rf /data/packages/usr/local/lib/python3.6/site-packages/opentrons*
+  rm -rf /data/packages/usr/local/lib/python3.6/site-packages/ot2serverlib*
+  rm -rf /data/packages/usr/local/lib/python3.6/site-packages/otupdate*
   echo "$current_id" > /data/id
 fi
 

--- a/compute/scripts/start.sh
+++ b/compute/scripts/start.sh
@@ -15,7 +15,9 @@ inetd -e /etc/inetd.conf
 mkdir -p /data/boot.d
 run-parts /data/boot.d
 
-# Start Jupyter Notebook server
+echo "Starting Opentrons update server"
+python -m otupdate --debug --port $OT_UPDATE_PORT &
+
 echo "Starting Jupyter Notebook server"
 mkdir -p /data/user_storage/opentrons_data/jupyter
 jupyter notebook --allow-root &

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "shared-data",
     "protocol-designer",
     "webpack-config",
+    "update-server/otupdate",
     "api/opentrons",
     "api-server-lib/ot2serverlib"
   ],

--- a/update-server/MANIFEST.in
+++ b/update-server/MANIFEST.in
@@ -1,0 +1,1 @@
+include otupdate/package.json

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,0 +1,46 @@
+SHELL := /bin/bash
+
+# add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
+PATH := $(shell cd .. && yarn bin):$(PATH)
+
+python := pipenv run python
+pipenv_opts := --dev
+pipenv_opts += $(and $(CI),--ignore-pipfile)
+port ?= 34000
+
+.PHONY: install
+install:
+	pipenv install $(pipenv_opts)
+
+.PHONY: dev
+dev:
+	ENABLE_VIRTUAL_SMOOTHIE=true $(python) -m otupdate --debug --port $(port)
+
+.PHONY: clean
+clean:
+	shx rm -rf \
+		build \
+		dist \
+		.coverage \
+		coverage.xml \
+		'*.egg-info' \
+		'**/__pycache__' \
+		'**/*.pyc'
+
+.PHONY: test
+test:
+	$(python) -m pytest \
+		--cov=otupdate \
+		--cov-report term-missing:skip-covered \
+		--cov-report xml:coverage.xml \
+		tests -s -vv
+
+.PHONY: lint
+lint:
+	$(python) -m pylama otupdate tests
+
+.PHONY: wheel
+wheel: clean
+	$(python) setup.py bdist_wheel
+	shx rm -rf build
+	shx ls dist

--- a/update-server/Pipfile
+++ b/update-server/Pipfile
@@ -1,0 +1,29 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+"e1839a8" = {path = ".", editable = true}
+virtualenv = "*"
+aiohttp = "==2.3.8"
+
+
+[dev-packages]
+
+pylama = "==7.4.3"
+pytest = "==3.4.2"
+pytest-cov = "==2.5.1"
+pytest-aiohttp = "==0.2.0"
+sphinx = "==1.4.8"
+twine = "==1.8.1"
+wheel = "==0.30.0"
+coverage = "==4.4.2"
+
+
+[requires]
+
+python_version = "3.6"

--- a/update-server/Pipfile.lock
+++ b/update-server/Pipfile.lock
@@ -1,0 +1,518 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d5ae5b398e3e2751c4a06bdd8a762f726d065549447edf27eeac5c35695e3a5e"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "aiohttp": {
+            "hashes": [
+                "sha256:02f77d7d5467d71144a07c5e817a81ef5ccb005cbbba61c2f207b60db320e716",
+                "sha256:335c1ac277784eb6ba3d3b4e6901b06df3c5c93926026c594c4fdb61e270542d",
+                "sha256:37b62fa71369f2d6c9828d427b9a22829d603943a915fab216a99fc98447342b",
+                "sha256:48a798891ec157049f6b02e8ed1909e09c35aa03a29a90006215b8fb936185c4",
+                "sha256:536e9b6d1f8c1ebc44af530879c41fa0204369b5d2257bd1995534faacefad92",
+                "sha256:56fd240c9eb3bc09c081ca2e5b677be433ac84657b13ac29bc8deb16ba0b4f0b",
+                "sha256:6a12fa57d0608da29060c6fac531d049317422eecb23f509f8fae5b9a24c5b79",
+                "sha256:709ef5e6172b58cadb6575509baf7dacd97504911b54a654ab74f728f764249d",
+                "sha256:862c68d1237b811915a2614e996a3d60ed8d167e1e66e0b6c031a4aace5cf67f",
+                "sha256:8b2c9b1f43e12fe8837455ce4caf3a8621c3ab474219f11bd0270ca1c0735fc7",
+                "sha256:9ca64837c9a6d66543c1b49e6f04132ef9f2683377fe28f2497b7152e9d3c312",
+                "sha256:afec8fd2a464f8837cf019a26c52271d65f72512ae8ef2c05217086230fa50f1",
+                "sha256:b67b4238498225db921911f873e4b6959d51de55d7b71ced8e902aed9d6ff2aa",
+                "sha256:b7b5a4e34d3a4d9ecce4aa9e172a0fd13c8f5acee46afeb5944c4489f71701c1",
+                "sha256:c7b8a47315e8c0b79a008e33eca4299baa002efd4b53ace068f0894133a8933e",
+                "sha256:e81997b2fb4b7f19a80257aa2bb6e35e521d62dcf595599bf34886b115607bad"
+            ],
+            "index": "pypi",
+            "version": "==2.3.8"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
+                "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
+            ],
+            "version": "==3.0.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+            ],
+            "version": "==1.0.1"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:1a1d76374a1e7fe93acef96b354a03c1d7f83e7512e225a527d283da0d7ba5e0",
+                "sha256:1d6e191965505652f194bc4c40270a842922685918a4f45e6936a6b15cc5816d",
+                "sha256:295961a6a88f1199e19968e15d9b42f3a191c89ec13034dbc212bf9c394c3c82",
+                "sha256:2be5af084de6c3b8e20d6421cb0346378a9c867dcf7c86030d6b0b550f9888e4",
+                "sha256:2eb99617c7a0e9f2b90b64bc1fb742611718618572747d6f3d6532b7b78755ab",
+                "sha256:4ba654c6b5ad1ae4a4d792abeb695b29ce981bb0f157a41d0fd227b385f2bef0",
+                "sha256:5ba766433c30d703f6b2c17eb0b6826c6f898e5f58d89373e235f07764952314",
+                "sha256:a59d58ee85b11f337b54933e8d758b2356fcdcc493248e004c9c5e5d11eedbe4",
+                "sha256:a6e35d28900cf87bcc11e6ca9e474db0099b78f0be0a41d95bef02d49101b5b2",
+                "sha256:b4df7ca9c01018a51e43937eaa41f2f5dce17a6382fda0086403bcb1f5c2cf8e",
+                "sha256:bbd5a6bffd3ba8bfe75b16b5e28af15265538e8be011b0b9fddc7d86a453fd4a",
+                "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
+                "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
+            ],
+            "version": "==4.3.1"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
+                "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
+            ],
+            "index": "pypi",
+            "version": "==16.0.0"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
+            ],
+            "version": "==1.2.6"
+        }
+    },
+    "develop": {
+        "aiohttp": {
+            "hashes": [
+                "sha256:02f77d7d5467d71144a07c5e817a81ef5ccb005cbbba61c2f207b60db320e716",
+                "sha256:335c1ac277784eb6ba3d3b4e6901b06df3c5c93926026c594c4fdb61e270542d",
+                "sha256:37b62fa71369f2d6c9828d427b9a22829d603943a915fab216a99fc98447342b",
+                "sha256:48a798891ec157049f6b02e8ed1909e09c35aa03a29a90006215b8fb936185c4",
+                "sha256:536e9b6d1f8c1ebc44af530879c41fa0204369b5d2257bd1995534faacefad92",
+                "sha256:56fd240c9eb3bc09c081ca2e5b677be433ac84657b13ac29bc8deb16ba0b4f0b",
+                "sha256:6a12fa57d0608da29060c6fac531d049317422eecb23f509f8fae5b9a24c5b79",
+                "sha256:709ef5e6172b58cadb6575509baf7dacd97504911b54a654ab74f728f764249d",
+                "sha256:862c68d1237b811915a2614e996a3d60ed8d167e1e66e0b6c031a4aace5cf67f",
+                "sha256:8b2c9b1f43e12fe8837455ce4caf3a8621c3ab474219f11bd0270ca1c0735fc7",
+                "sha256:9ca64837c9a6d66543c1b49e6f04132ef9f2683377fe28f2497b7152e9d3c312",
+                "sha256:afec8fd2a464f8837cf019a26c52271d65f72512ae8ef2c05217086230fa50f1",
+                "sha256:b67b4238498225db921911f873e4b6959d51de55d7b71ced8e902aed9d6ff2aa",
+                "sha256:b7b5a4e34d3a4d9ecce4aa9e172a0fd13c8f5acee46afeb5944c4489f71701c1",
+                "sha256:c7b8a47315e8c0b79a008e33eca4299baa002efd4b53ace068f0894133a8933e",
+                "sha256:e81997b2fb4b7f19a80257aa2bb6e35e521d62dcf595599bf34886b115607bad"
+            ],
+            "index": "pypi",
+            "version": "==2.3.8"
+        },
+        "alabaster": {
+            "hashes": [
+                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
+                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
+            ],
+            "version": "==0.7.11"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
+                "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
+            ],
+            "version": "==3.0.0"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
+                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+            ],
+            "version": "==2.6.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.3.9"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:007eeef7e23f9473622f7d94a3e029a45d55a92a1f083f0f3512f5ab9a669b05",
+                "sha256:0388c12539372bb92d6dde68b4627f0300d948965bbb7fc104924d715fdc0965",
+                "sha256:079248312838c4c8f3494934ab7382a42d42d5f365f0cf7516f938dbb3f53f3f",
+                "sha256:17307429935f96c986a1b1674f78079528833410750321d22b5fb35d1883828e",
+                "sha256:1afccd7e27cac1b9617be8c769f6d8a6d363699c9b86820f40c74cfb3328921c",
+                "sha256:2ad357d12971e77360034c1596011a03f50c0f9e1ecd12e081342b8d1aee2236",
+                "sha256:2b4d7f03a8a6632598cbc5df15bbca9f778c43db7cf1a838f4fa2c8599a8691a",
+                "sha256:2e1a5c6adebb93c3b175103c2f855eda957283c10cf937d791d81bef8872d6ca",
+                "sha256:309d91bd7a35063ec7a0e4d75645488bfab3f0b66373e7722f23da7f5b0f34cc",
+                "sha256:358d635b1fc22a425444d52f26287ae5aea9e96e254ff3c59c407426f44574f4",
+                "sha256:3f4d0b3403d3e110d2588c275540649b1841725f5a11a7162620224155d00ba2",
+                "sha256:43a155eb76025c61fc20c3d03b89ca28efa6f5be572ab6110b2fb68eda96bfea",
+                "sha256:493082f104b5ca920e97a485913de254cbe351900deed72d4264571c73464cd0",
+                "sha256:4c4f368ffe1c2e7602359c2c50233269f3abe1c48ca6b288dcd0fb1d1c679733",
+                "sha256:5ff16548492e8a12e65ff3d55857ccd818584ed587a6c2898a9ebbe09a880674",
+                "sha256:66f393e10dd866be267deb3feca39babba08ae13763e0fc7a1063cbe1f8e49f6",
+                "sha256:700d7579995044dc724847560b78ac786f0ca292867447afda7727a6fbaa082e",
+                "sha256:81912cfe276e0069dca99e1e4e6be7b06b5fc8342641c6b472cb2fed7de7ae18",
+                "sha256:82cbd3317320aa63c65555aa4894bf33a13fb3a77f079059eb5935eea415938d",
+                "sha256:845fddf89dca1e94abe168760a38271abfc2e31863fbb4ada7f9a99337d7c3dc",
+                "sha256:87d942863fe74b1c3be83a045996addf1639218c2cb89c5da18c06c0fe3917ea",
+                "sha256:9721f1b7275d3112dc7ccf63f0553c769f09b5c25a26ee45872c7f5c09edf6c1",
+                "sha256:a4497faa4f1c0fc365ba05eaecfb6b5d24e3c8c72e95938f9524e29dadb15e76",
+                "sha256:a7cfaebd8f24c2b537fa6a271229b051cdac9c1734bb6f939ccfc7c055689baa",
+                "sha256:ab3508df9a92c1d3362343d235420d08e2662969b83134f8a97dc1451cbe5e84",
+                "sha256:b0059630ca5c6b297690a6bf57bf2fdac1395c24b7935fd73ee64190276b743b",
+                "sha256:b6cebae1502ce5b87d7c6f532fa90ab345cfbda62b95aeea4e431e164d498a3d",
+                "sha256:bd4800e32b4c8d99c3a2c943f1ac430cbf80658d884123d19639bcde90dad44a",
+                "sha256:cdd92dd9471e624cd1d8c1a2703d25f114b59b736b0f1f659a98414e535ffb3d",
+                "sha256:d00e29b78ff610d300b2c37049a41234d48ea4f2d2581759ebcf67caaf731c31",
+                "sha256:d1ee76f560c3c3e8faada866a07a32485445e16ed2206ac8378bd90dadffb9f0",
+                "sha256:dd707a21332615108b736ef0b8513d3edaf12d2a7d5fc26cd04a169a8ae9b526",
+                "sha256:e3ba9b14607c23623cf38f90b23f5bed4a3be87cbfa96e2e9f4eabb975d1e98b",
+                "sha256:e9a0e1caed2a52f15c96507ab78a48f346c05681a49c5b003172f8073da6aa6b",
+                "sha256:eea9135432428d3ca7ee9be86af27cb8e56243f73764a9b6c3e0bda1394916be",
+                "sha256:f29841e865590af72c4b90d7b5b8e93fd560f5dea436c1d5ee8053788f9285de",
+                "sha256:f3a5c6d054c531536a83521c00e5d4004f1e126e2e2556ce399bef4180fbe540",
+                "sha256:f87f522bde5540d8a4b11df80058281ac38c44b13ce29ced1e294963dd51a8f8",
+                "sha256:f8c55dd0f56d3d618dfacf129e010cbe5d5f94b6951c1b2f13ab1a2f79c284da",
+                "sha256:f98b461cb59f117887aa634a66022c0bd394278245ed51189f63a036516e32de"
+            ],
+            "index": "pypi",
+            "version": "==4.4.2"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+            ],
+            "version": "==1.0.1"
+        },
+        "imagesize": {
+            "hashes": [
+                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
+                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
+            ],
+            "version": "==1.0.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+            ],
+            "version": "==1.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+            ],
+            "version": "==4.2.0"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:1a1d76374a1e7fe93acef96b354a03c1d7f83e7512e225a527d283da0d7ba5e0",
+                "sha256:1d6e191965505652f194bc4c40270a842922685918a4f45e6936a6b15cc5816d",
+                "sha256:295961a6a88f1199e19968e15d9b42f3a191c89ec13034dbc212bf9c394c3c82",
+                "sha256:2be5af084de6c3b8e20d6421cb0346378a9c867dcf7c86030d6b0b550f9888e4",
+                "sha256:2eb99617c7a0e9f2b90b64bc1fb742611718618572747d6f3d6532b7b78755ab",
+                "sha256:4ba654c6b5ad1ae4a4d792abeb695b29ce981bb0f157a41d0fd227b385f2bef0",
+                "sha256:5ba766433c30d703f6b2c17eb0b6826c6f898e5f58d89373e235f07764952314",
+                "sha256:a59d58ee85b11f337b54933e8d758b2356fcdcc493248e004c9c5e5d11eedbe4",
+                "sha256:a6e35d28900cf87bcc11e6ca9e474db0099b78f0be0a41d95bef02d49101b5b2",
+                "sha256:b4df7ca9c01018a51e43937eaa41f2f5dce17a6382fda0086403bcb1f5c2cf8e",
+                "sha256:bbd5a6bffd3ba8bfe75b16b5e28af15265538e8be011b0b9fddc7d86a453fd4a",
+                "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
+                "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
+            ],
+            "version": "==4.3.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
+                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
+            ],
+            "version": "==17.1"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474",
+                "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
+            ],
+            "version": "==1.4.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+            ],
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+            ],
+            "version": "==1.5.3"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0",
+                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
+                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+            ],
+            "version": "==2.4.0"
+        },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:08a870edc94508264ed90510db466c6357c7192e0e866561d740624a8fc7d90c",
+                "sha256:4d5bcde961107873bae621f3d580c3e35a426d3687ffc6f8fb356f6628da5a97",
+                "sha256:af9fcccb303899b83bec82dc9a1d56c60fc369973223a5e80c3dfa9bdf984405"
+            ],
+            "version": "==2.1.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
+                "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
+            ],
+            "version": "==2.0.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
+                "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+            ],
+            "version": "==2.2.0"
+        },
+        "pylama": {
+            "hashes": [
+                "sha256:390c1dab1daebdf3d6acc923e551b035c3faa77d8b96b98530c230493f9ec712",
+                "sha256:a3670459e7855529e2ccd3959e0bdebd694ac62bcdc7c58a877f3456c0a2058b"
+            ],
+            "index": "pypi",
+            "version": "==7.4.3"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
+                "sha256:281683241b25fe9b80ec9d66017485f6deff1af5cde372469134b56ca8447a07",
+                "sha256:8f1e18d3fd36c6795bb7e02a39fd05c611ffc2596c1e0d995d34d67630426c18",
+                "sha256:9e8143a3e15c13713506886badd96ca4b579a87fbdf49e550dbfc057d6cb218e",
+                "sha256:b8b3117ed9bdf45e14dcc89345ce638ec7e0e29b2b579fa1ecf32ce45ebac8a5",
+                "sha256:e4d45427c6e20a59bf4f88c639dcc03ce30d193112047f94012102f235853a58",
+                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
+            ],
+            "version": "==2.2.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:062027955bccbc04d2fcd5d79690947e018ba31abe4c90b2c6721abec734261b",
+                "sha256:117bad36c1a787e1a8a659df35de53ba05f9f3398fb9e4ac17e80ad5903eb8c5"
+            ],
+            "index": "pypi",
+            "version": "==3.4.2"
+        },
+        "pytest-aiohttp": {
+            "hashes": [
+                "sha256:7497601a9cfd567d2e7f7daaee1ceca32720710e8c0e1361a5b5b76f750ac3bd",
+                "sha256:ecbd8eb108c61351318ac69d5dd9d0d6185cb00694422eead2ced0dd4e9821f2"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
+                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+            ],
+            "index": "pypi",
+            "version": "==2.5.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
+                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
+            ],
+            "version": "==2018.4"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
+                "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
+            ],
+            "version": "==0.8.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128",
+                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
+            ],
+            "version": "==1.2.1"
+        },
+        "sphinx": {
+            "hashes": [
+                "sha256:41af978f653ef862eb4bb3776dabd8ff13afed17e431907310fe990a3947707f",
+                "sha256:c715b714228bd135a41b33ff91e5f41ac434ceb6e98a86447687a2177e7486b9"
+            ],
+            "index": "pypi",
+            "version": "==1.4.8"
+        },
+        "sphinxcontrib-websupport": {
+            "hashes": [
+                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
+                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
+            ],
+            "version": "==1.1.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:224291ee0d8c52d91b037fd90806f48c79bcd9994d3b0abc9e44b946a908fccd",
+                "sha256:77b8424d41b31e68f437c6dd9cd567aebc9a860507cb42fbd880a5f822d966fe"
+            ],
+            "version": "==4.23.4"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:3202d943a144962a821d9c5e92e07f9442dbbe6d6f18eae74e2a725b9980c559",
+                "sha256:68b663691a947b844f92853c992d42bb68b6333bffc9ab7f661346b001c1da82"
+            ],
+            "index": "pypi",
+            "version": "==1.8.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "version": "==1.23"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8",
+                "sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"
+            ],
+            "index": "pypi",
+            "version": "==0.30.0"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
+            ],
+            "version": "==1.2.6"
+        }
+    }
+}

--- a/update-server/README.md
+++ b/update-server/README.md
@@ -1,0 +1,43 @@
+# Opentrons Update Server
+
+An HTTP server for updating software, firmware, and configration files
+on Opentrons robots
+
+## Design considerations
+
+The absolute most vital task that this server can perform is to ensure
+that it is able to boostrap itself without failing. Whenever the update
+server receives an update to itself, it must test the new install and
+ensure that it is able to boot and receive a successive update. To
+guarantee this, the update server should install a potential update in
+a virtual environment and boot the new server, then ship an update to
+it (the successive update could be the same wheel as the new server
+itself). If it is able to boot and accept a health check and an update,
+then it should be installed and the server restarted so the new update
+server takes effect.
+
+This test is optional (though preferred) for updating configuration
+files and other applications, such as the API server.
+
+## Developement Environment and Testing
+
+To set up the development environment, see the contributing guide in the
+root of the [Opentrons/opentrons repository](https://github.com/Opentrons/opentrons).
+
+To test the update server, open a terminal to this directory and enter:
+
+```bash
+make install
+make test
+make lint
+```
+
+To run a development server (assuming this project is already installed)
+open a terminal to this directory and enter:
+
+```
+make dev
+```
+
+Once the server boots, you will see a message including the address on which
+the server is listening for requests.

--- a/update-server/otupdate/__init__.py
+++ b/update-server/otupdate/__init__.py
@@ -1,0 +1,66 @@
+import os
+import json
+import logging
+
+from aiohttp import web
+from functools import partial
+from otupdate import endpoints as endp
+
+log = logging.getLogger(__name__)
+
+
+def get_version(path) -> str:
+    """
+    Reads the version field from a package file
+
+    :param path: the path to a valid package.json file
+    :return: the version string or "unknown"
+    """
+    if path and os.path.exists(path):
+            with open(path) as pkg:
+                package_dict = json.load(pkg)
+                version = package_dict.get('version')
+    else:
+        version = 'not available'
+    return version
+
+
+# this naming logic is copied from compute/scripts/anounce_mdns.py
+def get_name() -> str:
+    device_name = 'opentrons-{}'.format(
+        os.environ.get('RESIN_DEVICE_NAME_AT_INIT', 'dev'))
+    return device_name
+
+
+def get_app(
+        api_package,
+        update_package,
+        smoothie_version,
+        test,
+        loop=None) -> web.Application:
+    # Health endpoint built here in order to keep from having state initialized
+    # on import of sub-modules
+    api_server_version = get_version(api_package)
+    update_server_version = get_version(update_package)
+    device_name = get_name()
+    log.info("  Device name:            {}".format(device_name))
+    log.info("  Update server version:  {}".format(update_server_version))
+    log.info("  API server version:     {}".format(api_server_version))
+    log.info("  Smoothie FW version:    {}".format(smoothie_version))
+    log.info("  Test mode:              {}".format(test))
+
+    health = endp.build_health_endpoint(
+        name=device_name,
+        update_server_version=update_server_version,
+        api_server_version=api_server_version,
+        smoothie_version=smoothie_version
+    )
+    bootstrap_fn = partial(
+        endp.bootstrap_update_server, test_flag=test)
+
+    app = web.Application(loop=loop)
+    app.router.add_routes([
+        web.get('/server/update/health', health),
+        web.post('/server/update/bootstrap', bootstrap_fn)
+    ])
+    return app

--- a/update-server/otupdate/__main__.py
+++ b/update-server/otupdate/__main__.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import logging
+import asyncio
+from aiohttp import web
+from otupdate import get_app
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', dest='port', type=int)
+    parser.add_argument('--host', dest='host', type=str, default='127.0.0.1')
+    parser.add_argument('--test', action='store_true')
+    parser.add_argument('--debug', action='store_true')
+    args = parser.parse_args()
+
+    if sys.platform == 'win32':
+        loop = asyncio.ProactorEventLoop()
+        asyncio.set_event_loop(loop)
+
+    # package.json location for the update server
+    update_package = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), 'package.json')
+
+    # package.json location for the API server installed in the update server's
+    # environment (e.g.: which version is available by import). This is one way
+    # of finding this info, but it could also be determined by making an HTTP
+    # request to the API server and selecting this info. In the future, this
+    # server should check the health of the API server process and possibly get
+    # the version that way instead.
+    try:
+        import opentrons
+        api_package = os.path.join(
+            os.path.abspath(os.path.dirname(opentrons.__file__)),
+            'package.json')
+        opentrons.robot.connect()
+        smoothie_version = opentrons.robot.fw_version
+    except Exception:
+        print("Module `opentrons` import failed")
+        api_package = None
+        smoothie_version = 'not available'
+
+    fmt = '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'
+    config_dict = {
+        'format': fmt,
+        'level': 'DEBUG' if args.debug else 'INFO'
+    }
+    logging.basicConfig(**config_dict)
+    log = logging.getLogger(__name__)
+
+    log.info('Starting update server on http://{}:{}'.format(
+        args.host, args.port))
+    app = get_app(
+        api_package=api_package,
+        update_package=update_package,
+        smoothie_version=smoothie_version,
+        test=args.test)
+    web.run_app(app, host=args.host, port=args.port)
+
+
+main()

--- a/update-server/otupdate/bootstrap.py
+++ b/update-server/otupdate/bootstrap.py
@@ -1,0 +1,257 @@
+"""
+This module is responsible for installing an update in a virtual environment
+and testing it, to ensure that the new version of software will boot correctly
+and accept successive updates.
+"""
+import os
+import sys
+import atexit
+import shutil
+import logging
+import tempfile
+import asyncio
+import aiohttp
+import subprocess as sp
+from otupdate import selftest
+
+log = logging.getLogger(__name__)
+VENV_NAME = 'env'
+
+
+async def _install(python, filename, loop) -> (str, str):
+    running_on_pi = os.environ.get('RUNNING_ON_PI') and '/tmp' in python
+    python_home = python.split(VENV_NAME)[0] + VENV_NAME
+
+    if running_on_pi:
+        env_vars = 'PYTHONHOME={} '.format(python_home)
+    else:
+        env_vars = ''
+
+    pip_opts = '--upgrade --force-reinstall --no-deps'
+    command = '{}{} -m pip install {} {}'.format(
+        env_vars, python, pip_opts, filename)
+
+    log.debug('cmd: {}'.format(command))
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        loop=loop)
+
+    rd_out = await proc.stdout.read()
+    rd_err = await proc.stderr.read()
+    out = rd_out.decode().strip()
+    err = rd_err.decode().strip()
+    log.debug("Out: {}".format(out))
+    log.debug("Err: {}".format(err))
+    await proc.communicate()
+
+    if running_on_pi:
+        # For some reason, the pip install above (using a python binary at
+        # "/tmp/tmp<hash>/env/bin/python" causes the package to be installed
+        # in "/data/packages/tmp/tmp<hash>/env/lib/python3.6/site-packages",
+        # so it is not found unless it is subsequently copied into the same
+        # path without the preceeding "/data/packages". Note that for the join
+        # to work correctly, the leading '/' has to be dropped from
+        # `python_home`. This whole difficulty is a side-effect of not calling
+        # the `activate` script of the virtual environment, but if the activate
+        # script is called in a subprocess then the server must be started in
+        # the same shell and we lose the reference to the server (the
+        # subprocess ends up pointing to the activate shell and killing it does
+        # not halt the server.
+        src_spk = os.path.join(
+            '/data/packages',
+            python_home[1:],
+            'lib',
+            'python3.6',
+            'site-packages')
+        dst_spk = os.path.join(python_home, 'lib', 'python3.6')
+        dst_packages = os.listdir(dst_spk)
+        for pkg in os.listdir(src_spk):
+            if pkg not in dst_packages:
+                src = os.path.join(src_spk, pkg)
+                dst = os.path.join(dst_spk, pkg)
+                log.debug("Moving {} to {}".format(src, dst))
+                shutil.move(src, dst)
+    return out, err
+
+
+async def create_virtual_environment(loop=None) -> (str, str):
+    """
+    Create a virtual environment, and return the path to the virtual env
+    directory, which should contain a "bin" directory with the `python` and
+    `pip` binaries that can be used to a test install of a software package.
+
+    :return: the path to python in the new virtual environment
+    """
+    tmp_dir = tempfile.mkdtemp()
+    venv_dir = os.path.join(tmp_dir, VENV_NAME)
+    proc1 = await asyncio.create_subprocess_shell(
+        'virtualenv {}'.format(venv_dir), loop=loop)
+    await proc1.communicate()
+    if sys.platform == 'win32':
+        python = os.path.join(venv_dir, 'Scripts', 'python.exe')
+    else:
+        python = os.path.join(venv_dir, 'bin', 'python')
+    venv_site_pkgs = install_dependencies(python)
+
+    log.info("Created virtual environment at {}".format(venv_dir))
+
+    return python, venv_site_pkgs
+
+
+def install_dependencies(python) -> str:
+    """
+    Copy aiohttp and virtualenv install locations (and their transitive
+    dependencies in new virtualenv so that the update server can install
+    without access to full system site-packages or connection to the internet.
+    Full access to system site-packages causes the install inside the
+    virtualenv to fail quietly because it does not have permission to overwrite
+    a package by the same name and then it picks up the system version of
+    otupdate. Also, we have to do a copy rather than a symlink because a non-
+    admin Windows account does not have permissions to create symlinks.
+    """
+    # Import all of the packages that need to be available in the virtualenv
+    # for the update server to boot, so we can locate them using their __file__
+    # attribute
+    import aiohttp
+    import virtualenv_support
+    import async_timeout
+    import chardet
+    import multidict
+    import yarl
+    import idna
+    import pip
+    import setuptools
+    import virtualenv
+
+    # Determine where the site-packages directory exists in the virtualenv
+    tmpdirname = python.split(VENV_NAME)[0]
+    paths_raw = sp.check_output(
+        '{} -c "import sys; [print(p) for p in sys.path]"'.format(python),
+        shell=True)
+    paths = paths_raw.decode().split()
+    venv_site_pkgs = list(
+        filter(
+            lambda x: tmpdirname in x and 'site-packages' in x, paths))[-1]
+
+    dependencies = [
+        ('aiohttp', aiohttp),
+        ('virtualenv_support', virtualenv_support),
+        ('async_timeout', async_timeout),
+        ('chardet', chardet),
+        ('multidict', multidict),
+        ('yarl', yarl),
+        ('idna', idna),
+        ('pip', pip),
+        ('setuptools', setuptools),
+        ('virtualenv.py', virtualenv)]
+
+    # Copy each dependency from is system-install location to the site-packages
+    # directory of the virtualenv
+    for dep_name, dep in dependencies:
+        src_dir = os.path.abspath(os.path.dirname(dep.__file__))
+        dst = os.path.join(venv_site_pkgs, dep_name)
+        if os.path.exists(dst):
+            log.debug('{} already exists--skipping'.format(dst))
+        else:
+            log.debug('Copying {} to {}'.format(dep_name, dst))
+            if dep_name.endswith('.py'):
+                shutil.copy2(os.path.join(src_dir, dep_name), dst)
+            else:
+                shutil.copytree(src_dir, dst)
+    return venv_site_pkgs
+
+
+async def _start_server(python, port, venv_site_pkgs=None) -> sp.Popen:
+    """
+    Starts an update server sandboxed in the virtual env, and attempts to read
+    the health endpoint with retries to determine when the server is available.
+    If the number of retries is exceeded, the returned server process will
+    already be terminated.
+
+    :return: the server process
+    """
+    log.info("Starting sandboxed update server on port {}".format(port))
+    if venv_site_pkgs:
+        python = 'PYTHONPATH={} {}'.format(venv_site_pkgs, python)
+    cmd = [python, '-m', 'otupdate', '--debug', '--test', '--port', str(port)]
+    log.debug('cmd: {}'.format(' '.join(cmd)))
+    proc = sp.Popen(' '.join(cmd), shell=True)
+    atexit.register(lambda: _stop_server(proc))
+
+    n_retries = 3
+    async with aiohttp.ClientSession() as session:
+        test_status, detail = await selftest.health_check(
+            session=session, port=port, retries=n_retries)
+    if test_status == 'failure':
+        log.debug(
+            "Test server failed to start after {} retries. Stopping.".format(
+                n_retries))
+        _stop_server(proc)
+    return proc
+
+
+def _stop_server(proc: sp.Popen):
+    log.info("Halting sandboxed update server")
+    proc.terminate()
+    proc.communicate()
+    clean('/data/packages/tmp')
+
+
+async def install_sandboxed_update(filename, loop) -> (dict, str, str):
+    """
+    Create a virtual environment and activate it, and then install an
+    update candidate (leaves virtual environment activated)
+
+    :return: a result dict and the path to python in the virtual environment
+    """
+    log.debug("Creating virtual environment")
+    python, venv_site_pkgs = await create_virtual_environment(loop=loop)
+    log.debug("Installing update server into virtual environment")
+    out, err = await _install(python, filename, loop)
+    if err:
+        log.error("Install failed: {}".format(err))
+        res = {'status': 'failure', 'error': err}
+    else:
+        log.debug("Install successful")
+        res = {'status': 'success'}
+    return res, python, venv_site_pkgs
+
+
+async def install_update(filename, loop) -> dict:
+    """
+    Install the update into the system environment.
+    """
+    log.info("Installing update server into system environment")
+    log.debug('File {} exists? {}'.format(filename, os.path.exists(filename)))
+    msg = await _install(sys.executable, filename, loop)
+    res = {'message': msg, 'filename': filename}
+    return res
+
+
+async def test_update_server(
+        python, test_port, filename, venv_site_pkgs=None) -> dict:
+    """
+    Starts a test server using the virtual environment, and then runs tests
+    against that server
+
+    :return: the result of `selftest.run_self_test`
+    """
+    log.debug('Testing update server on port {}'.format(test_port))
+
+    # Start the server on the test port, and then make health and update reqs
+    server_proc = await _start_server(python, test_port, venv_site_pkgs)
+    test_result = await selftest.run_self_test(test_port, filename)
+    _stop_server(server_proc)
+
+    # Delete the temporary directory containing the virtual environment
+    tmpdir = python.split(VENV_NAME)[0]
+    clean(tmpdir)
+
+    return test_result
+
+
+def clean(path):
+    if os.path.exists(path):
+        shutil.rmtree(path, ignore_errors=True)

--- a/update-server/otupdate/endpoints.py
+++ b/update-server/otupdate/endpoints.py
@@ -1,0 +1,88 @@
+import os
+import logging
+import tempfile
+from aiohttp import web
+from otupdate import bootstrap
+from time import time
+
+log = logging.getLogger(__name__)
+
+
+def build_health_endpoint(
+        name, update_server_version, api_server_version, smoothie_version):
+    async def health(request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                'name': name,
+                'updateServerVersion': update_server_version,
+                'apiServerVersion': api_server_version,
+                'smoothieVersion': smoothie_version
+            },
+            headers={'Access-Control-Allow-Origin': '*'}
+        )
+    return health
+
+
+async def bootstrap_update_server(
+        request: web.Request, test_flag=False) -> web.Response:
+    start_time = time()
+    data = await request.post()
+    wheel = data.get('whl')
+    log.debug('Got whl: {}'.format(wheel))
+    log.debug('  filename: {}'.format(wheel.filename))
+    res = {}
+    tmpd = None
+    filename = None
+    python = None
+    venv_site_pkgs = None
+
+    # Unpack wheel and install into a virtual environment
+    if not wheel:
+        log.debug('No wheel file provided')
+        res = {
+            'status': 'failure',
+            'error': '"whl" parameter missing from request'}
+
+    if 'error' not in res.keys():
+        tmpd = tempfile.mkdtemp()
+        filename = os.path.join(tmpd, wheel.filename)
+        log.info('Preparing to install: {}'.format(filename))
+        content = wheel.file.read()
+
+        with open(filename, 'wb') as wf:
+            wf.write(content)
+
+        log.debug('Bootstrapping update server {} [test mode: {}]'.format(
+            filename, test_flag))
+
+        res, python, venv_site_pkgs = await bootstrap.install_sandboxed_update(
+            filename, request.loop)
+        log.debug('Install complete with status: {}'.format(res.get('status')))
+
+    if python and 'error' not in res.keys():
+        if test_flag:
+            log.debug('Test mode, not testing successive install')
+            res = {'status': 'Successfully installed update'}
+        else:
+            test_port = 34001
+            res = await bootstrap.test_update_server(
+                python, test_port, filename, venv_site_pkgs)
+
+    if 'error' in res.keys():
+        log.debug('Test failed, not installing update')
+        status = 400
+    elif not test_flag:
+        log.debug('Test successful, installing update')
+        install_res = await bootstrap.install_update(
+            filename, request.loop)
+        res.update(install_res)
+        status = 200
+    else:
+        log.debug('Self-test successful on test server')
+        status = 200
+
+    bootstrap.clean(tmpd)
+
+    request_time = time() - start_time
+    log.info('Bootstrap request took {:.3f} seconds'.format(request_time))
+    return web.json_response(res, status=status)

--- a/update-server/otupdate/package.json
+++ b/update-server/otupdate/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@opentrons/update-server",
+  "version": "3.2.0-beta.3",
+  "description": "Update server for Opentrons robots",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Opentrons/opentrons.git"
+  },
+  "author": {
+    "name": "Opentrons Labworks",
+    "email": "engineering@opentrons.com"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Opentrons/opentrons/issues"
+  },
+  "homepage": "https://github.com/Opentrons/opentrons"
+}

--- a/update-server/otupdate/selftest.py
+++ b/update-server/otupdate/selftest.py
@@ -1,0 +1,91 @@
+import aiohttp
+import logging
+from time import sleep
+
+log = logging.getLogger(__name__)
+
+
+def _open(path):
+    ret = open(path, 'rb')
+    return ret
+
+
+async def health_check(
+        session: aiohttp.ClientSession,
+        port: int,
+        retries: int = 0,
+        backoff_interval: float = 2.0):
+    log.debug('Making health request (retries remaining: {})'.format(retries))
+    detail = ''
+    test_status = 'in progress'
+    try:
+        async with session.get(
+                'http://127.0.0.1:{}/server/update/health'.format(
+                    port)) as r1:
+            health_status = r1.status
+            log.debug('Health status: {}'.format(health_status))
+            if health_status != 200:
+                test_status = 'failure'
+                detail = 'Health check returned status {}'.format(
+                    health_status)
+    except Exception as e:
+        health_status = 500
+        detail = 'Exception during health check: {}'.format(
+            type(e).__name__)
+    if int(health_status/100.0) == 2:
+        # just return the test status and detail
+        pass
+    elif retries > 0:
+        log.debug("Health status: {} - retrying in {} seconds".format(
+            health_status, backoff_interval))
+        sleep(backoff_interval)
+        test_status, detail = await health_check(
+            session=session,
+            port=port,
+            retries=retries-1,
+            backoff_interval=backoff_interval*2)
+    else:
+        test_status = 'failure'
+    return test_status, detail
+
+
+async def run_self_test(port, filename) -> dict:
+    """
+    Make the following requests to the server running on the specified port:
+    - GET  /server/update/health
+    - POST /server/update/bootstrap {"whl": @wheelpath}
+
+    Test is successful if both requests return 200 and no exceptions are raised
+    :return: a dict with keys 'status' and 'details', where status is either
+        'success' or 'failure' and 'details contains a description
+    """
+    log.info('Running self test against server on port {}'.format(port))
+
+    async with aiohttp.ClientSession() as session:
+        test_status, detail = await health_check(session, port, retries=0)
+
+        if test_status != 'failure':
+            log.debug('Making update request')
+            try:
+                async with session.post(
+                        'http://127.0.0.1:{}/server/update/bootstrap'.format(
+                            port),
+                        data={'whl': _open(filename)}) as r2:
+                    update_status = r2.status
+                    log.debug('Update status: {}'.format(update_status))
+                    if update_status != 200:
+                        test_status = 'failure'
+                        detail = 'Update check returned status {}'.format(
+                            update_status)
+            except Exception as e:
+                log.exception('Exception during self test:')
+                test_status = 'failure'
+                detail = 'Exception during update check: {}'.format(
+                    type(e).__name__)
+
+    if test_status == 'failure':
+        res = {'status': 'failure', 'error': detail}
+    else:
+        res = {'status': 'success'}
+    log.debug('Selftest result: {}'.format(res))
+    return res

--- a/update-server/setup.cfg
+++ b/update-server/setup.cfg
@@ -1,0 +1,11 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = ../LICENSE
+
+[pep8]
+ignore = E221,E222
+
+[aliases]
+test=pytest

--- a/update-server/setup.py
+++ b/update-server/setup.py
@@ -1,0 +1,72 @@
+# Inspired by:
+# https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+import codecs
+import os
+from setuptools import setup, find_packages
+import json
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version():
+    with open(os.path.join(HERE, 'otupdate', 'package.json')) as pkg:
+        package_json = json.load(pkg)
+        return package_json.get('version')
+
+
+VERSION = get_version()
+
+DISTNAME = 'otupdate'
+LICENSE = 'Apache 2.0'
+AUTHOR = "Opentrons"
+EMAIL = "engineering@opentrons.com"
+URL = "https://github.com/Opentrons/opentrons"
+DOWNLOAD_URL = ''
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Environment :: Console',
+    'Operating System :: OS Independent',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Topic :: Scientific/Engineering',
+]
+KEYWORDS = ["robots", "automation", "lab"]
+DESCRIPTION = (
+    "A server to update software and firmware on Opentrons robots")
+PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
+INSTALL_REQUIRES = ['aiohttp==2.3.8']
+
+
+def read(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
+
+
+if __name__ == "__main__":
+    setup(
+        python_requires='>=3.6',
+        name=DISTNAME,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        version=VERSION,
+        author=AUTHOR,
+        author_email=EMAIL,
+        maintainer=AUTHOR,
+        maintainer_email=EMAIL,
+        keywords=KEYWORDS,
+        long_description=read("README.md"),
+        packages=PACKAGES,
+        zip_safe=False,
+        classifiers=CLASSIFIERS,
+        install_requires=INSTALL_REQUIRES,
+        setup_requires=['pytest-runner'],
+        tests_require=['pytest'],
+        include_package_data=True
+    )

--- a/update-server/tests/conftest.py
+++ b/update-server/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import pytest
+import asyncio
+
+
+@pytest.fixture
+def loop():
+    if sys.platform == 'win32':
+        _loop = asyncio.ProactorEventLoop()
+    else:
+        _loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(_loop)
+    return asyncio.get_event_loop()

--- a/update-server/tests/test_bootstrap_fns.py
+++ b/update-server/tests/test_bootstrap_fns.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import logging
+import tempfile
+import subprocess
+from collections import namedtuple
+from otupdate import bootstrap
+
+logging.basicConfig(level='DEBUG')
+
+wheel_data = namedtuple(
+    'wheel_data',
+    [
+        'filename',
+        'file'
+    ]
+)
+
+
+async def test_create_virtual_environment(loop):
+    python, _ = await bootstrap.create_virtual_environment(loop=loop)
+    assert os.path.exists(python)
+
+
+async def test_install_fail(monkeypatch, loop):
+    test_data = wheel_data('bad_test.whl', 'bad data')
+
+    async def mock_install(python, filename, _loop):
+        return '', 'error'
+
+    monkeypatch.setattr(bootstrap, '_install', mock_install)
+
+    res, python, _ = await bootstrap.install_sandboxed_update(
+        test_data, loop=loop)
+    assert res.get('status') == 'failure'
+
+
+async def test_install_sandboxed_update(monkeypatch, loop):
+    test_data = wheel_data('testy.whl', 'wheel data')
+
+    async def mock_install(python, filename, _loop):
+        return 'success', None
+
+    monkeypatch.setattr(bootstrap, '_install', mock_install)
+
+    res, python, _ = await bootstrap.install_sandboxed_update(
+        test_data, loop=loop)
+    assert res.get('status') == 'success'
+
+    python_check = '{} -V'.format(python)
+    proc = subprocess.run(python_check, check=True, shell=True)
+    assert proc.returncode == 0
+
+
+async def test_startstop_server(monkeypatch):
+    test_port = 34016
+
+    td = tempfile.mkdtemp()
+    tmpd = os.path.join(td, 'testy')
+    os.mkdir(tmpd)
+
+    test_setup = """
+from setuptools import setup
+
+setup(name='testy',
+    version='1.0.0',
+    description='Test package',
+    url='http://github.com/Opentrons/opentrons',
+    author='Opentrons',
+    author_email='test@example.com',
+    license='Apache 2.0',
+    packages=['testy'],
+    zip_safe=False)
+"""
+    test_setup_file = os.path.join(tmpd, 'setup.py')
+    with open(test_setup_file, 'w') as tsf:
+        tsf.write(test_setup)
+
+    src_dir = os.path.join(tmpd, 'testy')
+    os.mkdir(src_dir)
+    test_code = """
+print('testing')
+"""
+    test_file = os.path.join(src_dir, '__init__.py')
+
+    with open(test_file, 'w') as tf:
+        tf.write(test_code)
+
+    cmd = '{} setup.py bdist_wheel'.format(sys.executable)
+    subprocess.run(cmd, cwd=tmpd, shell=True)
+    test_wheel = os.path.join(tmpd, 'dist', 'testy-1.0.0-py3-none-any.whl')
+
+    res = await bootstrap.test_update_server(
+        sys.executable, test_port, test_wheel)
+
+    assert res.get('status') == 'success'

--- a/update-server/tests/test_server_boot.py
+++ b/update-server/tests/test_server_boot.py
@@ -1,0 +1,110 @@
+"""
+This is the most critical test package for this application--this server MUST
+be able to boot. If a version that fails to boot is installed, then the robot
+will almost certainly become unrecoverable.
+"""
+import os
+import sys
+import json
+import tempfile
+import subprocess
+import otupdate
+from otupdate import bootstrap
+# Tests should closely reflect the tasks in selftest.py
+
+
+async def test_server_boot(loop, test_client):
+    update_package = os.path.join(
+        os.path.abspath(os.path.dirname(otupdate.__file__)), 'package.json')
+    with open(update_package) as pkg:
+        pkg_data = json.load(pkg)
+        update_server_version = pkg_data.get('version')
+
+    app = otupdate.get_app(
+        api_package=None,
+        update_package=update_package,
+        smoothie_version='not available',
+        loop=loop,
+        test=True)
+    cli = await loop.create_task(test_client(app))
+
+    expected = {
+        'name': 'opentrons-dev',
+        'updateServerVersion': update_server_version,
+        'apiServerVersion': 'not available',
+        'smoothieVersion': 'not available'
+    }
+
+    resp = await cli.get('/server/update/health')
+    res = await resp.json()
+    assert resp.status == 200
+    assert res == expected
+
+
+async def test_bootstrap_fail(monkeypatch, loop, test_client):
+    async def mock_install(filename, _loop):
+        """
+        If this test passes (e.g.: if the self-test fails), this function
+        should not run--this mock exists to keep the test from installing
+        to the system if the self-test passes and the bootstrap endpoint
+        tries to actually install the package.
+        """
+        return {'message': 'test msg', 'filename': filename}
+
+    monkeypatch.setattr(bootstrap, 'install_update', mock_install)
+
+    pkg_name = 'otupdate'
+
+    td = tempfile.mkdtemp()
+    tmpd = os.path.join(td, pkg_name)
+    os.mkdir(tmpd)
+
+    test_setup = """
+from setuptools import setup
+
+setup(name='{}',
+version='1.0.0',
+description='Test package',
+url='http://github.com/Opentrons/opentrons',
+author='Opentrons',
+author_email='test@example.com',
+license='Apache 2.0',
+packages=['otupdate'],
+zip_safe=False)
+""".format(pkg_name)
+    test_setup_file = os.path.join(tmpd, 'setup.py')
+    with open(test_setup_file, 'w') as tsf:
+        tsf.write(test_setup)
+
+    src_dir = os.path.join(tmpd, pkg_name)
+    os.mkdir(src_dir)
+    test_code = """
+print('intentionally malformed'
+"""
+    test_file = os.path.join(src_dir, '__init__.py')
+
+    with open(test_file, 'w') as tf:
+        tf.write(test_code)
+
+    cmd = '{} setup.py bdist_wheel'.format(sys.executable)
+    subprocess.run(cmd, cwd=tmpd, shell=True)
+    test_wheel = os.path.join(
+        tmpd, 'dist', '{}-1.0.0-py3-none-any.whl'.format(pkg_name))
+
+    update_package = os.path.join(os.path.abspath(
+        os.path.dirname(otupdate.__file__)), 'package.json')
+
+    app = otupdate.get_app(
+        api_package=None,
+        update_package=update_package,
+        smoothie_version='not available',
+        loop=loop,
+        test=False)
+    cli = await loop.create_task(test_client(app))
+
+    resp = await cli.post(
+        '/server/update/bootstrap', data={'whl': open(test_wheel, 'rb')})
+    res = await resp.json()
+
+    assert res.get('status') == 'failure'
+    assert int(resp.status/100.0) == 4

--- a/update-server/updateServerDesignNotes.md
+++ b/update-server/updateServerDesignNotes.md
@@ -1,0 +1,52 @@
+# Update server design review
+
+## Problem
+
+Currently, update endpoint is in API server, and it does not do any safety 
+checking to ensure that the newly installed version will be able to come up
+and accept successive updates. In this scenario, the API can go down
+unrecoverably and require difficult intervention from engineering to get
+the robot back online.
+
+
+## Proposed solution
+
+Create a separate server that will handle updates of SW, FW, and configs.
+
+This server needs to:
+- report current versions of all relevant software installed on the robot
+  - minimally: self, API server, Smoothie FW
+  - optionally: module FW, Python, ResinOS, Docker container (as available)
+- accept updates to itself and install them safely. When it gets an update:
+  - Create a virtual environment
+  - Install the update into the virtual environment
+  - Start the server on another port
+  - Test the `health` and self-update endpoints in the new server (be 
+        careful here about recursion)
+  - Check test status. If success, install over top of self and restart. 
+        If failure, report status and delete virtual environment
+- accept updates to the API server and install them (safety checks optional 
+        for now)
+- accept updates to Smoothie and module FW and install them (safety checks 
+        optional for now)
+- provide other endpoints for modifying configurations such as feature-flags 
+        and robot configs
+
+For backward compatibility, core update endpoints must also be supported in 
+the API server, in case the update server is not present. Shared 
+implementations should live in "api-server-lib". Imports of `opentrons`
+should be limited, and wrapped in a `try...except` block with graceful
+failure (in general, all care should be taken to ensure that this server
+*can not* fail in its core task: bootstrapping itself from any prior
+version).
+
+Steps for manually testing (warning: this can modify your system install of `otupdate`):
+- run `make dev` with the "version" in package.json unchanged (this starts the update server on http://127.0.0.1:34000)
+- change "version" to a different value and `make wheel` in another terminal
+- use Postman or curl to check the health endpoint
+  - with curl: `curl http://127.0.0.1:34000/server/update/health`
+  - result should be a json packet including the server name and versions for update server, API server, and Smoothie
+- use Postman or curl to send the new wheel to the bootstrap endpoint
+  - with curl: `curl -X POST -H "Content-Type: multipart/form-data" -F "whl=@/path/to/otupdate-<version>.whl" http://127.0.0.1:34000/server/update/bootstrap`
+  - this will take a while, but it should eventually return a success message and then the installed version of update server on your system should be the new version string
+


### PR DESCRIPTION
## overview

Core update server, currently able to update itself safely. Notably missing: restart endpoint, and api and fw update endpoints. Those are out of scope for this PR. Fixes #1208 

## changelog

- Added update server sub-project to repo
- Added self-update endpoint in update server, with safety check in sandboxed environment
- Added health endpoint to provide versions of all robot software

## review requests

Has been tested on 🌔 🌔 and is able to boostrap itself (installing successive updates over itself properly, and rejecting ones that fail to boot or accept subsequent updates).

Note that this will have no effect on running robots until the Dockerfile is updated, and that follow-up PRs need to be completed to add API and FW update and restart endpoints before this application will be ready to ship.