### PR TITLE
fix(app): Switch to hash routes to fix back in prod on Win 7

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -5,7 +5,7 @@ import {Provider} from 'react-redux'
 import {AppContainer} from 'react-hot-loader'
 import {createStore, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
-import createHistory from 'history/createBrowserHistory'
+import createHistory from 'history/createHashHistory'
 import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 
 import createLogger from './logger'


### PR DESCRIPTION
## overview

During `3.2.0-beta.1` testing on Windows 7, we discovered that `react-router-redux`'s `goBack` action breaks in prod on Windows 7 by trying to goBack to a `file:` URL. This PR switches to hash routes to avoid this issue.

This PR serving as the bug report and the fix.

## changelog

- fix(app): Switch to hash routes to enable reload in prod 

## review requests

I'll be testing this with our Win 7 machine on Sunset.

- [x] `goBack` (used by the "back" button in Change Pipette) works in the prod build on Windows 7
- [x] App still works everywhere else
