### PR TITLE
fix(api): Remove incorrect call to `cache_instrument_models`

### DIFF
--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -395,7 +395,7 @@ class Robot(object):
             raise RuntimeError('Instrument {0} already on {1} mount'.format(
                 prev_instr.name, mount))
         self._instruments[mount] = instrument
-        self.cache_instrument_models()
+
         instrument.instrument_actuator = self._actuators[mount]['plunger']
         instrument.instrument_mover = self._actuators[mount]['carriage']
 


### PR DESCRIPTION
## overview

Remove an extraneous call to `cache_instrument_models` that caused pipette model cache to be invalidated and fall back to default. Fixes #1805 

## changelog

Remove call to `cache_instrument_models` in pipette

## review requests

Tested on Sunset