### PR TITLE
feat(protocol-designer): show no pipette on mount in file details

### DIFF
--- a/components/src/__tests__/__snapshots__/instrument-diagram.test.js.snap
+++ b/components/src/__tests__/__snapshots__/instrument-diagram.test.js.snap
@@ -36,7 +36,7 @@ exports[`InstrumentGroup Renders correctly 1`] = `
         <h2
           className="title"
         >
-          pipette
+          Pipette
         </h2>
         <span
           className="value"
@@ -50,7 +50,7 @@ exports[`InstrumentGroup Renders correctly 1`] = `
         <h2
           className="title"
         >
-          suggested tip type
+          Suggested Tip Type
         </h2>
         <span
           className="value"
@@ -79,7 +79,7 @@ exports[`InstrumentGroup Renders correctly 1`] = `
         <h2
           className="title"
         >
-          pipette
+          Pipette
         </h2>
         <span
           className="value"
@@ -93,7 +93,7 @@ exports[`InstrumentGroup Renders correctly 1`] = `
         <h2
           className="title"
         >
-          suggested tip type
+          Suggested Tip Type
         </h2>
         <span
           className="value"

--- a/components/src/instrument-diagram/InfoItem.js
+++ b/components/src/instrument-diagram/InfoItem.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import startCase from 'lodash/startCase'
 
 import styles from './instrument.css'
 
@@ -17,7 +18,7 @@ export default function InfoItem (props: Props) {
   const {title, value, className} = props
   return (
     <div className={className}>
-      <h2 className={styles.title}>{title}</h2>
+      <h2 className={styles.title}>{startCase(title)}</h2>
       <span className={styles.value}>{value}</span>
     </div>
   )

--- a/components/src/instrument-diagram/InstrumentGroup.js
+++ b/components/src/instrument-diagram/InstrumentGroup.js
@@ -11,17 +11,25 @@ type Props = {
   right?: InstrumentInfoProps
 }
 
+const EMPTY_INSTRUMENT_PROPS = {
+  description: 'None',
+  tiprackModel: 'N/A',
+  isDisabled: false
+}
+
 /**
  * Renders a left and right pipette diagram & info.
- * Takes an array of `InstrumentInfo` props.
+ * Takes child `InstrumentInfo` props in `right` and `left` props.
  */
 export default function InstrumentGroup (props: Props) {
   const {left, right, showMountLabel} = props
 
+  const leftProps = left || {...EMPTY_INSTRUMENT_PROPS, mount: 'left'}
+  const rightProps = right || {...EMPTY_INSTRUMENT_PROPS, mount: 'right'}
   return (
     <section className={styles.pipette_group}>
-      {left && <InstrumentInfo {...left} showMountLabel={showMountLabel} />}
-      {right && <InstrumentInfo {...right} showMountLabel={showMountLabel} />}
+      <InstrumentInfo {...leftProps} showMountLabel={showMountLabel} />
+      <InstrumentInfo {...rightProps} showMountLabel={showMountLabel} />
     </section>
   )
 }

--- a/components/src/instrument-diagram/InstrumentInfo.js
+++ b/components/src/instrument-diagram/InstrumentInfo.js
@@ -16,7 +16,9 @@ export type InstrumentInfoProps = {
   /** human-readable description, eg 'p300 Single-channel' */
   description: string,
   /** recommended tip type */
-  tipType: string,
+  tipType?: string,
+  /** paired tiprack model */
+  tiprackModel?: string,
   /** if disabled, pipette & its info are grayed out */
   isDisabled: boolean,
   /** usually 1 or 8 */
@@ -44,13 +46,15 @@ export default function InstrumentInfo (props: InstrumentInfoProps) {
           title={props.showMountLabel ? `${props.mount} pipette` : 'pipette'}
           value={props.description}
         />
-        <InfoItem title={'suggested tip type'} value={props.tipType} />
+        {props.tipType && <InfoItem title={'suggested tip type'} value={props.tipType} />}
+        {props.tiprackModel && <InfoItem title={'tip rack'} value={props.tiprackModel} />}
         {props.children}
       </div>
-      <InstrumentDiagram
-        channels={props.channels}
-        className={styles.pipette_icon}
-      />
+      {props.channels &&
+        <InstrumentDiagram
+          channels={props.channels}
+          className={styles.pipette_icon} />
+      }
     </div>
   )
 }

--- a/components/src/instrument-diagram/instrument.css
+++ b/components/src/instrument-diagram/instrument.css
@@ -43,11 +43,13 @@
 
 .title {
   font-size: var(--fs-body-2);
-  text-transform: uppercase;
+  font-weight: var(--fw-semibold);
+  color: var(--c-font-dark);
   margin: 2rem 0 0.25rem;
 }
 
 .value {
-  font-size: var(--fs-body-2);
+  @apply --font-body-2-dark;
+
   margin-left: 1rem;
 }

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -75,12 +75,14 @@ export const pipettesForInstrumentGroup: Selector<*> = createSelector(
 
     if (!pipetteData) return acc
 
+    const {mount, channels, tiprackModel} = pipetteData
+
     const pipetteForInstrumentGroup = {
-      mount: pipetteData.mount,
-      channels: pipetteData.channels,
+      mount,
+      channels,
       description: _getPipetteName(pipetteData),
       isDisabled: false,
-      tipType: `${pipetteData.maxVolume} μL`
+      tiprackModel: tiprackModel && tiprackModel.slice(tiprackModel.search(/\d./)) // TODO: BC 2018-07-23 tiprack displayName
     }
 
     return [...acc, pipetteForInstrumentGroup]


### PR DESCRIPTION
When a protocol has an empty pipette mount, explicitly show that in the file details page. Also,
display the selected tiprack, not the suggested. And, fix the typography inconsistencies.

Closes #1909

## review requests

<!--
  Describe any requests for your reviewers here.
-->
