### PR TITLE
feat(app): Add robot settings toggles to Advanced Settings card

### DIFF
--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -1,24 +1,89 @@
 // @flow
 // app info card with version and updated
 import * as React from 'react'
+import {connect} from 'react-redux'
 
-import {Card} from '@opentrons/components'
-import {LabeledButton} from '../controls'
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+import type {Setting} from '../../http-api-client'
+import {fetchSettings, setSettings, makeGetRobotSettings} from '../../http-api-client'
+
+import {RefreshCard} from '@opentrons/components'
+import {LabeledButton, LabeledToggle} from '../controls'
+
+type OP = Robot
+
+type SP = {settings: Array<Setting>}
+
+type DP = {
+  fetch: () => mixed,
+  set: (id: string, value: boolean) => mixed,
+}
+
+type Props = OP & SP & DP
+
+type BooleanSettingProps = {
+  id: string,
+  title: string,
+  description: string,
+  value: boolean,
+  set: (id: string, value: boolean) => mixed,
+}
 
 const TITLE = 'Advanced Settings'
 
-export default function AdvancedSettingsCard () {
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(AdvancedSettingsCard)
+
+class BooleanSettingToggle extends React.Component<BooleanSettingProps> {
+  toggle = (value) => this.props.set(this.props.id, !this.props.value)
+
+  render () {
+    return (
+      <LabeledToggle
+        label={this.props.title}
+        onClick={this.toggle}
+        toggledOn={this.props.value}
+      >
+        <p>{this.props.description}</p>
+      </LabeledToggle>
+    )
+  }
+}
+
+function AdvancedSettingsCard (props: Props) {
+  const {name, settings, set, fetch} = props
+
   return (
-    <Card title={TITLE} column>
-    <LabeledButton
-      label='Download Logs'
-      buttonProps={{
-        disabled: true,
-        children: 'Download'
-      }}
-    >
-      <p>Access logs from this robot.</p>
-    </LabeledButton>
-    </Card>
+    <RefreshCard watch={name} refresh={fetch} title={TITLE} column>
+      {settings.map(s => (
+        <BooleanSettingToggle {...s} key={s.id} set={set} />
+      ))}
+      <LabeledButton
+        label='Download Logs'
+        buttonProps={{
+          disabled: true,
+          children: 'Download'
+        }}
+      >
+        <p>Access logs from this robot.</p>
+      </LabeledButton>
+    </RefreshCard>
   )
+}
+
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
+  const getRobotSettings = makeGetRobotSettings()
+
+  return (state, ownProps) =>
+    getRobotSettings(state, ownProps).response || {settings: []}
+}
+
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  return {
+    fetch: () => dispatch(fetchSettings(ownProps)),
+    set: (id, value) => dispatch(setSettings(ownProps, id, value))
+  }
 }

--- a/app/src/http-api-client/__tests__/settings.test.js
+++ b/app/src/http-api-client/__tests__/settings.test.js
@@ -1,0 +1,249 @@
+// http api /settings tests
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import client from '../client'
+import {
+  reducer,
+  fetchSettings,
+  setSettings,
+  makeGetRobotSettings
+} from '..'
+
+jest.mock('../client')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+const NAME = 'opentrons-dev'
+
+describe('/settings', () => {
+  let robot
+  let state
+  let store
+
+  beforeEach(() => {
+    client.__clearMock()
+
+    robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
+    state = {api: {settings: {}}}
+    store = mockStore(state)
+  })
+
+  describe('fetchSettings action creator', () => {
+    const path = 'settings'
+    const response = {
+      settings: [{id: 'i', title: 't', description: 'd', value: true}]
+    }
+
+    test('calls GET /settings', () => {
+      client.__setMockResponse(response)
+
+      return store.dispatch(fetchSettings(robot))
+        .then(() =>
+          expect(client).toHaveBeenCalledWith(robot, 'GET', 'settings'))
+    })
+
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
+      const request = null
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
+      ]
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(fetchSettings(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches api:REQUEST and api:FAILURE', () => {
+      const request = null
+      const error = {name: 'ResponseError', status: 500, message: ''}
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(fetchSettings(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('setSettings action creator', () => {
+    const path = 'settings'
+    const response = {
+      settings: [{id: 'i', title: 't', description: 'd', value: true}]
+    }
+
+    test('calls GET /settings', () => {
+      const request = {id: 'i', value: true}
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(setSettings(robot, 'i', true))
+        .then(() =>
+          expect(client).toHaveBeenCalledWith(robot, 'POST', 'settings', request))
+    })
+
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
+      const request = {id: 'i', value: true}
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
+      ]
+
+      client.__setMockResponse(response)
+
+      return store.dispatch(setSettings(robot, 'i', true))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches api:REQUEST and api:FAILURE', () => {
+      const request = {id: 'i', value: true}
+      const error = {name: 'ResponseError', status: 500, message: ''}
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
+      ]
+
+      client.__setMockError(error)
+
+      return store.dispatch(setSettings(robot, 'i', true))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('reducer', () => {
+    beforeEach(() => {
+      state = state.api
+    })
+
+    const REDUCER_REQUEST_RESPONSE_TESTS = [
+      {
+        method: 'GET',
+        path: 'settings',
+        request: null,
+        response: {
+          settings: [{id: 'i', title: 't', description: 'd', value: true}]
+        }
+      },
+      {
+        method: 'POST',
+        path: 'settings',
+        request: {id: 'i', value: false},
+        response: {
+          settings: [{id: 'i', title: 't', description: 'd', value: false}]
+        }
+      }
+    ]
+
+    REDUCER_REQUEST_RESPONSE_TESTS.forEach((spec) => {
+      const {method, path, request, response} = spec
+
+      describe(`reducer with ${method} /${path}`, () => {
+        test('handles api:REQUEST', () => {
+          const action = {
+            type: 'api:REQUEST',
+            payload: {path, robot, request}
+          }
+
+          expect(reducer(state, action).settings).toEqual({
+            [NAME]: {
+              [path]: {
+                request,
+                inProgress: true,
+                error: null
+              }
+            }
+          })
+        })
+
+        test('handles api:SUCCESS', () => {
+          const action = {
+            type: 'api:SUCCESS',
+            payload: {path, robot, response}
+          }
+
+          state.settings[NAME] = {
+            [path]: {
+              request,
+              inProgress: true,
+              error: null,
+              response: null
+            }
+          }
+
+          expect(reducer(state, action).settings).toEqual({
+            [NAME]: {
+              [path]: {
+                request,
+                response,
+                inProgress: false,
+                error: null
+              }
+            }
+          })
+        })
+
+        test('handles api:FAILURE', () => {
+          const error = {message: 'we did not do it!'}
+          const action = {
+            type: 'api:FAILURE',
+            payload: {path, robot, error}
+          }
+
+          state.settings[NAME] = {
+            [path]: {
+              request,
+              inProgress: true,
+              error: null,
+              response: null
+            }
+          }
+
+          expect(reducer(state, action).settings).toEqual({
+            [NAME]: {
+              [path]: {
+                request,
+                error,
+                response: null,
+                inProgress: false
+              }
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('selectors', () => {
+    beforeEach(() => {
+      state.api.settings[NAME] = {
+        settings: {inProgress: true}
+      }
+    })
+
+    test('makeGetRobotSettings', () => {
+      const getSettings = makeGetRobotSettings()
+
+      expect(getSettings(state, robot))
+        .toEqual(state.api.settings[NAME].settings)
+
+      expect(getSettings(state, {name: 'foo'})).toEqual({inProgress: false})
+    })
+
+    test('makeGetRobotSettings with bad response', () => {
+      const getSettings = makeGetRobotSettings()
+
+      state.api.settings[NAME].settings.response = {foo: 'bar'}
+
+      expect(getSettings(state, robot)).toEqual({
+        ...state.api.settings[NAME].settings,
+        response: {settings: []}
+      })
+    })
+  })
+})

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -1,0 +1,59 @@
+// @flow
+// api actions
+// TODO(mc, 2018-07-02): these generic actions, along with a generic API
+// reducer should handle all API state, as opposed to bespoke reducers
+// in each API client submodule
+
+import type {BaseRobot} from '../robot'
+import type {ApiRequestError} from './types'
+
+export type ApiRequestAction<Path: string, Body: ?{}> = {|
+  type: 'api:REQUEST',
+  payload: {|
+    robot: BaseRobot,
+    path: Path,
+    request: Body,
+  |},
+|}
+
+export type ApiSuccessAction<Path: string, Body: {}> = {|
+  type: 'api:SUCCESS',
+  payload: {|
+    robot: BaseRobot,
+    path: Path,
+    response: Body,
+  |},
+|}
+
+export type ApiFailureAction<Path: string> = {|
+  type: 'api:FAILURE',
+  payload: {|
+    robot: BaseRobot,
+    path: Path,
+    error: ApiRequestError,
+  |},
+|}
+
+export function apiRequest<Path: string, Body: ?{}> (
+  robot: BaseRobot,
+  path: Path,
+  request: Body
+): ApiRequestAction<Path, Body> {
+  return {type: 'api:REQUEST', payload: {robot, path, request}}
+}
+
+export function apiSuccess<Path: string, Body: {}> (
+  robot: BaseRobot,
+  path: Path,
+  response: Body
+): ApiSuccessAction<Path, Body> {
+  return {type: 'api:SUCCESS', payload: {robot, path, response}}
+}
+
+export function apiFailure<Path: string> (
+  robot: BaseRobot,
+  path: Path,
+  error: ApiRequestError
+): ApiFailureAction<Path> {
+  return {type: 'api:FAILURE', payload: {robot, path, error}}
+}

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -8,6 +8,7 @@ import {motorsReducer, type MotorsAction} from './motors'
 import {pipettesReducer, type PipettesAction} from './pipettes'
 import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
+import {settingsReducer, type SettingsAction} from './settings'
 import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
@@ -18,6 +19,7 @@ export const reducer = combineReducers({
   pipettes: pipettesReducer,
   robot: robotReducer,
   server: serverReducer,
+  settings: settingsReducer,
   wifi: wifiReducer
 })
 
@@ -57,6 +59,10 @@ export type {
 } from './server'
 
 export type {
+  Setting
+} from './settings'
+
+export type {
   WifiListResponse,
   WifiStatusResponse,
   WifiConfigureResponse,
@@ -75,6 +81,7 @@ export type Action =
   | PipettesAction
   | RobotAction
   | ServerAction
+  | SettingsAction
   | WifiAction
 
 export {
@@ -134,6 +141,12 @@ export {
   setIgnoredUpdate,
   makeGetRobotIgnoredUpdateRequest
 } from './server'
+
+export {
+  fetchSettings,
+  setSettings,
+  makeGetRobotSettings
+} from './settings'
 
 export {
   fetchWifiList,

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -83,22 +83,12 @@ export function settingsReducer (
   state: SettingsState = {},
   action: Action
 ): SettingsState {
-  let name
-  let path
-  let request
-  let response
-  let error
-  let stateByName
-  let stateByPath
-
   switch (action.type) {
-    case 'api:REQUEST':
-      path = action.payload.path
+    case 'api:REQUEST': {
+      const {payload: {path, request, robot: {name}}} = action
       if (path !== SETTINGS_PATH) return state
-      name = action.payload.robot.name
-      request = action.payload.request
-      stateByName = state[name] || {}
-      stateByPath = stateByName[path] || {}
+      const stateByName = state[name] || {}
+      const stateByPath = stateByName[path] || {}
 
       return {
         ...state,
@@ -107,14 +97,13 @@ export function settingsReducer (
           [path]: {...stateByPath, request, inProgress: true, error: null}
         }
       }
+    }
 
-    case 'api:SUCCESS':
-      path = action.payload.path
+    case 'api:SUCCESS': {
+      const {payload: {path, response, robot: {name}}} = action
       if (path !== SETTINGS_PATH) return state
-      name = action.payload.robot.name
-      response = action.payload.response
-      stateByName = state[name] || {}
-      stateByPath = stateByName[path] || {}
+      const stateByName = state[name] || {}
+      const stateByPath = stateByName[path] || {}
 
       return {
         ...state,
@@ -123,14 +112,13 @@ export function settingsReducer (
           [path]: {...stateByPath, response, inProgress: false, error: null}
         }
       }
+    }
 
-    case 'api:FAILURE':
-      path = action.payload.path
+    case 'api:FAILURE': {
+      const {payload: {path, error, robot: {name}}} = action
       if (path !== SETTINGS_PATH) return state
-      name = action.payload.robot.name
-      error = action.payload.error
-      stateByName = state[name] || {}
-      stateByPath = stateByName[path] || {}
+      const stateByName = state[name] || {}
+      const stateByPath = stateByName[path] || {}
 
       return {
         ...state,
@@ -139,6 +127,7 @@ export function settingsReducer (
           [path]: {...stateByPath, error, inProgress: false}
         }
       }
+    }
   }
 
   return state

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -1,0 +1,172 @@
+// @flow
+// robot settings endpoints
+import {createSelector, type Selector} from 'reselect'
+
+import type {State, Action, ThunkPromiseAction} from '../types'
+import type {BaseRobot, RobotService} from '../robot'
+import type {ApiCall, ApiRequestError} from './types'
+import client from './client'
+
+import {apiRequest, apiSuccess, apiFailure} from './actions'
+import type {ApiRequestAction, ApiSuccessAction, ApiFailureAction} from './actions'
+
+type Id = string
+
+// TODO(mc, 2018-07-02): support more value types
+type Value = boolean
+
+export type Setting = {
+  id: Id,
+  title: string,
+  description: string,
+  value: Value,
+}
+
+type SettingsPath = 'settings'
+
+type SettingsRequest = ?{id: Id, value: Value}
+
+type SettingsResponse = {settings: Array<Setting>}
+
+export type SettingsAction =
+  | ApiRequestAction<SettingsPath, SettingsRequest>
+  | ApiSuccessAction<SettingsPath, SettingsResponse>
+  | ApiFailureAction<SettingsPath>
+
+type RobotSettingsRequestState = ApiCall<SettingsRequest, SettingsResponse>
+
+type RobotSettingsState = {
+  settings?: RobotSettingsRequestState
+}
+
+export type SettingsState = {
+  [robotName: string]: ?RobotSettingsState,
+}
+
+const SETTINGS_PATH: SettingsPath = 'settings'
+
+export function fetchSettings (robot: RobotService): ThunkPromiseAction {
+  const request: SettingsRequest = null
+
+  return (dispatch) => {
+    dispatch(apiRequest(robot, SETTINGS_PATH, request))
+
+    return client(robot, 'GET', SETTINGS_PATH)
+      .then(
+        (res: SettingsResponse) => apiSuccess(robot, SETTINGS_PATH, res),
+        (err: ApiRequestError) => apiFailure(robot, SETTINGS_PATH, err)
+      )
+      .then(dispatch)
+  }
+}
+
+export function setSettings (
+  robot: RobotService,
+  id: Id,
+  value: Value
+): ThunkPromiseAction {
+  const request: SettingsRequest = {id, value}
+
+  return (dispatch) => {
+    dispatch(apiRequest(robot, SETTINGS_PATH, request))
+
+    return client(robot, 'POST', SETTINGS_PATH, request)
+      .then(
+        (res: SettingsResponse) => apiSuccess(robot, SETTINGS_PATH, res),
+        (err: ApiRequestError) => apiFailure(robot, SETTINGS_PATH, err)
+      )
+      .then(dispatch)
+  }
+}
+
+export function settingsReducer (
+  state: SettingsState = {},
+  action: Action
+): SettingsState {
+  let name
+  let path
+  let request
+  let response
+  let error
+  let stateByName
+  let stateByPath
+
+  switch (action.type) {
+    case 'api:REQUEST':
+      path = action.payload.path
+      if (path !== SETTINGS_PATH) return state
+      name = action.payload.robot.name
+      request = action.payload.request
+      stateByName = state[name] || {}
+      stateByPath = stateByName[path] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {...stateByPath, request, inProgress: true, error: null}
+        }
+      }
+
+    case 'api:SUCCESS':
+      path = action.payload.path
+      if (path !== SETTINGS_PATH) return state
+      name = action.payload.robot.name
+      response = action.payload.response
+      stateByName = state[name] || {}
+      stateByPath = stateByName[path] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {...stateByPath, response, inProgress: false, error: null}
+        }
+      }
+
+    case 'api:FAILURE':
+      path = action.payload.path
+      if (path !== SETTINGS_PATH) return state
+      name = action.payload.robot.name
+      error = action.payload.error
+      stateByName = state[name] || {}
+      stateByPath = stateByName[path] || {}
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {...stateByPath, error, inProgress: false}
+        }
+      }
+  }
+
+  return state
+}
+
+export function makeGetRobotSettings () {
+  const selector: Selector<State, BaseRobot, RobotSettingsRequestState> =
+    createSelector(getRobotSettingsState, getSettingsRequest)
+
+  return selector
+}
+
+function getRobotSettingsState (
+  state: State,
+  props: BaseRobot
+): RobotSettingsState {
+  return state.api.settings[props.name] || {}
+}
+
+function getSettingsRequest (
+  state: RobotSettingsState
+): RobotSettingsRequestState {
+  let requestState = state[SETTINGS_PATH] || {inProgress: false}
+
+  // guard against an older version of GET /settings
+  if (requestState.response && !('settings' in requestState.response)) {
+    requestState = {...requestState, response: {settings: []}}
+  }
+
+  return requestState
+}

--- a/app/src/http-api-client/types.js
+++ b/app/src/http-api-client/types.js
@@ -13,7 +13,7 @@ export type ApiCall<T, U> = {
   /** request in progress flag */
   inProgress: boolean,
   /** possible error response */
-  error: ?ApiRequestError,
+  error?: ?ApiRequestError,
   /** possible request body */
   request?: ?T,
   /** possible success response body */


### PR DESCRIPTION
## overview

This PR is the front-end companion to #1786. It wires up `/settings` to the app.

Closes #1632

![2018-07-02 14 33 14](https://user-images.githubusercontent.com/2963448/42180356-e8e62ee0-7e04-11e8-9099-232cce944d8d.gif)

## changelog

- feat(app): Add robot settings toggles to Advanced Settings card 

## review requests

Sorry this PR is so large; it's mostly API client boilerplate and tests. I started work on a boilerplate reduction in this PR by creating generic API action creators (see `http-api-client/actions.js`). There's a path forward where all the reducers in each client module (e.g. `calibration`) are removed in favor of a monolithic one. Talk to me in real life if you're interested.

Otherwise, give this a shot on any robot that's update to date with `edge` from today (e.g. Sunset)
