### PR TITLE
fix(protocol-designer): fix labware copy mirroring

### DIFF
--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -52,36 +52,45 @@ describe('COPY_LABWARE action', () => {
     expect(containers(
       {
         clonePlate: {
+          id: 'clonePlate',
           type: '96-flat',
           name: 'Samples Plate',
-          slot: 'A2'
+          slot: '1',
+          disambiguationNumber: 1
         },
         otherPlate: {
+          id: 'otherPlate',
           type: '384-flat',
           name: 'Destination Plate',
-          slot: 'B2'
+          slot: '2',
+          disambiguationNumber: 1
         }
       },
       {
         type: 'COPY_LABWARE',
-        payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: 'A3'}
+        payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: '5'}
       }
     )).toEqual({
       clonePlate: {
+        id: 'clonePlate',
         type: '96-flat',
         name: 'Samples Plate',
-        slot: 'A2'
+        slot: '1',
+        disambiguationNumber: 1
       },
       newContainer: {
+        id: 'newContainer',
         type: '96-flat',
         name: 'Samples Plate',
-        slot: 'A3'
+        slot: '5',
+        disambiguationNumber: 2
       },
-
       otherPlate: {
+        id: 'otherPlate',
         type: '384-flat',
         name: 'Destination Plate',
-        slot: 'B2'
+        slot: '2',
+        disambiguationNumber: 1
       }
     })
   })

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -98,18 +98,18 @@ describe('COPY_LABWARE action', () => {
   test('copy ingredient locations from cloned container', () => {
     const copyLabwareAction = {
       type: 'COPY_LABWARE',
-      payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: 'A3'}
+      payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: '5'}
     }
 
     const prevIngredState = {
-      '3': {
+      ingred3: {
         name: 'Buffer',
         wellDetailsByLocation: null,
         concentration: '50 mol/ng',
         description: '',
         individualize: false
       },
-      '4': {
+      ingred4: {
         name: 'Other Ingred',
         wellDetailsByLocation: null,
         concentration: '100%',
@@ -119,22 +119,16 @@ describe('COPY_LABWARE action', () => {
     }
 
     const prevLocationsState = {
-      '3': {
-        myTrough: {
-          A1: {volume: 101},
-          A2: {volume: 102},
-          A3: {volume: 103}
-        },
-        otherContainer: {
-          D4: {volume: 201},
-          E4: {volume: 202}
-        }
+      myTrough: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
       },
-      '4': {
-        otherContainer: {
-          A4: {volume: 301},
-          B4: {volume: 302}
-        }
+      otherContainer: {
+        D4: {ingred3: {volume: 201}},
+        E4: {ingred3: {volume: 202}},
+        A4: {ingred4: {volume: 301}},
+        B4: {ingred4: {volume: 302}}
       }
     }
 
@@ -147,27 +141,22 @@ describe('COPY_LABWARE action', () => {
       prevLocationsState,
       copyLabwareAction
     )).toEqual({
-      '3': {
-        myTrough: {
-          A1: {volume: 101},
-          A2: {volume: 102},
-          A3: {volume: 103}
-        },
-        newContainer: { // this is newly copied
-          A1: {volume: 101},
-          A2: {volume: 102},
-          A3: {volume: 103}
-        },
-        otherContainer: {
-          D4: {volume: 201},
-          E4: {volume: 202}
-        }
+      myTrough: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
       },
-      '4': {
-        otherContainer: {
-          A4: {volume: 301},
-          B4: {volume: 302}
-        }
+      // this is newly copied
+      newContainer: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
+      },
+      otherContainer: {
+        D4: {ingred3: {volume: 201}},
+        E4: {ingred3: {volume: 202}},
+        A4: {ingred4: {volume: 301}},
+        B4: {ingred4: {volume: 302}}
       }
     })
   })


### PR DESCRIPTION
## overview

Closes #1616

## changelog

- fix labware copying - no mirroring of name or ingredients
- update old COPY_LABWARE-related tests (had entirely wrong state shape -- good case for keeping Flow in tests!)

## review requests

- [ ] Copying a labware with ingredient contents should copy the ingredients, but not mirror them (eg they show up, if you edit the clone parent or the clone child labware's ingredients, it doesn't affect the ingredients of the other labware)
- [ ] Copying a labware with no nickname should update its disambiguation number
- [ ] Steps using cloned labware should still work normally