### PR TITLE
fix(app): Fix alignment issues in modals, fix titlebar on page

### DIFF
--- a/app/src/components/LabwareCalibration/styles.css
+++ b/app/src/components/LabwareCalibration/styles.css
@@ -7,6 +7,10 @@
   right: 0;
 }
 
+.modal_contents {
+  background-color: white;
+}
+
 .in_progress_contents {
   background-color: transparent;
 
@@ -60,6 +64,6 @@
 .spinner {
   width: 6rem;
   display: block;
-  margin: 45% auto auto;
+  margin: 35vh auto auto;
   color: var(--c-font-light);
 }

--- a/app/src/components/LabwareCalibration/styles.css
+++ b/app/src/components/LabwareCalibration/styles.css
@@ -60,6 +60,6 @@
 .spinner {
   width: 6rem;
   display: block;
-  margin: auto;
+  margin: 45% auto auto;
   color: var(--c-font-light);
 }

--- a/app/src/components/Page/index.js
+++ b/app/src/components/Page/index.js
@@ -15,7 +15,7 @@ export default function Page (props: Props) {
   return (
     <main className={styles.task}>
       {titleBarProps && (
-         <TitleBar {...titleBarProps} />
+         <TitleBar {...titleBarProps} className={styles.fixed_title_bar}/>
        )}
       {children}
     </main>

--- a/app/src/components/Page/styles.css
+++ b/app/src/components/Page/styles.css
@@ -14,4 +14,12 @@
   @apply --relative-fill;
 
   overflow-y: auto;
+  padding-top: 3.5rem;
+}
+
+.fixed_title_bar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1;
 }

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -11,6 +11,13 @@
     border-radius: 0.5rem;
     position: relative;
   }
+
+  --flex-start: {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+  }
 }
 
 .modal {

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -23,7 +23,7 @@
   @apply --absolute-fill;
   @apply --flex-start;
 
-  padding-top: 5rem;
+  padding: 5rem 3rem 2rem;
 }
 
 .overlay {

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -9,24 +9,21 @@
     margin: 0 auto;
     padding: 1rem;
     border-radius: 0.5rem;
+    position: relative;
   }
 }
 
 .modal {
-  @apply --absolute-fill;
-  @apply --center-children;
+  @apply --modal;
 
   padding: 4rem;
 }
 
 .modal_page {
   @apply --absolute-fill;
+  @apply --flex-start;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 5rem 2rem 1rem;
+  padding-top: 5rem;
 }
 
 .overlay {
@@ -40,6 +37,7 @@
   top: 0;
   left: 0;
   right: 0;
+  width: 100%;
   z-index: 3;
 }
 

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -11,13 +11,6 @@
     border-radius: 0.5rem;
     position: relative;
   }
-
-  --flex-start: {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-  }
 }
 
 .modal {
@@ -30,6 +23,7 @@
   @apply --absolute-fill;
   @apply --flex-start;
 
+  flex-direction: column;
   padding: 4.5rem 3rem 1rem 3rem;
 }
 

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -23,7 +23,7 @@
   @apply --absolute-fill;
   @apply --flex-start;
 
-  padding: 5rem 3rem 2rem;
+  padding-top: 4.5rem 3rem 1rem;
 }
 
 .overlay {

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -23,7 +23,7 @@
   @apply --absolute-fill;
   @apply --flex-start;
 
-  padding-top: 4.5rem 3rem 1rem;
+  padding: 4.5rem 3rem 1rem 3rem;
 }
 
 .overlay {
@@ -53,6 +53,7 @@
   background-color: white;
   max-height: 100%;
   overflow-y: auto;
+  padding-top: 1rem;
 }
 
 .modal_page_heading {

--- a/components/src/styles/positioning.css
+++ b/components/src/styles/positioning.css
@@ -13,6 +13,12 @@
     align-items: center;
   };
 
+  --flex-start: {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+  };
+
   --modal: {
     @apply --absolute-fill;
     @apply --center-children;

--- a/components/src/styles/positioning.css
+++ b/components/src/styles/positioning.css
@@ -15,6 +15,7 @@
 
   --flex-start: {
     display: flex;
+    flex-direction: column;
     justify-content: flex-start;
     align-items: center;
   }

--- a/components/src/styles/positioning.css
+++ b/components/src/styles/positioning.css
@@ -13,13 +13,6 @@
     align-items: center;
   };
 
-  --flex-start: {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-  }
-
   --modal: {
     @apply --absolute-fill;
     @apply --center-children;


### PR DESCRIPTION
## overview

This PR fixes the alignment issues introduced by #1705. Some modal page titlebars had been cropped. This should standardize behavior once and for all. Worth noting labware calibration uses a spinner modal as modal page content, not the SpinnerModalPage component from comp_lib so a little css override in `LabwareCalibration` was necessary.  While I was in there, I made the TitleBar position fixed.

## changelog

- comp_lib update ModalPage styles
- app fixed titlebar when in page
- center spinner modal positioning in `LabwareCalibration`

## review requests

Please click though any and all modals in the app, some are not accessible in VS so a Robot is preferred.
- [ ] attach/change pipette modals and titlebars look as expected
- [ ] calibrate modals and titlebars look as expected (get to at least the first jog screen)
- [ ] labware calibration modals look as expected