### PR TITLE
feat(protocol-designer): add diagrams & copy to new file modal

### DIFF
--- a/protocol-designer/src/components/modals/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal.css
@@ -1,7 +1,0 @@
-@import '@opentrons/components';
-
-.pipette_text {
-  @apply --font-body-1-dark;
-
-  padding: 2rem 0 1rem 0;
-}

--- a/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
@@ -1,0 +1,38 @@
+@import '@opentrons/components';
+
+.diagrams {
+  display: flex;
+  align-items: baseline;
+}
+
+.tiprack_labware {
+  flex: 3;
+}
+
+.left_pipette,
+.right_pipette {
+  flex: 1;
+}
+
+.left_pipette {
+  text-align: right;
+  padding-right: 1rem;
+}
+
+.new_file_modal {
+  line-height: 1.5;
+
+  & form > * {
+    margin-bottom: 1rem;
+  }
+
+  & ol > li {
+    counter-increment: step-counter;
+    list-style: none;
+    margin: 1rem 0;
+  }
+
+  & ol > li::before {
+    content: counter(step-counter) ") ";
+  }
+}

--- a/protocol-designer/src/components/modals/NewFileModal/PipetteDiagram.js
+++ b/protocol-designer/src/components/modals/NewFileModal/PipetteDiagram.js
@@ -1,0 +1,41 @@
+// @flow
+import * as React from 'react'
+import styles from './NewFileModal.css'
+import {InstrumentDiagram} from '@opentrons/components'
+import {pipetteDataByName} from '../../../pipettes/pipetteData'
+
+function getChannels (pipetteModel: ?string): ?number {
+  if (!pipetteModel) return null
+
+  // TODO: Ian 2018-06-27 use getPipette fn from shared-data
+  // once PD's pipetteData.js is replaced with shared-data stuff
+  const pipetteData = pipetteDataByName[pipetteModel]
+  return (pipetteData && pipetteData.channels) || null
+}
+
+type Props = {
+  leftPipette: ?string,
+  rightPipette: ?string
+}
+export default function PipetteDiagram (props: Props) {
+  const {leftPipette, rightPipette} = props
+  const leftChannels = getChannels(leftPipette)
+  const rightChannels = getChannels(rightPipette)
+
+  return (
+    <React.Fragment>
+      {(leftPipette && leftChannels)
+          ? <InstrumentDiagram
+          channels={leftChannels}
+          className={styles.left_pipette} />
+          : <div className={styles.left_pipette} />
+      }
+      {(rightPipette && rightChannels)
+          ? <InstrumentDiagram
+            channels={rightChannels}
+            className={styles.right_pipette} />
+          : <div className={styles.right_pipette} />
+      }
+    </React.Fragment>
+  )
+}

--- a/protocol-designer/src/components/modals/NewFileModal/TiprackDiagram.js
+++ b/protocol-designer/src/components/modals/NewFileModal/TiprackDiagram.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react'
+import {Plate} from '@opentrons/components'
+import SingleLabware from '../../SingleLabware'
+import styles from './NewFileModal.css'
+
+type Props = {containerType: ?string}
+
+export default function TiprackDiagram (props: Props) {
+  const {containerType} = props
+  if (!containerType) {
+    return <div className={styles.tiprack_labware} />
+  }
+
+  return (
+    <SingleLabware className={styles.tiprack_labware}>
+      <Plate containerType={containerType} />
+    </SingleLabware>
+  )
+}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -1,16 +1,18 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import {
-  FormGroup,
-  InputField,
+  AlertModal,
   DropdownField,
-  AlertModal
+  FormGroup,
+  InputField
 } from '@opentrons/components'
-import {pipetteOptions} from '../../pipettes/pipetteData'
-
+import {pipetteOptions} from '../../../pipettes/pipetteData'
+import PipetteDiagram from './PipetteDiagram'
+import TiprackDiagram from './TiprackDiagram'
 import styles from './NewFileModal.css'
-import formStyles from '../forms.css'
-import modalStyles from './modal.css'
+import formStyles from '../../forms.css'
+import modalStyles from '../modal.css'
 
 type State = {
   name: string,
@@ -159,7 +161,7 @@ export default class NewFileModal extends React.Component<Props, State> {
         </FormGroup>
     ))
 
-    return <AlertModal className={modalStyles.modal}
+    return <AlertModal className={cx(modalStyles.modal, styles.new_file_modal)}
       buttons={[
         {onClick: this.props.onCancel, children: 'Cancel'},
         {onClick: this.handleSubmit, disabled: !canSubmit, children: 'Save'}
@@ -167,16 +169,25 @@ export default class NewFileModal extends React.Component<Props, State> {
       <form className={modalStyles.modal_contents}>
         <h2>Create New Protocol</h2>
 
-        <FormGroup label='Protocol Name:'>
+        <FormGroup label='Name:'>
           <InputField placeholder='Untitled'
             value={name}
             onChange={this.handleChange('name')}
           />
         </FormGroup>
 
-        <div className={styles.pipette_text}>
-          Select the pipettes you will be using. This cannot be changed later.
-        </div>
+        <h3>Beta Pipette Restrictions:</h3>
+        <ol>
+          <li>
+            You can't change your pipette selection later. If in doubt go for
+            smaller pipettes. The Protocol Designer automatically breaks up transfer
+            volumes that exceed pipette capacity into multiple transfers.
+          </li>
+          <li>
+            Pipettes can't share tip racks. There needs to be at least 1 tip rack per
+            pipette on the deck.
+          </li>
+        </ol>
 
         <div className={formStyles.row_wrapper}>
           {pipetteFields}
@@ -184,6 +195,15 @@ export default class NewFileModal extends React.Component<Props, State> {
 
         <div className={formStyles.row_wrapper}>
           {tiprackFields}
+        </div>
+
+        <div className={styles.diagrams}>
+          <TiprackDiagram containerType={this.state.leftTiprackModel} />
+          <PipetteDiagram
+            leftPipette={this.state.leftPipette}
+            rightPipette={this.state.rightPipette}
+          />
+          <TiprackDiagram containerType={this.state.rightTiprackModel} />
         </div>
       </form>
     </AlertModal>


### PR DESCRIPTION
## overview

Closes #1695

## changelog

- add new tiprack + pipette diagrams & copy to New File modal

## review requests

- Tipracks are not styled correctly, look very similar to plates. I'm going to fix that in my next PR