### PR TITLE
feat(protocol-designer): disallow saving ingred form w/o name & volume

### DIFF
--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -97,6 +97,7 @@
 }
 
 .input_caption {
+  padding-top: 0.25rem;
   font-size: var(--fs-caption);
   min-height: var(--fs-caption);
   color: var(--c-med-gray);

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -29,7 +29,7 @@ type FieldProps = {|
   type?: string,
   label?: string,
   units?: string,
-  error?: string,
+  error?: ?string,
   placeholder?: string,
   className?: string
 |}
@@ -183,36 +183,50 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     }
   }
 
+  getVolumeError (): ?string {
+    const {volume} = this.state.input
+    const {selectedWellsMaxVolume} = this.props
+
+    if (!(volume && volume > 0)) {
+      return 'Must be more than 0'
+    }
+
+    if (selectedWellsMaxVolume < volume) {
+      return `Warning: exceeded max volume per well: ${selectedWellsMaxVolume}µL`
+    }
+  }
+
   render () {
     const {
       onSave,
       onCancel,
       allIngredientNamesIds,
-      selectedWells,
-      selectedWellsMaxVolume
+      selectedWells
     } = this.props
 
     const {commonIngredGroupId} = this.state
     const {name, volume} = this.state.input
 
-    const maxVolExceeded = volume !== null && selectedWellsMaxVolume < volume
+    const volumeError = this.getVolumeError()
     const Field = this.Field // ensures we don't lose focus on input re-render during typing
 
-    const showForm = selectedWells.length > 0
     const showIngredientDropdown = allIngredientNamesIds.length > 0
+    const allowSave = Boolean(volume && name)
+    const showForm = selectedWells.length > 0
 
     if (!showForm) {
       return null
     }
-
-    const allowSave = Boolean(volume && name)
 
     return (
       <div className={formStyles.form}>
         <form className={styles.form_content}>
           <div className={formStyles.row_wrapper}>
               <FormGroup label='Ingredient title:' className={styles.ingred_title_field}>
-                <Field accessor='name' />
+                <Field
+                  error={name ? null : 'This field is required'}
+                  accessor='name'
+                />
               </FormGroup>
 
               <FormGroup
@@ -250,9 +264,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
           <div className={formStyles.row_wrapper}>
             <FormGroup label='Volume:' className={styles.volume_field}>
               <Field numeric accessor='volume' units='µL'
-                error={maxVolExceeded
-                  ? `Warning: exceeded max volume per well: ${selectedWellsMaxVolume}µL`
-                  : undefined}
+                error={volumeError}
               />
             </FormGroup>
           </div>

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -193,7 +193,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     } = this.props
 
     const {commonIngredGroupId} = this.state
-    const {volume} = this.state.input
+    const {name, volume} = this.state.input
 
     const maxVolExceeded = volume !== null && selectedWellsMaxVolume < volume
     const Field = this.Field // ensures we don't lose focus on input re-render during typing
@@ -204,6 +204,8 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     if (!showForm) {
       return null
     }
+
+    const allowSave = Boolean(volume && name)
 
     return (
       <div className={formStyles.form}>
@@ -266,6 +268,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
           <PrimaryButton onClick={onCancel}>Cancel</PrimaryButton>
 
           <PrimaryButton
+            disabled={!allowSave}
             onClick={() => onSave({
               ...this.state.input,
               groupId: this.state.commonIngredGroupId


### PR DESCRIPTION
## overview

Disallow saving Ingredient Properties Form w/o name & valid volume. Also show field-level errors

Closes #1609
Also closes #1671 

## changelog

- disable saving ingred props form w/o name & volume > 0
- show field-level errors
- COMPONENT LIBRARY: add some padding-top to the `InputField` captions, the new drop shadow overlaps them without it

## review requests

`IngredientPropertiesForm` overall needs a big refactor, but hopefully the new structures in `StepEditForm` can be applied here & we can trash all the `this.Field` junk down the road!

So this is a somewhat ugly, non-scalable fix to make UX for ingred properties form work as desired, for now.

@mcous @Kadee80 do you use the `caption` of `InputField`? Is this padding-top addition OK?