### PR TITLE
fix(protocol-designer): allow scroll when NewFileModal too tall

### DIFF
--- a/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
@@ -22,6 +22,10 @@
 .new_file_modal {
   line-height: 1.5;
 
+  /* override default modal top/bottom to allow scroll */
+  top: auto;
+  bottom: auto;
+
   & form > * {
     margin-bottom: 1rem;
   }

--- a/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
@@ -21,6 +21,7 @@
 
 .new_file_modal {
   line-height: 1.5;
+  min-height: 100%;
 
   /* override default modal top/bottom to allow scroll */
   top: auto;

--- a/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
@@ -24,7 +24,6 @@
   min-height: 100%;
 
   /* override default modal top/bottom to allow scroll */
-  top: auto;
   bottom: auto;
 
   & form > * {


### PR DESCRIPTION
## overview

Closes #1776

## changelog

- fix NewProtocolModal height

## review requests

Should modals do this by default?