### PR TITLE
feat(protocol-designer): alert user of unsaved changes to protocol

### DIFF
--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -44,6 +44,7 @@ function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: ThunkDispatc
     loadFile: (fileChangeEvent) => dispatch(loadFileActions.loadProtocolFile(fileChangeEvent)),
     createNewFile: _canCreateNew
       ? () => dispatch(actions.toggleNewProtocolModal(true))
-      : undefined
+      : undefined,
+    onDownload: () => dispatch(loadFileActions.saveProtocolFile())
   }
 }

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -14,24 +14,24 @@ type Props = {
   downloadData: ?{
     fileContents: string,
     fileName: string
-  }
+  },
+  onDownload: (event: SyntheticEvent<*>) => mixed
 }
 
 export default function FileSidebar (props: Props) {
-  const {downloadData, loadFile, createNewFile} = props
+  const {downloadData, loadFile, createNewFile, onDownload} = props
   return (
     <SidePanel title='Protocol File' className={styles.file_sidebar}>
-      <div>
-        <div className={styles.download_button}>
-          <PrimaryButton
-            Component='a'
-            download={downloadData && downloadData.fileName}
-            disabled={!downloadData}
-            href={downloadData && 'data:application/json;charset=utf-8,' + encodeURIComponent(downloadData.fileContents)}
-          >Export</PrimaryButton>
-        </div>
-        <div className={styles.divider} />
+      <div className={styles.download_button}>
+        <PrimaryButton
+          Component='a'
+          download={downloadData && downloadData.fileName}
+          onClick={onDownload}
+          disabled={!downloadData}
+          href={downloadData && 'data:application/json;charset=utf-8,' + encodeURIComponent(downloadData.fileContents)}
+        >Export</PrimaryButton>
       </div>
+      <div className={styles.divider} />
 
       <OutlineButton Component='label' className={cx(styles.upload_button, styles.bottom_button)}>
         Import JSON

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -5,8 +5,15 @@ import { AppContainer } from 'react-hot-loader'
 
 import configureStore from './configureStore.js'
 import App from './components/App'
-
+import {selectors as loadFileSelectors} from './load-file'
 const store = configureStore()
+
+window.onbeforeunload = (e) => {
+  // NOTE: the custom text will be ignored in modern browsers
+  return loadFileSelectors.hasUnsavedChanges(store.getState())
+    ? 'Are you sure you want to leave? You have may unsaved changes.'
+    : undefined
+}
 
 const render = (Component) => {
   ReactDOM.render(

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -8,11 +8,13 @@ import App from './components/App'
 import {selectors as loadFileSelectors} from './load-file'
 const store = configureStore()
 
-window.onbeforeunload = (e) => {
-  // NOTE: the custom text will be ignored in modern browsers
-  return loadFileSelectors.hasUnsavedChanges(store.getState())
-    ? 'Are you sure you want to leave? You have may unsaved changes.'
-    : undefined
+if (process.env.NODE_ENV === 'production') {
+  window.onbeforeunload = (e) => {
+    // NOTE: the custom text will be ignored in modern browsers
+    return loadFileSelectors.hasUnsavedChanges(store.getState())
+      ? 'Are you sure you want to leave? You have may unsaved changes.'
+      : undefined
+  }
 }
 
 const render = (Component) => {

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -55,3 +55,7 @@ export const createNewProtocol = (payload: NewProtocolFields) => ({
   type: 'CREATE_NEW_PROTOCOL',
   payload
 })
+
+export const saveProtocolFile = () => ({
+  type: 'SAVE_PROTOCOL_FILE'
+})

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -13,8 +13,9 @@ const fileErrors = handleActions({
 const unsavedChanges = (state: boolean = false, action: {type: string}): boolean => {
   switch (action.type) {
     case 'LOAD_FILE':
-    case 'CREATE_NEW_FILE':
+    case 'SAVE_PROTOCOL_FILE':
       return false
+    case 'CREATE_NEW_PROTOCOL':
     case 'DISMISS_WARNING':
     case 'CREATE_CONTAINER':
     case 'DELETE_CONTAINER':

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -8,12 +8,39 @@ const fileErrors = handleActions({
   FILE_ERRORS: (state, action: {payload: FileError}) => action.payload
 }, null)
 
+// NOTE: whenever we add or change any of the action types that indicate
+// "changes to the protocol", those action types need to be updated here.
+const unsavedChanges = (state: boolean = false, action: {type: string}): boolean => {
+  switch (action.type) {
+    case 'LOAD_FILE':
+    case 'CREATE_NEW_FILE':
+      return false
+    case 'DISMISS_WARNING':
+    case 'CREATE_CONTAINER':
+    case 'DELETE_CONTAINER':
+    case 'MODIFY_CONTAINER':
+    case 'COPY_LABWARE':
+    case 'EDIT_MODE_INGREDIENT_GROUP':
+    case 'DELETE_INGREDIENT':
+    case 'EDIT_INGREDIENT':
+    case 'ADD_STEP':
+    case 'DELETE_STEP':
+    case 'SAVE_STEP_FORM':
+    case 'SAVE_FILE_METADATA':
+      return true
+    default:
+      return state
+  }
+}
+
 export const _allReducers = {
-  fileErrors
+  fileErrors,
+  unsavedChanges
 }
 
 export type RootState = {
-  fileErrors: FileError
+  fileErrors: FileError,
+  unsavedChanges: boolean
 }
 
 const rootReducer = combineReducers(_allReducers)

--- a/protocol-designer/src/load-file/selectors.js
+++ b/protocol-designer/src/load-file/selectors.js
@@ -1,11 +1,16 @@
 // @flow
 import {createSelector} from 'reselect'
-import type {BaseState} from '../types'
+import type {BaseState, Selector} from '../types'
 import type {RootState} from './reducers'
 
 export const rootSelector = (state: BaseState): RootState => state.loadFile
 
-export const getFileLoadErrors = createSelector(
+export const getFileLoadErrors: Selector<$PropertyType<RootState, 'fileErrors'>> = createSelector(
   rootSelector,
   s => s.fileErrors
+)
+
+export const hasUnsavedChanges: Selector<$PropertyType<RootState, 'unsavedChanges'>> = createSelector(
+  rootSelector,
+  s => s.unsavedChanges
 )


### PR DESCRIPTION
## overview

Closes #1602

## changelog

- uses unsavedChanges reducer to keep track of any actions that might clean or dirty the "saved" state of the protocol

## review requests

:warning: **MUST HAVE `NODE_ENV === 'production'` for this to show up!** :warning: 
(In dev it's really annoying, because the onbeforeunload modal messes up hot reloading)

You could use the prod build here (after CI completes): https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_alert-unsaved-changes-1602/index.html

**Redux DevTools check:**
- [x] Changes to ingredients, labware, metadata fields, step forms, and warning dismissal should set `unsavedChanges` to `true` -- you're creating unsaved changes
- [x] Creating a new protocol should also set `unsavedChanges` to true
- [x] Exporting and importing a protocol should set `unsavedChanges` to `false` -- there are no longer any unsaved changes
- [x] Changes to temporary state (modals, selected step, highlighted well, etc) should be ignored here

- [x] When and only when unsavedChanges is true, the browser default "You may have unsaved changes, are you sure you want to leave this page?" dialog will show up