### PR TITLE
feat(protocol-designer): change copy for pipette missing tip error

### DIFF
--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -12,7 +12,17 @@ import {selectors as steplistSelectors} from '../../steplist'
 import {selectors as fileDataSelectors} from '../../file-data'
 import {AlertItem} from '@opentrons/components'
 import type {BaseState} from '../../types'
-import type {CommandCreatorError, CommandCreatorWarning} from '../../step-generation'
+import type {
+  CommandCreatorError,
+  CommandCreatorWarning,
+  ErrorType,
+  WarningType
+} from '../../step-generation'
+
+type AlertContent = {
+  title: string,
+  body?: ?React.Node
+}
 
 type SP = {
   errors: Array<CommandCreatorError>,
@@ -26,35 +36,68 @@ type DP = {
 
 type Props = SP & DP
 
-// These captions populate the AlertItem body, the title/message
-// comes from the CommandCreatorError / CommandCreatorWarning
-const captions: {[warningOrErrorType: string]: string} = {
-  'INSUFFICIENT_TIPS': 'Add another tip rack to an empty slot in Deck Setup',
-  'ASPIRATE_MORE_THAN_WELL_CONTENTS': 'You are trying to aspirate more than the current volume of one of your well(s). If you intended to add air to your tip, please use the Air Gap advanced setting.'
+/** Errors and Warnings from step-generation are written for developers
+  * who are using step-generation as an API for writing Opentrons protocols.
+  * These 'overrides' replace the content of some of those errors/warnings
+  * in order to make things clearer to the PD user.
+  *
+  * When an override is not specified here, the default behaviors is that
+  * the warning/error `message` gets put into the `title` of the Alert
+  */
+const errorOverrides: {[ErrorType]: AlertContent} = {
+  'INSUFFICIENT_TIPS': {
+    title: 'Not enough tips to complete action',
+    body: 'Add another tip rack to an empty slot in Deck Setup'
+  },
+  'NO_TIP_ON_PIPETTE': {
+    title: 'No tip on pipette',
+    body: 'For the first step in a protocol the "change tip" setting must be set to always or once.'
+  }
+}
+
+const warningOverrides: {[WarningType]: AlertContent} = {
+  'ASPIRATE_MORE_THAN_WELL_CONTENTS': {
+    title: 'Not enough liquid in well(s)',
+    body: 'You are trying to aspirate more than the current volume of one of your well(s). If you intended to add air to your tip, please use the Air Gap advanced setting.'
+  }
+}
+
+function getErrorContent (error: CommandCreatorError): AlertContent {
+  return errorOverrides[error.type] || {title: error.message}
+}
+
+function getWarningContent (warning: CommandCreatorWarning): AlertContent {
+  return warningOverrides[warning.type] || {title: warning.message}
 }
 
 function Alerts (props: Props) {
-  const errors = props.errors.map((error, key) => (
-    <AlertItem
-      type='warning'
-      key={`error:${key}`}
-      title={error.message}
-      onCloseClick={undefined}
-      >
-        {captions[error.type]}
-      </AlertItem>
-    ))
+  const errors = props.errors.map((error, key) => {
+    const {title, body} = getErrorContent(error)
+    return (
+      <AlertItem
+        type='warning'
+        key={`error:${key}`}
+        title={title}
+        onCloseClick={undefined}
+        >
+          {body}
+        </AlertItem>
+    )
+  })
 
-  const warnings = props.warnings.map((warning, key) => (
-    <AlertItem
-      type='warning'
-      key={`warning:${key}`}
-      title={warning.message}
-      onCloseClick={props.onDismiss(warning)}
-      >
-        {captions[warning.type]}
-      </AlertItem>
-    ))
+  const warnings = props.warnings.map((warning, key) => {
+    const {title, body} = getWarningContent(warning)
+    return (
+      <AlertItem
+        type='warning'
+        key={`warning:${key}`}
+        title={title}
+        onCloseClick={props.onDismiss(warning)}
+        >
+          {body}
+        </AlertItem>
+    )
+  })
 
   return (
     <div>

--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -21,7 +21,7 @@ import type {
 
 type AlertContent = {
   title: string,
-  body?: ?React.Node
+  body?: React.Node
 }
 
 type SP = {

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -55,7 +55,7 @@ export const generateNewForm = (stepId: StepIdType, stepType: StepType): BlankFo
   if (stepType === 'transfer' || stepType === 'consolidate' || stepType === 'mix') {
     return {
       ...baseForm,
-      'aspirate_change-tip': 'once'
+      'aspirate_changeTip': 'once'
     }
   }
 


### PR DESCRIPTION
## overview

Closes #1880, Closes #1815

## changelog

-allow more control in overriding step-generations warnings/errors w/in PD context
-fix bug with "Change tip" being blank (#1815)

## review requests

- Change tip to "Never" in a step that is the first for that pipette - error copy should match #1880 
- In new steps, "Change Tip" should be set to "Always" (not blank)