### PR TITLE
fix(api): Home Z axes before run to guarantee that pipettes will be retracted

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -209,6 +209,7 @@ class Session(object):
 
         try:
             self.resume()
+            robot.home_z()
             if self._is_json_protocol:
                 execute_protocol(self._protocol)
             else:


### PR DESCRIPTION
## overview

This PR is pulling double-duty as a ticket. Now that all steps of labware calibration are optional and some are order-independent, there are corner cases in which a pipette will not be retracted. The simplest way to guarantee that a pipette will not remain in the down position during run is to home both Z axes prior to beginning a run.

## changelog

- Home Z axes before run to guarantee that pipettes will be retracted

