### PR TITLE
feat(update-server): Add restart endpoint to Update Server and shorten sleep

### DIFF
--- a/api-server-lib/ot2serverlib/endpoints.py
+++ b/api-server-lib/ot2serverlib/endpoints.py
@@ -110,13 +110,15 @@ async def update_firmware(request):
     return web.json_response(res, status=status)
 
 
+def __wait_and_restart():
+    log.info('Restarting server')
+    sleep(1)
+    os.system('kill 1')
+
+
 async def restart(request):
     """
-    Returns OK, then waits approximately 3 seconds and restarts container
+    Returns OK, then waits approximately 1 second and restarts container
     """
-    def wait_and_restart():
-        log.info('Restarting server')
-        sleep(3)
-        os.system('kill 1')
-    Thread(target=wait_and_restart).start()
+    Thread(target=__wait_and_restart).start()
     return web.json_response({"message": "restarting"})

--- a/api/opentrons/server/endpoints/serverlib_fallback.py
+++ b/api/opentrons/server/endpoints/serverlib_fallback.py
@@ -191,11 +191,11 @@ async def update_firmware(request):
 
 async def restart(request):
     """
-    Returns OK, then waits approximately 3 seconds and restarts container
+    Returns OK, then waits approximately 1 second and restarts container
     """
     def wait_and_restart():
         log.info('Restarting server')
-        sleep(3)
+        sleep(1)
         os.system('kill 1')
     Thread(target=wait_and_restart).start()
     return web.json_response({"message": "restarting"})

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -8,6 +8,11 @@ pipenv_opts := --dev
 pipenv_opts += $(and $(CI),--ignore-pipfile)
 port ?= 34000
 
+# curl host
+host ?= \[fd00:0:cafe:fefe::1\]
+# make bootstrap wheel file (= rather than := to expand at every use)
+wheel = $(wildcard dist/*.whl)
+
 .PHONY: install
 install:
 	pipenv install $(pipenv_opts)
@@ -44,3 +49,14 @@ wheel: clean
 	$(python) setup.py bdist_wheel
 	shx rm -rf build
 	shx ls dist
+
+.PHONY: bootstrap
+bootstrap: wheel
+	curl -X POST \
+		-H "Content-Type: multipart/form-data" \
+		-F "whl=@$(wheel)" \
+		http://$(host):31950/server/update/bootstrap
+
+.PHONY: restart
+restart:
+	curl -X POST http://$(host):31950/server/update/restart

--- a/update-server/otupdate/__init__.py
+++ b/update-server/otupdate/__init__.py
@@ -4,7 +4,8 @@ import logging
 
 from aiohttp import web
 from functools import partial
-from otupdate import endpoints as endp
+from otupdate import control
+from otupdate import endpoints as bootstrap_endp
 
 log = logging.getLogger(__name__)
 
@@ -49,18 +50,19 @@ def get_app(
     log.info("  Smoothie FW version:    {}".format(smoothie_version))
     log.info("  Test mode:              {}".format(test))
 
-    health = endp.build_health_endpoint(
+    health = bootstrap_endp.build_health_endpoint(
         name=device_name,
         update_server_version=update_server_version,
         api_server_version=api_server_version,
         smoothie_version=smoothie_version
     )
     bootstrap_fn = partial(
-        endp.bootstrap_update_server, test_flag=test)
+        bootstrap_endp.bootstrap_update_server, test_flag=test)
 
     app = web.Application(loop=loop)
     app.router.add_routes([
         web.get('/server/update/health', health),
-        web.post('/server/update/bootstrap', bootstrap_fn)
+        web.post('/server/update/bootstrap', bootstrap_fn),
+        web.post('/server/update/restart', control.restart)
     ])
     return app

--- a/update-server/otupdate/control.py
+++ b/update-server/otupdate/control.py
@@ -1,0 +1,21 @@
+import os
+import logging
+from time import sleep
+from aiohttp import web
+from threading import Thread
+
+log = logging.getLogger(__name__)
+
+
+def __wait_and_restart():
+    log.info('Restarting server')
+    sleep(1)
+    os.system('kill 1')
+
+
+async def restart(request):
+    """
+    Returns OK, then waits approximately 1 second and restarts container
+    """
+    Thread(target=__wait_and_restart).start()
+    return web.json_response({"message": "restarting"})


### PR DESCRIPTION
## overview

Add restart endpoint to Update Server and shorten restart sleep to 1s

Fixes #1792

## changelog

- Add `POST /server/update/restart` to Update Server
- Shorten restart sleep to 1s

## review requests

Tested on 🌔 🌔 and unit tests passing locally
