### PR TITLE
feat(protocol-designer): add max volume to ingred selection modal volume field

### DIFF
--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -22,9 +22,9 @@ type Props = {
   /** if included, InputField will use error style and display error instead of caption */
   error?: ?string,
   /** optional caption. hidden when `error` is given */
-  caption?: string,
+  caption?: ?string,
   /** appears to the right of the caption. Used for character limits, eg '0/45' */
-  secondaryCaption?: string,
+  secondaryCaption?: ?string,
   /** optional input type (default "text") */
   type?: 'text' | 'password',
   /** mouse click handler */

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -33,6 +33,7 @@ type FieldProps = {|
   label?: string,
   units?: string,
   error?: ?string,
+  caption?: ?string,
   placeholder?: string,
   className?: string
 |}
@@ -48,6 +49,7 @@ const makeInputField = (args: {setSubstate: SetSubstate, getSubstate: GetSubstat
         label={props.label}
         units={props.units}
         error={props.error}
+        caption={props.caption}
         placeholder={placeholder}
         value={(getSubstate(accessor) || '').toString()}
         onChange={(e: SyntheticInputEvent<HTMLInputElement>) =>
@@ -252,7 +254,8 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
     const {
       onCancel,
       allIngredientNamesIds,
-      selectedWells
+      selectedWells,
+      selectedWellsMaxVolume
     } = this.props
 
     const {commonIngredGroupId} = this.state
@@ -326,6 +329,9 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
                 numeric
                 accessor='volume'
                 units='µL'
+                caption={isFinite(selectedWellsMaxVolume)
+                  ? `max ${selectedWellsMaxVolume}`
+                  : null}
                 error={visibleErrors.volume}
               />
             </FormGroup>

--- a/protocol-designer/src/components/IngredientPropertiesForm.js
+++ b/protocol-designer/src/components/IngredientPropertiesForm.js
@@ -329,7 +329,7 @@ class IngredientPropertiesForm extends React.Component<Props, State> {
                 numeric
                 accessor='volume'
                 units='µL'
-                caption={isFinite(selectedWellsMaxVolume)
+                caption={Number.isFinite(selectedWellsMaxVolume)
                   ? `max ${selectedWellsMaxVolume}`
                   : null}
                 error={visibleErrors.volume}


### PR DESCRIPTION
## overview

Closes #1835

## changelog

- for ingredient selection modal, the volume field contains caption "max {volume}", unless it's showing an error

## review requests

:alembic: 