### PR TITLE
feat(app): Add keyboard shortcuts to jog controls

### DIFF
--- a/app/src/components/JogControls/index.js
+++ b/app/src/components/JogControls/index.js
@@ -9,6 +9,7 @@ import {
   PrimaryButton,
   RadioGroup,
   Icon,
+  HandleKeypress,
   type IconName
 } from '@opentrons/components'
 
@@ -19,10 +20,7 @@ type Jog = (axis: JogAxis, direction: JogDirection, step: JogStep) => mixed
 type JogButtonProps = {
   name: string,
   icon: IconName,
-  jog: Jog,
-  axis: JogAxis,
-  direction: JogDirection,
-  step: JogStep,
+  onClick: () => mixed,
 }
 
 export type JogControlsProps = {
@@ -31,70 +29,131 @@ export type JogControlsProps = {
   onStepSelect: (event: SyntheticInputEvent<*>) => mixed,
 }
 
-const JOG_BUTTONS: Array<{
-  name: string,
-  axis: JogAxis,
-  direction: JogDirection,
-  icon: IconName
-}> = [
-  {name: 'left', axis: 'x', direction: -1, icon: 'ot-arrow-left'},
-  {name: 'right', axis: 'x', direction: 1, icon: 'ot-arrow-right'},
-  {name: 'back', axis: 'y', direction: 1, icon: 'ot-arrow-up'},
-  {name: 'forward', axis: 'y', direction: -1, icon: 'ot-arrow-down'},
-  {name: 'up', axis: 'z', direction: 1, icon: 'ot-arrow-up'},
-  {name: 'down', axis: 'z', direction: -1, icon: 'ot-arrow-down'}
-]
+const JOG_BUTTON_NAMES = ['left', 'right', 'back', 'forward', 'up', 'down']
 
-export default function JogControls (props: JogControlsProps) {
-  const {jog, step, onStepSelect} = props
+const JOG_ICONS_BY_NAME = {
+  left: 'ot-arrow-left',
+  right: 'ot-arrow-right',
+  back: 'ot-arrow-up',
+  forward: 'ot-arrow-down',
+  up: 'ot-arrow-up',
+  down: 'ot-arrow-down'
+}
 
-  return (
-    <div className={styles.jog_container}>
-      <div className={styles.jog_controls}>
-        <span className={styles.jog_label_xy}>
-          Across Deck
-        </span>
-        <span className={styles.jog_label_z}>
-          Up & Down
-        </span>
-        {JOG_BUTTONS.map((button) => (
-          <JogButton key={button.name} {...button} jog={jog} step={step} />
+const JOG_PARAMS_BY_NAME = {
+  left: ['x', -1],
+  right: ['x', 1],
+  back: ['y', 1],
+  forward: ['y', -1],
+  up: ['z', 1],
+  down: ['z', -1]
+}
+
+const STEPS = [0.1, 1, 10]
+const STEP_OPTIONS = STEPS.map(s => ({name: `${s} mm`, value: `${s}`}))
+
+export default class JogControls extends React.Component<JogControlsProps> {
+  increaseStepSize = () => {
+    const current = STEPS.indexOf(this.props.step)
+    if (current < STEPS.length - 1) {
+      // $FlowFixMe: (mc, 2018-06-26) refactor so event trickery isn't needed
+      this.props.onStepSelect({target: {value: `${STEPS[current + 1]}`}})
+    }
+  }
+
+  decreaseStepSize = () => {
+    const current = STEPS.indexOf(this.props.step)
+    if (current > 0) {
+      // $FlowFixMe: (mc, 2018-06-26) refactor so event trickery isn't needed
+      this.props.onStepSelect({target: {value: `${STEPS[current - 1]}`}})
+    }
+  }
+
+  getJogHandlers () {
+    const {jog, step} = this.props
+
+    return JOG_BUTTON_NAMES.reduce((result, name) => ({
+      ...result,
+      [name]: jog.bind(null, ...JOG_PARAMS_BY_NAME[name], step)
+    }), {})
+  }
+
+  renderJogControls () {
+    const jogHandlers = this.getJogHandlers()
+    const {step, onStepSelect} = this.props
+
+    return (
+      <HandleKeypress handlers={[
+        {key: 'ArrowLeft', shiftKey: false, onPress: jogHandlers.left},
+        {key: 'ArrowRight', shiftKey: false, onPress: jogHandlers.right},
+        {key: 'ArrowUp', shiftKey: false, onPress: jogHandlers.back},
+        {key: 'ArrowDown', shiftKey: false, onPress: jogHandlers.forward},
+        {key: 'ArrowUp', shiftKey: true, onPress: jogHandlers.up},
+        {key: 'ArrowDown', shiftKey: true, onPress: jogHandlers.down},
+        {key: '-', onPress: this.decreaseStepSize},
+        {key: '_', onPress: this.decreaseStepSize},
+        {key: '=', onPress: this.increaseStepSize},
+        {key: '+', onPress: this.increaseStepSize}
+      ]}>
+        {JOG_BUTTON_NAMES.map(name => (
+          <JogButton
+            key={name}
+            name={name}
+            icon={JOG_ICONS_BY_NAME[name]}
+            onClick={jogHandlers[name]}
+          />
         ))}
-        <span className={styles.jog_increment}>
-          Jump Size
-        </span>
         <span className={styles.increment_group}>
-        <RadioGroup
-          className={styles.increment_item}
-          value={`${step}`}
-          options={[
-            {name: '0.1 mm', value: '0.1'},
-            {name: '1 mm', value: '1'},
-            {name: '10 mm', value: '10'}
-          ]}
-          onChange={onStepSelect}
-        />
-      </span>
+          <RadioGroup
+            className={styles.increment_item}
+            value={`${step}`}
+            options={STEP_OPTIONS}
+            onChange={onStepSelect}
+            disableKeypress
+          />
+        </span>
+      </HandleKeypress>
+    )
+  }
+
+  render () {
+    return (
+      <div className={styles.jog_container}>
+        <div className={styles.jog_controls}>
+          <span className={styles.jog_increment}>
+            Jump Size
+            <span className={styles.jog_label_keys}>
+              Change with + and -
+            </span>
+          </span>
+          <span className={styles.jog_label_xy}>
+            Across Deck
+            <span className={styles.jog_label_keys}>
+              Arrow keys
+            </span>
+          </span>
+          <span className={styles.jog_label_z}>
+            Up & Down
+            <span className={styles.jog_label_keys}>
+              Arrow keys + SHIFT
+            </span>
+          </span>
+          {this.renderJogControls()}
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 function JogButton (props: JogButtonProps) {
-  const {name, icon, jog, axis, direction, step} = props
+  const {name, icon, onClick} = props
   const className = cx(styles.jog_button, styles[name])
-
-  // TODO(mc, 2018-05-07): I tried to make this a class based component to
-  //  have handleClick be a class method, but props ended up out-of-date in the
-  //  handler but not in render. No idea why this was happening but figure it
-  //  out because it's concerning
-  const handleClick = () => jog(axis, direction, step)
 
   return (
     <PrimaryButton
       className={className}
       title={name}
-      onClick={handleClick}
+      onClick={onClick}
     >
       <Icon name={icon} />
     </PrimaryButton>

--- a/app/src/components/JogControls/styles.css
+++ b/app/src/components/JogControls/styles.css
@@ -59,10 +59,11 @@
   grid-row: 2;
   grid-column: 1/4;
   padding-left: 1rem;
+  text-align: left;
 }
 
 .increment_item {
-  padding: 0.375rem;
+  padding: 0.375rem 0;
 }
 
 .jog_label_xy,
@@ -81,4 +82,10 @@
   grid-column: 9/12;
   grid-row: 1;
   text-align: center;
+}
+
+.jog_label_keys {
+  @apply --font-body-1-dark;
+
+  display: block;
 }

--- a/components/src/forms/RadioGroup.js
+++ b/components/src/forms/RadioGroup.js
@@ -25,6 +25,7 @@ type Props = {
 
 export default function RadioGroup (props: Props) {
   const error = props.error != null
+
   return (
     <div className={cx({[styles.inline]: props.inline, [styles.error]: error})}>
       {props.options && props.options.map(radio =>

--- a/components/src/interaction-enhancers/HandleKeypress.js
+++ b/components/src/interaction-enhancers/HandleKeypress.js
@@ -1,0 +1,61 @@
+// @flow
+import * as React from 'react'
+
+type KeypressEvent = SyntheticKeyboardEvent<*>
+
+type KeypressHandler = {
+  key: string,
+  shiftKey?: ?boolean,
+  onPress: () => mixed,
+}
+
+type Props = {
+  /** array of keypress handlers to attach to the window */
+  handlers: Array<KeypressHandler>,
+  /** wrapped children */
+  children?: React.Node,
+}
+
+const matchHandler = e => h => (
+  h.key === e.key &&
+  (h.shiftKey == null || h.shiftKey === e.shiftKey)
+)
+
+/**
+ * Keypress handler wrapper component. Takes an array of keypress handlers
+ * to call when a given key is pressed on the keyboard. Handler is called on
+ * `keyup` event. `event.preventDefault` will be called if a key is handled.
+ */
+export default class HandleKeypress extends React.Component<Props> {
+  handlePressIfKey = (event: KeypressEvent) => {
+    this.props.handlers
+      .filter(matchHandler(event))
+      .forEach(h => h.onPress())
+  }
+
+  preventDefaultIfKey = (event: KeypressEvent) => {
+    const pressHandled = this.props.handlers.some(matchHandler(event))
+
+    if (pressHandled) event.preventDefault()
+  }
+
+  componentDidMount () {
+    window.addEventListener('keyup', this.handlePressIfKey)
+    window.addEventListener('keyup', this.preventDefaultIfKey)
+    window.addEventListener('keydown', this.preventDefaultIfKey)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('keyup', this.handlePressIfKey)
+    window.removeEventListener('keyup', this.preventDefaultIfKey)
+    window.removeEventListener('keydown', this.preventDefaultIfKey)
+  }
+
+  render () {
+    return (
+      <React.Fragment>
+        {this.props.children}
+      </React.Fragment>
+    )
+  }
+}

--- a/components/src/interaction-enhancers/HandleKeypress.md
+++ b/components/src/interaction-enhancers/HandleKeypress.md
@@ -1,0 +1,17 @@
+Use `<HandleKeypress>` to register listeners for keypress events:
+
+```js
+initialState = {key: ''}
+
+;<HandleKeypress
+  handlers={[
+    {key: 'q', onPress: () => setState({key: 'q'})},
+    {key: 'w', onPress: () => setState({key: 'w'})},
+    {key: 'e', onPress: () => setState({key: 'e'})},
+    {key: 'ArrowLeft', shiftKey: false, onPress: () => setState({key: 'left'})},
+    {key: 'ArrowRight', shiftKey: true, onPress: () => setState({key: 'shift + right'})}
+  ]}
+>
+  Key: {state.key}
+</HandleKeypress>
+```

--- a/components/src/interaction-enhancers/index.js
+++ b/components/src/interaction-enhancers/index.js
@@ -1,7 +1,10 @@
 // @flow
 import clickOutside from './clickOutside'
+import HandleKeypress from './HandleKeypress'
+
 export type {ClickOutsideInterface} from './clickOutside'
 
 export {
-  clickOutside
+  clickOutside,
+  HandleKeypress
 }


### PR DESCRIPTION
## overview

This PR adds keyboard shortcuts to the JogControls component used by both Deck Calibration jogging and Labware Calibration jogging.

Closes #1476

## changelog

- feat(app): Add keyboard shortcuts to jog controls 

## review requests

We added a `<HandleKeypress>` wrapper component to the component library to attach `keyup` listeners on component mount and unmount. We then refactored the app's generic `<JogControls>` component to be class based and use `<HandleKeypress>`.

The `JogControls` refactor also involved trying to make the button construction more readable, so let me know what you think of `renderJogControls`.

Otherwise:

- [ ] Keyboard shortcuts work in deck calibration according to UI description
- [ ] Keyboard shortcuts work in labware calibration according to UI description
