### PR TITLE
feat(protocol-designer): user can collapse selected StepItem

### DIFF
--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -55,9 +55,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
   if (!(stepId === '__end__' || stepId === 0)) {
     // Leave collapsed undefined for special steps
-    collapsed = (selected)
-      ? false // selected steps never collapsed
-      : steplistSelectors.getCollapsedSteps(state)[stepId]
+    collapsed = steplistSelectors.getCollapsedSteps(state)[stepId]
   }
 
   return {

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -87,18 +87,10 @@ type ToggleStepCollapsedAction = {
   payload: StepIdType
 }
 
-export const toggleStepCollapsed = (stepId: StepIdType): ThunkAction<?ToggleStepCollapsedAction> =>
-  (dispatch: ThunkDispatch<*>, getState: GetState) => {
-    if (stepId === selectors.selectedStepId(getState())) {
-      // User cannot collapse the currently selected step
-      return
-    }
-
-    dispatch({
-      type: 'TOGGLE_STEP_COLLAPSED',
-      payload: stepId
-    })
-  }
+export const toggleStepCollapsed = (stepId: StepIdType): ToggleStepCollapsedAction => ({
+  type: 'TOGGLE_STEP_COLLAPSED',
+  payload: stepId
+})
 
 export type SelectStepAction = {
   type: 'SELECT_STEP',


### PR DESCRIPTION
## overview

Closes #1681

## changelog

- StepItems can be toggled collapsed/expanded, even when selected

## review requests

- Basic review :baby: 