### PR TITLE
feat(protocol-designer): restyle labware hover buttons

### DIFF
--- a/protocol-designer/src/components/labware/ClickableText.js
+++ b/protocol-designer/src/components/labware/ClickableText.js
@@ -4,19 +4,37 @@ import {Icon, type IconName} from '@opentrons/components'
 import styles from './labware.css'
 
 type Props = {
-  y: string | number;
+  y: string | number,
+  height?: string | number,
   text?: string,
   iconName?: IconName,
   onClick?: (e: SyntheticEvent<*>) => void,
 }
 
+const DEFAULT_HEIGHT = 15
+
 export default function (props: Props) {
+  const height = (props.height == null) ? DEFAULT_HEIGHT : props.height
   return (
-    <g className={styles.clickable_text} onClick={props.onClick}>
-      <text x='0' y={props.y}>{props.text}</text>
-      {props.iconName && <g className={styles.icon}>
-        <Icon name={props.iconName} y={props.y} height='15%' />
-      </g>}
+    <g onClick={props.onClick}>
+      {/* Invisible clickable area (otherwise line-drawing icons are hard
+        to get 'cursor: pointer' on!) */}
+      <rect
+        x='0'
+        y={props.y}
+        width='100%'
+        height={height}
+        className={styles.clickable_area}
+      />
+
+      <g className={styles.clickable_text}>
+        <text x='0' y={props.y}>{props.text}</text>
+        {props.iconName && (
+          <g className={styles.icon}>
+            <Icon name={props.iconName} y={props.y} height={height} />
+          </g>
+        )}
+      </g>
     </g>
   )
 }

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -44,17 +44,17 @@ function OccupiedDeckSlotOverlay ({
       <rect className={styles.overlay_panel} />
       {canAddIngreds &&
         <ClickableText onClick={() => openIngredientSelector(containerId)}
-          iconName='pencil' y='25%' text='Name & Liquids' />
+          iconName='pencil' y='15%' text='Name & Liquids' />
       }
       <ClickableText onClick={() => setCopyLabwareMode(containerId)}
-        iconName='cursor-move' y='50%' text='Copy' />
+        iconName='cursor-move' y='40%' text='Copy' />
       {/* TODO Ian 2018-02-16 Move labware, not copy labware. */}
 
       <ClickableText onClick={() =>
           window.confirm(`Are you sure you want to permanently delete ${containerName || containerType} in slot ${slot}?`) &&
           deleteContainer({containerId, slot, containerType})
       }
-        iconName='close' y='75%' text='Delete' />
+        iconName='close' y='65%' text='Delete' />
     </g>
   )
 }
@@ -193,9 +193,9 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
             : <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
               <rect className={styles.overlay_panel} />
               <ClickableText onClick={e => openLabwareSelector({slot})}
-                iconName='plus' y='40%' text='Add Labware' />
+                iconName='plus' y='30%' text='Add Labware' />
               <ClickableText onClick={e => window.alert('NOT YET IMPLEMENTED: Add Copy') /* TODO: New Copy feature */}
-                iconName='content-copy' y='65%' text='Add Copy' />
+                iconName='content-copy' y='55%' text='Add Copy' />
             </g>
         )
       }

--- a/protocol-designer/src/components/labware/labware.css
+++ b/protocol-designer/src/components/labware/labware.css
@@ -5,16 +5,12 @@
   --round-slot: {
     clip-path: url(#roundSlotClipPath);
   };
-
-  --slot-overlay: {
-    @apply --round-slot;
-
-    fill: black;
-  };
 }
 
 .slot_overlay {
-  @apply --slot-overlay;
+  @apply --round-slot;
+
+  fill: var(--c-black);
 
   & text {
     font-size: var(--fs-caption);
@@ -32,27 +28,28 @@
 
 .appear_on_mouseover {
   opacity: 0;
-}
 
-.appear_on_mouseover:hover {
-  opacity: 0.75;
+  &:hover {
+    opacity: 0.75;
+  }
 }
 
 .clickable_text {
-  color: var(--c-med-gray);
   fill: currentColor;
+  color: var(--c-white);
   cursor: pointer;
   transform: translate(20%, 0);
   text-transform: uppercase;
+  dominant-baseline: text-before-edge;
 
   & .icon {
-    transform: translate(-60%, -12%);
+    transform: translate(-60%, 0);
   }
+}
 
-  &:hover {
-    color: white;
-    fill: currentColor;
-  }
+.clickable_area {
+  cursor: pointer;
+  fill: transparent;
 }
 
 .name_input {


### PR DESCRIPTION
## overview

Closes #1519 (makes icon+text brighter, was mid-gray before. See picture in issue)

I tried to clean the SVG styles up a tiny bit:
- removed a magic transforms (instead aligned with `dominant-baseline: text-before-edge;`, thanks @mcous for showing me that rule)
- gave a `height` prop to the `ClickableText` component with a default value instead of having hard-coded height
- added a `rect` w/ `.clickable_area` that fills the whole area of icon+text because on `edge` right now, it's hard to hover/click thin line-drawing icons - you gotta click a pixel of the icon that has fill, instead of the general area.

## changelog

-update hover button styles to be bright white
-fix hover cursor finicky-ness
-style cleanup

## review requests

