### PR TITLE
refactor(protocol-designer): Split up step edit form logic into types

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import _ from 'lodash'
+import startCase from 'lodash/startCase'
 import cx from 'classnames'
 import {Icon} from '@opentrons/components'
 
@@ -25,7 +25,7 @@ const FormSection = (props: FormSectionProps) => {
   const childrenArray = React.Children.toArray(props.children)
   return (
     <div className={cx(styles.form_section, props.className)}>
-      <div className={styles.title}>{_.startCase(props.sectionName)}</div>
+      <div className={styles.title}>{startCase(props.sectionName)}</div>
 
       <div className={styles.content}>
         {/* First child always visible, following children only visible if not collapsed */}

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import _ from 'lodash';
+import _ from 'lodash'
 import cx from 'classnames'
 import {Icon} from '@opentrons/components'
 
@@ -51,7 +51,7 @@ const FormSectionSTP = (state: BaseState, ownProps: OP) => ({
   collapsed: steplistSelectors.formSectionCollapse(state)[ownProps.sectionName]
 })
 const FormSectionDTP = (dispatch: ThunkDispatch<*>, ownProps: OP) => ({
-  onCollapseToggle: () => collapseFormSection(ownProps.sectionName)
+  onCollapseToggle: () => dispatch(collapseFormSection(ownProps.sectionName))
 })
 const ConnectedFormSection = connect(FormSectionSTP, FormSectionDTP)(FormSection)
 

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -1,12 +1,19 @@
 // @flow
 import * as React from 'react'
+import {connect} from 'react-redux'
+import _ from 'lodash';
 import cx from 'classnames'
 import {Icon} from '@opentrons/components'
 
+import {selectors as steplistSelectors} from '../../steplist/reducers'
+import {collapseFormSection} from '../../steplist/actions'
+import type {BaseState, ThunkDispatch} from '../../types'
 import styles from './FormSection.css'
 
-type Props = {
-  title?: string,
+// TODO: get these from src/steplist/types.js
+type OP = {sectionName: 'aspirate' | 'dispense'}
+type FormSectionProps = {
+  sectionName?: string,
   children?: React.Node,
   className?: string,
   /** if defined, carat shows */
@@ -14,11 +21,11 @@ type Props = {
   collapsed?: boolean
 }
 
-export default function FormSection (props: Props) {
+const FormSection = (props: FormSectionProps) => {
   const childrenArray = React.Children.toArray(props.children)
   return (
     <div className={cx(styles.form_section, props.className)}>
-      <div className={styles.title}>{props.title}</div>
+      <div className={styles.title}>{_.startCase(props.sectionName)}</div>
 
       <div className={styles.content}>
         {/* First child always visible, following children only visible if not collapsed */}
@@ -26,7 +33,7 @@ export default function FormSection (props: Props) {
         {props.collapsed !== true && childrenArray.slice(1)}
       </div>
 
-      {props.onCollapseToggle &&
+      {props.collapsed !== undefined && // if doesn't exist in redux
         <div onClick={props.onCollapseToggle}>
           {/* TODO Ian 2018-01-29 use an IconButton once it exists */}
           <Icon
@@ -39,3 +46,13 @@ export default function FormSection (props: Props) {
     </div>
   )
 }
+
+const FormSectionSTP = (state: BaseState, ownProps: OP) => ({
+  collapsed: steplistSelectors.formSectionCollapse(state)[ownProps.sectionName]
+})
+const FormSectionDTP = (dispatch: ThunkDispatch<*>, ownProps: OP) => ({
+  onCollapseToggle: () => collapseFormSection(ownProps.sectionName)
+})
+const ConnectedFormSection = connect(FormSectionSTP, FormSectionDTP)(FormSection)
+
+export default ConnectedFormSection

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -1,0 +1,76 @@
+  // @flow
+import * as React from 'react'
+import cx from 'classnames'
+import {FormGroup, InputField} from '@opentrons/components'
+
+import {
+  CheckboxRow,
+  DelayField,
+  ConnectedPipetteField,
+  ConnectedLabwareOptionsDropdown,
+  TipSettingsColumn
+} from './formFields'
+import type {FormData} from '../../form-types'
+import WellSelectionInput from '../../containers/WellSelectionInput'
+import formStyles from '../forms.css'
+import styles from './StepEditForm.css'
+
+type MixFormProps = {formData: FormData}
+
+const MixForm = ({formData, formConnector}: MixFormProps) => (
+  <React.Fragment>
+    <div className={formStyles.row_wrapper}>
+      <FormGroup label='Labware:' className={styles.labware_field}>
+        <ConnectedLabwareOptionsDropdown {...formConnector('labware')} />
+      </FormGroup>
+      {/* TODO LATER: also 'disable' when selected labware is a trash */}
+      <WellSelectionInput
+        className={styles.well_selection_input}
+        labwareId={formData['labware']}
+        pipetteId={formData['pipette']}
+        initialSelectedWells={formData['wells']}
+        formFieldAccessor={'wells'}
+      />
+      <ConnectedPipetteField formConnector={formConnector}/>
+    </div>
+
+    <div className={cx(formStyles.row_wrapper)}>
+      <FormGroup label='Repetitions' className={styles.field_row}>
+        <InputField units='uL' {...formConnector('volume')} />
+        <InputField units='Times' {...formConnector('times')} />
+      </FormGroup>
+    </div>
+
+    <div className={formStyles.row_wrapper}>
+      <div className={styles.left_settings_column}>
+        <FormGroup label='TECHNIQUE'>
+          <DelayField
+            checkboxAccessor='dispense--delay--checkbox'
+            formConnector={formConnector}
+            minutesAccessor='dispense--delay-minutes'
+            secondsAccessor='dispense--delay-seconds'
+          />
+          <CheckboxRow
+            checkboxAccessor='dispense--blowout--checkbox'
+            formConnector={formConnector}
+            label='Blow out'
+          >
+            <ConnectedLabwareOptionsDropdown
+              className={styles.full_width}
+              {...formConnector('dispense--blowout--labware')}
+            />
+          </CheckboxRow>
+
+          <CheckboxRow
+            checkboxAccessor='touch-tip'
+            formConnector={formConnector}
+            label='Touch tip'
+          />
+        </FormGroup>
+      </div>
+      <TipSettingsColumn />
+    </div>
+  </React.Fragment>
+)
+
+export default MixForm

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -7,22 +7,22 @@ import {
   CheckboxRow,
   DelayField,
   ConnectedPipetteField,
-  ConnectedLabwareOptionsDropdown,
+  LabwareDropdown,
   TipSettingsColumn
 } from './formFields'
-import type {FormData} from '../../form-types'
+import type {MixForm as MixFormData} from '../../form-types'
 import type {FormConnector} from '../../utils'
 import WellSelectionInput from '../../containers/WellSelectionInput'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 
-type MixFormProps = {formData: FormData, formConnector: FormConnector}
+type MixFormProps = {formData: MixFormData, formConnector: FormConnector<*>}
 
 const MixForm = ({formData, formConnector}: MixFormProps) => (
   <React.Fragment>
     <div className={formStyles.row_wrapper}>
       <FormGroup label='Labware:' className={styles.labware_field}>
-        <ConnectedLabwareOptionsDropdown {...formConnector('labware')} />
+        <LabwareDropdown {...formConnector('labware')} />
       </FormGroup>
       {/* TODO LATER: also 'disable' when selected labware is a trash */}
       <WellSelectionInput
@@ -56,7 +56,7 @@ const MixForm = ({formData, formConnector}: MixFormProps) => (
             formConnector={formConnector}
             label='Blow out'
           >
-            <ConnectedLabwareOptionsDropdown
+            <LabwareDropdown
               className={styles.full_width}
               {...formConnector('dispense--blowout--labware')}
             />

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -1,4 +1,4 @@
-  // @flow
+// @flow
 import * as React from 'react'
 import cx from 'classnames'
 import {FormGroup, InputField} from '@opentrons/components'
@@ -11,11 +11,12 @@ import {
   TipSettingsColumn
 } from './formFields'
 import type {FormData} from '../../form-types'
+import type {FormConnector} from '../../utils'
 import WellSelectionInput from '../../containers/WellSelectionInput'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 
-type MixFormProps = {formData: FormData}
+type MixFormProps = {formData: FormData, formConnector: FormConnector}
 
 const MixForm = ({formData, formConnector}: MixFormProps) => (
   <React.Fragment>

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -6,7 +6,7 @@ import {FormGroup, InputField} from '@opentrons/components'
 import {
   CheckboxRow,
   DelayField,
-  ConnectedPipetteField,
+  PipetteField,
   LabwareDropdown,
   TipSettingsColumn
 } from './formFields'
@@ -32,7 +32,7 @@ const MixForm = ({formData, formConnector}: MixFormProps) => (
         initialSelectedWells={formData['wells']}
         formFieldAccessor={'wells'}
       />
-      <ConnectedPipetteField formConnector={formConnector}/>
+      <PipetteField formConnector={formConnector}/>
     </div>
 
     <div className={cx(formStyles.row_wrapper)}>

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -69,7 +69,7 @@ const MixForm = ({formData, formConnector}: MixFormProps) => (
           />
         </FormGroup>
       </div>
-      <TipSettingsColumn />
+      <TipSettingsColumn formConnector={formConnector} />
     </div>
   </React.Fragment>
 )

--- a/protocol-designer/src/components/StepEditForm/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/PauseForm.js
@@ -1,13 +1,12 @@
 // @flow
 import * as React from 'react'
-import cx from 'classnames'
 import {FormGroup, InputField, RadioGroup} from '@opentrons/components'
 
-import type {FormData} from '../../form-types'
+import type {PauseForm as PauseFormData} from '../../form-types'
 import type {FormConnector} from '../../utils'
 import formStyles from '../forms.css'
 
-type PauseFormProps = {formData: FormData, formConnector: FormConnector}
+type PauseFormProps = {formData: PauseFormData, formConnector: FormConnector<*>}
 const PauseForm = ({formData, formConnector}: PauseFormProps) => (
   <div className={formStyles.row_wrapper}>
     <div className={formStyles.column_1_2}>

--- a/protocol-designer/src/components/StepEditForm/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/PauseForm.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import {FormGroup, InputField, RadioGroup} from '@opentrons/components'
+
+import type {FormData} from '../../form-types'
+import type {FormConnector} from '../../utils'
+import formStyles from '../forms.css'
+
+type PauseFormProps = {formData: FormData, formConnector: FormConnector}
+const PauseForm = ({formData, formConnector}: PauseFormProps) => (
+  <div className={formStyles.row_wrapper}>
+    <div className={formStyles.column_1_2}>
+      <RadioGroup options={[{name: 'Pause for an amount of time', value: 'true'}]}
+        {...formConnector('pause-for-amount-of-time')} />
+      <InputField units='hr' {...formConnector('pause-hour')} />
+      <InputField units='m' {...formConnector('pause-minute')} />
+      <InputField units='s' {...formConnector('pause-second')} />
+    </div>
+    <div className={formStyles.column_1_2}>
+      <RadioGroup options={[{name: 'Pause until told to resume', value: 'false'}]}
+        {...formConnector('pause-for-amount-of-time')} />
+      <FormGroup label='Message to display'>
+        <InputField {...formConnector('pause-message')} />
+      </FormGroup>
+    </div>
+  </div>
+)
+
+export default PauseForm

--- a/protocol-designer/src/components/StepEditForm/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/PauseForm.js
@@ -2,28 +2,30 @@
 import * as React from 'react'
 import {FormGroup, InputField, RadioGroup} from '@opentrons/components'
 
-import type {PauseForm as PauseFormData} from '../../form-types'
 import type {FormConnector} from '../../utils'
 import formStyles from '../forms.css'
 
-type PauseFormProps = {formData: PauseFormData, formConnector: FormConnector<*>}
-const PauseForm = ({formData, formConnector}: PauseFormProps) => (
-  <div className={formStyles.row_wrapper}>
-    <div className={formStyles.column_1_2}>
-      <RadioGroup options={[{name: 'Pause for an amount of time', value: 'true'}]}
-        {...formConnector('pause-for-amount-of-time')} />
-      <InputField units='hr' {...formConnector('pause-hour')} />
-      <InputField units='m' {...formConnector('pause-minute')} />
-      <InputField units='s' {...formConnector('pause-second')} />
+type PauseFormProps = {formConnector: FormConnector<*>}
+function PauseForm (props: PauseFormProps) {
+  const {formConnector} = props
+  return (
+    <div className={formStyles.row_wrapper}>
+      <div className={formStyles.column_1_2}>
+        <RadioGroup options={[{name: 'Pause for an amount of time', value: 'true'}]}
+          {...formConnector('pause-for-amount-of-time')} />
+        <InputField units='hr' {...formConnector('pause-hour')} />
+        <InputField units='m' {...formConnector('pause-minute')} />
+        <InputField units='s' {...formConnector('pause-second')} />
+      </div>
+      <div className={formStyles.column_1_2}>
+        <RadioGroup options={[{name: 'Pause until told to resume', value: 'false'}]}
+          {...formConnector('pause-for-amount-of-time')} />
+        <FormGroup label='Message to display'>
+          <InputField {...formConnector('pause-message')} />
+        </FormGroup>
+      </div>
     </div>
-    <div className={formStyles.column_1_2}>
-      <RadioGroup options={[{name: 'Pause until told to resume', value: 'false'}]}
-        {...formConnector('pause-for-amount-of-time')} />
-      <FormGroup label='Message to display'>
-        <InputField {...formConnector('pause-message')} />
-      </FormGroup>
-    </div>
-  </div>
-)
+  )
+}
 
 export default PauseForm

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -17,7 +17,7 @@ import FormSection from './FormSection'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 import type {FormConnector} from '../../utils'
-import type {TransferLikeFrom as TransferLikeFormData} from '../../form-types'
+import type {TransferLikeForm as TransferLikeFormData} from '../../form-types'
 
 type TransferLikeFormProps = {formData: TransferLikeFormData, formConnector: FormConnector<*>}
 
@@ -127,7 +127,7 @@ const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
             </CheckboxRow>
           </FormGroup>
         </div>
-        <TipSettingsColumn hasChangeField={false} />
+        <TipSettingsColumn formConnector={formConnector} hasChangeField={false} />
       </div>
     </FormSection>
   </React.Fragment>

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -6,7 +6,7 @@ import {
   CheckboxRow,
   DelayField,
   MixField,
-  ConnectedPipetteField,
+  PipetteField,
   LabwareDropdown,
   VolumeField,
   TipSettingsColumn
@@ -36,7 +36,7 @@ const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
           initialSelectedWells={formData['aspirate--wells']}
           formFieldAccessor={'aspirate--wells'}
         />
-        <ConnectedPipetteField formConnector={formConnector}/>
+        <PipetteField formConnector={formConnector}/>
         {formData.stepType === 'consolidate' && <VolumeField formConnector={formConnector} />}
       </div>
 

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -7,7 +7,7 @@ import {
   DelayField,
   MixField,
   ConnectedPipetteField,
-  ConnectedLabwareOptionsDropdown,
+  LabwareDropdown,
   VolumeField,
   TipSettingsColumn
 } from './formFields'
@@ -17,16 +17,16 @@ import FormSection from './FormSection'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 import type {FormConnector} from '../../utils'
-import type {FormData} from '../../form-types'
+import type {TransferLikeFrom as TransferLikeFormData} from '../../form-types'
 
-type TransferLikeFormProps = {formData: FormData, formConnector: FormConnector<*>}
+type TransferLikeFormProps = {formData: TransferLikeFormData, formConnector: FormConnector<*>}
 
 const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
   <React.Fragment>
     <FormSection sectionName='aspirate'>
       <div className={formStyles.row_wrapper}>
         <FormGroup label='Labware:' className={styles.labware_field}>
-          <ConnectedLabwareOptionsDropdown {...formConnector('aspirate--labware')} />
+          <LabwareDropdown {...formConnector('aspirate--labware')} />
         </FormGroup>
         {/* TODO LATER: also 'disable' when selected labware is a trash */}
         <WellSelectionInput
@@ -86,7 +86,7 @@ const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
     <FormSection sectionName='dispense'>
       <div className={formStyles.row_wrapper}>
         <FormGroup label='Labware:' className={styles.labware_field}>
-          <ConnectedLabwareOptionsDropdown {...formConnector('dispense--labware')} />
+          <LabwareDropdown {...formConnector('dispense--labware')} />
         </FormGroup>
         <WellSelectionInput
           className={styles.well_selection_input}
@@ -120,7 +120,7 @@ const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
               formConnector={formConnector}
               label='Blow out'
             >
-              <ConnectedLabwareOptionsDropdown
+              <LabwareDropdown
                 className={styles.full_width}
                 {...formConnector('dispense--blowout--labware')}
               />

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -1,10 +1,6 @@
 // @flow
 import * as React from 'react'
-import {
-  FormGroup,
-  DropdownField,
-  InputField
-} from '@opentrons/components'
+import {FormGroup, InputField} from '@opentrons/components'
 
 import {
   CheckboxRow,

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -1,0 +1,140 @@
+// @flow
+import * as React from 'react'
+import {
+  FormGroup,
+  DropdownField,
+  InputField
+} from '@opentrons/components'
+
+import {
+  CheckboxRow,
+  DelayField,
+  MixField,
+  ConnectedPipetteField,
+  ConnectedLabwareOptionsDropdown,
+  VolumeField,
+  TipSettingsColumn
+} from './formFields'
+
+import WellSelectionInput from '../../containers/WellSelectionInput'
+import FormSection from './FormSection'
+import formStyles from '../forms.css'
+import styles from './StepEditForm.css'
+import type {FormConnector} from '../../utils'
+import type {FormData} from '../../form-types'
+
+type TransferLikeFormProps = {formData: FormData, formConnector: FormConnector<*>}
+
+const TransferLikeForm = ({formData, formConnector}: TransferLikeFormProps) => (
+  <React.Fragment>
+    <FormSection sectionName='aspirate'>
+      <div className={formStyles.row_wrapper}>
+        <FormGroup label='Labware:' className={styles.labware_field}>
+          <ConnectedLabwareOptionsDropdown {...formConnector('aspirate--labware')} />
+        </FormGroup>
+        {/* TODO LATER: also 'disable' when selected labware is a trash */}
+        <WellSelectionInput
+          className={styles.well_selection_input}
+          labwareId={formData['aspirate--labware']}
+          pipetteId={formData['pipette']}
+          initialSelectedWells={formData['aspirate--wells']}
+          formFieldAccessor={'aspirate--wells'}
+        />
+        <ConnectedPipetteField formConnector={formConnector}/>
+        {formData.stepType === 'consolidate' && <VolumeField formConnector={formConnector} />}
+      </div>
+
+      <div className={formStyles.row_wrapper}>
+        <div className={styles.left_settings_column}>
+          <FormGroup label='TECHNIQUE'>
+            <CheckboxRow
+              checkboxAccessor='aspirate--pre-wet-tip'
+              formConnector={formConnector}
+              label='Pre-wet tip'
+            />
+
+            <CheckboxRow
+              checkboxAccessor='aspirate--touch-tip'
+              formConnector={formConnector}
+              label='Touch tip'
+            />
+
+            <CheckboxRow
+              checkboxAccessor='aspirate--air-gap--checkbox'
+              formConnector={formConnector}
+              label='Air Gap'
+            >
+              <InputField units='μL' {...formConnector('aspirate--air-gap--volume')} />
+            </CheckboxRow>
+
+            <MixField
+              checkboxAccessor='aspirate--mix--checkbox'
+              formConnector={formConnector}
+              timesAccessor='aspirate--mix--times'
+              volumeAccessor='aspirate--mix--volume'
+            />
+
+            <CheckboxRow
+              checkboxAccessor='aspirate--disposal-vol--checkbox'
+              formConnector={formConnector}
+              label='Disposal Volume'
+            >
+              <InputField units='μL' {...formConnector('aspirate--disposal-vol--volume')} />
+            </CheckboxRow>
+          </FormGroup>
+        </div>
+        <TipSettingsColumn formConnector={formConnector} />
+      </div>
+    </FormSection>
+
+    <FormSection sectionName='dispense'>
+      <div className={formStyles.row_wrapper}>
+        <FormGroup label='Labware:' className={styles.labware_field}>
+          <ConnectedLabwareOptionsDropdown {...formConnector('dispense--labware')} />
+        </FormGroup>
+        <WellSelectionInput
+          className={styles.well_selection_input}
+          labwareId={formData['dispense--labware']}
+          pipetteId={formData['pipette']}
+          initialSelectedWells={formData['dispense--wells']}
+          formFieldAccessor={'dispense--wells'}
+        />
+        {(formData.stepType === 'transfer' || formData.stepType === 'distribute') &&
+          <VolumeField formConnector={formConnector} />}
+      </div>
+
+      <div className={formStyles.row_wrapper}>
+        <div className={styles.left_settings_column}>
+          <FormGroup label='TECHNIQUE'>
+            <MixField
+              checkboxAccessor='dispense--mix--checkbox'
+              formConnector={formConnector}
+              volumeAccessor='dispense--mix--volume'
+              timesAccessor='dispense--mix--times'
+            />
+            <DelayField
+              checkboxAccessor='dispense--delay--checkbox'
+              formConnector={formConnector}
+              minutesAccessor='dispense--delay-minutes'
+              secondsAccessor='dispense--delay-seconds'
+            />
+
+            <CheckboxRow
+              checkboxAccessor='dispense--blowout--checkbox'
+              formConnector={formConnector}
+              label='Blow out'
+            >
+              <ConnectedLabwareOptionsDropdown
+                className={styles.full_width}
+                {...formConnector('dispense--blowout--labware')}
+              />
+            </CheckboxRow>
+          </FormGroup>
+        </div>
+        <TipSettingsColumn hasChangeField={false} />
+      </div>
+    </FormSection>
+  </React.Fragment>
+)
+
+export default TransferLikeForm

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -88,7 +88,7 @@ export function MixField (props: MixFieldProps) {
 
 const PipetteFieldSTP = state => ({pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)})
 type PipetteFieldProps = {formConnector: FormConnector<*>, pipetteOptions: Options}
-export const ConnectedPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
+export const PipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
   ({formConnector, pipetteOptions}: PipetteFieldProps) => (
     <FormGroup label='Pipette:' className={styles.pipette_field}>
       <DropdownField options={pipetteOptions} {...formConnector('pipette')} />

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -87,13 +87,12 @@ export function MixField (props: MixFieldProps) {
   )
 }
 
-type PipetteFieldOP= {formConnector: FormConnector<*>}
+type PipetteFieldOP = {formConnector: FormConnector<*>}
 type PipetteFieldSP = {pipetteOptions: Options}
 const PipetteFieldSTP = (state: BaseState): PipetteFieldSP => ({
   pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)
 })
-const connectPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))
-export const PipetteField = connectPipetteField((props: PipetteFieldOP & PipetteFieldSP) => {
+export const PipetteField = connect(PipetteFieldSTP)((props: PipetteFieldOP & PipetteFieldSP) => {
   const {formConnector, pipetteOptions} = props
   return (
     <FormGroup label='Pipette:' className={styles.pipette_field}>
@@ -102,13 +101,12 @@ export const PipetteField = connectPipetteField((props: PipetteFieldOP & Pipette
   )
 })
 
-type LabwareDropdownOP= FormConnector<*>
+type LabwareDropdownOP = $Call<FormConnector<*>, string>
 type LabwareDropdownSP = {labwareOptions: Options}
 const LabwareDropdownSTP = (state: BaseState): LabwareDropdownSP => ({
   labwareOptions: labwareIngredSelectors.labwareOptions(state)
 })
-const connectLabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))
-export const LabwareDropdown = connectLabwareDropdown((props: LabwareDropdownOP & LabwareDropdownSP) => {
+export const LabwareDropdown = connect(LabwareDropdownSTP)((props: LabwareDropdownOP & LabwareDropdownSP) => {
   const {labwareOptions, ...restProps} = props
   return <DropdownField options={labwareOptions} {...restProps} />
 })

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -1,13 +1,19 @@
 // @flow
 import * as React from 'react'
+import {connect} from 'react-redux'
 import {
   FormGroup,
   CheckboxField,
-  InputField
+  InputField,
+  DropdownField,
+  type DropdownOption
 } from '@opentrons/components'
-
-import styles from './StepEditForm.css'
+import {selectors as fileDataSelectors} from '../../file-data'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {FormConnector} from '../../utils'
+import styles from './StepEditForm.css'
+
+type Options = Array<DropdownOption>
 
 type CheckboxRowProps = {
   label?: string,
@@ -55,16 +61,6 @@ export function DelayField (props: DelayFieldProps) {
   )
 }
 
-export function FlowRateField () {
-  // NOTE 2018-05-31 Flow rate cannot yet be adjusted,
-  // this is a placeholder
-  return (
-    <FormGroup label='FLOW RATE'>
-      Default
-    </FormGroup>
-  )
-}
-
 type MixFieldProps = {
   timesAccessor: string,
   volumeAccessor: string
@@ -90,12 +86,67 @@ export function MixField (props: MixFieldProps) {
   )
 }
 
-export function TipPositionField () {
-  // NOTE 2018-05-31 Tip position cannot yet be adjusted,
-  // this is a placeholder
-  return (
-    <FormGroup label='TIP POSITION'>
-      Bottom, center
+
+const PipetteFieldSTP = state => ({pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)})
+type PipetteFieldProps = {formConnector: FormConnector<*>, pipetteOptions: Options}
+export const ConnectedPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
+  ({formConnector, pipetteOptions}: PipetteFieldProps) => (
+    <FormGroup label='Pipette:' className={styles.pipette_field}>
+      <DropdownField options={pipetteOptions} {...formConnector('pipette')} />
     </FormGroup>
   )
-}
+)
+
+const LabwareOptionsDropdownSTP = state => ({labwareOptions: labwareIngredSelectors.labwareOptions(state)})
+type LabwareOptionsDropdownProps = {labwareOptions: Options}
+export const ConnectedLabwareOptionsDropdown = connect(LabwareOptionsDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
+  ({labwareOptions, ...restProps}: LabwareOptionsDropdownProps) => (
+    <DropdownField options={labwareOptions} {...restProps} />
+  )
+)
+
+type VolumeFieldProps = {formConnector: FormConnector<*>}
+export const VolumeField = ({formConnector}: VolumeFieldProps) => (
+  <FormGroup label='Volume:' className={styles.volume_field}>
+    <InputField units='μL' {...formConnector('volume')} />
+  </FormGroup>
+)
+
+// NOTE 2018-05-31 Flow rate cannot yet be adjusted,
+// this is a placeholder
+export const FlowRateField = () => (
+  <FormGroup label='FLOW RATE'>
+    Default
+  </FormGroup>
+)
+
+// NOTE 2018-05-31 Tip position cannot yet be adjusted,
+// this is a placeholder
+export const TipPositionField = () => (
+  <FormGroup label='TIP POSITION'>
+    Bottom, center
+  </FormGroup>
+)
+
+type ChangeTipFieldProps = {formConnector: FormConnector<*>}
+export const ChangeTipField = ({formConnector}: ChangeTipFieldProps) => (
+  <FormGroup label='CHANGE TIP'>
+    <DropdownField
+      {...formConnector('aspirate--change-tip')}
+      options={[
+        {name: 'Always', value: 'always'},
+        {name: 'Once', value: 'once'},
+        {name: 'Never', value: 'never'}
+      ]}
+    />
+  </FormGroup>
+)
+
+type TipSettingsColumnProps = {formConnector: FormConnector<*>, hasChangeField: boolean}
+export const TipSettingsColumn = ({formConnector, hasChangeField = true}: TipSettingsColumnProps) => (
+  <div className={styles.right_settings_column}>
+    {hasChangeField && <ChangeTipField formConnector={formConnector} />}
+    <FlowRateField />
+    <TipPositionField />
+  </div>
+)

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -86,7 +86,6 @@ export function MixField (props: MixFieldProps) {
   )
 }
 
-
 const PipetteFieldSTP = state => ({pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)})
 type PipetteFieldProps = {formConnector: FormConnector<*>, pipetteOptions: Options}
 export const ConnectedPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -92,13 +92,15 @@ type PipetteFieldSP = {pipetteOptions: Options}
 const PipetteFieldSTP = (state: BaseState): PipetteFieldSP => ({
   pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)
 })
-export const PipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({formConnector, pipetteOptions}: PipetteFieldOP & PipetteFieldSP) => (
+const connectPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))
+export const PipetteField = connectPipetteField((props: PipetteFieldOP & PipetteFieldSP) => {
+  const {formConnector, pipetteOptions} = props
+  return (
     <FormGroup label='Pipette:' className={styles.pipette_field}>
       <DropdownField options={pipetteOptions} {...formConnector('pipette')} />
     </FormGroup>
   )
-)
+})
 
 type LabwareDropdownOP= FormConnector<*>
 type LabwareDropdownSP = {labwareOptions: Options}

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -86,21 +86,26 @@ export function MixField (props: MixFieldProps) {
   )
 }
 
-const PipetteFieldSTP = state => ({pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)})
-type PipetteFieldProps = {formConnector: FormConnector<*>, pipetteOptions: Options}
+type PipetteFieldOP= {formConnector: FormConnector<*>}
+type PipetteFieldSP = {pipetteOptions: Options}
+const PipetteFieldSTP = (state: BaseState): PipetteFieldSP => ({
+  pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)
+})
 export const PipetteField = connect(PipetteFieldSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({formConnector, pipetteOptions}: PipetteFieldProps) => (
+  ({formConnector, pipetteOptions}: PipetteFieldOP & PipetteFieldSP) => (
     <FormGroup label='Pipette:' className={styles.pipette_field}>
       <DropdownField options={pipetteOptions} {...formConnector('pipette')} />
     </FormGroup>
   )
 )
 
-const LabwareDropdownSTP = state => ({labwareOptions: labwareIngredSelectors.labwareOptions(state)})
-type LabwareDropdownStateProps = {labwareOptions: Options}
-type LabwareDropdownOwnProps = FormConnector<*>
+type LabwareDropdownOP= FormConnector<*>
+type LabwareDropdownSP = {labwareOptions: Options}
+const LabwareDropdownSTP = (state: BaseState): LabwareDropdownSP => ({
+  labwareOptions: labwareIngredSelectors.labwareOptions(state)
+})
 export const LabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({labwareOptions, ...props}: LabwareDropdownOwnProps & LabwareDropdownStateProps) => (
+  ({labwareOptions, ...props}: LabwareDropdownOP & LabwareDropdownSP) => (
     <DropdownField options={labwareOptions} {...props} />
   )
 )

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -96,10 +96,11 @@ export const ConnectedPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatc
   )
 )
 
-const LabwareOptionsDropdownSTP = state => ({labwareOptions: labwareIngredSelectors.labwareOptions(state)})
-type LabwareOptionsDropdownProps = {labwareOptions: Options}
-export const ConnectedLabwareOptionsDropdown = connect(LabwareOptionsDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({labwareOptions, ...restProps}: LabwareOptionsDropdownProps) => (
+const LabwareDropdownSTP = state => ({labwareOptions: labwareIngredSelectors.labwareOptions(state)})
+type LabwareDropdownStateProps = {labwareOptions: Options}
+type LabwareDropdownOwnProps = {formConnector: FormConnector<*>}
+export const LabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
+  ({labwareOptions, ...restProps}: LabwareDropdownOwnProps & LabwareDropdownStateProps) => (
     <DropdownField options={labwareOptions} {...restProps} />
   )
 )
@@ -141,7 +142,7 @@ export const ChangeTipField = ({formConnector}: ChangeTipFieldProps) => (
   </FormGroup>
 )
 
-type TipSettingsColumnProps = {formConnector: FormConnector<*>, hasChangeField: boolean}
+type TipSettingsColumnProps = {formConnector: FormConnector<*>, hasChangeField?: boolean}
 export const TipSettingsColumn = ({formConnector, hasChangeField = true}: TipSettingsColumnProps) => (
   <div className={styles.right_settings_column}>
     {hasChangeField && <ChangeTipField formConnector={formConnector} />}

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -11,6 +11,7 @@ import {
 import {selectors as fileDataSelectors} from '../../file-data'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {FormConnector} from '../../utils'
+import type {BaseState} from '../../types'
 import styles from './StepEditForm.css'
 
 type Options = Array<DropdownOption>
@@ -104,11 +105,11 @@ type LabwareDropdownSP = {labwareOptions: Options}
 const LabwareDropdownSTP = (state: BaseState): LabwareDropdownSP => ({
   labwareOptions: labwareIngredSelectors.labwareOptions(state)
 })
-export const LabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({labwareOptions, ...props}: LabwareDropdownOP & LabwareDropdownSP) => (
-    <DropdownField options={labwareOptions} {...props} />
-  )
-)
+const connectLabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))
+export const LabwareDropdown = connectLabwareDropdown((props: LabwareDropdownOP & LabwareDropdownSP) => {
+  const {labwareOptions, ...restProps} = props
+  return <DropdownField options={labwareOptions} {...restProps} />
+})
 
 type VolumeFieldProps = {formConnector: FormConnector<*>}
 export const VolumeField = ({formConnector}: VolumeFieldProps) => (
@@ -119,19 +120,11 @@ export const VolumeField = ({formConnector}: VolumeFieldProps) => (
 
 // NOTE 2018-05-31 Flow rate cannot yet be adjusted,
 // this is a placeholder
-export const FlowRateField = () => (
-  <FormGroup label='FLOW RATE'>
-    Default
-  </FormGroup>
-)
+export const FlowRateField = () => <FormGroup label='FLOW RATE'>Default</FormGroup>
 
 // NOTE 2018-05-31 Tip position cannot yet be adjusted,
 // this is a placeholder
-export const TipPositionField = () => (
-  <FormGroup label='TIP POSITION'>
-    Bottom, center
-  </FormGroup>
-)
+export const TipPositionField = () => <FormGroup label='TIP POSITION'>Bottom, center</FormGroup>
 
 type ChangeTipFieldProps = {formConnector: FormConnector<*>}
 export const ChangeTipField = ({formConnector}: ChangeTipFieldProps) => (

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -98,10 +98,10 @@ export const ConnectedPipetteField = connect(PipetteFieldSTP, (dispatch: Dispatc
 
 const LabwareDropdownSTP = state => ({labwareOptions: labwareIngredSelectors.labwareOptions(state)})
 type LabwareDropdownStateProps = {labwareOptions: Options}
-type LabwareDropdownOwnProps = {formConnector: FormConnector<*>}
+type LabwareDropdownOwnProps = FormConnector<*>
 export const LabwareDropdown = connect(LabwareDropdownSTP, (dispatch: Dispatch) => ({dispatch: dispatch}))(
-  ({labwareOptions, ...restProps}: LabwareDropdownOwnProps & LabwareDropdownStateProps) => (
-    <DropdownField options={labwareOptions} {...restProps} />
+  ({labwareOptions, ...props}: LabwareDropdownOwnProps & LabwareDropdownStateProps) => (
+    <DropdownField options={labwareOptions} {...props} />
   )
 )
 

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -13,7 +13,7 @@ import TransferLikeForm from './TransferLikeForm'
 import PauseForm from './PauseForm'
 
 export type Props = {
-  formData: FormData, // TODO: make sure flow will give clear warning if you put transfer field in pause form, etc
+  formData: FormData,
   handleChange: (accessor: string) => (event: SyntheticEvent<HTMLInputElement> | SyntheticEvent<HTMLSelectElement>) => void,
   onClickMoreOptions: (event: SyntheticEvent<>) => mixed,
   onCancel: (event: SyntheticEvent<>) => mixed,
@@ -30,7 +30,7 @@ const StepFormTypeMap = {
 }
 
 const StepEditForm = ({formData, handleChange, onClickMoreOptions, onCancel, onSave, canSave}: Props) => {
-  const FormComponent = _.get(StepFormTypeMap, formData.stepType)
+  const FormComponent: any = _.get(StepFormTypeMap, formData.stepType)
   if (!FormComponent) return <div className={formStyles.form}><div>Todo: support {formData.stepType} step</div></div>
   return (
     <div className={cx(formStyles.form, styles[formData.stepType])}>

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -5,19 +5,10 @@ import {
   FlatButton,
   PrimaryButton,
   FormGroup,
-  DropdownField,
   InputField,
   RadioGroup,
   type DropdownOption
 } from '@opentrons/components'
-
-import {
-  // CheckboxRow,
-  // DelayField,
-  FlowRateField,
-  // MixField,
-  TipPositionField
-} from './formFields'
 
 import MixForm from './MixForm'
 import TransferLikeForm from './TransferLikeForm'

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -30,18 +30,16 @@ const StepFormTypeMap = {
 }
 
 const StepEditForm = ({formData, handleChange, onClickMoreOptions, onCancel, onSave, canSave}: Props) => {
-  const FormComponent = _.get(StepFormTypeMap, formData.stepType) || <div>Todo: support {formData.stepType} step</div>
+  const FormComponent = _.get(StepFormTypeMap, formData.stepType)
+  if (!FormComponent) return <div className={formStyles.form}><div>Todo: support {formData.stepType} step</div></div>
   return (
     <div className={cx(formStyles.form, styles[formData.stepType])}>
       <FormComponent formData={formData} formConnector={formConnectorFactory(handleChange, formData)} />
-      {
-        FormComponent &&
-        <div className={styles.button_row}>
-          <FlatButton className={styles.more_options_button} onClick={onClickMoreOptions}>MORE OPTIONS</FlatButton>
-          <PrimaryButton className={styles.cancel_button} onClick={onCancel}>CANCEL</PrimaryButton>
-          <PrimaryButton disabled={!canSave} onClick={onSave}>SAVE</PrimaryButton>
-        </div>
-      }
+      <div className={styles.button_row}>
+        <FlatButton className={styles.more_options_button} onClick={onClickMoreOptions}>MORE OPTIONS</FlatButton>
+        <PrimaryButton className={styles.cancel_button} onClick={onCancel}>CANCEL</PrimaryButton>
+        <PrimaryButton disabled={!canSave} onClick={onSave}>SAVE</PrimaryButton>
+      </div>
     </div>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -1,106 +1,47 @@
 // @flow
 import * as React from 'react'
+import _ from 'lodash'
 import cx from 'classnames'
-import {
-  FlatButton,
-  PrimaryButton,
-  FormGroup,
-  InputField,
-  RadioGroup,
-  type DropdownOption
-} from '@opentrons/components'
+import {FlatButton, PrimaryButton} from '@opentrons/components'
 
+import type {FormData} from '../../form-types'
+import {formConnectorFactory} from '../../utils'
+import formStyles from '../forms.css'
+import styles from './StepEditForm.css'
 import MixForm from './MixForm'
 import TransferLikeForm from './TransferLikeForm'
 import PauseForm from './PauseForm'
-import formStyles from '../forms.css'
-import styles from './StepEditForm.css'
-import type {FormSectionNames, FormSectionState} from '../../steplist/types' // TODO import from index.js
-import type {FormData} from '../../form-types'
-
-import {formConnectorFactory} from '../../utils'
-
-type Options = Array<DropdownOption>
 
 export type Props = {
-  // ingredientOptions: Options,
-  pipetteOptions: Options,
-  labwareOptions: Options,
-  formSectionCollapse: FormSectionState,
+  formData: FormData, // TODO: make sure flow will give clear warning if you put transfer field in pause form, etc
+  handleChange: (accessor: string) => (event: SyntheticEvent<HTMLInputElement> | SyntheticEvent<HTMLSelectElement>) => void,
+  onClickMoreOptions: (event: SyntheticEvent<>) => mixed,
   onCancel: (event: SyntheticEvent<>) => mixed,
   onSave: (event: SyntheticEvent<>) => mixed,
-  onClickMoreOptions: (event: SyntheticEvent<>) => mixed,
-  onToggleFormSection: (section: FormSectionNames) => mixed => mixed, // ???
-  handleChange: (accessor: string) => (event: SyntheticEvent<HTMLInputElement> | SyntheticEvent<HTMLSelectElement>) => void,
-  openWellSelectionModal: (args: {labwareId: string, pipetteId: string}) => mixed,
-  formData: FormData, // TODO: make sure flow will give clear warning if you put transfer field in pause form, etc
   canSave: boolean
-  /* TODO Ian 2018-01-24 **type** the different forms for different stepTypes,
-    this obj reflects the form selector's return values */
 }
 
-const StepEditForm = (props: Props) => {
-  const {formData} = props
-  const formConnector = formConnectorFactory(props.handleChange, formData)
+const StepFormTypeMap = {
+  mix: MixForm,
+  pause: PauseForm,
+  transfer: TransferLikeForm,
+  consolidate: TransferLikeForm,
+  distribute: TransferLikeForm
+}
 
-  const buttonRow = (
-    <div className={styles.button_row}>
-      <FlatButton className={styles.more_options_button} onClick={props.onClickMoreOptions}>
-        MORE OPTIONS
-      </FlatButton>
-      <PrimaryButton className={styles.cancel_button} onClick={props.onCancel}>CANCEL</PrimaryButton>
-      <PrimaryButton disabled={!props.canSave} onClick={props.onSave}>SAVE</PrimaryButton>
-    </div>
-  )
-  let FormComponent = null
-
-  switch (formData.stepType) {
-    case 'mix'
-    case 'pause'
-    case 'transfer'
-    case 'consolidate'
-    case 'distribute'
-
-  }
-'mix'
-'pause'
-'transfer'
-'consolidate'
-'distribute'
-
-  if (formData.stepType === 'mix') {
-    return (
-      <div className={formStyles.form}>
-        <MixForm formData={formData} formConnector={formConnector} />
-        {buttonRow}
-      </div>
-    )
-  }
-
-  if (formData.stepType === 'pause') {
-    return (
-      <div className={formStyles.form}>
-        <PauseForm formData={formData} formConnector={formConnector} />
-        {buttonRow}
-      </div>
-    )
-  }
-
-  if (formData.stepType === 'transfer' ||
-    formData.stepType === 'consolidate' ||
-    formData.stepType === 'distribute'
-  ) {
-    return (
-      <div className={cx(formStyles.form, styles[formData.stepType])}>
-        <TransferLikeForm formData={formData} formConnector={formConnector} />
-        {buttonRow}
-      </div>
-    )
-  }
-
+const StepEditForm = ({formData, handleChange, onClickMoreOptions, onCancel, onSave, canSave}: Props) => {
+  const FormComponent = _.get(StepFormTypeMap, formData.stepType) || <div>Todo: support {formData.stepType} step</div>
   return (
-    <div className={formStyles.form}>
-      <div>Todo: support {formData.stepType} step</div>
+    <div className={cx(formStyles.form, styles[formData.stepType])}>
+      <FormComponent formData={formData} formConnector={formConnectorFactory(handleChange, formData)} />
+      {
+        FormComponent &&
+        <div className={styles.button_row}>
+          <FlatButton className={styles.more_options_button} onClick={onClickMoreOptions}>MORE OPTIONS</FlatButton>
+          <PrimaryButton className={styles.cancel_button} onClick={onCancel}>CANCEL</PrimaryButton>
+          <PrimaryButton disabled={!canSave} onClick={onSave}>SAVE</PrimaryButton>
+        </div>
+      }
     </div>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -12,8 +12,7 @@ import {
 
 import MixForm from './MixForm'
 import TransferLikeForm from './TransferLikeForm'
-// import WellSelectionInput from '../../containers/WellSelectionInput'
-// import FormSection from './FormSection'
+import PauseForm from './PauseForm'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 import type {FormSectionNames, FormSectionState} from '../../steplist/types' // TODO import from index.js
@@ -40,17 +39,34 @@ export type Props = {
     this obj reflects the form selector's return values */
 }
 
-export default function StepEditForm (props: Props) {
+const StepEditForm = (props: Props) => {
   const {formData} = props
   const formConnector = formConnectorFactory(props.handleChange, formData)
 
-  const buttonRow = <div className={styles.button_row}>
-    <FlatButton className={styles.more_options_button} onClick={props.onClickMoreOptions}>
-      MORE OPTIONS
-    </FlatButton>
-    <PrimaryButton className={styles.cancel_button} onClick={props.onCancel}>CANCEL</PrimaryButton>
-    <PrimaryButton disabled={!props.canSave} onClick={props.onSave}>SAVE</PrimaryButton>
-  </div>
+  const buttonRow = (
+    <div className={styles.button_row}>
+      <FlatButton className={styles.more_options_button} onClick={props.onClickMoreOptions}>
+        MORE OPTIONS
+      </FlatButton>
+      <PrimaryButton className={styles.cancel_button} onClick={props.onCancel}>CANCEL</PrimaryButton>
+      <PrimaryButton disabled={!props.canSave} onClick={props.onSave}>SAVE</PrimaryButton>
+    </div>
+  )
+  let FormComponent = null
+
+  switch (formData.stepType) {
+    case 'mix'
+    case 'pause'
+    case 'transfer'
+    case 'consolidate'
+    case 'distribute'
+
+  }
+'mix'
+'pause'
+'transfer'
+'consolidate'
+'distribute'
 
   if (formData.stepType === 'mix') {
     return (
@@ -64,22 +80,7 @@ export default function StepEditForm (props: Props) {
   if (formData.stepType === 'pause') {
     return (
       <div className={formStyles.form}>
-        <div className={formStyles.row_wrapper}>
-          <div className={formStyles.column_1_2}>
-            <RadioGroup options={[{name: 'Pause for an amount of time', value: 'true'}]}
-              {...formConnector('pause-for-amount-of-time')} />
-            <InputField units='hr' {...formConnector('pause-hour')} />
-            <InputField units='m' {...formConnector('pause-minute')} />
-            <InputField units='s' {...formConnector('pause-second')} />
-          </div>
-          <div className={formStyles.column_1_2}>
-            <RadioGroup options={[{name: 'Pause until told to resume', value: 'false'}]}
-              {...formConnector('pause-for-amount-of-time')} />
-            <FormGroup label='Message to display'>
-              <InputField {...formConnector('pause-message')} />
-            </FormGroup>
-          </div>
-        </div>
+        <PauseForm formData={formData} formConnector={formConnector} />
         {buttonRow}
       </div>
     )
@@ -103,3 +104,5 @@ export default function StepEditForm (props: Props) {
     </div>
   )
 }
+
+export default StepEditForm

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -12,15 +12,17 @@ import {
 } from '@opentrons/components'
 
 import {
-  CheckboxRow,
-  DelayField,
+  // CheckboxRow,
+  // DelayField,
   FlowRateField,
-  MixField,
+  // MixField,
   TipPositionField
 } from './formFields'
 
-import WellSelectionInput from '../../containers/WellSelectionInput'
-import FormSection from './FormSection'
+import MixForm from './MixForm'
+import TransferLikeForm from './TransferLikeForm'
+// import WellSelectionInput from '../../containers/WellSelectionInput'
+// import FormSection from './FormSection'
 import formStyles from '../forms.css'
 import styles from './StepEditForm.css'
 import type {FormSectionNames, FormSectionState} from '../../steplist/types' // TODO import from index.js
@@ -51,20 +53,6 @@ export default function StepEditForm (props: Props) {
   const {formData} = props
   const formConnector = formConnectorFactory(props.handleChange, formData)
 
-  const pipetteField = (
-    <FormGroup label='Pipette:' className={styles.pipette_field}>
-      <DropdownField
-        options={props.pipetteOptions}
-        {...formConnector('pipette')} />
-    </FormGroup>
-  )
-
-  const volumeField = (
-    <FormGroup label='Volume:' className={styles.volume_field}>
-      <InputField units='μL' {...formConnector('volume')} />
-    </FormGroup>
-  )
-
   const buttonRow = <div className={styles.button_row}>
     <FlatButton className={styles.more_options_button} onClick={props.onClickMoreOptions}>
       MORE OPTIONS
@@ -73,80 +61,10 @@ export default function StepEditForm (props: Props) {
     <PrimaryButton disabled={!props.canSave} onClick={props.onSave}>SAVE</PrimaryButton>
   </div>
 
-  const formColumnRight = <div className={styles.right_settings_column}>
-      <FormGroup label='CHANGE TIP'>
-          <DropdownField
-            {...formConnector('aspirate--change-tip')}
-            options={[
-              {name: 'Always', value: 'always'},
-              {name: 'Once', value: 'once'},
-              {name: 'Never', value: 'never'}
-            ]}
-          />
-      </FormGroup>
-
-    <FlowRateField />
-    <TipPositionField />
-  </div>
-
-  // TODO Ian 2018-05-08 break these forms out into own components, put it all in a folder.
-  // Especially, make components for the re-used form parts instead of repeating them
   if (formData.stepType === 'mix') {
     return (
       <div className={formStyles.form}>
-        <div className={formStyles.row_wrapper}>
-          {/* TODO Ian 2018-05-08 this labware/wells/pipette could be a component,
-            it's common across most forms */}
-          <FormGroup label='Labware:' className={styles.labware_field}>
-            <DropdownField options={props.labwareOptions} {...formConnector('labware')} />
-          </FormGroup>
-          {/* TODO LATER: also 'disable' when selected labware is a trash */}
-          <WellSelectionInput
-            className={styles.well_selection_input}
-            labwareId={formData['labware']}
-            pipetteId={formData['pipette']}
-            initialSelectedWells={formData['wells']}
-            formFieldAccessor={'wells'}
-          />
-          {pipetteField}
-        </div>
-
-        <div className={cx(formStyles.row_wrapper)}>
-          <FormGroup label='Repetitions' className={styles.field_row}>
-            <InputField units='uL' {...formConnector('volume')} />
-            <InputField units='Times' {...formConnector('times')} />
-          </FormGroup>
-        </div>
-
-        <div className={formStyles.row_wrapper}>
-          <div className={styles.left_settings_column}>
-            <FormGroup label='TECHNIQUE'>
-              <DelayField
-                checkboxAccessor='dispense--delay--checkbox'
-                formConnector={formConnector}
-                minutesAccessor='dispense--delay-minutes'
-                secondsAccessor='dispense--delay-seconds'
-              />
-              <CheckboxRow
-                checkboxAccessor='dispense--blowout--checkbox'
-                formConnector={formConnector}
-                label='Blow out'
-              >
-                <DropdownField className={styles.full_width}
-                  options={props.labwareOptions}
-                  {...formConnector('dispense--blowout--labware')}
-                />
-              </CheckboxRow>
-
-              <CheckboxRow
-                checkboxAccessor='touch-tip'
-                formConnector={formConnector}
-                label='Touch tip'
-              />
-            </FormGroup>
-          </div>
-          {formColumnRight}
-        </div>
+        <MixForm formData={formData} formConnector={formConnector} />
         {buttonRow}
       </div>
     )
@@ -182,126 +100,7 @@ export default function StepEditForm (props: Props) {
   ) {
     return (
       <div className={cx(formStyles.form, styles[formData.stepType])}>
-        <FormSection title='Aspirate'
-          onCollapseToggle={props.onToggleFormSection('aspirate')}
-          collapsed={props.formSectionCollapse.aspirate}
-        >
-          <div className={formStyles.row_wrapper}>
-            <FormGroup label='Labware:' className={styles.labware_field}>
-              <DropdownField options={props.labwareOptions} {...formConnector('aspirate--labware')} />
-            </FormGroup>
-            {/* TODO LATER: also 'disable' when selected labware is a trash */}
-            <WellSelectionInput
-              className={styles.well_selection_input}
-              labwareId={formData['aspirate--labware']}
-              pipetteId={formData['pipette']}
-              initialSelectedWells={formData['aspirate--wells']}
-              formFieldAccessor={'aspirate--wells'}
-            />
-            {pipetteField}
-            {formData.stepType === 'consolidate' && volumeField}
-          </div>
-
-          <div className={formStyles.row_wrapper}>
-            <div className={styles.left_settings_column}>
-              <FormGroup label='TECHNIQUE'>
-                <CheckboxRow
-                  checkboxAccessor='aspirate--pre-wet-tip'
-                  formConnector={formConnector}
-                  label='Pre-wet tip'
-                />
-
-                <CheckboxRow
-                  checkboxAccessor='aspirate--touch-tip'
-                  formConnector={formConnector}
-                  label='Touch tip'
-                />
-
-                <CheckboxRow
-                  checkboxAccessor='aspirate--air-gap--checkbox'
-                  formConnector={formConnector}
-                  label='Air Gap'
-                >
-                  <InputField units='μL' {...formConnector('aspirate--air-gap--volume')} />
-                </CheckboxRow>
-
-                <MixField
-                  checkboxAccessor='aspirate--mix--checkbox'
-                  formConnector={formConnector}
-                  timesAccessor='aspirate--mix--times'
-                  volumeAccessor='aspirate--mix--volume'
-                />
-
-                <CheckboxRow
-                  checkboxAccessor='aspirate--disposal-vol--checkbox'
-                  formConnector={formConnector}
-                  label='Disposal Volume'
-                >
-                  <InputField units='μL' {...formConnector('aspirate--disposal-vol--volume')} />
-                </CheckboxRow>
-              </FormGroup>
-            </div>
-            {formColumnRight}
-          </div>
-
-        </FormSection>
-
-        <FormSection title='Dispense'
-          onCollapseToggle={props.onToggleFormSection('dispense')}
-          collapsed={props.formSectionCollapse.dispense}
-        >
-          <div className={formStyles.row_wrapper}>
-            <FormGroup label='Labware:' className={styles.labware_field}>
-              <DropdownField options={props.labwareOptions} {...formConnector('dispense--labware')} />
-            </FormGroup>
-            <WellSelectionInput
-              className={styles.well_selection_input}
-              labwareId={formData['dispense--labware']}
-              pipetteId={formData['pipette']}
-              initialSelectedWells={formData['dispense--wells']}
-              formFieldAccessor={'dispense--wells'}
-            />
-            {(formData.stepType === 'transfer' || formData.stepType === 'distribute') &&
-              volumeField}
-          </div>
-
-          <div className={formStyles.row_wrapper}>
-            <div className={styles.left_settings_column}>
-              <FormGroup label='TECHNIQUE'>
-                <MixField
-                  checkboxAccessor='dispense--mix--checkbox'
-                  formConnector={formConnector}
-                  volumeAccessor='dispense--mix--volume'
-                  timesAccessor='dispense--mix--times'
-                />
-                <DelayField
-                  checkboxAccessor='dispense--delay--checkbox'
-                  formConnector={formConnector}
-                  minutesAccessor='dispense--delay-minutes'
-                  secondsAccessor='dispense--delay-seconds'
-                />
-
-                <CheckboxRow
-                  checkboxAccessor='dispense--blowout--checkbox'
-                  formConnector={formConnector}
-                  label='Blow out'
-                >
-                  <DropdownField className={styles.full_width}
-                    options={props.labwareOptions}
-                    {...formConnector('dispense--blowout--labware')}
-                  />
-                </CheckboxRow>
-              </FormGroup>
-            </div>
-
-            <div className={styles.right_settings_column}>
-              <FlowRateField />
-              <TipPositionField />
-            </div>
-          </div>
-
-        </FormSection>
-
+        <TransferLikeForm formData={formData} formConnector={formConnector} />
         {buttonRow}
       </div>
     )

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import _ from 'lodash'
+import get from 'lodash/get'
 import cx from 'classnames'
 import {FlatButton, PrimaryButton} from '@opentrons/components'
 
@@ -30,7 +30,7 @@ const StepFormTypeMap = {
 }
 
 const StepEditForm = ({formData, handleChange, onClickMoreOptions, onCancel, onSave, canSave}: Props) => {
-  const FormComponent: any = _.get(StepFormTypeMap, formData.stepType)
+  const FormComponent: any = get(StepFormTypeMap, formData.stepType)
   if (!FormComponent) return <div className={formStyles.form}><div>Todo: support {formData.stepType} step</div></div>
   return (
     <div className={cx(formStyles.form, styles[formData.stepType])}>


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
The step edit form contained a lot of type-specific form logic that could be abstracted away. In
order to accomplish an ideal generalized solution for step form validation, the component needed to
be reorganized. Furthermore, instead of acting as a single connected parent to far downstream
components that might want data from redux. This adds connected leaf components that partition those
props to the field that needs them, and away from the general clutter in the Step Edit Form.
<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

-Try creating a step of each type and switching all the editable fields.
- make sure that the values persist when you navigate to a different step and back