### PR TITLE
style(js): Enable `plugin:react/recommended` eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
 
   extends: [
     'standard',
-    // TODO(mc, 2018-02-10): plugin:react/recommended
+    'plugin:react/recommended',
     'plugin:flowtype/recommended'
   ],
 
@@ -13,9 +13,10 @@ module.exports = {
   ],
 
   rules: {
-    'react/jsx-uses-react': 'error',
-    'react/jsx-uses-vars': 'error',
-    'camelcase': [0, {'properties': 'never'}]
+    'camelcase': [0, {'properties': 'never'}],
+    // TODO(mc, 2018-07-24): disabled until fix for crash is released
+    // https://github.com/yannickcr/eslint-plugin-react/pull/1860
+    'react/prop-types': [0]
   },
 
   globals: {},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   parser: 'babel-eslint',
 
@@ -25,5 +27,11 @@ module.exports = {
     node: true,
     browser: true,
     jest: true
+  },
+
+  settings: {
+    react: {
+      version: '16.2'
+    }
   }
 }

--- a/app/src/components/ConfirmTipProbeModal/Contents.js
+++ b/app/src/components/ConfirmTipProbeModal/Contents.js
@@ -5,7 +5,7 @@ import * as React from 'react'
 import removeTrashSrc from './img/trash@3x.png'
 import styles from './Contents.css'
 
-export default function () {
+export default function Contents () {
   return (
     <div>
       <p className={styles.attention}>

--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -9,7 +9,8 @@ import styles from './styles.css'
 
 export default class CommandList extends Component {
   componentDidUpdate () {
-    if (this.refs.ensureVisible) this.refs.ensureVisible.scrollIntoView(true)
+    // TODO(mc, 2018-07-24): use new refs
+    if (this.refs.ensureVisible) this.refs.ensureVisible.scrollIntoView(true) // eslint-disable-line react/no-string-refs
   }
 
   render () {

--- a/app/src/components/RunPanel/RunControls.js
+++ b/app/src/components/RunPanel/RunControls.js
@@ -16,7 +16,7 @@ type RunProps = {
   onResumeClick: () => mixed,
   onResetClick: () => mixed,
 }
-export default function (props: RunProps) {
+export default function RunControls (props: RunProps) {
   const {
     disabled,
     isReadyToRun,

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -53,13 +53,12 @@ function Robots (props: Props) {
     <Switch>
       <Route
         path={`${path}/instruments`}
-        render={(props) => (
-          <InstrumentSettings {...props} robot={robot} />
-        )} />
+        render={props => (<InstrumentSettings {...props} robot={robot} />)}
       />
-      <Route path={path} render={(props) => (
-        <RobotSettings robot={robot} />
-      )} />
+      <Route
+        path={path}
+        render={() => (<RobotSettings robot={robot} />)}
+      />
     </Switch>
   )
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^6.0.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.6.1",
+    "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-standard": "^3.0.1",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.5",

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -38,7 +38,7 @@ type FieldProps = {|
 |}
 
 const makeInputField = (args: {setSubstate: SetSubstate, getSubstate: GetSubstate}) =>
-  (props: FieldProps) => { /* otherProps */
+  function InputFieldFactory (props: FieldProps) { /* otherProps */
     const {setSubstate, getSubstate} = args
     const {accessor, numeric, type, placeholder, className} = props
 
@@ -173,7 +173,8 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps (nextProps: Props) {
+  // TODO(mc, 2018-07-24): use a different lifecycle hook
+  UNSAFE_componentWillReceiveProps (nextProps: Props) {
     const nextEditingId = nextProps.commonSelectedIngred
     const prevEditingId = this.props.commonSelectedIngred
 

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -174,7 +174,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
   }
 
   // TODO(mc, 2018-07-24): use a different lifecycle hook
-  UNSAFE_componentWillReceiveProps (nextProps: Props) {
+  componentWillReceiveProps (nextProps: Props) {
     const nextEditingId = nextProps.commonSelectedIngred
     const prevEditingId = this.props.commonSelectedIngred
 

--- a/protocol-designer/src/components/labware/ClickableText.js
+++ b/protocol-designer/src/components/labware/ClickableText.js
@@ -13,7 +13,7 @@ type Props = {
 
 const DEFAULT_HEIGHT = 15
 
-export default function (props: Props) {
+export default function ClickableText (props: Props) {
   const height = (props.height == null) ? DEFAULT_HEIGHT : props.height
   return (
     <g onClick={props.onClick}>

--- a/protocol-designer/src/components/modals/MoreOptionsModal.js
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.js
@@ -20,7 +20,7 @@ type Props = {
   hideModal: boolean
 }
 
-export default function (props: Props) {
+export default function MoreOptionsModal (props: Props) {
   const formConnector = formConnectorFactory(props.handleChange, props.formData)
 
   if (props.hideModal) {

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -65,7 +65,8 @@ export default class NewFileModal extends React.Component<Props, State> {
     this.state = initialState
   }
 
-  componentWillReceiveProps (nextProps: Props) {
+  // TODO(mc, 2018-07-24): use a different lifecycle hook
+  UNSAFE_componentWillReceiveProps (nextProps: Props) {
     // reset form state when modal is hidden
     if (!this.props.hideModal && nextProps.hideModal) this.setState(initialState)
   }
@@ -163,12 +164,12 @@ const BetaRestrictions = () => (
     <h3>Beta Pipette Restrictions:</h3>
     <ol>
       <li>
-        You can't change your pipette selection later. If in doubt go for
+        You can&apos;t change your pipette selection later. If in doubt go for
         smaller pipettes. The Protocol Designer automatically breaks up transfer
         volumes that exceed pipette capacity into multiple transfers.
       </li>
       <li>
-        Pipettes can't share tip racks. There needs to be at least 1 tip rack per
+        Pipettes can&apos;t share tip racks. There needs to be at least 1 tip rack per
         pipette on the deck.
       </li>
     </ol>

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -66,7 +66,7 @@ export default class NewFileModal extends React.Component<Props, State> {
   }
 
   // TODO(mc, 2018-07-24): use a different lifecycle hook
-  UNSAFE_componentWillReceiveProps (nextProps: Props) {
+  componentWillReceiveProps (nextProps: Props) {
     // reset form state when modal is hidden
     if (!this.props.hideModal && nextProps.hideModal) this.setState(initialState)
   }

--- a/protocol-designer/src/containers/LabwareNameEditForm.js
+++ b/protocol-designer/src/containers/LabwareNameEditForm.js
@@ -42,7 +42,7 @@ class LabwareNameEditForm extends React.Component<Props, State> {
   }
 
   // TODO(mc, 2018-07-24): use a different lifecycle hook
-  UNSAFE_componentWillReceiveProps (nextProps: Props) {
+  componentWillReceiveProps (nextProps: Props) {
     this.setState({name: nextProps.labwareName})
   }
 

--- a/protocol-designer/src/containers/LabwareNameEditForm.js
+++ b/protocol-designer/src/containers/LabwareNameEditForm.js
@@ -41,7 +41,8 @@ class LabwareNameEditForm extends React.Component<Props, State> {
     this.setState({name: e.target.value})
   }
 
-  componentWillReceiveProps (nextProps: Props) {
+  // TODO(mc, 2018-07-24): use a different lifecycle hook
+  UNSAFE_componentWillReceiveProps (nextProps: Props) {
     this.setState({name: nextProps.labwareName})
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,7 +3415,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.0.2:
+doctrine@^2.0.0, doctrine@^2.0.2, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -4022,14 +4022,14 @@ eslint-plugin-promise@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
 
-eslint-plugin-react@^7.6.1:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz#5d0e908be599f0c02fbf4eef0c7ed6f29dff7633"
+eslint-plugin-react@^7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz#af5c1fef31c4704db02098f9be18202993828b50"
   dependencies:
-    doctrine "^2.0.2"
-    has "^1.0.1"
+    doctrine "^2.1.0"
+    has "^1.0.3"
     jsx-ast-utils "^2.0.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
 
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
@@ -5142,6 +5142,12 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^2.0.0:
   version "2.0.2"
@@ -8543,7 +8549,7 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.1:
+prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:


### PR DESCRIPTION
## overview

As discussed in #1788, this PR enables the `plugin:react/recommended` rule and resolves (or, in the case of one error, ignores) existing lint errors.

## changelog

- style(js): Enable `plugin:react/recommended` eslint rules 

## review requests

This change should **have no affect** on app, component library, and protocol designer. Please check the touched files to make sure nothing broke.

I will annotate each change with the rule for clarity