### PR TITLE
feat(api): Brings back the shake after drop-tip

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -32,7 +32,7 @@ DEFAULT_TIP_PRESS_MM = -10
 
 DEFAULT_PLUNGE_CURRENT = 0.1
 
-SHAKE_OFF_TIPS_SPEED = 50
+SHAKE_OFF_TIPS_SPEED = 25
 SHAKE_OFF_TIPS_DISTANCE = 2
 
 
@@ -1026,6 +1026,7 @@ class Pipette:
                 self.robot.poses,
                 x=pos_drop_tip
             )
+            self._shake_off_tips(location)
 
             if home_after:
                 self._home_after_drop_tip()


### PR DESCRIPTION
## overview

Add `Pipette._shake_off_tips()` back to the end of a `drop_tip()` sequence, to help tips fully fall off.

This shaking is helpful for when tips are touching something while being dropped. Like for example, when touching the tip-rack when being returned, or when touching previously trashed tips in the trash box. This movement was inadvertently removed a couple of months ago, and is needed now for p1000 lifetime testing (because the tips/nozzles are bigger and therefore get stuck for more easily).