### PR TITLE
feat(app): Add advanced settings card to robot settings page

### DIFF
--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -1,0 +1,24 @@
+// @flow
+// app info card with version and updated
+import * as React from 'react'
+
+import {Card} from '@opentrons/components'
+import {LabeledButton} from '../controls'
+
+const TITLE = 'Advanced Settings'
+
+export default function AdvancedSettingsCard () {
+  return (
+    <Card title={TITLE} column>
+    <LabeledButton
+      label='Download Logs'
+      buttonProps={{
+        disabled: true,
+        children: 'Download'
+      }}
+    >
+      <p>Access logs from this robot.</p>
+    </LabeledButton>
+    </Card>
+  )
+}

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -9,6 +9,7 @@ import InformationCard from './InformationCard'
 import ControlsCard from './ControlsCard'
 import ConnectivityCard from './ConnectivityCard'
 import CalibrationCard from './CalibrationCard'
+import AdvancedSettingsCard from './AdvancedSettingsCard'
 import ConnectAlertModal from './ConnectAlertModal'
 import UpdateModal from './UpdateModal'
 import styles from './styles.css'
@@ -39,6 +40,9 @@ export default function RobotSettings (props: Props) {
         <div className={styles.column_50}>
           <CalibrationCard {...props} />
         </div>
+      </div>
+      <div className={styles.row}>
+        <AdvancedSettingsCard {...props} />
       </div>
     </div>
   )


### PR DESCRIPTION
## overview

This PR addresses #1632 and #1727 by adding an advanced settings card to Robot page with a disabled download logs section.

<img width="800" alt="screen shot 2018-06-27 at 10 41 00 am" src="https://user-images.githubusercontent.com/3430313/41981342-b0bf3ece-79f6-11e8-8985-779cc2ee57b9.png">

## changelog

- feat(app): Add advanced settings card to robot settings page

## review requests

Standard review. This ones super small and UI only.
