### PR TITLE
fix(protocol-designer): Only show deck setup prompt text when selected

### DIFF
--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -68,15 +68,13 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const orderedSteps = steplistSelectors.orderedSteps(state)
   const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
 
-  const deckSetupMode = steplistSelectors.deckSetupMode(state)
-
   const wellSelectionMode = true
   const wellSelectionModeForLabware = wellSelectionMode && selectedContainerId === containerId
 
   const prevStepId = steplistUtils.getPrevStepId(orderedSteps, stepId)
 
   let wellContents = {}
-  if (deckSetupMode) {
+  if (steplistUtils.isDeckSetupId(stepId)) {
     // selection for deck setup: shows initial state of liquids
     wellContents = wellContentsSelectors.wellContentsAllLabware(state)[containerId]
   } else {

--- a/protocol-designer/src/steplist/selectors.js
+++ b/protocol-designer/src/steplist/selectors.js
@@ -143,7 +143,7 @@ const isNewStepForm = createSelector(
 /** True if app is in Deck Setup Mode. */
 const deckSetupMode: Selector<boolean> = createSelector(
   getSteps,
-  hoveredOrSelectedStepId,
+  selectedStepId,
   (steps, selectedStepId) => (selectedStepId !== null && selectedStepId !== '__end__' && steps[selectedStepId])
     ? steps[selectedStepId].stepType === 'deck-setup'
     : false

--- a/protocol-designer/src/steplist/utils.js
+++ b/protocol-designer/src/steplist/utils.js
@@ -1,6 +1,7 @@
 // @flow
 import {END_STEP} from './types'
 import type {StepIdType} from '../form-types'
+import {INITIAL_DECK_SETUP_ID} from './constants'
 
 export function getPrevStepId (
   orderedSteps: Array<StepIdType>,
@@ -50,3 +51,7 @@ export function mergeWhen<T> (
 
   return result
 }
+
+export const isDeckSetupId = (stepId: StepIdType | typeof END_STEP | null) => (
+  stepId === INITIAL_DECK_SETUP_ID
+)


### PR DESCRIPTION
Previously the explanatory copy above the deck setup step was shown if deck setup was selected or
hovered. This led some jarring hover behavior, where the text (which acts as a title or subheader) would flicker in and out while the mouse hovered other steps in the step list. Now it is only shown when the deck setup step selected (`deckSetupMode` === when you are actively setting up the deck).

~BREAKING CHANGE: When deck setup step is selected, hovering over other steps will not change the appearance of the liquid state on the deck map, you will only see the initial liquid state while deck setup is in progress. You will still see the changing liquid state on hover if other "standard" steps are selected or no steps are selected.~