### PR TITLE
chore(*): OpenTrons -> Opentrons; v3a -> edge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
   Thanks for taking the time to open a pull request! Please make sure you've
   read the "Opening Pull Requests" section of our Contributing Guide:
 
-  https://github.com/Opentrons/opentrons/blob/v3a/CONTRIBUTING.md#opening-pull-requests
+  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests
 
   To ensure your code is reviewed quickly and thoroughly, please fill out the
   sections below to the best of your ability!

--- a/protocol-designer/CHANGELOG.md
+++ b/protocol-designer/CHANGELOG.md
@@ -4,17 +4,17 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.2.0-beta.0"></a>
-# [3.2.0-beta.0](https://github.com/OpenTrons/opentrons/compare/v3.1.2...v3.2.0-beta.0) (2018-06-13)
+# [3.2.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.1.2...v3.2.0-beta.0) (2018-06-13)
 
 
 ### Bug Fixes
 
-* **protocol-designer:** fix bug with multi-channel substeps ([#1663](https://github.com/OpenTrons/opentrons/issues/1663)) ([1fca294](https://github.com/OpenTrons/opentrons/commit/1fca294))
+* **protocol-designer:** fix bug with multi-channel substeps ([#1663](https://github.com/Opentrons/opentrons/issues/1663)) ([1fca294](https://github.com/Opentrons/opentrons/commit/1fca294))
 
 
 ### Features
 
-* **protocol-designer:** Darken font in labware selection modal ([#1646](https://github.com/OpenTrons/opentrons/issues/1646)) ([aacc76c](https://github.com/OpenTrons/opentrons/commit/aacc76c)), closes [#1341](https://github.com/OpenTrons/opentrons/issues/1341)
-* **protocol-designer:** elaborate on deck setup in title bar ([#1637](https://github.com/OpenTrons/opentrons/issues/1637)) ([6bda925](https://github.com/OpenTrons/opentrons/commit/6bda925)), closes [#1339](https://github.com/OpenTrons/opentrons/issues/1339)
-* **protocol-designer:** increase selected pipette font-size ([#1629](https://github.com/OpenTrons/opentrons/issues/1629)) ([b90e767](https://github.com/OpenTrons/opentrons/commit/b90e767)), closes [#1325](https://github.com/OpenTrons/opentrons/issues/1325)
-* **protocol-designer:** update behavior for well setup ([#1511](https://github.com/OpenTrons/opentrons/issues/1511)) ([8c611b5](https://github.com/OpenTrons/opentrons/commit/8c611b5))
+* **protocol-designer:** Darken font in labware selection modal ([#1646](https://github.com/Opentrons/opentrons/issues/1646)) ([aacc76c](https://github.com/Opentrons/opentrons/commit/aacc76c)), closes [#1341](https://github.com/Opentrons/opentrons/issues/1341)
+* **protocol-designer:** elaborate on deck setup in title bar ([#1637](https://github.com/Opentrons/opentrons/issues/1637)) ([6bda925](https://github.com/Opentrons/opentrons/commit/6bda925)), closes [#1339](https://github.com/Opentrons/opentrons/issues/1339)
+* **protocol-designer:** increase selected pipette font-size ([#1629](https://github.com/Opentrons/opentrons/issues/1629)) ([b90e767](https://github.com/Opentrons/opentrons/commit/b90e767)), closes [#1325](https://github.com/Opentrons/opentrons/issues/1325)
+* **protocol-designer:** update behavior for well setup ([#1511](https://github.com/Opentrons/opentrons/issues/1511)) ([8c611b5](https://github.com/Opentrons/opentrons/commit/8c611b5))

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -1,7 +1,7 @@
 {
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenTrons/opentrons.git"
+    "url": "https://github.com/Opentrons/opentrons.git"
   },
   "author": {
     "name": "Opentrons Labworks",
@@ -13,9 +13,9 @@
   "description": "Protocol designer app",
   "main": "src/index.js",
   "bugs": {
-    "url": "https://github.com/OpenTrons/opentrons/issues"
+    "url": "https://github.com/Opentrons/opentrons/issues"
   },
-  "homepage": "https://github.com/OpenTrons/opentrons",
+  "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
     "@opentrons/components": "3.2.0-beta.0",


### PR DESCRIPTION
#1701 reminded me that some `OpenTrons` not `Opentrons` lines still exist -- they're mostly in the outdated API docs, but I fixed the ones in PD.

Also tossed in changing the last remaining `v3a` to `edge` in PULL_REQUEST_TEMPLATE.

@mcous is it OK to edit PD's CHANGELOG like this? Or should I leave CHANGELOG and just change package.json, and it will correct it when it builds the next CHANGELOG?