### PR TITLE
fix(protocol-designer): fix substeps for consolidate using inner mix

### DIFF
--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -107,7 +107,8 @@ function transferLikeSubsteps (args: {
   } else if (validatedForm.stepType === 'consolidate') {
     const commandCallArgs = {
       ...validatedForm,
-      mixBeforeAspirate: null
+      mixFirstAspirate: null,
+      mixInDestination: null
     }
 
     result = consolidate(commandCallArgs)(robotState)


### PR DESCRIPTION
## overview

Closes #1919

## changelog

- fix consolidate substeps when using mix in advanced settings

## review requests

- Creating a Consolidate step with Mix (under Aspirate section, and/or under Dispense section) should not add the aspirate/dispense rows to the substeps of that Consolidate in the step list. In other words, toggling mix on and off inside a Consolidate and saving the form should no longer affect the substeps.

(Also I double-checked that Distribute and Transfer are not including the mix stuff in their substeps, you can check that too if you want)