### PR TITLE
feat(components): restyle field caption

### DIFF
--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -52,8 +52,8 @@
   border: 1px solid var(--c-warning);
 
   & > .title_bar {
-    background-color: var(--c-bg-warning);
-    color: var(--c-warningdark);
+    background-color: var(--c-warning-light);
+    color: var(--c-warning-dark);
 
     & svg {
       fill: var(--c-warning);

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -47,7 +47,7 @@
   }
 
   &.error {
-    color: var(--c-mustard);
+    color: var(--c-warning-dark);
   }
 }
 
@@ -104,6 +104,7 @@
 .input_caption {
   padding-top: 0.25rem;
   font-size: var(--fs-caption);
+  font-weight: var(--fw-semibold);
   min-height: var(--fs-caption);
   color: var(--c-med-gray);
 
@@ -152,15 +153,12 @@
 
 .error div,
 .error span {
-  color: var(--c-mustard);
+  color: var(--c-warning-dark);
 }
 
-.error select {
-  background-color: var(--c-mustard);
-}
-
+.error select,
 .error .input_field {
-  background-color: var(--c-mustard);
+  background-color: var(--c-warning-light);
 }
 
 .error_icon {

--- a/components/src/styles/colors.css
+++ b/components/src/styles/colors.css
@@ -15,13 +15,13 @@
   --c-bg-selected: #f0f3ff;
   --c-bg-hover: #f1f1f1;
   --c-bg-success: #b6febc;
-  --c-bg-warning: #ffd58f;
 
   /* general UI */
   --c-highlight: #5fd8ee;
   --c-selected-dark: #00c3e6;
+  --c-warning-dark: #9e5e00;
   --c-warning: #e28200;
-  --c-warningdark: #9e5e00;
+  --c-warning-light: #ffd58f;
   --c-success: #60b120;
 
   /* Misc */


### PR DESCRIPTION
## overview

Closes #1936

![image](https://user-images.githubusercontent.com/11590381/43543929-74ce48b4-959f-11e8-9cd7-0100a65f50d5.png)


## changelog

- rename --c-bg-warning to --c-warning-light to match zeplin
- rename --c-warningdark to --c-warning-dark for consistency
- restyle caption and error caption of InputField

## review requests

:baby_chick: 
