### PR TITLE
build(repo): Remove lerna from test commands for Python sub-projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ test: test-py test-js
 .PHONY: test-py
 test-py:
 #	lerna exec --scope @opentrons/update-server --since origin/edge -- $(MAKE) -C .. test
-	lerna exec --scope @opentrons/api-server --since origin/edge -- $(MAKE) -C .. test
-	lerna exec --scope @opentrons/ot2serverlib --since origin/edge -- $(MAKE) -C .. test
+	$(MAKE) -C api test
+	$(MAKE) -C api-server-lib test
 
 .PHONY: test-js
 test-js:


### PR DESCRIPTION
## overview

Remove lerna from test commands for Python sub-projects. This was meant to not run python tests on branches that do not have changes in those projects. This both fails to work on CI (though it does work on developers computers), and risks not running tests at all on `edge` builds.

## changelog

- Remove lerna from test commands for Python sub-projects

## review requests

Make sure all CI task that should execute do so