### PR TITLE
fix(app): Enable robot update even if API reports up-to-date

### DIFF
--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -75,7 +75,6 @@ function InformationCard (props: Props) {
       <OutlineButton
         Component={Link}
         to={updateUrl}
-        disabled={!availableUpdate}
       >
         {updateText}
       </OutlineButton>

--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -33,6 +33,7 @@ type DispatchProps = {
 type Props = StateProps & DispatchProps
 
 const UPDATE_MSG = "We recommend updating your robot's software to the latest version"
+const ALREADY_UPDATED_MSG = "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
 const RESTART_MSG = 'Restart your robot to finish the update. It may take several minutes for your robot to restart.'
 const DONE_MSG = 'Your robot has been updated. Please wait for your robot to fully restart, which may take several minutes.'
 
@@ -49,8 +50,14 @@ function UpdateModal (props: Props) {
   let message
   let button
 
+  const heading = availableUpdate
+    ? `Version ${availableUpdate || ''} available`
+    : 'Robot is up to date'
+
   if (!updateRequest.response) {
-    message = UPDATE_MSG
+    message = availableUpdate
+      ? UPDATE_MSG
+      : ALREADY_UPDATED_MSG
     button = inProgress
       ? {disabled: true, children: (<Spinner />)}
       : {onClick: update, children: 'update'}
@@ -68,7 +75,7 @@ function UpdateModal (props: Props) {
   return (
     <AlertModal
       onCloseClick={close}
-      heading={`Version ${availableUpdate || ''} Available`}
+      heading={heading}
       buttons={[
         {onClick: close, children: closeButtonText},
         button


### PR DESCRIPTION
## overview

This PR is also serving as the ticket. With the addition of firmware updates in the robot update flow, we ran into an issue where sometimes, the firmware would not update (for various valid / invalid reasons). However, because the API update usually succeeds, `/health` would report that the robot was up to date, and the update button would become disabled. This would then remove any firmware upgrade path from the user until the next API update.

Until we figure out a more refined approach to separating and communicating smoothie firmware, this PR removes the button disable logic and allows the user to send the update request even if the robot appears up to date.

![2018-06-19 11 42 32](https://user-images.githubusercontent.com/2963448/41608280-23711ccc-73b6-11e8-8a77-63779092373a.gif)

## changelog

- fix(app): Enable robot update even if API reports up-to-date 

## review requests

Tested on Sunset. Robot update should work even if robot is already up to date
