### PR TITLE
feat(protocol-designer): make form warnings & errors match TimelineAlerts

### DIFF
--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+
+export const links = {
+  'distribute': 'https://support.opentrons.com/protocol-designer/actions/distribute'
+}
+
+type Link = $Keys<typeof links>
+
+type Props = {
+  to: Link,
+  children: React.Node
+}
+
+/** Link which opens a page on the knowledge base to a new tab/window */
+function KnowledgeBaseLink (props: Props) {
+  return (
+    <a
+      target='_blank'
+      rel='noopener'
+      href={links[props.to]}
+    >
+      {props.children}
+    </a>
+  )
+}
+
+export default KnowledgeBaseLink

--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -37,17 +37,19 @@ class FormAlerts extends React.Component<FormAlertsProps> {
           <AlertItem
             type="warning"
             key={index}
-            title={error.title || error.message}>
-            {error.title ? error.message : null}
+            title={error.title}
+          >
+            {error.body}
           </AlertItem>
         ))}
         {this.props.warnings.map((warning, index) => (
           <AlertItem
             type="warning"
             key={index}
-            title={warning.title || warning.message}
-            onCloseClick={this.makeHandleCloseWarning(warning)}>
-            {warning.title ? warning.message : null}
+            title={warning.title}
+            onCloseClick={this.makeHandleCloseWarning(warning)}
+          >
+            {warning.body}
           </AlertItem>
         ))}
       </React.Fragment>

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -1,5 +1,5 @@
 // @flow
-
+import * as React from 'react'
 import {canPipetteUseLabware} from '@opentrons/shared-data'
 import type {StepFieldName} from '../fieldLevel'
 
@@ -12,30 +12,37 @@ export type FormErrorKey = 'INCOMPATIBLE_ASPIRATE_LABWARE'
   | 'WELL_RATIO_TRANSFER'
   | 'WELL_RATIO_CONSOLIDATE'
   | 'WELL_RATIO_DISTRIBUTE'
-export type FormError = {message: string, dependentFields: Array<StepFieldName>, title?: string}
+
+export type FormError = {
+  title: string,
+  body?: React.Node,
+  dependentFields: Array<StepFieldName>,
+}
+
 const FORM_ERRORS: {[FormErrorKey]: FormError} = {
   INCOMPATIBLE_ASPIRATE_LABWARE: {
-    message: 'Selected aspirate labware may be incompatible with selected pipette',
+    title: 'Selected aspirate labware may be incompatible with selected pipette',
     dependentFields: ['aspirate_labware', 'pipette']
   },
   INCOMPATIBLE_DISPENSE_LABWARE: {
-    message: 'Selected dispense labware may be incompatible with selected pipette',
+    title: 'Selected dispense labware may be incompatible with selected pipette',
     dependentFields: ['dispense_labware', 'pipette']
   },
   INCOMPATIBLE_LABWARE: {
-    message: 'Selected labware may be incompatible with selected pipette',
+    title: 'Selected labware may be incompatible with selected pipette',
     dependentFields: ['labware', 'pipette']
   },
   WELL_RATIO_TRANSFER: {
-    message: 'In transfer actions the number of source and destination wells must match',
+    title: 'In transfer actions the number of source and destination wells must match',
+    body: 'You may want to use a Distribute or Consolidate instead of Transfer',
     dependentFields: ['aspirate_wells', 'dispense_wells']
   },
   WELL_RATIO_CONSOLIDATE: {
-    message: 'In consolidate actions there must be multiple source wells and one destination well',
+    title: 'In consolidate actions there must be multiple source wells and one destination well',
     dependentFields: ['aspirate_wells', 'dispense_wells']
   },
   WELL_RATIO_DISTRIBUTE: {
-    message: 'In distribute actions there must be one source well and multiple destination wells',
+    title: 'In distribute actions there must be one source well and multiple destination wells',
     dependentFields: ['aspirate_wells', 'dispense_wells']
   }
 }

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,4 +1,5 @@
 // @flow
+import * as React from 'react'
 import {getWellTotalVolume} from '@opentrons/shared-data'
 import type {StepFieldName} from '../fieldLevel'
 
@@ -13,20 +14,26 @@ export type FormWarningType =
 
 export type FormWarning = {
   type: FormWarningType,
-  message: string,
-  dependentFields: Array<StepFieldName>,
-  title?: string
+  title: string,
+  body?: React.Node,
+  dependentFields: Array<StepFieldName>
 }
 const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {
   OVER_MAX_WELL_VOLUME: {
     type: 'OVER_MAX_WELL_VOLUME',
-    message: 'Dispense volume will overflow a destination well',
+    title: 'Dispense volume will overflow a destination well',
     dependentFields: ['dispense_labware', 'dispense_wells', 'volume']
   },
   BELOW_MIN_DISPOSAL_VOLUME: {
     type: 'BELOW_MIN_DISPOSAL_VOLUME',
     title: 'Below Recommended disposal volume',
-    message: 'For accuracy in distribute actions we recommend you use a disposal volume of at least 20% of the tip\'s capacity. Read more here:', // TODO: BC link knowledgebase article here.
+    body: (
+      <React.Fragment>
+        For accuracy in distribute actions we recommend you use a disposal volume
+        of at least 20% of the tip&apos;s capacity.
+        Read more <a target='_blank' rel='noopener' href='https://support.opentrons.com/protocol-designer/actions/distribute'>here</a>.
+      </React.Fragment>
+    ),
     dependentFields: ['aspirate_disposalVol_volume', 'pipette']
   }
 }

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {getWellTotalVolume} from '@opentrons/shared-data'
 import type {StepFieldName} from '../fieldLevel'
+import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 
 export const DISPOSAL_PERCENTAGE = 0.2 // 20% percent of pipette capacity
 /*******************
@@ -31,7 +32,7 @@ const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {
       <React.Fragment>
         For accuracy in distribute actions we recommend you use a disposal volume
         of at least 20% of the tip&apos;s capacity.
-        Read more <a target='_blank' rel='noopener' href='https://support.opentrons.com/protocol-designer/actions/distribute'>here</a>.
+        Read more <KnowledgeBaseLink to='distribute'>here</KnowledgeBaseLink>.
       </React.Fragment>
     ),
     dependentFields: ['aspirate_disposalVol_volume', 'pipette']


### PR DESCRIPTION
## overview

Closes #1882

See changelog

## changelog

-warning/error 'title' always goes to 'title' of Alert
-instead of 'message' string in form warnings/alerts, there's an optional 'body' which is a React.Node (this matches how TimelineAlerts handles)
-add link to knowledgebase for BELOW_MIN_DISPOSAL_VOLUME warning
-create KnowledgeBaseLink component as a place to organize links to support docs

## review requests

- do a transfer from 1 well to 2 wells or some other mismatched combo. You should see the error as specified in #1882.
- in a Distribute, set Disposal Volume to something lower than 20% of pipette max vol. You should see a link in the Alert body. Clicking the link should open the 'distribute' page of our knowledgebase in a new tab/window

Does this seem like a half-decent way to organize knowledgebase links for PD for now?