### PR TITLE
feat(api): Add "modules" field to RPC

### DIFF
--- a/api/opentrons/api/models.py
+++ b/api/opentrons/api/models.py
@@ -32,3 +32,10 @@ class Instrument:
             Container(container)
             for container in containers
         ]
+
+
+class Module:
+    def __init__(self, module):
+        self.id = id(module)
+        self.name = module.get_name()
+        self.slot = module.parent.get_name()


### PR DESCRIPTION
## overview

Add "modules" field to RPC. Closes #1733 

## changelog

- Add "modules" field to RPC

## review requests

Note: will always return an empty array until API object is in place