### PR TITLE
refactor(app): Refactor pipette selectors and types

### DIFF
--- a/app/src/components/CalibrateLabware/ConfirmModalContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmModalContents.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 
 import {
   selectors as robotSelectors,
-  type Instrument,
+  type Pipette,
   type Labware
 } from '../../robot'
 
@@ -16,7 +16,7 @@ import InProgressContents from './InProgressContents'
 type OwnProps = Labware
 
 type StateProps = {
-  calibrator: ?Instrument
+  calibrator: ?Pipette
 }
 
 type Props = OwnProps & StateProps
@@ -48,9 +48,9 @@ function ConfirmModalContents (props: Props) {
 
 function mapStateToProps (state, ownProps: OwnProps): StateProps {
   const calibratorMount = ownProps.calibratorMount
-  const instruments = robotSelectors.getInstruments(state)
+  const pipettes = robotSelectors.getPipettes(state)
   const calibrator = (
-    instruments.find((i) => i.mount === calibratorMount) ||
+    pipettes.find((i) => i.mount === calibratorMount) ||
     robotSelectors.getCalibrator(state)
   )
 

--- a/app/src/components/CalibrateLabware/ConfirmPickupContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPickupContents.js
@@ -6,13 +6,13 @@ import {connect} from 'react-redux'
 import {
   actions as robotActions,
   type Labware,
-  type Instrument
+  type Pipette
 } from '../../robot'
 
 import ConfirmPickupPrompt from './ConfirmPickupPrompt'
 
 type OwnProps = Labware & {
-  calibrator: Instrument
+  calibrator: Pipette
 }
 
 type DispatchProps = {

--- a/app/src/components/CalibrateLabware/ConfirmPickupPrompt.js
+++ b/app/src/components/CalibrateLabware/ConfirmPickupPrompt.js
@@ -2,13 +2,13 @@
 // pickup confirmation prompt component for ConfirmPickupContents
 import * as React from 'react'
 
-import type {Labware, Instrument} from '../../robot'
+import type {Labware, Pipette} from '../../robot'
 
 import {PrimaryButton} from '@opentrons/components'
 import styles from './styles.css'
 
 type Props = Labware & {
-  calibrator: Instrument,
+  calibrator: Pipette,
   onNoClick: () => void,
   onYesClick: () => void
 }

--- a/app/src/components/CalibrateLabware/ConfirmPositionContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionContents.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 
 import type {Dispatch} from '../../types'
-import type {Instrument, Labware} from '../../robot'
+import type {Pipette, Labware} from '../../robot'
 
 import {actions as robotActions} from '../../robot'
 import {PrimaryButton} from '@opentrons/components'
@@ -17,7 +17,7 @@ type DP = {
 }
 
 type OP = Labware & {
-  calibrator: Instrument
+  calibrator: Pipette
 }
 
 type Props = DP & OP

--- a/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
@@ -2,13 +2,13 @@
 // diagram and instructions for ConfirmPositionContents
 import * as React from 'react'
 
-import type {Labware, Instrument} from '../../robot'
+import type {Labware, Pipette} from '../../robot'
 import InstructionStep from '../InstructionStep'
 import {getInstructionsByType, getDiagramSrc} from './instructions-data'
 import styles from '../InstructionStep/styles.css'
 
 export type LabwareCalibrationProps = Labware & {
-  calibrator: Instrument,
+  calibrator: Pipette,
   buttonText: string
 }
 

--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -6,14 +6,14 @@ import {withRouter} from 'react-router'
 import {
   constants as robotConstants,
   selectors as robotSelectors,
-  type Instrument
+  type Pipette
 } from '../../robot'
 
 import {TitledList} from '@opentrons/components'
 import PipetteListItem from './PipetteListItem'
 
 type Props = {
-  instruments: Instrument[],
+  pipettes: Pipette[],
   isRunning: boolean,
 }
 
@@ -22,16 +22,16 @@ const TITLE = 'Pipette Calibration'
 export default withRouter(connect(mapStateToProps)(PipetteList))
 
 function PipetteList (props: Props) {
-  const {instruments, isRunning} = props
+  const {pipettes, isRunning} = props
 
   return (
     <TitledList title={TITLE}>
-      {robotConstants.INSTRUMENT_MOUNTS.map((mount) => (
+      {robotConstants.PIPETTE_MOUNTS.map((mount) => (
         <PipetteListItem
           key={mount}
           mount={mount}
           isRunning={isRunning}
-          instrument={instruments.find((i) => i.mount === mount)}
+          instrument={pipettes.find((i) => i.mount === mount)}
         />
       ))}
     </TitledList>
@@ -40,7 +40,7 @@ function PipetteList (props: Props) {
 
 function mapStateToProps (state): Props {
   return {
-    instruments: robotSelectors.getInstruments(state),
+    pipettes: robotSelectors.getPipettes(state),
     isRunning: robotSelectors.getIsRunning(state)
   }
 }

--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -13,7 +13,7 @@ import {TitledList} from '@opentrons/components'
 import PipetteListItem from './PipetteListItem'
 
 type Props = {
-  pipettes: Pipette[],
+  pipettes: Array<Pipette>,
   isRunning: boolean,
 }
 
@@ -31,7 +31,7 @@ function PipetteList (props: Props) {
           key={mount}
           mount={mount}
           isRunning={isRunning}
-          instrument={pipettes.find((i) => i.mount === mount)}
+          pipette={pipettes.find((i) => i.mount === mount)}
         />
       ))}
     </TitledList>

--- a/app/src/components/CalibratePanel/PipetteListItem.js
+++ b/app/src/components/CalibratePanel/PipetteListItem.js
@@ -13,13 +13,13 @@ import styles from './styles.css'
 type Props = {
   isRunning: boolean,
   mount: Mount,
-  instrument: ?Pipette
+  pipette: ?Pipette
 }
 
 export default function PipetteListItem (props: Props) {
-  const {isRunning, mount, instrument} = props
-  const confirmed = instrument && instrument.probed
-  const isDisabled = !instrument || isRunning
+  const {isRunning, mount, pipette} = props
+  const confirmed = pipette && pipette.probed
+  const isDisabled = !pipette || isRunning
   const url = !isDisabled
     ? `/calibrate/pipettes/${mount}`
     : '#'
@@ -28,12 +28,12 @@ export default function PipetteListItem (props: Props) {
     ? 'check-circle'
     : 'checkbox-blank-circle-outline'
 
-  const description = instrument
-    ? `${capitalize(instrument.channels === 8 ? 'multi' : 'single')}-channel`
+  const description = pipette
+    ? `${capitalize(pipette.channels === 8 ? 'multi' : 'single')}-channel`
     : 'N/A'
 
-  const name = instrument
-    ? instrument.name
+  const name = pipette
+    ? pipette.name
     : 'N/A'
 
   return (

--- a/app/src/components/CalibratePanel/PipetteListItem.js
+++ b/app/src/components/CalibratePanel/PipetteListItem.js
@@ -7,13 +7,13 @@ import {
   type IconName
 } from '@opentrons/components'
 
-import type {Mount, Instrument} from '../../robot'
+import type {Mount, Pipette} from '../../robot'
 import styles from './styles.css'
 
 type Props = {
   isRunning: boolean,
   mount: Mount,
-  instrument: ?Instrument
+  instrument: ?Pipette
 }
 
 export default function PipetteListItem (props: Props) {

--- a/app/src/components/TipProbe/ContinuePanel.js
+++ b/app/src/components/TipProbe/ContinuePanel.js
@@ -38,11 +38,11 @@ function RemoveTipPanel (props: Props) {
 }
 
 function mapStateToProps (state: State): SP {
-  const instruments = robotSelectors.getPipettes(state)
-  const nextInstrument = instruments.find((inst) => !inst.probed)
-  const buttonText = nextInstrument
+  const pipettes = robotSelectors.getPipettes(state)
+  const nextPipette = pipettes.find((pipette) => !pipette.probed)
+  const buttonText = nextPipette
     ? 'Continue to next pipette'
     : 'Continue to labware setup'
 
-  return {buttonText, done: nextInstrument == null}
+  return {buttonText, done: nextPipette == null}
 }

--- a/app/src/components/TipProbe/ContinuePanel.js
+++ b/app/src/components/TipProbe/ContinuePanel.js
@@ -38,7 +38,7 @@ function RemoveTipPanel (props: Props) {
 }
 
 function mapStateToProps (state: State): SP {
-  const instruments = robotSelectors.getInstruments(state)
+  const instruments = robotSelectors.getPipettes(state)
   const nextInstrument = instruments.find((inst) => !inst.probed)
   const buttonText = nextInstrument
     ? 'Continue to next pipette'

--- a/app/src/components/TipProbe/index.js
+++ b/app/src/components/TipProbe/index.js
@@ -2,7 +2,7 @@
 // TipProbe controls
 import * as React from 'react'
 
-import type {Instrument, InstrumentCalibrationStatus} from '../../robot'
+import type {Pipette, PipetteCalibrationStatus} from '../../robot'
 
 import CalibrationInfoBox from '../CalibrationInfoBox'
 import UnprobedPanel from './UnprobedPanel'
@@ -11,12 +11,12 @@ import AttachTipPanel from './AttachTipPanel'
 import RemoveTipPanel from './RemoveTipPanel'
 import ContinuePanel from './ContinuePanel'
 
-type Props = Instrument & {
+type Props = Pipette & {
   confirmTipProbeUrl: string
 }
 
 const PANEL_BY_CALIBRATION: {
-  [InstrumentCalibrationStatus]: React.ComponentType<Props>
+  [PipetteCalibrationStatus]: React.ComponentType<Props>
 } = {
   'unprobed': UnprobedPanel,
   'preparing-to-probe': InstrumentMovingPanel,

--- a/app/src/components/calibrate-pipettes/PipetteTabs.js
+++ b/app/src/components/calibrate-pipettes/PipetteTabs.js
@@ -3,24 +3,24 @@
 // used for left/right pipette selection during pipette calibration
 import * as React from 'react'
 
-import type {Instrument} from '../../robot'
+import type {Pipette} from '../../robot'
 import {constants as robotConstants} from '../../robot'
 
 import {PageTabs} from '@opentrons/components'
 
 type Props = {
-  instruments: Array<Instrument>,
-  currentInstrument: ?Instrument
+  pipettes: Array<Pipette>,
+  currentPipette: ?Pipette
 }
 
 export default function PipetteTabs (props: Props) {
-  const {instruments, currentInstrument} = props
+  const {pipettes, currentPipette} = props
 
-  const pages = robotConstants.INSTRUMENT_MOUNTS.map((mount) => ({
+  const pages = robotConstants.PIPETTE_MOUNTS.map((mount) => ({
     title: mount,
     href: `./${mount}`,
-    isActive: currentInstrument != null && mount === currentInstrument.mount,
-    isDisabled: !instruments.some((inst) => inst.mount === mount)
+    isActive: currentPipette != null && mount === currentPipette.mount,
+    isDisabled: !pipettes.some((pip) => pip.mount === mount)
   }))
 
   return (

--- a/app/src/components/calibrate-pipettes/PipetteTabs.js
+++ b/app/src/components/calibrate-pipettes/PipetteTabs.js
@@ -20,7 +20,7 @@ export default function PipetteTabs (props: Props) {
     title: mount,
     href: `./${mount}`,
     isActive: currentPipette != null && mount === currentPipette.mount,
-    isDisabled: !pipettes.some((pip) => pip.mount === mount)
+    isDisabled: !pipettes.some((pipette) => pipette.mount === mount)
   }))
 
   return (

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom'
 import cx from 'classnames'
 
 import type {PipettesResponse} from '../../http-api-client'
-import type {Instrument} from '../../robot'
+import type {Pipette} from '../../robot'
 import {constants as robotConstants} from '../../robot'
 
 import {getPipette} from '@opentrons/shared-data'
@@ -13,27 +13,27 @@ import styles from './styles.css'
 
 type Props = {
   name: string,
-  instruments: Array<Instrument>,
-  currentInstrument: ?Instrument,
+  pipettes: Array<Pipette>,
+  currentPipette: ?Pipette,
   actualPipettes: ?PipettesResponse
 }
 
-const {INSTRUMENT_MOUNTS} = robotConstants
+const {PIPETTE_MOUNTS} = robotConstants
 const ATTACH_ALERT = 'Pipette missing'
 const CHANGE_ALERT = 'Incorrect pipette attached'
 
 export default function Pipettes (props: Props) {
-  const {name, currentInstrument, instruments, actualPipettes} = props
-  const currentMount = currentInstrument && currentInstrument.mount
+  const {name, currentPipette, pipettes, actualPipettes} = props
+  const currentMount = currentPipette && currentPipette.mount
 
-  const infoByMount = INSTRUMENT_MOUNTS.reduce((result, mount) => {
-    const inst = instruments.find((i) => i.mount === mount)
+  const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
+    const pipette = pipettes.find((p) => p.mount === mount)
     // TODO(mc, 2018-04-25)
-    const pipetteConfig = inst
-      ? getPipette(inst.name)
+    const pipetteConfig = pipette
+      ? getPipette(pipette.name)
       : null
 
-    const isDisabled = !inst || mount !== currentMount
+    const isDisabled = !pipette || mount !== currentMount
     const details = !pipetteConfig
       ? {description: 'N/A', tipType: 'N/A'}
       : {

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -1,11 +1,11 @@
 // @flow
-// setup instruments component
+// setup pipettes component
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Route, Redirect, type ContextRouter} from 'react-router'
 
 import type {State} from '../../types'
-import type {Instrument} from '../../robot'
+import type {Pipette} from '../../robot'
 import {selectors as robotSelectors} from '../../robot'
 import {makeGetRobotPipettes} from '../../http-api-client'
 
@@ -17,8 +17,8 @@ import {PipetteTabs, Pipettes} from '../../components/calibrate-pipettes'
 import SessionHeader from '../../components/SessionHeader'
 
 type StateProps = {
-  instruments: Array<Instrument>,
-  currentInstrument: ?Instrument
+  pipettes: Array<Pipette>,
+  currentPipette: ?Pipette
 }
 
 type OwnProps = ContextRouter
@@ -28,11 +28,11 @@ type Props = StateProps & OwnProps
 export default connect(makeMapStateToProps)(CalibratePipettesPage)
 
 function CalibratePipettesPage (props: Props) {
-  const {instruments, currentInstrument, match: {url, params}} = props
+  const {pipettes, currentPipette, match: {url, params}} = props
   const confirmTipProbeUrl = `${url}/confirm-tip-probe`
 
   // redirect back to mountless route if mount doesn't exist
-  if (params.mount && !currentInstrument) {
+  if (params.mount && !currentPipette) {
     return (<Redirect to={url.replace(`/${params.mount}`, '')} />)
   }
 
@@ -40,18 +40,18 @@ function CalibratePipettesPage (props: Props) {
     <Page
       titleBarProps={{title: (<SessionHeader />)}}
     >
-      <PipetteTabs {...{instruments, currentInstrument}} />
+      <PipetteTabs {...{pipettes, currentPipette}} />
       <Pipettes {...props} />
-      {!!currentInstrument && (
+      {!!currentPipette && (
         <TipProbe
-          {...currentInstrument}
+          {...currentPipette}
           confirmTipProbeUrl={confirmTipProbeUrl}
         />
       )}
-      {!!currentInstrument && (
+      {!!currentPipette && (
         <Route path={confirmTipProbeUrl} render={() => (
           <ConfirmTipProbeModal
-            mount={currentInstrument.mount}
+            mount={currentPipette.mount}
             backUrl={url}
           />
         )} />
@@ -61,7 +61,7 @@ function CalibratePipettesPage (props: Props) {
 }
 
 function makeMapStateToProps (): (State, OwnProps) => StateProps {
-  const getCurrentInstrument = robotSelectors.makeGetCurrentInstrument()
+  const getCurrentPipette = robotSelectors.makeGetCurrentPipette()
   const getAttachedPipettes = makeGetRobotPipettes()
 
   return (state, props) => {
@@ -70,8 +70,8 @@ function makeMapStateToProps (): (State, OwnProps) => StateProps {
 
     return {
       name,
-      instruments: robotSelectors.getInstruments(state),
-      currentInstrument: getCurrentInstrument(state, props),
+      pipettes: robotSelectors.getPipettes(state),
+      currentPipette: getCurrentPipette(state, props),
       actualPipettes: pipettesResponse.response
     }
   }

--- a/app/src/pages/Calibrate/index.js
+++ b/app/src/pages/Calibrate/index.js
@@ -5,14 +5,14 @@ import {connect} from 'react-redux'
 import {Switch, Route, Redirect, type Match} from 'react-router'
 
 import type {State} from '../../types'
-import type {Instrument, Labware} from '../../robot'
+import type {Pipette, Labware} from '../../robot'
 
 import {selectors as robotSelectors} from '../../robot'
 import CalibratePipettes from './Pipettes'
 import CalibrateLabware from './Labware'
 
 type SP = {
-  nextInstrument: Instrument,
+  nextPipette: Pipette,
   labware: Array<Labware>,
   nextLabware: Labware,
   isTipsProbed: boolean
@@ -44,23 +44,23 @@ function Calibrate (props: Props) {
 
 function mapStateToProps (state: State): SP {
   return {
-    nextInstrument: robotSelectors.getNextInstrument(state),
+    nextPipette: robotSelectors.getNextPipette(state),
     labware: robotSelectors.getNotTipracks(state),
     nextLabware: robotSelectors.getNextLabware(state),
-    isTipsProbed: robotSelectors.getInstrumentsCalibrated(state)
+    isTipsProbed: robotSelectors.getPipettesCalibrated(state)
   }
 }
 
 function getRedirectUrl (props: Props) {
   const {
-    nextInstrument,
+    nextPipette,
     labware,
     nextLabware,
     isTipsProbed
   } = props
 
-  if (!isTipsProbed && nextInstrument) {
-    return `/calibrate/pipettes/${nextInstrument.mount}`
+  if (!isTipsProbed && nextPipette) {
+    return `/calibrate/pipettes/${nextPipette.mount}`
   }
   if (nextLabware) return `/calibrate/labware/${nextLabware.slot}`
   if (labware[0]) return `/calibrate/labware/${labware[0].slot}`

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -376,10 +376,10 @@ export const actions = {
     }
   },
 
-  moveToFront (pipette: Mount) {
+  moveToFront (mount: Mount) {
     return tagForRobotApi({
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {pipette}
+      payload: {mount}
     })
   },
 
@@ -393,8 +393,8 @@ export const actions = {
     return action
   },
 
-  probeTip (pipette: Mount) {
-    return tagForRobotApi({type: actionTypes.PROBE_TIP, payload: {pipette}})
+  probeTip (mount: Mount) {
+    return tagForRobotApi({type: actionTypes.PROBE_TIP, payload: {mount}})
   },
 
   probeTipResponse (error: ?Error = null) {
@@ -407,12 +407,12 @@ export const actions = {
     return action
   },
 
-  confirmProbed (pipette: Mount): ConfirmProbedAction {
-    return {type: 'robot:CONFIRM_PROBED', payload: pipette}
+  confirmProbed (mount: Mount): ConfirmProbedAction {
+    return {type: 'robot:CONFIRM_PROBED', payload: mount}
   },
 
-  returnTip (pipette: Mount) {
-    return tagForRobotApi({type: actionTypes.RETURN_TIP, payload: {pipette}})
+  returnTip (mount: Mount) {
+    return tagForRobotApi({type: actionTypes.RETURN_TIP, payload: {mount}})
   },
 
   returnTipResponse (error: ?Error = null) {

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -322,7 +322,7 @@ export const actions = {
     }
   },
 
-  // drop the tip on instrument on `mount` into the tiprack in `slot`
+  // drop the tip on pipette on `mount` into the tiprack in `slot`
   dropTipAndHome (mount: Mount, slot: Slot): LabwareCalibrationAction {
     return {
       type: 'robot:DROP_TIP_AND_HOME',
@@ -357,7 +357,7 @@ export const actions = {
   },
 
   // response for pickup and home
-  // payload.tipOn is a flag for whether a tip remains on the instrument
+  // payload.tipOn is a flag for whether a tip remains on the pipette
   confirmTiprackResponse (
     error: ?Error = null,
     tipOn: boolean = false
@@ -376,10 +376,10 @@ export const actions = {
     }
   },
 
-  moveToFront (instrument: Mount) {
+  moveToFront (pipette: Mount) {
     return tagForRobotApi({
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {instrument}
+      payload: {pipette}
     })
   },
 
@@ -393,8 +393,8 @@ export const actions = {
     return action
   },
 
-  probeTip (instrument: Mount) {
-    return tagForRobotApi({type: actionTypes.PROBE_TIP, payload: {instrument}})
+  probeTip (pipette: Mount) {
+    return tagForRobotApi({type: actionTypes.PROBE_TIP, payload: {pipette}})
   },
 
   probeTipResponse (error: ?Error = null) {
@@ -407,12 +407,12 @@ export const actions = {
     return action
   },
 
-  confirmProbed (instrument: Mount): ConfirmProbedAction {
-    return {type: 'robot:CONFIRM_PROBED', payload: instrument}
+  confirmProbed (pipette: Mount): ConfirmProbedAction {
+    return {type: 'robot:CONFIRM_PROBED', payload: pipette}
   },
 
-  returnTip (instrument: Mount) {
-    return tagForRobotApi({type: actionTypes.RETURN_TIP, payload: {instrument}})
+  returnTip (pipette: Mount) {
+    return tagForRobotApi({type: actionTypes.RETURN_TIP, payload: {pipette}})
   },
 
   returnTipResponse (error: ?Error = null) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -118,8 +118,8 @@ export default function client (dispatch) {
   }
 
   function moveToFront (state, action) {
-    const {payload: {instrument: axis}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {pipette: axis}} = action
+    const instrument = {_id: selectors.getPipettesByMount(state)[axis]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.moveToFrontResponse()), 1000)
@@ -132,7 +132,7 @@ export default function client (dispatch) {
   // saves container offset and then attempts a tip pickup
   function pickupAndHome (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
@@ -147,7 +147,7 @@ export default function client (dispatch) {
 
   function dropTipAndHome (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
@@ -163,7 +163,7 @@ export default function client (dispatch) {
   // drop the tip unless the tiprack is the last one to be confirmed
   function confirmTiprack (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     if (selectors.getUnconfirmedTipracks(state).length === 1) {
@@ -179,32 +179,32 @@ export default function client (dispatch) {
   }
 
   function probeTip (state, action) {
-    const {payload: {instrument: axis}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[axis]._id}
+    const {payload: {pipette: axis}} = action
+    const pipette = {_id: selectors.getPipettesByMount(state)[axis]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.probeTipResponse()), 1000)
 
-    remote.calibration_manager.tip_probe(instrument)
+    remote.calibration_manager.tip_probe(pipette)
       .then(() => dispatch(actions.probeTipResponse()))
       .catch((error) => dispatch(actions.probeTipResponse(error)))
   }
 
   function returnTip (state, action) {
-    const {payload: {instrument: mount}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const {payload: {pipette: mount}} = action
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.return_tipResponse()), 1000)
 
-    remote.calibration_manager.return_tip(instrument)
+    remote.calibration_manager.return_tip(pipette)
       .then(() => dispatch(actions.returnTipResponse()))
       .catch((error) => dispatch(actions.returnTipResponse(error)))
   }
 
   function moveTo (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME - MORE DEBUG CODE
@@ -223,7 +223,7 @@ export default function client (dispatch) {
 
   function jog (state, action) {
     const {payload: {mount, axis, direction, step}} = action
-    const instrument = selectors.getInstrumentsByMount(state)[mount]
+    const instrument = selectors.getPipettesByMount(state)[mount]
     const distance = step * direction
 
     // FIXME(mc, 2017-10-06): DEBUG CODE
@@ -240,7 +240,7 @@ export default function client (dispatch) {
     const {payload: {mount, slot}} = action
     const labwareObject = selectors.getLabwareBySlot(state)[slot]
 
-    const instrument = {_id: selectors.getInstrumentsByMount(state)[mount]._id}
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: labwareObject._id}
 
     // FIXME(mc, 2017-10-06): DEBUG CODE
@@ -330,7 +330,7 @@ export default function client (dispatch) {
       }
 
       if (apiSession.instruments) {
-        update.instrumentsByMount = {}
+        update.pipettesByMount = {}
         apiSession.instruments.forEach(apiInstrumentToInstrument)
       }
 
@@ -377,7 +377,7 @@ export default function client (dispatch) {
       //  interacts with
       const volume = Number(name.match(RE_VOLUME)[1])
 
-      update.instrumentsByMount[mount] = {_id, mount, name, channels, volume}
+      update.pipettesByMount[mount] = {_id, mount, name, channels, volume}
     }
 
     function apiContainerToContainer (apiContainer) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -118,8 +118,8 @@ export default function client (dispatch) {
   }
 
   function moveToFront (state, action) {
-    const {payload: {pipette: axis}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[axis]._id}
+    const {payload: {mount}} = action
+    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.moveToFrontResponse()), 1000)
@@ -179,8 +179,8 @@ export default function client (dispatch) {
   }
 
   function probeTip (state, action) {
-    const {payload: {pipette: axis}} = action
-    const pipette = {_id: selectors.getPipettesByMount(state)[axis]._id}
+    const {payload: {mount}} = action
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.probeTipResponse()), 1000)
@@ -191,7 +191,7 @@ export default function client (dispatch) {
   }
 
   function returnTip (state, action) {
-    const {payload: {pipette: mount}} = action
+    const {payload: {mount}} = action
     const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -132,30 +132,30 @@ export default function client (dispatch) {
   // saves container offset and then attempts a tip pickup
   function pickupAndHome (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.pickupAndHomeResponse()), 1000)
 
     remote.calibration_manager
-      .update_container_offset(labware, instrument)
-      .then(() => remote.calibration_manager.pick_up_tip(instrument, labware))
+      .update_container_offset(labware, pipette)
+      .then(() => remote.calibration_manager.pick_up_tip(pipette, labware))
       .then(() => dispatch(actions.pickupAndHomeResponse()))
       .catch((error) => dispatch(actions.pickupAndHomeResponse(error)))
   }
 
   function dropTipAndHome (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.dropTipAndHomeResponse()), 1000)
 
-    remote.calibration_manager.drop_tip(instrument, labware)
-      .then(() => remote.calibration_manager.home(instrument))
-      .then(() => remote.calibration_manager.move_to(instrument, labware))
+    remote.calibration_manager.drop_tip(pipette, labware)
+      .then(() => remote.calibration_manager.home(pipette))
+      .then(() => remote.calibration_manager.move_to(pipette, labware))
       .then(() => dispatch(actions.dropTipAndHomeResponse()))
       .catch((error) => dispatch(actions.dropTipAndHomeResponse(error)))
   }
@@ -163,7 +163,7 @@ export default function client (dispatch) {
   // drop the tip unless the tiprack is the last one to be confirmed
   function confirmTiprack (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     if (selectors.getUnconfirmedTipracks(state).length === 1) {
@@ -173,7 +173,7 @@ export default function client (dispatch) {
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.confirmTiprackResponse()), 1000)
 
-    remote.calibration_manager.drop_tip(instrument, labware)
+    remote.calibration_manager.drop_tip(pipette, labware)
       .then(() => dispatch(actions.confirmTiprackResponse()))
       .catch((error) => dispatch(actions.confirmTiprackResponse(error)))
   }
@@ -204,7 +204,7 @@ export default function client (dispatch) {
 
   function moveTo (state, action) {
     const {payload: {mount, slot}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: selectors.getLabwareBySlot(state)[slot]._id}
 
     // FIXME - MORE DEBUG CODE
@@ -213,7 +213,7 @@ export default function client (dispatch) {
     //   dispatch(push(`/setup-deck/${slot}/confirm`))
     // }, 1000)
 
-    remote.calibration_manager.move_to(instrument, labware)
+    remote.calibration_manager.move_to(pipette, labware)
       .then(() => {
         dispatch(actions.moveToResponse())
         dispatch(push(`/calibrate/labware/${slot}/confirm`))
@@ -223,13 +223,13 @@ export default function client (dispatch) {
 
   function jog (state, action) {
     const {payload: {mount, axis, direction, step}} = action
-    const instrument = selectors.getPipettesByMount(state)[mount]
+    const pipette = selectors.getPipettesByMount(state)[mount]
     const distance = step * direction
 
     // FIXME(mc, 2017-10-06): DEBUG CODE
     // return setTimeout(() => dispatch(actions.jogResponse()), 1000)
 
-    remote.calibration_manager.jog(instrument, distance, axis)
+    remote.calibration_manager.jog(pipette, distance, axis)
       .then(() => dispatch(actions.jogResponse()))
       .catch((error) => dispatch(actions.jogResponse(error)))
   }
@@ -240,14 +240,14 @@ export default function client (dispatch) {
     const {payload: {mount, slot}} = action
     const labwareObject = selectors.getLabwareBySlot(state)[slot]
 
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
     const labware = {_id: labwareObject._id}
 
     // FIXME(mc, 2017-10-06): DEBUG CODE
     // return setTimeout(() => dispatch(actions.updateOffsetResponse()), 2000)
 
     remote.calibration_manager
-      .update_container_offset(labware, instrument)
+      .update_container_offset(labware, pipette)
       .then(() => dispatch(actions.updateOffsetResponse()))
       .catch((error) => dispatch(actions.updateOffsetResponse(error)))
   }

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -119,12 +119,12 @@ export default function client (dispatch) {
 
   function moveToFront (state, action) {
     const {payload: {mount}} = action
-    const instrument = {_id: selectors.getPipettesByMount(state)[mount]._id}
+    const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
     // FIXME(mc, 2017-10-05): DEBUG CODE
     // return setTimeout(() => dispatch(actions.moveToFrontResponse()), 1000)
 
-    remote.calibration_manager.move_to_front(instrument)
+    remote.calibration_manager.move_to_front(pipette)
       .then(() => dispatch(actions.moveToFrontResponse()))
       .catch((error) => dispatch(actions.moveToFrontResponse(error)))
   }

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -59,7 +59,7 @@ export const LABWARE_CONFIRMATION_TYPE = PropTypes.oneOf([
 ])
 
 // deck layout
-export const INSTRUMENT_MOUNTS: Mount[] = ['left', 'right']
+export const PIPETTE_MOUNTS: Mount[] = ['left', 'right']
 export const DECK_SLOTS: Slot[] = [
   '1',
   '2',

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -59,8 +59,8 @@ export const LABWARE_CONFIRMATION_TYPE = PropTypes.oneOf([
 ])
 
 // deck layout
-export const PIPETTE_MOUNTS: Mount[] = ['left', 'right']
-export const DECK_SLOTS: Slot[] = [
+export const PIPETTE_MOUNTS: Array<Mount> = ['left', 'right']
+export const DECK_SLOTS: Array<Slot> = [
   '1',
   '2',
   '3',

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -169,9 +169,9 @@ function handleSetDeckPopulated (state: State, action: any): State {
 }
 
 function handleMoveToFront (state: State, action: any): State {
-  if (!action.payload || !action.payload.instrument) return state
+  if (!action.payload || !action.payload.pipette) return state
 
-  const {payload: {instrument: mount}} = action
+  const {payload: {pipette: mount}} = action
 
   return {
     ...state,
@@ -201,21 +201,21 @@ function handleMoveToFrontResponse (state: State, action: any): State {
 }
 
 function handleProbeTip (state: State, action: any) {
-  if (!action.payload || !action.payload.instrument) return state
+  if (!action.payload || !action.payload.pipette) return state
 
-  const {payload: {instrument}} = action
+  const {payload: {pipette}} = action
 
   return {
     ...state,
     calibrationRequest: {
       type: 'PROBE_TIP',
-      mount: instrument,
+      mount: pipette,
       inProgress: true,
       error: null
     },
     probedByMount: {
       ...state.probedByMount,
-      [instrument]: false
+      [pipette]: false
     }
   }
 }

--- a/app/src/robot/reducer/calibration.js
+++ b/app/src/robot/reducer/calibration.js
@@ -169,9 +169,9 @@ function handleSetDeckPopulated (state: State, action: any): State {
 }
 
 function handleMoveToFront (state: State, action: any): State {
-  if (!action.payload || !action.payload.pipette) return state
+  if (!action.payload || !action.payload.mount) return state
 
-  const {payload: {pipette: mount}} = action
+  const {payload: {mount}} = action
 
   return {
     ...state,
@@ -201,21 +201,21 @@ function handleMoveToFrontResponse (state: State, action: any): State {
 }
 
 function handleProbeTip (state: State, action: any) {
-  if (!action.payload || !action.payload.pipette) return state
+  if (!action.payload || !action.payload.mount) return state
 
-  const {payload: {pipette}} = action
+  const {payload: {mount}} = action
 
   return {
     ...state,
     calibrationRequest: {
       type: 'PROBE_TIP',
-      mount: pipette,
+      mount: mount,
       inProgress: true,
       error: null
     },
     probedByMount: {
       ...state.probedByMount,
-      [pipette]: false
+      [mount]: false
     }
   }
 }

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -2,7 +2,7 @@
 // robot session (protocol) state and reducer
 import type {
   Command,
-  StateInstrument,
+  StatePipette,
   StateLabware,
   Mount,
   Slot,
@@ -33,8 +33,8 @@ export type State = {
   protocolCommandsById: {
     [number]: Command
   },
-  instrumentsByMount: {
-    [Mount]: StateInstrument
+  pipettesByMount: {
+    [Mount]: StatePipette
   },
   labwareBySlot: {
     [Slot]: StateLabware
@@ -73,7 +73,7 @@ const INITIAL_STATE: State = {
   protocolCommandsById: {},
 
   // deck setup from protocol
-  instrumentsByMount: {},
+  pipettesByMount: {},
   labwareBySlot: {},
 
   // running a protocol

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -242,7 +242,7 @@ export const getPipettes = createSelector(
     probedByMount,
     tipOnByMount,
     calibrationRequest
-  ): Pipette[] => {
+  ): Array<Pipette> => {
     return PIPETTE_MOUNTS
       .filter((mount) => pipettesByMount[mount] != null)
       .map((mount) => {

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -140,7 +140,7 @@ describe('robot actions', () => {
   test('move tip to front action', () => {
     const expected = {
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {pipette: 'right'},
+      payload: {mount: 'right'},
       meta: {robotCommand: true}
     }
 
@@ -242,7 +242,7 @@ describe('robot actions', () => {
   test('probe tip action', () => {
     const expected = {
       type: actionTypes.PROBE_TIP,
-      payload: {pipette: 'left'},
+      payload: {mount: 'left'},
       meta: {robotCommand: true}
     }
 

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -140,7 +140,7 @@ describe('robot actions', () => {
   test('move tip to front action', () => {
     const expected = {
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {instrument: 'right'},
+      payload: {pipette: 'right'},
       meta: {robotCommand: true}
     }
 
@@ -242,7 +242,7 @@ describe('robot actions', () => {
   test('probe tip action', () => {
     const expected = {
       type: actionTypes.PROBE_TIP,
-      payload: {instrument: 'left'},
+      payload: {pipette: 'left'},
       meta: {robotCommand: true}
     }
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -278,7 +278,7 @@ describe('api client', () => {
         protocolText: session.protocol_text,
         protocolCommands: [],
         protocolCommandsById: {},
-        instrumentsByMount: {},
+        pipettesByMount: {},
         labwareBySlot: {}
       })
     })
@@ -347,7 +347,7 @@ describe('api client', () => {
 
     test('maps api instruments and intruments by mount', () => {
       const expected = actions.sessionResponse(null, expect.objectContaining({
-        instrumentsByMount: {
+        pipettesByMount: {
           left: {_id: 2, mount: 'left', name: 'p200', channels: 1, volume: 200},
           right: {_id: 1, mount: 'right', name: 'p50', channels: 8, volume: 50}
         }
@@ -425,7 +425,7 @@ describe('api client', () => {
             labwareBySlot: {}
           },
           session: {
-            instrumentsByMount: {
+            pipettesByMount: {
               left: {_id: 'inst-2'},
               right: {_id: 'inst-1'}
             },

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -316,7 +316,7 @@ describe('robot reducer - calibration', () => {
     }
     const action = {
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {instrument: 'left'}
+      payload: {pipette: 'left'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
@@ -382,7 +382,7 @@ describe('robot reducer - calibration', () => {
     }
     const action = {
       type: actionTypes.PROBE_TIP,
-      payload: {instrument: 'left'}
+      payload: {pipette: 'left'}
     }
 
     expect(reducer(state, action).calibration).toEqual({

--- a/app/src/robot/test/calibration-reducer.test.js
+++ b/app/src/robot/test/calibration-reducer.test.js
@@ -316,7 +316,7 @@ describe('robot reducer - calibration', () => {
     }
     const action = {
       type: actionTypes.MOVE_TO_FRONT,
-      payload: {pipette: 'left'}
+      payload: {mount: 'left'}
     }
 
     expect(reducer(state, action).calibration).toEqual({
@@ -382,7 +382,7 @@ describe('robot reducer - calibration', () => {
     }
     const action = {
       type: actionTypes.PROBE_TIP,
-      payload: {pipette: 'left'}
+      payload: {mount: 'left'}
     }
 
     expect(reducer(state, action).calibration).toEqual({

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -19,14 +19,14 @@ const {
   getIsPaused,
   getIsDone,
   getRunTime,
-  getInstruments,
+  getPipettes,
   getCalibratorMount,
-  getInstrumentsCalibrated,
+  getPipettesCalibrated,
   getLabware,
   getUnconfirmedTipracks,
   getUnconfirmedLabware,
   getNextLabware,
-  makeGetCurrentInstrument
+  makeGetCurrentPipette
 } = selectors
 
 describe('robot selectors', () => {
@@ -350,7 +350,7 @@ describe('robot selectors', () => {
     beforeEach(() => {
       state = makeState({
         session: {
-          instrumentsByMount: {
+          pipettesByMount: {
             left: {mount: 'left', name: 'p200m', channels: 8, volume: 200},
             right: {mount: 'right', name: 'p50s', channels: 1, volume: 50}
           }
@@ -373,8 +373,8 @@ describe('robot selectors', () => {
     })
 
     // TODO(mc: 2018-01-10): rethink the instrument level "calibration" prop
-    test('get instruments', () => {
-      expect(getInstruments(state)).toEqual([
+    test('get pipettes', () => {
+      expect(getPipettes(state)).toEqual([
         {
           mount: 'left',
           name: 'p200m',
@@ -397,10 +397,10 @@ describe('robot selectors', () => {
     })
 
     test('make get current instrument from props', () => {
-      const getCurrentInstrument = makeGetCurrentInstrument()
+      const getCurrentPipette = makeGetCurrentPipette()
       let props = {match: {params: {mount: 'left'}}}
 
-      expect(getCurrentInstrument(state, props)).toEqual({
+      expect(getCurrentPipette(state, props)).toEqual({
         mount: 'left',
         name: 'p200m',
         channels: 8,
@@ -411,7 +411,7 @@ describe('robot selectors', () => {
       })
 
       props = {match: {params: {mount: 'right'}}}
-      expect(getCurrentInstrument(state, props)).toEqual({
+      expect(getCurrentPipette(state, props)).toEqual({
         mount: 'right',
         name: 'p50s',
         channels: 1,
@@ -422,14 +422,14 @@ describe('robot selectors', () => {
       })
 
       props = {match: {params: {}}}
-      expect(getCurrentInstrument(state, props)).toBeFalsy()
+      expect(getCurrentPipette(state, props)).toBeFalsy()
     })
   })
 
   test('get calibrator mount', () => {
     const leftState = makeState({
       session: {
-        instrumentsByMount: {
+        pipettesByMount: {
           left: {mount: 'left', name: 'p200m', channels: 8, volume: 200},
           right: {mount: 'right', name: 'p50s', channels: 1, volume: 50}
         }
@@ -443,7 +443,7 @@ describe('robot selectors', () => {
 
     const rightState = makeState({
       session: {
-        instrumentsByMount: {
+        pipettesByMount: {
           left: {mount: 'left', name: 'p200m', channels: 8, volume: 200},
           right: {mount: 'right', name: 'p50s', channels: 1, volume: 50}
         }
@@ -462,7 +462,7 @@ describe('robot selectors', () => {
   test('get instruments are calibrated', () => {
     const twoPipettesCalibrated = makeState({
       session: {
-        instrumentsByMount: {
+        pipettesByMount: {
           left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
           right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
@@ -476,7 +476,7 @@ describe('robot selectors', () => {
 
     const twoPipettesNotCalibrated = makeState({
       session: {
-        instrumentsByMount: {
+        pipettesByMount: {
           left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
           right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
@@ -490,7 +490,7 @@ describe('robot selectors', () => {
 
     const onePipetteCalibrated = makeState({
       session: {
-        instrumentsByMount: {
+        pipettesByMount: {
           right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
         }
       },
@@ -501,9 +501,9 @@ describe('robot selectors', () => {
       }
     })
 
-    expect(getInstrumentsCalibrated(twoPipettesCalibrated)).toBe(true)
-    expect(getInstrumentsCalibrated(twoPipettesNotCalibrated)).toBe(false)
-    expect(getInstrumentsCalibrated(onePipetteCalibrated)).toBe(true)
+    expect(getPipettesCalibrated(twoPipettesCalibrated)).toBe(true)
+    expect(getPipettesCalibrated(twoPipettesNotCalibrated)).toBe(false)
+    expect(getPipettesCalibrated(onePipetteCalibrated)).toBe(true)
   })
 
   describe('labware selectors', () => {
@@ -528,7 +528,7 @@ describe('robot selectors', () => {
             5: {slot: '5', type: 'a', isTiprack: false},
             9: {slot: '9', type: 'b', isTiprack: false}
           },
-          instrumentsByMount: {
+          pipettesByMount: {
             left: {name: 'p200', mount: 'left', channels: 8, volume: 200},
             right: {name: 'p50', mount: 'right', channels: 1, volume: 50}
           }

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -23,7 +23,7 @@ describe('robot reducer - session', () => {
       protocolCommandsById: {},
 
       // deck setup from protocol
-      instrumentsByMount: {},
+      pipettesByMount: {},
       labwareBySlot: {},
 
       // running a protocol

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -54,7 +54,7 @@ export type ProtocolFile = {
 
 // TODO(mc, 2018-01-22): pay attention to this when deprecating status contants
 //   in constants.js. Also re-evaluate the need for this logic / type
-export type InstrumentCalibrationStatus =
+export type PipetteCalibrationStatus =
   | 'unprobed'
   | 'preparing-to-probe'
   | 'ready-to-probe'
@@ -87,7 +87,7 @@ export type Command = {
 }
 
 // instrument as stored in redux state
-export type StateInstrument = {
+export type StatePipette = {
   // resource ID
   _id: number,
   // robot mount instrument is installed on
@@ -102,8 +102,8 @@ export type StateInstrument = {
   volume: number,
 }
 
-export type Instrument = StateInstrument & {
-  calibration: InstrumentCalibrationStatus,
+export type Pipette = StatePipette & {
+  calibration: PipetteCalibrationStatus,
   probed: boolean,
   tipOn: boolean
 }


### PR DESCRIPTION
## overview

This PR is the follow up for #1765. Refactors the app selectors, actions, and types to refer to Pipettes and Pipettes rather than instruments to avoid future confusion once modules are in place.

## changelog

- refactor(app): Refactor pipette selectors and types no longer use the term instrument

## review request
 
This one touched a lot of files, but its mainly types and selectors. Tested on Sunset. Please make sure everything still works on robot/VS.

- [x] attach/change pipette works
- [x] deck calibration works
- [x] tip probe works
- [x] labware calibration works