### PR TITLE
refactor(components): Tweak deck to help support modules

### DIFF
--- a/components/src/CenteredTextSvg.js
+++ b/components/src/CenteredTextSvg.js
@@ -8,8 +8,15 @@ type CenteredTextSvgProps = {
 
 export function CenteredTextSvg (props: CenteredTextSvgProps) {
   const { text, className } = props
+
   return (
-    <text x='50%' y='50%' textAnchor='middle' {...{className}}>
+    <text
+      className={className}
+      x='50%'
+      y='50%'
+      textAnchor='middle'
+      dominantBaseline='middle'
+    >
       {text}
     </text>
   )

--- a/components/src/deck/ContainerNameOverlay.js
+++ b/components/src/deck/ContainerNameOverlay.js
@@ -5,7 +5,7 @@ import styles from './LabwareContainer.css'
 
 type Props = {
   title: string,
-  subtitle?: string
+  subtitle?: string,
 }
 
 export function ContainerNameOverlay (props: Props) {
@@ -31,9 +31,11 @@ export function ContainerNameOverlay (props: Props) {
         >
           {title}
         </text>
-        {subtitle && <text x={paddingLeft} y={0.85 * boxHeight + paddingTop}>
-          {subtitle}
-        </text>}
+        {subtitle && (
+          <text x={paddingLeft} y={0.85 * boxHeight + paddingTop}>
+            {subtitle}
+          </text>
+        )}
       </g>
     </g>
   )

--- a/components/src/deck/Deck.css
+++ b/components/src/deck/Deck.css
@@ -8,7 +8,9 @@
 }
 
 .deck {
+  /* TODO(mc, 2018-07-16): remove max-height from common styling */
   max-height: 90vh;
+  overflow: visible;
 }
 
 .deck_outline {

--- a/components/src/deck/Deck.js
+++ b/components/src/deck/Deck.js
@@ -12,6 +12,8 @@ import {
   SLOT_OFFSET,
   TRASH_SLOTNAME
 } from './constants'
+import DeckOutline from './DeckOutline'
+import {EmptyDeckSlot} from './EmptyDeckSlot'
 
 import styles from './Deck.css'
 
@@ -23,36 +25,20 @@ export type LabwareComponentProps = {
 
 type Props = {
   className?: string,
-  LabwareComponent: React.ComponentType<LabwareComponentProps>
+  LabwareComponent?: React.ComponentType<LabwareComponentProps>
 }
 
 export default function Deck (props: Props) {
   const {className, LabwareComponent} = props
 
   return (
-    // TODO css not inline style on svg
+    // TODO(mc, 2018-07-16): is this viewBox in mm?
     <svg viewBox={'0 0 427 390'} className={cx(styles.deck, className)}>
-
-      {/* Deck outline */}
-      <g transform='scale(0.666)' className={styles.deck_outline}>
-        <path d='M414.541436,0.75 L20,0.75 C9.36851857,0.75 0.75,9.36851857 0.75,20 L0.75,564 C0.75,574.631481 9.36851857,583.25 20,583.25 L620,583.25 C630.631481,583.25 639.25,574.631481 639.25,564 L639.25,161.915663 C639.25,157.911598 636.004064,154.665663 632,154.665663 L432.541436,154.665663 C426.604375,154.665663 421.791436,149.852724 421.791436,143.915663 L421.791436,8 C421.791436,3.99593556 418.545501,0.75 414.541436,0.75 Z' />
-
-        {/* Trash */}
-        <g transform='translate(424 0)' className={styles.trash}>
-          <rect x='0' y='0' width='216' height='152' rx='11' className={styles.trash_outer} />
-          <path
-            transform='translate(8 8)'
-            d='M38.6180258,136 L193,136 C196.865993,136 200,132.865993 200,129 L200,7 C200,3.13400675 196.865993,1.21364172e-14 193,-8.8817842e-16 L7,8.8817842e-16 C3.13400675,1.59834986e-15 4.14730794e-16,3.13400675 8.8817842e-16,7 L0,89.9509202 C4.05812251e-16,93.2646287 2.6862915,95.9509202 6,95.9509202 L26.6180258,95.9509202 C29.9317343,95.9509202 32.6180258,98.6372117 32.6180258,101.95092 L32.6180258,130 C32.6180258,133.313708 35.3043173,136 38.6180258,136 Z'
-            className={styles.trash_inner} />
-          <text x='108' y='86'>TRASH</text>
-        </g>
-      </g>
-
+      <DeckOutline />
       {/* All containers */}
       <g transform={`translate(${SLOT_OFFSET} ${SLOT_OFFSET})`}>
         {renderLabware(LabwareComponent)}
       </g>
-
     </svg>
   )
 }
@@ -64,6 +50,7 @@ function renderLabware (LabwareComponent): React.Node[] {
       return columns.map((slot: DeckSlot, col: number) => {
         if (slot === TRASH_SLOTNAME) return null
 
+        const props = {slot, width: SLOT_WIDTH, height: SLOT_HEIGHT}
         const transform = `translate(${[
           SLOT_WIDTH * col + SLOT_SPACING * (col + 1),
           SLOT_HEIGHT * row + SLOT_SPACING * (row + 1)
@@ -71,11 +58,10 @@ function renderLabware (LabwareComponent): React.Node[] {
 
         return (
           <g key={slot} transform={transform}>
-            <LabwareComponent
-              slot={slot}
-              width={SLOT_WIDTH}
-              height={SLOT_HEIGHT}
-            />
+            <EmptyDeckSlot {...props} />
+            {!!LabwareComponent && (
+              <LabwareComponent {...props} />
+            )}
           </g>
         )
       })

--- a/components/src/deck/Deck.md
+++ b/components/src/deck/Deck.md
@@ -1,0 +1,5 @@
+Deck map:
+
+```js
+<Deck />
+```

--- a/components/src/deck/DeckOutline.js
+++ b/components/src/deck/DeckOutline.js
@@ -1,0 +1,38 @@
+// @flow
+// deck outline path
+import * as React from 'react'
+import styles from './Deck.css'
+
+const OUTLINE_PATH = 'M414.541436,0.75 L20,0.75 C9.36851857,0.75 0.75,9.36851857 0.75,20 L0.75,564 C0.75,574.631481 9.36851857,583.25 20,583.25 L620,583.25 C630.631481,583.25 639.25,574.631481 639.25,564 L639.25,161.915663 C639.25,157.911598 636.004064,154.665663 632,154.665663 L432.541436,154.665663 C426.604375,154.665663 421.791436,149.852724 421.791436,143.915663 L421.791436,8 C421.791436,3.99593556 418.545501,0.75 414.541436,0.75 Z'
+
+const TRASH_PATH = 'M38.6180258,136 L193,136 C196.865993,136 200,132.865993 200,129 L200,7 C200,3.13400675 196.865993,1.21364172e-14 193,-8.8817842e-16 L7,8.8817842e-16 C3.13400675,1.59834986e-15 4.14730794e-16,3.13400675 8.8817842e-16,7 L0,89.9509202 C4.05812251e-16,93.2646287 2.6862915,95.9509202 6,95.9509202 L26.6180258,95.9509202 C29.9317343,95.9509202 32.6180258,98.6372117 32.6180258,101.95092 L32.6180258,130 C32.6180258,133.313708 35.3043173,136 38.6180258,136 Z'
+
+// TODO(mc, 2018-07-16): consolidate into OUTLINE_PATH
+const TRASH_OUTLINE_PROPS = {
+  x: '0',
+  y: '0',
+  width: '216',
+  height: '152',
+  rx: '11'
+}
+
+export default function DeckOutline () {
+  return (
+    // TODO(mc, 2018-07-16): consolidate transform into path
+    <g className={styles.deck_outline} transform='scale(0.666)'>
+      <path d={OUTLINE_PATH} />
+      {/* TODO(mc, 2018-07-16): consolidate transforms into path / rect */}
+      <g className={styles.trash} transform='translate(424 0)'>
+        <rect className={styles.trash_outer} {...TRASH_OUTLINE_PROPS} />
+        <path
+          className={styles.trash_inner}
+          transform='translate(8 8)'
+          d={TRASH_PATH}
+        />
+        <text x='108' y='86'>
+          TRASH
+        </text>
+      </g>
+    </g>
+  )
+}

--- a/components/src/deck/EmptyDeckSlot.js
+++ b/components/src/deck/EmptyDeckSlot.js
@@ -7,8 +7,10 @@ import styles from './LabwareContainer.css'
 
 import type {DeckSlotProps} from '../../interfaces/DeckSlot'
 
+// TODO(mc, 2018-07-16): this should be the default export
 export function EmptyDeckSlot (props: DeckSlotProps) {
   const {slot} = props
+
   return <LabwareContainer {...props}>
     <g className={styles.empty_slot}>
       <rect width='100%' height='100%' />

--- a/components/src/deck/LabwareContainer.css
+++ b/components/src/deck/LabwareContainer.css
@@ -59,6 +59,6 @@ NOTE: available defs are:
 }
 
 .name_overlay .display_name {
-  font-weight: var(--fw-bold);
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
 }

--- a/components/src/deck/LabwareContainer.js
+++ b/components/src/deck/LabwareContainer.js
@@ -5,6 +5,8 @@ import styles from './LabwareContainer.css'
 const defs = {roundSlotClipPath: 'roundSlotClipPath'} // TODO: import these defs instead of hard-coding in applications? Or should they be passed to children?
 
 type Props = {
+  x?: number,
+  y?: number,
   height: number,
   width: number,
   highlighted?: boolean,
@@ -12,11 +14,11 @@ type Props = {
 }
 
 export default function LabwareContainer (props: Props) {
-  const {height, width, highlighted, children} = props
+  const {x, y, height, width, highlighted, children} = props
 
   return (
     <g>
-      <svg {...{height, width}} className={styles.deck_slot}>
+      <svg {...{x, y, height, width}} className={styles.deck_slot}>
         {/* Defs for anything inside this SVG. TODO: how to better organize IDs and defined elements? */}
         <defs>
           <clipPath id={defs.roundSlotClipPath}>


### PR DESCRIPTION
## overview

This PR does a little bit of cleanup work in the Deck to increase clarity for future refactor work and to better support modules in the app. I wanted to open this PR so that it wouldn't clog up a modules PR.

I tried to only incorporate changes that we discussed and agreed upon in our minimeeting the other day. Let me know if I got something wrong (e.g. made a change we _didn't_ agree upon) or left anything out that would make sense to include now!

This PR is part of #1739 

## changelog

- refactor(components): Tweak deck components to help support modules 
    - Vertically centered `<CenteredTextSvg>` using `dominant-baseline` (for slot numbers)
    - Set `overflow: visible` on `<Deck>` so modules aren't clipped
    - Moved the deck outline and trash to its own component: `<DeckOutline>`
    - Added `<EmptyDeckSlot>`s to the base `<Deck>` component as discussed
    - Made `LabwareComponent` prop of the `<Deck>` optional
    - Changed font-weight of the `<ContainerNameOverlay>` to match screens
    - Added optional `x` and `y` props to `<LabwareContainer>`, because modules' top-left is not at `[0, 0]` of the slot

## review requests

Please make sure I didn't break anything (especially in the PD @b-cooper and @IanLondon)
