### PR TITLE
fix(app): Make WiFi card more lenient and understandable

### DIFF
--- a/app/src/components/RobotSettings/ConnectivityCard.js
+++ b/app/src/components/RobotSettings/ConnectivityCard.js
@@ -92,6 +92,7 @@ function ConnectivityCard (props: Props) {
           value={`${connectedBy} - ${ip}`}
         />
         <WifiConnectForm
+          key={name}
           disabled={configInProgress}
           activeSsid={activeSsid}
           networks={listOptions}

--- a/app/src/components/RobotSettings/ConnectivityCard.js
+++ b/app/src/components/RobotSettings/ConnectivityCard.js
@@ -9,7 +9,6 @@ import {actions as robotActions, type Robot} from '../../robot'
 import {
   fetchWifiList,
   configureWifi,
-  setConfigureWifiBody,
   clearConfigureWifiResponse,
   makeGetRobotWifiList,
   makeGetRobotWifiConfigure,
@@ -30,11 +29,10 @@ type StateProps = {
 }
 
 type DispatchProps = {
-  fetchList: () => *,
-  configure: () => *,
-  setConfigureBody: ({['ssid' | 'psk']: string}) => *,
-  clearSuccessfulConfigure: () => *,
-  clearFailedConfigure: () => *
+  fetchList: () => mixed,
+  configure: (?string, ?string) => mixed,
+  clearSuccessfulConfigure: () => mixed,
+  clearFailedConfigure: () => mixed,
 }
 
 type Props = OwnProps & StateProps & DispatchProps
@@ -53,7 +51,6 @@ function ConnectivityCard (props: Props) {
     wired,
     name,
     fetchList,
-    setConfigureBody,
     clearSuccessfulConfigure,
     clearFailedConfigure,
     configure,
@@ -63,23 +60,26 @@ function ConnectivityCard (props: Props) {
     },
     configureRequest: {
       inProgress: configInProgress,
-      request: configRequest,
       response: configResponse,
       error: configError
     }
   } = props
 
-  const credentials = configRequest || {ssid: '', psk: ''}
   const list = (listResponse && listResponse.list) || []
 
   const active = list.find((network) => network.active)
+  const activeSsid = active && active.ssid
+  const connectedBy = wired
+    ? 'USB'
+    : `${activeSsid || ''} (WiFi)`
+
   const listOptions = list.map(({active, ssid}) => ({
-    name: (active ? `${ssid} *` : ssid),
+    name: active ? `${ssid} *` : ssid,
     value: ssid
   }))
 
   return (
-    <div>
+    <React.Fragment>
       <RefreshCard
         watch={name}
         refresh={fetchList}
@@ -89,29 +89,26 @@ function ConnectivityCard (props: Props) {
       >
         <LabeledValue
           label={CONNECTED_BY_LABEL}
-          value={`${wired ? 'USB' : 'WiFi'} - ${ip}`}
+          value={`${connectedBy} - ${ip}`}
         />
         <WifiConnectForm
-          disabled={!wired || configInProgress}
-          ssid={credentials.ssid}
-          psk={credentials.psk}
-          activeSsid={active && active.ssid}
+          disabled={configInProgress}
+          activeSsid={activeSsid}
           networks={listOptions}
-          onChange={setConfigureBody}
           onSubmit={configure}
         />
       </RefreshCard>
       {(!!configError || !!configResponse) && (
         <WifiConnectModal
-          onClose={(configError
+          error={configError}
+          response={configResponse}
+          close={(configError
             ? clearFailedConfigure
             : clearSuccessfulConfigure
           )}
-          error={configError}
-          response={configResponse}
         />
       )}
-    </div>
+    </React.Fragment>
   )
 }
 
@@ -130,11 +127,7 @@ function mapDispatchToProps (
   ownProps: OwnProps
 ): DispatchProps {
   const fetchList = () => dispatch(fetchWifiList(ownProps))
-  const configure = () => dispatch(configureWifi(ownProps))
-
-  const setConfigureBody = (update) => {
-    dispatch(setConfigureWifiBody(ownProps, update))
-  }
+  const configure = (ssid, psk) => dispatch(configureWifi(ownProps, ssid, psk))
 
   // TODO(mc, 2018-02-26): handle refreshing the list and kicking off dispatch
   //   more elegantly and closer to the configure response
@@ -147,7 +140,6 @@ function mapDispatchToProps (
   return {
     fetchList,
     configure,
-    setConfigureBody,
     clearSuccessfulConfigure,
     clearFailedConfigure
   }

--- a/app/src/components/RobotSettings/WifiConnectForm.js
+++ b/app/src/components/RobotSettings/WifiConnectForm.js
@@ -2,68 +2,86 @@
 import * as React from 'react'
 
 import {OutlineButton, type DropdownOption} from '@opentrons/components'
-import type {FormProps, InputProps} from './inputs'
 import {Form, Select, TextInput} from './inputs'
 import styles from './styles.css'
 
 type Props = {
   disabled: boolean,
-  ssid: ?string,
-  psk: ?string,
   activeSsid: ?string,
   networks: Array<DropdownOption>,
-  onChange: $PropertyType<InputProps<*>, 'onChange'>,
-  onSubmit: $PropertyType<FormProps, 'onSubmit'>,
+  onSubmit: (?string, ?string) => mixed,
 }
 
-export default function ConfigureWifiForm (props: Props) {
-  const {
-    ssid,
-    psk,
-    activeSsid,
-    networks,
-    onChange,
-    onSubmit
-  } = props
+type State = {
+  ssid: ?string,
+  psk: ?string,
+}
 
-  const inputDisabled = props.disabled
-  const formDisabled = inputDisabled || !ssid || (ssid === activeSsid)
+type Update = {
+  ssid?: string,
+  psk?: string,
+}
 
-  return (
-    <Form
-      onSubmit={onSubmit}
-      disabled={formDisabled}
-      className={styles.configure_form}
-    >
-      <label className={styles.configure_label}>
-        {'WiFi network:'}
-        <Select
-          name='ssid'
-          value={ssid || activeSsid}
-          options={networks}
-          disabled={inputDisabled}
-          onChange={onChange}
-          className={styles.configure_input}
-        />
-      </label>
-      <label className={styles.configure_label}>
-        {'Password:'}
-        <TextInput
-          type='password'
-          name='psk'
-          value={psk}
-          disabled={inputDisabled}
-          onChange={onChange}
-          className={styles.configure_input}
-        />
-      </label>
-      <OutlineButton
-        type='submit'
+export default class ConfigureWifiForm extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {ssid: null, psk: null}
+  }
+
+  onChange = (update: Update) => this.setState(update)
+
+  onSubmit = () => {
+    this.props.onSubmit(this.getSsid(), this.state.psk)
+    this.setState({psk: null})
+  }
+
+  getSsid (): ?string {
+    return this.state.ssid || this.props.activeSsid
+  }
+
+  render () {
+    const {activeSsid, networks} = this.props
+    const {psk} = this.state
+    const ssid = this.getSsid()
+    const inputDisabled = this.props.disabled
+    const formDisabled = inputDisabled || !ssid
+
+    return (
+      <Form
+        onSubmit={this.onSubmit}
         disabled={formDisabled}
-        className={styles.configure_button}
+        className={styles.configure_form}
       >
-        Join
-      </OutlineButton>
-    </Form>
-  )
+        <label className={styles.configure_label}>
+          {'WiFi network:'}
+          <Select
+            name='ssid'
+            value={ssid}
+            options={networks}
+            disabled={inputDisabled}
+            onChange={this.onChange}
+            className={styles.configure_input}
+          />
+        </label>
+        <label className={styles.configure_label}>
+          {'Password:'}
+          <TextInput
+            type='password'
+            name='psk'
+            value={psk}
+            disabled={inputDisabled}
+            onChange={this.onChange}
+            className={styles.configure_input}
+          />
+        </label>
+        <OutlineButton
+          type='submit'
+          disabled={formDisabled}
+          className={styles.configure_button}
+        >
+          {(ssid && ssid === activeSsid) ? 'Connected' : 'Join'}
+        </OutlineButton>
+      </Form>
+    )
+  }
 }

--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -8,9 +8,10 @@ import type {
 } from '../../http-api-client'
 
 import {AlertModal} from '@opentrons/components'
+import {ErrorModal} from '../modals'
 
 type Props = {
-  onClose: () => mixed,
+  close: () => mixed,
   error: ?ApiRequestError,
   response: ?WifiConfigureResponse
 }
@@ -19,30 +20,36 @@ const SUCCESS_TITLE = 'Successfully connected to '
 const FAILURE_TITLE = 'Could not join network'
 
 const SUCCESS_MESSAGE = 'Your robot has successfully connected to WiFi and should appear in the robot list shortly. If not, try refreshing the list manually or rebooting the robot.'
-const FAILURE_MESSAGE = 'Please double check your network credentials. If this problem persists, try rebooting the robot or contacting our support team.'
+const FAILURE_MESSAGE = 'The robot was unable to connect to the selected WiFi network. Please double check your network credentials.'
 
 export default function WifiConnectModal (props: Props) {
-  const {onClose} = props
-  let title
-  let message
+  const {response, error, close} = props
 
-  if (props.response) {
-    title = `${SUCCESS_TITLE} ${props.response.ssid}`
-    message = SUCCESS_MESSAGE
-  } else {
-    title = FAILURE_TITLE
-    message = FAILURE_MESSAGE
+  if (error || !response) {
+    const modalError = error || {
+      name: 'NoResponseError',
+      message: 'No response received'
+    }
+
+    return (
+      <ErrorModal
+        heading={FAILURE_TITLE}
+        description={FAILURE_MESSAGE}
+        close={close}
+        error={modalError}
+      />
+    )
   }
 
   return (
     <AlertModal
-      heading={title}
-      onCloseClick={onClose}
+      heading={`${SUCCESS_TITLE} ${response.ssid}`}
+      onCloseClick={close}
       buttons={[
-        {onClick: onClose, children: 'close'}
+        {onClick: close, children: 'close'}
       ]}
     >
-      {message}
+      {SUCCESS_MESSAGE}
     </AlertModal>
   )
 }

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -6,6 +6,8 @@
 }
 
 .robot_settings {
+  /* TODO(mc, 2018-06-28): hotfix for wifi response modal; remove */
+  position: relative;
   overflow-y: auto;
   padding: calc(2 * var(--robot_settings_card_spacing));
   padding-bottom: 0;

--- a/app/src/http-api-client/__tests__/wifi.test.js
+++ b/app/src/http-api-client/__tests__/wifi.test.js
@@ -6,7 +6,6 @@ import client from '../client'
 import {
   fetchWifiList,
   fetchWifiStatus,
-  setConfigureWifiBody,
   clearConfigureWifiResponse,
   configureWifi,
   reducer,
@@ -189,29 +188,6 @@ describe('wifi', () => {
     })
   })
 
-  describe('setConfigureWifiBody action creator', () => {
-    const ssid = 'some-ssid'
-    const psk = 'some-psk'
-
-    test('works with ssid', () => {
-      const expected = {
-        type: 'api:SET_CONFIGURE_WIFI_BODY',
-        payload: {robot, update: {ssid}}
-      }
-
-      expect(setConfigureWifiBody(robot, {ssid})).toEqual(expected)
-    })
-
-    test('works with psk', () => {
-      const expected = {
-        type: 'api:SET_CONFIGURE_WIFI_BODY',
-        payload: {robot, update: {psk}}
-      }
-
-      expect(setConfigureWifiBody(robot, {psk})).toEqual(expected)
-    })
-  })
-
   test('clearConfigureWifiResponse action creator', () => {
     const expected = {
       type: 'api:CLEAR_CONFIGURE_WIFI_RESPONSE',
@@ -225,24 +201,13 @@ describe('wifi', () => {
     const ssid = 'some-ssid'
     const psk = 'some-psk'
     const response = {ssid, message: 'Success!'}
-    const initialState = {
-      api: {
-        wifi: {
-          opentrons: {
-            configure: {
-              request: {ssid, psk}
-            }
-          }
-        }
-      }
-    }
 
     test('calls POST /wifi/configure, GET /wifi/list', () => {
-      const store = mockStore(initialState)
+      const store = mockStore({})
 
       client.__setMockResponse(response)
 
-      return store.dispatch(configureWifi(robot))
+      return store.dispatch(configureWifi(robot, ssid, psk))
         .then(() => expect(client).toHaveBeenCalledWith(
           robot,
           'POST',
@@ -252,7 +217,7 @@ describe('wifi', () => {
     })
 
     test('dispatches WIFI_REQUEST and WIFI_SUCCESS', () => {
-      const store = mockStore(initialState)
+      const store = mockStore({})
       const expectedActions = [
         {type: 'api:WIFI_REQUEST', payload: {robot, path: 'configure'}},
         {
@@ -263,13 +228,13 @@ describe('wifi', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(configureWifi(robot))
+      return store.dispatch(configureWifi(robot, 'ssid', 'psk'))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
     test('dispatches WIFI_REQUEST and WIFI_FAILURE', () => {
       const error = {name: 'ResponseError', status: '400'}
-      const store = mockStore(initialState)
+      const store = mockStore({})
       const expectedActions = [
         {type: 'api:WIFI_REQUEST', payload: {robot, path: 'configure'}},
         {type: 'api:WIFI_FAILURE', payload: {robot, error, path: 'configure'}}
@@ -277,7 +242,7 @@ describe('wifi', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(configureWifi(robot))
+      return store.dispatch(configureWifi(robot, 'ssid', 'psk'))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
@@ -466,37 +431,6 @@ describe('wifi', () => {
 
   describe('reducer with /wifi/configure', () => {
     const path = 'configure'
-
-    test('handles SET_CONFIGURE_WIFI_BODY', () => {
-      const state = {
-        wifi: {
-          opentrons: {
-            configure: {
-              request: null,
-              inProgress: false,
-              error: new Error('AH'),
-              response: {ssid: 'foo', message: 'bar'}
-            }
-          }
-        }
-      }
-
-      const action = {
-        type: 'api:SET_CONFIGURE_WIFI_BODY',
-        payload: {robot, update: {ssid: 'baz', psk: 'qux'}}
-      }
-
-      expect(reducer(state, action).wifi).toEqual({
-        opentrons: {
-          configure: {
-            request: {ssid: 'baz', psk: 'qux'},
-            inProgress: false,
-            error: new Error('AH'),
-            response: {ssid: 'foo', message: 'bar'}
-          }
-        }
-      })
-    })
 
     test('handles CLEAR_CONFIGURE_WIFI_RESPONSE', () => {
       const state = {

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -138,7 +138,6 @@ export {
 export {
   fetchWifiList,
   fetchWifiStatus,
-  setConfigureWifiBody,
   clearConfigureWifiResponse,
   configureWifi,
   makeGetRobotWifiStatus,


### PR DESCRIPTION
## overview

This PR serving as both a ticket and a fix.

WiFi card no longer disables the submit button arbitrarily and more obviously communicates which WiFi network is currently connected. We also now display the `nmcli` error message (if we get an error) to help out the support team.

* Connected to WiFi
    * Note that "Connected" button still allows the user to re-submit a password just in case
    ![screenshot 2018-06-28 14 55 48](https://user-images.githubusercontent.com/2963448/42054860-87a24ebc-7ae3-11e8-9098-35d6f9f5055e.png)
* Trying to join a new network while connected over WiFi
    * Note button is no longer disabled even though we're not on USB
    ![screenshot 2018-06-28 14 56 03](https://user-images.githubusercontent.com/2963448/42054865-88f74a6a-7ae3-11e8-9b8f-e4627384a515.png)
* Failed connect
    * Note the `nmcli` error message and generic `<ErrorModal>`
    ![screenshot 2018-06-28 14 56 19](https://user-images.githubusercontent.com/2963448/42054947-c077f034-7ae3-11e8-9a88-4f4d3e3e36ef.png)

## changelog

- fix(app): Make WiFi card more lenient and understandable

## review requests

- [x] Can change WiFi network of a robot while connected over WiFi
- [x] Can change WiFi network of a robot while connected over "USB"
- [x] You feel like you know what network a robot is connected to
- [x] Get back `nmcli` error message if something goes wrong (e.g. bad password)
