### PR TITLE
fix(api): pipette.delay() does not block during simulation

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -1307,7 +1307,8 @@ class Pipette:
         seconds += float(minutes * 60)
 
         self.robot.pause()
-        _sleep(seconds)
+        if not self.robot.is_simulating():
+            _sleep(seconds)
         self.robot.resume()
 
         return self

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -254,6 +254,10 @@ def test_delay_calls(monkeypatch):
     def mock_sleep(seconds):
         cmd.append("sleep {}".format(seconds))
 
+    def mock_is_simulating():
+        return False
+
+    monkeypatch.setattr(robot, 'is_simulating', mock_is_simulating)
     monkeypatch.setattr(robot, 'pause', mock_pause)
     monkeypatch.setattr(robot, 'resume', mock_resume)
     monkeypatch.setattr(pipette, '_sleep', mock_sleep)


### PR DESCRIPTION
## overview

Fix `pipette.delay()` so it does not perform a blocking sleep while the protocol is simulating
