### PR TITLE
fix(api): Fix row order in labware.create

### DIFF
--- a/api/opentrons/containers/__init__.py
+++ b/api/opentrons/containers/__init__.py
@@ -76,6 +76,25 @@ def list():
 
 
 def create(name, grid, spacing, diameter, depth, volume=0):
+    """
+    Creates a labware definition based on a rectangular gird, depth, diameter,
+    and spacing. Note that this function can only create labware with regularly
+    spaced wells in a rectangular format, of equal height, depth, and radius.
+    Irregular labware defintions will have to be made in other ways or modified
+    using a regular definition as a starting point. Also, upon creation a
+    definition always has its lower-left well at (0, 0, 0), such that this
+    labware _must_ be calibrated before use.
+
+    :param name: the name of the labware to be used with `labware.load`
+    :param grid: a 2-tuple of integers representing (<n_columns>, <n_rows>)
+    :param spacing: a 2-tuple of floats representing
+        (<col_spacing, <row_spacing)
+    :param diameter: a float representing the internal diameter of each well
+    :param depth: a float representing the distance from the top of each well
+        to the internal bottom of the same well
+    :param volume: [optional] the maximum volume of each well
+    :return: the labware object created by this function
+    """
     columns, rows = grid
     col_spacing, row_spacing = spacing
     custom_container = Container()
@@ -90,7 +109,7 @@ def create(name, grid, spacing, diameter, depth, volume=0):
         for c in range(columns):
             well = Well(properties=properties)
             well_name = chr(r + ord('A')) + str(1 + c)
-            coordinates = (c * col_spacing, r * row_spacing, 0)
+            coordinates = (c * col_spacing, (rows - r - 1) * row_spacing, 0)
             custom_container.add(well, well_name, coordinates)
     database.save_new_container(custom_container, name)
     return database.load_container(name)

--- a/api/tests/opentrons/containers/test_labware_fns.py
+++ b/api/tests/opentrons/containers/test_labware_fns.py
@@ -1,0 +1,42 @@
+from opentrons import labware
+
+
+def test_labware_create(dummy_db):
+    n_cols = 6
+    n_rows = 4
+    x_dist = 19.6
+    y_dist = 19.6
+    radius = 5.65
+    depth = 84
+
+    lw = labware.create(
+        'testing-lw',
+        grid=(n_cols, n_rows),
+        spacing=(x_dist, y_dist),  # distances (mm) between each (column, row)
+        diameter=radius * 2,
+        depth=depth)
+
+    row_a_center = ((n_rows - 1) * y_dist) + radius
+    col_1_center = radius
+
+    row_d_center = radius
+    col_6_center = ((n_cols - 1) * x_dist) + radius
+
+    expected = {
+        'A1': (col_1_center, row_a_center, depth),
+        'D1': (col_1_center, row_d_center, depth),
+        'A6': (col_6_center, row_a_center, depth),
+        'D6': (col_6_center, row_d_center, depth)
+    }
+
+    labware_coords = lw.coordinates()  # currently (0, 0, 0)
+
+    def top(well):
+        wc = well.coordinates()
+        wt = well.top()[1]
+        return labware_coords + wc + wt
+
+    actual = {key: top(lw[key]) for key in expected.keys()}
+
+    for key in expected.keys():
+        assert expected[key] == actual[key]

--- a/api/tests/opentrons/database/test_labware_definitions.py
+++ b/api/tests/opentrons/database/test_labware_definitions.py
@@ -111,9 +111,9 @@ def test_save_user_definition():
 
 
 def test_labware_create(dummy_db):
-    from opentrons import containers
+    from opentrons import labware
     lw_name = '15-well-plate'
-    if lw_name in containers.list():
+    if lw_name in labware.list():
         database.delete_container(lw_name)
     n_cols = 5
     n_rows = 3
@@ -122,7 +122,7 @@ def test_labware_create(dummy_db):
     diameter = 5
     height = 20
     volume = 3.14 * (diameter / 2.0)**2
-    res = containers.create(
+    res = labware.create(
         lw_name,
         (n_cols, n_rows),
         (col_space, row_space),
@@ -138,12 +138,14 @@ def test_labware_create(dummy_db):
         assert res[name].coordinates() == well.coordinates()
         for prop in ['height', 'diameter']:
             assert res[name].properties[prop] == well.properties[prop]
-    assert lw.well("C5").coordinates() == (
-        (n_cols - 1) * col_space, (n_rows - 1) * row_space, 0)
+    assert lw.well("B5").coordinates() == (
+        (n_cols - 1) * col_space, row_space, 0)
+    assert lw.well("C3").coordinates() == (
+        2 * col_space, 0, 0)
 
 
 def test_new_labware_create(split_labware_def):
-    from opentrons import containers
+    from opentrons import labware
     lw_name = '15-well-plate'
     n_cols = 5
     n_rows = 3
@@ -152,7 +154,7 @@ def test_new_labware_create(split_labware_def):
     diameter = 5
     height = 20
     volume = 3.14 * (diameter / 2.0)**2
-    res = containers.create(
+    res = labware.create(
         lw_name,
         (n_cols, n_rows),
         (col_space, row_space),
@@ -167,5 +169,7 @@ def test_new_labware_create(split_labware_def):
         assert res[name].coordinates() == well.coordinates()
         for prop in ['height', 'diameter']:
             assert res[name].properties[prop] == well.properties[prop]
-    assert lw.well("C5").coordinates() == (
-        (n_cols - 1) * col_space, (n_rows - 1) * row_space, 0)
+    assert lw.well("B5").coordinates() == (
+        (n_cols - 1) * col_space, row_space, 0)
+    assert lw.well("C3").coordinates() == (
+        2 * col_space, 0, 0)


### PR DESCRIPTION
## overview

Fix row order in `labware.create`. Fixes #1748

## changelog

- Reverse row order in `labware.create` so that the top row is A

## review requests

See steps to reproduce in attached bug ticket