### PR TITLE
feat(protocol-designer): disable export button with no protocol

### DIFF
--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -22,12 +22,15 @@ export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
 function mapStateToProps (state: BaseState): SP & MP {
   const protocolName = fileDataSelectors.fileMetadata(state).name || 'untitled'
   const fileData = fileDataSelectors.createFile(state)
+  const canDownload = selectors.currentPage(state) !== 'file-splash'
 
   return {
-    downloadData: fileData && {
-      fileContents: JSON.stringify(fileData, null, 4),
-      fileName: protocolName + '.json'
-    },
+    downloadData: (canDownload)
+      ? {
+        fileContents: JSON.stringify(fileData, null, 4),
+        fileName: protocolName + '.json'
+      }
+      : null,
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.newProtocolModal(state)
   }

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -21,16 +21,17 @@ export default function FileSidebar (props: Props) {
   const {downloadData, loadFile, createNewFile} = props
   return (
     <SidePanel title='Protocol File' className={styles.file_sidebar}>
-      {downloadData &&
-        <div>
-          <div className={styles.download_button}>
-            <PrimaryButton Component='a' download={downloadData.fileName}
-              href={'data:application/json;charset=utf-8,' + encodeURIComponent(downloadData.fileContents)}
-            >Export</PrimaryButton>
-          </div>
-          <div className={styles.divider} />
+      <div>
+        <div className={styles.download_button}>
+          <PrimaryButton
+            Component='a'
+            download={downloadData && downloadData.fileName}
+            disabled={!downloadData}
+            href={downloadData && 'data:application/json;charset=utf-8,' + encodeURIComponent(downloadData.fileContents)}
+          >Export</PrimaryButton>
         </div>
-      }
+        <div className={styles.divider} />
+      </div>
 
       <OutlineButton Component='label' className={cx(styles.upload_button, styles.bottom_button)}>
         Import JSON


### PR DESCRIPTION
## overview

Closes #967

## changelog

- disable Download Protocol button (aka Export) when on the splash page

## review requests

:radio: 