### PR TITLE
feat(protocol-designer): disposal volume only on distribute

### DIFF
--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -55,9 +55,11 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
                 <StepInputField name="aspirate_mix_volume" units='μL' {...focusHandlers} />
                 <StepInputField name="aspirate_mix_times" units='Times' {...focusHandlers} />
               </StepCheckboxRow>
-              <StepCheckboxRow name="aspirate_disposalVol_checkbox" label="Disposal Volume" >
-                <StepInputField name="aspirate_disposalVol_volume" units="μL" {...focusHandlers} />
-              </StepCheckboxRow>
+              {stepType === 'distribute' &&
+                <StepCheckboxRow name="aspirate_disposalVol_checkbox" label="Disposal Volume" >
+                  <StepInputField name="aspirate_disposalVol_volume" units="μL" {...focusHandlers} />
+                </StepCheckboxRow>
+              }
             </FormGroup>
           </div>
           <div className={styles.right_settings_column}>


### PR DESCRIPTION

Make distribute steps the only type with the option to add a disposal volume

Closes #1867
