### PR TITLE
 fix(protocol-designer): disable tiprack select if no pipette selected

### DIFF
--- a/app/src/components/RobotSettings/inputs.js
+++ b/app/src/components/RobotSettings/inputs.js
@@ -20,17 +20,12 @@ export type FormProps = {
 export type InputProps<T> = {
   name: T,
   value: ?string,
-  disabled: ?boolean,
+  disabled?: ?boolean,
   onChange: ({[name: T]: string}) => *,
   className?: string,
 }
 
-type SelectProps<T> = {
-  name: T,
-  value: ?string,
-  disabled: boolean,
-  onChange: ({[name: T]: string}) => *,
-  className?: string,
+type SelectProps<T> = InputProps<T> & {
   options: Array<DropdownOption>
 }
 

--- a/app/src/components/RobotSettings/inputs.js
+++ b/app/src/components/RobotSettings/inputs.js
@@ -25,7 +25,12 @@ export type InputProps<T> = {
   className?: string,
 }
 
-type SelectProps<T> = InputProps<T> & {
+type SelectProps<T> = {
+  name: T,
+  value: ?string,
+  disabled: boolean,
+  onChange: ({[name: T]: string}) => *,
+  className?: string,
   options: Array<DropdownOption>
 }
 

--- a/app/src/components/RobotSettings/inputs.js
+++ b/app/src/components/RobotSettings/inputs.js
@@ -20,7 +20,7 @@ export type FormProps = {
 export type InputProps<T> = {
   name: T,
   value: ?string,
-  disabled?: ?boolean,
+  disabled?: boolean,
   onChange: ({[name: T]: string}) => *,
   className?: string,
 }

--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -89,6 +89,7 @@ exports[`DropdownField renders correctly with a falsey value 1`] = `
   >
     <select
       className="dropdown"
+      disabled={undefined}
       onBlur={undefined}
       onChange={undefined}
       onFocus={undefined}
@@ -154,6 +155,7 @@ exports[`DropdownField renders correctly with a value 1`] = `
   >
     <select
       className="dropdown"
+      disabled={undefined}
       onBlur={undefined}
       onChange={undefined}
       onFocus={undefined}

--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -27,7 +27,9 @@ type Props = {
   /** optional caption. hidden when `error` is given */
   caption?: string,
   /** if included, DropdownField will use error style and display error instead of caption */
-  error?: ?string
+  error?: ?string,
+  /** dropdown is disabled if value is true */
+  disabled?: boolean,
 }
 
 export default function DropdownField (props: Props) {
@@ -37,7 +39,7 @@ export default function DropdownField (props: Props) {
     : [{name: '', value: ''}, ...props.options]
 
   const error = props.error != null
-  const className = cx(props.className, {[styles.error]: error})
+  const className = cx(props.className, {[styles.error]: error, [styles.dropdown_disabled]: props.disabled})
 
   return (
     <div className={className}>
@@ -47,6 +49,7 @@ export default function DropdownField (props: Props) {
           onChange={props.onChange}
           onBlur={props.onBlur}
           onFocus={props.onFocus}
+          disabled={props.disabled}
           className={styles.dropdown}>
           {options.map(opt =>
             <option key={opt.value} value={opt.value}>

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -51,6 +51,7 @@
   }
 }
 
+.dropdown_disabled,
 .checkbox_disabled {
   opacity: 0.5;
 }

--- a/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
+++ b/protocol-designer/src/components/modals/NewFileModal/NewFileModal.css
@@ -40,3 +40,16 @@
     content: counter(step-counter) ") ";
   }
 }
+
+.mount_fields_row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.mount_column {
+  flex-grow: 1;
+}
+
+.mount_column:first-child {
+  margin-right: 0.5rem;
+}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -7,6 +7,7 @@ import {
   FormGroup,
   InputField
 } from '@opentrons/components'
+import startCase from 'lodash/startCase'
 import {pipetteOptions} from '../../../pipettes/pipetteData'
 import PipetteDiagram from './PipetteDiagram'
 import TiprackDiagram from './TiprackDiagram'
@@ -53,10 +54,8 @@ const tiprackOptions = [
 
 const initialState = {
   name: '',
-  leftPipetteModel: USER_HAS_NOT_SELECTED,
-  rightPipetteModel: USER_HAS_NOT_SELECTED,
-  leftTiprackModel: null,
-  rightTiprackModel: null
+  left: {pipetteModel: USER_HAS_NOT_SELECTED, tiprackModel: null},
+  right: {pipetteModel: USER_HAS_NOT_SELECTED, tiprackModel: null}
 }
 
 export default class NewFileModal extends React.Component<Props, State> {
@@ -67,136 +66,110 @@ export default class NewFileModal extends React.Component<Props, State> {
 
   componentWillReceiveProps (nextProps: Props) {
     // reset form state when modal is hidden
-    if (!this.props.hideModal && nextProps.hideModal) {
-      this.setState(initialState)
-    }
+    if (!this.props.hideModal && nextProps.hideModal) this.setState(initialState)
   }
 
-  handleChange = (accessor: $Keys<State>) => (e: SyntheticInputEvent<*>) => {
-    // skip tiprack update if no pipette selected
-    if (accessor === 'leftTiprackModel' && !this.state.leftPipetteModel) return
-    if (accessor === 'rightTiprackModel' && !this.state.rightPipetteModel) return
-
+  makeHandleMountFieldChange = (mount: 'left' | 'right', fieldName) => (e: SyntheticInputEvent<*>) => {
     const value: string = e.target.value
-
-    const nextState: {[$Keys<State>]: mixed} = {
-      [accessor]: value
-    }
-
-    // clear tiprack selection if corresponding pipette model is deselected
-    if (accessor === 'leftPipetteModel' && !value) {
-      nextState.leftTiprackModel = null
-    } else if (accessor === 'rightPipetteModel' && !value) {
-      nextState.rightTiprackModel = null
-    }
-
-    this.setState({
-      ...this.state,
-      ...nextState
-    })
+    let nextMountState = {[fieldName]: value}
+    if (fieldName === 'pipetteModel' && !value) nextMountState = {...nextMountState, tiprackModel: null}
+    this.setState({[mount]: {...this.state.mount, ...nextMountState}})
   }
+  handleNameChange = (e: SyntheticInputEvent<*>) => this.setState({name: e.target.value})
 
-  handleSubmit = () => {
-    this.props.onSave(this.state)
-  }
+  handleSubmit = () => { this.props.onSave(this.state) }
 
   render () {
-    if (this.props.hideModal) {
-      return null
-    }
+    if (this.props.hideModal) return null
 
-    const {
-      name,
-      leftPipetteModel,
-      rightPipetteModel,
-      leftTiprackModel,
-      rightTiprackModel
-    } = this.state
+    const {name, left, right} = this.state
 
     const pipetteSelectionIsValid = (
       // neither can be invalid
-      (leftPipetteModel !== USER_HAS_NOT_SELECTED && rightPipetteModel !== USER_HAS_NOT_SELECTED) &&
+      (left.pipetteModel !== USER_HAS_NOT_SELECTED && right.pipetteModel !== USER_HAS_NOT_SELECTED) &&
       // at least one must not be none (empty string)
-      (leftPipetteModel || rightPipetteModel)
+      (left.pipetteModel || right.pipetteModel)
     )
 
     // if pipette selected, corresponding tiprack type also selected
     const tiprackSelectionIsValid = (
-      (leftPipetteModel ? Boolean(leftTiprackModel) : true) &&
-      (rightPipetteModel ? Boolean(rightTiprackModel) : true)
+      (left.pipetteModel ? Boolean(left.tiprackModel) : true) &&
+      (right.pipetteModel ? Boolean(right.tiprackModel) : true)
     )
 
     const canSubmit = pipetteSelectionIsValid && tiprackSelectionIsValid
 
-    const pipetteFields = [
-      ['leftPipetteModel', 'Left Pipette'],
-      ['rightPipetteModel', 'Right Pipette']
-    ].map(([name, label]) => {
-      const value = this.state[name]
-      return (
-        <FormGroup key={name} label={`${label}*:`} className={formStyles.column_1_2}>
-          <DropdownField options={value === USER_HAS_NOT_SELECTED
-              ? pipetteOptionsWithInvalid
-              : pipetteOptionsWithNone}
-            value={value}
-            onChange={this.handleChange(name)} />
-        </FormGroup>
-      )
-    })
+    return (
+      <AlertModal
+        className={cx(modalStyles.modal, styles.new_file_modal)}
+        buttons={[
+          {onClick: this.props.onCancel, children: 'Cancel'},
+          {onClick: this.handleSubmit, disabled: !canSubmit, children: 'Save'}
+        ]}>
+        <form className={modalStyles.modal_contents}>
+          <h2>Create New Protocol</h2>
 
-    const tiprackFields = ['leftTiprackModel', 'rightTiprackModel'].map(name => (
-      <FormGroup key={name} label='Tip rack*:' className={formStyles.column_1_2}>
-        <DropdownField options={tiprackOptions}
-          value={this.state[name]}
-          onChange={this.handleChange(name)} />
-        </FormGroup>
-    ))
+          <FormGroup label='Name:'>
+            <InputField placeholder='Untitled' value={name} onChange={this.handleNameChange} />
+          </FormGroup>
+          <BetaRestrictions />
 
-    return <AlertModal className={cx(modalStyles.modal, styles.new_file_modal)}
-      buttons={[
-        {onClick: this.props.onCancel, children: 'Cancel'},
-        {onClick: this.handleSubmit, disabled: !canSubmit, children: 'Save'}
-      ]}>
-      <form className={modalStyles.modal_contents}>
-        <h2>Create New Protocol</h2>
+          <div className={formStyles.row_wrapper}>
+            <MountFields mount="left" values={this.state.left} makeOnChange={this.makeHandleMountFieldChange} />
+            <MountFields mount="right" values={this.state.right} makeOnChange={this.makeHandleMountFieldChange} />
+          </div>
 
-        <FormGroup label='Name:'>
-          <InputField placeholder='Untitled'
-            value={name}
-            onChange={this.handleChange('name')}
-          />
-        </FormGroup>
-
-        <h3>Beta Pipette Restrictions:</h3>
-        <ol>
-          <li>
-            You can't change your pipette selection later. If in doubt go for
-            smaller pipettes. The Protocol Designer automatically breaks up transfer
-            volumes that exceed pipette capacity into multiple transfers.
-          </li>
-          <li>
-            Pipettes can't share tip racks. There needs to be at least 1 tip rack per
-            pipette on the deck.
-          </li>
-        </ol>
-
-        <div className={formStyles.row_wrapper}>
-          {pipetteFields}
-        </div>
-
-        <div className={formStyles.row_wrapper}>
-          {tiprackFields}
-        </div>
-
-        <div className={styles.diagrams}>
-          <TiprackDiagram containerType={this.state.leftTiprackModel} />
-          <PipetteDiagram
-            leftPipette={this.state.leftPipetteModel}
-            rightPipette={this.state.rightPipetteModel}
-          />
-          <TiprackDiagram containerType={this.state.rightTiprackModel} />
-        </div>
-      </form>
-    </AlertModal>
+          <div className={styles.diagrams}>
+            <TiprackDiagram containerType={this.state.left.tiprackModel} />
+            <PipetteDiagram
+              leftPipette={this.state.left.pipetteModel}
+              rightPipette={this.state.right.pipetteModel}
+            />
+            <TiprackDiagram containerType={this.state.right.tiprackModel} />
+          </div>
+        </form>
+      </AlertModal>
+    )
   }
 }
+
+type MountFieldsProps = {
+  mount: 'left' | 'right',
+  values: {pipetteModel: ?string, tiprackModel: ?string},
+  makeOnChange: (mount: 'left' | 'right', fieldName: string) => (SyntheticInputEvent<*>) => void
+}
+const MountFields = (props: MountFieldsProps) => (
+  <div className={styles.mountColumn}>
+    <FormGroup key={`${props.mount}PipetteModel`} label={`${startCase(props.mount)} Pipette*`}>
+      <DropdownField
+        options={props.values.pipetteModel === USER_HAS_NOT_SELECTED ? pipetteOptionsWithInvalid : pipetteOptionsWithNone}
+        value={props.values.pipetteModel}
+        onChange={props.makeOnChange(props.mount, 'pipetteModel')} />
+    </FormGroup>
+
+    <FormGroup key={`${props.mount}TiprackModel`} label={`${startCase(props.mount)} Tiprack*`}>
+      <DropdownField
+        disabled={!props.values.pipetteModel}
+        options={tiprackOptions}
+        value={props.values.tiprackModel}
+        onChange={props.makeOnChange(props.mount, 'tiprackModel')} />
+    </FormGroup>
+  </div>
+)
+
+const BetaRestrictions = () => (
+  <React.Fragment>
+    <h3>Beta Pipette Restrictions:</h3>
+    <ol>
+      <li>
+        You can't change your pipette selection later. If in doubt go for
+        smaller pipettes. The Protocol Designer automatically breaks up transfer
+        volumes that exceed pipette capacity into multiple transfers.
+      </li>
+      <li>
+        Pipettes can't share tip racks. There needs to be at least 1 tip rack per
+        pipette on the deck.
+      </li>
+    </ol>
+  </React.Fragment>
+)

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -5,7 +5,8 @@ import {
   AlertModal,
   DropdownField,
   FormGroup,
-  InputField
+  InputField,
+  type Mount
 } from '@opentrons/components'
 import startCase from 'lodash/startCase'
 import isEmpty from 'lodash/isEmpty'
@@ -13,9 +14,8 @@ import {pipetteOptions} from '../../../pipettes/pipetteData'
 import PipetteDiagram from './PipetteDiagram'
 import TiprackDiagram from './TiprackDiagram'
 import styles from './NewFileModal.css'
-import formStyles from '../../forms.css'
 import modalStyles from '../modal.css'
-import type {NewProtocolFields} from '../../../load-file'
+import type {NewProtocolFields, PipetteFields} from '../../../load-file'
 
 type State = NewProtocolFields
 
@@ -70,7 +70,7 @@ export default class NewFileModal extends React.Component<Props, State> {
     if (!this.props.hideModal && nextProps.hideModal) this.setState(initialState)
   }
 
-  makeHandleMountFieldChange = (mount: 'left' | 'right', fieldName) => (e: SyntheticInputEvent<*>) => {
+  makeHandleMountFieldChange = (mount: Mount, fieldName: $Keys<PipetteFields>) => (e: SyntheticInputEvent<*>) => {
     const value: string = e.target.value
     let nextMountState = {[fieldName]: value}
     if (fieldName === 'pipetteModel') nextMountState = {...nextMountState, tiprackModel: null}
@@ -135,9 +135,9 @@ export default class NewFileModal extends React.Component<Props, State> {
 }
 
 type MountFieldsProps = {
-  mount: 'left' | 'right',
-  values: {pipetteModel: ?string, tiprackModel: ?string},
-  makeOnChange: (mount: 'left' | 'right', fieldName: string) => (SyntheticInputEvent<*>) => void
+  mount: Mount,
+  values: {pipetteModel: string, tiprackModel: ?string},
+  makeOnChange: (mount: Mount, fieldName: $Keys<PipetteFields>) => (SyntheticInputEvent<*>) => void
 }
 const MountFields = (props: MountFieldsProps) => (
   <div className={styles.mount_column}>

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -148,9 +148,9 @@ const MountFields = (props: MountFieldsProps) => (
         onChange={props.makeOnChange(props.mount, 'pipetteModel')} />
     </FormGroup>
 
-    <FormGroup key={`${props.mount}TiprackModel`} label={`${startCase(props.mount)} Tiprack*`}>
+    <FormGroup disabled={isEmpty(props.values.pipetteModel)} key={`${props.mount}TiprackModel`} label={`${startCase(props.mount)} Tiprack*`}>
       <DropdownField
-        disabled={isEmpty(props.values.pipetteModel) || props.values.pipetteModel === USER_HAS_NOT_SELECTED}
+        disabled={isEmpty(props.values.pipetteModel)}
         options={tiprackOptions}
         value={props.values.tiprackModel}
         onChange={props.makeOnChange(props.mount, 'tiprackModel')} />

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -74,7 +74,6 @@ export default class NewFileModal extends React.Component<Props, State> {
     const value: string = e.target.value
     let nextMountState = {[fieldName]: value}
     if (fieldName === 'pipetteModel') nextMountState = {...nextMountState, tiprackModel: null}
-    console.log('PREV: ', this.state[mount])
     this.setState({[mount]: {...this.state[mount], ...nextMountState}})
   }
   handleNameChange = (e: SyntheticInputEvent<*>) => this.setState({name: e.target.value})
@@ -116,7 +115,7 @@ export default class NewFileModal extends React.Component<Props, State> {
           </FormGroup>
           <BetaRestrictions />
 
-          <div className={formStyles.row_wrapper}>
+          <div className={styles.mount_fields_row}>
             <MountFields mount="left" values={this.state.left} makeOnChange={this.makeHandleMountFieldChange} />
             <MountFields mount="right" values={this.state.right} makeOnChange={this.makeHandleMountFieldChange} />
           </div>
@@ -141,7 +140,7 @@ type MountFieldsProps = {
   makeOnChange: (mount: 'left' | 'right', fieldName: string) => (SyntheticInputEvent<*>) => void
 }
 const MountFields = (props: MountFieldsProps) => (
-  <div className={styles.mountColumn}>
+  <div className={styles.mount_column}>
     <FormGroup key={`${props.mount}PipetteModel`} label={`${startCase(props.mount)} Pipette*`}>
       <DropdownField
         options={props.values.pipetteModel === USER_HAS_NOT_SELECTED ? pipetteOptionsWithInvalid : pipetteOptionsWithNone}
@@ -151,7 +150,7 @@ const MountFields = (props: MountFieldsProps) => (
 
     <FormGroup key={`${props.mount}TiprackModel`} label={`${startCase(props.mount)} Tiprack*`}>
       <DropdownField
-        disabled={isEmpty(props.values.pipetteModel)}
+        disabled={isEmpty(props.values.pipetteModel) || props.values.pipetteModel === USER_HAS_NOT_SELECTED}
         options={tiprackOptions}
         value={props.values.tiprackModel}
         onChange={props.makeOnChange(props.mount, 'tiprackModel')} />

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -8,6 +8,7 @@ import {
   InputField
 } from '@opentrons/components'
 import startCase from 'lodash/startCase'
+import isEmpty from 'lodash/isEmpty'
 import {pipetteOptions} from '../../../pipettes/pipetteData'
 import PipetteDiagram from './PipetteDiagram'
 import TiprackDiagram from './TiprackDiagram'
@@ -72,8 +73,9 @@ export default class NewFileModal extends React.Component<Props, State> {
   makeHandleMountFieldChange = (mount: 'left' | 'right', fieldName) => (e: SyntheticInputEvent<*>) => {
     const value: string = e.target.value
     let nextMountState = {[fieldName]: value}
-    if (fieldName === 'pipetteModel' && !value) nextMountState = {...nextMountState, tiprackModel: null}
-    this.setState({[mount]: {...this.state.mount, ...nextMountState}})
+    if (fieldName === 'pipetteModel') nextMountState = {...nextMountState, tiprackModel: null}
+    console.log('PREV: ', this.state[mount])
+    this.setState({[mount]: {...this.state[mount], ...nextMountState}})
   }
   handleNameChange = (e: SyntheticInputEvent<*>) => this.setState({name: e.target.value})
 
@@ -149,7 +151,7 @@ const MountFields = (props: MountFieldsProps) => (
 
     <FormGroup key={`${props.mount}TiprackModel`} label={`${startCase(props.mount)} Tiprack*`}>
       <DropdownField
-        disabled={!props.values.pipetteModel}
+        disabled={isEmpty(props.values.pipetteModel)}
         options={tiprackOptions}
         value={props.values.tiprackModel}
         onChange={props.makeOnChange(props.mount, 'tiprackModel')} />

--- a/protocol-designer/src/load-file/types.js
+++ b/protocol-designer/src/load-file/types.js
@@ -15,8 +15,10 @@ export type LoadFileAction = {
   payload: ProtocolFile
 }
 
+export type PipetteFields = {pipetteModel: string, tiprackModel: ?string}
+
 export type NewProtocolFields = {
   name: ?string,
-  left: {pipetteModel: string, tiprackModel: ?string},
-  right: {pipetteModel: string, tiprackModel: ?string}
+  left: PipetteFields,
+  right: PipetteFields
 }

--- a/protocol-designer/src/load-file/types.js
+++ b/protocol-designer/src/load-file/types.js
@@ -17,10 +17,6 @@ export type LoadFileAction = {
 
 export type NewProtocolFields = {
   name: ?string,
-
-  leftPipetteModel: string,
-  rightPipetteModel: string,
-
-  leftTiprackModel: ?string,
-  rightTiprackModel: ?string
+  left: {pipetteModel: string, tiprackModel: ?string},
+  right: {pipetteModel: string, tiprackModel: ?string}
 }

--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -73,19 +73,14 @@ const pipettes = handleActions({
     state: PipetteReducerState,
     action: {payload: NewProtocolFields}
   ): PipetteReducerState => {
-    const {
-      leftPipetteModel,
-      rightPipetteModel,
-      leftTiprackModel,
-      rightTiprackModel
-    } = action.payload
+    const {left, right} = action.payload
 
-    const leftPipette = (leftPipetteModel && leftTiprackModel)
-      ? createPipette('left', leftPipetteModel, leftTiprackModel)
+    const leftPipette = (left.pipetteModel && left.tiprackModel)
+      ? createPipette('left', left.pipetteModel, left.tiprackModel)
       : null
 
-    const rightPipette = (rightPipetteModel && rightTiprackModel)
-      ? createPipette('right', rightPipetteModel, rightTiprackModel)
+    const rightPipette = (right.pipetteModel && right.tiprackModel)
+      ? createPipette('right', right.pipetteModel, right.tiprackModel)
       : null
 
     const newPipettes = ([leftPipette, rightPipette]).reduce(


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Upon creating a new protocol, if the user has not selected a pipette model for a given mount, that
mount's tiprack select should be disabled.

Closes #1780

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

 - changed the structure of the `NewFileModal` to accommodate coupling `pipetteModels` to their corresponding `tiprackModels` and abstracting out duplicate logic that is shared between both mounts.
 - Added a `disabled` prop to the `DropdownField` component in the component library.  There was already a sneaky unused component in `RobotSettings/inputs` that was trying to use the `disabled` prop on the `DropdownField` in order to keep flow happy I had to update the type of that unused component so that disabled is `boolean` and not `?boolean`. 
<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Switch around pipette and tiprack selection in the initial `NewFileModal`. You should not be able to select a tiprack as long as you haven't selected a pipette for that mount or you have selected "None" in the pipette dropdown. Other behavior that shouldn't have changed:
- If you select a new pipette and have a tiprack selected, it should be cleared out
- You should not be allowed to save if you have either, not selected a pipette or "None" for a both mounts, both pipettes are "None", or you have selected a Pipette model, but not it's corresponding tiprack.

<!--
  Describe any requests for your reviewers here.
-->
