### PR TITLE
fix(app): Show spinner during home on deck calibration exit

### DIFF
--- a/app/src/__tests__/util.test.js
+++ b/app/src/__tests__/util.test.js
@@ -25,9 +25,11 @@ describe('chainActions utility', () => {
       {type: 'baz'}
     ]
 
-    const result = store.dispatch(chainActions(...actions))
-    expect(result).toEqual(actions[2])
-    expect(store.getActions()).toEqual(actions)
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(actions[2])
+        expect(store.getActions()).toEqual(actions)
+      })
   })
 
   test('dispatches a chain of thunk actions', () => {
@@ -38,9 +40,11 @@ describe('chainActions utility', () => {
     ]
     const thunks = actions.map(a => dispatch => dispatch(a))
 
-    const result = store.dispatch(chainActions(...thunks))
-    expect(result).toEqual(actions[2])
-    expect(store.getActions()).toEqual(actions)
+    return store.dispatch(chainActions(...thunks))
+      .then(result => {
+        expect(result).toEqual(actions[2])
+        expect(store.getActions()).toEqual(actions)
+      })
   })
 
   test('dispatches a chain of thunk promise actions', () => {
@@ -83,9 +87,11 @@ describe('chainActions utility', () => {
       {type: 'bar'}
     ]
 
-    const result = store.dispatch(chainActions(...actions))
-    expect(result).toEqual(actions[0])
-    expect(store.getActions()).toEqual(actions.slice(0, 1))
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(actions[0])
+        expect(store.getActions()).toEqual(actions.slice(0, 1))
+      })
   })
 
   test('bails out early if a thunk action has an error', () => {
@@ -95,9 +101,11 @@ describe('chainActions utility', () => {
       {type: 'bar'}
     ]
 
-    const result = store.dispatch(chainActions(...actions))
-    expect(result).toEqual(errorAction)
-    expect(store.getActions()).toEqual([errorAction])
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(errorAction)
+        expect(store.getActions()).toEqual([errorAction])
+      })
   })
 
   test('bails out early if a thunk promise has an error', () => {
@@ -120,9 +128,11 @@ describe('chainActions utility', () => {
       {type: 'bar'}
     ]
 
-    const result = store.dispatch(chainActions(...actions))
-    expect(result).toEqual(actions[0])
-    expect(store.getActions()).toEqual(actions.slice(0, 1))
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(actions[0])
+        expect(store.getActions()).toEqual(actions.slice(0, 1))
+      })
   })
 
   test('bails out early if a thunk action has an error in the payload', () => {
@@ -132,9 +142,11 @@ describe('chainActions utility', () => {
       {type: 'bar'}
     ]
 
-    const result = store.dispatch(chainActions(...actions))
-    expect(result).toEqual(errorAction)
-    expect(store.getActions()).toEqual([errorAction])
+    return store.dispatch(chainActions(...actions))
+      .then(result => {
+        expect(result).toEqual(errorAction)
+        expect(store.getActions()).toEqual([errorAction])
+      })
   })
 
   test('bails out early if a thunk promise has an error in the payload', () => {

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -8,6 +8,7 @@ import type {State, Dispatch} from '../../types'
 import type {OP, SP, DP, CalibrateDeckProps, CalibrationStep} from './types'
 
 import {getPipette} from '@opentrons/shared-data'
+import {chainActions} from '../../util'
 import createLogger from '../../logger'
 
 import {
@@ -164,9 +165,11 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
     },
     forceStart: () => dispatch(startDeckCalibration(robot, true)),
     // exit button click in title bar, opens exit alert modal, confirm exit click
-    exit: () => dispatch(home(robot))
-      .then(() => dispatch(deckCalibrationCommand(robot, {command: 'release'})))
-      .then(() => dispatch(push(parentUrl))),
+    exit: () => dispatch(chainActions(
+      deckCalibrationCommand(robot, {command: 'release'}),
+      push(parentUrl),
+      home(robot)
+    )),
     // cancel button click in exit alert modal
     back: () => dispatch(goBack())
   }

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -25,7 +25,7 @@ type StateProps = {
 }
 
 type DispatchProps = {
-  fetchHealth: () => mixed // TODO (ka 2018-6-21): fetchHealthAndIgnored uses chainActions, how do we type this?
+  fetchHealth: () => mixed
 }
 
 type Props = OwnProps & StateProps & DispatchProps
@@ -96,7 +96,6 @@ function mapDispatchToProps (
   ownProps: OwnProps
 ): DispatchProps {
   return {
-    // $FlowFixMe(ka, 2018-06-21): figure out chainActions type here
     fetchHealth: () => dispatch(fetchHealthAndIgnored(ownProps))
   }
 }


### PR DESCRIPTION
## overview

This PR reorganizes the action chain on "Exit" click during deck calibration so that the homing spinner from #1726 gets shows during DC exit.

Closes #1613

## changelog

- fix(app): Show spinner during home on deck calibration exit 

## review requests

Required some tweaks in the bespoke action chaining util to handle the fact that the (now deprecated) react-router-redux middleware swallows route change actions rather than returning them, which goes against redux conventions and results in `dispatch(push(path))` returning `undefined` rather that the `push` object. Hurray.

- [ ] Deck calibration still works

Tested on Sunset and looks good to me