### PR TITLE
PD: load file all metadata

### DIFF
--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -3,6 +3,8 @@ import {combineReducers} from 'redux'
 import {handleActions} from 'redux-actions'
 import omit from 'lodash/omit'
 import {dismissWarning} from './actions'
+import {LOAD_FILE, type LoadFileAction} from '../load-file'
+import {getPDMetadata} from '../file-types'
 import type {ActionType} from 'redux-actions'
 import type {BaseState} from '../types'
 import type {CommandCreatorWarning} from '../step-generation'
@@ -27,7 +29,9 @@ const dismissedWarnings = handleActions({
     // remove key for deleted step
     const stepId = action.payload.toString(10)
     return omit(state, stepId)
-  }
+  },
+  [LOAD_FILE]: (state: DismissedWarningState, action: LoadFileAction): DismissedWarningState =>
+    getPDMetadata(action.payload).dismissedWarnings
 }, {})
 
 export const _allReducers = {

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -54,6 +54,11 @@ export const createFile: BaseState => ProtocolFile = createSelector(
       })
     )
 
+    // TODO: Ian 2018-07-10 allow user to save steps in JSON file, even if those
+    // step never have saved forms.
+    // (We could just export the `steps` reducer, but we've sunset it)
+    const savedOrderedSteps = orderedSteps.filter(stepId => savedStepForms[stepId])
+
     return {
       'protocol-schema': protocolSchemaVersion,
 
@@ -80,7 +85,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
           ingredients,
           ingredLocations,
           savedStepForms,
-          orderedSteps
+          orderedSteps: savedOrderedSteps
         }
       },
 

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -19,6 +19,19 @@ export type FileLabware = {
   'display-name': string
 }
 
+export type PDMetadata = {
+  // pipetteId to tiprackModel. may be unassigned
+  pipetteTiprackAssignments: {[pipetteId: string]: ?string},
+
+  dismissedWarnings: $PropertyType<DismissRoot, 'dismissedWarnings'>,
+
+  ingredients: $PropertyType<IngredRoot, 'ingredients'>,
+  ingredLocations: $PropertyType<IngredRoot, 'ingredLocations'>,
+
+  savedStepForms: $PropertyType<StepformRoot, 'savedStepForms'>,
+  orderedSteps: $PropertyType<StepformRoot, 'orderedSteps'>
+}
+
 // A JSON protocol
 export type ProtocolFile = {
   'protocol-schema': VersionString,
@@ -38,18 +51,7 @@ export type ProtocolFile = {
   'designer-application': {
     'application-name': 'opentrons/protocol-designer',
     'application-version': VersionString,
-    data: {
-      // pipetteId to tiprackModel. may be unassigned
-      pipetteTiprackAssignments: {[pipetteId: string]: ?string},
-
-      dismissedWarnings: $PropertyType<DismissRoot, 'dismissedWarnings'>,
-
-      ingredients: $PropertyType<IngredRoot, 'ingredients'>,
-      ingredLocations: $PropertyType<IngredRoot, 'ingredLocations'>,
-
-      savedStepForms: $PropertyType<StepformRoot, 'savedStepForms'>,
-      orderedSteps: $PropertyType<StepformRoot, 'orderedSteps'>
-    }
+    data: PDMetadata
   },
 
   robot: {
@@ -71,4 +73,8 @@ export type ProtocolFile = {
     },
     subprocedure: Array<Command>
   }>
+}
+
+export function getPDMetadata (file: ProtocolFile): PDMetadata {
+  return file['designer-application'].data
 }


### PR DESCRIPTION
## overview

Closes #1604

Fully-functional file loading in PD!

## changelog

- Enable populating steplist / step forms, ingredients and ingredient locations, labware, and dismissed warnings from a saved JSON Protocol file.

## review requests

Does anything not load in a saved file that should be persisted?

Can you break it? Especially mess with selection states, adding and editing ingreds/labware/steps, deleting things.

NOTE: saved files from before didn't have all the fields and will not work. Make sure any saved files you test were saved from PD using this branch!