### PR TITLE
feat(app): Add and implement module selectors in calibration

### DIFF
--- a/app/src/components/Page/RefreshWrapper.js
+++ b/app/src/components/Page/RefreshWrapper.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+
+type Props = {
+  watch?: string,
+  refreshing?: boolean,
+  refresh: () => mixed,
+  children: React.Node,
+}
+export default class RefreshWrapper extends React.Component<Props> {
+  render () {
+    const {children} = this.props
+    return (
+      <React.Fragment>
+        {children}
+      </React.Fragment>
+    )
+  }
+  componentDidMount () {
+    this.props.refresh()
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    if (prevProps.watch !== this.props.watch) {
+      this.props.refresh()
+    }
+  }
+}

--- a/app/src/components/Page/RefreshWrapper.js
+++ b/app/src/components/Page/RefreshWrapper.js
@@ -2,8 +2,6 @@
 import * as React from 'react'
 
 type Props = {
-  watch?: string,
-  refreshing?: boolean,
   refresh: () => mixed,
   children: React.Node,
 }
@@ -18,11 +16,5 @@ export default class RefreshWrapper extends React.Component<Props> {
   }
   componentDidMount () {
     this.props.refresh()
-  }
-
-  componentDidUpdate (prevProps: Props) {
-    if (prevProps.watch !== this.props.watch) {
-      this.props.refresh()
-    }
   }
 }

--- a/app/src/components/Page/index.js
+++ b/app/src/components/Page/index.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import styles from './styles.css'
 import {TitleBar, type TitleBarProps} from '@opentrons/components'
 import PageWrapper from './PageWrapper'
+import RefreshWrapper from './RefreshWrapper'
 
 type Props = {
   titleBarProps?: TitleBarProps,
@@ -22,4 +23,4 @@ export default function Page (props: Props) {
   )
 }
 
-export {PageWrapper}
+export {PageWrapper, RefreshWrapper}

--- a/app/src/components/UploadStatus/Status.js
+++ b/app/src/components/UploadStatus/Status.js
@@ -46,8 +46,6 @@ function UploadResults (props: Props) {
 
   let instructions
 
-  console.log(props)
-
   if (uploadError) {
     // instructions for an unsuccessful upload
     instructions = (

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -11,7 +11,7 @@ import {
   selectors as robotSelectors,
   constants as robotConstants
 } from '../../robot'
-import {getAnyRobotUpdateAvailable, fetchPipettes} from '../../http-api-client'
+import {getAnyRobotUpdateAvailable} from '../../http-api-client'
 import {getShellUpdate} from '../../shell'
 
 import {NavButton} from '@opentrons/components'
@@ -26,9 +26,7 @@ type SP = Props & {
   _robot: ?RobotService,
 }
 
-type DP = {dispatch: Dispatch}
-
-export default withRouter(connect(mapStateToProps, null, mergeProps)(NavButton))
+export default withRouter(connect(mapStateToProps)(NavButton))
 
 function mapStateToProps (state: State, ownProps: OP): SP {
   const {name} = ownProps
@@ -77,16 +75,4 @@ function mapStateToProps (state: State, ownProps: OP): SP {
   }
 
   return {...NAV_ITEM_BY_NAME[name], _robot}
-}
-
-function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
-  const {dispatch} = dispatchProps
-  const {_robot, url, disabled} = stateProps
-  let props: Props = {...ownProps, ...stateProps}
-
-  if (_robot && url === '/calibrate' && !disabled) {
-    props = {...props, onClick: () => dispatch(fetchPipettes(_robot))}
-  }
-
-  return props
 }

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -341,6 +341,14 @@ export default function client (dispatch) {
 
       if (apiSession.modules) {
         update.modulesBySlot = {}
+        // TODO (ka 2018-7-17): MOCKED MODULES by slot here instead of session.py uncomment below to test
+        // update.modulesBySlot = {
+        //   '1': {
+        //     id: '4374062089',
+        //     name: 'magdeck',
+        //     slot: '1'
+        //   }
+        // }
         apiSession.modules.forEach(addApiModuleToModules)
       }
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -15,7 +15,8 @@ import type {
   LabwareCalibrationStatus,
   LabwareType,
   Robot,
-  SessionStatus
+  SessionStatus,
+  StateModule
 } from './types'
 
 import {
@@ -311,6 +312,22 @@ export const getPipettesCalibrated = createSelector(
     pipettes.length !== 0 &&
     pipettes.every((i) => i.probed)
   )
+)
+
+export function getModulesBySlot (state: State) {
+  return session(state).modulesBySlot
+}
+
+export const getModules = createSelector(
+  getModulesBySlot,
+  (modules): ?StateModule[] => {
+    return Object.keys(modules)
+     .filter(isSlot)
+     .map((slot) => {
+       const module = modules[slot]
+       return {...module}
+     })
+  }
 )
 
 export function getLabwareBySlot (state: State) {

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -26,7 +26,9 @@ const {
   getUnconfirmedTipracks,
   getUnconfirmedLabware,
   getNextLabware,
-  makeGetCurrentPipette
+  makeGetCurrentPipette,
+  getModulesBySlot,
+  getModules
 } = selectors
 
 describe('robot selectors', () => {
@@ -504,6 +506,44 @@ describe('robot selectors', () => {
     expect(getPipettesCalibrated(twoPipettesCalibrated)).toBe(true)
     expect(getPipettesCalibrated(twoPipettesNotCalibrated)).toBe(false)
     expect(getPipettesCalibrated(onePipetteCalibrated)).toBe(true)
+  })
+
+  describe('module selectors', () => {
+    let state
+
+    beforeEach(() => {
+      state = makeState({
+        session: {
+          modulesBySlot: {
+            1: {
+              _id: 1,
+              slot: '1',
+              name: 'tempdeck'
+            }
+          }
+        }
+      })
+    })
+
+    test('get modules by slot', () => {
+      expect(getModulesBySlot(state)).toEqual({
+        1: {
+          _id: 1,
+          slot: '1',
+          name: 'tempdeck'
+        }
+      })
+    })
+
+    test('get modules', () => {
+      expect(getModules(state)).toEqual([
+        {
+          _id: 1,
+          slot: '1',
+          name: 'tempdeck'
+        }
+      ])
+    })
   })
 
   describe('labware selectors', () => {


### PR DESCRIPTION
## overview

This PR addresses #1737 by adding and implementing module selectors and actions in `Calibrate/Labware`.  It also introduces a RefreshWrapper for pages which is implemented on page mount in order to `fetchPipettes` and `fetchModules` from the api.

## changelog

- feat(app): Add and implement module selectors in calibration
- add `RefreshWrapper` component and implement on calibration pages

## review requests
If you'd like to see a populated `modulesBySlot` comment out line `343` and uncomment lines` 345-351` in `app/src/robot/api-client/client.js`.  *Please note tests wont pass with this uncommented.

- [ ] fetchPipettes is called on mount for `calibrate/pipettes`
- [ ] fetchModules is called on mount for `calibrate/labware`
- [ ] `api[RobotName].api.modules` exists and `response = { modules: [ ] }`
