### PR TITLE
 fix(api): maintain speed state after collision recovery

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -872,8 +872,8 @@ class SmoothieDriver_3_0_0:
         log.debug("_home_x")
         # move the gantry forward on Y axis with low power
         self._save_current({'Y': Y_BACKOFF_LOW_CURRENT})
-        self.push_speed()
-        self.set_speed(Y_BACKOFF_SLOW_SPEED)
+        self.push_axis_max_speed()
+        self.set_axis_max_speed({'Y': Y_BACKOFF_SLOW_SPEED})
 
         # move away from the Y endstop switch, then backward half that distance
         relative_retract_command = '{0} {1}Y{2} {3}Y{4} {5}'.format(
@@ -888,13 +888,11 @@ class SmoothieDriver_3_0_0:
         command = '{0} {1}'.format(
             self._generate_current_command(), relative_retract_command)
         self._send_command(command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
-        self.pop_speed()
         self.dwell_axes('Y')
 
         # now it is safe to home the X axis
         try:
             # override firmware's default XY homing speed, to avoid resonance
-            self.push_axis_max_speed()
             self.set_axis_max_speed({'X': XY_HOMING_SPEED})
             self.activate_axes('X')
             command = '{0} {1}'.format(

--- a/api/opentrons/tools/gantry_test.py
+++ b/api/opentrons/tools/gantry_test.py
@@ -9,11 +9,13 @@ Author: Carlos Fernandez
 """
 
 from opentrons import robot
-from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieError
+from opentrons.drivers.smoothie_drivers.driver_3_0 import \
+    SmoothieError, DEFAULT_AXES_SPEED
 
 
 def setup_motor_current():
     # only set the current, keeping all other settings at the driver's default
+    robot._driver.set_speed(DEFAULT_AXES_SPEED)
     x_current = robot.config.high_current['X'] * 0.85
     y_current = robot.config.high_current['Y'] * 0.85
     robot._driver.set_active_current(

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -212,9 +212,8 @@ def test_plunger_commands(smoothie, monkeypatch):
     expected = [
         ['M907 A0.8 B0.5 C0.5 X0.3 Y0.3 Z0.8 G4P0.005 G28.2.+[ABCZ].+ M400'],
         ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'],
-        ['G0F3000 M400'],
+        ['M203.1 Y50 M400'],
         ['M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4P0.005 G91 G0Y-28 G0Y10 G90 M400'],  # NOQA
-        ['G0F24000 M400'],
         ['M203.1 X80 M400'],
         ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G28.2X M400'],
         ['M203.1 A125 B50 C50 X600 Y400 Z125 M400'],


### PR DESCRIPTION
## overview

Fix a bug involving pushing/popping gantry speeds, causing one the the QC scripts to move very slowly after 1 cycle. This PR avoids the issue in the QC script by explicitly setting the speed there. But then also we address the underlying problem in the driver, which simply involved replacing any calls to `self.push_speed()` to be instead `self.push_axis_max_speed()`

The bug happens in the following scenario:
```python
try:
    driver.push_speed()  # save the current combined speed (400 mm/sec)
    driver.set_speed(10)  # set to a slower speed
    driver.move({'X': 430})  # hits the switch, forcing a home
except SmoothieError:
    driver.pop_speed()  # ERROR OCCURS HERE, b/c previously "pushed" speed was overwritten
    # the driver has now been set to the (unexpected) speed of 10 mm/sec
```
Here is the sequence of the events in the driver that cause this:

1. The X axis hits its limit switch, which...
2. forces an automatic home on the X, which...
3. then runs `driver._home_x()`, which...
4. then calls `driver.push_speed()` on whatever the current speed happens to be
5. in the example above, that means that the pushed speed is now 10mm/sec