### PR TITLE
fix(app): Remove holdover /calibrate/instruments missed by #1765

### DIFF
--- a/app/src/components/calibrate-pipettes/PipetteTabs.js
+++ b/app/src/components/calibrate-pipettes/PipetteTabs.js
@@ -18,7 +18,7 @@ export default function PipetteTabs (props: Props) {
 
   const pages = robotConstants.INSTRUMENT_MOUNTS.map((mount) => ({
     title: mount,
-    href: `/calibrate/instruments/${mount}`,
+    href: `./${mount}`,
     isActive: currentInstrument != null && mount === currentInstrument.mount,
     isDisabled: !instruments.some((inst) => inst.mount === mount)
   }))

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -31,7 +31,7 @@ function CalibratePipettesPage (props: Props) {
   const {instruments, currentInstrument, match: {url, params}} = props
   const confirmTipProbeUrl = `${url}/confirm-tip-probe`
 
-  // redirect back to /calibrate/instruments if mount doesn't exist
+  // redirect back to mountless route if mount doesn't exist
   if (params.mount && !currentInstrument) {
     return (<Redirect to={url.replace(`/${params.mount}`, '')} />)
   }


### PR DESCRIPTION
## overview

This PR is a continuation of #1765. We missed a couple links that were still pointing to `/calibrate/instruments` instead of the newer `/calibrate/pipettes`

## changelog

- fix(app): Remove holdover /calibrate/instruments missed by #1765 

## review requests

Try to break tip probe and labware calibration! Virtual smoothie is fine