### PR TITLE
perf(api): Slow axis-testing speed to 8mm/sec during QC

### DIFF
--- a/api/opentrons/tools/gantry_test.py
+++ b/api/opentrons/tools/gantry_test.py
@@ -54,7 +54,7 @@ def test_axis(axis, tolerance):
     # expected_point = home_position + retract
     # safe distance from switch?
     robot._driver.push_speed()
-    robot._driver.set_speed(10)
+    robot._driver.set_speed(8)
     try:
         robot._driver.move({axis: points[0]})
     except SmoothieError:

--- a/api/opentrons/tools/overnight_test.py
+++ b/api/opentrons/tools/overnight_test.py
@@ -185,7 +185,7 @@ def test_axis(driver, logger, axis):
     if axis == 'Y':
         driver.move({'X': driver.homed_position['X']})
     driver.push_speed()
-    driver.set_speed(10)
+    driver.set_speed(8)
     driver.update_position()
     try:
         driver.move({axis: points[0]})

--- a/api/opentrons/tools/z_stage_test.py
+++ b/api/opentrons/tools/z_stage_test.py
@@ -59,7 +59,7 @@ def test_axis(axis, tolerance):
     expected_point = robot._driver.homed_position[axis] + retract
     points = [expected_point - tolerance, expected_point + tolerance]
     robot._driver.push_speed()
-    robot._driver.set_speed(10)
+    robot._driver.set_speed(8)
     try:
         robot._driver.move({axis: points[0]})
     except SmoothieError:


### PR DESCRIPTION
<!--
## overview

Set the speed to 8mm/sec while testing for skipped steps during QC. This change in speed is to avoid a resonance on the Z axes, which occurs at 10mm/sec