### PR TITLE
feat(protocol-designer): switch well order colors

### DIFF
--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -7,9 +7,9 @@ export const MIXED_WELL_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in col
 // TODO factor into CSS or constants or elsewhere
 export const swatchColors = (n: number) => {
   const colors = [
+    '#00d781',
     '#0076ff',
     '#ff4888',
-    '#00d781',
     '#7b21d6',
     '#ff6161',
     '#065596',


### PR DESCRIPTION
Closes #1862

## overview

- Well color order (when adding new ingredients) was blue, pink, green. now green, pink, blue.

## changelog

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_swap-well-color-order-1862/index.html

![Bob Ross](https://upload.wikimedia.org/wikipedia/en/thumb/7/70/Bob_at_Easel.jpg/220px-Bob_at_Easel.jpg)