### PR TITLE
refactor(protocol-designer): move pipettes into own dir (Tiprack assignment part 1!)

### DIFF
--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -8,7 +8,7 @@ import {
   DropdownField,
   type DropdownOption
 } from '@opentrons/components'
-import {selectors as fileDataSelectors} from '../../file-data'
+import {selectors as pipetteSelectors} from '../../pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {FormConnector} from '../../utils'
 import type {BaseState} from '../../types'
@@ -90,7 +90,7 @@ export function MixField (props: MixFieldProps) {
 type PipetteFieldOP = {formConnector: FormConnector<*>}
 type PipetteFieldSP = {pipetteOptions: Options}
 const PipetteFieldSTP = (state: BaseState): PipetteFieldSP => ({
-  pipetteOptions: fileDataSelectors.equippedPipetteOptions(state)
+  pipetteOptions: pipetteSelectors.equippedPipetteOptions(state)
 })
 export const PipetteField = connect(PipetteFieldSTP)((props: PipetteFieldOP & PipetteFieldSP) => {
   const {formConnector, pipetteOptions} = props

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -6,7 +6,7 @@ import {
   DropdownField,
   AlertModal
 } from '@opentrons/components'
-import {pipetteData} from '../../file-data'
+import {pipetteOptions} from '../../pipettes/pipetteData'
 
 import styles from './NewFileModal.css'
 import formStyles from '../forms.css'
@@ -30,7 +30,7 @@ const INVALID = 'INVALID'
 const pipetteOptionsWithInvalid = [
   {name: '', value: INVALID},
   {name: 'None', value: ''},
-  ...pipetteData.pipetteOptions
+  ...pipetteOptions
 ]
 
 const initialState = {

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -1,29 +1,32 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 
-import labwareIngredRootReducer from './labware-ingred/reducers'
-import steplistRootReducer from './steplist/reducers'
-import {rootReducer as navigationRootReducer} from './navigation'
 import {rootReducer as fileDataRootReducer} from './file-data'
+import labwareIngredRootReducer from './labware-ingred/reducers'
+import {rootReducer as navigationRootReducer} from './navigation'
+import {rootReducer as pipetteRootReducer} from './pipettes'
+import steplistRootReducer from './steplist/reducers'
 import wellSelectionRootReducer from './well-selection/reducers'
 
 // TODO: Ian 2018-01-15 how to make this more DRY with hot reloading?
 function getRootReducer () {
   return combineReducers({
-    labwareIngred: require('./labware-ingred/reducers'),
-    steplist: require('./steplist/reducers'),
-    navigation: require('./navigation').rootReducer,
     fileData: require('./file-data').rootReducer,
+    labwareIngred: require('./labware-ingred/reducers'),
+    navigation: require('./navigation').rootReducer,
+    pipettes: require('./pipettes').rootReducer,
+    steplist: require('./steplist/reducers'),
     wellSelection: require('./well-selection/reducers')
   })
 }
 
 export default function configureStore () {
   const reducer = combineReducers({
-    labwareIngred: labwareIngredRootReducer,
-    steplist: steplistRootReducer,
-    navigation: navigationRootReducer,
     fileData: fileDataRootReducer,
+    labwareIngred: labwareIngredRootReducer,
+    navigation: navigationRootReducer,
+    pipettes: pipetteRootReducer,
+    steplist: steplistRootReducer,
     wellSelection: wellSelectionRootReducer
   })
 
@@ -41,10 +44,11 @@ export default function configureStore () {
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
-    module.hot.accept('./labware-ingred/reducers', replaceReducers)
-    module.hot.accept('./steplist/reducers', replaceReducers)
-    module.hot.accept('./navigation/reducers', replaceReducers)
     module.hot.accept('./file-data/reducers', replaceReducers)
+    module.hot.accept('./labware-ingred/reducers', replaceReducers)
+    module.hot.accept('./navigation/reducers', replaceReducers)
+    module.hot.accept('./pipettes', replaceReducers)
+    module.hot.accept('./steplist/reducers', replaceReducers)
     module.hot.accept('./well-selection/reducers', replaceReducers)
   }
 

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -3,7 +3,8 @@ import {connect} from 'react-redux'
 import type {BaseState} from '../types'
 import FilePage from '../components/FilePage'
 import type {FilePageProps} from '../components/FilePage'
-import {actions, selectors} from '../file-data'
+import {actions, selectors as fileSelectors} from '../file-data'
+import {selectors as pipetteSelectors} from '../pipettes'
 import type {FileMetadataFields} from '../file-data'
 import {formConnectorFactory, type FormConnector} from '../utils'
 
@@ -19,10 +20,10 @@ type DP = {
 }
 
 const mapStateToProps = (state: BaseState): SP => {
-  const pipetteData = selectors.pipettesForInstrumentGroup(state)
+  const pipetteData = pipetteSelectors.pipettesForInstrumentGroup(state)
   return {
-    _values: selectors.fileFormValues(state),
-    isFormAltered: selectors.isUnsavedMetadatFormAltered(state),
+    _values: fileSelectors.fileFormValues(state),
+    isFormAltered: fileSelectors.isUnsavedMetadatFormAltered(state),
     instruments: {
       left: pipetteData.find(i => i.mount === 'left'),
       right: pipetteData.find(i => i.mount === 'right')

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -5,6 +5,7 @@ import type {Dispatch} from 'redux'
 import type {BaseState} from '../types'
 import {selectors, actions as navigationActions} from '../navigation'
 import {actions as fileActions} from '../file-data'
+import {actions as pipetteActions} from '../pipettes'
 
 import NewFileModal from '../components/modals/NewFileModal'
 
@@ -32,7 +33,7 @@ function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
         description: ''
       }))
 
-      dispatch(fileActions.updatePipettes({
+      dispatch(pipetteActions.updatePipettes({
         left: fields.leftPipette,
         right: fields.rightPipette
       }))

--- a/protocol-designer/src/containers/ConnectedStepEditForm.js
+++ b/protocol-designer/src/containers/ConnectedStepEditForm.js
@@ -12,7 +12,7 @@ import {
 
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors} from '../steplist/reducers' // TODO use steplist/index.js
-import {selectors as fileDataSelectors} from '../file-data'
+import {selectors as pipetteSelectors} from '../pipettes'
 import type {FormData} from '../form-types'
 import type {BaseState, ThunkDispatch} from '../types'
 
@@ -36,7 +36,7 @@ function mapStateToProps (state: BaseState) {
     formData: selectors.formData(state),
     formSectionCollapse: selectors.formSectionCollapse(state),
     canSave: selectors.currentFormCanBeSaved(state),
-    pipetteOptions: fileDataSelectors.equippedPipetteOptions(state),
+    pipetteOptions: pipetteSelectors.equippedPipetteOptions(state),
     labwareOptions: labwareIngredSelectors.labwareOptions(state)
   }
 }

--- a/protocol-designer/src/containers/ConnectedWellSelectionModal.js
+++ b/protocol-designer/src/containers/ConnectedWellSelectionModal.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 import type {BaseState} from '../types'
 import type {Dispatch} from 'redux'
 import wellSelectionSelectors from '../well-selection/selectors'
-import {selectors as fileDataSelectors} from '../file-data'
+import {selectors as pipetteSelectors} from '../pipettes'
 import {
   closeWellSelectionModal,
   saveWellSelectionModal
@@ -42,7 +42,7 @@ function mapStateToProps (state: BaseState): SP | HideModal {
   const pipetteId = wellSelectionModalData.pipetteId
 
   return {
-    pipette: fileDataSelectors.equippedPipettes(state)[pipetteId]
+    pipette: pipetteSelectors.equippedPipettes(state)[pipetteId]
   }
 }
 

--- a/protocol-designer/src/file-data/actions.js
+++ b/protocol-designer/src/file-data/actions.js
@@ -1,6 +1,5 @@
 // @flow
 import type {FileMetadataFieldAccessors} from './types'
-import type {PipetteName} from './pipetteData'
 
 export const updateFileMetadataFields = (payload: {[accessor: FileMetadataFieldAccessors]: string}) => ({
   type: 'UPDATE_FILE_METADATA_FIELDS',
@@ -9,10 +8,5 @@ export const updateFileMetadataFields = (payload: {[accessor: FileMetadataFieldA
 
 export const saveFileMetadata = (payload: {[accessor: FileMetadataFieldAccessors]: string}) => ({
   type: 'SAVE_FILE_METADATA',
-  payload
-})
-
-export const updatePipettes = (payload: {['left' | 'right']: ?PipetteName}) => ({
-  type: 'UPDATE_PIPETTES',
   payload
 })

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,11 +2,7 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
-import {updateFileMetadataFields, updatePipettes, saveFileMetadata} from '../actions'
-import {pipetteDataByName, type PipetteName} from '../pipetteData'
-
-import type {Mount} from '@opentrons/components'
-import type {PipetteData} from '../../step-generation'
+import {updateFileMetadataFields, saveFileMetadata} from '../actions'
 import type {FileMetadataFields} from '../types'
 
 const defaultFields = {
@@ -33,51 +29,14 @@ const fileMetadata = handleActions({
   })
 }, defaultFields)
 
-type PipetteState = {|
-  left: ?PipetteData,
-  right: ?PipetteData
-|}
-
-function createPipette (name: PipetteName, mount: Mount) {
-  const pipetteData = pipetteDataByName[name]
-  if (!pipetteData) {
-    // TODO Ian 2018-03-01 I want Flow to enforce `name` is a key in pipetteDataByName,
-    // but it doesn't seem to want to be strict about it
-    throw new Error('Invalid pipette name, no entry in pipetteDataByName')
-  }
-  return {
-    id: `${mount}:${name}`,
-    mount,
-    maxVolume: pipetteData.maxVolume,
-    channels: pipetteData.channels
-  }
-}
-
-const pipettes = handleActions({
-  UPDATE_PIPETTES: (state: PipetteState, action: ActionType<typeof updatePipettes>) => {
-    const {left, right} = action.payload // left and/or right pipette names, eg 'P10 Single-Channel'
-
-    return {
-      left: left
-        ? createPipette(left, 'left')
-        : null,
-      right: right
-        ? createPipette(right, 'right')
-        : null
-    }
-  }
-}, {left: null, right: null})
-
 export type RootState = {
   unsavedMetadataForm: FileMetadataFields,
-  fileMetadata: FileMetadataFields,
-  pipettes: PipetteState
+  fileMetadata: FileMetadataFields
 }
 
 const _allReducers = {
   unsavedMetadataForm,
-  fileMetadata,
-  pipettes
+  fileMetadata
 }
 
 export const rootReducer = combineReducers(_allReducers)

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -9,7 +9,7 @@ import type {BaseState, Selector} from '../../types'
 import {getAllWellsForLabware} from '../../constants'
 import * as StepGeneration from '../../step-generation'
 import {selectors as steplistSelectors} from '../../steplist/reducers'
-import {equippedPipettes} from './pipettes'
+import {selectors as pipetteSelectors} from '../../pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {Labware} from '../../labware-ingred/types'
 
@@ -56,7 +56,7 @@ function labwareConverter (labwareAppState: {[labwareId: string]: Labware}): {[l
 }
 
 export const getInitialRobotState: BaseState => StepGeneration.RobotState = createSelector(
-  equippedPipettes,
+  pipetteSelectors.equippedPipettes,
   labwareIngredSelectors.getLabware,
   getLabwareLiquidState,
   (pipettes, labwareAppState, labwareLiquidState) => {

--- a/protocol-designer/src/file-data/selectors/index.js
+++ b/protocol-designer/src/file-data/selectors/index.js
@@ -2,4 +2,3 @@
 export * from './commands'
 export * from './fileCreator'
 export * from './fileFields'
-export * from './pipettes'

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,7 +1,7 @@
 // @flow
 import type {PipetteName} from './pipetteData'
 
-export const updatePipettes = (payload: {['left' | 'right']: ?PipetteName}) => ({
+export const updatePipettes = (payload: {'left'?: ?PipetteName, 'right'?: ?PipetteName}) => ({
   type: 'UPDATE_PIPETTES',
   payload
 })

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,0 +1,7 @@
+// @flow
+import type {PipetteName} from './pipetteData'
+
+export const updatePipettes = (payload: {['left' | 'right']: ?PipetteName}) => ({
+  type: 'UPDATE_PIPETTES',
+  payload
+})

--- a/protocol-designer/src/pipettes/index.js
+++ b/protocol-designer/src/pipettes/index.js
@@ -1,7 +1,6 @@
 // @flow
-/** This is the big selector that generates a .json file to download */
 import * as actions from './actions'
-import {rootReducer, type RootState} from './reducers'
+import {rootReducer} from './reducers'
 import * as selectors from './selectors'
 export * from './types'
 
@@ -9,8 +8,4 @@ export {
   actions,
   rootReducer,
   selectors
-}
-
-export type {
-  RootState
 }

--- a/protocol-designer/src/pipettes/pipetteData.js
+++ b/protocol-designer/src/pipettes/pipetteData.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Channels} from '@opentrons/components'
 
+// TODO: Ian 2018-06-22 use shared-data
 export const pipetteDataByName: {[pipetteName: string]: {maxVolume: number, channels: Channels}} = {
   'P10 Single-Channel': {
     maxVolume: 10,

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -1,0 +1,44 @@
+// @flow
+import {combineReducers} from 'redux'
+import {handleActions, type ActionType} from 'redux-actions'
+import {pipetteDataByName, type PipetteName} from './pipetteData'
+import {updatePipettes} from './actions'
+
+import type {PipetteState} from './types'
+import type {Mount} from '@opentrons/components'
+
+function createPipette (name: PipetteName, mount: Mount) {
+  const pipetteData = pipetteDataByName[name]
+  if (!pipetteData) {
+    // TODO Ian 2018-03-01 I want Flow to enforce `name` is a key in pipetteDataByName,
+    // but it doesn't seem to want to be strict about it
+    throw new Error('Invalid pipette name, no entry in pipetteDataByName')
+  }
+  return {
+    id: `${mount}:${name}`,
+    mount,
+    maxVolume: pipetteData.maxVolume,
+    channels: pipetteData.channels
+  }
+}
+
+const pipettes = handleActions({
+  UPDATE_PIPETTES: (state: PipetteState, action: ActionType<typeof updatePipettes>) => {
+    const {left, right} = action.payload // left and/or right pipette names, eg 'P10 Single-Channel'
+
+    return {
+      left: left
+        ? createPipette(left, 'left')
+        : null,
+      right: right
+        ? createPipette(right, 'right')
+        : null
+    }
+  }
+}, {left: null, right: null})
+
+const _allReducers = {
+  pipettes
+}
+
+export const rootReducer = combineReducers(_allReducers)

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -1,10 +1,12 @@
 // @flow
 import {createSelector} from 'reselect'
-import type {BaseState, Selector} from '../../types'
+import type {BaseState, Selector} from '../types'
 import reduce from 'lodash/reduce'
 import type {DropdownOption} from '@opentrons/components'
-import type {PipetteData} from '../../step-generation'
-import {pipetteDataByName} from '../pipetteData'
+import type {PipetteData} from '../step-generation'
+import {pipetteDataByName} from './pipetteData'
+
+const rootSelector = (state: BaseState) => state.pipettes.pipettes
 
 function _getPipetteName (pipetteData) {
   const result = Object.keys(pipetteDataByName).find(pipetteName => {
@@ -20,8 +22,6 @@ function _getPipetteName (pipetteData) {
   }
   return result
 }
-
-const rootSelector = (state: BaseState) => state.fileData.pipettes
 
 function _makePipetteOption (pipetteData: ?PipetteData, idPrefix: 'left' | 'right') {
   if (!pipetteData) {

--- a/protocol-designer/src/pipettes/types.js
+++ b/protocol-designer/src/pipettes/types.js
@@ -1,0 +1,12 @@
+// @flow
+import type {PipetteData} from '../step-generation'
+// TODO: Ian 2018-06-22 move PipetteData type into pipettes dir
+
+export type PipetteState = {|
+  left: ?PipetteData,
+  right: ?PipetteData
+|}
+
+export type RootState = {
+  pipettes: PipetteState
+}

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -2,7 +2,7 @@
 import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
 
-import {equippedPipettes} from '../file-data/selectors/pipettes'
+import {selectors as pipetteSelectors} from '../pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
@@ -19,7 +19,7 @@ import type {StepSubItemData} from '../steplist/types'
 
 export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
   steplistSelectors.validatedForms,
-  equippedPipettes,
+  pipetteSelectors.equippedPipettes,
   labwareIngredSelectors.getLabware,
   namedIngredsByLabware,
   steplistSelectors.orderedSteps,

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -1,15 +1,17 @@
 // @flow
-import type {RootState as StepList} from './steplist/reducers'
-import type {RootState as Navigation} from './navigation'
-import type {RootState as LabwareIngred} from './labware-ingred/reducers'
 import type {RootState as FileData} from './file-data'
+import type {RootState as LabwareIngred} from './labware-ingred/reducers'
+import type {RootState as Navigation} from './navigation'
+import type {RootState as Pipettes} from './pipettes'
+import type {RootState as StepList} from './steplist/reducers'
 import type {RootState as WellSelection} from './well-selection/reducers'
 
 export type BaseState = {
-  steplist: StepList,
-  navigation: Navigation,
-  labwareIngred: LabwareIngred,
   fileData: FileData,
+  labwareIngred: LabwareIngred,
+  navigation: Navigation,
+  pipettes: Pipettes,
+  steplist: StepList,
   wellSelection: WellSelection
 }
 

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -4,7 +4,7 @@ import selectors from './selectors'
 import {changeFormInput} from '../steplist/actions'
 
 import {selectors as steplistSelectors} from '../steplist/reducers'
-import {selectors as fileDataSelectors} from '../file-data'
+import {selectors as pipetteSelectors} from '../pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 
 import type {ThunkDispatch, GetState} from '../types'
@@ -62,7 +62,7 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
     // initially selected wells in form get selected in state before modal opens
     dispatch(selectWells(wells))
 
-    const pipettes = fileDataSelectors.equippedPipettes(state)
+    const pipettes = pipetteSelectors.equippedPipettes(state)
     const labware = labwareIngredSelectors.getLabware(state)
     // TODO type this action, make an underline fn action creator
 


### PR DESCRIPTION
## overview

This is a big ol' diff but it's just taking pipette-related concerns out of `file-data/` and into a new atom `pipettes/`. Nothing should be changed for now except `fileData.pipettes` state is now in `pipettes.pipettes`

## changelog

- factor out `pipettes/` from `file-data/`
- alphabetize some imports

## review requests

On UI side, nothing should look/act different.