### PR TITLE
feat(protocol-designer): clear everything when new protocol is created

### DIFF
--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {actions, selectors} from '../../navigation'
 import {selectors as fileDataSelectors} from '../../file-data'
-import {loadFile} from '../../load-file'
+import {actions as loadFileActions} from '../../load-file'
 import FileSidebar from './FileSidebar'
 import type {BaseState, ThunkDispatch} from '../../types'
 
@@ -38,7 +38,7 @@ function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: ThunkDispatc
   const {dispatch} = dispatchProps
   return {
     downloadData,
-    loadFile: (fileChangeEvent) => dispatch(loadFile(fileChangeEvent)),
+    loadFile: (fileChangeEvent) => dispatch(loadFileActions.loadProtocolFile(fileChangeEvent)),
     createNewFile: _canCreateNew
       ? () => dispatch(actions.toggleNewProtocolModal(true))
       : undefined

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -13,23 +13,14 @@ import TiprackDiagram from './TiprackDiagram'
 import styles from './NewFileModal.css'
 import formStyles from '../../forms.css'
 import modalStyles from '../modal.css'
+import type {NewProtocolFields} from '../../../load-file'
 
-type State = {
-  name: string,
-
-  // TODO: make this union of pipette option values
-  leftPipette: string,
-  rightPipette: string,
-
-  // TODO: Ian 2018-06-22 type as labware-type enums of tipracks
-  leftTiprackModel: ?string,
-  rightTiprackModel: ?string
-}
+type State = NewProtocolFields
 
 type Props = {
   hideModal: boolean,
   onCancel: () => mixed,
-  onSave: State => mixed
+  onSave: (NewProtocolFields) => mixed
 }
 
 // 'USER_HAS_NOT_SELECTED' state is just a concern of these dropdowns,
@@ -62,8 +53,8 @@ const tiprackOptions = [
 
 const initialState = {
   name: '',
-  leftPipette: USER_HAS_NOT_SELECTED,
-  rightPipette: USER_HAS_NOT_SELECTED,
+  leftPipetteModel: USER_HAS_NOT_SELECTED,
+  rightPipetteModel: USER_HAS_NOT_SELECTED,
   leftTiprackModel: null,
   rightTiprackModel: null
 }
@@ -83,8 +74,8 @@ export default class NewFileModal extends React.Component<Props, State> {
 
   handleChange = (accessor: $Keys<State>) => (e: SyntheticInputEvent<*>) => {
     // skip tiprack update if no pipette selected
-    if (accessor === 'leftTiprackModel' && !this.state.leftPipette) return
-    if (accessor === 'rightTiprackModel' && !this.state.rightPipette) return
+    if (accessor === 'leftTiprackModel' && !this.state.leftPipetteModel) return
+    if (accessor === 'rightTiprackModel' && !this.state.rightPipetteModel) return
 
     const value: string = e.target.value
 
@@ -93,9 +84,9 @@ export default class NewFileModal extends React.Component<Props, State> {
     }
 
     // clear tiprack selection if corresponding pipette model is deselected
-    if (accessor === 'leftPipette' && !value) {
+    if (accessor === 'leftPipetteModel' && !value) {
       nextState.leftTiprackModel = null
-    } else if (accessor === 'rightPipette' && !value) {
+    } else if (accessor === 'rightPipetteModel' && !value) {
       nextState.rightTiprackModel = null
     }
 
@@ -116,30 +107,30 @@ export default class NewFileModal extends React.Component<Props, State> {
 
     const {
       name,
-      leftPipette,
-      rightPipette,
+      leftPipetteModel,
+      rightPipetteModel,
       leftTiprackModel,
       rightTiprackModel
     } = this.state
 
     const pipetteSelectionIsValid = (
       // neither can be invalid
-      (leftPipette !== USER_HAS_NOT_SELECTED && rightPipette !== USER_HAS_NOT_SELECTED) &&
+      (leftPipetteModel !== USER_HAS_NOT_SELECTED && rightPipetteModel !== USER_HAS_NOT_SELECTED) &&
       // at least one must not be none (empty string)
-      (leftPipette || rightPipette)
+      (leftPipetteModel || rightPipetteModel)
     )
 
     // if pipette selected, corresponding tiprack type also selected
     const tiprackSelectionIsValid = (
-      (leftPipette ? Boolean(leftTiprackModel) : true) &&
-      (rightPipette ? Boolean(rightTiprackModel) : true)
+      (leftPipetteModel ? Boolean(leftTiprackModel) : true) &&
+      (rightPipetteModel ? Boolean(rightTiprackModel) : true)
     )
 
     const canSubmit = pipetteSelectionIsValid && tiprackSelectionIsValid
 
     const pipetteFields = [
-      ['leftPipette', 'Left Pipette'],
-      ['rightPipette', 'Right Pipette']
+      ['leftPipetteModel', 'Left Pipette'],
+      ['rightPipetteModel', 'Right Pipette']
     ].map(([name, label]) => {
       const value = this.state[name]
       return (
@@ -200,8 +191,8 @@ export default class NewFileModal extends React.Component<Props, State> {
         <div className={styles.diagrams}>
           <TiprackDiagram containerType={this.state.leftTiprackModel} />
           <PipetteDiagram
-            leftPipette={this.state.leftPipette}
-            rightPipette={this.state.rightPipette}
+            leftPipette={this.state.leftPipetteModel}
+            rightPipette={this.state.rightPipetteModel}
           />
           <TiprackDiagram containerType={this.state.rightTiprackModel} />
         </div>

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -2,8 +2,6 @@ import {createStore, combineReducers, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
 
 function getRootReducer () {
-  const LOAD_FILE = require('./load-file').LOAD_FILE
-
   const rootReducer = combineReducers({
     dismiss: require('./dismiss').rootReducer,
     fileData: require('./file-data').rootReducer,
@@ -16,8 +14,8 @@ function getRootReducer () {
   })
 
   return (state, action) => {
-    if (action.type === LOAD_FILE) {
-      // reset entire state, then pass LOAD_FILE action
+    if (action.type === 'LOAD_FILE' || action.type === 'CREATE_NEW_PROTOCOL') {
+      // reset entire state, then pass the action
       return rootReducer(undefined, action)
     }
     return rootReducer(state, action)

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -4,8 +4,7 @@ import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
 import type {BaseState} from '../types'
 import {selectors, actions as navigationActions} from '../navigation'
-import {actions as fileActions} from '../file-data'
-import {actions as pipetteActions} from '../pipettes'
+import {actions as fileActions} from '../load-file'
 
 import NewFileModal from '../components/modals/NewFileModal'
 
@@ -28,21 +27,7 @@ function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
     onSave: fields => {
-      dispatch(fileActions.saveFileMetadata({
-        name: fields.name || '',
-        description: ''
-      }))
-
-      dispatch(pipetteActions.updatePipettes({
-        leftModel: fields.leftPipette,
-        rightModel: fields.rightPipette,
-        leftTiprackModel: fields.leftTiprackModel,
-        rightTiprackModel: fields.rightTiprackModel
-      }))
-
-      dispatch(navigationActions.toggleNewProtocolModal(false))
-
-      dispatch(navigationActions.navigateToPage('file-detail'))
+      dispatch(fileActions.createNewProtocol(fields))
     }
   }
 }

--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -3,10 +3,10 @@ import {combineReducers} from 'redux'
 import {handleActions} from 'redux-actions'
 import omit from 'lodash/omit'
 import {dismissWarning} from './actions'
-import {LOAD_FILE, type LoadFileAction} from '../load-file'
 import {getPDMetadata} from '../file-types'
 import type {ActionType} from 'redux-actions'
 import type {BaseState} from '../types'
+import type {LoadFileAction} from '../load-file'
 import type {CommandCreatorWarning} from '../step-generation'
 import type {DeleteStepAction} from '../steplist/actions'
 
@@ -30,7 +30,7 @@ const dismissedWarnings = handleActions({
     const stepId = action.payload.toString(10)
     return omit(state, stepId)
   },
-  [LOAD_FILE]: (state: DismissedWarningState, action: LoadFileAction): DismissedWarningState =>
+  LOAD_FILE: (state: DismissedWarningState, action: LoadFileAction): DismissedWarningState =>
     getPDMetadata(action.payload).dismissedWarnings
 }, {})
 

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -7,7 +7,7 @@ import {
   updateFileMetadataFields
 } from '../actions'
 import type {FileMetadataFields} from '../types'
-import {LOAD_FILE, type LoadFileAction} from '../../load-file'
+import type {LoadFileAction, NewProtocolFields} from '../../load-file'
 
 const defaultFields = {
   name: '',
@@ -27,21 +27,33 @@ const updateMetadataFields = (
   }
 }
 
+function newProtocolMetadata (
+  state: FileMetadataFields,
+  action: {payload: NewProtocolFields}
+): FileMetadataFields {
+  return {
+    ...defaultFields,
+    name: action.payload.name || ''
+  }
+}
+
 const unsavedMetadataForm = handleActions({
-  [LOAD_FILE]: updateMetadataFields,
-  UPDATE_FILE_METADATA_FIELDS: (state: FileMetadataFields, action: ActionType<typeof updateFileMetadataFields>) => ({
+  LOAD_FILE: updateMetadataFields,
+  CREATE_NEW_PROTOCOL: newProtocolMetadata,
+  UPDATE_FILE_METADATA_FIELDS: (state: FileMetadataFields, action: ActionType<typeof updateFileMetadataFields>): FileMetadataFields => ({
     ...state,
     ...action.payload
   }),
-  SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>) => ({
+  SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>): FileMetadataFields => ({
     ...state,
     ...action.payload
   })
 }, defaultFields)
 
 const fileMetadata = handleActions({
-  [LOAD_FILE]: updateMetadataFields,
-  SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>) => ({
+  LOAD_FILE: updateMetadataFields,
+  CREATE_NEW_PROTOCOL: newProtocolMetadata,
+  SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>): FileMetadataFields => ({
     ...state,
     ...action.payload
   })

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -25,9 +25,9 @@ import type {
   Wells
 } from '../types'
 import * as actions from '../actions'
-import {LOAD_FILE, type LoadFileAction} from '../../load-file'
 import {getPDMetadata} from '../../file-types'
 import type {BaseState, Selector, Options} from '../../types'
+import type {LoadFileAction} from '../../load-file'
 import type {CopyLabware, DeleteIngredient, EditIngredient} from '../actions'
 
 // external actions (for types)
@@ -127,7 +127,7 @@ export const containers = handleActions({
     const { fromContainer, toContainer, toSlot } = action.payload
     return {...state, [toContainer]: {...state[fromContainer], slot: toSlot}}
   },
-  [LOAD_FILE]: (state: ContainersState, action: LoadFileAction): ContainersState => {
+  LOAD_FILE: (state: ContainersState, action: LoadFileAction): ContainersState => {
     const file = action.payload
     const allFileLabware = file.labware
     const labwareIds: Array<string> = Object.keys(allFileLabware).sort((a, b) =>
@@ -161,7 +161,7 @@ export const savedLabware = handleActions({
     ...state,
     [action.payload.containerId]: true
   }),
-  [LOAD_FILE]: (state: SavedLabwareState, action: LoadFileAction): SavedLabwareState =>
+  LOAD_FILE: (state: SavedLabwareState, action: LoadFileAction): SavedLabwareState =>
     mapValues(action.payload.labware, () => true)
 }, {})
 
@@ -190,7 +190,7 @@ export const ingredients = handleActions({
       // otherwise, the whole ingred group is deleted
       : omit(state, [groupId])
   },
-  [LOAD_FILE]: (state: IngredientsState, action: LoadFileAction): IngredientsState =>
+  LOAD_FILE: (state: IngredientsState, action: LoadFileAction): IngredientsState =>
     getPDMetadata(action.payload).ingredients
 }, {})
 
@@ -253,7 +253,7 @@ export const ingredLocations = handleActions({
       }
     }, {})
   },
-  [LOAD_FILE]: (state: LocationsState, action: LoadFileAction): LocationsState =>
+  LOAD_FILE: (state: LocationsState, action: LoadFileAction): LocationsState =>
     getPDMetadata(action.payload).ingredLocations
 }, {})
 

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -1,10 +1,7 @@
 // @flow
 import type {ProtocolFile} from '../file-types'
-import type {ActionType} from 'redux-actions'
 import type {GetState, ThunkAction, ThunkDispatch} from '../types'
-import type {FileError} from './types'
-
-export const LOAD_FILE: 'LOAD_FILE' = 'LOAD_FILE'
+import type {FileError, LoadFileAction, NewProtocolFields} from './types'
 
 export const fileErrors = (payload: FileError) => ({
   type: 'FILE_ERRORS',
@@ -12,13 +9,13 @@ export const fileErrors = (payload: FileError) => ({
 })
 
 // expects valid, parsed JSON protocol.
-const loadFileAction = (payload: ProtocolFile) => ({
-  type: LOAD_FILE,
+const loadFileAction = (payload: ProtocolFile): LoadFileAction => ({
+  type: 'LOAD_FILE',
   payload
 })
 
 // load file thunk, handles file loading errors
-export const loadFile = (event: SyntheticInputEvent<HTMLInputElement>): ThunkAction<*> =>
+export const loadProtocolFile = (event: SyntheticInputEvent<HTMLInputElement>): ThunkAction<*> =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
     const parseAndLoadFile = fileBody => {
       const parsedProtocol: ProtocolFile = JSON.parse(fileBody)
@@ -54,4 +51,7 @@ export const loadFile = (event: SyntheticInputEvent<HTMLInputElement>): ThunkAct
     }
   }
 
-export type LoadFileAction = ActionType<typeof loadFile>
+export const createNewProtocol = (payload: NewProtocolFields) => ({
+  type: 'CREATE_NEW_PROTOCOL',
+  payload
+})

--- a/protocol-designer/src/load-file/index.js
+++ b/protocol-designer/src/load-file/index.js
@@ -4,19 +4,12 @@ import * as actions from './actions'
 import * as selectors from './selectors'
 export * from './types'
 
-const {loadFile, LOAD_FILE} = actions
-type LoadFileAction = actions.LoadFileAction
-
 export {
   actions,
   rootReducer,
-  selectors,
-  // redundant top-level exports for importer's convenience
-  loadFile,
-  LOAD_FILE
+  selectors
 }
 
 export type {
-  RootState,
-  LoadFileAction
+  RootState
 }

--- a/protocol-designer/src/load-file/types.js
+++ b/protocol-designer/src/load-file/types.js
@@ -1,4 +1,6 @@
 // @flow
+import type {ProtocolFile} from '../file-types'
+
 export type FileUploadErrorType =
   | 'INVALID_FILE_TYPE'
   | 'INVALID_JSON_FILE'
@@ -7,3 +9,18 @@ export type FileError = {
     errorType: FileUploadErrorType,
     message?: string
   } | null
+
+export type LoadFileAction = {
+  type: 'LOAD_FILE',
+  payload: ProtocolFile
+}
+
+export type NewProtocolFields = {
+  name: ?string,
+
+  leftPipetteModel: string,
+  rightPipetteModel: string,
+
+  leftTiprackModel: ?string,
+  rightTiprackModel: ?string
+}

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -4,18 +4,19 @@ import {handleActions} from 'redux-actions'
 import type {ActionType} from 'redux-actions'
 
 import {navigateToPage, toggleNewProtocolModal} from '../actions'
-import {LOAD_FILE} from '../../load-file'
 import type {BaseState} from '../../types'
 import type {Page} from '../types'
 
 const page = handleActions({
-  [LOAD_FILE]: (): Page => 'file-detail',
+  LOAD_FILE: (): Page => 'file-detail',
+  CREATE_NEW_PROTOCOL: (): Page => 'file-detail',
   NAVIGATE_TO_PAGE: (state, action: ActionType<typeof navigateToPage>) => action.payload
 }, 'file-splash')
 
 const newProtocolModal = handleActions({
-  TOGGLE_NEW_PROTOCOL_MODAL: (state, action: ActionType<typeof toggleNewProtocolModal>) =>
-    action.payload
+  TOGGLE_NEW_PROTOCOL_MODAL: (state, action: ActionType<typeof toggleNewProtocolModal>): boolean =>
+    action.payload,
+  CREATE_NEW_PROTOCOL: () => false
 }, false)
 
 export const _allReducers = {

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,11 +1,3 @@
 // @flow
-type UpdatePipettesPayload = {
-  leftModel: ?string,
-  rightModel: ?string,
-  leftTiprackModel: ?string,
-  rightTiprackModel: ?string
-}
-export const updatePipettes = (payload: UpdatePipettesPayload) => ({
-  type: 'UPDATE_PIPETTES',
-  payload
-})
+
+// NOTE: no pipettes/ actions for now!

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -1,12 +1,11 @@
 // @flow
 import {combineReducers} from 'redux'
-import {handleActions, type ActionType} from 'redux-actions'
+import {handleActions} from 'redux-actions'
 import reduce from 'lodash/reduce'
 import {getPipette, getLabware} from '@opentrons/shared-data'
-import {updatePipettes} from './actions'
-import {LOAD_FILE, type LoadFileAction} from '../load-file'
 
 import type {Mount} from '@opentrons/components'
+import type {LoadFileAction, NewProtocolFields} from '../load-file'
 import type {PipetteData} from '../step-generation'
 import type {FilePipette} from '../file-types'
 
@@ -47,7 +46,7 @@ export type PipetteReducerState = {
 }
 
 const pipettes = handleActions({
-  [LOAD_FILE]: (state: PipetteReducerState, action: LoadFileAction): PipetteReducerState => {
+  LOAD_FILE: (state: PipetteReducerState, action: LoadFileAction): PipetteReducerState => {
     const file = action.payload
     const {pipettes} = file
     // TODO: Ian 2018-06-29 create fns to access ProtocolFile data
@@ -68,15 +67,23 @@ const pipettes = handleActions({
         }, {})
     }
   },
-  UPDATE_PIPETTES: (state: PipetteReducerState, action: ActionType<typeof updatePipettes>) => {
-    const {leftModel, rightModel, leftTiprackModel, rightTiprackModel} = action.payload
+  CREATE_NEW_PROTOCOL: (
+    state: PipetteReducerState,
+    action: {payload: NewProtocolFields}
+  ): PipetteReducerState => {
+    const {
+      leftPipetteModel,
+      rightPipetteModel,
+      leftTiprackModel,
+      rightTiprackModel
+    } = action.payload
 
-    const leftPipette = (leftModel && leftTiprackModel)
-      ? createPipette('left', leftModel, leftTiprackModel)
+    const leftPipette = (leftPipetteModel && leftTiprackModel)
+      ? createPipette('left', leftPipetteModel, leftTiprackModel)
       : null
 
-    const rightPipette = (rightModel && rightTiprackModel)
-      ? createPipette('right', rightModel, rightTiprackModel)
+    const rightPipette = (rightPipetteModel && rightTiprackModel)
+      ? createPipette('right', rightPipetteModel, rightTiprackModel)
       : null
 
     const newPipettes = ([leftPipette, rightPipette]).reduce(

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -5,11 +5,11 @@ import type {ActionType} from 'redux-actions'
 import omit from 'lodash/omit'
 
 import {INITIAL_DECK_SETUP_ID} from './constants'
-import {LOAD_FILE, type LoadFileAction} from '../load-file'
 import {getPDMetadata} from '../file-types'
 import {END_STEP} from './types'
 
 import type { StepItemData, FormSectionState, SubstepIdentifier } from './types'
+import type {LoadFileAction} from '../load-file'
 import type { FormData, StepIdType, FormModalFields } from '../form-types'
 
 import type {
@@ -103,7 +103,7 @@ const steps = handleActions({
     [action.payload.id]: createDefaultStep(action)
   }),
   DELETE_STEP: (state, action: DeleteStepAction) => omit(state, action.payload.toString()),
-  [LOAD_FILE]: (state: StepsState, action: LoadFileAction): StepsState => {
+  LOAD_FILE: (state: StepsState, action: LoadFileAction): StepsState => {
     const {savedStepForms, orderedSteps} = getPDMetadata(action.payload)
     return orderedSteps.reduce((acc: StepsState, stepId) => {
       const stepForm = savedStepForms[stepId]
@@ -135,7 +135,7 @@ const savedStepForms = handleActions({
     [action.payload.id]: action.payload
   }),
   DELETE_STEP: (state, action: DeleteStepAction) => omit(state, action.payload.toString()),
-  [LOAD_FILE]: (state: SavedStepFormState, action: LoadFileAction): SavedStepFormState =>
+  LOAD_FILE: (state: SavedStepFormState, action: LoadFileAction): SavedStepFormState =>
     getPDMetadata(action.payload).savedStepForms
 }, {})
 
@@ -164,8 +164,8 @@ const orderedSteps = handleActions({
   DELETE_STEP: (state: OrderedStepsState, action: DeleteStepAction) =>
     // TODO Ian 2018-05-10 standardize StepIdType to string, number is implicitly cast to string somewhere
     state.filter(stepId => !(stepId === action.payload || `${stepId}` === action.payload)),
-  [LOAD_FILE]: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
-    getPDMetadata(action.payload).orderedSteps
+  LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
+    [INITIAL_DECK_SETUP_ID, ...getPDMetadata(action.payload).orderedSteps]
 }, [INITIAL_DECK_SETUP_ID])
 
 type SelectedStepState = null | StepIdType | typeof END_STEP


### PR DESCRIPTION
## overview

Closes #970

## changelog

- refactor load-file/ atom to be more standard
- remove UPDATE_PIPETTE action
- new CREATE_NEW_PROTOCOL action (replaces heavy mapDispatchToProps on
  NewFileModal)

## review requests

- [x] Creating a new protocol (via Create New button on File Details page) should clear out all existing metadata, steps, ingredients, labware, dismissal state, pipettes, etc. And it should set the name & pipettes that you specified.