### PR TITLE
feat(api): add magdeck api object

### DIFF
--- a/api/opentrons/config/containers/default-containers.json
+++ b/api/opentrons/config/containers/default-containers.json
@@ -5515,6 +5515,22 @@
                     }
                }
           },
+          "magdeck": {
+               "origin-offset": {
+                    "x": 0,
+                    "y": 0
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 82.25,
+                         "depth": 0,
+                         "length": 127.8,
+                         "width": 85.6
+                    }
+               }
+          },
           "trash-box": {
                "origin-offset": {
                     "x": 42.75,

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -11,6 +11,9 @@ from opentrons.util.vector import Vector
 from opentrons.config import feature_flags as ff
 
 
+SUPPORTED_MODULES = ['magdeck']
+
+
 def unpack_location(location):
     """
     Returns (:Placeable:, :Vector:) tuple
@@ -283,6 +286,14 @@ class Placeable(object):
         # Pop last (and hopefully only Deck) or None if there is no deck
         return res.pop()
 
+    def get_module(self):
+        """
+        Returns the module placeable if present
+        """
+        res = list(map(lambda x: self.get_child_by_name(x), SUPPORTED_MODULES))
+        # No probability of a slot having more than one module
+        return res[0] if len(res) > 0 else None
+
     def get_parent(self):
         """
         Returns parent
@@ -489,6 +500,13 @@ class Well(Placeable):
 class Slot(Placeable):
     """
     Class representing a Slot
+    """
+    stackable = True
+
+
+class Module(Placeable):
+    """
+    Class representing a module as a child of Slot and parent of Labware
     """
     stackable = True
 

--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -2,7 +2,7 @@
 import sqlite3
 # import warnings
 from typing import List
-from opentrons.containers.placeable import Container, Well
+from opentrons.containers.placeable import Container, Well, Module
 from opentrons.data_storage import database_queries as db_queries
 from opentrons.util import environment
 from opentrons.util.vector import Vector
@@ -10,6 +10,8 @@ from opentrons.data_storage import labware_definitions as ldef
 from opentrons.data_storage import serializers
 from opentrons.config import feature_flags as fflags
 import logging
+
+SUPPORTED_MODULES = ['magdeck']
 
 log = logging.getLogger(__file__)
 database_path = environment.get_path('DATABASE_FILE')
@@ -67,7 +69,11 @@ def _load_container_object_from_db(db, container_name: str):
             .format(container_name)
         )
 
-    container = Container()
+    if container_name in SUPPORTED_MODULES:
+        container = Module()
+    else:
+        container = Container()
+
     container.properties['type'] = container_type
     container._coordinates = Vector(rel_coords)
     log.debug("Loading {} with coords {}".format(rel_coords, container_type))

--- a/api/opentrons/drivers/mag_deck/driver.py
+++ b/api/opentrons/drivers/mag_deck/driver.py
@@ -352,6 +352,10 @@ class MagDeck:
             " because another process is currently using it, or"
             " the Serial port is disabled on this device (OS)"
             raise SerialException(error_msg)
+        except TypeError:
+            # This happens if there are no ttyMagDeck devices in /dev
+            # For development use ENABLE_VIRTUAL_SMOOTHIE=true
+            raise SerialException('No port specified')
 
     def _update_plate_height(self) -> str:
         try:

--- a/api/opentrons/modules/__init__.py
+++ b/api/opentrons/modules/__init__.py
@@ -1,0 +1,102 @@
+import os
+import logging
+from opentrons import robot, labware
+from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
+
+
+log = logging.getLogger(__name__)
+
+
+class UnsupportedModuleError(Exception):
+    pass
+
+
+def load(name, slot):
+    if name in SUPPORTED_MODULES.keys():
+        lw = labware.load(name, slot)
+        _cls = SUPPORTED_MODULES.get(name)
+        mod = _cls(lw)
+    else:
+        raise UnsupportedModuleError("{} is not a valid module".format(name))
+    return mod
+
+
+def discover_devices(module_prefix):
+    if os.environ.get('RUNNING_ON_PI'):
+        devices = os.listdir('/dev')
+    else:
+        devices = []
+    matches = filter(
+        lambda x: x.startswith('tty{}'.format(module_prefix)), devices)
+    res = list(map(lambda x: '/dev/{}'.format(x), matches))
+    log.debug('Discovered devices for prefix {}: {}'.format(
+        module_prefix, res))
+    return res
+
+
+class MagDeck:
+    '''
+    Under development. API subject to change
+    '''
+    def __init__(self, lw):
+        self.labware = lw
+        self.driver = MagDeckDriver()
+        self.connect()
+        self._engaged = False
+        self._device_info = self.driver.get_device_info()
+
+    def calibrate(self):
+        '''
+        Calibration involves probing for top plate to get the plate height
+        '''
+        if not robot.is_simulating():
+            self.driver.probe_plate()
+            # return if successful or not?
+            self._engaged = False
+
+    def engage(self):
+        '''
+        Move the magnet to plate top - 1 mm
+        '''
+        if not robot.is_simulating():
+            self.driver.move(self.driver.plate_height - 1.0)
+            self._engaged = True
+
+    def disengage(self):
+        '''
+        Home the magnet
+        '''
+        if not robot.is_simulating():
+            self.driver.home()
+            self._engaged = False
+
+    def disconnect(self):
+        '''
+        Disconnect the serial connection
+        '''
+        if not robot.is_simulating():
+            self.driver.disconnect()
+
+    def connect(self):
+        '''
+        Connect to the 'MagDeck' port
+        Planned change- will connect to the correct port in case of multiple
+        MagDecks
+        '''
+        if not robot.is_simulating():
+            ports = discover_devices('MagDeck')
+            # Connect to the first module. Need more advanced selector to
+            # support more than one of the same type of module
+            port = ports[0] if len(ports) > 0 else None
+            self.driver.connect(port)
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    @property
+    def status(self):
+        return 'engaged' if self._engaged else 'disengaged'
+
+
+SUPPORTED_MODULES = {'magdeck': MagDeck}

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -1,0 +1,45 @@
+# Test loading container onto a module
+import pytest
+from opentrons import robot, labware, modules
+from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
+
+
+@pytest.fixture
+def non_simulating():
+    robot._driver.simulating = False
+    yield
+    robot._driver.simulating = True
+
+
+def test_load_container_onto_module():
+    module_name = 'magdeck'
+    slot = '4'
+    md = modules.load(module_name, slot)
+    assert md.labware.parent == robot._deck[slot]
+
+    test_container = labware.load('96-flat', slot, share=True)
+    assert test_container.parent == md.labware
+
+
+def test_simulating(virtual_smoothie_env, monkeypatch):
+    connected = False
+
+    def mock_connect(self, port):
+        nonlocal connected
+        connected = True
+
+    monkeypatch.setattr(MagDeckDriver, 'connect', mock_connect)
+    modules.load('magdeck', '1')
+    assert not connected
+
+
+def test_run_connected(non_simulating, virtual_smoothie_env, monkeypatch):
+    connected = False
+
+    def mock_connect(self, port):
+        nonlocal connected
+        connected = True
+
+    monkeypatch.setattr(MagDeckDriver, 'connect', mock_connect)
+    modules.load('magdeck', '2')
+    assert connected


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->
Closes #1889, Closes #1887, Closes #1886, Closes #1645

This PR adds Magdeck API object that enables us to add a magdeck and control it. To properly use the API methods, changes to Docker Container setup are required [init system, udev rules]. Magdeck's functionality is fully implemented (sans update firmware):
- Load a Magdeck module (Discover and connect to it)
- Control: calibrate/engage/ disengage, connect/disconnect
- Get device info (Serial no., Model no, firmware version)

**Modules geometry tracking is in progress**
## changelog
1. `opentrons/modules`: Magdeck API object & load modules
2. `default-containers.json` now includes a magdeck definition
3. `Module` added to `placeables`
4. `opentrons/data_storage/database.py` now loads a `Module` object on `module.load()`
5. `robot.py` now checks for presence of a module in given slot in `_get_placement_location` (using `get_module()` from `placeable` class) and if present, returns the module object as the location to add the labware to
6. `tests/labware/test_modules.py` has load and simulating mode behavior tests
<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
**Known Issues**
- Incorrect calibration of z height for labware placed on modules (Pipette does not go to the correct labware position) (#1931)
- Need to decide where the SUPPORTED_MODULES definition should lie
- Need a better way to handle magdeck in simulating mode