### PR TITLE
feat(protocol-designer): save version in PD file with git-describe

### DIFF
--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -27,3 +27,7 @@ Use them like: `OT_PD_COOL_FLAG=true OT_PD_SWAG_FLAG=100 make dev`.
 ### `OT_PD_SHOW_WARNINGS`
 
 Shows warning AlertItems (which are hidden by default) when `process.env.OT_PD_SHOW_WARNINGS === 'true'`
+
+### `OT_PD_VERSION`
+
+Defaults to the `git describe` version specified in the Webpack build. This version string is saved to the `designer-application.application-name` field in PD files.

--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -30,4 +30,4 @@ Shows warning AlertItems (which are hidden by default) when `process.env.OT_PD_S
 
 ### `OT_PD_VERSION`
 
-Defaults to the `git describe` version specified in the Webpack build. This version string is saved to the `designer-application.application-name` field in PD files.
+Defaults to the `git describe` version specified in the Webpack build. This version string is saved to the `designer-application.application-version` field in PD files.

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "flow-bin": "^0.76.0",
-    "flow-typed": "^2.5.1"
+    "flow-typed": "^2.5.1",
+    "git-describe": "^4.0.3"
   }
 }

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -12,7 +12,7 @@ import type {LabwareData, PipetteData} from '../../step-generation'
 
 // TODO LATER Ian 2018-02-28 deal with versioning
 const protocolSchemaVersion = '1.0.0'
-const applicationVersion = '1.0.0'
+const applicationVersion = process.env.OT_PD_VERSION || 'unknown version'
 
 export const createFile: BaseState => ProtocolFile = createSelector(
   fileMetadata,

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -5,9 +5,26 @@ const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 const {rules} = require('@opentrons/webpack-config')
+const {gitDescribeSync} = require('git-describe')
 
 const DEV = process.env.NODE_ENV !== 'production'
 const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
+
+const gitInfo = gitDescribeSync()
+const OT_PD_VERSION = gitInfo && gitInfo.raw
+
+const passThruEnvVars = Object.keys(process.env)
+  .filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX))
+  .concat(['NODE_ENV'])
+
+const envVarsWithDefaults = {OT_PD_VERSION}
+
+const envVars = passThruEnvVars.reduce((acc, envVar) =>
+  ({[envVar]: '', ...acc}),
+  {...envVarsWithDefaults}
+)
+
+console.log('PD version: ' + (process.env.OT_PD_VERSION || OT_PD_VERSION || 'UNKNOWN!'))
 
 module.exports = {
   entry: [
@@ -34,11 +51,7 @@ module.exports = {
   devtool: DEV ? 'eval-source-map' : 'source-map',
 
   plugins: [
-    new webpack.EnvironmentPlugin(
-      Object.keys(process.env).filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX)).concat([
-        'NODE_ENV'
-      ])
-    ),
+    new webpack.EnvironmentPlugin(envVars),
 
     new ExtractTextPlugin({
       filename: 'bundle.css',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4804,6 +4804,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-describe@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/git-describe/-/git-describe-4.0.3.tgz#d81482a8ada7a1d81e060d438ac8e11b4a390336"
+  dependencies:
+    lodash "^4.16.6"
+  optionalDependencies:
+    semver "^5.3.0"
+
 git-raw-commits@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.6.tgz#27c35a32a67777c1ecd412a239a6c19d71b95aff"
@@ -6677,7 +6685,7 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.17.5:
+lodash@^4.16.6, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
## overview

No ticket for this! For PD closed beta, we'll ask users to send us their files with their feedback. It's hard to trace down bugs if we don't know the version. Having PD's version saved in the file will also help with backwards compatibility issues (even if that's just saying, "this old file is no longer supported"). 

Since PD is kinda stuck with the monorepo version until we figure something else out, it can't really follow semver itself without some monorepo versioning changes. So for now, this PR just uses https://github.com/tvdstaaij/node-git-describe defaults, with commit distance and hash from the last git tag (if different from the tag). It's running `git describe --dirty`.

I figured we could keep the `-dirty` suffix because it might disambiguate cases where a developer saves a file using some intermediate version of PD that doesn't actually correspond to a commit.

In the future, we might want to tag PD versions when PD has breaking changes regarding its own file metadata structure, and then we can use `match` to filter PD-specific tags with regex.

## changelog

- add git-describe npm module
- save `git describe` "version" in `designer-application.application-name` in PD files

## review requests

- `make -C protocol-designer/ dev` will log `PD version: v3.3.0-beta.0-62-COMMIT_HASH_HERE` in your console
- Saving/exporting a file will put that value into `designer-application.application-name` in the JSON file
- Does this "version" makes sense for the next few weeks while we figure out versioning PD vs monorepo?
- Does `git-describe` seem like a good choice
- This works in Travis (use the S3 url and save a file)
