### PR TITLE
refactor(app): Use generic actions in /calibration API module

### DIFF
--- a/app/src/components/CalibrateDeck/ConfirmPosition.js
+++ b/app/src/components/CalibrateDeck/ConfirmPosition.js
@@ -13,11 +13,7 @@ export default function ConfirmPosition (props: Props) {
   return (
     <div>
       <Instructions {...props} />
-      <JogControls
-        jog={props.jog}
-        step={props.jogStep}
-        onStepSelect={props.onJogStepSelect}
-      />
+      <JogControls jog={props.jog} />
       <PrimaryButton onClick={props.proceed}>
         Save Calibration and Continue
       </PrimaryButton>

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -15,8 +15,6 @@ import {
   home,
   startDeckCalibration,
   deckCalibrationCommand,
-  setCalibrationJogStep,
-  getCalibrationJogStep,
   makeGetDeckCalibrationCommandState,
   makeGetDeckCalibrationStartState
 } from '../../http-api-client'
@@ -127,11 +125,11 @@ function CalibrateDeck (props: CalibrateDeckProps) {
   )
 }
 
-function makeMapStateToProps () {
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getDeckCalCommand = makeGetDeckCalibrationCommandState()
   const getDeckCalStartState = makeGetDeckCalibrationStartState()
 
-  return (state: State, ownProps: OP): SP => {
+  return (state, ownProps) => {
     const {robot} = ownProps
     const startRequest = getDeckCalStartState(state, robot)
     const pipetteInfo = startRequest.response && startRequest.response.pipette
@@ -146,8 +144,7 @@ function makeMapStateToProps () {
     return {
       startRequest,
       pipetteProps,
-      commandRequest: getDeckCalCommand(state, robot),
-      jogStep: getCalibrationJogStep(state)
+      commandRequest: getDeckCalCommand(state, robot)
     }
   }
 }
@@ -159,10 +156,6 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
     jog: (axis, direction, step) => dispatch(
       deckCalibrationCommand(robot, {command: 'jog', axis, direction, step})
     ),
-    onJogStepSelect: (event) => {
-      const step = Number(event.target.value)
-      dispatch(setCalibrationJogStep(step))
-    },
     forceStart: () => dispatch(startDeckCalibration(robot, true)),
     // exit button click in title bar, opens exit alert modal, confirm exit click
     exit: () => dispatch(chainActions(

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -3,7 +3,7 @@ import type {Match} from 'react-router'
 import type {PipetteConfig} from '@opentrons/shared-data'
 import type {RobotService, Mount} from '../../robot'
 import type {DeckCalCommandState, DeckCalStartState} from '../../http-api-client'
-import type {JogControlsProps} from '../JogControls'
+import type {Jog} from '../JogControls'
 
 export type CalibrationStep = '1' | '2' | '3' | '4' | '5' | '6'
 
@@ -16,7 +16,6 @@ export type OP = {
 export type SP = {
   startRequest: DeckCalStartState,
   commandRequest: DeckCalCommandState,
-  jogStep: $PropertyType<JogControlsProps, 'step'>,
   pipetteProps: ?{
     mount: Mount,
     pipette: ?PipetteConfig,
@@ -25,8 +24,7 @@ export type SP = {
 
 export type DP = {
   forceStart: () => mixed,
-  jog: $PropertyType<JogControlsProps, 'jog'>,
-  onJogStepSelect: $PropertyType<JogControlsProps, 'onStepSelect'>,
+  jog: Jog,
   exit: () => mixed,
   back: () => mixed
 }

--- a/app/src/components/CalibrateLabware/ConfirmPositionContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionContents.js
@@ -3,31 +3,26 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
-import type {State, Dispatch} from '../../types'
+import type {Dispatch} from '../../types'
 import type {Instrument, Labware} from '../../robot'
 
-import {selectors as robotSelectors, actions as robotActions} from '../../robot'
+import {actions as robotActions} from '../../robot'
 import {PrimaryButton} from '@opentrons/components'
 import ConfirmPositionDiagram from './ConfirmPositionDiagram'
-import JogControls, {type JogControlsProps} from '../JogControls'
-
-type SP = {
-  step: $PropertyType<JogControlsProps, 'step'>,
-}
+import JogControls, {type Jog} from '../JogControls'
 
 type DP = {
-  onConfirmClick: () => void,
-  jog: $PropertyType<JogControlsProps, 'jog'>,
-  onStepSelect: $PropertyType<JogControlsProps, 'onStepSelect'>,
+  onConfirmClick: () => mixed,
+  jog: Jog,
 }
 
 type OP = Labware & {
   calibrator: Instrument
 }
 
-type Props = SP & DP & OP
+type Props = DP & OP
 
-export default connect(mapStateToProps, mapDispatchToProps)(ConfirmPositionContents)
+export default connect(null, mapDispatchToProps)(ConfirmPositionContents)
 
 function ConfirmPositionContents (props: Props) {
   const {isTiprack, onConfirmClick, calibrator: {channels}} = props
@@ -46,12 +41,6 @@ function ConfirmPositionContents (props: Props) {
   )
 }
 
-function mapStateToProps (state: State): SP {
-  return {
-    step: robotSelectors.getJogDistance(state)
-  }
-}
-
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {slot, isTiprack, calibrator: {mount}} = ownProps
   const onConfirmAction = isTiprack
@@ -59,13 +48,9 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
     : robotActions.updateOffset(mount, slot)
 
   return {
-    jog: (axis, direction) => {
-      dispatch(robotActions.jog(mount, axis, direction))
+    jog: (axis, direction, step) => {
+      dispatch(robotActions.jog(mount, axis, direction, step))
     },
-    onStepSelect: (event) => {
-      const step = Number(event.target.value)
-      dispatch(robotActions.setJogDistance(step))
-    },
-    onConfirmClick: () => { dispatch(onConfirmAction) }
+    onConfirmClick: () => dispatch(onConfirmAction)
   }
 }

--- a/app/src/components/JogControls/index.js
+++ b/app/src/components/JogControls/index.js
@@ -15,7 +15,7 @@ import {
 
 import styles from './styles.css'
 
-type Jog = (axis: JogAxis, direction: JogDirection, step: JogStep) => mixed
+export type Jog = (axis: JogAxis, direction: JogDirection, step: JogStep) => mixed
 
 type JogButtonProps = {
   name: string,
@@ -23,11 +23,9 @@ type JogButtonProps = {
   onClick: () => mixed,
 }
 
-export type JogControlsProps = {
-  jog: Jog,
-  step: JogStep,
-  onStepSelect: (event: SyntheticInputEvent<*>) => mixed,
-}
+type Props = {jog: Jog}
+
+type State = {step: JogStep}
 
 const JOG_BUTTON_NAMES = ['left', 'right', 'back', 'forward', 'up', 'down']
 
@@ -49,28 +47,32 @@ const JOG_PARAMS_BY_NAME = {
   down: ['z', -1]
 }
 
-const STEPS = [0.1, 1, 10]
+const STEPS: Array<JogStep> = [0.1, 1, 10]
 const STEP_OPTIONS = STEPS.map(s => ({name: `${s} mm`, value: `${s}`}))
 
-export default class JogControls extends React.Component<JogControlsProps> {
+export default class JogControls extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {step: STEPS[0]}
+  }
+
   increaseStepSize = () => {
-    const current = STEPS.indexOf(this.props.step)
-    if (current < STEPS.length - 1) {
-      // $FlowFixMe: (mc, 2018-06-26) refactor so event trickery isn't needed
-      this.props.onStepSelect({target: {value: `${STEPS[current + 1]}`}})
-    }
+    const i = STEPS.indexOf(this.state.step)
+    if (i < STEPS.length - 1) this.setState({step: STEPS[i + 1]})
   }
 
   decreaseStepSize = () => {
-    const current = STEPS.indexOf(this.props.step)
-    if (current > 0) {
-      // $FlowFixMe: (mc, 2018-06-26) refactor so event trickery isn't needed
-      this.props.onStepSelect({target: {value: `${STEPS[current - 1]}`}})
-    }
+    const i = STEPS.indexOf(this.state.step)
+    if (i > 0) this.setState({step: STEPS[i - 1]})
+  }
+
+  handleStepSelect = (event: SyntheticInputEvent<*>) => {
+    this.setState({step: Number(event.target.value)})
   }
 
   getJogHandlers () {
-    const {jog, step} = this.props
+    const {jog} = this.props
+    const {step} = this.state
 
     return JOG_BUTTON_NAMES.reduce((result, name) => ({
       ...result,
@@ -79,8 +81,8 @@ export default class JogControls extends React.Component<JogControlsProps> {
   }
 
   renderJogControls () {
+    const {step} = this.state
     const jogHandlers = this.getJogHandlers()
-    const {step, onStepSelect} = this.props
 
     return (
       <HandleKeypress
@@ -111,7 +113,7 @@ export default class JogControls extends React.Component<JogControlsProps> {
             className={styles.increment_item}
             value={`${step}`}
             options={STEP_OPTIONS}
-            onChange={onStepSelect}
+            onChange={this.handleStepSelect}
             disableKeypress
           />
         </span>

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -87,10 +87,8 @@ export type Action =
 export {
   startDeckCalibration,
   deckCalibrationCommand,
-  setCalibrationJogStep,
   makeGetDeckCalibrationStartState,
-  makeGetDeckCalibrationCommandState,
-  getCalibrationJogStep
+  makeGetDeckCalibrationCommandState
 } from './calibration'
 
 export {

--- a/app/src/http-api-client/robot.js
+++ b/app/src/http-api-client/robot.js
@@ -104,11 +104,13 @@ type RobotState = {
 
 // note: POSITIONS only used inside `moveRobotTo`
 const POSITIONS = 'robot/positions'
-const MOVE: RobotPath = 'robot/move'
-const HOME: RobotPath = 'robot/home'
-const LIGHTS: RobotPath = 'robot/lights'
+const MOVE: 'robot/move' = 'robot/move'
+const HOME: 'robot/home' = 'robot/home'
+const LIGHTS: 'robot/lights' = 'robot/lights'
 
-// TODO(mc, 2018-07-03): flow helper until we have one reducer
+// TODO(mc, 2018-07-03): flow helper until we have one reducer, since
+// p === 'constant' checks but p === CONSTANT does not, even if
+// CONSTANT is defined as `const CONSTANT: 'constant' = 'constant'`
 function getRobotPath (p: string): ?RobotPath {
   if (p === 'robot/move' || p === 'robot/home' || p === 'robot/lights') {
     return p

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -45,9 +45,9 @@ export type SettingsState = {
 
 const SETTINGS: 'settings' = 'settings'
 
-// TODO(mc, 2018-07-03): flow helper until we have one reducer
-// note: p === 'settings' works but p === SETTINGS does not, even if
-// SETTINGS is defined as `const SETTINGS: 'settings' = 'settings'`
+// TODO(mc, 2018-07-03): flow helper until we have one reducer, since
+// p === 'constant' checks but p === CONSTANT does not, even if
+// CONSTANT is defined as `const CONSTANT: 'constant' = 'constant'`
 function getSettingsPath (p: string): ?SettingsPath {
   if (p === 'settings') return p
 

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -91,7 +91,8 @@ export type PipetteCalibrationAction = {|
   payload: {|
     mount: Mount,
     axis?: Axis,
-    direction?: Direction
+    direction?: Direction,
+    step?: number
   |},
   meta: {|
     robotCommand: true
@@ -451,11 +452,12 @@ export const actions = {
   jog (
     mount: Mount,
     axis: Axis,
-    direction: Direction
+    direction: Direction,
+    step: number
   ): PipetteCalibrationAction {
     return {
       type: 'robot:JOG',
-      payload: {mount, axis, direction},
+      payload: {mount, axis, direction, step},
       meta: {robotCommand: true}
     }
   },

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -222,9 +222,9 @@ export default function client (dispatch) {
   }
 
   function jog (state, action) {
-    const {payload: {mount, axis, direction}} = action
+    const {payload: {mount, axis, direction, step}} = action
     const instrument = selectors.getInstrumentsByMount(state)[mount]
-    const distance = selectors.getJogDistance(state) * direction
+    const distance = step * direction
 
     // FIXME(mc, 2017-10-06): DEBUG CODE
     // return setTimeout(() => dispatch(actions.jogResponse()), 1000)

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -39,7 +39,6 @@ type CalibrationRequest = {
 
 export type State = {
   +deckPopulated: ?boolean,
-  +jogDistance: number,
 
   +probedByMount: {[Mount]: boolean},
   +tipOnByMount: {[Mount]: boolean},
@@ -62,7 +61,6 @@ const {
 
 const INITIAL_STATE: State = {
   deckPopulated: null,
-  jogDistance: 0.1,
 
   // TODO(mc, 2018-01-22): combine these into subreducer
   probedByMount: {},
@@ -137,9 +135,6 @@ export default function calibrationReducer (
 
     case 'robot:DISCONNECT_RESPONSE':
       return handleDisconnectResponse(state, action)
-
-    case 'robot:SET_JOG_DISTANCE':
-      return handleSetJogDistance(state, action)
 
     case 'robot:REFRESH_SESSION':
       return handleSession(state, action)
@@ -482,13 +477,6 @@ function handleConfirmTiprackFailure (
       inProgress: false,
       error
     }
-  }
-}
-
-function handleSetJogDistance (state: State, action: any) {
-  return {
-    ...state,
-    jogDistance: Number(action.payload)
   }
 }
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -432,10 +432,6 @@ export function getOffsetUpdateInProgress (state: State): boolean {
   return request.type === 'UPDATE_OFFSET' && request.inProgress
 }
 
-export function getJogDistance (state: State): number {
-  return calibration(state).jogDistance
-}
-
 // get current instrument selector factory
 // to be used by a react-router Route component
 export const makeGetCurrentInstrument = () => createSelector(

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -298,19 +298,14 @@ describe('robot actions', () => {
     expect(actions.moveToResponse(new Error('AH'))).toEqual(failure)
   })
 
-  test('set jog distance action', () => {
-    const expected = {type: 'robot:SET_JOG_DISTANCE', payload: 10}
-    expect(actions.setJogDistance(10)).toEqual(expected)
-  })
-
   test('JOG action', () => {
     const expected = {
       type: 'robot:JOG',
-      payload: {mount: 'left', axis: 'x', direction: -1},
+      payload: {mount: 'left', axis: 'x', direction: -1, step: 10},
       meta: {robotCommand: true}
     }
 
-    expect(actions.jog('left', 'x', -1)).toEqual(expected)
+    expect(actions.jog('left', 'x', -1, 10)).toEqual(expected)
   })
 
   test('jog response action', () => {

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -422,8 +422,7 @@ describe('api client', () => {
           calibration: {
             calibrationRequest: {},
             confirmedBySlot: {},
-            labwareBySlot: {},
-            jogDistance: constants.JOG_DISTANCE_FAST_MM
+            labwareBySlot: {}
           },
           session: {
             instrumentsByMount: {
@@ -670,7 +669,7 @@ describe('api client', () => {
     })
 
     test('handles JOG success', () => {
-      const action = actions.jog('left', 'y', -1)
+      const action = actions.jog('left', 'y', -1, 10)
       const expectedResponse = actions.jogResponse()
 
       mockResolvedValue(calibrationManager.jog)
@@ -680,7 +679,7 @@ describe('api client', () => {
         .then(() => {
           expect(calibrationManager.jog).toHaveBeenCalledWith(
             {_id: 'inst-2'},
-            -constants.JOG_DISTANCE_FAST_MM,
+            -10,
             'y'
           )
           expect(dispatch).toHaveBeenCalledWith(expectedResponse)
@@ -688,7 +687,7 @@ describe('api client', () => {
     })
 
     test('handles JOG failure', () => {
-      const action = actions.jog('left', 'x', 1)
+      const action = actions.jog('left', 'x', 1, 10)
       const expectedResponse = actions.jogResponse(new Error('AH'))
 
       mockRejectedValue(calibrationManager.jog, new Error('AH'))

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -1,25 +1,32 @@
 // calibration reducer tests
 import {reducer, actionTypes} from '../'
 
+const EXPECTED_INITIAL_STATE = {
+  deckPopulated: null,
+
+  // intrument probed + basic tip-tracking flags
+  // TODO(mc, 2018-01-22): combine these into subreducer
+  probedByMount: {},
+  tipOnByMount: {},
+
+  // labware confirmed flags
+  confirmedBySlot: {},
+
+  // TODO(mc, 2018-01-22): make this state a sub-reducer
+  calibrationRequest: {type: '', inProgress: false, error: null}
+}
+
 describe('robot reducer - calibration', () => {
   test('initial state', () => {
-    const state = reducer(undefined, {}).calibration
+    const state = reducer(undefined, {})
 
-    expect(state).toEqual({
-      deckPopulated: null,
-      jogDistance: 0.1,
+    expect(state.calibration).toEqual(EXPECTED_INITIAL_STATE)
+  })
 
-      // intrument probed + basic tip-tracking flags
-      // TODO(mc, 2018-01-22): combine these into subreducer
-      probedByMount: {},
-      tipOnByMount: {},
+  test('handles robot:REFRESH_SESSION', () => {
+    const state = reducer({calibration: {}}, {type: 'robot:REFRESH_SESSION'})
 
-      // labware confirmed flags
-      confirmedBySlot: {},
-
-      // TODO(mc, 2018-01-22): make this state a sub-reducer
-      calibrationRequest: {type: '', inProgress: false, error: null}
-    })
+    expect(state.calibration).toEqual(EXPECTED_INITIAL_STATE)
   })
 
   test('handles DISCONNECT_RESPONSE success', () => {
@@ -508,19 +515,6 @@ describe('robot reducer - calibration', () => {
         mount: 'right',
         slot: '5'
       }
-    })
-  })
-
-  test('handles SET_JOG_DISTANCE action', () => {
-    const state = {
-      calibration: {
-        jogDistance: 10
-      }
-    }
-
-    const action = {type: 'robot:SET_JOG_DISTANCE', payload: 1}
-    expect(reducer(state, action).calibration).toEqual({
-      jogDistance: 1
     })
   })
 

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -26,7 +26,6 @@ const {
   getUnconfirmedTipracks,
   getUnconfirmedLabware,
   getNextLabware,
-  getJogDistance,
   makeGetCurrentInstrument
 } = selectors
 
@@ -425,14 +424,6 @@ describe('robot selectors', () => {
       props = {match: {params: {}}}
       expect(getCurrentInstrument(state, props)).toBeFalsy()
     })
-  })
-
-  test('get jog distance', () => {
-    const state = makeState({
-      calibration: {jogDistance: constants.JOG_DISTANCE_SLOW_MM}
-    })
-
-    expect(getJogDistance(state)).toBe(constants.JOG_DISTANCE_SLOW_MM)
   })
 
   test('get calibrator mount', () => {

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -77,34 +77,11 @@ describe('robot reducer - session', () => {
   })
 
   test('handles robot:REFRESH_SESSION action', () => {
-    const INITIAL_CALIBRATION_STATE = {
-      deckPopulated: null,
-      jogDistance: 0.1,
-
-      // TODO(mc, 2018-01-22): combine these into subreducer
-      probedByMount: {},
-      tipOnByMount: {},
-
-      confirmedBySlot: {},
-
-      calibrationRequest: {type: '', inProgress: false, error: null}
-    }
-
     const state = {
       session: {
         sessionRequest: {inProgress: false, error: null},
         startTime: 40,
         runTime: 42
-      },
-      calibration: {
-        deckPopulated: true,
-        jogDistance: 1,
-        probedByMount: {
-          left: true
-        },
-        confirmedBySlot: {
-          9: true
-        }
       }
     }
     const action = {type: 'robot:REFRESH_SESSION'}
@@ -114,7 +91,6 @@ describe('robot reducer - session', () => {
       startTime: null,
       runTime: 0
     })
-    expect(reducer(state, action).calibration).toEqual(INITIAL_CALIBRATION_STATE)
   })
 
   test('handles SESSION_RESPONSE success', () => {


### PR DESCRIPTION
## overview

This PR removes the `calibration.js` module specific `api:CAL_REQUEST`, etc actions in favor of
the new, generic `api:REQUEST`, etc actions. Making the calibration module more generic also meant moving the jog step size out of redux and into the state of the `JogControls` component, as had been discussed with @b-cooper.

This PR is prep work for a `modules.js` API client module for #1735 and continues work started in #1813.

## changelog

- refactor(app): Use generic actions in /calibration API module 

## review requests

The following peices of logic have been touched, and we should verify all is still well:

- [ ] Token release clears `/calibration/deck/start` response state
    - Happens whenever you click "Exit" in Deck Calibration
- [ ] Jogging in Deck Calibration
- [ ] Jogging in runtime Labware Calibration
