### PR TITLE
fix(app): Check if modulesRequired when displaying review modals

### DIFF
--- a/app/src/pages/Calibrate/Labware.js
+++ b/app/src/pages/Calibrate/Labware.js
@@ -95,8 +95,9 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const calibrateToBottom = !!calToBottomFlag && calToBottomFlag.value
 
     const modulesEnabled = getModulesOn(state)
+    const modulesRequired = robotSelectors.getModules(state).length > 0
     const modulesReviewed = robotSelectors.getModulesReviewed(state)
-    const reviewModules = modulesEnabled && !modulesReviewed
+    const reviewModules = modulesEnabled && modulesRequired && !modulesReviewed
 
     return {
       slot,

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -17,7 +17,7 @@ function KnowledgeBaseLink (props: Props) {
   return (
     <a
       target='_blank'
-      rel="noopener noreferrer"
+      rel='noopener noreferrer'
       href={links[props.to]}
     >
       {props.children}

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -17,7 +17,7 @@ function KnowledgeBaseLink (props: Props) {
   return (
     <a
       target='_blank'
-      rel='noopener'
+      rel="noopener noreferrer"
       href={links[props.to]}
     >
       {props.children}


### PR DESCRIPTION
## overview

While reviewing the lovely deckmap style refactor branch, I noticed the ReviewDeck modal did not render when modules flag was enabled but no modules were required by the protocol. This is tiny temporary fix. In the future we will combine the ReviewDeck and ReviewModules modals.

Also, with the merge of the new lint rules, KnowlegeBaseLink needed `rel="noopener noreferrer"` this PR adds that so that future builds wont fail.

## changelog

- fix(app): Check if modulesRequired when displaying review modals

## review requests

**Run app normally** 
`make dev` 
- [ ] review deck modal renders as expected


**Run app with modules enabled**
 `OT_APP_MODULES=1 make dev` (with no modules required by protocol)
- [ ] review deck modal renders as expected


**Mock session modules** 
uncomment lines 345-351 in `app/src/robot/api-client/client.js` 
- [ ] review modules modal appears with missing module


**Mock modules API response** 
comment out line 77 and uncomment lines 79-110 in `app/src/http-api-client/modules.js`
- [ ] review modules modal appears with module detected message
- [ ] clicking continue button displayed review deck modal
