### PR TITLE
feat(protocol-designer): support tiprack-to-pipette assignment

### DIFF
--- a/protocol-designer/src/step-generation/replaceTip.js
+++ b/protocol-designer/src/step-generation/replaceTip.js
@@ -15,9 +15,10 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
   let robotState = cloneDeep(prevRobotState)
 
   // get next full tiprack in slot order
-  const nextTiprack = getNextTiprack(pipetteData.channels, robotState)
+  const nextTiprack = getNextTiprack(pipetteData, robotState)
 
   if (!nextTiprack) {
+    // no valid next tip / tiprack, bail out
     return {
       errors: [insufficientTips()]
     }
@@ -45,6 +46,12 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
 
   // pipette now has tip
   robotState.tipState.pipettes[pipetteId] = true
+
+  // update tiprack-to-pipette assignment
+  robotState.tiprackAssignment = {
+    ...robotState.tiprackAssignment,
+    [nextTiprack.tiprackId]: pipetteId
+  }
 
   // remove tips from tiprack
   if (pipetteData.channels === 1 && nextTiprack.well) {

--- a/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {p300Single, createEmptyLiquidState, getTiprackTipstate, getTipColumn} from './fixtures'
+import {p300Single, p300Multi, createEmptyLiquidState, getTiprackTipstate, getTipColumn} from './fixtures'
 import {sortLabwareBySlot, getNextTiprack, _getNextTip} from '../'
 
 // just a blank liquidState to appease flow
@@ -12,7 +12,8 @@ describe('sortLabwareBySlot', () => {
   test('sorts all labware by slot', () => {
     // TODO use a fixture, standardize
     const _instrumentsState = {
-      p300SingleId: p300Single
+      p300SingleId: p300Single,
+      p300MultiId: p300Multi
     }
 
     const robotState = {
@@ -159,7 +160,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(1, robotState)
+    const result = getNextTiprack(p300Single, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('B1')
@@ -197,7 +198,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(1, robotState)
+    const result = getNextTiprack(p300Single, robotState)
 
     expect(result).toEqual(null)
   })
@@ -251,7 +252,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(1, robotState)
+    const result = getNextTiprack(p300Single, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -308,7 +309,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(1, robotState)
+    const result = getNextTiprack(p300Single, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('B1')
@@ -358,7 +359,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -408,7 +409,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A3')
@@ -445,7 +446,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result).toEqual(null)
   })
@@ -503,7 +504,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result).toEqual(null)
   })
@@ -565,7 +566,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -655,7 +656,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack10Id')
     expect(result && result.well).toEqual('A2')
@@ -754,7 +755,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState
     }
 
-    const result = getNextTiprack(8, robotState)
+    const result = getNextTiprack(p300Multi, robotState)
 
     expect(result).toEqual(null)
   })

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -155,6 +155,12 @@ export type RobotState = {|
   labware: {
     [labwareId: string]: LabwareData
   },
+  // tiprackAssignment: maps tiprackLabwareId to its assigned PipetteId.
+  // Each tiprack is either unassigned, or assigned to one pipette.
+  // `tiprackAssignment` will go away when tiprack sharing is implemented
+  tiprackAssignment?: ?{
+    [tiprackLabwareId: string]: ?string
+  },
   tipState: {
     tipracks: {
       [labwareId: string]: {


### PR DESCRIPTION
## overview

Closes #1573

## changelog

- `tiprackAssignment` key in RobotState
- `getNextTiprack` fn uses new `tiprackIsAvailableToPipette` so that `replaceTip` will not get tips from tipracks assigned to other pipettes
- add tiprack assignment cases to `replaceTip` tests

## review requests

- [ ] Single lone pipette uses tips correctly
- [ ] Two pipettes with same tiprack type do not share tipracks, but auto-assign. For example, with one tiprack, using Pipette 1 for a transfer will auto-assign Tiprack 1 to Pipette 1. If pipette 2 does a transfer, PD will prompt you to add a 2nd tiprack
- [ ] Two pipettes with different tiprack type only use their own tip type, and never the other's tips (easiest test: look at the saved .json)
- [ ] Tiprack assignment is still saved in the JSON file correctly
