### PR TITLE
PD: make form warnings dismissable 1843

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -56,22 +56,17 @@ class FormAlerts extends React.Component<FormAlertsProps> {
 }
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
-  const errors = steplistSelectors.formLevelErrors(state)
-  const warnings = steplistSelectors.formLevelWarnings(state)
-  const dismissedWarnings = dismissSelectors.getDismissedWarningsForSelectedStep(state)
-  const dismissedTypesForStep = dismissedWarnings.map(dw => dw.type)
-  const visibleWarnings = warnings.filter(w => !dismissedTypesForStep.includes(w.type))
-
   const {focusedField, dirtyFields} = ownProps
+  const visibleWarnings = dismissSelectors.makeGetVisibleFormWarningsForSelectedStep({focusedField, dirtyFields})(state)
+
+  const errors = steplistSelectors.formLevelErrors(state)
   const filteredErrors = errors.filter(e => (
     !e.dependentFields.includes(focusedField) && difference(e.dependentFields, dirtyFields).length === 0)
   )
-  const filteredWarnings = visibleWarnings.filter(w => (
-    !w.dependentFields.includes(focusedField) && difference(w.dependentFields, dirtyFields).length === 0)
-  )
+
   return {
     errors: filteredErrors,
-    warnings: filteredWarnings,
+    warnings: visibleWarnings,
     stepId: steplistSelectors.selectedStepId(state)
   }
 }

--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -2,9 +2,9 @@
 import * as React from 'react'
 import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
-import difference from 'lodash/difference'
 import {AlertItem} from '@opentrons/components'
 import {actions as dismissActions, selectors as dismissSelectors} from '../../dismiss'
+import {getVisibleAlerts} from './helpers'
 import type {StepIdType} from '../../form-types'
 import {selectors as steplistSelectors} from '../../steplist'
 import type {StepFieldName} from '../../steplist/fieldLevel'
@@ -57,12 +57,18 @@ class FormAlerts extends React.Component<FormAlertsProps> {
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
   const {focusedField, dirtyFields} = ownProps
-  const visibleWarnings = dismissSelectors.makeGetVisibleFormWarningsForSelectedStep({focusedField, dirtyFields})(state)
+  const visibleWarnings = getVisibleAlerts({
+    focusedField,
+    dirtyFields,
+    alerts: dismissSelectors.getFormWarningsForSelectedStep(state)
+  })
 
   const errors = steplistSelectors.formLevelErrors(state)
-  const filteredErrors = errors.filter(e => (
-    !e.dependentFields.includes(focusedField) && difference(e.dependentFields, dirtyFields).length === 0)
-  )
+  const filteredErrors = getVisibleAlerts({
+    focusedField,
+    dirtyFields,
+    alerts: errors
+  })
 
   return {
     errors: filteredErrors,

--- a/protocol-designer/src/components/StepEditForm/helpers.js
+++ b/protocol-designer/src/components/StepEditForm/helpers.js
@@ -1,0 +1,14 @@
+// @flow
+import difference from 'lodash/difference'
+
+export function getVisibleAlerts<Field, Alert: {dependentFields: Array<Field>}> (args: {
+  focusedField: ?Field,
+  dirtyFields: Array<Field>,
+  alerts: Array<Alert>
+}): Array<Alert> {
+  const {focusedField, dirtyFields, alerts} = args
+  return alerts.filter(alert => (
+    !alert.dependentFields.includes(focusedField) &&
+    difference(alert.dependentFields, dirtyFields).length === 0)
+  )
+}

--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -67,7 +67,7 @@ function Alerts (props: Props) {
 function mapStateToProps (state: BaseState): SP {
   const timeline = fileDataSelectors.robotStateTimeline(state)
   const errors = timeline.errors || []
-  const warnings = dismissSelectors.getVisibleWarningsForSelectedStep(state)
+  const warnings = dismissSelectors.getVisibleTimelineWarningsForSelectedStep(state)
   const _stepId: any = steplistSelectors.selectedStepId(state) // TODO: Ian 2018-07-02 type properly once stepId is always string type
 
   return {

--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -67,7 +67,7 @@ function Alerts (props: Props) {
 function mapStateToProps (state: BaseState): SP {
   const timeline = fileDataSelectors.robotStateTimeline(state)
   const errors = timeline.errors || []
-  const warnings = dismissSelectors.getVisibleTimelineWarningsForSelectedStep(state)
+  const warnings = dismissSelectors.getTimelineWarningsForSelectedStep(state)
   const _stepId: any = steplistSelectors.selectedStepId(state) // TODO: Ian 2018-07-02 type properly once stepId is always string type
 
   return {

--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -80,7 +80,7 @@ function mapStateToProps (state: BaseState): SP {
 function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Props {
   const {dispatch} = dispatchProps
   const onDismiss = (warning: CommandCreatorWarning) =>
-    () => dispatch(dismissActions.dismissWarning({
+    () => dispatch(dismissActions.dismissTimelineWarning({
       warning,
       stepId: stateProps._stepId
     }))

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -66,7 +66,7 @@ function Alerts (props: Props) {
 function mapStateToProps (state: BaseState): SP {
   const timeline = fileDataSelectors.robotStateTimeline(state)
   const errors = timeline.errors || []
-  const warnings = dismissSelectors.getVisibleTimelineWarningsForSelectedStep(state)
+  const warnings = dismissSelectors.getTimelineWarningsForSelectedStep(state)
   const _stepId: any = steplistSelectors.selectedStepId(state) // TODO: Ian 2018-07-02 type properly once stepId is always string type
 
   return {

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -79,7 +79,7 @@ function mapStateToProps (state: BaseState): SP {
 function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Props {
   const {dispatch} = dispatchProps
   const onDismiss = (warning: CommandCreatorWarning) =>
-    () => dispatch(dismissActions.dismissWarning({
+    () => dispatch(dismissActions.dismissTimelineWarning({
       warning,
       stepId: stateProps._stepId
     }))

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -66,7 +66,7 @@ function Alerts (props: Props) {
 function mapStateToProps (state: BaseState): SP {
   const timeline = fileDataSelectors.robotStateTimeline(state)
   const errors = timeline.errors || []
-  const warnings = dismissSelectors.getVisibleWarningsForSelectedStep(state)
+  const warnings = dismissSelectors.getVisibleTimelineWarningsForSelectedStep(state)
   const _stepId: any = steplistSelectors.selectedStepId(state) // TODO: Ian 2018-07-02 type properly once stepId is always string type
 
   return {

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -46,10 +46,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId
   const warnings = dismissSelectors.getVisibleWarningsPerStep(state)[stepId]
-  // TODO: Ian 2018-07-03 show warnings once dismissable
-  const hasWarnings = process.env.OT_PD_SHOW_WARNINGS === 'true'
-    ? warnings && warnings.length > 0
-    : false
+  const hasWarnings = warnings && warnings.length > 0
 
   const showErrorState = hasError || hasWarnings
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -46,7 +46,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId
   const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
-    ? dismissSelectors.getVisibleTimelineWarningsPerStep(state)[stepId]
+    ? dismissSelectors.getTimelineWarningsPerStep(state)[stepId]
     : []
   const hasWarnings = warnings && warnings.length > 0
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -45,7 +45,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const selected = steplistSelectors.selectedStepId(state) === stepId
 
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId
-  const warnings = dismissSelectors.getVisibleWarningsPerStep(state)[stepId]
+  const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
+    ? dismissSelectors.getVisibleTimelineWarningsPerStep(state)[stepId]
+    : []
   const hasWarnings = warnings && warnings.length > 0
 
   const showErrorState = hasError || hasWarnings

--- a/protocol-designer/src/dismiss/actions.js
+++ b/protocol-designer/src/dismiss/actions.js
@@ -1,16 +1,28 @@
 // @flow
 import type {CommandCreatorWarning} from '../step-generation'
+import type {FormWarning} from '../steplist'
 
-type DismissWarning = {
-  type: 'DISMISS_WARNING',
+export type DismissAction<ActionType, WarningType> = {
+  type: ActionType,
   payload: {
-    warning: CommandCreatorWarning,
+    warning: WarningType,
     stepId: number
   }
 }
-export const dismissWarning = (
-  payload: $PropertyType<DismissWarning, 'payload'>
-): DismissWarning => ({
-  type: 'DISMISS_WARNING',
+
+export type DismissFormWarning = DismissAction<'DISMISS_FORM_WARNING', FormWarning>
+export type DismissTimelineWarning = DismissAction<'DISMISS_TIMELINE_WARNING', CommandCreatorWarning>
+
+export const dismissFormWarning = (
+  payload: $PropertyType<DismissFormWarning, 'payload'>
+): DismissFormWarning => ({
+  type: 'DISMISS_FORM_WARNING',
+  payload
+})
+
+export const dismissTimelineWarning = (
+  payload: $PropertyType<DismissTimelineWarning, 'payload'>
+): DismissTimelineWarning => ({
+  type: 'DISMISS_TIMELINE_WARNING',
   payload
 })

--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -1,6 +1,6 @@
 // @flow
 import {combineReducers} from 'redux'
-import {combineActions, handleActions} from 'redux-actions'
+import {handleActions} from 'redux-actions'
 import omit from 'lodash/omit'
 import type {
   DismissFormWarning,
@@ -13,31 +13,55 @@ import type {CommandCreatorWarning} from '../step-generation'
 import type {FormWarning} from '../steplist'
 import type {DeleteStepAction} from '../steplist/actions'
 
-export type MixedWarnings = CommandCreatorWarning | FormWarning
-type DismissedWarningState = {[stepId: number]: ?Array<MixedWarnings>}
-
+export type DismissedWarningsAllSteps<WarningType> = {[stepId: number]: ?Array<WarningType>}
+export type DismissedWarningState = {
+  form: DismissedWarningsAllSteps<FormWarning>,
+  timeline: DismissedWarningsAllSteps<CommandCreatorWarning>
+}
 const dismissedWarnings = handleActions({
-  [combineActions('DISMISS_FORM_WARNING', 'DISMISS_TIMELINE_WARNING')]: (
+  DISMISS_FORM_WARNING: (
     state: DismissedWarningState,
-    action: DismissFormWarning | DismissTimelineWarning
+    action: DismissFormWarning
   ): DismissedWarningState => {
     const {stepId, warning} = action.payload
     return {
       ...state,
-      [stepId]: [
-        ...(state[stepId] || []),
-        warning
-      ]
+      form: {
+        ...state.form,
+        [stepId]: [
+          ...(state.form[stepId] || []),
+          warning
+        ]
+      }
+    }
+  },
+  DISMISS_TIMELINE_WARNING: (
+    state: DismissedWarningState,
+    action: DismissTimelineWarning
+  ): DismissedWarningState => {
+    const {stepId, warning} = action.payload
+    return {
+      ...state,
+      timeline: {
+        ...state.timeline,
+        [stepId]: [
+          ...(state.timeline[stepId] || []),
+          warning
+        ]
+      }
     }
   },
   DELETE_STEP: (state: DismissedWarningState, action: DeleteStepAction): DismissedWarningState => {
     // remove key for deleted step
     const stepId = action.payload.toString(10)
-    return omit(state, stepId)
+    return {
+      form: omit(state.form, stepId),
+      timeline: omit(state.timeline, stepId)
+    }
   },
   LOAD_FILE: (state: DismissedWarningState, action: LoadFileAction): DismissedWarningState =>
     getPDMetadata(action.payload).dismissedWarnings
-}, {})
+}, {form: {}, timeline: {}})
 
 export const _allReducers = {
   dismissedWarnings

--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -1,20 +1,25 @@
 // @flow
 import {combineReducers} from 'redux'
-import {handleActions} from 'redux-actions'
+import {combineActions, handleActions} from 'redux-actions'
 import omit from 'lodash/omit'
-import {dismissWarning} from './actions'
+import type {
+  DismissFormWarning,
+  DismissTimelineWarning
+} from './actions'
 import {getPDMetadata} from '../file-types'
-import type {ActionType} from 'redux-actions'
 import type {BaseState} from '../types'
 import type {LoadFileAction} from '../load-file'
 import type {CommandCreatorWarning} from '../step-generation'
+import type {FormWarning} from '../steplist'
 import type {DeleteStepAction} from '../steplist/actions'
 
-export type DismissedWarningState = {[stepId: number]: ?Array<CommandCreatorWarning>}
+export type MixedWarnings = CommandCreatorWarning | FormWarning
+type DismissedWarningState = {[stepId: number]: ?Array<MixedWarnings>}
+
 const dismissedWarnings = handleActions({
-  DISMISS_WARNING: (
+  [combineActions('DISMISS_FORM_WARNING', 'DISMISS_TIMELINE_WARNING')]: (
     state: DismissedWarningState,
-    action: ActionType<typeof dismissWarning>
+    action: DismissFormWarning | DismissTimelineWarning
   ): DismissedWarningState => {
     const {stepId, warning} = action.payload
     return {
@@ -25,7 +30,7 @@ const dismissedWarnings = handleActions({
       ]
     }
   },
-  DELETE_STEP: (state: DismissedWarningState, action: DeleteStepAction) => {
+  DELETE_STEP: (state: DismissedWarningState, action: DeleteStepAction): DismissedWarningState => {
     // remove key for deleted step
     const stepId = action.payload.toString(10)
     return omit(state, stepId)

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -1,29 +1,27 @@
 // @flow
 import {createSelector} from 'reselect'
-
 // TODO: Ian 2018-07-02 split apart file-data concerns to avoid circular dependencies
 // Eg, right now if you import {selectors as fileDataSelectors} from '../file-data',
 // PD won't start, b/c of circular dependency when fileData/selectors/fileCreator
 // imports getDismissedWarnings selector from 'dismiss/
-import {warningsPerStep} from '../file-data/selectors/commands'
+import {timelineWarningsPerStep} from '../file-data/selectors/commands'
 
 import {selectors as steplistSelectors} from '../steplist'
 import type {BaseState, Selector} from '../types'
-import type {CommandCreatorWarning} from '../step-generation'
-import type {RootState, DismissedWarningState} from './reducers'
+import type {RootState} from './reducers'
 
 export const rootSelector = (state: BaseState): RootState => state.dismiss
 
-export const getDismissedWarnings: Selector<DismissedWarningState> = createSelector(
+export const getDismissedWarnings: Selector<*> = createSelector(
   rootSelector,
   s => s.dismissedWarnings
 )
 
-type WarningsPerStep = {[stepId: string | number]: Array<CommandCreatorWarning>}
+type WarningsPerStep = {[stepId: string | number]: Array<*>}
 /** Non-dismissed warnings for each step */
 export const getVisibleWarningsPerStep: Selector<WarningsPerStep> = createSelector(
   getDismissedWarnings,
-  warningsPerStep,
+  timelineWarningsPerStep,
   steplistSelectors.orderedSteps,
   (dismissedWarnings, warningsPerStep, orderedSteps) => {
     return orderedSteps.reduce(
@@ -47,9 +45,15 @@ export const getVisibleWarningsPerStep: Selector<WarningsPerStep> = createSelect
   }
 )
 
-export const getVisibleWarningsForSelectedStep: Selector<Array<CommandCreatorWarning>> = createSelector(
+export const getVisibleWarningsForSelectedStep: Selector<Array<*>> = createSelector(
   getVisibleWarningsPerStep,
   steplistSelectors.selectedStepId,
   (warningsPerStep, stepId) =>
     (typeof stepId === 'number' && warningsPerStep[stepId]) || []
+)
+
+export const getDismissedWarningsForSelectedStep: Selector<Array<*>> = createSelector(
+  getDismissedWarnings,
+  steplistSelectors.selectedStepId,
+  (dismissedWarnings, stepId) => (typeof stepId === 'number' && dismissedWarnings[stepId]) || []
 )

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -27,7 +27,7 @@ export const getDismissedTimelineWarnings: Selector<DismissedWarningsAllSteps<Co
   all => all.timeline
 )
 
-export const getVisibleTimelineWarningsPerStep: Selector<DismissedWarningsAllSteps<CommandCreatorWarning>> = createSelector(
+export const getTimelineWarningsPerStep: Selector<DismissedWarningsAllSteps<CommandCreatorWarning>> = createSelector(
   getDismissedTimelineWarnings,
   timelineWarningsPerStep,
   steplistSelectors.orderedSteps,
@@ -53,8 +53,8 @@ export const getVisibleTimelineWarningsPerStep: Selector<DismissedWarningsAllSte
   }
 )
 
-export const getVisibleTimelineWarningsForSelectedStep: Selector<Array<CommandCreatorWarning>> = createSelector(
-  getVisibleTimelineWarningsPerStep,
+export const getTimelineWarningsForSelectedStep: Selector<Array<CommandCreatorWarning>> = createSelector(
+  getTimelineWarningsPerStep,
   steplistSelectors.selectedStepId,
   (warningsPerStep, stepId) =>
     (typeof stepId === 'number' && warningsPerStep[stepId]) || []

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -1,5 +1,4 @@
 // @flow
-import difference from 'lodash/difference'
 import {createSelector} from 'reselect'
 // TODO: Ian 2018-07-02 split apart file-data concerns to avoid circular dependencies
 // Eg, right now if you import {selectors as fileDataSelectors} from '../file-data',
@@ -7,7 +6,6 @@ import {createSelector} from 'reselect'
 // imports getDismissedWarnings selector from 'dismiss/
 import {timelineWarningsPerStep} from '../file-data/selectors/commands'
 import {selectors as steplistSelectors, type FormWarning} from '../steplist'
-import type {StepFieldName} from '../steplist/fieldLevel'
 import type {CommandCreatorWarning} from '../step-generation'
 import type {BaseState, Selector} from '../types'
 import type {RootState, DismissedWarningsAllSteps} from './reducers'
@@ -68,21 +66,13 @@ export const getDismissedFormWarningsForSelectedStep: Selector<Array<FormWarning
   (dismissedWarnings, stepId) => (typeof stepId === 'number' && dismissedWarnings[stepId]) || []
 )
 
-export const makeGetVisibleFormWarningsForSelectedStep: ({
-  focusedField: ?StepFieldName,
-  dirtyFields: Array<StepFieldName>
-}) => Selector<Array<FormWarning>> = ({focusedField, dirtyFields}) =>
-  createSelector(
-    steplistSelectors.formLevelWarnings,
-    getDismissedFormWarningsForSelectedStep,
-    (warnings, dismissedWarnings) => {
-      const dismissedTypesForStep = dismissedWarnings.map(dw => dw.type)
-      const visibleWarnings = warnings.filter(w => !dismissedTypesForStep.includes(w.type))
-
-      const filteredWarnings = visibleWarnings.filter(w => (
-        !w.dependentFields.includes(focusedField) &&
-        difference(w.dependentFields, dirtyFields).length === 0)
-      )
-      return filteredWarnings
-    }
-  )
+/** Non-dismissed form-level warnings for selected step */
+export const getFormWarningsForSelectedStep: Selector<Array<FormWarning>> = createSelector(
+  steplistSelectors.formLevelWarnings,
+  getDismissedFormWarningsForSelectedStep,
+  (warnings, dismissedWarnings) => {
+    const dismissedTypesForStep = dismissedWarnings.map(dw => dw.type)
+    const formWarnings = warnings.filter(w => !dismissedTypesForStep.includes(w.type))
+    return formWarnings
+  }
+)

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -171,7 +171,7 @@ export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelec
 )
 
 type WarningsPerStep = {[stepId: number | string]: ?Array<StepGeneration.CommandCreatorWarning>}
-export const warningsPerStep: Selector<WarningsPerStep> = createSelector(
+export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector(
   steplistSelectors.orderedSteps,
   robotStateTimeline,
   (orderedSteps, timeline) => timeline.timeline.reduce((acc: WarningsPerStep, frame, timelineIndex) => {

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -18,7 +18,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   fileMetadata,
   getInitialRobotState,
   robotStateTimeline,
-  dismissSelectors.getDismissedWarnings,
+  dismissSelectors.getAllDismissedWarnings,
   ingredSelectors.getIngredientGroups,
   ingredSelectors.getIngredientLocations,
   steplistSelectors.getSavedForms,

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -16,7 +16,8 @@ const unsavedChanges = (state: boolean = false, action: {type: string}): boolean
     case 'SAVE_PROTOCOL_FILE':
       return false
     case 'CREATE_NEW_PROTOCOL':
-    case 'DISMISS_WARNING':
+    case 'DISMISS_FORM_WARNING':
+    case 'DISMISS_TIMELINE_WARNING':
     case 'CREATE_CONTAINER':
     case 'DELETE_CONTAINER':
     case 'MODIFY_CONTAINER':

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -14,7 +14,7 @@ import {
   maxDispenseWellVolume,
   minDisposalVolume,
   type FormWarning,
-  type FormWarningKey
+  type FormWarningType
 } from './warnings'
 import type {StepType} from '../../form-types'
 
@@ -36,7 +36,7 @@ const stepFormHelperMap: {[StepType]: FormHelpers} = {
   }
 }
 
-export type {FormError, FormWarning, FormWarningKey}
+export type {FormError, FormWarning, FormWarningType}
 
 export const getFormErrors = (stepType: StepType, formData: mixed): Array<FormError> => {
   const formErrorGetter = stepFormHelperMap[stepType] && stepFormHelperMap[stepType].getErrors
@@ -47,6 +47,5 @@ export const getFormErrors = (stepType: StepType, formData: mixed): Array<FormEr
 export const getFormWarnings = (stepType: StepType, formData: mixed): Array<FormWarning> => {
   const formWarningGetter = stepFormHelperMap[stepType] && stepFormHelperMap[stepType].getWarnings
   const warnings = formWarningGetter ? formWarningGetter(formData) : []
-  // TODO: filter out dismissed warnings here
   return warnings
 }

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -7,21 +7,24 @@ export const DISPOSAL_PERCENTAGE = 0.2 // 20% percent of pipette capacity
 ** Warning Messages **
 ********************/
 
-export type FormWarningKey = 'OVER_MAX_WELL_VOLUME' | 'BELOW_MIN_DISPOSAL_VOLUME'
+export type FormWarningType =
+  | 'OVER_MAX_WELL_VOLUME'
+  | 'BELOW_MIN_DISPOSAL_VOLUME'
+
 export type FormWarning = {
-  warningId: FormWarningKey,
+  type: FormWarningType,
   message: string,
   dependentFields: Array<StepFieldName>,
   title?: string
 }
-const FORM_WARNINGS: {[FormWarningKey]: FormWarning} = {
+const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {
   OVER_MAX_WELL_VOLUME: {
-    warningId: 'OVER_MAX_WELL_VOLUME',
+    type: 'OVER_MAX_WELL_VOLUME',
     message: 'Dispense volume will overflow a destination well',
     dependentFields: ['dispense_labware', 'dispense_wells', 'volume']
   },
   BELOW_MIN_DISPOSAL_VOLUME: {
-    warningId: 'BELOW_MIN_DISPOSAL_VOLUME',
+    type: 'BELOW_MIN_DISPOSAL_VOLUME',
     title: 'Below Recommended disposal volume',
     message: 'For accuracy in distribute actions we recommend you use a disposal volume of at least 20% of the tip\'s capacity. Read more here:', // TODO: BC link knowledgebase article here.
     dependentFields: ['aspirate_disposalVol_volume', 'pipette']

--- a/protocol-designer/src/steplist/index.js
+++ b/protocol-designer/src/steplist/index.js
@@ -6,8 +6,13 @@ import selectors from './selectors'
 import * as actions from './actions'
 import * as utils from './utils'
 import {getFieldErrors, processField} from './fieldLevel'
+import type {FormWarning, FormWarningType} from './formLevel'
 
-export type {RootState}
+export type {
+  RootState,
+  FormWarning,
+  FormWarningType
+}
 export {
   actions,
   rootReducer,


### PR DESCRIPTION
## overview

Closes #1843 

## changelog

- make form-level warnings dismissable
- disambiguate dismissWarning action: now dismissTimelineWarning vs dismissFormWarning

## review requests

- Form level warnings should show up (eg, set a low disposal volume on a Distribute)
- Form level warnings should be dismissable (each warning type is dismissable per-step)
- Timeline warnings (eg not enough liquid in well) still work, and are dismissable per-step as before
- Loading a file (saved via this branch's version of PD! not earlier files) will restore all dismiss state (both form-level and timeline-level)