### PR TITLE
feat(protocol-designer): implement move labware in place of copy

### DIFF
--- a/components/src/deck/Deck.css
+++ b/components/src/deck/Deck.css
@@ -9,7 +9,6 @@
 
 .deck {
   overflow: visible;
-  width: 100vh;
 }
 
 .deck_outline {

--- a/components/src/deck/Deck.css
+++ b/components/src/deck/Deck.css
@@ -8,9 +8,8 @@
 }
 
 .deck {
-  /* TODO(mc, 2018-07-16): remove max-height from common styling */
-  max-height: 90vh;
   overflow: visible;
+  width: 100vh;
 }
 
 .deck_outline {

--- a/components/src/interaction-enhancers/clickOutside.js
+++ b/components/src/interaction-enhancers/clickOutside.js
@@ -66,12 +66,12 @@ export default function clickOutside<
 // TODO: BC 2018-7-25 deprecate HOC version (clickOutside) and move to just ClickOutside FOC
 type ClickOutsideProps = {
   onClickOutside: ?(MouseEvent => mixed),
-  children: ({ref: React.Ref<*>}) => React.Element
+  children: ({ref: React.Ref<*>}) => React.Element<*>
 }
 export class ClickOutside extends React.Component<ClickOutsideProps> {
-  wrapperRef: React.Ref<*>
+  wrapperRef: ?Element
 
-  constructor (props: Props) {
+  constructor (props: ClickOutsideProps) {
     super(props)
     this.wrapperRef = null
   }
@@ -82,7 +82,7 @@ export class ClickOutside extends React.Component<ClickOutsideProps> {
   componentWillUnmount () {
     document.removeEventListener('mousedown', this.handleClickOutside)
   }
-  setWrapperRef = (el) => { this.wrapperRef = el }
+  setWrapperRef = (el: ?Element) => { this.wrapperRef = el }
 
   handleClickOutside = (event: MouseEvent) => {
     const clickedElem = event.target

--- a/components/src/interaction-enhancers/clickOutside.js
+++ b/components/src/interaction-enhancers/clickOutside.js
@@ -31,7 +31,6 @@ export default function clickOutside<
     handleClickOutside = (event: MouseEvent) => {
       const clickedElem = event.target
 
-      console.log('INTERNAL HANDLER', this.wrapperRef)
       if (!(clickedElem instanceof Node)) {
         // NOTE: this is some flow type checking funkiness
         // TODO Ian 2018-05-24 use assert.

--- a/components/src/interaction-enhancers/index.js
+++ b/components/src/interaction-enhancers/index.js
@@ -1,10 +1,11 @@
 // @flow
-import clickOutside from './clickOutside'
+import clickOutside, {ClickOutside} from './clickOutside'
 import HandleKeypress from './HandleKeypress'
 
 export type {ClickOutsideInterface} from './clickOutside'
 
 export {
   clickOutside,
+  ClickOutside,
   HandleKeypress
 }

--- a/protocol-designer/src/components/LabwareDropdown.js
+++ b/protocol-designer/src/components/LabwareDropdown.js
@@ -29,7 +29,7 @@ function LabwareItem (props: LabwareItemProps) {
 type LabwareDropdownProps = {
   onClose: (e?: SyntheticEvent<*>) => void,
   onContainerChoose: OnContainerChoose,
-  slot: DeckSlot | false,
+  slot: ?DeckSlot,
   permittedTipracks: Array<string>
 }
 

--- a/protocol-designer/src/components/LabwareDropdown.js
+++ b/protocol-designer/src/components/LabwareDropdown.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import type {DeckSlot} from '@opentrons/components'
 import styles from './LabwareDropdown.css'
 import Accordion from './Accordion.js'
 
@@ -28,7 +29,7 @@ function LabwareItem (props: LabwareItemProps) {
 type LabwareDropdownProps = {
   onClose: (e?: SyntheticEvent<*>) => void,
   onContainerChoose: OnContainerChoose,
-  slot: string | false,
+  slot: DeckSlot | false,
   permittedTipracks: Array<string>
 }
 

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react'
 import cx from 'classnames'
-import {HandleKeypress} from '@opentrons/components'
+import {HandleKeypress, type DeckSlot} from '@opentrons/components'
 import styles from './labware.css'
 
-type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: DeckSlot) => void}
+type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: DeckSlot | false) => void}
 class DisabledSelectSlotOverlay extends React.Component<DisabledSelectSlotOverlayProps> {
   cancelMove = () => {
     this.props.setMoveLabwareMode(false)

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react'
+import cx from 'classnames'
+import {HandleKeypress} from '@opentrons/components'
+import styles from './labware.css'
+
+type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: DeckSlot) => void}
+class DisabledSelectSlotOverlay extends React.Component<DisabledSelectSlotOverlayProps> {
+  cancelMove = () => {
+    this.props.setMoveLabwareMode(false)
+  }
+  render () {
+    return (
+      <HandleKeypress preventDefault handlers={[{key: 'Escape', onPress: this.cancelMove}]}>
+        <g className={cx(styles.slot_overlay, styles.disabled)}>
+          <rect className={styles.overlay_panel} />
+          <g className={styles.clickable_text}>
+            <text x="0" y="40%">Select a slot</text>
+          </g>
+        </g>
+      </HandleKeypress>
+    )
+  }
+}
+
+export default DisabledSelectSlotOverlay

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -4,10 +4,10 @@ import cx from 'classnames'
 import {HandleKeypress, type DeckSlot} from '@opentrons/components'
 import styles from './labware.css'
 
-type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: DeckSlot | false) => void}
+type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: ?DeckSlot) => void}
 class DisabledSelectSlotOverlay extends React.Component<DisabledSelectSlotOverlayProps> {
   cancelMove = () => {
-    this.props.setMoveLabwareMode(false)
+    this.props.setMoveLabwareMode()
   }
   render () {
     return (

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -116,8 +116,8 @@ type LabwareOnDeckProps = {
   openLabwareSelector: ({slot: DeckSlot}) => void,
   // closeLabwareSelector: ({slot: string}) => mixed,
 
-  setMoveLabwareMode: (slot: DeckSlot | false) => void,
-  slotToMoveFrom: DeckSlot | false,
+  setMoveLabwareMode: (slot: ?DeckSlot) => void,
+  slotToMoveFrom: ?DeckSlot,
   moveLabware: (slot: DeckSlot) => void,
 
   height?: number,
@@ -180,7 +180,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     moveLabware(slot)
   }
   const cancelMove = () => {
-    setMoveLabwareMode(false)
+    setMoveLabwareMode()
   }
 
   return (

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -17,10 +17,10 @@ import {
   SLOT_WIDTH,
   SLOT_HEIGHT,
   humanizeLabwareType,
-  clickOutside
+  clickOutside,
+  type DeckSlot
 } from '@opentrons/components'
-import type {ClickOutsideInterface} from '@opentrons/components'
-import {getLabware, type DeckSlot} from '@opentrons/shared-data'
+import {getLabware} from '@opentrons/shared-data'
 import styles from './labware.css'
 
 import ClickableText from './ClickableText'
@@ -91,7 +91,7 @@ function SlotWithContainer (props: SlotWithContainerProps) {
 }
 
 type LabwareOnDeckProps = {
-  slot: string,
+  slot: DeckSlot,
 
   containerId: string,
   containerType: string,
@@ -103,22 +103,22 @@ type LabwareOnDeckProps = {
   activeModals: {
     ingredientSelection: ?{
       containerName: ?string,
-      slot: ?string
+      slot: ?DeckSlot
     },
     labwareSelection: boolean
   },
   openIngredientSelector: (containerId: string) => void,
 
   // createContainer: ({slot: string, containerType: string}) => mixed,
-  deleteContainer: ({containerId: string, slot: string, containerType: string}) => void,
+  deleteContainer: ({containerId: string, slot: DeckSlot, containerType: string}) => void,
   modifyContainer: ({containerId: string, modify: {[field: string]: mixed}}) => void, // eg modify = {name: 'newName'}
 
-  openLabwareSelector: ({slot: string}) => void,
+  openLabwareSelector: ({slot: DeckSlot}) => void,
   // closeLabwareSelector: ({slot: string}) => mixed,
 
-  setMoveLabwareMode: (slot: DeckSlot) => void,
+  setMoveLabwareMode: (slot: DeckSlot | false) => void,
   slotToMoveFrom: DeckSlot | false,
-  moveLabware: (slot: string) => void,
+  moveLabware: (slot: DeckSlot) => void,
 
   height?: number,
   width?: number,
@@ -175,7 +175,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     modify: {name: null}
   })
 
-  const makeHandleSelectMoveDestination = (slot) => (e: SyntheticMouseEvent<*>) => {
+  const makeHandleSelectMoveDestination = (slot) => (e: SyntheticEvent<*>) => {
     e.preventDefault()
     moveLabware(slot)
   }

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -175,7 +175,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     modify: {name: null}
   })
 
-  const makeHandleSelectMoveDestination = (slot) => (e: SyntheticEvent<*>) => {
+  const handleSelectMoveDestination = (e: SyntheticEvent<*>) => {
     e.preventDefault()
     moveLabware(slot)
   }
@@ -198,7 +198,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
             // Mouseover empty slot -- Add (or Copy if in copy mode)
             ? <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
               <rect className={styles.overlay_panel} onClick={() => moveLabware(slot)} />
-              <ClickableText onClick={makeHandleSelectMoveDestination(slot)} iconName='cursor-move' y='40%' text='Place Here' />
+              <ClickableText onClick={handleSelectMoveDestination} iconName='cursor-move' y='40%' text='Place Here' />
             </g>
             : <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
               <rect className={styles.overlay_panel} />

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -36,24 +36,25 @@ function OccupiedDeckSlotOverlay ({
   containerType,
   containerName,
   openIngredientSelector,
-  setCopyLabwareMode,
+  setMoveLabwareMode,
   deleteContainer
 }) {
   return (
     <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
       <rect className={styles.overlay_panel} />
       {canAddIngreds &&
-        <ClickableText onClick={() => openIngredientSelector(containerId)}
+        <ClickableText
+          onClick={() => openIngredientSelector(containerId)}
           iconName='pencil' y='15%' text='Name & Liquids' />
       }
-      <ClickableText onClick={() => setCopyLabwareMode(containerId)}
-        iconName='cursor-move' y='40%' text='Copy' />
-      {/* TODO Ian 2018-02-16 Move labware, not copy labware. */}
-
-      <ClickableText onClick={() =>
+      <ClickableText
+        onClick={() => setMoveLabwareMode(containerId)}
+        iconName='cursor-move' y='40%' text='Move' />
+      <ClickableText
+        onClick={() => (
           window.confirm(`Are you sure you want to permanently delete ${containerName || containerType} in slot ${slot}?`) &&
           deleteContainer({containerId, slot, containerType})
-      }
+        )}
         iconName='close' y='65%' text='Delete' />
     </g>
   )
@@ -114,9 +115,9 @@ type LabwareOnDeckProps = {
   openLabwareSelector: ({slot: string}) => void,
   // closeLabwareSelector: ({slot: string}) => mixed,
 
-  setCopyLabwareMode: (containerId: string) => void,
-  labwareToCopy: string | false,
-  copyLabware: (slot: string) => void,
+  setMoveLabwareMode: (containerId: string) => void,
+  labwareToMove: string | false,
+  moveLabware: (slot: string) => void,
 
   height?: number,
   width?: number,
@@ -146,9 +147,9 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     openLabwareSelector,
     // closeLabwareSelector,
 
-    setCopyLabwareMode,
-    labwareToCopy,
-    copyLabware,
+    setMoveLabwareMode,
+    labwareToMove,
+    moveLabware,
 
     height,
     width,
@@ -184,11 +185,11 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
       {(!deckSetupMode || (!slotIsOccupied && activeModals.labwareSelection))
         // "Add Labware" labware selection dropdown menu
         ? null
-        : (labwareToCopy
+        : (labwareToMove
             // Mouseover empty slot -- Add (or Copy if in copy mode)
             ? <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
-              <rect className={styles.overlay_panel} onClick={() => copyLabware(slot)} />
-              <CenteredTextSvg className={cx(styles.pass_thru_mouse, styles.clickable_text)} text='Place Copy' />
+              <rect className={styles.overlay_panel} onClick={() => moveLabware(slot)} />
+              <CenteredTextSvg className={cx(styles.pass_thru_mouse, styles.clickable_text)} text='Place Here' />
             </g>
             : <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
               <rect className={styles.overlay_panel} />
@@ -208,7 +209,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
           containerType,
           containerName,
           openIngredientSelector,
-          setCopyLabwareMode,
+          setMoveLabwareMode,
           deleteContainer
         }} />}
 

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -20,7 +20,7 @@ import {
   humanizeLabwareType,
   clickOutside
 } from '@opentrons/components'
-import {getLabware} from '@opentrons/shared-data'
+import {getLabware, type DeckSlot} from '@opentrons/shared-data'
 import styles from './labware.css'
 
 import ClickableText from './ClickableText'
@@ -48,7 +48,7 @@ function OccupiedDeckSlotOverlay ({
           iconName='pencil' y='15%' text='Name & Liquids' />
       }
       <ClickableText
-        onClick={() => setMoveLabwareMode(containerId)}
+        onClick={() => setMoveLabwareMode(slot)}
         iconName='cursor-move' y='40%' text='Move' />
       <ClickableText
         onClick={() => (
@@ -115,8 +115,8 @@ type LabwareOnDeckProps = {
   openLabwareSelector: ({slot: string}) => void,
   // closeLabwareSelector: ({slot: string}) => mixed,
 
-  setMoveLabwareMode: (containerId: string) => void,
-  labwareToMove: string | false,
+  setMoveLabwareMode: (slot: DeckSlot) => void,
+  slotToMoveFrom: DeckSlot | false,
   moveLabware: (slot: string) => void,
 
   height?: number,
@@ -148,7 +148,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
     // closeLabwareSelector,
 
     setMoveLabwareMode,
-    labwareToMove,
+    slotToMoveFrom,
     moveLabware,
 
     height,
@@ -185,7 +185,7 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
       {(!deckSetupMode || (!slotIsOccupied && activeModals.labwareSelection))
         // "Add Labware" labware selection dropdown menu
         ? null
-        : (labwareToMove
+        : (slotToMoveFrom
             // Mouseover empty slot -- Add (or Copy if in copy mode)
             ? <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
               <rect className={styles.overlay_panel} onClick={() => moveLabware(slot)} />

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -3,15 +3,15 @@ import * as React from 'react'
 import ForeignDiv from '../../components/ForeignDiv.js'
 import ClickableText from './ClickableText'
 import styles from './labware.css'
-import type {ClickOutsideInterface} from '@opentrons/components'
+import type {ClickOutsideInterface, DeckSlot} from '@opentrons/components'
 
 type Props = {
   containerType: string,
   containerId: string,
-  slot: string,
+  slot: DeckSlot,
   // TODO Ian 2018-02-16 type these fns elsewhere and import the type
   modifyContainer: (args: {containerId: string, modify: {[field: string]: mixed}}) => void,
-  deleteContainer: (args: {containerId: string, slot: string, containerType: string}) => void
+  deleteContainer: (args: {containerId: string, slot: DeckSlot, containerType: string}) => void
 } & ClickOutsideInterface
 
 type State = {

--- a/protocol-designer/src/components/labware/labware.css
+++ b/protocol-designer/src/components/labware/labware.css
@@ -38,12 +38,6 @@
   pointer-events: none;
 }
 
-.move_icon {
-  height: 15px;
-  fill: currentColor;
-  color: var(--c-white);
-}
-
 .appear_on_mouseover {
   opacity: 0;
 

--- a/protocol-designer/src/components/labware/labware.css
+++ b/protocol-designer/src/components/labware/labware.css
@@ -11,19 +11,37 @@
   @apply --round-slot;
 
   fill: var(--c-black);
+}
 
-  & text {
-    font-size: var(--fs-caption);
-  }
+.slot_overlay.disabled {
+  fill: var(--c-light-gray);
+}
 
-  & .overlay_panel {
-    width: 100%;
-    height: 100%;
-  }
+.overlay_panel {
+  width: 100%;
+  height: 100%;
+}
+
+.slot_overlay.disabled .overlay_panel {
+  opacity: 0.9;
+}
+
+.slot_overlay text {
+  font-size: var(--fs-caption);
+}
+
+.slot_overlay.disabled text {
+  color: var(--c-font-dark);
 }
 
 .pass_thru_mouse {
   pointer-events: none;
+}
+
+.move_icon {
+  height: 15px;
+  fill: currentColor;
+  color: var(--c-white);
 }
 
 .appear_on_mouseover {

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -61,12 +61,12 @@ class DeckSetup extends React.Component<StateProps & DispatchProps> {
     // Once DeckSetup is broken apart and moved into ProtocolEditor,
     // this will go away
     return (
-      <div>
+      <React.Fragment>
         <LabwareDropdown />
         {this.props.ingredSelectionMode && <IngredientSelectionModal />}
         <div className={styles.deck_header}>{DECK_HEADER}</div>
         {this.renderDeck()}
-      </div>
+      </React.Fragment>
     )
   }
 }

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -17,23 +17,24 @@ import type {BaseState, ThunkDispatch} from '../types'
 const ingredSelModIsVisible = activeModals => activeModals.ingredientSelection && activeModals.ingredientSelection.slot
 const DECK_HEADER = 'Tell the robot where labware and liquids start on the deck'
 
-type DeckSetupProps = {
+type StateProps = {
   deckSetupMode: boolean,
   ingredSelectionMode: boolean
 }
+type DispatchProps = {cancelMoveLabwareMode: () => mixed}
 
-const mapStateToProps = (state: BaseState): DeckSetupProps => ({
+const mapStateToProps = (state: BaseState): StateProps => ({
   deckSetupMode: steplistSelectors.deckSetupMode(state),
   // TODO SOON remove all uses of the `activeModals` selector
   ingredSelectionMode: !!ingredSelModIsVisible(selectors.activeModals(state))
 })
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<*>) => ({
+const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DispatchProps => ({
   cancelMoveLabwareMode: () => dispatch(actions.setMoveLabwareMode(false))
 })
 
 // TODO Ian 2018-02-16 this will be broken apart and incorporated into ProtocolEditor
-class DeckSetup extends React.Component<DeckSetupProps> {
+class DeckSetup extends React.Component<StateProps & DispatchProps> {
   renderDeck = () => (
     <div className={styles.deck_row}>
       <ClickOutside onClickOutside={this.props.cancelMoveLabwareMode}>

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {connect} from 'react-redux'
 
-import {Deck} from '@opentrons/components'
+import {Deck, ClickOutside} from '@opentrons/components'
 import styles from './Deck.css'
 
 import IngredientSelectionModal from '../components/IngredientSelectionModal.js'
@@ -10,8 +10,9 @@ import LabwareContainer from '../containers/LabwareContainer.js'
 import LabwareDropdown from '../containers/LabwareDropdown.js'
 
 import {selectors} from '../labware-ingred/reducers'
+import * as actions from '../labware-ingred/actions'
 import {selectors as steplistSelectors} from '../steplist'
-import type {BaseState} from '../types'
+import type {BaseState, ThunkDispatch} from '../types'
 
 const ingredSelModIsVisible = activeModals => activeModals.ingredientSelection && activeModals.ingredientSelection.slot
 const DECK_HEADER = 'Tell the robot where labware and liquids start on the deck'
@@ -21,37 +22,52 @@ type DeckSetupProps = {
   ingredSelectionMode: boolean
 }
 
-function mapStateToProps (state: BaseState): DeckSetupProps {
-  return {
-    deckSetupMode: steplistSelectors.deckSetupMode(state),
-    // TODO SOON remove all uses of the `activeModals` selector
-    ingredSelectionMode: !!ingredSelModIsVisible(selectors.activeModals(state))
-  }
-}
+const mapStateToProps = (state: BaseState): DeckSetupProps => ({
+  deckSetupMode: steplistSelectors.deckSetupMode(state),
+  // TODO SOON remove all uses of the `activeModals` selector
+  ingredSelectionMode: !!ingredSelModIsVisible(selectors.activeModals(state))
+})
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<*>) => ({
+  cancelMoveLabwareMode: () => dispatch(actions.setMoveLabwareMode(false))
+})
 
 // TODO Ian 2018-02-16 this will be broken apart and incorporated into ProtocolEditor
-function DeckSetup (props: DeckSetupProps) {
-  const deck = <Deck LabwareComponent={LabwareContainer} className={styles.deck} />
-  if (!props.deckSetupMode) {
-    // Temporary quickfix: if we're not in deck setup mode,
-    // hide the labware dropdown and ingredient selection modal
-    // and just show the deck.
-    // TODO Ian 2018-05-30 this shouldn't be a responsibility of DeckSetup
-    return deck
-  }
-
-  // NOTE: besides `Deck`, these are all modal-like components that show up
-  // only when user is on deck setup / ingred selection "page".
-  // Once DeckSetup is broken apart and moved into ProtocolEditor,
-  // this will go away
-  return (
-    <div>
-      <LabwareDropdown />
-      {props.ingredSelectionMode && <IngredientSelectionModal />}
-      <div className={styles.deck_header}>{DECK_HEADER}</div>
-      {deck}
+class DeckSetup extends React.Component<DeckSetupProps> {
+  renderDeck = () => (
+    <div className={styles.deck_row}>
+      <ClickOutside onClickOutside={this.props.cancelMoveLabwareMode}>
+        {({ref}) => (
+          <div ref={ref}>
+            <Deck LabwareComponent={LabwareContainer} className={styles.deck} />
+          </div>
+        )}
+      </ClickOutside>
     </div>
   )
+
+  render () {
+    if (!this.props.deckSetupMode) {
+      // Temporary quickfix: if we're not in deck setup mode,
+      // hide the labware dropdown and ingredient selection modal
+      // and just show the deck.
+      // TODO Ian 2018-05-30 this shouldn't be a responsibility of DeckSetup
+      return this.renderDeck()
+    }
+
+    // NOTE: besides `Deck`, these are all modal-like components that show up
+    // only when user is on deck setup / ingred selection "page".
+    // Once DeckSetup is broken apart and moved into ProtocolEditor,
+    // this will go away
+    return (
+      <div>
+        <LabwareDropdown />
+        {this.props.ingredSelectionMode && <IngredientSelectionModal />}
+        <div className={styles.deck_header}>{DECK_HEADER}</div>
+        {this.renderDeck()}
+      </div>
+    )
+  }
 }
 
-export default connect(mapStateToProps)(DeckSetup)
+export default connect(mapStateToProps, mapDispatchToProps)(DeckSetup)

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -30,7 +30,7 @@ const mapStateToProps = (state: BaseState): StateProps => ({
 })
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DispatchProps => ({
-  cancelMoveLabwareMode: () => dispatch(actions.setMoveLabwareMode(false))
+  cancelMoveLabwareMode: () => dispatch(actions.setMoveLabwareMode())
 })
 
 // TODO Ian 2018-02-16 this will be broken apart and incorporated into ProtocolEditor

--- a/protocol-designer/src/containers/Deck.css
+++ b/protocol-designer/src/containers/Deck.css
@@ -3,6 +3,7 @@
 .deck {
   padding: 1rem;
   max-width: 100%;
+  width: 100vh;
 }
 
 .deck_header {

--- a/protocol-designer/src/containers/Deck.css
+++ b/protocol-designer/src/containers/Deck.css
@@ -14,7 +14,5 @@
 }
 
 .deck_row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  @apply --center-children;
 }

--- a/protocol-designer/src/containers/Deck.css
+++ b/protocol-designer/src/containers/Deck.css
@@ -11,3 +11,9 @@
   text-align: center;
   padding-top: 1rem;
 }
+
+.deck_row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -68,7 +68,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     showNameOverlay: container && !isTiprack && !labwareHasName,
     canAdd: selectors.canAdd(state),
     activeModals: selectors.activeModals(state),
-    labwareToMove: selectors.labwareToMove(state),
+    slotToMoveFrom: selectors.slotToMoveFrom(state),
     highlighted: (deckSetupMode)
       // in deckSetupMode, labware is highlighted when selected (currently editing ingredients)
       // or when targeted by an open "Add Labware" modal

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -14,8 +14,8 @@ import {
   openLabwareSelector,
   closeLabwareSelector,
 
-  setCopyLabwareMode,
-  copyLabware
+  setMoveLabwareMode,
+  moveLabware
 } from '../labware-ingred/actions'
 import {selectors as steplistSelectors} from '../steplist'
 
@@ -39,8 +39,8 @@ type DispatchProps = {
 
   closeLabwareSelector: mixed,
 
-  setCopyLabwareMode: mixed,
-  copyLabware: mixed
+  setMoveLabwareMode: mixed,
+  moveLabware: mixed
 }
 
 type StateProps = $Diff<Props, DispatchProps>
@@ -68,7 +68,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
     showNameOverlay: container && !isTiprack && !labwareHasName,
     canAdd: selectors.canAdd(state),
     activeModals: selectors.activeModals(state),
-    labwareToCopy: selectors.labwareToCopy(state),
+    labwareToMove: selectors.labwareToMove(state),
     highlighted: (deckSetupMode)
       // in deckSetupMode, labware is highlighted when selected (currently editing ingredients)
       // or when targeted by an open "Add Labware" modal
@@ -79,7 +79,7 @@ function mapStateToProps (state: BaseState, ownProps: OwnProps): StateProps {
   }
 }
 
-const dispatchObj = {
+const mapDispatchToProps = {
   createContainer,
   deleteContainer,
   modifyContainer,
@@ -89,8 +89,8 @@ const dispatchObj = {
 
   closeLabwareSelector,
 
-  setCopyLabwareMode,
-  copyLabware
+  setMoveLabwareMode,
+  moveLabware
 }
 
-export default connect(mapStateToProps, dispatchObj)(LabwareOnDeck)
+export default connect(mapStateToProps, mapDispatchToProps)(LabwareOnDeck)

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -47,51 +47,52 @@ describe('DELETE_CONTAINER action', () => {
   })
 })
 
-describe('COPY_LABWARE action', () => {
-  test('copy correct container', () => {
-    expect(containers(
-      {
-        clonePlate: {
-          id: 'clonePlate',
-          type: '96-flat',
-          name: 'Samples Plate',
-          slot: '1',
-          disambiguationNumber: 1
-        },
-        otherPlate: {
-          id: 'otherPlate',
-          type: '384-flat',
-          name: 'Destination Plate',
-          slot: '2',
-          disambiguationNumber: 1
-        }
-      },
-      {
-        type: 'COPY_LABWARE',
-        payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: '5'}
-      }
-    )).toEqual({
-      clonePlate: {
-        id: 'clonePlate',
-        type: '96-flat',
-        name: 'Samples Plate',
-        slot: '1',
-        disambiguationNumber: 1
-      },
-      newContainer: {
-        id: 'newContainer',
-        type: '96-flat',
-        name: 'Samples Plate',
-        slot: '5',
-        disambiguationNumber: 2
-      },
-      otherPlate: {
-        id: 'otherPlate',
-        type: '384-flat',
-        name: 'Destination Plate',
-        slot: '2',
-        disambiguationNumber: 1
-      }
-    })
-  })
-})
+// TODO: BC 2018-7-25 test MOVE_LABWARE
+// describe('COPY_LABWARE action', () => {
+//   test('copy correct container', () => {
+//     expect(containers(
+//       {
+//         clonePlate: {
+//           id: 'clonePlate',
+//           type: '96-flat',
+//           name: 'Samples Plate',
+//           slot: '1',
+//           disambiguationNumber: 1
+//         },
+//         otherPlate: {
+//           id: 'otherPlate',
+//           type: '384-flat',
+//           name: 'Destination Plate',
+//           slot: '2',
+//           disambiguationNumber: 1
+//         }
+//       },
+//       {
+//         type: 'COPY_LABWARE',
+//         payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: '5'}
+//       }
+//     )).toEqual({
+//       clonePlate: {
+//         id: 'clonePlate',
+//         type: '96-flat',
+//         name: 'Samples Plate',
+//         slot: '1',
+//         disambiguationNumber: 1
+//       },
+//       newContainer: {
+//         id: 'newContainer',
+//         type: '96-flat',
+//         name: 'Samples Plate',
+//         slot: '5',
+//         disambiguationNumber: 2
+//       },
+//       otherPlate: {
+//         id: 'otherPlate',
+//         type: '384-flat',
+//         name: 'Destination Plate',
+//         slot: '2',
+//         disambiguationNumber: 1
+//       }
+//     })
+//   })
+// })

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -48,51 +48,51 @@ describe('DELETE_CONTAINER action', () => {
 })
 
 // TODO: BC 2018-7-25 test MOVE_LABWARE
-// describe('COPY_LABWARE action', () => {
-//   test('copy correct container', () => {
-//     expect(containers(
-//       {
-//         clonePlate: {
-//           id: 'clonePlate',
-//           type: '96-flat',
-//           name: 'Samples Plate',
-//           slot: '1',
-//           disambiguationNumber: 1
-//         },
-//         otherPlate: {
-//           id: 'otherPlate',
-//           type: '384-flat',
-//           name: 'Destination Plate',
-//           slot: '2',
-//           disambiguationNumber: 1
-//         }
-//       },
-//       {
-//         type: 'COPY_LABWARE',
-//         payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: '5'}
-//       }
-//     )).toEqual({
-//       clonePlate: {
-//         id: 'clonePlate',
-//         type: '96-flat',
-//         name: 'Samples Plate',
-//         slot: '1',
-//         disambiguationNumber: 1
-//       },
-//       newContainer: {
-//         id: 'newContainer',
-//         type: '96-flat',
-//         name: 'Samples Plate',
-//         slot: '5',
-//         disambiguationNumber: 2
-//       },
-//       otherPlate: {
-//         id: 'otherPlate',
-//         type: '384-flat',
-//         name: 'Destination Plate',
-//         slot: '2',
-//         disambiguationNumber: 1
-//       }
-//     })
-//   })
-// })
+describe.skip('COPY_LABWARE action', () => {
+  test('copy correct container', () => {
+    expect(containers(
+      {
+        clonePlate: {
+          id: 'clonePlate',
+          type: '96-flat',
+          name: 'Samples Plate',
+          slot: '1',
+          disambiguationNumber: 1
+        },
+        otherPlate: {
+          id: 'otherPlate',
+          type: '384-flat',
+          name: 'Destination Plate',
+          slot: '2',
+          disambiguationNumber: 1
+        }
+      },
+      {
+        type: 'COPY_LABWARE',
+        payload: {fromContainer: 'clonePlate', toContainer: 'newContainer', toSlot: '5'}
+      }
+    )).toEqual({
+      clonePlate: {
+        id: 'clonePlate',
+        type: '96-flat',
+        name: 'Samples Plate',
+        slot: '1',
+        disambiguationNumber: 1
+      },
+      newContainer: {
+        id: 'newContainer',
+        type: '96-flat',
+        name: 'Samples Plate',
+        slot: '5',
+        disambiguationNumber: 2
+      },
+      otherPlate: {
+        id: 'otherPlate',
+        type: '384-flat',
+        name: 'Destination Plate',
+        slot: '2',
+        disambiguationNumber: 1
+      }
+    })
+  })
+})

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -94,6 +94,7 @@ describe('DELETE_INGREDIENT action', () => {
   test.skip('delete ingredient by ingredient group id, when id does exist', () => {})
 })
 
+// TODO: IMMEDIATELY BC 2018-7-24 test move instead
 describe('COPY_LABWARE action', () => {
   test('copy ingredient locations from cloned container', () => {
     const copyLabwareAction = {

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -95,73 +95,73 @@ describe('DELETE_INGREDIENT action', () => {
 })
 
 // TODO: BC 2018-7-24 test MOVE_LABWARE instead
-// describe('COPY_LABWARE action', () => {
-//   test('copy ingredient locations from cloned container', () => {
-//     const copyLabwareAction = {
-//       type: 'COPY_LABWARE',
-//       payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: '5'}
-//     }
+describe.skip('COPY_LABWARE action', () => {
+  test('copy ingredient locations from cloned container', () => {
+    const copyLabwareAction = {
+      type: 'COPY_LABWARE',
+      payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: '5'}
+    }
 
-//     const prevIngredState = {
-//       ingred3: {
-//         name: 'Buffer',
-//         wellDetailsByLocation: null,
-//         concentration: '50 mol/ng',
-//         description: '',
-//         individualize: false
-//       },
-//       ingred4: {
-//         name: 'Other Ingred',
-//         wellDetailsByLocation: null,
-//         concentration: '100%',
-//         description: '',
-//         individualize: false
-//       }
-//     }
+    const prevIngredState = {
+      ingred3: {
+        name: 'Buffer',
+        wellDetailsByLocation: null,
+        concentration: '50 mol/ng',
+        description: '',
+        individualize: false
+      },
+      ingred4: {
+        name: 'Other Ingred',
+        wellDetailsByLocation: null,
+        concentration: '100%',
+        description: '',
+        individualize: false
+      }
+    }
 
-//     const prevLocationsState = {
-//       myTrough: {
-//         A1: {ingred3: {volume: 101}},
-//         A2: {ingred3: {volume: 102}},
-//         A3: {ingred3: {volume: 103}}
-//       },
-//       otherContainer: {
-//         D4: {ingred3: {volume: 201}},
-//         E4: {ingred3: {volume: 202}},
-//         A4: {ingred4: {volume: 301}},
-//         B4: {ingred4: {volume: 302}}
-//       }
-//     }
+    const prevLocationsState = {
+      myTrough: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
+      },
+      otherContainer: {
+        D4: {ingred3: {volume: 201}},
+        E4: {ingred3: {volume: 202}},
+        A4: {ingred4: {volume: 301}},
+        B4: {ingred4: {volume: 302}}
+      }
+    }
 
-//     expect(ingredients(
-//       prevIngredState,
-//       copyLabwareAction
-//     )).toEqual(prevIngredState)
+    expect(ingredients(
+      prevIngredState,
+      copyLabwareAction
+    )).toEqual(prevIngredState)
 
-//     expect(ingredLocations(
-//       prevLocationsState,
-//       copyLabwareAction
-//     )).toEqual({
-//       myTrough: {
-//         A1: {ingred3: {volume: 101}},
-//         A2: {ingred3: {volume: 102}},
-//         A3: {ingred3: {volume: 103}}
-//       },
-//       // this is newly copied
-//       newContainer: {
-//         A1: {ingred3: {volume: 101}},
-//         A2: {ingred3: {volume: 102}},
-//         A3: {ingred3: {volume: 103}}
-//       },
-//       otherContainer: {
-//         D4: {ingred3: {volume: 201}},
-//         E4: {ingred3: {volume: 202}},
-//         A4: {ingred4: {volume: 301}},
-//         B4: {ingred4: {volume: 302}}
-//       }
-//     })
-//   })
-// })
+    expect(ingredLocations(
+      prevLocationsState,
+      copyLabwareAction
+    )).toEqual({
+      myTrough: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
+      },
+      // this is newly copied
+      newContainer: {
+        A1: {ingred3: {volume: 101}},
+        A2: {ingred3: {volume: 102}},
+        A3: {ingred3: {volume: 103}}
+      },
+      otherContainer: {
+        D4: {ingred3: {volume: 201}},
+        E4: {ingred3: {volume: 202}},
+        A4: {ingred4: {volume: 301}},
+        B4: {ingred4: {volume: 302}}
+      }
+    })
+  })
+})
 
 describe('EDIT_INGREDIENT action', () => {
   const ingredFields = {

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -94,74 +94,74 @@ describe('DELETE_INGREDIENT action', () => {
   test.skip('delete ingredient by ingredient group id, when id does exist', () => {})
 })
 
-// TODO: IMMEDIATELY BC 2018-7-24 test move instead
-describe('COPY_LABWARE action', () => {
-  test('copy ingredient locations from cloned container', () => {
-    const copyLabwareAction = {
-      type: 'COPY_LABWARE',
-      payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: '5'}
-    }
+// TODO: BC 2018-7-24 test MOVE_LABWARE instead
+// describe('COPY_LABWARE action', () => {
+//   test('copy ingredient locations from cloned container', () => {
+//     const copyLabwareAction = {
+//       type: 'COPY_LABWARE',
+//       payload: {fromContainer: 'myTrough', toContainer: 'newContainer', toSlot: '5'}
+//     }
 
-    const prevIngredState = {
-      ingred3: {
-        name: 'Buffer',
-        wellDetailsByLocation: null,
-        concentration: '50 mol/ng',
-        description: '',
-        individualize: false
-      },
-      ingred4: {
-        name: 'Other Ingred',
-        wellDetailsByLocation: null,
-        concentration: '100%',
-        description: '',
-        individualize: false
-      }
-    }
+//     const prevIngredState = {
+//       ingred3: {
+//         name: 'Buffer',
+//         wellDetailsByLocation: null,
+//         concentration: '50 mol/ng',
+//         description: '',
+//         individualize: false
+//       },
+//       ingred4: {
+//         name: 'Other Ingred',
+//         wellDetailsByLocation: null,
+//         concentration: '100%',
+//         description: '',
+//         individualize: false
+//       }
+//     }
 
-    const prevLocationsState = {
-      myTrough: {
-        A1: {ingred3: {volume: 101}},
-        A2: {ingred3: {volume: 102}},
-        A3: {ingred3: {volume: 103}}
-      },
-      otherContainer: {
-        D4: {ingred3: {volume: 201}},
-        E4: {ingred3: {volume: 202}},
-        A4: {ingred4: {volume: 301}},
-        B4: {ingred4: {volume: 302}}
-      }
-    }
+//     const prevLocationsState = {
+//       myTrough: {
+//         A1: {ingred3: {volume: 101}},
+//         A2: {ingred3: {volume: 102}},
+//         A3: {ingred3: {volume: 103}}
+//       },
+//       otherContainer: {
+//         D4: {ingred3: {volume: 201}},
+//         E4: {ingred3: {volume: 202}},
+//         A4: {ingred4: {volume: 301}},
+//         B4: {ingred4: {volume: 302}}
+//       }
+//     }
 
-    expect(ingredients(
-      prevIngredState,
-      copyLabwareAction
-    )).toEqual(prevIngredState)
+//     expect(ingredients(
+//       prevIngredState,
+//       copyLabwareAction
+//     )).toEqual(prevIngredState)
 
-    expect(ingredLocations(
-      prevLocationsState,
-      copyLabwareAction
-    )).toEqual({
-      myTrough: {
-        A1: {ingred3: {volume: 101}},
-        A2: {ingred3: {volume: 102}},
-        A3: {ingred3: {volume: 103}}
-      },
-      // this is newly copied
-      newContainer: {
-        A1: {ingred3: {volume: 101}},
-        A2: {ingred3: {volume: 102}},
-        A3: {ingred3: {volume: 103}}
-      },
-      otherContainer: {
-        D4: {ingred3: {volume: 201}},
-        E4: {ingred3: {volume: 202}},
-        A4: {ingred4: {volume: 301}},
-        B4: {ingred4: {volume: 302}}
-      }
-    })
-  })
-})
+//     expect(ingredLocations(
+//       prevLocationsState,
+//       copyLabwareAction
+//     )).toEqual({
+//       myTrough: {
+//         A1: {ingred3: {volume: 101}},
+//         A2: {ingred3: {volume: 102}},
+//         A3: {ingred3: {volume: 103}}
+//       },
+//       // this is newly copied
+//       newContainer: {
+//         A1: {ingred3: {volume: 101}},
+//         A2: {ingred3: {volume: 102}},
+//         A3: {ingred3: {volume: 103}}
+//       },
+//       otherContainer: {
+//         D4: {ingred3: {volume: 201}},
+//         E4: {ingred3: {volume: 202}},
+//         A4: {ingred4: {volume: 301}},
+//         B4: {ingred4: {volume: 302}}
+//       }
+//     })
+//   })
+// })
 
 describe('EDIT_INGREDIENT action', () => {
   const ingredFields = {

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -14,7 +14,7 @@ import type {DeckSlot} from '@opentrons/components'
 
 export const openLabwareSelector = createAction(
   'OPEN_LABWARE_SELECTOR',
-  (args: {slot: string}) => args
+  (args: {slot: DeckSlot}) => args
 )
 
 export const closeLabwareSelector = createAction(
@@ -24,7 +24,7 @@ export const closeLabwareSelector = createAction(
 
 export const setMoveLabwareMode = createAction(
   'SET_MOVE_LABWARE_MODE',
-  (slot: DeckSlot) => slot
+  (slot: DeckSlot | false) => slot
 )
 
 // ===== Open and close Ingredient Selector modal ====
@@ -54,7 +54,7 @@ export const editModeIngredientGroup = createAction(
 export const createContainer = createAction(
   'CREATE_CONTAINER',
   (args: {|
-    slot: string,
+    slot: DeckSlot,
     containerType: string
   |}) => args
 )
@@ -63,7 +63,7 @@ export const deleteContainer = createAction(
   'DELETE_CONTAINER',
   (args: {|
     containerId: string,
-    slot: string,
+    slot: DeckSlot,
     containerType: string
   |}) => args
 )
@@ -102,10 +102,12 @@ export type MoveLabware = {
 export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
   const state = getState()
   const fromSlot = selectors.slotToMoveFrom(state)
-  return dispatch({
-    type: 'MOVE_LABWARE',
-    payload: {fromSlot, toSlot}
-  })
+  if (fromSlot) {
+    return dispatch({
+      type: 'MOVE_LABWARE',
+      payload: {fromSlot, toSlot}
+    })
+  }
 }
 
 type DeleteIngredientPrepayload = {

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -24,7 +24,7 @@ export const closeLabwareSelector = createAction(
 
 export const setMoveLabwareMode = createAction(
   'SET_MOVE_LABWARE_MODE',
-  (slot: DeckSlot | false) => slot
+  (slot: ?DeckSlot) => slot
 )
 
 // ===== Open and close Ingredient Selector modal ====

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -3,7 +3,6 @@ import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 import max from 'lodash/max'
 
-import {uuid} from '../utils'
 import {selectors} from './reducers'
 import wellSelectionSelectors from '../well-selection/selectors'
 
@@ -25,7 +24,7 @@ export const closeLabwareSelector = createAction(
 
 export const setMoveLabwareMode = createAction(
   'SET_MOVE_LABWARE_MODE',
-  (containerId: string) => containerId
+  (slot: DeckSlot) => slot
 )
 
 // ===== Open and close Ingredient Selector modal ====
@@ -100,7 +99,9 @@ export type MoveLabware = {
   }
 }
 
-export const moveLabware = (fromSlot: DeckSlot, toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
+export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
+  const state = getState()
+  const fromSlot = selectors.slotToMoveFrom(state)
   return dispatch({
     type: 'MOVE_LABWARE',
     payload: {fromSlot, toSlot}

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -23,8 +23,8 @@ export const closeLabwareSelector = createAction(
   () => {}
 )
 
-export const setCopyLabwareMode = createAction(
-  'SET_COPY_LABWARE_MODE',
+export const setMoveLabwareMode = createAction(
+  'SET_MOVE_LABWARE_MODE',
   (containerId: string) => containerId
 )
 
@@ -92,31 +92,18 @@ export const closeRenameLabwareForm = createAction(
 
 // ===========
 
-export type CopyLabware = {
-  type: 'COPY_LABWARE',
+export type MoveLabware = {
+  type: 'MOVE_LABWARE',
   payload: {
-    fromContainer: string,
-    toContainer: string,
+    fromSlot: DeckSlot,
     toSlot: DeckSlot
   }
 }
 
-export const copyLabware = (slot: DeckSlot) => (dispatch: Dispatch<CopyLabware>, getState: GetState) => {
-  const state = getState()
-  const fromContainer = selectors.labwareToCopy(state)
-  if (fromContainer === false) {
-    console.warn('Attempted to copy labware with no fromContainer')
-    return
-  }
+export const moveLabware = (fromSlot: DeckSlot, toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
   return dispatch({
-    type: 'COPY_LABWARE',
-    payload: {
-      fromContainer,
-      toContainer: uuid() + ':' + fromContainer.split(':')[1],
-      // 'toContainer' is the containerId of the new clone.
-      // So you get 'uuid:containerType', or 'uuid:undefined' if you're cloning 'FIXED_TRASH_ID'.
-      toSlot: slot
-    }
+    type: 'MOVE_LABWARE',
+    payload: {fromSlot, toSlot}
   })
 }
 

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -128,7 +128,7 @@ export const containers = handleActions({
     return {...state, [containerId]: {...state[containerId], ...modify}}
   },
   MOVE_LABWARE: (state: ContainersState, action: MoveLabware): ContainersState => {
-    const { fromSlot, toSlot } = action.payload
+    const { toSlot, fromSlot } = action.payload
     const fromContainers = reduce(state, (acc, container, id) => (
       container.slot === fromSlot ? {...acc, [id]: {...container, slot: toSlot}} : acc
     ), {})
@@ -421,7 +421,7 @@ const activeModals: Selector<ActiveModals> = createSelector(
 
 const getRenameLabwareFormMode = (state: BaseState) => rootSelector(state).renameLabwareFormMode
 
-const labwareToMove = (state: BaseState) => rootSelector(state).moveLabwareMode
+const slotToMoveFrom = (state: BaseState) => rootSelector(state).moveLabwareMode
 
 const hasLiquid = (state: BaseState) => !isEmpty(getIngredientGroups(state))
 
@@ -442,7 +442,7 @@ export const selectors = {
   activeModals,
   getRenameLabwareFormMode,
 
-  labwareToMove,
+  slotToMoveFrom,
 
   allIngredientGroupFields,
   allIngredientNamesIds,

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -4,7 +4,6 @@ import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 import {createSelector} from 'reselect'
 
-import cloneDeep from 'lodash/cloneDeep'
 import omit from 'lodash/omit'
 import mapValues from 'lodash/mapValues'
 import pickBy from 'lodash/pickBy'

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -257,8 +257,8 @@ export const ingredLocations = handleActions({
 }, {})
 
 export type RootState = {|
-  modeLabwareSelection: DeckSlot | false, // TODO use null, not false
-  moveLabwareMode: DeckSlot | false,
+  modeLabwareSelection: ?DeckSlot,
+  moveLabwareMode: ?DeckSlot,
   selectedContainerId: SelectedContainerId,
   containers: ContainersState,
   savedLabware: SavedLabwareState,

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -257,8 +257,8 @@ export const ingredLocations = handleActions({
 }, {})
 
 export type RootState = {|
-  modeLabwareSelection: string | false, // TODO use null, not false
-  moveLabwareMode: string | false,
+  modeLabwareSelection: DeckSlot | false, // TODO use null, not false
+  moveLabwareMode: DeckSlot | false,
   selectedContainerId: SelectedContainerId,
   containers: ContainersState,
   savedLabware: SavedLabwareState,
@@ -397,7 +397,7 @@ const allIngredientNamesIds: BaseState => Array<{ingredientId: string, name: ?st
 type ActiveModals = {
   labwareSelection: boolean,
   ingredientSelection: ?{
-    slot: ?string,
+    slot: ?DeckSlot,
     containerName: ?string
   }
 }
@@ -411,7 +411,7 @@ const activeModals: Selector<ActiveModals> = createSelector(
     return ({
       labwareSelection: state.modeLabwareSelection !== false,
       ingredientSelection: {
-        slot: selectedContainer && selectedContainer.slot,
+        slot: selectedContainer ? selectedContainer.slot : null,
         containerName: selectedContainer && selectedContainer.type
       }
     })

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -21,7 +21,7 @@ const unsavedChanges = (state: boolean = false, action: {type: string}): boolean
     case 'CREATE_CONTAINER':
     case 'DELETE_CONTAINER':
     case 'MODIFY_CONTAINER':
-    case 'COPY_LABWARE':
+    case 'MOVE_LABWARE':
     case 'EDIT_MODE_INGREDIENT_GROUP':
     case 'DELETE_INGREDIENT':
     case 'EDIT_INGREDIENT':


### PR DESCRIPTION
where you're currently given the option to copy labware, allow users to move labware with expected
swapping behavior. Alter deck component to assume less about bounding element

Closes #1908