### PR TITLE
PD: download file with all metadata PD will need to load

### DIFF
--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -1,6 +1,12 @@
 // @flow
 import {createSelector} from 'reselect'
-import {selectors as fileDataSelectors} from '../file-data'
+
+// TODO: Ian 2018-07-02 split apart file-data concerns to avoid circular dependencies
+// Eg, right now if you import {selectors as fileDataSelectors} from '../file-data',
+// PD won't start, b/c of circular dependency when fileData/selectors/fileCreator
+// imports getDismissedWarnings selector from 'dismiss/
+import {warningsPerStep} from '../file-data/selectors/commands'
+
 import {selectors as steplistSelectors} from '../steplist'
 import type {BaseState, Selector} from '../types'
 import type {CommandCreatorWarning} from '../step-generation'
@@ -8,7 +14,7 @@ import type {RootState, DismissedWarningState} from './reducers'
 
 export const rootSelector = (state: BaseState): RootState => state.dismiss
 
-const getDismissedWarnings: Selector<DismissedWarningState> = createSelector(
+export const getDismissedWarnings: Selector<DismissedWarningState> = createSelector(
   rootSelector,
   s => s.dismissedWarnings
 )
@@ -17,7 +23,7 @@ type WarningsPerStep = {[stepId: string | number]: Array<CommandCreatorWarning>}
 /** Non-dismissed warnings for each step */
 export const getVisibleWarningsPerStep: Selector<WarningsPerStep> = createSelector(
   getDismissedWarnings,
-  fileDataSelectors.warningsPerStep,
+  warningsPerStep,
   steplistSelectors.orderedSteps,
   (dismissedWarnings, warningsPerStep, orderedSteps) => {
     return orderedSteps.reduce(

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -1,11 +1,13 @@
 // @flow
 import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
+import {fileMetadata} from './fileFields'
+import {getInitialRobotState, robotStateTimeline} from './commands'
+import {selectors as ingredSelectors} from '../../labware-ingred/reducers'
+import {selectors as steplistSelectors} from '../../steplist/reducers'
 import type {BaseState} from '../../types'
 import type {ProtocolFile, FilePipette, FileLabware} from '../../file-types'
 import type {LabwareData, PipetteData} from '../../step-generation'
-import {fileMetadata} from './fileFields'
-import {getInitialRobotState, robotStateTimeline} from './commands'
 
 // TODO LATER Ian 2018-02-28 deal with versioning
 const protocolSchemaVersion = '1.0.0'
@@ -15,7 +17,19 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   fileMetadata,
   getInitialRobotState,
   robotStateTimeline,
-  (fileMetadata, initialRobotState, _robotStateTimeline) => {
+  ingredSelectors.getIngredientGroups,
+  ingredSelectors.getIngredientLocations,
+  steplistSelectors.getSavedForms,
+  steplistSelectors.orderedSteps,
+  (
+    fileMetadata,
+    initialRobotState,
+    _robotStateTimeline,
+    ingredients,
+    ingredLocations,
+    savedStepForms,
+    orderedSteps
+  ) => {
     const {author, description} = fileMetadata
     const name = fileMetadata.name || 'untitled'
 
@@ -58,8 +72,12 @@ export const createFile: BaseState => ProtocolFile = createSelector(
           pipetteTiprackAssignments: mapValues(
             initialRobotState.instruments,
             (p: PipetteData): ?string => p.tiprackModel
-          )
-          // TODO: Ian 2018-06-29 Add all info needed to restore a protocol
+          ),
+          // TODO IMMEDIATELY add dismissedWarnings after PR merge & rebase
+          ingredients,
+          ingredLocations,
+          savedStepForms,
+          orderedSteps
         }
       },
 

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -3,6 +3,7 @@ import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
 import {fileMetadata} from './fileFields'
 import {getInitialRobotState, robotStateTimeline} from './commands'
+import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../../steplist/reducers'
 import type {BaseState} from '../../types'
@@ -17,6 +18,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   fileMetadata,
   getInitialRobotState,
   robotStateTimeline,
+  dismissSelectors.getDismissedWarnings,
   ingredSelectors.getIngredientGroups,
   ingredSelectors.getIngredientLocations,
   steplistSelectors.getSavedForms,
@@ -25,6 +27,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
     fileMetadata,
     initialRobotState,
     _robotStateTimeline,
+    dismissedWarnings,
     ingredients,
     ingredLocations,
     savedStepForms,
@@ -73,7 +76,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
             initialRobotState.instruments,
             (p: PipetteData): ?string => p.tiprackModel
           ),
-          // TODO IMMEDIATELY add dismissedWarnings after PR merge & rebase
+          dismissedWarnings,
           ingredients,
           ingredLocations,
           savedStepForms,

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -3,6 +3,7 @@ import type {DeckSlot, Mount} from '@opentrons/components'
 import type {Command} from './step-generation/types'
 import type {RootState as IngredRoot} from './labware-ingred/reducers'
 import type {RootState as StepformRoot} from './steplist/reducers'
+import type {RootState as DismissRoot} from './dismiss'
 
 type MsSinceEpoch = number
 type VersionString = string // eg '1.0.0'
@@ -41,10 +42,10 @@ export type ProtocolFile = {
       // pipetteId to tiprackModel. may be unassigned
       pipetteTiprackAssignments: {[pipetteId: string]: ?string},
 
+      dismissedWarnings: $PropertyType<DismissRoot, 'dismissedWarnings'>,
+
       ingredients: $PropertyType<IngredRoot, 'ingredients'>,
       ingredLocations: $PropertyType<IngredRoot, 'ingredLocations'>,
-
-      // dismissedWarnings: $PropertyType<DismissedRoot, 'dismissedWarnings'> // TODO IMMEDIATELY merge dismissed
 
       savedStepForms: $PropertyType<StepformRoot, 'savedStepForms'>,
       orderedSteps: $PropertyType<StepformRoot, 'orderedSteps'>

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -1,6 +1,8 @@
 // @flow
 import type {DeckSlot, Mount} from '@opentrons/components'
 import type {Command} from './step-generation/types'
+import type {RootState as IngredRoot} from './labware-ingred/reducers'
+import type {RootState as StepformRoot} from './steplist/reducers'
 
 type MsSinceEpoch = number
 type VersionString = string // eg '1.0.0'
@@ -37,9 +39,15 @@ export type ProtocolFile = {
     'application-version': VersionString,
     data: {
       // pipetteId to tiprackModel. may be unassigned
-      pipetteTiprackAssignments: {[pipetteId: string]: ?string}
+      pipetteTiprackAssignments: {[pipetteId: string]: ?string},
 
-      // TODO add more fields
+      ingredients: $PropertyType<IngredRoot, 'ingredients'>,
+      ingredLocations: $PropertyType<IngredRoot, 'ingredLocations'>,
+
+      // dismissedWarnings: $PropertyType<DismissedRoot, 'dismissedWarnings'> // TODO IMMEDIATELY merge dismissed
+
+      savedStepForms: $PropertyType<StepformRoot, 'savedStepForms'>,
+      orderedSteps: $PropertyType<StepformRoot, 'orderedSteps'>
     }
   },
 


### PR DESCRIPTION
## overview

Closes #1789 

## changelog

- save additional PD metadata fields: dismissedWarnings, ingredients, ingredLocations, savedStepForms, and orderedSteps to JSON Protocol File

## review requests

Are we still Missing any data? Well, we'll see in the next PR where these saved fields are actually used :)