### PR TITLE
 feat(protocol-designer): add i18next and start with tooltips

### DIFF
--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@opentrons/components": "3.3.0-beta.0",
     "classnames": "^2.2.5",
+    "i18next": "^11.5.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
+import {t} from 'i18next'
 import {FormGroup, HoverTooltip} from '@opentrons/components'
 
 import {
@@ -43,7 +44,7 @@ const MixForm = (props: MixFormProps): React.Element<React.Fragment> => {
       <div className={formStyles.row_wrapper}>
         <div className={styles.left_settings_column}>
           <FormGroup label='TECHNIQUE'>
-            <HoverTooltip tooltipComponent="This feature is not available in Beta">
+            <HoverTooltip tooltipComponent={t('tooltip:not_in_beta')}>
               {(hoverTooltipHandlers) => (
                 <DispenseDelayFields
                   disabled

--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {t} from 'i18next'
+import i18n from '../../localization'
 import {FormGroup, HoverTooltip} from '@opentrons/components'
 
 import {
@@ -44,7 +44,7 @@ const MixForm = (props: MixFormProps): React.Element<React.Fragment> => {
       <div className={formStyles.row_wrapper}>
         <div className={styles.left_settings_column}>
           <FormGroup label='TECHNIQUE'>
-            <HoverTooltip tooltipComponent={t('tooltip:not_in_beta')}>
+            <HoverTooltip tooltipComponent={i18n.t('tooltip.not_in_beta')}>
               {(hoverTooltipHandlers) => (
                 <DispenseDelayFields
                   disabled

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {FormGroup, HoverTooltip} from '@opentrons/components'
 
+import i18n from '../../localization'
 import {
   StepInputField,
   StepCheckboxRow,
@@ -48,7 +49,7 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
             <FormGroup label='TECHNIQUE'>
               <StepCheckboxRow name="aspirate_preWetTip" label="Pre-wet tip" />
               <StepCheckboxRow name="aspirate_touchTip" label="Touch tip" />
-              <HoverTooltip tooltipComponent="This feature is not available in Beta">
+              <HoverTooltip tooltipComponent={i18n.t('tooltip.not_in_beta')}>
                 {(hoverTooltipHandlers) => (
                   <StepCheckboxRow disabled hoverTooltipHandlers={hoverTooltipHandlers} name="aspirate_airGap_checkbox" label="Air Gap">
                     <StepInputField disabled name="aspirate_airGap_volume" units="μL" {...focusHandlers} />
@@ -97,7 +98,7 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
                 <StepInputField name="dispense_mix_volume" units="μL" {...focusHandlers} />
                 <StepInputField name="dispense_mix_times" units="Times" {...focusHandlers} />
               </StepCheckboxRow>
-              <HoverTooltip tooltipComponent="This feature is not available in Beta">
+              <HoverTooltip tooltipComponent={i18n.t('tooltip.not_in_beta')}>
                 {(hoverTooltipHandlers) => (
                   <DispenseDelayFields
                     disabled

--- a/protocol-designer/src/localization/en/index.js
+++ b/protocol-designer/src/localization/en/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import tooltip from './tooltip.json'
+
+export default {
+  translation: {
+    tooltip
+  }
+}

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -1,0 +1,3 @@
+{
+  "not_in_beta": "This feature is not available in Beta"
+}

--- a/protocol-designer/src/localization/index.js
+++ b/protocol-designer/src/localization/index.js
@@ -1,0 +1,16 @@
+// @flow
+
+import i18next from 'i18next'
+import en from './en'
+​
+i18next.init({
+  lng: 'en',
+  debug: true,
+  resources: {
+    ...en
+  }
+}, (err, t) => {
+  if (err) {
+    console.error('Internationalization was not initialized properly. error: ', err)
+  }
+});

--- a/protocol-designer/src/localization/index.js
+++ b/protocol-designer/src/localization/index.js
@@ -2,7 +2,7 @@
 
 import i18next from 'i18next'
 import en from './en'
-​
+
 i18next.init({
   lng: 'en',
   debug: true,
@@ -13,4 +13,4 @@ i18next.init({
   if (err) {
     console.error('Internationalization was not initialized properly. error: ', err)
   }
-});
+})

--- a/protocol-designer/src/localization/index.js
+++ b/protocol-designer/src/localization/index.js
@@ -7,10 +7,12 @@ i18next.init({
   lng: 'en',
   debug: true,
   resources: {
-    ...en
+    en
   }
 }, (err, t) => {
   if (err) {
     console.error('Internationalization was not initialized properly. error: ', err)
   }
 })
+
+export default i18next

--- a/yarn.lock
+++ b/yarn.lock
@@ -5388,6 +5388,10 @@ https-proxy-agent@^2.2.0:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+i18next@^11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-11.5.0.tgz#1e8df15d5d7e96b27da964abde6e7367169fb4c1"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"


### PR DESCRIPTION
*Overview*

Add the i18next library (https://www.i18next.com/overview/api) to help organize our copy. 

Start off by moving tooltip copy into translations json file.