### PR TITLE
fix(protocol-designer): fix file load bug w mismatched pipette ids

### DIFF
--- a/protocol-designer/src/pipettes/reducers.js
+++ b/protocol-designer/src/pipettes/reducers.js
@@ -11,8 +11,13 @@ import type {LoadFileAction, NewProtocolFields} from '../load-file'
 import type {PipetteData} from '../step-generation'
 import type {FilePipette} from '../file-types'
 
-function createPipette (mount: Mount, model: string, tiprackModel: ?string): ?PipetteData {
-  const id = `pipette:${model}:${uuid()}`
+function createPipette (
+  mount: Mount,
+  model: string,
+  tiprackModel: ?string,
+  overrideId?: string
+): ?PipetteData {
+  const id = overrideId || `pipette:${model}:${uuid()}`
   const pipetteData = getPipette(model)
 
   if (!pipetteData) {
@@ -62,7 +67,7 @@ const pipettes = handleActions({
       byId: reduce(
         pipettes,
         (acc: {[pipetteId: string]: PipetteData}, p: FilePipette, id: string) => {
-          const newPipette = createPipette(p.mount, p.model, pipetteTiprackAssignments[id])
+          const newPipette = createPipette(p.mount, p.model, pipetteTiprackAssignments[id], id)
           return newPipette
             ? {...acc, [id]: newPipette}
             : acc


### PR DESCRIPTION
## overview

This is the issue and fix for a bug in PD.

### Bug Symptoms:
Commit: cd8b9202e0cd954b8f9ecf7bba96f61641a00445

When loading a json file into PD, substeps don't appear for any steps (except Pause), and deleting all tipracks doesn't cause "not enough tips" error. New steps you create after loading a file also have this problem, even if you delete all the protocol's steps. This doesn't happen when you create a protocol from scratch (ie when you do not upload a file)

### Cause:
Pipette were being given new unique IDs upon load, instead of using the IDs referenced in the uploaded file.

## changelog

- fix file load bug w mismatched pipette ids

## review requests

- Make sure bug is fixed: saving, refreshing, then loading a file shouldn't cause strange behavior around pipettes & tips. There have been a few breaking changes to file loading in the past weeks, so to be safe, save a file off of this branch, don't try to use one that's a couple weeks old.