### PR TITLE
PD file upload: starting point

### DIFF
--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -1,34 +1,19 @@
-import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
+import {createStore, combineReducers, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
 
-import {rootReducer as fileDataRootReducer} from './file-data'
-import labwareIngredRootReducer from './labware-ingred/reducers'
-import {rootReducer as navigationRootReducer} from './navigation'
-import {rootReducer as pipetteRootReducer} from './pipettes'
-import steplistRootReducer from './steplist/reducers'
-import wellSelectionRootReducer from './well-selection/reducers'
-
-// TODO: Ian 2018-01-15 how to make this more DRY with hot reloading?
 function getRootReducer () {
   return combineReducers({
     fileData: require('./file-data').rootReducer,
-    labwareIngred: require('./labware-ingred/reducers'),
+    labwareIngred: require('./labware-ingred/reducers').default,
     navigation: require('./navigation').rootReducer,
     pipettes: require('./pipettes').rootReducer,
-    steplist: require('./steplist/reducers'),
-    wellSelection: require('./well-selection/reducers')
+    steplist: require('./steplist/reducers').default,
+    wellSelection: require('./well-selection/reducers').default
   })
 }
 
 export default function configureStore () {
-  const reducer = combineReducers({
-    fileData: fileDataRootReducer,
-    labwareIngred: labwareIngredRootReducer,
-    navigation: navigationRootReducer,
-    pipettes: pipetteRootReducer,
-    steplist: steplistRootReducer,
-    wellSelection: wellSelectionRootReducer
-  })
+  const reducer = getRootReducer()
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
   const store = createStore(
@@ -44,12 +29,14 @@ export default function configureStore () {
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
-    module.hot.accept('./file-data/reducers', replaceReducers)
-    module.hot.accept('./labware-ingred/reducers', replaceReducers)
-    module.hot.accept('./navigation/reducers', replaceReducers)
-    module.hot.accept('./pipettes', replaceReducers)
-    module.hot.accept('./steplist/reducers', replaceReducers)
-    module.hot.accept('./well-selection/reducers', replaceReducers)
+    module.hot.accept([
+      './file-data/reducers',
+      './labware-ingred/reducers',
+      './navigation/reducers',
+      './pipettes',
+      './steplist/reducers',
+      './well-selection/reducers'
+    ], replaceReducers)
   }
 
   return store

--- a/protocol-designer/src/containers/ConnectedFileSidebar.js
+++ b/protocol-designer/src/containers/ConnectedFileSidebar.js
@@ -4,6 +4,7 @@ import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {actions, selectors} from '../navigation'
 import {selectors as fileDataSelectors} from '../file-data'
+import {actions as loadFileActions} from '../load-file'
 import FileSidebar from '../components/FileSidebar'
 import type {BaseState} from '../types'
 
@@ -53,8 +54,7 @@ function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: Dispatch<*>}
             const parsedProtocol = JSON.parse(result)
             // TODO LATER Ian 2018-05-18 validate file with JSON Schema here
 
-            // TODO IMMEDIATELY (next PR) dispatch a FILE_UPLOAD action
-            console.log({parsedProtocol})
+            dispatch(loadFileActions.loadFile(parsedProtocol))
           } catch (error) {
             // TODO LATER Ian 2018-05-18 use a real modal
             window.alert(`Could not parse JSON protocol.\n\nError message: "${error.message}"`)

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,8 +2,14 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
-import {updateFileMetadataFields, saveFileMetadata} from '../actions'
+import {actions as loadFileActions} from '../../load-file'
+import {
+  saveFileMetadata,
+  updateFileMetadataFields
+} from '../actions'
 import type {FileMetadataFields} from '../types'
+
+const {LOAD_FILE, loadFile} = loadFileActions
 
 const defaultFields = {
   name: '',
@@ -12,6 +18,7 @@ const defaultFields = {
 }
 
 const unsavedMetadataForm = handleActions({
+  [LOAD_FILE]: () => defaultFields,
   UPDATE_FILE_METADATA_FIELDS: (state: FileMetadataFields, action: ActionType<typeof updateFileMetadataFields>) => ({
     ...state,
     ...action.payload
@@ -23,6 +30,14 @@ const unsavedMetadataForm = handleActions({
 }, defaultFields)
 
 const fileMetadata = handleActions({
+  [LOAD_FILE]: (state: FileMetadataFields, action: ActionType<typeof loadFile>) => {
+    const {metadata} = action.payload
+    return {
+      author: metadata.author,
+      description: metadata.description,
+      name: metadata['protocol-name']
+    }
+  },
   SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>) => ({
     ...state,
     ...action.payload

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,14 +2,11 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
-import {actions as loadFileActions} from '../../load-file'
 import {
   saveFileMetadata,
   updateFileMetadataFields
 } from '../actions'
 import type {FileMetadataFields} from '../types'
-
-const {LOAD_FILE, loadFile} = loadFileActions
 
 const defaultFields = {
   name: '',
@@ -18,7 +15,6 @@ const defaultFields = {
 }
 
 const unsavedMetadataForm = handleActions({
-  [LOAD_FILE]: () => defaultFields,
   UPDATE_FILE_METADATA_FIELDS: (state: FileMetadataFields, action: ActionType<typeof updateFileMetadataFields>) => ({
     ...state,
     ...action.payload
@@ -30,14 +26,6 @@ const unsavedMetadataForm = handleActions({
 }, defaultFields)
 
 const fileMetadata = handleActions({
-  [LOAD_FILE]: (state: FileMetadataFields, action: ActionType<typeof loadFile>) => {
-    const {metadata} = action.payload
-    return {
-      author: metadata.author,
-      description: metadata.description,
-      name: metadata['protocol-name']
-    }
-  },
   SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>) => ({
     ...state,
     ...action.payload

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -62,6 +62,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   (pipettes, labwareAppState, labwareLiquidState) => {
     type TipState = $PropertyType<StepGeneration.RobotState, 'tipState'>
     type TiprackTipState = $PropertyType<TipState, 'tipracks'>
+    console.log('get initial robot state!!!')
 
     const labware = labwareConverter(labwareAppState)
 

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -2,7 +2,7 @@
 import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
 import type {BaseState} from '../../types'
-import type {ProtocolFile, FilePipette, FileLabware} from '../types'
+import type {ProtocolFile, FilePipette, FileLabware} from '../../file-types'
 import type {LabwareData, PipetteData} from '../../step-generation'
 import {fileMetadata} from './fileFields'
 import {getInitialRobotState, robotStateTimeline} from './commands'

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,7 +1,4 @@
 // @flow
-import type {DeckSlot, Mount} from '@opentrons/components'
-import type {Command} from '../step-generation/types'
-
 export type FileMetadataFields = {
   name: string,
   author: string,
@@ -9,62 +6,3 @@ export type FileMetadataFields = {
 }
 
 export type FileMetadataFieldAccessors = $Keys<FileMetadataFields>
-
-type MsSinceEpoch = number
-type VersionString = string // eg '1.0.0'
-
-export type FilePipette = {
-  mount: Mount,
-  model: string // TODO Ian 2018-05-11 use pipette-definitions model types
-}
-
-export type FileLabware = {
-  slot: DeckSlot,
-  model: string,
-  'display-name': string
-}
-
-// A JSON protocol
-export type ProtocolFile = {
-  'protocol-schema': VersionString,
-
-  metadata: {
-    'protocol-name': string,
-    author: string,
-    description: string,
-    created: MsSinceEpoch,
-    'last-modified': MsSinceEpoch | null,
-    // TODO LATER string enums for category/subcategory? Or just strings?
-    category: string | null,
-    subcategory: string | null,
-    tags: Array<string>
-  },
-
-  'designer-application': {
-    'application-name': 'opentrons/protocol-designer',
-    'application-version': VersionString,
-    data: {
-      // TODO
-    }
-  },
-
-  robot: {
-    model: 'OT-2 Standard' // TODO LATER support additional models
-  },
-
-  pipettes: {
-    [instrumentId: string]: FilePipette
-  },
-
-  labware: {
-    [labwareId: string]: FileLabware
-  },
-
-  procedure: Array<{
-    annotation: {
-      name: string,
-      description: string
-    },
-    subprocedure: Array<Command>
-  }>
-}

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -1,0 +1,62 @@
+// @flow
+import type {DeckSlot, Mount} from '@opentrons/components'
+import type {Command} from './step-generation/types'
+
+type MsSinceEpoch = number
+type VersionString = string // eg '1.0.0'
+
+export type FilePipette = {
+  mount: Mount,
+  model: string // TODO Ian 2018-05-11 use pipette-definitions model types
+}
+
+export type FileLabware = {
+  slot: DeckSlot,
+  model: string,
+  'display-name': string
+}
+
+// A JSON protocol
+export type ProtocolFile = {
+  'protocol-schema': VersionString,
+
+  metadata: {
+    'protocol-name': string,
+    author: string,
+    description: string,
+    created: MsSinceEpoch,
+    'last-modified': MsSinceEpoch | null,
+    // TODO LATER string enums for category/subcategory? Or just strings?
+    category: string | null,
+    subcategory: string | null,
+    tags: Array<string>
+  },
+
+  'designer-application': {
+    'application-name': 'opentrons/protocol-designer',
+    'application-version': VersionString,
+    data: {
+      // TODO
+    }
+  },
+
+  robot: {
+    model: 'OT-2 Standard' // TODO LATER support additional models
+  },
+
+  pipettes: {
+    [instrumentId: string]: FilePipette
+  },
+
+  labware: {
+    [labwareId: string]: FileLabware
+  },
+
+  procedure: Array<{
+    annotation: {
+      name: string,
+      description: string
+    },
+    subprocedure: Array<Command>
+  }>
+}

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -1,7 +1,9 @@
 // @flow
 import type {ProtocolFile} from '../file-types'
 
+// exporting these individually for easier import
 export const LOAD_FILE: 'LOAD_FILE' = 'LOAD_FILE'
+
 // expects valid, parsed JSON protocol.
 export const loadFile = (payload: ProtocolFile) => ({
   type: LOAD_FILE,

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -1,0 +1,9 @@
+// @flow
+import type {ProtocolFile} from '../file-types'
+
+export const LOAD_FILE: 'LOAD_FILE' = 'LOAD_FILE'
+// expects valid, parsed JSON protocol.
+export const loadFile = (payload: ProtocolFile) => ({
+  type: LOAD_FILE,
+  payload
+})

--- a/protocol-designer/src/load-file/index.js
+++ b/protocol-designer/src/load-file/index.js
@@ -1,0 +1,6 @@
+// @flow
+import * as actions from './actions'
+
+export {
+  actions
+}

--- a/protocol-designer/src/load-file/reducers/file-data.js
+++ b/protocol-designer/src/load-file/reducers/file-data.js
@@ -1,0 +1,19 @@
+// @flow
+import type {ProtocolFile} from '../../file-types'
+import type {FileMetadataFields} from '../../file-data'
+
+const fileMetadata = (file: ProtocolFile): FileMetadataFields => {
+  const {metadata} = file
+  return {
+    author: metadata.author,
+    description: metadata.description,
+    name: metadata['protocol-name']
+  }
+}
+
+const allReducers = {
+  unsavedMetadataForm: fileMetadata, // use matching fields
+  fileMetadata
+}
+
+export default allReducers

--- a/protocol-designer/src/load-file/reducers/navigation.js
+++ b/protocol-designer/src/load-file/reducers/navigation.js
@@ -1,0 +1,11 @@
+// @flow
+import type {Page} from '../../navigation'
+
+// Initial page to go to after loading protocol file
+const page = (): Page => 'file-detail'
+
+const allReducers = {
+  page
+}
+
+export default allReducers

--- a/protocol-designer/src/load-file/reducers/pipettes.js
+++ b/protocol-designer/src/load-file/reducers/pipettes.js
@@ -1,0 +1,46 @@
+// @flow
+import mapValues from 'lodash/mapValues'
+
+import {getPipette} from '@opentrons/shared-data'
+
+import type {FilePipette, ProtocolFile} from '../../file-types'
+import type {PipetteReducerState} from '../../pipettes/reducers'
+import type {PipetteData} from '../../step-generation'
+
+// TODO IMMEDIATELY have space in file for pipette tiprack type
+const TODO_TIPRACK_MODEL = 'tiprack-10ul'
+
+function createPipette (p: FilePipette, id: string, tiprackModel: string): PipetteData {
+  const pipetteData = getPipette(p.model)
+  if (!pipetteData) {
+    // TODO Ian 2018-03-01 I want Flow to enforce `name` is a key in pipetteDataByName,
+    // but it doesn't seem to want to be strict about it
+    throw new Error('Invalid pipette name, no entry in pipetteDataByName')
+  }
+  return {
+    id,
+    mount: p.mount,
+    maxVolume: pipetteData.nominalMaxVolumeUl,
+    channels: pipetteData.channels,
+    tiprackModel
+  }
+}
+
+const pipettes = (file: ProtocolFile): PipetteReducerState => {
+  const {pipettes} = file
+  const pipetteIds = Object.keys(pipettes)
+  return {
+    byMount: {
+      left: pipetteIds.find(id => pipettes[id].mount === 'left'),
+      right: pipetteIds.find(id => pipettes[id].mount === 'right')
+    },
+    byId: mapValues(pipettes, (p: FilePipette, id: string) =>
+      createPipette(p, id, TODO_TIPRACK_MODEL))
+  }
+}
+
+const allReducers = {
+  pipettes
+}
+
+export default allReducers

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -23,7 +23,7 @@ function createPipette (name: PipetteName, mount: Mount, tiprackModel: string): 
   }
 }
 
-type PipetteReducerState = {
+export type PipetteReducerState = {
   byMount: {|
     left: ?string,
     right: ?string


### PR DESCRIPTION
## overview

First steps at File Upload in PD.

### Features in this PR:
- Load pipettes
- Load metadata fields

### How it works

Loading a JSON Protocol File triggers the entire Redux state to reset to the default values of all its reducers -- except for a few special reducers that update in response to loading a file.

A new atom, `load-file/`, has a set of functions I'm calling "prereducers". :eyes: They are responsible for mapping Protocol File data on to the new reducer state. They are organized in a way that mirrors the corresponding atom's reducers (ie, names match). Since they don't need to actually reduce anything but instead just pick from file data or set to a static value, they don't have a `(state, action) => nextState` signature. Instead they look like `(fileData) => newState`. This makes things simpler and more restricted, since file loading resets the state and doesn't care about a previous state.

After being used to generate values, the "prereducers" are merged onto the initial/reset Redux state. This ensures all the reducers reset to their initial states, except the select few that we want to update.

Alternative 1: don't do this "prereducer" business. Handle the `LOAD_FILE` action in every single reducer, even in reducers that just reset to default. *Upside*: more canonical. *Downside*: most reducers simply reset, so it's easy to forget to reset for LOAD_FILE every time you make a new reducer. It's boilerplatey to do this for every reducer and may make it easy to introduce bugs.

Alternative 2: instead of having the "prereducers" in `load-file`, that code could be colocated with the corresponding reducers inside each atom. It would work the same way, building a reducer that handles LOAD_FILE and otherwise just uses the normal rootReducer of that atom. But it would happen a half dozen different times, one for each atom.

Or there might be a better trick?

### Later work

- Labware needs to be loaded (should be enough info)
- Ingreds steplist info needs to be 

### TODO:
- Separate small PR: Save pipette tip assignment in PD metadata
- After that: load that tip assignment data in, instead of hard-coding the 10uL tiprack placeholder

## changelog

- DRY up getReducers fn
- Loading a file resets the state and loads the metadata fields & pipette info

## review requests

Thoughts?

I'm marking this DO NOT MERGE b/c I need to implement the tiprack assignment saving in a prerequisite PR, but that's not a fundamental part of this PR so I'd appreciate a high-level review to see if this structure is going in the right direction before I go too far ahead. Thanks!