### PR TITLE
refactor(app): Refactor /health modules to use generic API actions

### DIFF
--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -11,7 +11,7 @@ import {
   actions as robotActions
 } from '../../robot'
 
-import {makeGetHealthCheckOk} from '../../http-api-client'
+import {makeGetHealthCheckOk} from '../../health-check'
 
 import {AlertModal} from '@opentrons/components'
 import ModalCopy from './ModalCopy'

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -2,7 +2,7 @@
 // config redux module
 import {setIn} from '@thi.ng/paths'
 import {getShellConfig} from '../shell'
-import type {State, Action} from '../types'
+import type {State, Action, ThunkAction} from '../types'
 import type {LogLevel} from '../logger'
 
 type UrlProtocol = 'file:' | 'http:'
@@ -95,7 +95,7 @@ export function getModulesOn (state: State): boolean {
   return state.config.modules
 }
 
-export function toggleDevTools (): Action {
+export function toggleDevTools (): ThunkAction {
   return (dispatch, getState) => {
     const devToolsOn = getDevToolsOn(getState())
     return dispatch(updateConfig('devtools', !devToolsOn))

--- a/app/src/http-api-client/__tests__/health.test.js
+++ b/app/src/http-api-client/__tests__/health.test.js
@@ -10,9 +10,10 @@ jest.mock('../client')
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
+const path = 'health'
 const name = 'opentrons-dev'
 const robot = {name, ip: '1.2.3.4', port: '1234'}
-const health = {name, api_version: '1.2.3', fw_version: '4.5.6'}
+const response = {name, api_version: '1.2.3', fw_version: '4.5.6'}
 
 describe('health', () => {
   beforeEach(() => client.__clearMock())
@@ -22,9 +23,11 @@ describe('health', () => {
       api: {
         health: {
           [name]: {
-            inProgress: true,
-            error: null,
-            response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+            [path]: {
+              inProgress: true,
+              error: null,
+              response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+            }
           }
         }
       }
@@ -48,39 +51,35 @@ describe('health', () => {
 
     const getRobotHealth = makeGetRobotHealth()
 
-    expect(getRobotHealth(state, {name})).toEqual({
-      inProgress: false,
-      error: null,
-      response: null
-    })
+    expect(getRobotHealth(state, {name})).toEqual({inProgress: false})
   })
 
   test('fetchHealth calls GET /health', () => {
-    client.__setMockResponse(health)
+    client.__setMockResponse(response)
 
     return fetchHealth(robot)(() => {})
       .then(() => expect(client).toHaveBeenCalledWith(robot, 'GET', 'health'))
   })
 
-  test('fetchHealth dispatches HEALTH_REQUEST and HEALTH_SUCCESS', () => {
+  test('fetchHealth dispatches api:REQUEST and api:SUCCESS', () => {
     const store = mockStore({})
     const expectedActions = [
-      {type: 'api:HEALTH_REQUEST', payload: {robot}},
-      {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+      {type: 'api:REQUEST', payload: {robot, path, request: null}},
+      {type: 'api:SUCCESS', payload: {robot, path, response}}
     ]
 
-    client.__setMockResponse(health)
+    client.__setMockResponse(response)
 
     return store.dispatch(fetchHealth(robot))
       .then(() => expect(store.getActions()).toEqual(expectedActions))
   })
 
-  test('fetchHealth dispatches HEALTH_REQUEST and HEALTH_FAILURE', () => {
+  test('fetchHealth dispatches api:REQUEST and api:FAILURE', () => {
     const error = new Error('AH')
     const store = mockStore({})
     const expectedActions = [
-      {type: 'api:HEALTH_REQUEST', payload: {robot}},
-      {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
+      {type: 'api:REQUEST', payload: {robot, path, request: null}},
+      {type: 'api:FAILURE', payload: {robot, path, error}}
     ]
 
     client.__setMockError(error)
@@ -89,20 +88,22 @@ describe('health', () => {
       .then(() => expect(store.getActions()).toEqual(expectedActions))
   })
 
-  test('reducer handles HEALTH_REQUEST', () => {
+  test('reducer handles api:REQUEST', () => {
     const state = {
       health: {
         [name]: {
-          inProgress: false,
-          error: new Error('AH'),
-          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          [path]: {
+            inProgress: false,
+            error: new Error('AH'),
+            response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          }
         }
       }
     }
-    const action = {type: 'api:HEALTH_REQUEST', payload: {robot}}
+    const action = {type: 'api:REQUEST', payload: {robot, path}}
 
-    expect(reducer(state, action).health).toEqual({
-      [name]: {
+    expect(reducer(state, action).health[name]).toEqual({
+      [path]: {
         inProgress: true,
         error: null,
         response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
@@ -110,21 +111,23 @@ describe('health', () => {
     })
   })
 
-  test('reducer handles HEALTH_SUCCESS', () => {
-    const health = {name, api_version: '4.5.6', fw_version: '7.8.9'}
+  test('reducer handles api:SUCCESS', () => {
+    const response = {name, api_version: '4.5.6', fw_version: '7.8.9'}
     const state = {
       health: {
         [name]: {
-          inProgress: true,
-          error: null,
-          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          [path]: {
+            inProgress: true,
+            error: null,
+            response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          }
         }
       }
     }
-    const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+    const action = {type: 'api:SUCCESS', payload: {robot, path, response}}
 
-    expect(reducer(state, action).health).toEqual({
-      [name]: {
+    expect(reducer(state, action).health[name]).toEqual({
+      [path]: {
         inProgress: false,
         error: null,
         response: {name, api_version: '4.5.6', fw_version: '7.8.9'}
@@ -132,21 +135,23 @@ describe('health', () => {
     })
   })
 
-  test('reducer handles HEALTH_FAILURE', () => {
+  test('reducer handles api:FAILURE', () => {
     const error = new Error('AH')
     const state = {
       health: {
         [name]: {
-          inProgress: true,
-          error: null,
-          response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          [path]: {
+            inProgress: true,
+            error: null,
+            response: {name, api_version: '1.2.3', fw_version: '4.5.6'}
+          }
         }
       }
     }
-    const action = {type: 'api:HEALTH_FAILURE', payload: {robot, error}}
+    const action = {type: 'api:FAILURE', payload: {robot, path, error}}
 
-    expect(reducer(state, action).health).toEqual({
-      [name]: {
+    expect(reducer(state, action).health[name]).toEqual({
+      [path]: {
         inProgress: false,
         error,
         response: {name, api_version: '1.2.3', fw_version: '4.5.6'}

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -252,9 +252,12 @@ describe('server API client', () => {
       }
     }))
 
-    test('sets availableUpdate on HEALTH_SUCCESS', () => {
+    test('sets availableUpdate on /health api:SUCCESS', () => {
       const health = {name, api_version: 'foobar', fw_version: '7.8.9'}
-      const action = {type: 'api:HEALTH_SUCCESS', payload: {robot, health}}
+      const action = {
+        type: 'api:SUCCESS',
+        payload: {robot, path: 'health', response: health}
+      }
 
       // test update available
       state.server[robot.name].availableUpdate = null
@@ -267,7 +270,7 @@ describe('server API client', () => {
       })
 
       // test no update available
-      action.payload.health.api_version = mockApiUpdate.AVAILABLE_UPDATE
+      action.payload.response.api_version = mockApiUpdate.AVAILABLE_UPDATE
       state.server[robot.name].availableUpdate = mockApiUpdate.AVAILABLE_UPDATE
       expect(reducer(state, action).server).toEqual({
         [robot.name]: {availableUpdate: null, update: null, restart: null}

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -3,7 +3,7 @@
 
 import type {Error} from '../types'
 import type {RobotService} from '../robot'
-import type {ApiRequestError} from './client'
+import type {ApiRequestError} from './types'
 
 type Method = 'GET' | 'POST'
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -3,7 +3,6 @@
 import {combineReducers} from 'redux'
 import {calibrationReducer, type CalibrationAction} from './calibration'
 import {healthReducer, type HealthAction} from './health'
-import {healthCheckReducer, type HealthCheckAction} from './health-check'
 import {motorsReducer, type MotorsAction} from './motors'
 import {pipettesReducer, type PipettesAction} from './pipettes'
 import {robotReducer, type RobotAction} from './robot'
@@ -14,7 +13,6 @@ import {wifiReducer, type WifiAction} from './wifi'
 export const reducer = combineReducers({
   calibration: calibrationReducer,
   health: healthReducer,
-  healthCheck: healthCheckReducer,
   motors: motorsReducer,
   pipettes: pipettesReducer,
   robot: robotReducer,
@@ -26,6 +24,13 @@ export const reducer = combineReducers({
 export * from './types'
 
 export type {
+  ApiRequestAction,
+  ApiSuccessAction,
+  ApiFailureAction,
+  ClearApiResponseAction
+} from './actions'
+
+export type {
   DeckCalStartState,
   DeckCalCommandState,
   JogAxis,
@@ -35,9 +40,7 @@ export type {
 } from './calibration'
 
 export type {
-  RobotHealth,
-  HealthSuccessAction,
-  HealthFailureAction
+  RobotHealth
 } from './health'
 
 export type {
@@ -76,7 +79,6 @@ export type State = $Call<typeof reducer>
 export type Action =
   | CalibrationAction
   | HealthAction
-  | HealthCheckAction
   | MotorsAction
   | PipettesAction
   | RobotAction
@@ -95,16 +97,6 @@ export {
   fetchHealth,
   makeGetRobotHealth
 } from './health'
-
-export {
-  startHealthCheck,
-  stopHealthCheck,
-  setHealthCheckId,
-  clearHealthCheckId,
-  resetHealthCheck,
-  healthCheckMiddleware,
-  makeGetHealthCheckOk
-} from './health-check'
 
 export {
   disengagePipetteMotors

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -202,11 +202,13 @@ export function serverReducer (
         }
       }
 
-    case 'api:HEALTH_SUCCESS':
-      ({robot: {name}} = action.payload)
+    // TODO(mc, 2018-07-05): this logic should live in a selector
+    case 'api:SUCCESS': {
+      if (action.payload.path !== 'health') return state
+      const name = action.payload.robot.name
       let stateByName = state[name]
       const previousUpdate = stateByName && stateByName.availableUpdate
-      const currentVersion = action.payload.health.api_version
+      const currentVersion = action.payload.response.api_version
       const availableUpdate = currentVersion !== AVAILABLE_UPDATE
         ? AVAILABLE_UPDATE
         : null
@@ -216,6 +218,7 @@ export function serverReducer (
       }
 
       return {...state, [name]: {...stateByName, availableUpdate}}
+    }
   }
 
   return state

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -11,7 +11,7 @@ import {ConnectedRouter, routerMiddleware} from 'react-router-redux'
 import createLogger from './logger'
 import {checkForShellUpdates, shellMiddleware} from './shell'
 
-import {healthCheckMiddleware} from './http-api-client'
+import {healthCheckMiddleware} from './health-check'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {initializeAnalytics, analyticsMiddleware} from './analytics'
 

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -9,6 +9,8 @@ import {NAME as ROBOT_NAME, reducer as robotReducer} from './robot'
 // api state
 import {reducer as httpApiReducer} from './http-api-client'
 
+import {healthCheckReducer} from './health-check'
+
 // app shell state
 import {shellReducer} from './shell'
 
@@ -19,6 +21,7 @@ export default combineReducers({
   [ROBOT_NAME]: robotReducer,
   api: httpApiReducer,
   config: configReducer,
+  healthCheck: healthCheckReducer,
   shell: shellReducer,
   router: routerReducer
 })

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -228,7 +228,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('adds wired robot to discovered on HEALTH_SUCCESS', () => {
+  test('adds wired robot to discovered on /health api:SUCCESS', () => {
     const state = {
       connection: {
         discovered: ['foo'],
@@ -239,9 +239,10 @@ describe('robot reducer - connection', () => {
     }
 
     const action = {
-      type: 'api:HEALTH_SUCCESS',
+      type: 'api:SUCCESS',
       payload: {
-        robot: {name: 'bar', host: 'ghijkl.local', wired: true}
+        robot: {name: 'bar', host: 'ghijkl.local', wired: true},
+        path: 'health'
       }
     }
 
@@ -254,7 +255,7 @@ describe('robot reducer - connection', () => {
     })
   })
 
-  test('removes wired robot from discovered on HEALTH_FAILURE', () => {
+  test('removes wired robot from discovered on /health api:FAILURE', () => {
     const state = {
       connection: {
         discovered: ['foo', 'bar'],
@@ -266,9 +267,10 @@ describe('robot reducer - connection', () => {
     }
 
     const action = {
-      type: 'api:HEALTH_FAILURE',
+      type: 'api:FAILURE',
       payload: {
-        robot: {name: 'bar', host: 'ghijkl.local', wired: true}
+        robot: {name: 'bar', host: 'ghijkl.local', wired: true},
+        path: 'health'
       }
     }
 

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -10,6 +10,7 @@ import type {RouterAction} from 'react-router-redux'
 
 import typeof reducer from './reducer'
 import type {Action as RobotAction} from './robot'
+import type {HealthCheckAction} from './health-check'
 import type {Action as HttpApiAction} from './http-api-client'
 import type {ShellAction} from './shell'
 import type {ConfigAction} from './config'
@@ -20,6 +21,7 @@ export type GetState = () => State
 
 export type Action =
   | RobotAction
+  | HealthCheckAction
   | HttpApiAction
   | ShellAction
   | ConfigAction


### PR DESCRIPTION
## overview

This PR continues the work of #1813 and #1819 by switching the `/health` API client module over to generic API actions. As part of this effort, the `health-check` module was moved to be a sibling rather than child of the API reducer to separate the states in preparation for a simplified API reducer.

## changelog

- refactor(app): Refactor /health modules to use generic API actions 

## review requests

Stuff that was touched:

- [x] Health check routine for connected robot (and offline detection)
    - I like to test this by connecting to a robot and then turning off wifi or killing the VS process
- [x] Robot information card
- [x] Robot update logic and notification
    - I test this by bumping the version in `app-shell/package.json` before launching `make -C app dev`

I tested on Sunset and it looked good to me

This all l