### PR TITLE
feat(protocol-designer): update copy for 'no tip on pipette' error

### DIFF
--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -51,7 +51,7 @@ const errorOverrides: {[ErrorType]: AlertContent} = {
   },
   'NO_TIP_ON_PIPETTE': {
     title: 'No tip on pipette',
-    body: 'For the first step in a protocol the "change tip" setting must be set to always or once.'
+    body: 'The first time a pipette is used in a protocol the "change tip" setting must be set to always or once.'
   }
 }
 


### PR DESCRIPTION
## overview

Closes #1975


Was: `For the first step in a protocol the "change tip" setting must be set to always or once.`

Now: `The first time a pipette is used in a protocol the "change tip" setting must be set to always or once.`

## changelog


## review requests

:bulb: 