### PR TITLE
fix(protocol-designer): fix bug where tips not dropped at end of protocol

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -164,7 +164,15 @@ export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelec
         return [...acc, commandCreator]
       }, [])
 
-    const timeline = StepGeneration.commandCreatorsTimeline(commandCreators)(initialRobotState)
+    // cleanup procedure(s) after last step
+    const cleanupCommandCreators = [
+      StepGeneration.dropAllTips()
+    ]
+
+    const timeline = StepGeneration.commandCreatorsTimeline([
+      ...commandCreators,
+      ...cleanupCommandCreators
+    ])(initialRobotState)
 
     return timeline
   }

--- a/protocol-designer/src/step-generation/dropAllTips.js
+++ b/protocol-designer/src/step-generation/dropAllTips.js
@@ -1,0 +1,15 @@
+// @flow
+import type {CommandCreator, RobotState} from './'
+import {reduceCommandCreators} from './utils'
+import dropTip from './dropTip'
+
+/** Drop all tips from equipped pipettes.
+  * If no tips are attached to a pipette, do nothing.
+  */
+const dropAllTips = (): CommandCreator => (prevRobotState: RobotState) => {
+  const pipetteIds = Object.keys(prevRobotState.instruments)
+  const commandCreators = pipetteIds.map(pipetteId => dropTip(pipetteId))
+  return reduceCommandCreators(commandCreators)(prevRobotState)
+}
+
+export default dropAllTips

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -5,6 +5,7 @@ import consolidate from './consolidate'
 import distribute from './distribute'
 import delay from './delay'
 import dispense from './dispense'
+import dropAllTips from './dropAllTips'
 import dropTip from './dropTip'
 import mix from './mix'
 import replaceTip from './replaceTip'
@@ -22,6 +23,7 @@ export {
   distribute,
   delay,
   dispense,
+  dropAllTips,
   dropTip,
   mix,
   replaceTip,

--- a/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
@@ -1,0 +1,71 @@
+// @flow
+import type {RobotState} from '../types'
+import {createRobotState, commandCreatorNoErrors} from './fixtures'
+import _dropAllTips from '../dropAllTips'
+
+const dropAllTips = commandCreatorNoErrors(_dropAllTips)
+
+const p300SingleId = 'p300SingleId'
+const p300MultiId = 'p300MultiId'
+
+let initialRobotState
+
+beforeEach(() => {
+  initialRobotState = createRobotState({
+    sourcePlateType: 'trough-12row',
+    destPlateType: '96-flat',
+    fillTiprackTips: true,
+    fillPipetteTips: false,
+    tipracks: [200, 200]
+  })
+})
+
+function expectNoTipsRemaining (robotState: RobotState) {
+  const pipetteIds = Object.keys(robotState.tipState.pipettes)
+  pipetteIds.forEach(pipetteId => {
+    expect(robotState.tipState.pipettes[pipetteId]).toBe(false)
+  })
+}
+
+describe('drop all tips', () => {
+  test('should do nothing with no pipettes', () => {
+    initialRobotState.instruments = {}
+    initialRobotState.tipState.pipettes = {}
+
+    const result = dropAllTips()(initialRobotState)
+    expect(result.commands).toHaveLength(0)
+    expectNoTipsRemaining(result.robotState)
+  })
+
+  test('should do nothing with pipette that does not have tips', () => {
+    const result = dropAllTips()(initialRobotState)
+    expect(result.commands).toHaveLength(0)
+    expectNoTipsRemaining(result.robotState)
+  })
+
+  test('should drop tips of one pipette that has them, and not one without', () => {
+    initialRobotState.tipState.pipettes = {
+      [p300SingleId]: true,
+      [p300MultiId]: false
+    }
+
+    const result = dropAllTips()(initialRobotState)
+    expect(result.commands).toHaveLength(1)
+    expect(result.commands[0].params).toMatchObject({pipette: p300SingleId})
+
+    expectNoTipsRemaining(result.robotState)
+  })
+
+  test('should drop tips for both pipettes, with 2 pipettes that have tips', () => {
+    initialRobotState.tipState.pipettes = {
+      [p300SingleId]: true,
+      [p300MultiId]: true
+    }
+
+    const result = dropAllTips()(initialRobotState)
+    // order of which pipettes drops tips first is arbitrary
+    expect(result.commands).toHaveLength(2)
+
+    expectNoTipsRemaining(result.robotState)
+  })
+})


### PR DESCRIPTION
## overview

Tips should now always be dropped at end of protocol.

Closes #969

## changelog

- add `dropAllTips` CommandCreator and use it in PD at end of timeline

## review requests

- drops all tips at end of protocol (you can look at the saved JSON commands to check)
- doesn't break anything timeline-related, ie PD still works normally
