### PR TITLE
fix(app): Remove tip-probed check in calibrator selector

### DIFF
--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -293,11 +293,7 @@ export const getNextPipette = createSelector(
 // TODO(mc, 2018-02-07): be smarter about the backup case
 export const getCalibrator = createSelector(
   getPipettes,
-  (pipettes): ?Pipette => {
-    const tipOn = pipettes.find((i) => i.probed && i.tipOn)
-
-    return tipOn || pipettes[0]
-  }
+  (pipettes): ?Pipette => pipettes.find(i => i.tipOn) || pipettes[0]
 )
 
 // TODO(mc, 2018-02-07): remove this selector in favor of the one above

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -436,7 +436,7 @@ describe('robot selectors', () => {
       },
       calibration: {
         calibrationRequest: {},
-        probedByMount: {left: true, right: true},
+        probedByMount: {},
         tipOnByMount: {left: true}
       }
     })
@@ -450,7 +450,7 @@ describe('robot selectors', () => {
       },
       calibration: {
         calibrationRequest: {},
-        probedByMount: {left: true, right: true},
+        probedByMount: {},
         tipOnByMount: {right: true}
       }
     })


### PR DESCRIPTION
## overview

This PR serving as a bug report and a fix.

The `getCalibrator` selector was incorrectly checking tip-probe status to decide if a pipette could be used for labware calibration. Since tip-probe is optional, this PR removes that check to make sure the correct pipette is used.

## changelog

- fix(app): Remove tip-probed check in calibrator selector 

## review requests

1. Load a protocol / robot with multi on left and single on right
2. Do not tip probe
3. Go through tiprack calibration so you end up with a tip on the right single channel pipette
4. Proceed to labware calibration
- [x] Robot uses right, single-channel pipette with tip on for labware calibration

(Tested on Sunset)