### PR TITLE
feat(protocol-designer): enable user to swap pipette mounts

### DIFF
--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -977,6 +977,26 @@ exports[`icons settings renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons swap-horizontal renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  height={undefined}
+  style={undefined}
+  version="1.1"
+  viewBox="0 0 24 24"
+  width={undefined}
+  x={undefined}
+  y={undefined}
+>
+  <path
+    d="M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons upload renders correctly 1`] = `
 <svg
   aria-hidden="true"

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -200,6 +200,10 @@ const ICON_DATA_BY_NAME = {
   'information': {
     viewBox: '0 0 24 24',
     path: 'M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'
+  },
+  'swap-horizontal': {
+    viewBox: '0 0 24 24',
+    path: 'M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z'
   }
 }
 

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -17,22 +17,26 @@ type Props = {
   column?: boolean,
   /** If card can not be used, gray it out and remove pointer events */
   disabled?: boolean,
+  /** Override children's className with this class, if given */
+  contentClassNameOverride?: ?string,
   /** Additional class names */
   className?: string
 }
 
 export default function Card (props: Props) {
-  const {title, column, children} = props
+  const {title, column, children, contentClassNameOverride} = props
 
-  const style = cx(styles.card, props.className, {
+  const className = cx(styles.card, props.className, {
     [styles.disabled]: props.disabled
   })
-  const childrenStyle = cx(styles.card_content, {
-    [styles.card_column]: column
-  })
+  const contentClassName = contentClassNameOverride !== undefined
+    ? contentClassNameOverride
+    : cx(styles.card_content, {
+      [styles.card_column]: column
+    })
 
   return (
-    <section className={style}>
+    <section className={className}>
       <h3 className={styles.card_title}>{title}</h3>
       {props.description &&
         (<p
@@ -41,7 +45,7 @@ export default function Card (props: Props) {
           {props.description}
         </p>)
       }
-      <div className={childrenStyle}>
+      <div className={contentClassName}>
         {children}
       </div>
     </section>

--- a/components/src/structure/Card.js
+++ b/components/src/structure/Card.js
@@ -17,26 +17,22 @@ type Props = {
   column?: boolean,
   /** If card can not be used, gray it out and remove pointer events */
   disabled?: boolean,
-  /** Override children's className with this class, if given */
-  contentClassNameOverride?: ?string,
   /** Additional class names */
   className?: string
 }
 
 export default function Card (props: Props) {
-  const {title, column, children, contentClassNameOverride} = props
+  const {title, column, children} = props
 
-  const className = cx(styles.card, props.className, {
+  const style = cx(styles.card, props.className, {
     [styles.disabled]: props.disabled
   })
-  const contentClassName = contentClassNameOverride !== undefined
-    ? contentClassNameOverride
-    : cx(styles.card_content, {
-      [styles.card_column]: column
-    })
+  const childrenStyle = cx(styles.card_content, {
+    [styles.card_column]: column
+  })
 
   return (
-    <section className={className}>
+    <section className={style}>
       <h3 className={styles.card_title}>{title}</h3>
       {props.description &&
         (<p
@@ -45,7 +41,7 @@ export default function Card (props: Props) {
           {props.description}
         </p>)
       }
-      <div className={contentClassName}>
+      <div className={childrenStyle}>
         {children}
       </div>
     </section>

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -30,7 +30,8 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "flow-bin": "^0.76.0",

--- a/protocol-designer/src/components/FilePage.css
+++ b/protocol-designer/src/components/FilePage.css
@@ -1,5 +1,11 @@
 @import '@opentrons/components';
 
+/* TODO: Ian 2018-07-17 When Card doesn't impose flex, remove this */
+.override_card_flex {
+  width: 100%;
+  height: 100%;
+}
+
 .file_page h1 {
   @apply var(--font-header-dark);
 }

--- a/protocol-designer/src/components/FilePage.css
+++ b/protocol-designer/src/components/FilePage.css
@@ -4,13 +4,18 @@
   @apply var(--font-header-dark);
 }
 
-.file_page section {
-  margin: 0 2.5rem;
+.file_page > * {
+  margin: 1rem 2.5rem;
 }
 
 .button_row {
   display: flex;
   justify-content: flex-end;
+}
+
+.swap_button {
+  display: block;
+  margin: auto;
 }
 
 .update_button {

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -31,8 +31,8 @@ const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, 
   }
   return (
     <div className={styles.file_page}>
-      <Card title='Information' contentClassNameOverride={null}>
-        <form onSubmit={handleSubmit}>
+      <Card title='Information'>
+        <form onSubmit={handleSubmit} className={styles.override_card_flex}>
           <div className={formStyles.row_wrapper}>
             <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
               <InputField placeholder='Untitled' {...formConnector('name')} />
@@ -54,15 +54,17 @@ const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, 
         </form>
       </Card>
 
-      <Card title='Pipettes' contentClassNameOverride={null}>
-        <InstrumentGroup {...instruments} showMountLabel />
-        <OutlineButton
-          onClick={swapPipettes}
-          className={styles.swap_button}
-          iconName='swap-horizontal'
-        >
-          Swap
-        </OutlineButton>
+      <Card title='Pipettes'>
+        <div className={styles.override_card_flex}>
+          <InstrumentGroup {...instruments} showMountLabel />
+          <OutlineButton
+            onClick={swapPipettes}
+            className={styles.swap_button}
+            iconName='swap-horizontal'
+          >
+            Swap
+          </OutlineButton>
+        </div>
       </Card>
 
       <div className={styles.button_row}>

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import {
+  Card,
   FormGroup,
   InputField,
   InstrumentGroup,
@@ -16,11 +17,12 @@ export type FilePageProps = {
   formConnector: FormConnector<FileMetadataFields>,
   isFormAltered: boolean,
   instruments: React.ElementProps<typeof InstrumentGroup>,
-  goToDesignPage: () => void,
-  saveFileMetadata: () => void
+  goToDesignPage: () => mixed,
+  saveFileMetadata: () => mixed,
+  swapPipettes: () => mixed
 }
 
-const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, goToDesignPage}: FilePageProps) => {
+const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, goToDesignPage, swapPipettes}: FilePageProps) => {
   const handleSubmit = (e: SyntheticEvent<*>) => {
     // blur focused field on submit
     if (document && document.activeElement) document.activeElement.blur()
@@ -29,10 +31,7 @@ const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, 
   }
   return (
     <div className={styles.file_page}>
-      <section>
-        <h2>
-          Information
-        </h2>
+      <Card title='Information' contentClassNameOverride={null}>
         <form onSubmit={handleSubmit}>
           <div className={formStyles.row_wrapper}>
             <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
@@ -53,19 +52,28 @@ const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, 
             </OutlineButton>
           </div>
         </form>
-      </section>
+      </Card>
 
-      <section>
-        <h2>
-          Pipettes
-        </h2>
+      <Card title='Pipettes' contentClassNameOverride={null}>
         <InstrumentGroup {...instruments} showMountLabel />
-        <div className={styles.button_row}>
-          <PrimaryButton onClick={goToDesignPage} className={styles.continue_button} iconName="arrow-right">
-             Continue to Design
-          </PrimaryButton>
-        </div>
-      </section>
+        <OutlineButton
+          onClick={swapPipettes}
+          className={styles.swap_button}
+          iconName='swap-horizontal'
+        >
+          Swap
+        </OutlineButton>
+      </Card>
+
+      <div className={styles.button_row}>
+        <PrimaryButton
+          onClick={goToDesignPage}
+          className={styles.continue_button}
+          iconName="arrow-right"
+        >
+          Continue to Design
+        </PrimaryButton>
+      </div>
     </div>
   )
 }

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -4,21 +4,22 @@ import type {BaseState} from '../types'
 import FilePage from '../components/FilePage'
 import type {FilePageProps} from '../components/FilePage'
 import {actions, selectors as fileSelectors} from '../file-data'
-import {selectors as pipetteSelectors} from '../pipettes'
-import type {FileMetadataFields} from '../file-data'
+import {actions as pipetteActions, selectors as pipetteSelectors} from '../pipettes'
+import type {FileMetadataFields, FileMetadataFieldAccessors} from '../file-data'
 import {actions as navActions} from '../navigation'
 import {formConnectorFactory, type FormConnector} from '../utils'
 
 type SP = {
   instruments: $PropertyType<FilePageProps, 'instruments'>,
-  isFormAltered: boolean,
-  _values: {[string]: string}
+  isFormAltered: $PropertyType<FilePageProps, 'isFormAltered'>,
+  _values: {[accessor: FileMetadataFieldAccessors]: string}
 }
 
 type DP = {
   _updateFileMetadataFields: typeof actions.updateFileMetadataFields,
-  _saveFileMetadata: ({[string]: string}) => void,
-  goToDesignPage: () => void
+  _saveFileMetadata: ({[accessor: FileMetadataFieldAccessors]: string}) => mixed,
+  goToDesignPage: $PropertyType<FilePageProps, 'goToDesignPage'>,
+  swapPipettes: $PropertyType<FilePageProps, 'swapPipettes'>
 }
 
 const mapStateToProps = (state: BaseState): SP => {
@@ -33,15 +34,16 @@ const mapStateToProps = (state: BaseState): SP => {
   }
 }
 
-const mapDispatchToProps = {
+const mapDispatchToProps: DP = {
   _updateFileMetadataFields: actions.updateFileMetadataFields,
   _saveFileMetadata: actions.saveFileMetadata,
-  goToDesignPage: () => navActions.navigateToPage('steplist')
+  goToDesignPage: () => navActions.navigateToPage('steplist'),
+  swapPipettes: pipetteActions.swapPipettes
 }
 
 const mergeProps = (
   {instruments, isFormAltered, _values}: SP,
-  {_updateFileMetadataFields, _saveFileMetadata, goToDesignPage}: DP
+  {_updateFileMetadataFields, _saveFileMetadata, goToDesignPage, swapPipettes}: DP
 ): FilePageProps => {
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
     if (accessor === 'name' || accessor === 'description' || accessor === 'author') {
@@ -58,7 +60,8 @@ const mergeProps = (
     isFormAltered,
     instruments,
     goToDesignPage,
-    saveFileMetadata: () => _saveFileMetadata(_values)
+    saveFileMetadata: () => _saveFileMetadata(_values),
+    swapPipettes
   }
 }
 

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,3 +1,5 @@
 // @flow
 
-// NOTE: no pipettes/ actions for now!
+export const swapPipettes = () => ({
+  type: 'SWAP_PIPETTES'
+})

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -1,7 +1,9 @@
 // @flow
 import {combineReducers} from 'redux'
 import {handleActions} from 'redux-actions'
+import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import {uuid} from '../utils'
 import {getPipette, getLabware} from '@opentrons/shared-data'
 
 import type {Mount} from '@opentrons/components'
@@ -10,7 +12,7 @@ import type {PipetteData} from '../step-generation'
 import type {FilePipette} from '../file-types'
 
 function createPipette (mount: Mount, model: string, tiprackModel: ?string): ?PipetteData {
-  const id = `${mount}:${model}`
+  const id = `pipette:${model}:${uuid()}`
   const pipetteData = getPipette(model)
 
   if (!pipetteData) {
@@ -105,6 +107,23 @@ const pipettes = handleActions({
         ...newPipettes
       }
     }
+  },
+  SWAP_PIPETTES: (
+    state: PipetteReducerState,
+    action: {payload: NewProtocolFields}
+  ): PipetteReducerState => {
+    const byId = mapValues(state.byId, (pipette: PipetteData): PipetteData => ({
+      ...pipette,
+      mount: (pipette.mount === 'left') ? 'right' : 'left'
+    }))
+
+    return ({
+      byMount: {
+        left: state.byMount.right,
+        right: state.byMount.left
+      },
+      byId
+    })
   }
 }, {byMount: {left: null, right: null}, byId: {}})
 

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -3,7 +3,7 @@ import {createSelector} from 'reselect'
 import reduce from 'lodash/reduce'
 import {getPipetteModels, getPipette} from '@opentrons/shared-data'
 
-import type {BaseState, Selector, Options} from '../types'
+import type {BaseState, Selector} from '../types'
 import type {DropdownOption} from '@opentrons/components'
 import type {PipetteData} from '../step-generation'
 
@@ -32,30 +32,23 @@ function _getPipetteName (pipetteData): string {
   return pipette ? pipette.displayName : '???'
 }
 
-function _makePipetteOption (
-  byId: PipettesById,
-  pipetteId: ?string,
-  idPrefix: 'left' | 'right'
-): Options {
-  if (!pipetteId || !byId[pipetteId]) {
-    return []
-  }
-  const pipetteData = byId[pipetteId]
-  const name = _getPipetteName(pipetteData)
-  return [{
-    name,
-    value: `${idPrefix}:${pipetteData.model}`
-  }]
-}
-
 export const equippedPipetteOptions: Selector<Array<DropdownOption>> = createSelector(
   rootSelector,
   pipettes => {
     const byId = pipettes.byId
-    const leftOption = _makePipetteOption(byId, pipettes.byMount.left, 'left')
-    const rightOption = _makePipetteOption(byId, pipettes.byMount.right, 'right')
 
-    return [...leftOption, ...rightOption]
+    const pipetteIds: Array<?string> = [pipettes.byMount.left, pipettes.byMount.right]
+    return pipetteIds.reduce((acc: Array<DropdownOption>, pipetteId: ?string): Array<DropdownOption> =>
+      (pipetteId && byId[pipetteId])
+        ? [
+          ...acc,
+          {
+            name: _getPipetteName(byId[pipetteId]),
+            value: pipetteId
+          }
+        ]
+        : acc,
+      [])
   }
 )
 

--- a/protocol-designer/src/utils.js
+++ b/protocol-designer/src/utils.js
@@ -1,4 +1,5 @@
 // @flow
+import uuidv1 from 'uuid/v1'
 import {wellNameSplit} from '@opentrons/components'
 import type {BoundingRect, GenericRect} from './collision-types'
 import type {Wells} from './labware-ingred/types'
@@ -22,8 +23,7 @@ export const formConnectorFactory = (
   value: formData[accessor] || ''
 })
 
-// Not really a UUID, but close enough...?
-export const uuid = () => new Date().getTime() + '.' + Math.random()
+export const uuid: () => string = uuidv1
 
 export const intToAlphabetLetter = (i: number, lowerCase: boolean = false) =>
   String.fromCharCode((lowerCase ? 96 : 65) + i)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11119,6 +11119,10 @@ uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"


### PR DESCRIPTION
## overview

Closes #1536

Allows user to swap pipette mounts. If you set up a protocol with one or two pipettes, then swap the mounts, the protocol should function the same with no other changes required. Ie, you can just click "SWAP", and swapping shouldn't ever require the user to make any other changes to the steps etc.

## changelog

- Add `swap-horizontal` icon
- Add `contentClassNameOverride` prop to `Card` component (this is so I can opt out of `display: flex`)
- Use `Card`s to organize FilePage contents to match design
- Add swap button to FilePage
- Clean up pipette ID creation (was ID'd by mount and model, not a unique id)
- Use `uuid` library for uuids instead of custom implementation (and start using uuid for pipettes instead of ID derived from pipette data)
- Clean up `ConnectedFilePage` types (`connect` still untyped b/c Flow doesn't understand that form of mapDispatchToProps :disappointed: )

## review requests

- Changes to `Card` component OK? I just don't want to use `flex` inside the Card here...
- Try to break it, including saving and loading files