### PR TITLE
fix(protocol-designer): do not navigate on FilePage form submit

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -19,10 +19,11 @@ export type FilePageProps = {
 }
 
 const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata}: FilePageProps) => {
-  const handleSubmit = () => {
+  const handleSubmit = (e: SyntheticEvent<*>) => {
     // blur focused field on submit
     if (document && document.activeElement) document.activeElement.blur()
     saveFileMetadata()
+    e.preventDefault()
   }
   return (
     <div className={styles.file_page}>


### PR DESCRIPTION
## overview

Before, clicking "Update" button on FilePage's form (not the New File modal, but the "Information" name/author/desc form) would navigate away to `http://localhost:8080/?#/` and refresh the page!

## changelog

- fix: do not navigate on FilePage form submit

## review requests

No more navigation/refresh on clicking "Update"

:palm_tree: 