### PR TITLE
feat(app): Add support for modules to RPC API client

### DIFF
--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -331,12 +331,17 @@ export default function client (dispatch) {
 
       if (apiSession.instruments) {
         update.pipettesByMount = {}
-        apiSession.instruments.forEach(apiInstrumentToInstrument)
+        apiSession.instruments.forEach(addApiInstrumentToPipettes)
       }
 
       if (apiSession.containers) {
         update.labwareBySlot = {}
-        apiSession.containers.forEach(apiContainerToContainer)
+        apiSession.containers.forEach(addApiContainerToLabware)
+      }
+
+      if (apiSession.modules) {
+        update.modulesBySlot = {}
+        apiSession.modules.forEach(addApiModuleToModules)
       }
 
       if (apiSession.protocol_text) {
@@ -371,7 +376,7 @@ export default function client (dispatch) {
       }
     }
 
-    function apiInstrumentToInstrument (apiInstrument) {
+    function addApiInstrumentToPipettes (apiInstrument) {
       const {_id, mount, name, channels} = apiInstrument
       // TODO(mc, 2018-01-17): pull this somehow from tiprack the instrument
       //  interacts with
@@ -380,7 +385,7 @@ export default function client (dispatch) {
       update.pipettesByMount[mount] = {_id, mount, name, channels, volume}
     }
 
-    function apiContainerToContainer (apiContainer) {
+    function addApiContainerToLabware (apiContainer) {
       const {_id, name, type, slot} = apiContainer
       const isTiprack = RE_TIPRACK.test(type)
       const labware = {_id, name, slot, type, isTiprack}
@@ -390,6 +395,10 @@ export default function client (dispatch) {
       }
 
       update.labwareBySlot[slot] = labware
+    }
+
+    function addApiModuleToModules (apiModule) {
+      update.modulesBySlot[apiModule.slot] = apiModule
     }
   }
 

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -4,6 +4,7 @@ import type {
   Command,
   StatePipette,
   StateLabware,
+  StateModule,
   Mount,
   Slot,
   SessionStatus
@@ -31,13 +32,16 @@ export type State = {
   // TODO(mc, 2018-01-11): command IDs should be strings
   protocolCommands: number[],
   protocolCommandsById: {
-    [number]: Command
+    [number]: Command,
   },
   pipettesByMount: {
-    [Mount]: StatePipette
+    [Mount]: StatePipette,
   },
   labwareBySlot: {
-    [Slot]: StateLabware
+    [Slot]: StateLabware,
+  },
+  modulesBySlot: {
+    [Slot]: StateModule,
   },
   runRequest: Request,
   pauseRequest: Request,
@@ -75,6 +79,7 @@ const INITIAL_STATE: State = {
   // deck setup from protocol
   pipettesByMount: {},
   labwareBySlot: {},
+  modulesBySlot: {},
 
   // running a protocol
   runRequest: {inProgress: false, error: null},

--- a/app/src/robot/test/__mocks__/session.js
+++ b/app/src/robot/test/__mocks__/session.js
@@ -10,6 +10,9 @@ export default function MockSession () {
     instruments: [],
     containers: [],
 
+    // TODO(mc, 2018-07-16): THIS IS A MOCK
+    modules: [],
+
     run: jest.fn(),
     pause: jest.fn(),
     resume: jest.fn(),

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -279,7 +279,8 @@ describe('api client', () => {
         protocolCommands: [],
         protocolCommandsById: {},
         pipettesByMount: {},
-        labwareBySlot: {}
+        labwareBySlot: {},
+        modulesBySlot: {}
       })
     })
 
@@ -388,6 +389,39 @@ describe('api client', () => {
         },
         {_id: 2, slot: '5', name: 'b', type: 'B'},
         {_id: 3, slot: '9', name: 'c', type: 'C'}
+      ]
+
+      return sendConnect()
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    test('maps api modules to modules by slot', () => {
+      const expected = actions.sessionResponse(null, expect.objectContaining({
+        modulesBySlot: {
+          1: {
+            _id: 1,
+            slot: '1',
+            name: 'tempdeck'
+          },
+          9: {
+            _id: 9,
+            slot: '9',
+            name: 'magdeck'
+          }
+        }
+      }))
+
+      session.modules = [
+        {
+          _id: 1,
+          slot: '1',
+          name: 'tempdeck'
+        },
+        {
+          _id: 9,
+          slot: '9',
+          name: 'magdeck'
+        }
       ]
 
       return sendConnect()

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -25,6 +25,7 @@ describe('robot reducer - session', () => {
       // deck setup from protocol
       pipettesByMount: {},
       labwareBySlot: {},
+      modulesBySlot: {},
 
       // running a protocol
       runRequest: {inProgress: false, error: null},

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -132,6 +132,15 @@ export type Labware = StateLabware & {
 
 export type LabwareType = 'tiprack' | 'labware'
 
+export type StateModule = {
+  // resource ID
+  _id: number,
+  // slot module is installed in
+  slot: Slot,
+  // name identifier of the module
+  type: 'magdeck' | 'tempdeck',
+}
+
 export type SessionStatus =
   | ''
   | 'loaded'


### PR DESCRIPTION
## overview

This PR adds basic RPC client support for the modules (initial work on API side in #1890).

Adds plumbing for #1737 and #1738 so that the app can know which modules a protocol needs.

## changelog

- feat(app): Add support for modules to RPC API client

## review requests

Not super testable by hand without modifying the API. Code (and unit test) review should be fine since we'll have more PRs coming in for this functionality.