### PR TITLE
refactor(app): Convert /robot HTTP API module to generic API actions

### DIFF
--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import type {State} from '../../types'
 import type {Robot} from '../../robot'
 import type {Pipette} from '../../http-api-client'
-import {makeGetRobotPipettes, fetchPipettes, clearRobotMoveResponse} from '../../http-api-client'
+import {makeGetRobotPipettes, fetchPipettes, clearMoveResponse} from '../../http-api-client'
 
 import InstrumentInfo from './InstrumentInfo'
 import {RefreshCard} from '@opentrons/components'
@@ -61,6 +61,6 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   return {
     fetchPipettes: () => dispatch(fetchPipettes(ownProps)),
-    clearMove: () => dispatch(clearRobotMoveResponse(ownProps))
+    clearMove: () => dispatch(clearMoveResponse(ownProps))
   }
 }

--- a/app/src/http-api-client/__tests__/robot.test.js
+++ b/app/src/http-api-client/__tests__/robot.test.js
@@ -8,6 +8,8 @@ import {
   home,
   fetchRobotLights,
   setRobotLights,
+  clearHomeResponse,
+  clearMoveResponse,
   reducer,
   makeGetRobotMove,
   makeGetRobotHome,
@@ -35,7 +37,7 @@ describe('robot/*', () => {
   })
 
   describe('moveRobotTo action creator', () => {
-    const path = 'move'
+    const path = 'robot/move'
     const request = {position: 'change_pipette', mount: 'left'}
     const mockPositionsResponse = {
       positions: {
@@ -64,10 +66,10 @@ describe('robot/*', () => {
       ]))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
       ]
 
       client.__setMockResponse(mockPositionsResponse, response)
@@ -76,11 +78,11 @@ describe('robot/*', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches ROBOT_REQUEST amd ROBOT_FAILURE', () => {
+    test('dispatches api:REQUEST amd api:FAILURE', () => {
       const error = {name: 'ResponseError', status: '400'}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
       ]
 
       client.__setMockError(error)
@@ -88,10 +90,17 @@ describe('robot/*', () => {
       return store.dispatch(moveRobotTo(robot, request))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
+
+    test('clearMoveResponse action creator', () => {
+      expect(clearMoveResponse(robot)).toEqual({
+        type: 'api:CLEAR_RESPONSE',
+        payload: {robot, path}
+      })
+    })
   })
 
   describe('home action creator', () => {
-    const path = 'home'
+    const path = 'robot/home'
     const response = {message: 'success'}
 
     test('calls POST /robot/home to home robot', () => {
@@ -114,11 +123,11 @@ describe('robot/*', () => {
           .toHaveBeenCalledWith(robot, 'POST', 'robot/home', expectedBody))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
       const request = {target: 'pipette', mount: 'left'}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
       ]
 
       client.__setMockResponse(response)
@@ -127,12 +136,12 @@ describe('robot/*', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_FAILURE', () => {
+    test('dispatches api:REQUEST and api:FAILURE', () => {
       const request = {target: 'robot'}
       const error = {name: 'ResponseError', status: '400'}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
       ]
 
       client.__setMockError(error)
@@ -140,10 +149,18 @@ describe('robot/*', () => {
       return store.dispatch(home(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
+
+    test('clearHomeResponse action creator', () => {
+      expect(clearHomeResponse(robot)).toEqual({
+        type: 'api:CLEAR_RESPONSE',
+        payload: {robot, path}
+      })
+    })
   })
 
   describe('fetchRobotLights action creator', () => {
-    const path = 'lights'
+    const path = 'robot/lights'
+    const request = null
     const response = {on: true}
 
     test('calls GET /robot/lights', () => {
@@ -154,10 +171,10 @@ describe('robot/*', () => {
           .toHaveBeenCalledWith(robot, 'GET', 'robot/lights'))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, path}},
-        {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
       ]
 
       client.__setMockResponse(response)
@@ -166,11 +183,11 @@ describe('robot/*', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_FAILURE', () => {
+    test('dispatches api:REQUEST and api:FAILURE', () => {
       const error = {name: 'ResponseError', status: '400'}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, path}},
-        {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
       ]
 
       client.__setMockError(error)
@@ -181,7 +198,7 @@ describe('robot/*', () => {
   })
 
   describe('setRobotLights action creator', () => {
-    const path = 'lights'
+    const path = 'robot/lights'
     const response = {on: false}
 
     test('calls POST /robot/home to home robot', () => {
@@ -194,11 +211,11 @@ describe('robot/*', () => {
           .toHaveBeenCalledWith(robot, 'POST', 'robot/lights', expectedBody))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_SUCCESS', () => {
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
       const request = {on: true}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_SUCCESS', payload: {robot, response, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}}
       ]
 
       client.__setMockResponse(response)
@@ -207,12 +224,12 @@ describe('robot/*', () => {
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
-    test('dispatches ROBOT_REQUEST and ROBOT_FAILURE', () => {
+    test('dispatches api:REQUEST and api:FAILURE', () => {
       const request = {on: false}
       const error = {name: 'ResponseError', status: '400'}
       const expectedActions = [
-        {type: 'api:ROBOT_REQUEST', payload: {robot, request, path}},
-        {type: 'api:ROBOT_FAILURE', payload: {robot, error, path}}
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}}
       ]
 
       client.__setMockError(error)
@@ -224,17 +241,17 @@ describe('robot/*', () => {
 
   const REDUCER_REQUEST_RESPONSE_TESTS = [
     {
-      path: 'move',
+      path: 'robot/move',
       request: {target: 'mount', mount: 'left', point: [1, 2, 3]},
       response: {message: 'we did it!'}
     },
     {
-      path: 'home',
+      path: 'robot/home',
       request: {target: 'pipette', mount: 'left'},
       response: {message: 'we did it!'}
     },
     {
-      path: 'lights',
+      path: 'robot/lights',
       request: null,
       response: {on: true}
     }
@@ -243,14 +260,14 @@ describe('robot/*', () => {
   REDUCER_REQUEST_RESPONSE_TESTS.forEach((spec) => {
     const {path, request, response} = spec
 
-    describe(`reducer with /robot/${path}`, () => {
+    describe(`reducer with ${path}`, () => {
       beforeEach(() => {
         state = state.api
       })
 
-      test('handles ROBOT_REQUEST', () => {
+      test('handles api:REQUEST', () => {
         const action = {
-          type: 'api:ROBOT_REQUEST',
+          type: 'api:REQUEST',
           payload: {path, robot, request}
         }
 
@@ -266,9 +283,9 @@ describe('robot/*', () => {
         })
       })
 
-      test('handles ROBOT_SUCCESS', () => {
+      test('handles api:SUCCESS', () => {
         const action = {
-          type: 'api:ROBOT_SUCCESS',
+          type: 'api:SUCCESS',
           payload: {path, robot, response}
         }
 
@@ -293,10 +310,10 @@ describe('robot/*', () => {
         })
       })
 
-      test('handles ROBOT_FAILURE', () => {
+      test('handles api:FAILURE', () => {
         const error = {message: 'we did not do it!'}
         const action = {
-          type: 'api:ROBOT_FAILURE',
+          type: 'api:FAILURE',
           payload: {path, robot, error}
         }
 
@@ -323,33 +340,67 @@ describe('robot/*', () => {
     })
   })
 
+  describe('reducer with api:CLEAR_RESPONSE', () => {
+    const PATHS = ['robot/move', 'robot/home']
+
+    beforeEach(() => {
+      state = state.api
+    })
+
+    PATHS.forEach(path => test(`with ${path}`, () => {
+      const action = {
+        type: 'api:CLEAR_RESPONSE',
+        payload: {robot, path}
+      }
+
+      state.robot[NAME] = {
+        [path]: {
+          inProgress: false,
+          request: {},
+          response: 'foo',
+          error: 'bar'
+        }
+      }
+
+      expect(reducer(state, action).robot[NAME][path]).toEqual({
+        inProgress: false,
+        request: {},
+        response: null,
+        error: null
+      })
+    }))
+  })
+
   describe('selectors', () => {
     beforeEach(() => {
       state.api.robot[NAME] = {
-        home: {inProgress: true},
-        move: {inProgress: true},
-        lights: {inProgress: true}
+        'robot/home': {inProgress: true},
+        'robot/move': {inProgress: true},
+        'robot/lights': {inProgress: true}
       }
     })
 
     test('makeGetRobotMove', () => {
       const getMove = makeGetRobotMove()
 
-      expect(getMove(state, robot)).toEqual(state.api.robot[NAME].move)
+      expect(getMove(state, robot))
+        .toEqual(state.api.robot[NAME]['robot/move'])
       expect(getMove(state, {name: 'foo'})).toEqual({inProgress: false})
     })
 
     test('makeGetRobotHome', () => {
       const getHome = makeGetRobotHome()
 
-      expect(getHome(state, robot)).toEqual(state.api.robot[NAME].home)
+      expect(getHome(state, robot))
+        .toEqual(state.api.robot[NAME]['robot/home'])
       expect(getHome(state, {name: 'foo'})).toEqual({inProgress: false})
     })
 
     test('makeGetRobotLights', () => {
       const getLights = makeGetRobotLights()
 
-      expect(getLights(state, robot)).toEqual(state.api.robot[NAME].lights)
+      expect(getLights(state, robot))
+        .toEqual(state.api.robot[NAME]['robot/lights'])
       expect(getLights(state, {name: 'foo'})).toEqual({inProgress: false})
     })
   })

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -34,6 +34,14 @@ export type ApiFailureAction<Path: string> = {|
   |},
 |}
 
+export type ClearApiResponseAction<Path: string> = {|
+  type: 'api:CLEAR_RESPONSE',
+  payload: {|
+    robot: BaseRobot,
+    path: Path,
+  |}
+|}
+
 export function apiRequest<Path: string, Body: ?{}> (
   robot: BaseRobot,
   path: Path,
@@ -56,4 +64,11 @@ export function apiFailure<Path: string> (
   error: ApiRequestError
 ): ApiFailureAction<Path> {
   return {type: 'api:FAILURE', payload: {robot, path, error}}
+}
+
+export function clearApiResponse<Path: string> (
+  robot: BaseRobot,
+  path: Path
+): ClearApiResponseAction<Path> {
+  return {type: 'api:CLEAR_RESPONSE', payload: {robot, path}}
 }

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -121,7 +121,7 @@ export {
   home,
   clearHomeResponse,
   moveRobotTo,
-  clearRobotMoveResponse,
+  clearMoveResponse,
   fetchRobotLights,
   setRobotLights,
   makeGetRobotMove,

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -43,18 +43,27 @@ export type SettingsState = {
   [robotName: string]: ?RobotSettingsState,
 }
 
-const SETTINGS_PATH: SettingsPath = 'settings'
+const SETTINGS: 'settings' = 'settings'
+
+// TODO(mc, 2018-07-03): flow helper until we have one reducer
+// note: p === 'settings' works but p === SETTINGS does not, even if
+// SETTINGS is defined as `const SETTINGS: 'settings' = 'settings'`
+function getSettingsPath (p: string): ?SettingsPath {
+  if (p === 'settings') return p
+
+  return null
+}
 
 export function fetchSettings (robot: RobotService): ThunkPromiseAction {
   const request: SettingsRequest = null
 
   return (dispatch) => {
-    dispatch(apiRequest(robot, SETTINGS_PATH, request))
+    dispatch(apiRequest(robot, SETTINGS, request))
 
-    return client(robot, 'GET', SETTINGS_PATH)
+    return client(robot, 'GET', SETTINGS)
       .then(
-        (res: SettingsResponse) => apiSuccess(robot, SETTINGS_PATH, res),
-        (err: ApiRequestError) => apiFailure(robot, SETTINGS_PATH, err)
+        (res: SettingsResponse) => apiSuccess(robot, SETTINGS, res),
+        (err: ApiRequestError) => apiFailure(robot, SETTINGS, err)
       )
       .then(dispatch)
   }
@@ -68,25 +77,27 @@ export function setSettings (
   const request: SettingsRequest = {id, value}
 
   return (dispatch) => {
-    dispatch(apiRequest(robot, SETTINGS_PATH, request))
+    dispatch(apiRequest(robot, SETTINGS, request))
 
-    return client(robot, 'POST', SETTINGS_PATH, request)
+    return client(robot, 'POST', SETTINGS, request)
       .then(
-        (res: SettingsResponse) => apiSuccess(robot, SETTINGS_PATH, res),
-        (err: ApiRequestError) => apiFailure(robot, SETTINGS_PATH, err)
+        (res: SettingsResponse) => apiSuccess(robot, SETTINGS, res),
+        (err: ApiRequestError) => apiFailure(robot, SETTINGS, err)
       )
       .then(dispatch)
   }
 }
 
+// TODO(mc, 2018-07-03): remove in favor of single HTTP API reducer
 export function settingsReducer (
   state: SettingsState = {},
   action: Action
 ): SettingsState {
   switch (action.type) {
     case 'api:REQUEST': {
-      const {payload: {path, request, robot: {name}}} = action
-      if (path !== SETTINGS_PATH) return state
+      const path = getSettingsPath(action.payload.path)
+      if (!path) return state
+      const {payload: {request, robot: {name}}} = action
       const stateByName = state[name] || {}
       const stateByPath = stateByName[path] || {}
 
@@ -100,8 +111,9 @@ export function settingsReducer (
     }
 
     case 'api:SUCCESS': {
-      const {payload: {path, response, robot: {name}}} = action
-      if (path !== SETTINGS_PATH) return state
+      const path = getSettingsPath(action.payload.path)
+      if (!path) return state
+      const {payload: {response, robot: {name}}} = action
       const stateByName = state[name] || {}
       const stateByPath = stateByName[path] || {}
 
@@ -115,8 +127,9 @@ export function settingsReducer (
     }
 
     case 'api:FAILURE': {
-      const {payload: {path, error, robot: {name}}} = action
-      if (path !== SETTINGS_PATH) return state
+      const path = getSettingsPath(action.payload.path)
+      if (!path) return state
+      const {payload: {error, robot: {name}}} = action
       const stateByName = state[name] || {}
       const stateByPath = stateByName[path] || {}
 
@@ -150,7 +163,7 @@ function getRobotSettingsState (
 function getSettingsRequest (
   state: RobotSettingsState
 ): RobotSettingsRequestState {
-  let requestState = state[SETTINGS_PATH] || {inProgress: false}
+  let requestState = state[SETTINGS] || {inProgress: false}
 
   // guard against an older version of GET /settings
   if (requestState.response && !('settings' in requestState.response)) {


### PR DESCRIPTION
## overview

Following up on work started in #1795, this PR converts the `/robots` HTTP API client module to use the new generic API actions in preparation for a single API client reducer.

Three of the existing modules have code that doesn't fit cleanly into a generic reducer, and `robot.js` is one of them. I'm going to follow up with two more refactor PRs (one for `calibration.js` and one for `health-check.js`) before doing the reducer refactor to keep things sane.

## changelog

- refactor(app): Convert robot HTTP API client module to generic API actions

## review requests

The `/robot` enpoints are used for

- Lights toggle
- Home button
- Pipette swap

Please make sure all of them still work properly. Tested on Sunset and it looked good. VS should work, too (although VS does funky stuff with `/robot/lights`, which is out of scope)