### PR TITLE
refactor(api): Move lights endpoints to /robot/lights and provide getter

### DIFF
--- a/api/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/opentrons/drivers/rpi_drivers/gpio.py
@@ -129,9 +129,9 @@ def set_low(pin):
 
 def read(pin):
     """
-    Reads a pin's value. This pin must have been previously initialized
-    and set up as with direction of IN, otherwise this operation will not
-    behave as expected.
+    Reads a pin's value. If the pin has been previously initialized with
+    a direction of IN, the value will be the input signal. If pin is configured
+    as OUT, the value will be the current output state.
 
     :param pin: An integer corresponding to the GPIO number of the pin in RPi
       GPIO board numbering (not physical pin numbering)

--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1265,6 +1265,10 @@ class SmoothieDriver_3_0_0:
     def turn_off_rail_lights(self):
         gpio.set_low(gpio.OUTPUT_PINS['FRAME_LEDS'])
 
+    def get_rail_lights_on(self):
+        value = gpio.read(gpio.OUTPUT_PINS['FRAME_LEDS'])
+        return True if value == 1 else False
+
     def read_button(self):
         # button is normal-HIGH, so invert
         return not bool(gpio.read(gpio.INPUT_PINS['BUTTON_INPUT']))

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -312,6 +312,9 @@ class Robot(object):
     def turn_off_rail_lights(self):
         self._driver.turn_off_rail_lights()
 
+    def get_rail_lights_on(self):
+        return self._driver.get_rail_lights_on()
+
     def identify(self, seconds):
         """
         Identify a robot by flashing the light around the frame button for 10s

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -283,14 +283,21 @@ async def identify(request):
     return web.json_response({"message": "identifying"})
 
 
-async def turn_on_rail_lights(request):
-    robot.turn_on_rail_lights()
-    return web.json_response({"lights": "on"})
+async def get_rail_lights(request):
+    return web.json_response({'on': robot.get_rail_lights_on()})
 
 
-async def turn_off_rail_lights(request):
-    robot.turn_off_rail_lights()
-    return web.json_response({"lights": "off"})
+async def set_rail_lights(request):
+    data = await request.json()
+    on = data.get('on')
+
+    if on is None:
+        return web.json_response(
+            {'message': '"on" must be true or false, got {}'.format(on)},
+            status=400)
+
+    robot.turn_on_rail_lights() if on else robot.turn_off_rail_lights()
+    return web.json_response({'on': on})
 
 
 async def take_picture(request):

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -153,10 +153,6 @@ def init(loop=None):
     server.app.router.add_post(
         '/identify', control.identify)
     server.app.router.add_post(
-        '/lights/on', control.turn_on_rail_lights)
-    server.app.router.add_post(
-        '/lights/off', control.turn_off_rail_lights)
-    server.app.router.add_post(
         '/camera/picture', control.take_picture)
     server.app.router.add_post(
         '/server/update', endpoints.update_api)
@@ -184,6 +180,10 @@ def init(loop=None):
         '/robot/move', control.move)
     server.app.router.add_post(
         '/robot/home', control.home)
+    server.app.router.add_get(
+        '/robot/lights', control.get_rail_lights)
+    server.app.router.add_post(
+        '/robot/lights', control.set_rail_lights)
     server.app.router.add_get(
         '/settings', update.get_feature_flag)
     server.app.router.add_get(


### PR DESCRIPTION
## overview

This PR reworks the rail lights endpoints so we'll be able to satisfy #1684. It's also serving as the ticket because additional API work for #1684 was not anticipated.

## changelog

- refactor(api): Move lights endpoints to /robot/lights and provide getter 

## review requests

This branch is currently pushed to Sunset

- [x] `POST /robot/lights {on: true}` turns lights on
- [x] `POST /robot/lights {on: false}` turns lights off
- [x] `GET /robot/lights` returns `{on: false}` if lights are off
- [x] `GET /robot/lights` returns `{on: true}` if lights are on