### PR TITLE
feat(app): Wire modules card to API calls (and keep stubbed response)

### DIFF
--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -3,20 +3,26 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
-import type {State} from '../../types'
+import type {State, Dispatch} from '../../types'
 import type {Module} from '../../http-api-client'
-import {Card} from '@opentrons/components'
+import type {Robot} from '../../robot'
+
+import {RefreshCard} from '@opentrons/components'
 import {getModulesOn} from '../../config'
+import {fetchModules, makeGetRobotModules} from '../../http-api-client'
 import ModulesCardContents from './ModulesCardContents'
+
+type OP = Robot
 
 type SP = {
   modulesFlag: ?boolean,
-  inProgress?: ?boolean,
-  modules?: Array<Module>,
-  fetchModules?: () => mixed
+  modules: Array<Module>,
+  refreshing: boolean
 }
 
-type Props = SP
+type DP = {refresh: () => mixed}
+
+type Props = OP & SP & DP
 
 const TITLE = 'Modules'
 
@@ -38,26 +44,44 @@ const STUBBED_MODULE_DATA = [
     displayName: 'Magnetic Bead Module'
   }
 ]
-export default connect(mapStateToProps, null)(AttachedModulesCard)
+export default connect(makeSTP, DTP)(AttachedModulesCard)
 
 // TODO (ka 2018-6-29): change this to a refresh card once we have endpoints
 function AttachedModulesCard (props: Props) {
   if (props.modulesFlag) {
     return (
-      <Card
+      <RefreshCard
         title={TITLE}
+        watch={props.name}
+        refreshing={props.refreshing}
+        refresh={props.refresh}
         column
       >
-        <ModulesCardContents {...props}/>
-      </Card>
+        <ModulesCardContents modules={props.modules} />
+      </RefreshCard>
     )
   }
   return null
 }
 
-function mapStateToProps (state: State): SP {
+function makeSTP (): (state: State, ownProps: OP) => SP {
+  const getRobotModules = makeGetRobotModules()
+
+  return (state, ownProps) => {
+    const modulesCall = getRobotModules(state, ownProps)
+    const modulesResponse = modulesCall.response
+    const modules = modulesResponse && modulesResponse.modules
+
+    return {
+      modulesFlag: getModulesOn(state),
+      modules: modules || STUBBED_MODULE_DATA,
+      refreshing: modulesCall.inProgress
+    }
+  }
+}
+
+function DTP (dispatch: Dispatch, ownProps: OP): DP {
   return {
-    modulesFlag: getModulesOn(state),
-    modules: STUBBED_MODULE_DATA
+    refresh: () => dispatch(fetchModules(ownProps))
   }
 }

--- a/app/src/components/InstrumentSettings/ModulesCardContents.js
+++ b/app/src/components/InstrumentSettings/ModulesCardContents.js
@@ -9,14 +9,14 @@ type Props = {
 
 export default function ModulesCardContents (props: Props) {
   const modulesFound = props.modules[0]
-  if (modulesFound) {
-    return (
-      <React.Fragment>
+
+  if (!modulesFound) return (<NoModulesMessage />)
+
+  return (
+    <React.Fragment>
       {props.modules.map((mod, index) => (
         <ModuleItem {...mod} key={index}/>
       ))}
-      </React.Fragment>
-    )
-  }
-  return (<NoModulesMessage />)
+    </React.Fragment>
+  )
 }

--- a/app/src/components/InstrumentSettings/index.js
+++ b/app/src/components/InstrumentSettings/index.js
@@ -1,6 +1,7 @@
 // @flow
 // robot status panel with connect button
 import * as React from 'react'
+
 import type {Robot} from '../../robot'
 
 import AttachedPipettesCard from './AttachedPipettesCard'

--- a/app/src/components/ModuleItem/styles.css
+++ b/app/src/components/ModuleItem/styles.css
@@ -8,10 +8,10 @@
 }
 
 .module_item {
-  width: 100%;
-  margin-bottom: 1rem;
   display: flex;
   justify-content: space-between;
+  width: 100%;
+  margin-top: 1.5rem;
 }
 
 .module_image_wrapper {


### PR DESCRIPTION
## overview

This PR is modules plumbing work so the app actually calls the GET /modules endpoint to populate the card. The stubbed responses are left in place if you hit a robot that doesn't know what to do with `GET /pipettes`. This stubbing logic will be removed before we take modules out from behind the experimental feature flag.

## changelog

- feat(app): Wire modules card to API calls (and keep stubbed response) 

## review requests

- [ ] Modules card displays stubbed modules if you hit a robot that doesn't support `GET /modules`
- [ ] Modules card displays actual response (e.g. "No modules found") if you hit a robot that _does_ support `GET /modules`
    - Sunset is up to date with modules endpoint work
