### PR TITLE
fix(app): Call GET /pipettes before starting calibration

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,8 @@
 .*/coverage/.*
 .*/docs/.*
 api/.*
+api-server-lib/.*
+update-server/.*
 
 [include]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -5,6 +5,8 @@
 .*/docs/.*
 api/.*
 api-server-lib/.*
+audio/.*
+compute/.*
 update-server/.*
 
 [include]

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -5,31 +5,34 @@ import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 
 import type {State} from '../../types'
+import type {RobotService} from '../../robot'
 
 import {
   selectors as robotSelectors,
   constants as robotConstants
 } from '../../robot'
-import {getAnyRobotUpdateAvailable} from '../../http-api-client'
+import {getAnyRobotUpdateAvailable, fetchPipettes} from '../../http-api-client'
 import {getShellUpdate} from '../../shell'
 
-import type {IconName} from '@opentrons/components'
 import {NavButton} from '@opentrons/components'
 
-type OwnProps = {
+type Props = React.ElementProps<typeof NavButton>
+
+type OP = {
   name: string
 }
 
-type StateProps = {
-  iconName: IconName,
-  title?: string,
-  url?: string
+type SP = Props & {
+  _robot: ?RobotService,
 }
 
-export default withRouter(connect(mapStateToProps)(NavButton))
+type DP = {dispatch: Dispatch}
 
-function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
+export default withRouter(connect(mapStateToProps, null, mergeProps)(NavButton))
+
+function mapStateToProps (state: State, ownProps: OP): SP {
   const {name} = ownProps
+  const _robot = robotSelectors.getConnectedRobot(state)
   const isProtocolLoaded = robotSelectors.getSessionIsLoaded(state)
   const isProtocolRunning = robotSelectors.getIsRunning(state)
   const isProtocolDone = robotSelectors.getIsDone(state)
@@ -73,5 +76,20 @@ function mapStateToProps (state: State, ownProps: OwnProps): StateProps {
     }
   }
 
-  return NAV_ITEM_BY_NAME[name]
+  return {...NAV_ITEM_BY_NAME[name], _robot}
+}
+
+function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
+  const {dispatch} = dispatchProps
+  const {_robot, url, disabled} = stateProps
+  let sp = stateProps
+
+  if (_robot && url === '/calibrate' && !disabled) {
+    sp = {...stateProps, onClick: () => dispatch(fetchPipettes(_robot))}
+  }
+
+  return {
+    ...ownProps,
+    ...sp
+  }
 }

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -82,14 +82,11 @@ function mapStateToProps (state: State, ownProps: OP): SP {
 function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   const {dispatch} = dispatchProps
   const {_robot, url, disabled} = stateProps
-  let sp = stateProps
+  let props: Props = {...ownProps, ...stateProps}
 
   if (_robot && url === '/calibrate' && !disabled) {
-    sp = {...stateProps, onClick: () => dispatch(fetchPipettes(_robot))}
+    props = {...props, onClick: () => dispatch(fetchPipettes(_robot))}
   }
 
-  return {
-    ...ownProps,
-    ...sp
-  }
+  return props
 }


### PR DESCRIPTION
## overview

This PR is serving as the bug report and fix.

By moving the pipettes card to a different page in #1785, we lost a little side-effect we were relying on whereby clicking "Connect" would always open the "Pipettes" card, thereby ensuring that a `GET /pipettes` call had been made before the user eventually got to the "Calibrate" page. With pipettes on a separate page from the "Connect" button, the user can make it to "Calibrate" without `GET /pipettes` ever being called, resulting in an erroneous "Incorrect Pipettes Attached" warning message.

This PR adds a `GET /pipettes` call to the onClick handler of the "Calibrate" nav button to ensure we always have the pipette state we need before starting calibration.

## changelog

- fix(app): Call GET /pipettes before starting calibration 

## review requests

1. Connect to robot
2. Upload protocol
3. Go to "Calibrate" page
    - [ ] App makes `GET /pipettes` request
    - [ ] Calibrate page does not show "Incorrect Pipette" warnings if robot has correct pipettes for protocol