### PR TITLE
fix(api): Sanitize wifi inputs to handle special characters

### DIFF
--- a/api/opentrons/server/endpoints/wifi.py
+++ b/api/opentrons/server/endpoints/wifi.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import subprocess
+from shlex import quote
 from aiohttp import web
 
 log = logging.getLogger(__name__)
@@ -66,9 +67,8 @@ async def configure(request):
             status = 400
             message = 'Error: "ssid" string is required'
         else:
-            cmd = 'nmcli device wifi connect "{}"'.format(
-                ssid)
-            password = ' password "{}"'.format(psk) if psk else ''
+            cmd = 'nmcli device wifi connect {}'.format(quote(ssid))
+            password = ' password {}'.format(quote(psk)) if psk else ''
             # some nmcli errors go to stdout (e.g. bad psk), while others go to
             # stderr (e.g. bad ssid), so we put both outputs together
             res, err = _subprocess(cmd + password)


### PR DESCRIPTION
## overview

This PR is a bug report and a fix.

### bug

We received a report of a user being unable to connect to WiFi even with correct credentials. We were unable to get the actual error message the app was receiving, but we know the PSK had a `$` in it. Our inputs to `nmcli` are completely unsanitized aside from being wrapped in double-quotes, which (in addition to being a security hole) means they won't handle SSIDs or PSKs with various "special" characters.

### fix

This PR uses the [`shlex.quote`](https://docs.python.org/dev/library/shlex.html#shlex.quote) builtin to properly sanitize the ssid and psk inputs before passing them to `nmcli`

## changelog

- fix(api): Sanitize wifi inputs to handle special characters

## review requests

Please ensure the WiFi configure endpoint is still functional on real robots!