### PR TITLE
fix(api): Allows floating-point temperatures

### DIFF
--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -90,10 +90,10 @@ def test_set_temp_deck_temperature(monkeypatch):
     temp_deck._send_command = types.MethodType(_mock_send_command, temp_deck)
 
     temp_deck.set_temperature(99)
-    assert command_log[-1] == 'M104 S99'
+    assert command_log[-1] == 'M104 S99.0'
 
     temp_deck.set_temperature(-9)
-    assert command_log[-1] == 'M104 S-9'
+    assert command_log[-1] == 'M104 S-9.0'
 
 
 def test_fail_set_temp_deck_temperature(monkeypatch):


### PR DESCRIPTION
## overview

This PR enables Temp-Deck's API driver to set/get temperatures as floating point.

The temp-deck driver was previously casting all temperatures to integers (both read-from and sent-to), however the temp-deck accepts floating point temperatures, as well as reports it's own temperature as a floating-point value with 3 decimal places.

[Documentation of Temp-Deck gcodes and argument scan be found in it's readme](https://github.com/Opentrons/opentrons-modules/tree/edge/modules/temp-deck#set-temperature)