### PR TITLE
refactor(protocol-designer): factor out PDTitledList and PDListItem

### DIFF
--- a/protocol-designer/src/components/IngredientsList.css
+++ b/protocol-designer/src/components/IngredientsList.css
@@ -1,33 +1,13 @@
 @import '@opentrons/components';
 
-.ingredient_titled_list {
-  & > ol > :last-child {
-    padding-bottom: 0;
-    border: none;
+.close_icon {
+  & svg {
+    width: 100%;
+    max-height: 1rem;
   }
 
-  margin-bottom: 0.5rem;
-}
-
-/* --------- */
-
-.ingredient_row,
-.ingredient_row_header {
-  lost-utility: clearfix;
-  padding: 0.25rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 2px solid var(--c-light-gray);
-
-  & > * {
-    lost-column: 1/4;
-
-    /* Space out empty divs too */
-    min-height: 1px;
-  }
-
-  & *:first-child {
-    /* Well name */
-    padding-left: 1rem;
+  &:hover {
+    color: var(--c-red);
   }
 }
 

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -2,7 +2,8 @@
 // TODO: Ian 2018-06-07 break out these components into their own files (make IngredientsList a directory)
 import React from 'react'
 
-import {IconButton, SidePanel, TitledList, swatchColors} from '@opentrons/components'
+import {IconButton, SidePanel, swatchColors} from '@opentrons/components'
+import {PDTitledList} from './lists'
 import stepItemStyles from './steplist/StepItem.css'
 import StepDescription from './StepDescription'
 import styles from './IngredientsList.css'
@@ -59,7 +60,7 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
     }
 
     return (
-      <TitledList
+      <PDTitledList
         title={name || 'Unnamed Ingredient'}
         className={styles.ingredient_titled_list}
         iconProps={{style: {fill: swatchColors(Number(groupId))}}}
@@ -99,7 +100,7 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
             deleteIngredient={deleteIngredient}
           />
         })}
-      </TitledList>
+      </PDTitledList>
     )
   }
 }
@@ -165,7 +166,7 @@ export default function IngredientsList (props: Props) {
   return (
     <SidePanel title='Name & Liquids'>
         {/* Labware Name "button" to open LabwareNameEditForm */}
-        <TitledList
+        <PDTitledList
           className={stepItemStyles.step_item}
           title='labware name'
           iconName='pencil'

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -70,7 +70,7 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
         onClick={() => editModeIngredientGroup({groupId, wellName: null})}
         description={<StepDescription description={description} header='Description:' />}
       >
-        <PDListItem border className={styles.ingredient_row_header}>
+        <PDListItem className={styles.ingredient_row_header}>
           <span>Well</span>
           <span>μL</span>
           <span>Name</span>

--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -3,7 +3,7 @@
 import React from 'react'
 
 import {IconButton, SidePanel, swatchColors} from '@opentrons/components'
-import {PDTitledList} from './lists'
+import {PDTitledList, PDListItem} from './lists'
 import stepItemStyles from './steplist/StepItem.css'
 import StepDescription from './StepDescription'
 import styles from './IngredientsList.css'
@@ -62,7 +62,6 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
     return (
       <PDTitledList
         title={name || 'Unnamed Ingredient'}
-        className={styles.ingredient_titled_list}
         iconProps={{style: {fill: swatchColors(Number(groupId))}}}
         iconName='circle'
         onCollapseToggle={() => this.toggleAccordion()}
@@ -71,12 +70,13 @@ class IngredGroupCard extends React.Component<CardProps, CardState> {
         onClick={() => editModeIngredientGroup({groupId, wellName: null})}
         description={<StepDescription description={description} header='Description:' />}
       >
-        <div className={styles.ingredient_row_header}>
+        <PDListItem border className={styles.ingredient_row_header}>
           <span>Well</span>
-          <span>Volume</span>
+          <span>μL</span>
           <span>Name</span>
           <span />
-        </div>
+        </PDListItem>
+
         {wellsWithIngred.map((well, i) => {
           const wellIngredForCard = labwareWellContents[well][groupId]
           const volume = wellIngredForCard && wellIngredForCard.volume
@@ -128,18 +128,18 @@ function IngredIndividual (props: IndividProps) {
   } = props
 
   return (
-    <div
-      className={styles.ingredient_row}
-    >
-      <div>{wellName}</div>
-      <div>{volume ? volume + ' μL' : '-'}</div>
-      <div>{name}</div>
-      {canDelete && <IconButton name='close'
+    <PDListItem border>
+      <span>{wellName}</span>
+      <span>{volume ? volume + ' μL' : '-'}</span>
+      <span>{name}</span>
+      {canDelete && <IconButton
+        className={styles.close_icon}
+        name='close'
         onClick={
           () => window.confirm(`Are you sure you want to delete well ${wellName} ?`) &&
           deleteIngredient({wellName, groupId})
         } />}
-    </div>
+    </PDListItem>
   )
 }
 

--- a/protocol-designer/src/components/StepDescription.css
+++ b/protocol-designer/src/components/StepDescription.css
@@ -2,7 +2,7 @@
 
 .step_description {
   padding: 0.5rem;
-  border-bottom: 2px solid var(--c-light-gray);
+  border-bottom: var(--bd-light);
 }
 
 .step_description header {

--- a/protocol-designer/src/components/lists/PDListItem.js
+++ b/protocol-designer/src/components/lists/PDListItem.js
@@ -1,0 +1,13 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import styles from './styles.css'
+
+type Props = {
+  className?: ?string
+}
+
+/** Light wrapper around li for PD-specific styles */
+export default function PDListItem (props: Props) {
+  return <li {...props} className={cx(styles.pd_list_item, props.className)} />
+}

--- a/protocol-designer/src/components/lists/PDListItem.js
+++ b/protocol-designer/src/components/lists/PDListItem.js
@@ -4,10 +4,18 @@ import cx from 'classnames'
 import styles from './styles.css'
 
 type Props = {
-  className?: ?string
+  className?: ?string,
+  border?: ?boolean,
 }
 
 /** Light wrapper around li for PD-specific styles */
 export default function PDListItem (props: Props) {
-  return <li {...props} className={cx(styles.pd_list_item, props.className)} />
+  const className = cx(
+    {
+      [styles.border]: props.border
+    },
+    styles.pd_list_item,
+    props.className
+  )
+  return <li {...props} className={className} />
 }

--- a/protocol-designer/src/components/lists/PDTitledList.js
+++ b/protocol-designer/src/components/lists/PDTitledList.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import {TitledList} from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = React.ElementProps<typeof TitledList>
+
+/** Light wrapper around TitledList for PD-specific styles */
+export default function PDTitledList (props: Props) {
+  return <TitledList {...props} className={cx(styles.pd_titled_list, props.className)} />
+}

--- a/protocol-designer/src/components/lists/index.js
+++ b/protocol-designer/src/components/lists/index.js
@@ -1,0 +1,8 @@
+// @flow
+import PDListItem from './PDListItem'
+import PDTitledList from './PDTitledList'
+
+export {
+  PDListItem,
+  PDTitledList
+}

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -23,5 +23,5 @@
 }
 
 .border {
-  border-top: 2px solid var(--c-light-gray);
+  border-top: var(--bd-light);
 }

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -1,0 +1,32 @@
+@import '@opentrons/components';
+
+.pd_titled_list {
+  margin: 0.4rem 0.125rem;
+  color: var(--c-dark-gray);
+  box-shadow: 0 0.125rem 0.5rem color(var(--c-black) alpha(0.25));
+
+  & ol {
+    padding: 0;
+    margin: 0;
+  }
+
+  & h3 {
+    text-transform: uppercase;
+  }
+}
+
+.pd_list_item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: var(--fs-body-1);
+
+  & > * {
+    flex: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -4,15 +4,6 @@
   margin: 0.4rem 0.125rem;
   color: var(--c-dark-gray);
   box-shadow: 0 0.125rem 0.5rem color(var(--c-black) alpha(0.25));
-
-  & ol {
-    padding: 0;
-    margin: 0;
-  }
-
-  & h3 {
-    text-transform: uppercase;
-  }
 }
 
 .pd_list_item {

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -29,4 +29,8 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+
+  &.border {
+    border-bottom: 2px solid var(--c-light-gray);
+  }
 }

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -29,8 +29,8 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+}
 
-  &.border {
-    border-bottom: 2px solid var(--c-light-gray);
-  }
+.border {
+  border-top: 2px solid var(--c-light-gray);
 }

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import {Icon} from '@opentrons/components'
+import {PDListItem} from '../lists'
 import styles from './StepItem.css'
 
 type AspirateDispenseHeaderProps = {
@@ -12,20 +13,22 @@ type AspirateDispenseHeaderProps = {
 function AspirateDispenseHeader (props: AspirateDispenseHeaderProps) {
   const {sourceLabwareName, destLabwareName} = props
 
-  return [
-    <li key='header-0' className={styles.aspirate_dispense}>
-        <span>ASPIRATE</span>
-        <span className={styles.spacer}/>
-        <span>DISPENSE</span>
-    </li>,
+  return (
+    <React.Fragment>
+      <li className={styles.aspirate_dispense}>
+          <span>ASPIRATE</span>
+          <span className={styles.spacer}/>
+          <span>DISPENSE</span>
+      </li>
 
-    <li key='header-1' className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
-      <span>{sourceLabwareName}</span>
-      {/* This is always a "transfer icon" (arrow pointing right) for any step: */}
-      <Icon name='ot-transfer' />
-      <span>{destLabwareName}</span>
-    </li>
-  ]
+      <PDListItem className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
+        <span>{sourceLabwareName}</span>
+        {/* This is always a "transfer icon" (arrow pointing right) for any step: */}
+        <Icon name='ot-transfer' />
+        <span>{destLabwareName}</span>
+      </PDListItem>
+    </React.Fragment>
+  )
 }
 
 export default AspirateDispenseHeader

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -1,8 +1,6 @@
 @import '@opentrons/components';
 
 .step_subitem {
-  border-top: 2px solid var(--c-light-gray);
-
   & svg {
     /* Subitem group carat */
     flex: 1;
@@ -24,7 +22,7 @@
 .step_subitem_column_header {
   & svg {
     /* Source labware -> Dest Labware arrow icon */
-    flex: 1;
+    flex: 0.5;
     height: 1.5rem;
     color: var(--c-med-gray);
   }
@@ -52,6 +50,7 @@
 
 /* Multi-channel row representing a single channel */
 .step_subitem_channel_row {
+  border-top: 0;
   border-bottom: 1px var(--c-med-gray) dashed;
   background-color: var(--c-light-gray);
 }

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -1,33 +1,7 @@
 @import '@opentrons/components';
 
-:root {
-  --step_subitem: {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    padding: 0.5rem;
-    text-align: center;
-    font-size: var(--fs-body-1);
-  };
-
-  --subitem_cell: {
-    flex: 2;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  };
-}
-
 .step_subitem {
-  @apply --step_subitem;
-
   border-top: 2px solid var(--c-light-gray);
-
-  & > * {
-    @apply --subitem_cell;
-
-    flex: 1;
-  }
 
   & svg {
     /* Subitem group carat */
@@ -41,21 +15,6 @@
   }
 }
 
-.step_item {
-  margin: 0.4rem 0.125rem;
-  color: var(--c-dark-gray);
-  box-shadow: 0 0.125rem 0.5rem color(var(--c-black) alpha(0.25));
-}
-
-.step_item ol {
-  padding: 0;
-  margin: 0;
-}
-
-.step_item h3 {
-  text-transform: uppercase;
-}
-
 .emphasized_cell {
   font-weight: bold;
 }
@@ -63,8 +22,6 @@
 /* Step Subitem Column Header */
 
 .step_subitem_column_header {
-  @apply --step_subitem;
-
   & svg {
     /* Source labware -> Dest Labware arrow icon */
     flex: 1;
@@ -73,8 +30,6 @@
   }
 
   & > * {
-    @apply --subitem_cell;
-
     text-align: left;
   }
 }
@@ -97,14 +52,8 @@
 
 /* Multi-channel row representing a single channel */
 .step_subitem_channel_row {
-  @apply --step_subitem;
-
   border-bottom: 1px var(--c-med-gray) dashed;
   background-color: var(--c-light-gray);
-
-  & > * {
-    @apply --subitem_cell;
-  }
 }
 
 /* Inner collapse carat */

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {TitledList} from '@opentrons/components'
+import {PDTitledList} from '../lists'
 import SourceDestSubstep from './SourceDestSubstep'
 import styles from './StepItem.css'
 
@@ -63,8 +63,7 @@ export default function StepItem (props: StepItemProps) {
   const Description = <StepDescription description={step && step.description} />
 
   return (
-    <TitledList
-      className={styles.step_item}
+    <PDTitledList
       description={Description}
       iconName={error ? 'alert-circle' : iconName}
       iconProps={{className: error ? styles.error_icon : ''}}
@@ -76,7 +75,7 @@ export default function StepItem (props: StepItemProps) {
       {...{selected, collapsed, hovered}}
     >
       {getStepItemContents(props)}
-    </TitledList>
+    </PDTitledList>
   )
 }
 

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -74,7 +74,9 @@ export default function SubstepRow (props: SubstepRowProps) {
   const formattedVolume = formatVolume(props.volume)
 
   return (
-    <PDListItem className={props.className}
+    <PDListItem
+      border
+      className={props.className}
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
     >

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -4,7 +4,7 @@ import last from 'lodash/last'
 
 import {Icon} from '@opentrons/components'
 import IngredPill from '../IngredPill'
-
+import {PDListItem} from '../lists'
 import styles from './StepItem.css'
 
 import type {NamedIngred} from '../../steplist/types'
@@ -74,7 +74,7 @@ export default function SubstepRow (props: SubstepRowProps) {
   const formattedVolume = formatVolume(props.volume)
 
   return (
-    <li className={props.className}
+    <PDListItem className={props.className}
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
     >
@@ -93,6 +93,6 @@ export default function SubstepRow (props: SubstepRowProps) {
         </span>
         : <IngredPill ingreds={props.destIngredients} />
       }
-    </li>
+    </PDListItem>
   )
 }


### PR DESCRIPTION
## overview

I talked with Katie, Morgan, & Pantea and derived:

1. `TitledList` is working pretty good, Run App just doesn't use a lot of its options. It doesn't seem like it needs any refactor - simply don't use some props, and it will behave very vanilla. However, within PD the same styles are always applied to it (outer drop shadow, different margin), so this PR wraps it in some common-across-PD styles in `PDTitledList`.

2. `ListItem` isn't working really for anybody. It doesn't seem to actually be a reusable component. There's a single place in Run App that it's used without additional styles. Everywhere else, it's pretty much overridden. In PD, ListItem-like things (ie any `<li>`s inside `TitledList`s) seem like they are always tabular data, and it seems OK to make the PD version `flex` by default. PD ListItem-things also often have a light gray border separating the items, so that's a `border` prop on the new `PDListItem`.

3. PD's `IngredientsList` is an example of where it'd be nice to reuse the styled `PDListItem`s. This PR brings us almost to #740 (but doesn't quite close it: selection stuff is not implemented, so I didn't want to cram that in here, and the volume decimal sig-fig stuff is out of scope too).

## changelog

- add styled wrappers of TitledList and li to new components/lists dir
- remove extra styles from StepItem.css
- make IngredientsList look somewhat more like design
- clean up IngredientsList styles

## review requests

- Any leftover redundant styles?
- Everything in Step List should look **exactly** the same -- I've been making 2 tabs one on edge via S3 link, one on this branch, and flipbooking between them
- Ingredient List should look nicer and approach #740 illustrations