### PR TITLE
fix(api): Fixes bug in replacing substring of old p50 pipettes

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -383,7 +383,7 @@ class SmoothieDriver_3_0_0:
                 # Backward compatibility for pipettes programmed with model
                 # strings that did not include the "." to seperate version
                 # major and minor values
-                res = res.replace('_v13', 'v1.3')
+                res = res.replace('_v13', '_v1.3')
 
         return res
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -481,6 +481,26 @@ def test_read_and_write_pipettes(model):
     driver._send_command = types.MethodType(_old_send_command, driver)
 
 
+def test_read_pipette_v13(model):
+    import types
+    from opentrons.drivers.smoothie_drivers.driver_3_0 import \
+        _byte_array_to_hex_string
+
+    driver = model.robot._driver
+    _old_send_command = driver._send_command
+    driver.simulating = False
+
+    def _new_send_message(self, command, timeout=None):
+        return 'L:' + _byte_array_to_hex_string(b'p300_single_v13')
+
+    driver._send_command = types.MethodType(_new_send_message, driver)
+
+    res = driver.read_pipette_model('left')
+    assert res == 'p300_single_v1.3'
+
+    driver._send_command = types.MethodType(_old_send_command, driver)
+
+
 def test_fast_home(model):
     import types
     driver = model.robot._driver


### PR DESCRIPTION
## overview

This PR fixes a bug with older p50 pipettes not being recognized by the robot.

A small subset of p50 pipettes were written with model strings ending with `"v13"` instead of the currently used format `"v1.3"`. The driver's `read_pipette_model()` method was intending to replace those old substrings with the new one, but was replacing with an invalid string (missing the underscore)