### PR TITLE
fix(protocol-designer): set max width of form field rows

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -60,6 +60,7 @@
 .field_row {
   lost-utility: clearfix;
   min-height: 2.25rem;
+  max-width: 24rem;
 
   /* Field row is for: (optional checkbox) + label + associated fields
    * All items in field row sum to 15/16, leaving 1/16 gap on the right.


### PR DESCRIPTION
Closes #1488 with this last style tweak

## overview

## changelog

- set max width of form field rows

## review requests

