### PR TITLE
PD timeline warnings: not enough liquid in well

### DIFF
--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -2,14 +2,15 @@
 import * as React from 'react'
 import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
-import {selectors} from '../file-data'
+import {selectors as fileDataSelectors} from '../file-data'
+import {selectors as steplistSelectors} from '../steplist'
 import {AlertItem} from '@opentrons/components'
 import type {BaseState} from '../types'
-import type {ErrorType, CommandCreatorError} from '../step-generation'
+import type {CommandCreatorError, CommandCreatorWarning} from '../step-generation'
 
 type SP = {
-  alerts: Array<{
-    ...CommandCreatorError,
+  alerts: Array<CommandCreatorError | {
+    ...CommandCreatorWarning,
     dismissId?: string // presence of dismissId allows alert to be dismissed
   }>
 }
@@ -20,8 +21,11 @@ type DP = {
 
 type Props = SP & DP
 
-const captions: {[ErrorType]: string} = {
-  'INSUFFICIENT_TIPS': 'Add another tip rack to an empty slot in Deck Setup'
+// These captions populate the AlertItem body, the title/message
+// comes from the CommandCreatorError / CommandCreatorWarning
+const captions: {[warningOrErrorType: string]: string} = {
+  'INSUFFICIENT_TIPS': 'Add another tip rack to an empty slot in Deck Setup',
+  'ASPIRATE_MORE_THAN_WELL_CONTENTS': 'You are trying to aspirate more than the current volume of one of your well(s). If you intended to add air to your tip, please use the Air Gap advanced setting.'
 }
 
 function Alerts (props: Props) {
@@ -45,19 +49,31 @@ function Alerts (props: Props) {
 }
 
 function mapStateToProps (state: BaseState): SP {
-  const timeline = selectors.robotStateTimeline(state)
-  const {errors} = timeline
+  const timeline = fileDataSelectors.robotStateTimeline(state)
+  const warningsPerStep = fileDataSelectors.warningsPerStep(state)
+  const selectedStepId = steplistSelectors.selectedStepId(state)
 
-  if (!errors || errors.length === 0) {
-    return {
-      alerts: []
-    }
-  }
+  const {errors} = timeline
+  const rawWarnings = (
+    // hide warnings without explicit FEATURE FLAG
+    process.env.OT_PD_SHOW_WARNINGS === 'true' &&
+    // show warnings only for the selected step
+    selectedStepId &&
+    warningsPerStep[selectedStepId]
+  ) || []
+
+  const warnings = rawWarnings.map(warning => ({
+    ...warning,
+    // TODO Ian 2018-06-14 once warning dismissal is actually implemented,
+    // the dismiss ID will probably have more info than just the type.
+    // This is a placeholder.
+    dismissId: warning.type
+  }))
+
+  let alerts = errors ? [...errors, ...warnings] : warnings
 
   return {
-    alerts: errors.map(err => ({...err})) // NOTE Flow complains about exact obj types if you don't map & unpack here
-
-    // TODO LATER Ian 2018-05-01 generate warnings somewhere, and merge in here with dismissId's
+    alerts
   }
 }
 

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -45,8 +45,8 @@ function Alerts (props: Props) {
 }
 
 function mapStateToProps (state: BaseState): SP {
-  const timelineFull = selectors.robotStateTimeline(state)
-  const errors = timelineFull.timelineErrors
+  const timeline = selectors.robotStateTimeline(state)
+  const {errors} = timeline
 
   if (!errors || errors.length === 0) {
     return {

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -43,16 +43,13 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = steplistSelectors.hoveredStepId(state)
   const selected = steplistSelectors.selectedStepId(state) === stepId
 
-  // TODO: Ian 2018-06-14 make mini selector?
-  const errorIndex = fileDataSelectors.robotStateTimeline(state).errorIndex
-  const error = (errorIndex != null) && ((errorIndex + 1) === stepId)
-
+  const hasError = fileDataSelectors.getErrorStepId(state) === stepId
   const warnings = fileDataSelectors.warningsPerStep(state)[stepId]
   const hasWarnings = warnings && warnings.length > 0
 
   const showErrorState = (process.env.OT_PD_SHOW_WARNINGS === 'true')
-    ? error || hasWarnings
-    : error // ignore warnings w/o FEATURE FLAG
+    ? hasError || hasWarnings
+    : hasError // ignore warnings w/o FEATURE FLAG
 
   let collapsed
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -43,6 +43,10 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = steplistSelectors.hoveredStepId(state)
   const selected = steplistSelectors.selectedStepId(state) === stepId
 
+  // TODO: Ian 2018-06-14 make mini selector
+  const errorIndex = fileDataSelectors.robotStateTimeline(state).errorIndex
+  const error = (errorIndex != null) && ((errorIndex + 1) === stepId)
+
   let collapsed
 
   if (!(stepId === '__end__' || stepId === 0)) {
@@ -64,12 +68,11 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     hoveredSubstep,
     collapsed,
     selected,
+    error,
 
     // no double-highlighting: whole step is only "hovered" when
     // user is not hovering on substep.
     hovered: hoveredStep === stepId && !hoveredSubstep,
-
-    error: fileDataSelectors.robotStateTimeline(state).errorStepId === stepId, // TODO make mini selector
 
     getLabwareName: (labwareId: ?string) => labwareId && labwareIngredSelectors.getLabwareNames(state)[labwareId]
   }

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -50,7 +50,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const warnings = fileDataSelectors.warningsPerStep(state)[stepId]
   const hasWarnings = warnings && warnings.length > 0
 
-  const showErrorState = error || hasWarnings
+  const showErrorState = (process.env.OT_PD_SHOW_WARNINGS === 'true')
+    ? error || hasWarnings
+    : error // ignore warnings w/o FEATURE FLAG
 
   let collapsed
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -43,9 +43,14 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = steplistSelectors.hoveredStepId(state)
   const selected = steplistSelectors.selectedStepId(state) === stepId
 
-  // TODO: Ian 2018-06-14 make mini selector
+  // TODO: Ian 2018-06-14 make mini selector?
   const errorIndex = fileDataSelectors.robotStateTimeline(state).errorIndex
   const error = (errorIndex != null) && ((errorIndex + 1) === stepId)
+
+  const warnings = fileDataSelectors.warningsPerStep(state)[stepId]
+  const hasWarnings = warnings && warnings.length > 0
+
+  const showErrorState = error || hasWarnings
 
   let collapsed
 
@@ -68,7 +73,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     hoveredSubstep,
     collapsed,
     selected,
-    error,
+    error: showErrorState,
 
     // no double-highlighting: whole step is only "hovered" when
     // user is not hovering on substep.

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -141,7 +141,7 @@ export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelec
     const orderedSteps = orderedStepsWithDeckSetup.slice(1)
     const allFormData: Array<StepGeneration.CommandCreatorData | null> = orderedSteps.map(stepId => {
       return (forms[stepId] && forms[stepId].validatedForm) || null
-    }, [])
+    })
 
     // TODO: Ian 2018-06-14 `takeWhile` isn't inferring the right type
     // $FlowFixMe

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -115,6 +115,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   }
 )
 
+// TODO IMMEDIATELY replace with commandCreatorsTimeline util, and StepGeneration.Timeline type!
 export type RobotStateTimeline = {
   formErrors: {[string]: string},
   timeline: Array<StepGeneration.CommandsAndRobotState>,

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -117,22 +117,18 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
 )
 
 function commandCreatorsFromFormData (validatedForm: StepGeneration.CommandCreatorData) {
-  if (validatedForm.stepType === 'consolidate') {
-    return StepGeneration.consolidate(validatedForm)
-  } else
-  if (validatedForm.stepType === 'transfer') {
-    return StepGeneration.transfer(validatedForm)
-  } else
-  if (validatedForm.stepType === 'distribute') {
-    return StepGeneration.distribute(validatedForm)
-  } else
-  if (validatedForm.stepType === 'pause') {
-    return StepGeneration.delay(validatedForm)
-  } else
-  if (validatedForm.stepType === 'mix') {
-    return StepGeneration.mix(validatedForm)
+  switch (validatedForm.stepType) {
+    case 'consolidate':
+      return StepGeneration.consolidate(validatedForm)
+    case 'transfer':
+      return StepGeneration.transfer(validatedForm)
+    case 'distribute':
+      return StepGeneration.distribute(validatedForm)
+    case 'pause':
+      return StepGeneration.delay(validatedForm)
+    case 'mix':
+      return StepGeneration.mix(validatedForm)
   }
-
   return null
 }
 

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -115,7 +115,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   }
 )
 
-function commandCreatorsFromFormData (validatedForm: StepGeneration.UnionFormData) {
+function commandCreatorsFromFormData (validatedForm: StepGeneration.CommandCreatorData) {
   if (validatedForm.stepType === 'consolidate') {
     return StepGeneration.consolidate(validatedForm)
   } else
@@ -142,14 +142,13 @@ export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelec
   getInitialRobotState,
   (forms, orderedStepsWithDeckSetup, initialRobotState) => {
     const orderedSteps = orderedStepsWithDeckSetup.slice(1)
-    const allFormData: Array<StepGeneration.UnionFormData | null> = orderedSteps.map(stepId => {
-      // TODO IMMEDIATELY replace ProcessedFormData with UnionFormData
+    const allFormData: Array<StepGeneration.CommandCreatorData | null> = orderedSteps.map(stepId => {
       return (forms[stepId] && forms[stepId].validatedForm) || null
     }, [])
 
     // TODO: Ian 2018-06-14 `takeWhile` isn't inferring the right type
     // $FlowFixMe
-    const continuousValidForms: Array<StepGeneration.UnionFormData> = takeWhile(
+    const continuousValidForms: Array<StepGeneration.CommandCreatorData> = takeWhile(
       allFormData,
       f => f
     )

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -175,8 +175,7 @@ export const warningsPerStep: Selector<WarningsPerStep> = createSelector(
   steplistSelectors.orderedSteps,
   robotStateTimeline,
   (orderedSteps, timeline) => timeline.timeline.reduce((acc: WarningsPerStep, frame, timelineIndex) => {
-    // add 1 to timelineIdx, because the 0th orderedStep is always initial deck setup,
-    // which isn't included in the timeline
+    // TODO: Ian 2018-06-15 add 1 to orderedSteps because 0th orderedStep is deck setup. DRYer way?
     const stepId = orderedSteps[timelineIndex + 1]
 
     // remove warnings of duplicate 'type'. chosen arbitrarily
@@ -185,6 +184,22 @@ export const warningsPerStep: Selector<WarningsPerStep> = createSelector(
       [stepId]: uniqBy(frame.warnings, w => w.type)
     }
   }, {})
+)
+
+export const getErrorStepId: Selector<?number> = createSelector(
+  steplistSelectors.orderedSteps,
+  robotStateTimeline,
+  (orderedSteps, timeline) => {
+    const hasErrors = timeline.errors && timeline.errors.length > 0
+    if (hasErrors) {
+      // the frame *after* the last frame in the timeline is the error-throwing one
+      const errorIndex = timeline.timeline.length
+      // TODO: Ian 2018-06-15 add 1 to orderedSteps because 0th orderedStep is deck setup. DRYer way?
+      const errorStepId = orderedSteps[errorIndex + 1]
+      return errorStepId
+    }
+    return null
+  }
 )
 
 export const lastValidRobotState: Selector<StepGeneration.RobotState> = createSelector(

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -1,9 +1,9 @@
 // @flow
 import {createSelector} from 'reselect'
-import isEmpty from 'lodash/isEmpty'
 import last from 'lodash/last'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import takeWhile from 'lodash/takeWhile'
 import type {BaseState, Selector} from '../../types'
 import {getAllWellsForLabware} from '../../constants'
 import * as StepGeneration from '../../step-generation'
@@ -115,130 +115,70 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   }
 )
 
-// TODO IMMEDIATELY replace with commandCreatorsTimeline util, and StepGeneration.Timeline type!
-export type RobotStateTimeline = {
-  formErrors: {[string]: string},
-  timeline: Array<StepGeneration.CommandsAndRobotState>,
-  robotState: StepGeneration.RobotState,
-  timelineErrors?: ?Array<StepGeneration.CommandCreatorError>,
-  errorStepId?: number
+function commandCreatorsFromFormData (validatedForm: StepGeneration.UnionFormData) {
+  if (validatedForm.stepType === 'consolidate') {
+    return StepGeneration.consolidate(validatedForm)
+  } else
+  if (validatedForm.stepType === 'transfer') {
+    return StepGeneration.transfer(validatedForm)
+  } else
+  if (validatedForm.stepType === 'distribute') {
+    return StepGeneration.distribute(validatedForm)
+  } else
+  if (validatedForm.stepType === 'pause') {
+    return StepGeneration.delay(validatedForm)
+  } else
+  if (validatedForm.stepType === 'mix') {
+    return StepGeneration.mix(validatedForm)
+  }
+
+  return null
 }
 
 // exposes errors and last valid robotState
-export const robotStateTimeline: Selector<RobotStateTimeline> = createSelector(
+export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelector(
   steplistSelectors.validatedForms,
   steplistSelectors.orderedSteps,
   getInitialRobotState,
-  (forms, orderedSteps, initialRobotState) => {
-    const finalStepId = last(orderedSteps)
+  (forms, orderedStepsWithDeckSetup, initialRobotState) => {
+    const orderedSteps = orderedStepsWithDeckSetup.slice(1)
+    const allFormData: Array<StepGeneration.UnionFormData | null> = orderedSteps.map(stepId => {
+      // TODO IMMEDIATELY replace ProcessedFormData with UnionFormData
+      return (forms[stepId] && forms[stepId].validatedForm) || null
+    }, [])
 
-    const result: RobotStateTimeline = orderedSteps.reduce((acc: RobotStateTimeline, stepId): RobotStateTimeline => {
-      if (!isEmpty(acc.formErrors)) {
-        // short-circut the reduce if there were errors with validating / processing the form
-        return acc
-      }
+    // TODO: Ian 2018-06-14 `takeWhile` isn't inferring the right type
+    // $FlowFixMe
+    const continuousValidForms: Array<StepGeneration.UnionFormData> = takeWhile(
+      allFormData,
+      f => f
+    )
 
-      if (acc.timelineErrors) {
-        // short-circut the reduce if there were timeline errors
-        return acc
-      }
+    const commandCreators = continuousValidForms.reduce(
+      (acc: Array<StepGeneration.CommandCreator>, formData) => {
+        const {stepType} = formData
+        const commandCreator = commandCreatorsFromFormData(formData)
 
-      const form = forms[stepId]
-
-      if (stepId === 0) {
-        // The first stepId is the "initial deck setup" step.
-        // It doesn't have a form, it just sets up initialRobotState
-        return {
-          ...acc,
-          timeline: [
-            ...acc.timeline,
-            {
-              commands: [],
-              robotState: initialRobotState
-            }
-          ]
+        if (!commandCreator) {
+          // TODO Ian 2018-05-08 use assert
+          console.warn(`StepType "${stepType}" not yet implemented`)
+          return acc
         }
-      }
 
-      // un-nest to make flow happy
-      const validatedForm = form.validatedForm
+        return [...acc, commandCreator]
+      }, [])
 
-      // put form errors into accumulator
-      if (!validatedForm) {
-        return {
-          ...acc,
-          formErrors: form.errors
-        }
-      }
+    const timeline = StepGeneration.commandCreatorsTimeline(commandCreators)(initialRobotState)
 
-      // finally, deal with valid step forms
-      let commandCreators = []
+    return timeline
+  }
+)
 
-      if (validatedForm.stepType === 'consolidate') {
-        commandCreators.push(StepGeneration.consolidate(validatedForm))
-      } else
-      if (validatedForm.stepType === 'transfer') {
-        commandCreators.push(StepGeneration.transfer(validatedForm))
-      } else
-      if (validatedForm.stepType === 'distribute') {
-        commandCreators.push(StepGeneration.distribute(validatedForm))
-      } else
-      if (validatedForm.stepType === 'pause') {
-        commandCreators.push(StepGeneration.delay(validatedForm))
-      } else
-      if (validatedForm.stepType === 'mix') {
-        commandCreators.push(StepGeneration.mix(validatedForm))
-      } else {
-        // TODO Ian 2018-05-08 use assert
-        console.warn(`StepType "${validatedForm.stepType}" not yet implemented`)
-        return {
-          ...acc,
-          formErrors: {
-            ...acc.formErrors,
-            'STEP NOT IMPLEMENTED': validatedForm.stepType
-          }
-        }
-      }
-
-      if (stepId === finalStepId) {
-        // Drop any tips at end of protocol
-        // (dropTip should do no-op when pipette has no tips)
-        const allPipettes = Object.keys(acc.robotState.instruments)
-
-        allPipettes.forEach(pipetteId =>
-          commandCreators.push(StepGeneration.dropTip(pipetteId))
-        )
-      }
-
-      const nextCommandsAndState = StepGeneration.reduceCommandCreators(commandCreators)(acc.robotState)
-
-      // for supported steps
-      if (nextCommandsAndState.errors) {
-        return {
-          ...acc,
-          timelineErrors: nextCommandsAndState.errors,
-          errorStepId: stepId
-        }
-      }
-
-      return {
-        ...acc,
-        timeline: [...acc.timeline, nextCommandsAndState],
-        robotState: nextCommandsAndState.robotState
-      }
-    }, {formErrors: {}, timeline: [], robotState: initialRobotState, timelineErrors: null})
-    // TODO Ian 2018-03-01 pass along name and description of steps for command annotations in file
-
-    if (!isEmpty(result.formErrors)) {
-      // TODO Ian 2018-03-01 remove log later
-      console.log('Got form errors while constructing timeline', result)
-    }
-
-    if (result.timelineErrors) {
-      // TODO Ian 2018-04-30 remove log later
-      console.log('Got timeline errors', result)
-    }
-
-    return result
+export const lastValidRobotState: Selector<StepGeneration.RobotState> = createSelector(
+  robotStateTimeline,
+  getInitialRobotState,
+  (timeline, initialRobotState) => {
+    const lastTimelineFrame = last(timeline.timeline)
+    return (lastTimelineFrame && lastTimelineFrame.robotState) || initialRobotState
   }
 )

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -1,13 +1,6 @@
 // @flow
 import type {IconName} from '@opentrons/components'
-import type {
-  ChangeTipOptions,
-  ConsolidateFormData,
-  DistributeFormData,
-  TransferFormData,
-  MixFormData,
-  PauseFormData
-} from './step-generation'
+import type {ChangeTipOptions} from './step-generation'
 
 export type StepIdType = number // TODO Ian 2018-05-10 change to string
 
@@ -120,11 +113,3 @@ export type BlankForm = {
   stepType: StepType,
   id: StepIdType
 }
-
-// TODO gradually create & use definitions from step-generation/types.js
-export type ProcessedFormData =
-  | ConsolidateFormData
-  | DistributeFormData
-  | MixFormData
-  | PauseFormData
-  | TransferFormData

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -42,21 +42,26 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     }
   }]
 
+  const liquidStateAndWarnings = updateLiquidState({
+    pipetteId: pipette,
+    pipetteData: prevRobotState.instruments[pipette],
+    labwareId: labware,
+    labwareType: prevRobotState.labware[labware].type,
+    volume,
+    well
+  }, prevRobotState.liquidState)
+
+  const {liquidState, warnings: liquidUpdateWarnings} = liquidStateAndWarnings
+
   const robotState = {
     ...prevRobotState,
-    liquidState: updateLiquidState({
-      pipetteId: pipette,
-      pipetteData: prevRobotState.instruments[pipette],
-      labwareId: labware,
-      labwareType: prevRobotState.labware[labware].type,
-      volume,
-      well
-    }, prevRobotState.liquidState)
+    liquidState
   }
 
   return {
     commands,
-    robotState
+    robotState,
+    warnings: liquidUpdateWarnings
   }
 }
 

--- a/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
+++ b/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
@@ -18,6 +18,7 @@ export default function updateLiquidState (
   },
   prevLiquidState: LiquidState
 ): LiquidState {
+  // TODO: Ian 2018-06-14 return same shape as aspirateUpdateLiquidState fn: {liquidState, warnings}.
   const {pipetteId, pipetteData, volume, labwareId, labwareType, well} = args
   type SourceAndDest = {|source: LocationLiquidState, dest: LocationLiquidState|}
 

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -13,6 +13,17 @@ jest.mock('../aspirateUpdateLiquidState')
 const aspirate = commandCreatorNoErrors(_aspirate)
 const aspirateWithErrors = commandCreatorHasErrors(_aspirate)
 
+const mockLiquidReturnValue = {
+  // using strings instead of properly-shaped objects for easier assertions
+  liquidState: 'expected liquid state',
+  warnings: 'expected warnings'
+}
+
+beforeEach(() => {
+  // $FlowFixMe
+  updateLiquidState.mockReturnValue(mockLiquidReturnValue)
+})
+
 describe('aspirate', () => {
   let initialRobotState
   let robotStateWithTip
@@ -121,12 +132,6 @@ describe('aspirate', () => {
   })
 
   describe('liquid tracking', () => {
-    const mockLiquidReturnValue = 'expected liquid state'
-    beforeEach(() => {
-      // $FlowFixMe
-      updateLiquidState.mockReturnValue(mockLiquidReturnValue)
-    })
-
     test('aspirate calls aspirateUpdateLiquidState with correct args and puts result into robotState.liquidState', () => {
       const result = aspirate({
         pipette: 'p300SingleId',
@@ -147,7 +152,8 @@ describe('aspirate', () => {
         robotStateWithTip.liquidState
       )
 
-      expect(result.robotState.liquidState).toBe(mockLiquidReturnValue)
+      expect(result.robotState.liquidState).toBe(mockLiquidReturnValue.liquidState)
+      expect(result.warnings).toBe(mockLiquidReturnValue.warnings)
     })
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/aspirateUpdateLiquidState.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirateUpdateLiquidState.test.js
@@ -50,7 +50,7 @@ describe('...single-channel pipette', () => {
         initialLiquidState
       )
 
-      expect(result).toMatchObject({
+      expect(result.liquidState).toMatchObject({
         pipettes: {
           p300SingleId: {
             '0': {ingred1: {volume: 50}}
@@ -85,7 +85,7 @@ describe('...single-channel pipette', () => {
         initialLiquidState
       )
 
-      expect(result).toMatchObject({
+      expect(result.liquidState).toMatchObject({
         pipettes: {
           p300SingleId: {
             '0': {ingred1: {volume: 200}, [AIR]: {volume: 100}}
@@ -115,7 +115,7 @@ describe('...single-channel pipette', () => {
 
       const result = updateLiquidState(args, initialLiquidState)
 
-      expect(result).toMatchObject({
+      expect(result.liquidState).toMatchObject({
         pipettes: {
           p300SingleId: {
             '0': {ingred1: {volume: 40}, ingred2: {volume: 20}}
@@ -143,7 +143,7 @@ describe('...single-channel pipette', () => {
 
       const result = updateLiquidState(args, initialLiquidState)
 
-      expect(result).toMatchObject({
+      expect(result.liquidState).toMatchObject({
         pipettes: {
           p300SingleId: {
             '0': {ingred1: {volume: 60}, ingred2: {volume: 70}, [AIR]: {volume: 20}}
@@ -170,7 +170,7 @@ describe('...single-channel pipette', () => {
 
       const result = updateLiquidState(aspirateSingleCh50FromA1Args, initialLiquidState)
 
-      expect(result).toMatchObject({
+      expect(result.liquidState).toMatchObject({
         pipettes: {
           p300SingleId: {
             '0': {ingred1: {volume: 30 + 50}}
@@ -217,7 +217,7 @@ describe('...8-channel pipette', () => {
 
     const result = updateLiquidState(aspirate8Ch50FromA1Args, initialLiquidState)
 
-    expect(result).toMatchObject({
+    expect(result.liquidState).toMatchObject({
       pipettes: {
         p300MultiId: {
           ...createTipLiquidState(8, {[AIR]: {volume: 50}, ingred1: {volume: 30}}),
@@ -251,7 +251,7 @@ describe('...8-channel pipette', () => {
 
     const result = updateLiquidState(args, initialLiquidState)
 
-    expect(result).toMatchObject({
+    expect(result.liquidState).toMatchObject({
       pipettes: {
         p300MultiId: {
           ...createTipLiquidState(8, {[AIR]: {volume: 250}}),
@@ -287,7 +287,7 @@ describe('...8-channel pipette', () => {
 
     const result = updateLiquidState(args, initialLiquidState)
 
-    expect(result).toMatchObject({
+    expect(result.liquidState).toMatchObject({
       pipettes: {
         p300MultiId: {
           // aspirate volume divided among the 8 tips

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -79,7 +79,7 @@ describe('reduceCommandCreators', () => {
         message: 'Cannot divide by zero',
         type: 'DIVIDE_BY_ZERO'
       }],
-      errorStep: 1, // divide step passed the error // TODO IMMEDIATELY this should be a timeline responsibility, not reduceCommandCreators
+      errorStep: 1, // divide step passed the error
       warnings: []
     })
   })

--- a/protocol-designer/src/step-generation/test-with-flow/utils.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/utils.test.js
@@ -108,7 +108,7 @@ describe('reduceCommandCreators', () => {
 })
 
 describe('commandCreatorsTimeline', () => {
-  test('any errors short-circuit the timeline chain and set the correct errorIndex', () => {
+  test('any errors short-circuit the timeline chain', () => {
     const initialState: any = {count: 5}
     const result = commandCreatorsTimeline([
       addCreatorWithWarning(4),
@@ -118,8 +118,6 @@ describe('commandCreatorsTimeline', () => {
 
     expect(result).toEqual({
       // error-creating "divide by zero" commands's index in the command creators array
-      errorIndex: 1,
-
       errors: [
         {
           message: 'Cannot divide by zero',

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -217,13 +217,36 @@ export type CommandCreatorError = {|
   type: ErrorType
 |}
 
+export type WarningType = string // TODO define
+
+export type CommandCreatorWarning = {|
+    message: string,
+    type: WarningType
+|}
+
+// TODO IMMEDIATELY move to timeline reducer
+export type ChainedWarningsByIndex = Array<{|
+  index: number,
+  content: Array<CommandCreatorWarning>
+|}>
+
 export type CommandsAndRobotState = {|
   commands: Array<Command>,
-  robotState: RobotState
+  robotState: RobotState,
+  warnings?: Array<CommandCreatorWarning>
 |}
 
 export type CommandCreatorErrorResponse = {
-  errors: Array<CommandCreatorError>
+  errors: Array<CommandCreatorError>,
+  warnings?: Array<CommandCreatorWarning>
 }
 
 export type CommandCreator = (prevRobotState: RobotState) => CommandsAndRobotState | CommandCreatorErrorResponse
+
+export type Timeline = {
+  // formErrors: {[string]: string}, // TODO IMMEDIATELY revisit this, copied from RobotStateTimeline type
+  timeline: Array<CommandsAndRobotState>,
+  // robotState: RobotState,
+  errors?: ?Array<CommandCreatorError>, // TODO was timelineErrors
+  errorIndex: ?number // NOTE: was renamed from errorStepId TODO remove this note once addressed
+}

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -224,7 +224,8 @@ export type CommandCreatorError = {|
   type: ErrorType
 |}
 
-export type WarningType = string // TODO: Ian 2018-06-14 define string enums
+export type WarningType =
+  | 'ASPIRATE_MORE_THAN_WELL_CONTENTS'
 
 export type CommandCreatorWarning = {|
     message: string,
@@ -245,7 +246,7 @@ export type CommandCreatorErrorResponse = {
 export type CommandCreator = (prevRobotState: RobotState) => CommandsAndRobotState | CommandCreatorErrorResponse
 
 export type Timeline = {
-  timeline: Array<CommandsAndRobotState>, // TODO: Ian 2018-06-14 avoid timeline.timeline
+  timeline: Array<CommandsAndRobotState>, // TODO: Ian 2018-06-14 avoid timeline.timeline shape, better names
   errors?: ?Array<CommandCreatorError>,
   errorIndex: ?number
 }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -114,6 +114,13 @@ export type PauseFormData = {|
   }
 |}
 
+export type UnionFormData =
+  | ConsolidateFormData
+  | DistributeFormData
+  | MixFormData
+  | PauseFormData
+  | TransferFormData
+
 export type PipetteData = {| // TODO refactor all 'pipette fields', split PipetteData into its own export type
   id: string, // TODO PipetteId export type here instead of string?
   mount: Mount,
@@ -217,18 +224,12 @@ export type CommandCreatorError = {|
   type: ErrorType
 |}
 
-export type WarningType = string // TODO define
+export type WarningType = string // TODO: Ian 2018-06-14 define string enums
 
 export type CommandCreatorWarning = {|
     message: string,
     type: WarningType
 |}
-
-// TODO IMMEDIATELY move to timeline reducer
-export type ChainedWarningsByIndex = Array<{|
-  index: number,
-  content: Array<CommandCreatorWarning>
-|}>
 
 export type CommandsAndRobotState = {|
   commands: Array<Command>,
@@ -244,9 +245,7 @@ export type CommandCreatorErrorResponse = {
 export type CommandCreator = (prevRobotState: RobotState) => CommandsAndRobotState | CommandCreatorErrorResponse
 
 export type Timeline = {
-  // formErrors: {[string]: string}, // TODO IMMEDIATELY revisit this, copied from RobotStateTimeline type
-  timeline: Array<CommandsAndRobotState>,
-  // robotState: RobotState,
-  errors?: ?Array<CommandCreatorError>, // TODO was timelineErrors
-  errorIndex: ?number // NOTE: was renamed from errorStepId TODO remove this note once addressed
+  timeline: Array<CommandsAndRobotState>, // TODO: Ian 2018-06-14 avoid timeline.timeline
+  errors?: ?Array<CommandCreatorError>,
+  errorIndex: ?number
 }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -114,7 +114,7 @@ export type PauseFormData = {|
   }
 |}
 
-export type UnionFormData =
+export type CommandCreatorData =
   | ConsolidateFormData
   | DistributeFormData
   | MixFormData

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -245,8 +245,7 @@ export type CommandCreatorErrorResponse = {
 
 export type CommandCreator = (prevRobotState: RobotState) => CommandsAndRobotState | CommandCreatorErrorResponse
 
-export type Timeline = {
+export type Timeline = {|
   timeline: Array<CommandsAndRobotState>, // TODO: Ian 2018-06-14 avoid timeline.timeline shape, better names
-  errors?: ?Array<CommandCreatorError>,
-  errorIndex: ?number
-}
+  errors?: ?Array<CommandCreatorError>
+|}

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -24,7 +24,7 @@ export function repeatArray<T> (array: Array<T>, repeats: number): Array<T> {
 export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): CommandCreator =>
   (prevRobotState: RobotState) => (
     commandCreators.reduce(
-      (prev, reducerFn, stepIdx) => {
+      (prev: $Call<CommandCreator, *>, reducerFn: CommandCreator, stepIdx) => {
         if (prev.errors) {
           // if there are errors, short-circuit the reduce
           return prev
@@ -38,7 +38,7 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
             commands: prev.commands,
             errors: next.errors,
             errorStep: stepIdx,
-            warnings: prev.warnings || undefined // flow fix
+            warnings: prev.warnings
           }
         }
 

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -8,8 +8,6 @@ import last from 'lodash/last'
 import {computeWellAccess} from '@opentrons/shared-data'
 import type {
   CommandCreator,
-  CommandCreatorError,
-  CommandsAndRobotState,
   RobotState,
   Timeline,
   LocationLiquidState
@@ -56,15 +54,10 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
     )
   )
 
-type TimelineAcc = {
-  timeline: Array<CommandsAndRobotState>,
-  errorIndex: ?number,
-  errors: ?Array<CommandCreatorError>
-}
 export const commandCreatorsTimeline = (commandCreators: Array<CommandCreator>) =>
 (initialRobotState: RobotState): Timeline => {
   const timeline = commandCreators.reduce(
-    (acc: TimelineAcc, commandCreator: CommandCreator, index: number) => {
+    (acc: Timeline, commandCreator: CommandCreator, index: number) => {
       const prevRobotState = (acc.timeline.length === 0)
         ? initialRobotState
         : last(acc.timeline).robotState
@@ -79,21 +72,18 @@ export const commandCreatorsTimeline = (commandCreators: Array<CommandCreator>) 
       if (nextResult.errors) {
         return {
           timeline: acc.timeline,
-          errorIndex: index,
           errors: nextResult.errors
         }
       }
 
       return {
         timeline: [...acc.timeline, nextResult],
-        errorIndex: null,
         errors: null
       }
-    }, {timeline: [], errorIndex: null, errors: null})
+    }, {timeline: [], errors: null})
 
   return {
     timeline: timeline.timeline,
-    errorIndex: timeline.errorIndex,
     errors: timeline.errors
   }
 }

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -39,7 +39,7 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
             commands: prev.commands,
             errors: next.errors,
             errorStep: stepIdx,
-            warnings: prev.warnings || undefined // TODO IMMEDIATELY this is a flow trick
+            warnings: prev.warnings || undefined // flow fix
           }
         }
 

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -56,7 +56,7 @@ export const reduceCommandCreators = (commandCreators: Array<CommandCreator>): C
     )
   )
 
-type TimelineAcc = { // TODO
+type TimelineAcc = {
   timeline: Array<CommandsAndRobotState>,
   errorIndex: ?number,
   errors: ?Array<CommandCreatorError>

--- a/protocol-designer/src/step-generation/warningCreators.js
+++ b/protocol-designer/src/step-generation/warningCreators.js
@@ -1,0 +1,9 @@
+// @flow
+import type {CommandCreatorWarning} from './types'
+
+export function aspirateMoreThanWellContents (): CommandCreatorWarning {
+  return {
+    type: 'ASPIRATE_MORE_THAN_WELL_CONTENTS',
+    message: 'Not enough liquid in well(s)'
+  }
+}

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -6,7 +6,6 @@ import type {
   StepIdType,
   FormData,
   BlankForm,
-  ProcessedFormData,
   TransferLikeForm,
   MixForm,
   PauseForm
@@ -17,7 +16,8 @@ import type {
   DistributeFormData,
   MixFormData,
   PauseFormData,
-  TransferFormData
+  TransferFormData,
+  CommandCreatorData
 } from '../step-generation'
 
 import {FIXED_TRASH_ID} from '../constants'
@@ -27,7 +27,7 @@ const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'
 // TODO LATER Ian 2018-03-01 remove or consolidate these 2 similar types?
 export type ValidFormAndErrors = {
   errors: {[string]: string},
-  validatedForm: ProcessedFormData | null // TODO: incompleteData field when this is null?
+  validatedForm: CommandCreatorData | null // TODO: incompleteData field when this is null?
 }
 
 type ValidationAndErrors<F> = {

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -21,7 +21,6 @@ import type {
 } from './types'
 
 import type {StepIdType} from '../form-types'
-import type {RobotStateTimeline} from '../file-data/selectors'
 import {
   consolidate,
   distribute,
@@ -30,7 +29,8 @@ import {
 } from '../step-generation'
 
 import type {
-  AspirateDispenseArgs
+  AspirateDispenseArgs,
+  Timeline
   // CommandCreator
 } from '../step-generation'
 
@@ -62,7 +62,7 @@ function transferLikeSubsteps (args: {
   prevStepId: StepIdType,
   getIngreds: GetIngreds,
   getLabwareType: GetLabwareType,
-  robotStateTimeline: RobotStateTimeline
+  robotStateTimeline: Timeline
 }): ?SourceDestSubstepItem {
   const {
     validatedForm,
@@ -88,7 +88,11 @@ function transferLikeSubsteps (args: {
   const robotState = (
     robotStateTimeline.timeline[prevStepId] &&
     robotStateTimeline.timeline[prevStepId].robotState
-  ) || robotStateTimeline.robotState
+  )
+
+  if (!robotState) {
+    return null
+  }
 
   // if false, show aspirate vol instead
   const showDispenseVol = validatedForm.stepType === 'distribute'
@@ -285,9 +289,8 @@ export function generateSubsteps (
   allLabwareTypes: AllLabwareTypes,
   namedIngredsByLabwareAllSteps: NamedIngredsByLabwareAllSteps,
   orderedSteps: Array<StepIdType>,
-  robotStateTimeline: RobotStateTimeline
+  robotStateTimeline: Timeline
 ): SubSteps {
-  console.log('generateSubsteps', namedIngredsByLabwareAllSteps)
   return mapValues(validatedForms, (valForm: ValidFormAndErrors, stepId: StepIdType) => {
     const validatedForm = valForm.validatedForm
     const prevStepId = steplistUtils.getPrevStepId(orderedSteps, stepId)

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -64,7 +64,8 @@ type FormState = FormData | null
 // the `unsavedForm` state holds temporary form info that is saved or thrown away with "cancel".
 const unsavedForm = handleActions({
   CHANGE_FORM_INPUT: (state: FormState, action: ChangeFormInputAction) => {
-    // $FlowFixMe TODO IMMEDIATELY
+    // TODO: Ian 2018-06-14 type properly
+    // $FlowFixMe
     return {
       ...state,
       ...action.payload.update

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -170,7 +170,11 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
 
     function highlightedWellsForTimelineFrame (liquidState, timelineIdx): AllWellHighlightsAllLabware {
       const robotState = timeline[timelineIdx].robotState
-      const formIdx = timelineIdx + 1 // add 1 to make up for initial deck setup action
+      // TODO: Ian 2018-06-15 BUG! this doesn't work where there are deleted steps.
+      // Need to use orderedSteps[timelineIdx + 1] to get stepId
+      // (just like in warningsPerStep and getErrorStepId selectors in file-data/selectors/commands)
+      // Make stepId's always UNIQUE STRINGS to avoid trying to add 1 to them?
+      const formIdx = timelineIdx + 1
       const form = _forms[formIdx] && _forms[formIdx].validatedForm
 
       // replace value of each labware with highlighted wells info

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -11,7 +11,6 @@ import {selectors as fileDataSelectors} from '../file-data'
 
 import type {Selector} from '../types'
 import type {StepSubItemData} from '../steplist/types'
-import type {ProcessedFormData} from '../form-types'
 
 type AllWellHighlights = {[wellName: string]: true} // NOTE: all keys are true
 type AllWellHighlightsAllLabware = {[labwareId: string]: AllWellHighlights}
@@ -32,7 +31,7 @@ function _wellsForPipette (pipetteChannels: 1 | 8, labwareType: string, wells: A
 }
 
 function _getSelectedWellsForStep (
-  form: ProcessedFormData,
+  form: StepGeneration.CommandCreatorData,
   labwareId: string,
   robotState: StepGeneration.RobotState
 ): Array<string> {
@@ -87,7 +86,7 @@ function _getSelectedWellsForStep (
 
 /** Scan through given substep rows to get a list of source/dest wells for the given labware */
 function _getSelectedWellsForSubstep (
-  form: ProcessedFormData,
+  form: StepGeneration.CommandCreatorData,
   labwareId: string,
   substeps: StepSubItemData | null,
   substepId: number
@@ -145,7 +144,7 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
       labwareLiquids: StepGeneration.SingleLabwareLiquidState,
       labwareId: string,
       robotState: StepGeneration.RobotState,
-      form: ProcessedFormData,
+      form: StepGeneration.CommandCreatorData,
       formIdx: number
     ): AllWellHighlights {
       let selectedWells: Array<string> = []

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -90,15 +90,15 @@ export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWe
 )
 
 export const lastValidWellContents: Selector<{[labwareId: string]: AllWellContents}> = createSelector(
-  fileDataSelectors.robotStateTimeline,
-  (timelineFull) => {
+  fileDataSelectors.lastValidRobotState,
+  (robotState) => {
     return mapValues(
-      timelineFull.robotState.labware,
+      robotState.labware,
       (labwareLiquids: StepGeneration.SingleLabwareLiquidState, labwareId: string) => {
         return _wellContentsForLabware(
-          timelineFull.robotState.liquidState.labware[labwareId],
+          robotState.liquidState.labware[labwareId],
           labwareId,
-          timelineFull.robotState.labware[labwareId].type
+          robotState.labware[labwareId].type
         )
       }
     )


### PR DESCRIPTION
## overview

Closes #1089 and closes #1697

1. This PR separates concerns of validating step forms vs creating a "timeline" data object from an array of CommandCreators. Instead of the timeline being created inside the `robotStateTimeline` selector in `file-data`, that logic is moved to `commandCreatorsTimeline`, simplifying the `robotStateTimeline` selector

2. This PR creates a new `warnings` pipeline for *timeline-level warnings*.

3. To show that the warning pipeline works, this PR also includes the first warning in PD: "Not enough liquid in well(s)" when the user aspirates more liquid from a well than the well contains.

Unlike timeline-level errors, warnings do not stop timeline creation pipeline. They indicate to the user that something may or may not have gone wrong, and the protocol may still be valid. They are associated with a particular CommandCreator (and therefore in how PD uses them, a particular Step in the Step List).

## changelog

- use a new util 'commandCreatorsTimeline' to make timeline instead of 'robotStateTimeline'
- warnings inside the timeline items will show up for the selected step
- split out timeline creation logic from file-data selector to step-generation module's utils.js
- replace ProcessedFormData type with CommandCreatorData type (finally uniting the 2!)
- aspirateUpdateLiquidState generates ASPIRATE_MORE_THAN_WELL_CONTENTS warning

## review requests

We're using a feature flag to hide warnings in production since they can't be dismissed yet. :warning: So you must run the dev server with `OT_PD_SHOW_WARNINGS=true make dev` to see them. :warning: 

**NOTE:** Warnings will NOT be dismissable in this PR (clicking dismiss :x: will just do a `console.log`)

**Big QA checklist for this one!!!**

Please check whatever boxes you confirm are OK.

- [x] If you aspirate more volume than your source well(s) contain, a **single** "Not enough liquid in well" warning should show up. Please confirm you only get one warning when you over-aspirate from multiple wells.
- [x] `make dev`, with no `OT_PD_SHOW_WARNINGS=true` env var, should not show warnings. The "production" build of this branch on S3 should not show warnings either.
- [x] Warnings are per-step: if you do not have the corresponding step selected, you won't see the AlertItems.
- [x] A Step Item "card" in the Step List should have the warning/error circle icon next to it. This should happen if it has a warning ("not enough liquid in well") or an error ("ran out of tips"). But when the feature flag is not enabled, the warning icon should not show in the cards for warnings, just errors.
- [x] Deleting some steps will break the pattern of `step id === timeline idx + 1`. So please delete some steps and make a messy step list to make sure it's really robust and not doing `stepId idx + 1` anywhere that I may have missed
- [x] This "not enough liquid in well" is a timeline-level WARNING: if you run into a timeline-level ERROR (like running out of tips) upstream of the step that generates this warning, the "Not enough liquid in well" warning should *not* appear. Just the upstream error.
