### PR TITLE
fix(app): Fix overlay and redirect duplication in robot settings page

### DIFF
--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -28,9 +28,9 @@ type SP = {
 type DP = {dispatch: Dispatch}
 
 type Props = OP & SP & {
-  update: () => *,
-  restart: () => *,
-  ignoreUpdate: () => *,
+  update: () => mixed,
+  restart: () => mixed,
+  ignoreUpdate: () => mixed,
 }
 
 const UPDATE_MSG = "We recommend updating your robot's software to the latest version"
@@ -41,7 +41,6 @@ const DONE_MSG = 'Your robot has been updated. Please wait for your robot to ful
 // TODO(mc, 2018-03-19): prop or component for text-height icons
 const Spinner = () => (<Icon name='ot-spinner' height='1em' spin />)
 
-// $FlowFixMe(ka, 2018-06-22): flow throwing error because of mergeprops?
 export default connect(makeMapStateToProps, null, mergeProps)(UpdateModal)
 
 function UpdateModal (props: Props) {
@@ -76,7 +75,6 @@ function UpdateModal (props: Props) {
 
   return (
     <AlertModal
-      onCloseClick={close}
       heading={heading}
       buttons={[
         {onClick: ignoreUpdate, children: closeButtonText},
@@ -89,12 +87,12 @@ function UpdateModal (props: Props) {
   )
 }
 
-function makeMapStateToProps () {
+function makeMapStateToProps (): (State, OP) => SP {
   const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
   const getRobotUpdateRequest = makeGetRobotUpdateRequest()
   const getRobotRestartRequest = makeGetRobotRestartRequest()
 
-  return (state: State, ownProps: OP): SP => ({
+  return (state, ownProps) => ({
     availableUpdate: getAvailableRobotUpdate(state, ownProps),
     updateRequest: getRobotUpdateRequest(state, ownProps),
     restartRequest: getRobotRestartRequest(state, ownProps)

--- a/app/src/pages/Robots.js
+++ b/app/src/pages/Robots.js
@@ -90,14 +90,6 @@ function RobotSettingsPage (props: Props) {
           <UpdateModal {...robot} />
         )} />
 
-        <Route render={() => {
-          if (showUpdateModal) {
-            return (<Redirect to={`/robots/${robot.name}/update`} />)
-          }
-
-          return null
-        }} />
-
         <Route path={`${path}/pipettes`} render={(props) => (
           <ChangePipette {...props} robot={robot} parentUrl={url} />
         )} />
@@ -105,23 +97,38 @@ function RobotSettingsPage (props: Props) {
         <Route path={`${path}/calibrate-deck`} render={(props) => (
           <CalibrateDeck match={props.match} robot={robot} parentUrl={url} />
         )} />
+
+        <Route exact path={path} render={() => {
+          if (showUpdateModal) {
+            return (<Redirect to={`/robots/${robot.name}/update`} />)
+          }
+
+          // only show homing spinner and error on main page
+          // otherwise, it will show up during homes in pipette swap
+          return (
+            <React.Fragment>
+              {homeInProgress && (
+                <SpinnerModalPage
+                  titleBar={titleBarProps}
+                  message='Robot is homing.'
+                />
+              )}
+
+              {!!homeError && (
+                <ErrorModal
+                  heading='Robot unable to home'
+                  error={homeError}
+                  description='Robot was unable to home, please try again.'
+                  close={closeHomeAlert}
+                />
+              )}
+            </React.Fragment>
+          )
+        }} />
       </Switch>
 
       {showConnectAlert && (
         <ConnectAlertModal onCloseClick={closeConnectAlert} />
-      )}
-
-      {homeInProgress && (
-        <SpinnerModalPage titleBar={titleBarProps} message='Robot is homing.' />
-      )}
-
-      {!!homeError && (
-        <ErrorModal
-          heading='Robot unable to home'
-          error={homeError}
-          description='Robot was unable to home, please try again.'
-          close={closeHomeAlert}
-        />
       )}
      </React.Fragment>
   )

--- a/components/src/modals/Overlay.js
+++ b/components/src/modals/Overlay.js
@@ -16,13 +16,14 @@ type OverlayProps = {
  * just want to use `<Modal>`
  */
 export default function Overlay (props: OverlayProps) {
-  const clickable = props.onClick && !props.alertOverlay
-  const className = cx(
-    styles.overlay,
-    {[styles.clickable]: clickable, [styles.alert_modal_overlay]: props.alertOverlay}
-  )
+  const {alertOverlay, onClick} = props
+
+  const className = cx(styles.overlay, {
+    [styles.clickable]: onClick,
+    [styles.alert_modal_overlay]: alertOverlay
+  })
 
   return (
-    <div className={className} onClick={clickable && props.onClick} />
+    <div className={className} onClick={onClick} />
   )
 }


### PR DESCRIPTION
## overview

#1726 and #1745 introduced some bugs in how modals are(n't) displayed on the robot settings page. This PR / bug ticket fixes those bugs up.

## changelog

- fix(app): Fix overlay and redirect duplication in robot settings page 

## review requests

- [x] New robot update alert works
- [x] Change pipette modal is openable
- [x] Deck calibration modal is openable
- [x] Homing the pipette in change pipette doesn't also trigger the home button modal
