### PR TITLE
feat(protocol-designer): allow button to look hovered via .hover class

### DIFF
--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -13,6 +13,8 @@ export type ButtonProps = {
   title?: string,
   /** disabled attribute (setting disabled removes onClick) */
   disabled?: ?boolean,
+  /** use hover style even when not hovered */
+  hover?: ?boolean,
   /** optional Icon name */
   iconName?: IconName,
   /** classes to apply */
@@ -40,7 +42,8 @@ const STRIP_PROPS = ['inverted', 'iconName', 'children', 'Component']
  * ```
  */
 export default function Button (props: ButtonProps) {
-  const {title, disabled, className} = props
+  const {title, disabled, hover} = props
+  const className = cx(props.className, {[styles.hover]: hover})
   const onClick = !disabled ? props.onClick : undefined
   const Component = props.Component || 'button'
   const type = props.type || 'button'

--- a/components/src/buttons/buttons.css
+++ b/components/src/buttons/buttons.css
@@ -30,10 +30,6 @@
     background: transparent;
     border-radius: var(--bd-radius-default);
 
-    &:hover {
-      background-color: color(var(--c-bg-light) shade(5%));
-    }
-
     &:active {
       font-weight: var(--fw-regular);
       background-color: color(var(--c-bg-light) shade(10%));
@@ -43,15 +39,18 @@
     &.disabled {
       @apply --button-disabled;
     }
+
+    /* stylelint-disable no-descending-specificity */
+    &:hover,
+    &.hover {
+      background-color: color(var(--c-bg-light) shade(5%));
+    }
+    /* stylelint-enable */
   }
 
   --button-inverted: {
     color: var(--c-font-light);
     border-color: var(--c-font-light);
-
-    &:hover {
-      background-color: color(var(--c-bg-dark) tint(5%));
-    }
 
     &:active {
       font-weight: var(--fw-regular);
@@ -62,6 +61,13 @@
     &.disabled {
       @apply --button-disabled;
     }
+
+    /* stylelint-disable no-descending-specificity */
+    &:hover,
+    &.hover {
+      background-color: color(var(--c-bg-dark) tint(5%));
+    }
+    /* stylelint-enable */
   }
 }
 
@@ -79,7 +85,8 @@
     0 0 2px rgba(0, 0, 0, 0.12),
     0 2px 2px rgba(0, 0, 0, 0.24);
 
-  &:hover {
+  &:hover,
+  &.hover {
     background-color: color(var(--c-bg-dark) shade(30%));
   }
 
@@ -97,7 +104,8 @@
     background-color: var(--c-bg-light);
     color: var(--c-font-dark);
 
-    &:hover {
+    &:hover,
+    &.hover {
       background-color: color(var(--c-bg-light) shade(5%));
     }
 

--- a/protocol-designer/src/components/StepEditForm/FormSection.css
+++ b/protocol-designer/src/components/StepEditForm/FormSection.css
@@ -26,5 +26,4 @@
   position: absolute;
   top: 0;
   right: 0;
-  fill: var(--c-dark-gray);
 }

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -35,7 +35,6 @@ const FormSection = (props: FormSectionProps) => {
 
       {props.collapsed !== undefined && // if doesn't exist in redux
         <div onClick={props.onCollapseToggle}>
-          {/* TODO Ian 2018-01-29 use an IconButton once it exists */}
           <IconButton
             width='30px'
             name='settings'

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import startCase from 'lodash/startCase'
 import cx from 'classnames'
-import {Icon} from '@opentrons/components'
+import {IconButton} from '@opentrons/components'
 
 import {selectors as steplistSelectors} from '../../steplist/reducers'
 import {collapseFormSection} from '../../steplist/actions'
@@ -36,9 +36,10 @@ const FormSection = (props: FormSectionProps) => {
       {props.collapsed !== undefined && // if doesn't exist in redux
         <div onClick={props.onCollapseToggle}>
           {/* TODO Ian 2018-01-29 use an IconButton once it exists */}
-          <Icon
+          <IconButton
             width='30px'
-            name={props.collapsed === true ? 'chevron-down' : 'chevron-up'}
+            name='settings'
+            hover={!props.collapsed}
             className={styles.carat}
           />
         </div>

--- a/protocol-designer/src/css/reset.css
+++ b/protocol-designer/src/css/reset.css
@@ -5,6 +5,10 @@ body {
   line-height: 1;
 }
 
+button:focus {
+  outline: 0;
+}
+
 * {
   font-family: 'Open Sans', sans-serif;
   box-sizing: border-box;


### PR DESCRIPTION
## overview

Closes #1690

## changelog

- components: buttons can take `hover` prop to appear hovered
- protocol-designer: update design of FormSection's toggle-collapse button
- protocol-designer: global reset of browser default blue button outline

## review requests

:monkey: 