### PR TITLE
feat(api): Add tempdeck api object

### DIFF
--- a/api/opentrons/config/containers/default-containers.json
+++ b/api/opentrons/config/containers/default-containers.json
@@ -5531,6 +5531,22 @@
                     }
                }
           },
+          "tempdeck": {
+               "origin-offset": {
+                    "x": 0,
+                    "y": 0
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 0,
+                         "depth": 80.09,
+                         "length": 127.8,
+                         "width": 85.6
+                    }
+               }
+          },
           "trash-box": {
                "origin-offset": {
                     "x": 42.75,

--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -11,7 +11,7 @@ from opentrons.util.vector import Vector
 from opentrons.config import feature_flags as ff
 
 
-SUPPORTED_MODULES = ['magdeck']
+SUPPORTED_MODULES = ['magdeck', 'tempdeck']
 
 
 def unpack_location(location):
@@ -290,9 +290,12 @@ class Placeable(object):
         """
         Returns the module placeable if present
         """
-        res = list(map(lambda x: self.get_child_by_name(x), SUPPORTED_MODULES))
-        # No probability of a slot having more than one module
-        return res[0] if len(res) > 0 else None
+        for md in SUPPORTED_MODULES:
+            maybe_module = self.get_child_by_name(md)
+            if maybe_module:
+                # No probability of a placeable having more than one module
+                return maybe_module
+        return None
 
     def get_parent(self):
         """

--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -11,7 +11,7 @@ from opentrons.data_storage import serializers
 from opentrons.config import feature_flags as fflags
 import logging
 
-SUPPORTED_MODULES = ['magdeck']
+SUPPORTED_MODULES = ['magdeck', 'tempdeck']
 
 log = logging.getLogger(__file__)
 database_path = environment.get_path('DATABASE_FILE')

--- a/api/opentrons/drivers/temp_deck/driver.py
+++ b/api/opentrons/drivers/temp_deck/driver.py
@@ -194,6 +194,7 @@ class TempDeck:
             return None
         return self._connection.port
 
+    # TODO: change to 'deactivate'/'stop'
     def disengage(self) -> str:
         self.run_flag.wait()
 
@@ -234,6 +235,23 @@ class TempDeck:
     @property
     def temperature(self) -> int:
         return self._temperature.get('current')
+
+    @property
+    def status(self) -> str:
+        self.update_temperature()
+        current = self._temperature.get('current')
+        target = self._temperature.get('target')
+        delta = 0.7
+        if target:
+            diff = target - current
+            if abs(diff) < delta:   # To avoid status fluctuation near target
+                return 'holding at target'
+            elif diff < 0:
+                return 'cooling'
+            else:
+                return 'heating'
+        else:
+            return 'idle'
 
     def get_device_info(self) -> dict:
         '''

--- a/api/opentrons/modules/__init__.py
+++ b/api/opentrons/modules/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging
 from opentrons import robot, labware
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
-
+from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 
 log = logging.getLogger(__name__)
 
@@ -35,9 +35,9 @@ def discover_devices(module_prefix):
 
 
 class MagDeck:
-    '''
-    Under development. API subject to change
-    '''
+    """
+    Under development. API subject to change without a version bump
+    """
     def __init__(self, lw):
         self.labware = lw
         self.driver = MagDeckDriver()
@@ -46,43 +46,36 @@ class MagDeck:
         self._device_info = self.driver.get_device_info()
 
     def calibrate(self):
-        '''
+        """
         Calibration involves probing for top plate to get the plate height
-        '''
+        """
         if not robot.is_simulating():
             self.driver.probe_plate()
             # return if successful or not?
             self._engaged = False
 
     def engage(self):
-        '''
+        """
         Move the magnet to plate top - 1 mm
-        '''
+        """
         if not robot.is_simulating():
             self.driver.move(self.driver.plate_height - 1.0)
             self._engaged = True
 
     def disengage(self):
-        '''
+        """
         Home the magnet
-        '''
+        """
         if not robot.is_simulating():
             self.driver.home()
             self._engaged = False
 
-    def disconnect(self):
-        '''
-        Disconnect the serial connection
-        '''
-        if not robot.is_simulating():
-            self.driver.disconnect()
-
     def connect(self):
-        '''
+        """
         Connect to the 'MagDeck' port
         Planned change- will connect to the correct port in case of multiple
         MagDecks
-        '''
+        """
         if not robot.is_simulating():
             ports = discover_devices('MagDeck')
             # Connect to the first module. Need more advanced selector to
@@ -90,13 +83,123 @@ class MagDeck:
             port = ports[0] if len(ports) > 0 else None
             self.driver.connect(port)
 
+    def disconnect(self):
+        """
+        Disconnect the serial connection
+        """
+        if not robot.is_simulating():
+            self.driver.disconnect()
+
     @property
     def device_info(self):
+        """
+        Returns a dict:
+        {
+                'serial': '1aa11bb22',
+                'model': '1aa11bb22',
+                'version': '1aa11bb22'
+        }
+        """
         return self._device_info
 
     @property
     def status(self):
+        """
+        Returns a string: 'engaged'/'disengaged'
+        """
         return 'engaged' if self._engaged else 'disengaged'
 
 
-SUPPORTED_MODULES = {'magdeck': MagDeck}
+class TempDeck:
+    """
+    Under development. API subject to change without a version bump
+    """
+    def __init__(self, lw):
+        self.labware = lw
+        self.driver = TempDeckDriver()
+        self.connect()
+        self._device_info = self.driver.get_device_info()
+
+    def set_temperature(self, celsius):
+        """
+        Set temperature in degree Celsius
+        Range: -9 to 99 degree Celsius.
+        The range is limited by the 2-digit temperature display. Any input
+        outside of this range will be clipped to the nearest limit
+        """
+        if not robot.is_simulating():
+            self.driver.set_temperature(celsius)
+
+    def deactivate(self):
+        """
+        Stop heating/cooling and turn off the fan
+        """
+        if not robot.is_simulating():
+            self.driver.disengage()
+
+    def _wait_for_temp(self):
+        """
+        This method exits only if set temperature has reached.Subject to change
+        """
+        if not robot.is_simulating():
+            while self.status != 'holding at target':
+                pass
+
+    def connect(self):
+        """
+        Connect to the 'TempDeck' port
+        Planned change- will connect to the correct port in case of multiple
+        TempDecks
+        """
+        if not robot.is_simulating():
+            ports = discover_devices('TempDeck')
+            # Connect to the first module. Need more advanced selector to
+            # support more than one of the same type of module
+            port = ports[0] if len(ports) > 0 else None
+            self.driver.connect(port)
+
+    def disconnect(self):
+        """
+        Disconnect the serial connection
+        """
+        if not robot.is_simulating():
+            self.driver.disconnect()
+
+    @property
+    def device_info(self):
+        """
+        Returns a dict:
+        {
+                'serial': '1aa11bb22',
+                'model': '1aa11bb22',
+                'version': '1aa11bb22'
+        }
+        """
+        return self._device_info
+
+    @property
+    def temperature(self):
+        """
+        Current temperature in degree celsius
+        """
+        self.driver.update_temperature()
+        return self.driver.temperature
+
+    @property
+    def target(self):
+        """
+        Target temperature in degree celsius.
+        Returns None if no target set
+        """
+        self.driver.update_temperature()
+        return self.driver.target
+
+    @property
+    def status(self):
+        """
+        Returns a string: 'heating'/'cooling'/'holding at target'/'idle'
+        """
+        return self.driver.status
+
+
+SUPPORTED_MODULES = {'magdeck': MagDeck, 'tempdeck': TempDeck}

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -2,6 +2,7 @@
 import pytest
 from opentrons import robot, labware, modules
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
+from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 
 
 @pytest.fixture
@@ -11,9 +12,21 @@ def non_simulating():
     robot._driver.simulating = True
 
 
-def test_load_container_onto_module():
+def test_load_container_onto_magdeck():
     module_name = 'magdeck'
-    slot = '4'
+    slot = '1'
+
+    md = modules.load(module_name, slot)
+    assert md.labware.parent == robot._deck[slot]
+
+    test_container = labware.load('96-flat', slot, share=True)
+    assert test_container.parent == md.labware
+
+
+def test_load_container_onto_tempdeck():
+    module_name = 'tempdeck'
+    slot = '2'
+
     md = modules.load(module_name, slot)
     assert md.labware.parent == robot._deck[slot]
 
@@ -29,11 +42,12 @@ def test_simulating(virtual_smoothie_env, monkeypatch):
         connected = True
 
     monkeypatch.setattr(MagDeckDriver, 'connect', mock_connect)
-    modules.load('magdeck', '1')
+    modules.load('magdeck', '3')
     assert not connected
 
 
-def test_run_connected(non_simulating, virtual_smoothie_env, monkeypatch):
+def test_run_magdeck_connected(
+        non_simulating, virtual_smoothie_env, monkeypatch):
     connected = False
 
     def mock_connect(self, port):
@@ -41,5 +55,18 @@ def test_run_connected(non_simulating, virtual_smoothie_env, monkeypatch):
         connected = True
 
     monkeypatch.setattr(MagDeckDriver, 'connect', mock_connect)
-    modules.load('magdeck', '2')
+    modules.load('magdeck', '4')
+    assert connected
+
+
+def test_run_tempdeck_connected(
+        non_simulating, virtual_smoothie_env, monkeypatch):
+    connected = False
+
+    def mock_connect(self, port):
+        nonlocal connected
+        connected = True
+
+    monkeypatch.setattr(TempDeckDriver, 'connect', mock_connect)
+    modules.load('tempdeck', '5')
     assert connected


### PR DESCRIPTION


## overview
This PR adds the TempDeck api object which is implemented similar to the MagDeck api object. Closes #1648 
A TempDeck will be loaded with ```modules.load('tempdeck', <slot number>)``` 
Available TempDeck methods are:
1. ```connect()```
2. ```set_temperature(celsius)```
3. ```disengage()```
4. ```disconnect()```
And properties are:
1. ```device_info```: returns a dict of ```{ 'serial': '', 'model':'', 'version':'' }```
2. ```temperature```: gives current TempDeck temperature
3. ```target```: gives target temperature if set or None
4. ```status```: returns a string- ```heating```, ```cooling```, ```disengaged``` or ```holding at target```

## changelog

- Added ```TempDeck``` modules class
- Added a driver method to determine status based on current and target temperatures
- Fixed a problem with the ```get_modules()``` method in ```placeable.py``` so that it returns the actual found module in a slot and not the first element of list returned by the lambda function (which includes results of checks for non-connected modules as well, i.e, 'None' values)
- Added tempdeck load and connect tests
- Added tempdeck container definition

## review requests
Please review the changed files for any corrections/suggestions, esp tempdeck methods and properties. The api implementation has been successfully tested on a robot by uploading a basic protocol that loads a PCR plate on the tempdeck, heats it to 40C and distributes sample to wells while holding it to the target temperature, then disengages in the end.
<!--
  Describe any requests for your reviewers here.
-->
## Known Issues ##
- Need to revisit SUPPORTED_MODULES definition