### PR TITLE
PD: fix destination well pills in substeps

### DIFF
--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -16,7 +16,9 @@ export const swatchColors = (n: number) => {
     '#2a97dc',
     '#d24193'
   ]
-  return colors[n % colors.length]
+  return (Number.isInteger(n))
+    ? colors[n % colors.length]
+    : MIXED_WELL_COLOR
 }
 
 // ========= SPECIAL SELECTORS ========

--- a/components/src/constants.js
+++ b/components/src/constants.js
@@ -5,7 +5,7 @@
 export const MIXED_WELL_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in colors.css
 
 // TODO factor into CSS or constants or elsewhere
-export const swatchColors = (n: number) => {
+export const swatchColors = (n: number): string => {
   const colors = [
     '#00d781',
     '#0076ff',
@@ -16,9 +16,11 @@ export const swatchColors = (n: number) => {
     '#2a97dc',
     '#d24193'
   ]
-  return (Number.isInteger(n))
-    ? colors[n % colors.length]
-    : MIXED_WELL_COLOR
+  if (!Number.isInteger(n)) {
+    // TODO: Ian 2018-07-20 use assert
+    console.warn(`swatchColors expected an integer, got ${n}`)
+  }
+  return colors[n % colors.length]
 }
 
 // ========= SPECIAL SELECTORS ========

--- a/protocol-designer/src/components/IngredPill.js
+++ b/protocol-designer/src/components/IngredPill.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from 'react'
-import {Pill, MIXED_WELL_COLOR} from '@opentrons/components'
+import {Pill, swatchColors, MIXED_WELL_COLOR} from '@opentrons/components'
 import type {NamedIngred} from '../steplist/types'
-import {swatchColors} from '../constants.js'
 
 type Props = {
   ingreds: ?Array<NamedIngred>
@@ -17,7 +16,7 @@ function IngredPill (props: Props) {
   }
 
   const color = (ingreds.length === 1)
-    ? swatchColors(ingreds[0].id)
+    ? swatchColors(Number(ingreds[0].id))
     : MIXED_WELL_COLOR
 
   return <Pill color={color}>{

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -62,7 +62,7 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
       <TitledList
         title={name || 'Unnamed Ingredient'}
         className={styles.ingredient_titled_list}
-        iconProps={{style: {fill: swatchColors(parseInt(groupId))}}}
+        iconProps={{style: {fill: swatchColors(Number(groupId))}}}
         iconName='circle'
         onCollapseToggle={() => this.toggleAccordion()}
         collapsed={!isExpanded}

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -2,12 +2,11 @@
 // TODO: Ian 2018-06-07 break out these components into their own files (make IngredientsList a directory)
 import React from 'react'
 
-import {IconButton, SidePanel, TitledList} from '@opentrons/components'
+import {IconButton, SidePanel, TitledList, swatchColors} from '@opentrons/components'
 import stepItemStyles from './steplist/StepItem.css'
 import StepDescription from './StepDescription'
-import {swatchColors} from '../constants.js'
 import styles from './IngredientsList.css'
-import type {IngredientGroups, PersistedIngredInputFields} from '../labware-ingred/types'
+import type {IngredientGroups, IngredientInstance} from '../labware-ingred/types'
 import type {SingleLabwareLiquidState} from '../step-generation'
 
 type DeleteIngredient = (args: {|groupId: string, wellName?: string|}) => mixed
@@ -22,7 +21,7 @@ type CommonProps = {|
 
 type CardProps = {|
   groupId: string,
-  ingredGroup: PersistedIngredInputFields,
+  ingredGroup: IngredientInstance,
   labwareWellContents: SingleLabwareLiquidState,
   ...CommonProps
 |}

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -11,14 +11,14 @@ import {
 } from '@opentrons/components'
 
 import SelectionRect from '../components/SelectionRect.js'
-import type {AllWellContents, WellContents} from '../labware-ingred/types'
+import type {ContentsByWell, WellContents} from '../labware-ingred/types'
 import type {RectEvent} from '../collision-types'
 
 type PlateProps = React.ElementProps<typeof Plate>
 type PlateWellContents = $PropertyType<PlateProps, 'wellContents'>
 
 export type Props = {
-  wellContents: AllWellContents,
+  wellContents: ContentsByWell,
   containerType: $PropertyType<PlateProps, 'containerType'>,
 
   selectable?: $PropertyType<PlateProps, 'selectable'>,
@@ -33,7 +33,7 @@ export type Props = {
   pipetteChannels?: Channels
 }
 
-function wellContentsGroupIdsToColor (wc: AllWellContents): PlateWellContents {
+function wellContentsGroupIdsToColor (wc: ContentsByWell): PlateWellContents {
   return mapValues(
     wc,
     (well: WellContents): SingleWell => ({

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -49,13 +49,14 @@ function wellContentsGroupIdsToColor (wc: ContentsByWell): PlateWellContents {
   )
 }
 
+// TODO Ian 2018-07-20: make sure '__air__' or other pseudo-ingredients don't get in here
 function getFillColor (groupIds: Array<string>): ?string {
   if (groupIds.length === 0) {
     return null
   }
 
   if (groupIds.length === 1) {
-    return swatchColors(parseInt(groupIds[0]))
+    return swatchColors(Number(groupIds[0]))
   }
 
   return MIXED_WELL_COLOR

--- a/protocol-designer/src/components/steplist/SourceDestSubstep.js
+++ b/protocol-designer/src/components/steplist/SourceDestSubstep.js
@@ -32,12 +32,12 @@ export default function SourceDestSubstep (props: SourceDestSubstepProps) {
           rowGroup={rowGroup}
           onMouseEnter={() => onSelectSubstep({
             stepId: substeps.parentStepId,
-            substepId: groupKey
+            substepIndex: groupKey
           })}
           onMouseLeave={() => onSelectSubstep(null)}
           highlighted={!!hoveredSubstep &&
             hoveredSubstep.stepId === substeps.parentStepId &&
-            hoveredSubstep.substepId === groupKey
+            hoveredSubstep.substepIndex === groupKey
           }
         />
       )}
@@ -45,20 +45,20 @@ export default function SourceDestSubstep (props: SourceDestSubstepProps) {
   }
 
   // single-channel row item
-  return substeps.rows.map((row, substepId) =>
+  return substeps.rows.map((row, substepIndex) =>
     <SubstepRow
-      key={substepId}
+      key={substepIndex}
       className={cx(
         styles.step_subitem,
         {[styles.highlighted]:
           !!hoveredSubstep &&
           hoveredSubstep.stepId === substeps.parentStepId &&
-          substepId === hoveredSubstep.substepId
+          substepIndex === hoveredSubstep.substepIndex
         }
       )}
       onMouseEnter={() => onSelectSubstep({
         stepId: substeps.parentStepId,
-        substepId
+        substepIndex
       })}
       onMouseLeave={() => onSelectSubstep(null)}
       volume={row.volume}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -13,14 +13,14 @@ import {stepIconsByType} from '../../form-types'
 import type {
   SubstepIdentifier,
   StepItemData,
-  StepSubItemData,
+  SubstepItemData,
   StepIdTypeWithEnd
 } from '../../steplist/types'
 
 type StepItemProps = {
   stepId: StepIdTypeWithEnd,
   step: ?StepItemData,
-  substeps: ?StepSubItemData,
+  substeps: ?SubstepItemData,
 
   collapsed?: boolean,
   error?: ?boolean,

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -21,8 +21,9 @@ import type {
   IngredInputFields,
   IngredientGroups,
   AllIngredGroupFields,
-  PersistedIngredInputFields,
-  Labware
+  IngredientInstance,
+  Labware,
+  LabwareTypeById
 } from '../types'
 import * as actions from '../actions'
 import {getPDMetadata} from '../../file-types'
@@ -182,7 +183,7 @@ type IngredientsState = IngredientGroups
 export const ingredients = handleActions({
   EDIT_INGREDIENT: (state, action: EditIngredient) => {
     const {groupId, description, individualize, name, serializeName} = action.payload
-    const ingredFields: PersistedIngredInputFields = {
+    const ingredFields: IngredientInstance = {
       description,
       individualize,
       name,
@@ -301,8 +302,21 @@ const getLabwareNames: Selector<{[labwareId: string]: string}> = createSelector(
     (l: Labware) => l.name || `${humanizeLabwareType(l.type)} (${l.disambiguationNumber})`)
 )
 
+const getLabwareTypes: Selector<LabwareTypeById> = createSelector(
+  getLabware,
+  (_labware) => mapValues(
+    _labware,
+    (l: Labware) => l.type
+  )
+)
+
 const getIngredientGroups = (state: BaseState) => rootSelector(state).ingredients
 const getIngredientLocations = (state: BaseState) => rootSelector(state).ingredLocations
+
+const getIngredientNames: Selector<{[ingredId: string]: string}> = createSelector(
+  getIngredientGroups,
+  ingredGroups => mapValues(ingredGroups, (ingred: IngredientInstance) => ingred.name)
+)
 
 const _loadedContainersBySlot = (containers: ContainersState) =>
   reduce(containers, (acc, container: Labware, containerId) => (container.slot)
@@ -422,8 +436,10 @@ export const selectors = {
 
   getIngredientGroups,
   getIngredientLocations,
+  getIngredientNames,
   getLabware,
   getLabwareNames,
+  getLabwareTypes,
   getSavedLabware,
   getSelectedContainer,
   getSelectedContainerId,

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -12,6 +12,8 @@ export type Labware = {|
   disambiguationNumber: number
 |}
 
+export type LabwareTypeById = {[labwareId: string]: ?string}
+
 // ==== WELLS ==========
 
 export type Wells = {
@@ -27,8 +29,12 @@ export type WellContents = {| // non-ingredient well state, for SelectablePlate
   groupIds: Array<string>
 |}
 
-export type AllWellContents = {
+export type ContentsByWell = {
   [wellName: string]: WellContents
+}
+
+export type WellContentsByLabware = {
+  [labwareId: string]: ContentsByWell
 }
 
 // ==== INGREDIENTS ====
@@ -45,10 +51,10 @@ export type IngredInputFields = $Exact<IngredInputs>
 
 export type IngredGroupAccessor = $Keys<IngredInputs>
 
-export type PersistedIngredInputFields = $Diff<IngredInputFields, {volume: *}>
+export type IngredientInstance = $Diff<IngredInputFields, {volume: *}>
 
 export type IngredientGroups = {
-  [groupId: string]: PersistedIngredInputFields
+  [groupId: string]: IngredientInstance
 }
 
 export type AllIngredGroupFields = {

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -1,6 +1,7 @@
 // @flow
 import range from 'lodash/range'
 
+import type {Channels} from '@opentrons/components'
 import {getWellsForTips} from '../step-generation/utils'
 import {
   utils as steplistUtils,
@@ -220,7 +221,7 @@ function commandToMultiRows (
   command: AspDispCommandType,
   getIngreds: GetIngreds,
   getLabwareType: GetLabwareType,
-  channels: 1 | 8
+  channels: Channels
 ): ?Array<StepItemSourceDestRowMulti> {
   const labwareId = command.params.labware
   const labwareType = getLabwareType(labwareId)

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -1,7 +1,6 @@
 // @flow
 import range from 'lodash/range'
 
-import type {LabwareTypeById} from '../labware-ingred/types'
 import {getWellsForTips} from '../step-generation/utils'
 import {
   utils as steplistUtils,
@@ -12,8 +11,6 @@ import {
   formHasErrors,
   type ValidFormAndErrors
 } from './formProcessing'
-
-import type {WellContentsByLabware} from '../top-selectors/well-contents'
 
 import type {
   SubstepItemData,
@@ -48,7 +45,7 @@ type AllPipetteData = {[pipetteId: string]: PipetteData}
 type SourceDestSubstepItemRows = $PropertyType<SourceDestSubstepItemSingleChannel, 'rows'>
 type SourceDestSubstepItemMultiRows = Array<Array<StepItemSourceDestRowMulti>>
 
-type GetIngreds = (labware: string, well: string) => Array<NamedIngred>
+export type GetIngreds = (labware: string, well: string) => Array<NamedIngred>
 type GetLabwareType = (labwareId: string) => ?string
 
 type AspDispCommandType = {
@@ -261,32 +258,12 @@ function commandToMultiRows (
   })
 }
 
-// TODO IMMEDIATELY: move these factories into the selector, getIngreds / getLabwareType is passed into generateSubsteps fn in allSubsteps
-const getIngredsFactory = (
-  wellContentsByLabware: WellContentsByLabware,
-  ingredNames: {[ingredId: string]: string}
-): GetIngreds => (labware, well) => {
-  const wellContents = (wellContentsByLabware &&
-    wellContentsByLabware[labware] &&
-    wellContentsByLabware[labware][well])
-
-  return wellContents.groupIds.map(id => ({
-    id: id,
-    name: ingredNames[id]
-  })) || []
-}
-
-const getLabwareTypeFactory = (allLabwareTypes: LabwareTypeById): GetLabwareType => (labwareId) => {
-  return allLabwareTypes && allLabwareTypes[labwareId]
-}
-
 // NOTE: This is the fn used by the `allSubsteps` selector
 export function generateSubsteps (
   valForm: ?ValidFormAndErrors,
   allPipetteData: AllPipetteData,
-  allLabwareTypes: LabwareTypeById,
-  ingredNames: {[ingredId: string]: string},
-  wellContentsByLabware: WellContentsByLabware,
+  getLabwareType: GetLabwareType,
+  getIngreds: GetIngreds,
   robotState: ?RobotState,
   stepId: number
 ): ?SubstepItemData {
@@ -316,9 +293,6 @@ export function generateSubsteps (
     validatedForm.stepType === 'transfer' ||
     validatedForm.stepType === 'mix'
   ) {
-    const getIngreds = getIngredsFactory(wellContentsByLabware, ingredNames)
-    const getLabwareType = getLabwareTypeFactory(allLabwareTypes)
-
     return transferLikeSubsteps({
       validatedForm,
       allPipetteData,

--- a/protocol-designer/src/steplist/index.js
+++ b/protocol-designer/src/steplist/index.js
@@ -8,6 +8,7 @@ import * as utils from './utils'
 import {getFieldErrors, processField} from './fieldLevel'
 import type {FormWarning, FormWarningType} from './formLevel'
 export * from './types'
+export * from './constants'
 export type {
   RootState,
   FormWarning,

--- a/protocol-designer/src/steplist/index.js
+++ b/protocol-designer/src/steplist/index.js
@@ -7,7 +7,7 @@ import * as actions from './actions'
 import * as utils from './utils'
 import {getFieldErrors, processField} from './fieldLevel'
 import type {FormWarning, FormWarningType} from './formLevel'
-
+export * from './types'
 export type {
   RootState,
   FormWarning,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -54,7 +54,7 @@ export type SourceDestSubstepItemMultiChannel = {|
 
 export type SourceDestSubstepItem = SourceDestSubstepItemSingleChannel | SourceDestSubstepItemMultiChannel
 
-export type StepSubItemData =
+export type SubstepItemData =
   | SourceDestSubstepItem
   | PauseFormData // Pause substep uses same data as processed form
 
@@ -66,6 +66,6 @@ export type StepItemData = {
   formData: ?FormData
 }
 
-export type SubSteps = {[StepIdType]: StepSubItemData | null}
+export type SubSteps = {[StepIdType]: ?SubstepItemData}
 
 export type StepIdTypeWithEnd = StepIdType | typeof END_STEP

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -11,19 +11,16 @@ export const END_STEP: '__end__' = '__end__' // Special ID of "End" pseudo-step.
 
 export type SubstepIdentifier = {|
   stepId: StepIdType,
-  substepId: number
+  substepIndex: number
 |} | null
 
 export type NamedIngred = {|
-  id: number,
+  id: string,
   name: string
 |}
 
-export type NamedIngredsByLabware = {[labwareId: string]: {[well: string]: Array<NamedIngred>}}
-export type NamedIngredsByLabwareAllSteps = Array<NamedIngredsByLabware>
-
 export type StepItemSourceDestRow = {|
-  substepId?: number, // TODO should this be a string or is this ID properly a number?
+  substepIndex?: number,
   sourceIngredients?: Array<NamedIngred>,
   destIngredients?: Array<NamedIngred>,
   sourceWell?: ?string,

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -89,22 +89,22 @@ function _getSelectedWellsForSubstep (
   form: StepGeneration.CommandCreatorData,
   labwareId: string,
   substeps: StepSubItemData | null,
-  substepId: number
+  substepIndex: number
 ): Array<string> {
   if (substeps === null) {
     return []
   }
 
   function getWells (wellField): Array<string> {
-    if (substeps && substeps.rows && substeps.rows[substepId]) {
+    if (substeps && substeps.rows && substeps.rows[substepIndex]) {
       // single-channel
-      const well = substeps.rows[substepId][wellField]
+      const well = substeps.rows[substepIndex][wellField]
       return well ? [well] : []
     }
 
-    if (substeps && substeps.multiRows && substeps.multiRows[substepId]) {
+    if (substeps && substeps.multiRows && substeps.multiRows[substepIndex]) {
       // multi-channel
-      return substeps.multiRows[substepId].reduce((acc, multiRow) => {
+      return substeps.multiRows[substepIndex].reduce((acc, multiRow) => {
         const well = multiRow[wellField]
         return well ? [...acc, well] : acc
       }, [])
@@ -158,7 +158,7 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
             form,
             labwareId,
             _allSubsteps[_hoveredSubstep.stepId],
-            _hoveredSubstep.substepId
+            _hoveredSubstep.substepIndex
           )
         } else {
           // wells for step overall

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -10,7 +10,7 @@ import {selectors as steplistSelectors} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
 
 import type {Selector} from '../types'
-import type {StepSubItemData} from '../steplist/types'
+import type {SubstepItemData} from '../steplist/types'
 
 type AllWellHighlights = {[wellName: string]: true} // NOTE: all keys are true
 type AllWellHighlightsAllLabware = {[labwareId: string]: AllWellHighlights}
@@ -88,7 +88,7 @@ function _getSelectedWellsForStep (
 function _getSelectedWellsForSubstep (
   form: StepGeneration.CommandCreatorData,
   labwareId: string,
-  substeps: StepSubItemData | null,
+  substeps: ?SubstepItemData,
   substepIndex: number
 ): Array<string> {
   if (substeps === null) {
@@ -170,13 +170,13 @@ export const wellHighlightsForSteps: Selector<Array<AllWellHighlightsAllLabware>
       return selectedWells.reduce((acc, well) => ({...acc, [well]: true}), {})
     }
 
-    function highlightedWellsForTimelineFrame (liquidState, timelineIdx): AllWellHighlightsAllLabware {
-      const robotState = timeline[timelineIdx].robotState
+    function highlightedWellsForTimelineFrame (liquidState, timelineIndex): AllWellHighlightsAllLabware {
+      const robotState = timeline[timelineIndex].robotState
       // TODO: Ian 2018-06-15 BUG! this doesn't work where there are deleted steps.
-      // Need to use orderedSteps[timelineIdx + 1] to get stepId
+      // Need to use orderedSteps[timelineIndex + 1] to get stepId
       // (just like in warningsPerStep and getErrorStepId selectors in file-data/selectors/commands)
       // Make stepId's always UNIQUE STRINGS to avoid trying to add 1 to them?
-      const formIdx = timelineIdx + 1
+      const formIdx = timelineIndex + 1
       const form = _forms[formIdx] && _forms[formIdx].validatedForm
 
       // replace value of each labware with highlighted wells info

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -3,7 +3,7 @@ import {createSelector} from 'reselect'
 
 import {selectors as pipetteSelectors} from '../pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
-import {selectors as steplistSelectors} from '../steplist'
+import {INITIAL_DECK_SETUP_ID, selectors as steplistSelectors} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
 import {allWellContentsForSteps} from './well-contents'
 
@@ -13,9 +13,10 @@ import {
 
 import type {Selector} from '../types'
 import type {StepIdType} from '../form-types'
-import type {StepSubItemData} from '../steplist/types'
+import type {SubstepItemData} from '../steplist/types'
 
-export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
+type AllSubsteps = {[StepIdType]: ?SubstepItemData}
+export const allSubsteps: Selector<AllSubsteps> = createSelector(
   steplistSelectors.validatedForms,
   pipetteSelectors.equippedPipettes,
   labwareIngredSelectors.getLabwareTypes,
@@ -23,5 +24,34 @@ export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = cre
   allWellContentsForSteps,
   steplistSelectors.orderedSteps,
   fileDataSelectors.robotStateTimeline,
-  generateSubsteps
+  (
+    validatedForms,
+    allPipetteData,
+    allLabwareTypes,
+    ingredNames,
+    _allWellContentsForSteps,
+    orderedSteps,
+    robotStateTimeline
+  ) => {
+    return orderedSteps
+    .filter(stepId => stepId !== INITIAL_DECK_SETUP_ID) // TODO: Ian 2018-07-18 once deck setup step isn't in orderedSteps, this filter can be removed
+    .reduce((acc: AllSubsteps, stepId, timelineIndex) => {
+      const robotState = robotStateTimeline.timeline[timelineIndex] &&
+        robotStateTimeline.timeline[timelineIndex].robotState
+
+      const substeps = generateSubsteps(
+        validatedForms[stepId],
+        allPipetteData,
+        allLabwareTypes,
+        ingredNames,
+        _allWellContentsForSteps[timelineIndex],
+        robotState,
+        stepId
+      )
+      return {
+        ...acc,
+        [stepId]: substeps
+      }
+    }, {})
+  }
 )

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -1,31 +1,27 @@
 // @flow
 import {createSelector} from 'reselect'
-import mapValues from 'lodash/mapValues'
 
 import {selectors as pipetteSelectors} from '../pipettes'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
-import {namedIngredsByLabware} from './well-contents'
+import {allWellContentsForSteps} from './well-contents'
 
 import {
   generateSubsteps
 } from '../steplist/generateSubsteps' // TODO Ian 2018-04-11 move generateSubsteps closer to this substeps.js file?
 
 import type {Selector} from '../types'
-import type {LabwareData} from '../step-generation/types'
 import type {StepIdType} from '../form-types'
 import type {StepSubItemData} from '../steplist/types'
 
 export const allSubsteps: Selector<{[StepIdType]: StepSubItemData | null}> = createSelector(
   steplistSelectors.validatedForms,
   pipetteSelectors.equippedPipettes,
-  labwareIngredSelectors.getLabware,
-  namedIngredsByLabware,
+  labwareIngredSelectors.getLabwareTypes,
+  labwareIngredSelectors.getIngredientNames,
+  allWellContentsForSteps,
   steplistSelectors.orderedSteps,
   fileDataSelectors.robotStateTimeline,
-  (_validatedForms, _pipetteData, _allLabware, _namedIngredsByLabware, _orderedSteps, _robotStateTimeline) => {
-    const allLabwareTypes: {[labwareId: string]: string} = mapValues(_allLabware, (l: LabwareData) => l.type)
-    return generateSubsteps(_validatedForms, _pipetteData, allLabwareTypes, _namedIngredsByLabware, _orderedSteps, _robotStateTimeline)
-  }
+  generateSubsteps
 )

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -8,12 +8,28 @@ import {selectors as fileDataSelectors} from '../file-data'
 import {allWellContentsForSteps} from './well-contents'
 
 import {
-  generateSubsteps
+  generateSubsteps,
+  type GetIngreds
 } from '../steplist/generateSubsteps' // TODO Ian 2018-04-11 move generateSubsteps closer to this substeps.js file?
 
 import type {Selector} from '../types'
 import type {StepIdType} from '../form-types'
 import type {SubstepItemData} from '../steplist/types'
+import type {WellContentsByLabware} from './well-contents'
+
+const getIngredsFactory = (
+  wellContentsByLabware: WellContentsByLabware,
+  ingredNames: {[ingredId: string]: string}
+): GetIngreds => (labware, well) => {
+  const wellContents = (wellContentsByLabware &&
+    wellContentsByLabware[labware] &&
+    wellContentsByLabware[labware][well])
+
+  return wellContents.groupIds.map(id => ({
+    id: id,
+    name: ingredNames[id]
+  })) || []
+}
 
 type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
@@ -42,9 +58,8 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
       const substeps = generateSubsteps(
         validatedForms[stepId],
         allPipetteData,
-        allLabwareTypes,
-        ingredNames,
-        _allWellContentsForSteps[timelineIndex],
+        (labwareId: string) => allLabwareTypes[labwareId],
+        getIngredsFactory(_allWellContentsForSteps[timelineIndex], ingredNames),
         robotState,
         stepId
       )

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -14,13 +14,17 @@ import wellSelectionSelectors from '../../well-selection/selectors'
 import {getAllWellsForLabware, getMaxVolumes} from '../../constants'
 
 import type {Selector} from '../../types'
-import type {WellContents, AllWellContents} from '../../labware-ingred/types'
-import type {NamedIngredsByLabwareAllSteps} from '../../steplist/types'
+import type {
+  WellContents,
+  WellContentsByLabware,
+  ContentsByWell
+} from '../../labware-ingred/types'
 
 // TODO Ian 2018-04-19: factor out all these selectors to their own files,
 // and make this index.js just imports and exports.
 import wellContentsAllLabwareExport from './wellContentsAllLabware'
 export const wellContentsAllLabware = wellContentsAllLabwareExport
+export type {WellContentsByLabware}
 
 function _wellContentsForWell (
   liquidVolState: StepGeneration.LocationLiquidState,
@@ -46,7 +50,7 @@ export function _wellContentsForLabware (
   labwareLiquids: StepGeneration.SingleLabwareLiquidState,
   labwareId: string,
   labwareType: string
-): AllWellContents {
+): ContentsByWell {
   const allWellsForContainer = getAllWellsForLabware(labwareType)
 
   return reduce(
@@ -64,7 +68,7 @@ export function _wellContentsForLabware (
   )
 }
 
-export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWellContents}>> = createSelector(
+export const allWellContentsForSteps: Selector<Array<WellContentsByLabware>> = createSelector(
   fileDataSelectors.robotStateTimeline,
   steplistSelectors.validatedForms,
   (_robotStateTimeline, _forms) => {
@@ -89,7 +93,7 @@ export const allWellContentsForSteps: Selector<Array<{[labwareId: string]: AllWe
   }
 )
 
-export const lastValidWellContents: Selector<{[labwareId: string]: AllWellContents}> = createSelector(
+export const lastValidWellContents: Selector<WellContentsByLabware> = createSelector(
   fileDataSelectors.lastValidRobotState,
   (robotState) => {
     return mapValues(
@@ -103,27 +107,6 @@ export const lastValidWellContents: Selector<{[labwareId: string]: AllWellConten
       }
     )
   }
-)
-
-/** NamedIngred-formatted contents of wells, across all steps on the timeline */
-// TODO: Ian 2018-06-08 do not used NamedIngreds. Stay close to 'native' liquid state shape.
-export const namedIngredsByLabware: Selector<NamedIngredsByLabwareAllSteps> = createSelector(
-  allWellContentsForSteps,
-  labwareIngredSelectors.getIngredientGroups,
-  (_allWellContentsForSteps, _ingredientGroups) =>
-    _allWellContentsForSteps.map(stepWellContents =>
-      mapValues(stepWellContents, (labwareContents: AllWellContents, labwareId: string) =>
-        mapValues(labwareContents, (wellContents: WellContents, wellId: string) => {
-          return wellContents.groupIds
-            .filter(id => id in _ingredientGroups) // strip out __air__, etc pseudo-ingreds not in ingredientGroups
-            .map(id => ({
-              id: parseInt(id),
-              name: _ingredientGroups[id].name
-              // NOTE: serializeName is available too, but is being deprecated?
-            }))
-        })
-      )
-    )
 )
 
 export const selectedWellsMaxVolume: Selector<number> = createSelector(

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -69,17 +69,18 @@ export function _wellContentsForLabware (
 }
 
 export const allWellContentsForSteps: Selector<Array<WellContentsByLabware>> = createSelector(
+  fileDataSelectors.getInitialRobotState,
   fileDataSelectors.robotStateTimeline,
   steplistSelectors.validatedForms,
-  (_robotStateTimeline, _forms) => {
-    const timeline = _robotStateTimeline.timeline
+  (_initialRobotState, _robotStateTimeline, _forms) => {
+    const timeline = [{robotState: _initialRobotState}, ..._robotStateTimeline.timeline]
     const liquidStateTimeline = timeline.map(t => t.robotState.liquidState.labware)
 
     return liquidStateTimeline.map(
-      (liquidState, timelineIdx) => mapValues(
+      (liquidState, timelineIndex) => mapValues(
         liquidState,
         (labwareLiquids: StepGeneration.SingleLabwareLiquidState, labwareId: string) => {
-          const robotState = timeline[timelineIdx].robotState
+          const robotState = timeline[timelineIndex].robotState
           const labwareType = robotState.labware[labwareId].type
 
           return _wellContentsForLabware(

--- a/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
@@ -8,7 +8,11 @@ import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers
 import wellSelectionSelectors from '../../well-selection/selectors'
 
 import type {Selector} from '../../types'
-import type {Wells, AllWellContents} from '../../labware-ingred/types'
+import type {
+  Wells,
+  ContentsByWell,
+WellContentsByLabware
+  } from '../../labware-ingred/types'
 import type {SingleLabwareLiquidState} from '../../step-generation'
 
 const _getWellContents = (
@@ -16,7 +20,7 @@ const _getWellContents = (
   __ingredientsForContainer: SingleLabwareLiquidState,
   selectedWells: ?Wells,
   highlightedWells: ?Wells
-): AllWellContents | null => {
+): ContentsByWell | null => {
   // selectedWells and highlightedWells args may both be null,
   // they're only relevant to the selected container.
   if (!containerType) {
@@ -32,7 +36,7 @@ const _getWellContents = (
 
   const allWells = containerData.wells
 
-  return reduce(allWells, (acc: AllWellContents, well: WellDefinition, wellName: string): AllWellContents => {
+  return reduce(allWells, (acc: ContentsByWell, well: WellDefinition, wellName: string): ContentsByWell => {
     const groupIds = (__ingredientsForContainer && __ingredientsForContainer[wellName])
       ? Object.keys(__ingredientsForContainer[wellName])
       : []
@@ -49,7 +53,7 @@ const _getWellContents = (
   }, {})
 }
 
-const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> = createSelector(
+const wellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
   labwareIngredSelectors.getLabware,
   labwareIngredSelectors.getIngredientLocations,
   labwareIngredSelectors.getSelectedContainer,
@@ -58,7 +62,7 @@ const wellContentsAllLabware: Selector<{[labwareId: string]: AllWellContents}> =
   (_labware, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
     const allLabwareIds: Array<string> = Object.keys(_labware) // TODO Ian 2018-05-29 weird flow error w/o annotation
 
-    return allLabwareIds.reduce((acc: {[labwareId: string]: AllWellContents | null}, labwareId: string) => {
+    return allLabwareIds.reduce((acc: {[labwareId: string]: ContentsByWell | null}, labwareId: string) => {
       const ingredsForLabware = _ingredsByLabware[labwareId]
       const isSelectedLabware = _selectedLabware && (_selectedLabware.id === labwareId)
 


### PR DESCRIPTION
## overview

Closes #1812 and refactors `generateSubsteps` fn to lessen that fn's responsibilities. This bug was harder to see b/c `generateSubsteps` was managing timeline indicies, whereas now it's just fed the relevant timeline frames.

## changelog

    -calls to swatchColors use `Number` not `parseInt`, warns on non-integer input (NaNs)
    -clean up swatchColors import (no re-routing)
    
    -clarify names of labware/ingred types
    -rename 'substepId' to 'substepIndex' in PD substeps
    -less argument boilerplate in allSubsteps selector
    -remove namedIngredsByLabware selector, convert WellContents to NamedIngreds in getIngredsFactory fn instead
    -make generateSubsteps fn work on a single step, no longer is responsible
    for mapping across step list itself


## review requests

- See #1812 -- in substep Pills, do ingredients show up in the state of the beginning of that step (eg, matching what you see on the deck for this step and not the deck liquids on the **next** step?)
- Multi and single-channel substeps work