### PR TITLE
feat(protocol-designer): support distribute with volume over pipette max

### DIFF
--- a/protocol-designer/src/step-generation/distribute.js
+++ b/protocol-designer/src/step-generation/distribute.js
@@ -7,7 +7,7 @@ import {aspirate, dispense, blowout, replaceTip, touchTip, reduceCommandCreators
 import transfer from './transfer'
 import {mixUtil} from './mix'
 import * as errorCreators from './errorCreators'
-import type {DistributeFormData, RobotState, CommandCreator} from './'
+import type {DistributeFormData, RobotState, CommandCreator, TransferLikeFormDataFields, TransferFormData} from './'
 
 const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState: RobotState) => {
   /**
@@ -51,27 +51,13 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
   if (maxWellsPerChunk === 0) {
     // distribute vol exceeds pipette vol, break up into 1 transfer per dest well
     const transferCommands = data.destWells.map((destWell) => {
-      const transferData = {
+      const transferData: TransferFormData = {
+        ...(data: TransferLikeFormDataFields),
         stepType: 'transfer',
         sourceWells: [data.sourceWell],
         destWells: [destWell],
-        mixInDestination: null,
-
-        // can't do `...data` b/c of flow, must be explicit:
-        name: data.name,
-        description: data.description,
-        volume: data.volume,
-        blowout: data.blowout,
-        changeTip: data.changeTip,
-        delayAfterDispense: data.delayAfterDispense,
-        destLabware: data.destLabware,
-        disposalVolume: data.disposalVolume,
         mixBeforeAspirate: data.mixBeforeAspirate,
-        pipette: data.pipette,
-        preWetTip: data.preWetTip,
-        sourceLabware: data.sourceLabware,
-        touchTipAfterAspirate: data.touchTipAfterAspirate,
-        touchTipAfterDispense: data.touchTipAfterDispense
+        mixInDestination: null
       }
       return transfer(transferData)
     })

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -417,80 +417,102 @@ describe('invalid input + state errors', () => {
   })
 })
 
-describe('weirdos TBD', () => {
-  // TODO Ian 2018-05-03 is this a valid distribute?
-  // It's gonna be equivalent to a transfer under the hood anyway, right?
-  // SKIPPING for now
-  // I think this is also an issue with consolidate!
-  test.skip('each well exceeds pipette max vol', () => {
+describe('distribute volume exceeds pipette max volume', () => {
+  test(`change tip: always`, () => {
+    const changeTip = 'always'
     const distributeArgs: DistributeFormData = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
-      changeTip: 'never', // TODO additional test with changeTip='always'
+      changeTip,
       volume: 350,
-      blowout: null
+      blowout: null // TODO additional test with blowout
     }
     const result = distribute(distributeArgs)(robotInitialState)
 
     expect(result.commands).toEqual([
-      {
-        command: 'aspirate',
-        labware: 'sourcePlateId',
-        pipette: 'p300SingleId',
-        volume: 300,
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        labware: 'destPlateId',
-        pipette: 'p300SingleId',
-        volume: 300,
-        well: 'A2'
-      },
-      {
-        command: 'aspirate',
-        labware: 'sourcePlateId',
-        pipette: 'p300SingleId',
-        volume: 50,
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        labware: 'destPlateId',
-        pipette: 'p300SingleId',
-        volume: 50,
-        well: 'A2'
-      },
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 300),
+      dispense('A2', 300),
+
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('B1'),
+
+      cmd.aspirate('A1', 50),
+      dispense('A2', 50),
+
       // A2 done, move to A3
-      {
-        command: 'aspirate',
-        labware: 'sourcePlateId',
-        pipette: 'p300SingleId',
-        volume: 300,
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        labware: 'destPlateId',
-        pipette: 'p300SingleId',
-        volume: 300,
-        well: 'A3'
-      },
-      {
-        command: 'aspirate',
-        labware: 'sourcePlateId',
-        pipette: 'p300SingleId',
-        volume: 50,
-        well: 'A1'
-      },
-      {
-        command: 'dispense',
-        labware: 'destPlateId',
-        pipette: 'p300SingleId',
-        volume: 50,
-        well: 'A3'
-      }
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('C1'),
+
+      cmd.aspirate('A1', 300),
+      dispense('A3', 300),
+
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('D1'),
+
+      cmd.aspirate('A1', 50),
+      dispense('A3', 50)
+    ])
+  })
+
+  test(`change tip: once`, () => {
+    const changeTip = 'once'
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3'],
+      changeTip,
+      volume: 350,
+      blowout: null // TODO additional test with blowout
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 300),
+      dispense('A2', 300),
+      cmd.aspirate('A1', 50),
+      dispense('A2', 50),
+
+      // A2 done, move to A3
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('B1'),
+
+      cmd.aspirate('A1', 300),
+      dispense('A3', 300),
+      cmd.aspirate('A1', 50),
+      dispense('A3', 50)
+    ])
+  })
+
+  test(`change tip: never`, () => {
+    const changeTip = 'never'
+    const distributeArgs: DistributeFormData = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3'],
+      changeTip,
+      volume: 350,
+      blowout: null // TODO additional test with blowout
+    }
+    const result = distribute(distributeArgs)(robotInitialState)
+
+    expect(result.commands).toEqual([
+      cmd.aspirate('A1', 300),
+      dispense('A2', 300),
+      cmd.aspirate('A1', 50),
+      dispense('A2', 50),
+
+      // A2 done, move to A3
+      cmd.aspirate('A1', 300),
+      dispense('A3', 300),
+      cmd.aspirate('A1', 50),
+      dispense('A3', 50)
     ])
   })
 })


### PR DESCRIPTION
## overview

Closes #1763

## changelog

- support distribute step when volume exceeds pipette max

## review requests

Create a distribute step with a volume greater than the pipette max (eg P10 distributing 11uL). Instead of generating an empty step, it should act as expected.