### PR TITLE
feat(app): Add realtime status TempDeck card to run panel

### DIFF
--- a/app/src/components/InstrumentSettings/ModulesCardContents.js
+++ b/app/src/components/InstrumentSettings/ModulesCardContents.js
@@ -13,7 +13,7 @@ export default function ModulesCardContents (props: Props) {
   return (
     <React.Fragment>
       {props.modules.map((mod, index) => (
-        <ModuleItem {...mod} key={index}/>
+        <ModuleItem module={mod} key={index}/>
       ))}
     </React.Fragment>
   )

--- a/app/src/components/ModuleItem/ModuleInfo.js
+++ b/app/src/components/ModuleItem/ModuleInfo.js
@@ -7,16 +7,21 @@ import {LabeledValue} from '@opentrons/components'
 
 import styles from './styles.css'
 
-export default function ModuleInfo (props: Module) {
+type Props = {
+  module: Module
+}
+
+export default function ModuleInfo (props: Props) {
+  const {displayName, serial, status, fwVersion} = props.module
   return (
     <div className={styles.module_info}>
       <div className={styles.grid_50} >
-        <LabeledValue label='Name' value={props.displayName} />
-        <LabeledValue label='Serial' value={props.serial} />
+        <LabeledValue label='Name' value={displayName} />
+        <LabeledValue label='Serial' value={serial} />
       </div>
       <div className={styles.grid_50} >
-        <LabeledValue label='Status' value={props.status} />
-        <LabeledValue label='Firmware Version' value={props.fwVersion} />
+        <LabeledValue label='Status' value={status} />
+        <LabeledValue label='Firmware Version' value={fwVersion} />
       </div>
     </div>
   )

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -20,8 +20,7 @@ export default function ModuleItem (props: Props) {
   return (
     <div className={styles.module_item}>
       <ModuleImage name={module.name}/>
-      {/* $FlowFixMe: `...props` type doesn't include necessary keys */}
-      <ModuleInfo {...module}/>
+      <ModuleInfo module={module}/>
       <ModuleUpdate availableUpdate={props.availableUpdate}/>
     </div>
   )

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -10,16 +10,18 @@ import NoModulesMessage from './NoModulesMessage'
 
 import styles from './styles.css'
 
-type Props = Module & {
+type Props = {
+  module: Module,
   availableUpdate?: ?string
 }
 
 export default function ModuleItem (props: Props) {
+  const {module} = props
   return (
     <div className={styles.module_item}>
-      <ModuleImage name={props.name}/>
+      <ModuleImage name={module.name}/>
       {/* $FlowFixMe: `...props` type doesn't include necessary keys */}
-      <ModuleInfo {...props}/>
+      <ModuleInfo {...module}/>
       <ModuleUpdate availableUpdate={props.availableUpdate}/>
     </div>
   )

--- a/app/src/components/ModuleItem/styles.css
+++ b/app/src/components/ModuleItem/styles.css
@@ -16,7 +16,7 @@
 
 .module_image_wrapper {
   flex-basis: 25%;
-  padding-right: 1rem;
+  padding-right: 0.5rem;
 }
 
 .module_image {
@@ -24,7 +24,7 @@
 }
 
 .module_info {
-  flex-basis: 55%;
+  flex-basis: 65%;
 }
 
 .grid_50 {

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -10,7 +10,7 @@ import {getModulesOn} from '../../config'
 import {SidePanel, SidePanelGroup} from '@opentrons/components'
 import RunTimer from './RunTimer'
 import RunControls from './RunControls'
-import TempdeckStatusCard from '../TempdeckStatusCard'
+import TempDeckStatusCard from '../TempDeckStatusCard'
 
 const mapStateToProps = (state) => ({
   modulesFlag: getModulesOn(state),
@@ -41,7 +41,7 @@ function RunPanel (props) {
           <RunControls {...props} />
         </SidePanelGroup>
         {props.modulesFlag && (
-          <TempdeckStatusCard />
+          <TempDeckStatusCard />
         )}
     </SidePanel>
   )

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -6,12 +6,14 @@ import {
   actions as robotActions,
   selectors as robotSelectors
 } from '../../robot'
-
+import {getModulesOn} from '../../config'
 import {SidePanel, SidePanelGroup} from '@opentrons/components'
 import RunTimer from './RunTimer'
 import RunControls from './RunControls'
+import TempdeckStatusCard from '../TempdeckStatusCard'
 
 const mapStateToProps = (state) => ({
+  modulesFlag: getModulesOn(state),
   isRunning: robotSelectors.getIsRunning(state),
   isPaused: robotSelectors.getIsPaused(state),
   startTime: robotSelectors.getStartTime(state),
@@ -34,12 +36,13 @@ const mapDispatchToProps = (dispatch) => ({
 function RunPanel (props) {
   return (
     <SidePanel title='Execute Run'>
-      <div>
         <SidePanelGroup>
           <RunTimer startTime={props.startTime} runTime={props.runTime} />
           <RunControls {...props} />
         </SidePanelGroup>
-      </div>
+        {props.modulesFlag && (
+          <TempdeckStatusCard />
+        )}
     </SidePanel>
   )
 }

--- a/app/src/components/TempDeckStatusCard/CardContentRow.js
+++ b/app/src/components/TempDeckStatusCard/CardContentRow.js
@@ -1,0 +1,15 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import styles from './styles.css'
+type Props = {
+  children: React.Node,
+  className?: string
+}
+export default function CardContentRow (props: Props) {
+  return (
+    <div className={cx(styles.card_row, props.className)}>
+      {props.children}
+    </div>
+  )
+}

--- a/app/src/components/TempDeckStatusCard/StatusCard.js
+++ b/app/src/components/TempDeckStatusCard/StatusCard.js
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import styles from './styles.css'
+
+type Props = {
+  /** Title for the card */
+  title: string,
+  /** Card Content, each child will be separated with a grey bottom border */
+  children: React.Node,
+  /** Optional className for card contents */
+  className?: string,
+}
+
+// TODO (ka 2018-7-24): This component should be replaced with refactored refresh card
+export default function StatusCard (props: Props) {
+  return (
+    <div className={styles.status_card}>
+      <h3 className={styles.card_title}>{props.title}</h3>
+      <div className={cx(styles.card_contents, props.className)}>
+        {props.children}
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/TempDeckStatusCard/StatusItem.js
+++ b/app/src/components/TempDeckStatusCard/StatusItem.js
@@ -1,0 +1,14 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+type Props = {status: string}
+
+export default function StatusItem (props: Props) {
+  return (
+    <div>
+      <span className={styles.label}>Status: </span>
+      <span className={styles.value}>{props.status}</span>
+    </div>
+  )
+}

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import type {State} from '../../types'
+import {
+  selectors as robotSelectors
+} from '../../robot'
+import type {TempDeckModule} from '../../http-api-client'
+import {makeGetRobotModules} from '../../http-api-client'
+import {LabeledValue} from '@opentrons/components'
+import StatusCard from './StatusCard'
+import CardContentRow from './CardContentRow'
+import StatusItem from './StatusItem'
+
+type SP = {
+  tempDeck: ?TempDeckModule
+}
+
+type Props = SP
+
+export default connect(makeSTP, null)(TempdeckStatusCard)
+
+function TempdeckStatusCard (props: Props) {
+  const {tempDeck} = props
+
+  if (!tempDeck) return null
+
+  const STATUS = tempDeck.status
+  const CURRENT = `${tempDeck.data.currentTemp} º C`
+  const TARGET = `${tempDeck.data.targetTemp} º C`
+  return (
+    <React.Fragment>
+        <StatusCard title={tempDeck.displayName}>
+          <CardContentRow>
+            <StatusItem status={STATUS} />
+          </CardContentRow>
+          <CardContentRow>
+            <LabeledValue label='Current Temp' value={CURRENT} />
+            <LabeledValue label='Current Temp' value={TARGET} />
+          </CardContentRow>
+        </StatusCard>
+    </React.Fragment>
+  )
+}
+
+function makeSTP (): (state: State) => SP {
+  const getRobotModules = makeGetRobotModules()
+  return (state) => {
+    const _robot = robotSelectors.getConnectedRobot(state)
+    const modulesCall = _robot && getRobotModules(state, _robot)
+    const modulesResponse = modulesCall && modulesCall.response
+    const modules = modulesResponse && modulesResponse.modules
+    // TOD0 (ka 2018-7-25): Only supporting 1 temp deck at a time at launch
+    const tempDeck = modules && ((modules.find(m => m.name === 'tempdeck'): any): TempDeckModule)
+    return {
+      tempDeck
+    }
+  }
+}

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -36,7 +36,7 @@ function TempDeckStatusCard (props: Props) {
           </CardContentRow>
           <CardContentRow>
             <LabeledValue label='Current Temp' value={CURRENT} />
-            <LabeledValue label='Current Temp' value={TARGET} />
+            <LabeledValue label='Target Temp' value={TARGET} />
           </CardContentRow>
         </StatusCard>
     </React.Fragment>

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -18,9 +18,9 @@ type SP = {
 
 type Props = SP
 
-export default connect(makeSTP, null)(TempdeckStatusCard)
+export default connect(makeSTP, null)(TempDeckStatusCard)
 
-function TempdeckStatusCard (props: Props) {
+function TempDeckStatusCard (props: Props) {
   const {tempDeck} = props
 
   if (!tempDeck) return null

--- a/app/src/components/TempDeckStatusCard/styles.css
+++ b/app/src/components/TempDeckStatusCard/styles.css
@@ -1,0 +1,45 @@
+@import '@opentrons/components';
+
+/*
+TODO (ka 2018-7-25): These components and thier styles should be replaced width
+updated component library cards after redesign/refactor
+*/
+
+.status_card {
+  position: relative;
+  margin-top: 1rem;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33);
+}
+
+.card_title {
+  @apply --font-body-2-dark;
+
+  padding: 1rem 0.5rem 0;
+  font-weight: --fw-bold;
+  text-transform: uppercase;
+}
+
+.card_row {
+  padding: 1rem 0.5rem;
+  text-align: justify;
+  font-size: var(--fs-body-1);
+}
+
+.card_row:not(:last-child) {
+  border-bottom: var(--bd-light);
+  border-bottom-width: 1px;
+}
+
+.card_row > div {
+  display: inline-block;
+  width: 50%;
+}
+
+.label {
+  text-transform: capitalize;
+  font-weight: var(--fw-semibold);
+}
+
+.value {
+  text-transform: capitalize;
+}

--- a/app/src/http-api-client/modules.js
+++ b/app/src/http-api-client/modules.js
@@ -11,14 +11,37 @@ import {apiRequest, apiSuccess, apiFailure} from './actions'
 import {getRobotApiState} from './reducer'
 import client from './client'
 
-export type Module = {
-  name: 'magdeck' | 'tempdeck',
+export type BaseModule = {|
   model: string,
   serial: string,
   fwVersion: string,
   status: string,
-  displayName: string,
-}
+|}
+
+type TempDeckData = {|
+  currentTemp: number,
+  targetTemp: number,
+|}
+
+type MagDeckData = {|
+  engaged: boolean,
+|}
+
+export type TempDeckModule = {|
+  ...BaseModule,
+  name: 'tempdeck',
+  displayName: 'Temperature Module',
+  data: TempDeckData,
+|}
+
+export type MagDeckModule = {|
+  ...BaseModule,
+  name: 'magdeck',
+  displayName: 'Magnetic Bead Module',
+  data: MagDeckData,
+|}
+
+export type Module = MagDeckModule | TempDeckModule
 
 type FetchModulesResponse = {
   modules: Array<Module>,
@@ -64,8 +87,12 @@ export function makeGetRobotModules () {
     //         model: 'temp_deck',
     //         serial: '123123124',
     //         fwVersion: '1.2.13',
-    //         status: '86',
-    //         displayName: 'Temperature Module'
+    //         status: 'heating',
+    //         displayName: 'Temperature Module',
+    //         data: {
+    //           currentTemp: 60,
+    //           targetTemp: 70
+    //         }
     //       },
     //       {
     //         name: 'magdeck',
@@ -73,7 +100,10 @@ export function makeGetRobotModules () {
     //         serial: '123123124',
     //         fwVersion: '1.2.13',
     //         status: 'disengaged',
-    //         displayName: 'Magnetic Bead Module'
+    //         displayName: 'Magnetic Bead Module',
+    //         data: {
+    //           engaged: false
+    //         }
     //       }
     //     ]
     //   }

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -345,7 +345,7 @@ export default function client (dispatch) {
         // update.modulesBySlot = {
         //   '1': {
         //     id: '4374062089',
-        //     name: 'magdeck',
+        //     name: 'tempdeck',
         //     slot: '1'
         //   }
         // }

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -31,6 +31,10 @@
   background-color: white;
 }
 
+.panel_group {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33);
+}
+
 .hover_border {
   outline: var(--bd-width-default) solid var(--c-highlight);
 }


### PR DESCRIPTION
## overview

This PR closes #1740 - Adds the realtime status card to the run panel (UI only, endpoint still pending). It also adds some mock module data fields for TempDeck and MagDeck see `app/src/http-api-client/modules.js`.

<img width="1025" alt="screen shot 2018-07-25 at 11 16 56 am" src="https://user-images.githubusercontent.com/3430313/43210214-7ab5cf66-8ffc-11e8-804f-e28db9ca0483.png">

## changelog

- feat(app): Add realtime status TempDeck card to run panel

## review requests

*For the full module experience:*

comment out line 77, uncomment lines 79-110 in `app/src/http-api-client/modules.js`

uncomment lines 345-351 in `app/src/robot/api-client/client.js`

run `OT_APP_MODULES=1 make dev` in app (this card is hidden behind the modules flag)

- [ ] Modules Card in Instrument Settings page are unaffected 
- [ ] Check for Module screens are unaffected in Calibrate Labware page
- [ ] Tempdeck Status Card shows up below run timer + buttons in the RunPanel

*Notes:*

It is worth nothing that we will only be supporting one TempDeck at a time for launch. See comments in #1740. TempDeck prop is a single TempDeckModule object, not an array.

The TempDeck status card's visibility is based what is returned by the API endpoint only at this time. It does not check if there is a TempDeck in the protocol/session. 

Finally, we are due for a `Card` component refactor. Same with app specific `SideBar` components/flow in the app. Rather than go down a rabbit hole here, I made a bunch of 1-off card-ish components for the `TempdeckStatusCard` with the assumption these will all be revisited in near future refactors.