### PR TITLE
Pd pipette tip assignment: Part 2

### DIFF
--- a/protocol-designer/src/components/LabwareDropdown.js
+++ b/protocol-designer/src/components/LabwareDropdown.js
@@ -28,11 +28,12 @@ function LabwareItem (props: LabwareItemProps) {
 type LabwareDropdownProps = {
   onClose: (e?: SyntheticEvent<*>) => void,
   onContainerChoose: OnContainerChoose,
-  slot: string | false
+  slot: string | false,
+  permittedTipracks: Array<string>
 }
 
 export default function LabwareDropdown (props: LabwareDropdownProps) {
-  const {onClose, onContainerChoose, slot} = props
+  const {onClose, onContainerChoose, slot, permittedTipracks} = props
   // do not render without a slot
   if (!slot) return null
 
@@ -58,7 +59,9 @@ export default function LabwareDropdown (props: LabwareDropdownProps) {
             ['tiprack-200ul', '200uL Tip Rack', 'Tiprack-200ul'],
             ['tiprack-1000ul', '1000uL Tip Rack', 'Tiprack-200ul'],
             ['tiprack-1000ul-chem', '10x10 1000uL Chem-Tip Rack', 'Tiprack-1000ul-chem']
-          ].map(labwareItemMapper)}
+          ].filter(labwareModelNameImage =>
+            permittedTipracks.includes(labwareModelNameImage[0])
+          ).map(labwareItemMapper)}
         </Accordion>
         <Accordion title='Tube Rack'>
           {[

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -13,9 +13,15 @@ import formStyles from '../forms.css'
 import modalStyles from './modal.css'
 
 type State = {
-  name?: string,
-  leftPipette?: string, // TODO: make this union of pipette option values
-  rightPipette?: string,
+  name: string,
+
+  // TODO: make this union of pipette option values
+  leftPipette: string,
+  rightPipette: string,
+
+  // TODO: Ian 2018-06-22 type as labware-type enums of tipracks
+  leftTiprackModel: ?string,
+  rightTiprackModel: ?string
 }
 
 type Props = {
@@ -24,19 +30,40 @@ type Props = {
   onSave: State => mixed
 }
 
-// 'invalid' state is just a concern of these dropdowns, not selected pipette state in general
-const INVALID = 'INVALID'
+// 'USER_HAS_NOT_SELECTED' state is just a concern of these dropdowns,
+// not selected pipette state in general
+// It's needed b/c user must select 'None' explicitly,
+// they cannot just leave the dropdown blank.
+const USER_HAS_NOT_SELECTED = 'USER_HAS_NOT_SELECTED'
+// TODO: Ian 2018-06-22 use pristinity instead of this?
 
-const pipetteOptionsWithInvalid = [
-  {name: '', value: INVALID},
+const pipetteOptionsWithNone = [
   {name: 'None', value: ''},
   ...pipetteOptions
 ]
 
+const pipetteOptionsWithInvalid = [
+  {name: '', value: USER_HAS_NOT_SELECTED},
+  ...pipetteOptionsWithNone
+]
+
+// TODO: Ian 2018-06-22 get this programatically from shared-data labware defs
+// and exclude options that are incompatible with pipette
+// and also auto-select tiprack if there's only one compatible tiprack for a pipette
+const tiprackOptions = [
+  {name: '10 uL', value: 'tiprack-10ul'},
+  {name: '200 uL', value: 'tiprack-200ul'},
+  {name: '1000 uL', value: 'tiprack-1000ul'},
+  {name: '1000 uL Chem', value: 'tiprack-1000ul-chem'},
+  {name: '300 uL', value: 'GEB-tiprack-300ul'} // TODO IMMEDATELY does PD have the def for this?
+]
+
 const initialState = {
   name: '',
-  leftPipette: INVALID,
-  rightPipette: INVALID
+  leftPipette: USER_HAS_NOT_SELECTED,
+  rightPipette: USER_HAS_NOT_SELECTED,
+  leftTiprackModel: null,
+  rightTiprackModel: null
 }
 
 export default class NewFileModal extends React.Component<Props, State> {
@@ -54,9 +81,25 @@ export default class NewFileModal extends React.Component<Props, State> {
 
   handleChange = (accessor: $Keys<State>) => (e: SyntheticInputEvent<*>) => {
     const value: string = e.target.value
+
+    const update: {[$Keys<State>]: mixed} = {
+      [accessor]: value
+    }
+
+    // clear tiprack selection if corresponding pipette model is deselected
+    if (accessor === 'leftPipette' && !value) {
+      update.leftTiprackModel = null
+    } else if (accessor === 'rightPipette' && !value) {
+      update.rightTiprackModel = null
+    }
+
+    // skip tiprack update if no pipette selected
+    if (accessor === 'leftTiprackModel' && !this.state.leftPipette) return
+    if (accessor === 'rightTiprackModel' && !this.state.rightPipette) return
+
     this.setState({
       ...this.state,
-      [accessor]: value
+      ...update
     })
   }
 
@@ -69,9 +112,28 @@ export default class NewFileModal extends React.Component<Props, State> {
       return null
     }
 
-    const {name, leftPipette, rightPipette} = this.state
-    const canSubmit = (leftPipette !== INVALID && rightPipette !== INVALID) && // neither can be invalid
-      (leftPipette || rightPipette) // at least one must not be none (empty string)
+    const {
+      name,
+      leftPipette,
+      rightPipette,
+      leftTiprackModel,
+      rightTiprackModel
+    } = this.state
+
+    const pipetteSelectionIsValid = (
+      // neither can be invalid
+      (leftPipette !== USER_HAS_NOT_SELECTED && rightPipette !== USER_HAS_NOT_SELECTED) &&
+      // at least one must not be none (empty string)
+      (leftPipette || rightPipette)
+    )
+
+    // if pipette selected, corresponding tiprack type also selected
+    const tiprackSelectionIsValid = (
+      (leftPipette ? Boolean(leftTiprackModel) : true) &&
+      (rightPipette ? Boolean(rightTiprackModel) : true)
+    )
+
+    const canSubmit = pipetteSelectionIsValid && tiprackSelectionIsValid
 
     return <AlertModal className={modalStyles.modal}
       buttons={[
@@ -82,7 +144,10 @@ export default class NewFileModal extends React.Component<Props, State> {
         <h2>Create New Protocol</h2>
 
         <FormGroup label='Protocol Name:'>
-          <InputField placeholder='Untitled' value={name} onChange={this.handleChange('name')} />
+          <InputField placeholder='Untitled'
+            value={name}
+            onChange={this.handleChange('name')}
+          />
         </FormGroup>
 
         <div className={styles.pipette_text}>
@@ -90,14 +155,30 @@ export default class NewFileModal extends React.Component<Props, State> {
         </div>
 
         <div className={formStyles.row_wrapper}>
-          <FormGroup label='Left pipette*:' className={formStyles.column_1_2}>
-            <DropdownField options={pipetteOptionsWithInvalid}
-              value={leftPipette} onChange={this.handleChange('leftPipette')} />
-          </FormGroup>
-          <FormGroup label='Right pipette*:' className={formStyles.column_1_2}>
-            <DropdownField options={pipetteOptionsWithInvalid}
-              value={rightPipette} onChange={this.handleChange('rightPipette')} />
-          </FormGroup>
+          {[
+            ['leftPipette', 'Left Pipette'],
+            ['rightPipette', 'Right Pipette']
+          ].map(([stateField, label]) => {
+            const fieldValue = this.state[stateField]
+            return (
+              <FormGroup key={stateField} label={`${label}*:`} className={formStyles.column_1_2}>
+                <DropdownField options={fieldValue === USER_HAS_NOT_SELECTED
+                    ? pipetteOptionsWithInvalid
+                    : pipetteOptionsWithNone}
+                  value={fieldValue} onChange={this.handleChange(stateField)} />
+              </FormGroup>
+            )
+          })}
+        </div>
+
+        <div className={formStyles.row_wrapper}>
+          {['leftTiprackModel', 'rightTiprackModel'].map(stateField => (
+            <FormGroup key={stateField} label='Tip rack*:' className={formStyles.column_1_2}>
+              <DropdownField options={tiprackOptions}
+                value={this.state[stateField]}
+                onChange={this.handleChange(stateField)} />
+              </FormGroup>
+          ))}
         </div>
       </form>
     </AlertModal>

--- a/protocol-designer/src/components/modals/NewFileModal.js
+++ b/protocol-designer/src/components/modals/NewFileModal.js
@@ -54,8 +54,8 @@ const tiprackOptions = [
   {name: '10 uL', value: 'tiprack-10ul'},
   {name: '200 uL', value: 'tiprack-200ul'},
   {name: '1000 uL', value: 'tiprack-1000ul'},
-  {name: '1000 uL Chem', value: 'tiprack-1000ul-chem'},
-  {name: '300 uL', value: 'GEB-tiprack-300ul'} // TODO IMMEDATELY does PD have the def for this?
+  {name: '1000 uL Chem', value: 'tiprack-1000ul-chem'}
+  // {name: '300 uL', value: 'GEB-tiprack-300ul'} // NOTE this is not supported by Python API yet
 ]
 
 const initialState = {

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -35,7 +35,11 @@ function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
 
       dispatch(pipetteActions.updatePipettes({
         left: fields.leftPipette,
-        right: fields.rightPipette
+        right: fields.rightPipette,
+
+        // TODO IMMEDATELY handle this in the action
+        leftTiprackModel: fields.leftTiprackModel,
+        rightTiprackModel: fields.rightTiprackModel
       }))
 
       dispatch(navigationActions.toggleNewProtocolModal(false))

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -36,8 +36,6 @@ function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
       dispatch(pipetteActions.updatePipettes({
         left: fields.leftPipette,
         right: fields.rightPipette,
-
-        // TODO IMMEDATELY handle this in the action
         leftTiprackModel: fields.leftTiprackModel,
         rightTiprackModel: fields.rightTiprackModel
       }))

--- a/protocol-designer/src/containers/LabwareDropdown.js
+++ b/protocol-designer/src/containers/LabwareDropdown.js
@@ -1,30 +1,41 @@
 // @flow
-import { connect } from 'react-redux'
+import * as React from 'react'
+import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
-import { closeLabwareSelector, createContainer } from '../labware-ingred/actions'
-import { selectors } from '../labware-ingred/reducers'
+import {closeLabwareSelector, createContainer} from '../labware-ingred/actions'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors as pipetteSelectors} from '../pipettes'
 import LabwareDropdown from '../components/LabwareDropdown.js'
 import type {BaseState} from '../types'
 
-export default connect(
-  (state: BaseState) => ({
-    slot: selectors.canAdd(state)
-  }),
-  (dispatch: Dispatch<*>) => ({dispatch}), // TODO Ian 2018-02-19 what does flow want for no-op mapDispatchToProps?
-  (stateProps, dispatchProps: {dispatch: Dispatch<*>}) => {
-    // TODO Ian 2017-12-04: Use thunks to grab slot, don't use this funky mergeprops
-    const dispatch = dispatchProps.dispatch
+type Props = React.ElementProps<typeof LabwareDropdown>
 
-    return {
-      ...stateProps,
-      onClose: () => {
-        dispatch(closeLabwareSelector())
-      },
-      onContainerChoose: (containerType) => {
-        if (stateProps.slot) {
-          dispatch(createContainer({slot: stateProps.slot, containerType}))
-        }
+type SP = {
+  slot: $PropertyType<Props, 'slot'>,
+  permittedTipracks: $PropertyType<Props, 'permittedTipracks'>
+}
+
+function mapStateToProps (state: BaseState): SP {
+  return {
+    slot: labwareIngredSelectors.canAdd(state),
+    permittedTipracks: pipetteSelectors.permittedTipracks(state)
+  }
+}
+
+function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Props {
+  const dispatch = dispatchProps.dispatch
+
+  return {
+    ...stateProps,
+    onClose: () => {
+      dispatch(closeLabwareSelector())
+    },
+    onContainerChoose: (containerType) => {
+      if (stateProps.slot) {
+        dispatch(createContainer({slot: stateProps.slot, containerType}))
       }
     }
   }
-)(LabwareDropdown)
+}
+
+export default connect(mapStateToProps, null, mergeProps)(LabwareDropdown)

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -25,7 +25,7 @@ import type {
   Wells
 } from '../types'
 import * as actions from '../actions'
-import type {BaseState, Selector} from '../../types'
+import type {BaseState, Selector, Options} from '../../types'
 import type {CopyLabware, DeleteIngredient, EditIngredient} from '../actions'
 
 // external actions (for types)
@@ -282,7 +282,6 @@ const loadedContainersBySlot = createSelector(
 )
 
 /** Returns options for dropdowns, excluding tiprack labware */
-type Options = Array<{value: string, name: string}>
 const labwareOptions: Selector<Options> = createSelector(
   getLabware,
   getLabwareNames,

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,7 +1,13 @@
 // @flow
 import type {PipetteName} from './pipetteData'
 
-export const updatePipettes = (payload: {'left'?: ?PipetteName, 'right'?: ?PipetteName}) => ({
+type UpdatePipettesPayload = {
+  left: ?PipetteName,
+  right: ?PipetteName,
+  leftTiprackModel: ?string,
+  rightTiprackModel: ?string
+}
+export const updatePipettes = (payload: UpdatePipettesPayload) => ({
   type: 'UPDATE_PIPETTES',
   payload
 })

--- a/protocol-designer/src/pipettes/index.js
+++ b/protocol-designer/src/pipettes/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as actions from './actions'
-import {rootReducer} from './reducers'
+import {rootReducer, type RootState} from './reducers'
 import * as selectors from './selectors'
 export * from './types'
 
@@ -8,4 +8,8 @@ export {
   actions,
   rootReducer,
   selectors
+}
+
+export type {
+  RootState
 }

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -4,10 +4,10 @@ import {handleActions, type ActionType} from 'redux-actions'
 import {pipetteDataByName, type PipetteName} from './pipetteData'
 import {updatePipettes} from './actions'
 
-import type {PipetteState} from './types'
 import type {Mount} from '@opentrons/components'
+import type {PipetteData} from '../step-generation'
 
-function createPipette (name: PipetteName, mount: Mount) {
+function createPipette (name: PipetteName, mount: Mount, tiprackModel: string): PipetteData {
   const pipetteData = pipetteDataByName[name]
   if (!pipetteData) {
     // TODO Ian 2018-03-01 I want Flow to enforce `name` is a key in pipetteDataByName,
@@ -18,27 +18,61 @@ function createPipette (name: PipetteName, mount: Mount) {
     id: `${mount}:${name}`,
     mount,
     maxVolume: pipetteData.maxVolume,
-    channels: pipetteData.channels
+    channels: pipetteData.channels,
+    tiprackModel
+  }
+}
+
+type PipetteReducerState = {
+  byMount: {|
+    left: ?string,
+    right: ?string
+  |},
+  byId: {
+    [pipetteId: string]: PipetteData
   }
 }
 
 const pipettes = handleActions({
-  UPDATE_PIPETTES: (state: PipetteState, action: ActionType<typeof updatePipettes>) => {
-    const {left, right} = action.payload // left and/or right pipette names, eg 'P10 Single-Channel'
+  UPDATE_PIPETTES: (state: PipetteReducerState, action: ActionType<typeof updatePipettes>) => {
+    const {left, right, leftTiprackModel, rightTiprackModel} = action.payload
+
+    const leftPipette = (left && leftTiprackModel)
+      ? createPipette(left, 'left', leftTiprackModel)
+      : null
+
+    const rightPipette = (right && rightTiprackModel)
+      ? createPipette(right, 'right', rightTiprackModel)
+      : null
+
+    const newPipettes = ([leftPipette, rightPipette]).reduce(
+      (acc: {[string]: PipetteData}, pipette: PipetteData | null) => {
+        if (!pipette) return acc
+        return {
+          ...acc,
+          [pipette.id]: pipette
+        }
+      }, {})
 
     return {
-      left: left
-        ? createPipette(left, 'left')
-        : null,
-      right: right
-        ? createPipette(right, 'right')
-        : null
+      byMount: {
+        left: leftPipette ? leftPipette.id : state.byMount.left,
+        right: rightPipette ? rightPipette.id : state.byMount.right
+      },
+      byId: {
+        ...state.byId,
+        ...newPipettes
+      }
     }
   }
-}, {left: null, right: null})
+}, {byMount: {left: null, right: null}, byId: {}})
 
 const _allReducers = {
   pipettes
+}
+
+export type RootState = {
+  pipettes: PipetteReducerState
 }
 
 export const rootReducer = combineReducers(_allReducers)

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -81,7 +81,7 @@ export const pipettesForInstrumentGroup: Selector<*> = createSelector(
       channels: pipetteData.channels,
       description: _getPipetteName(pipetteData),
       isDisabled: false,
-      tipType: `${pipetteData.maxVolume} uL`
+      tipType: `${pipetteData.maxVolume} μL`
     }
 
     return [...acc, pipetteForInstrumentGroup]

--- a/protocol-designer/src/pipettes/types.js
+++ b/protocol-designer/src/pipettes/types.js
@@ -1,12 +1,2 @@
 // @flow
-import type {PipetteData} from '../step-generation'
-// TODO: Ian 2018-06-22 move PipetteData type into pipettes dir
-
-export type PipetteState = {|
-  left: ?PipetteData,
-  right: ?PipetteData
-|}
-
-export type RootState = {
-  pipettes: PipetteState
-}
+// Placeholder

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -125,7 +125,8 @@ export type PipetteData = {| // TODO refactor all 'pipette fields', split Pipett
   id: string, // TODO PipetteId export type here instead of string?
   mount: Mount,
   maxVolume: number,
-  channels: Channels
+  channels: Channels,
+  tiprackModel?: string // NOTE: this will go away when tiprack sharing is implemented
 |}
 
 export type LabwareData = {|

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -32,3 +32,5 @@ export type VolumeJson = {
     [wellName: string]: JsonWellData
   }
 }
+
+export type Options = Array<{value: string, name: string}>


### PR DESCRIPTION
## overview

Addresses UI parts of #1573 ("get next tip" selector is blocked by labware definitions lacking tip volume, so PD continues to use existing "get next tip" behavior -- which doesn't work right with 2 pipettes)

## changelog

- User can select tiprack model for pipette in New File modal
- User can only add tipracks that have been selected there to the deck, other tip rack options are not shown in the Add Labware modal/list

## review requests

- In New File modal, tiprack model dropdown clears if you set corresponding Pipette dropdown to None
- When adding labware, you should only be able to select the 1 or 2 tiprack types that have been assigned to pipettes (but since we don't have GEB 300 tips in the dropdown yet, those don't show up as an option to add. ~That will be in the next PR.~ GEB tips aren't actually supported in Python API yet :disappointed: )