### PR TITLE
fix(config): change udev rule to include multiple modules

### DIFF
--- a/api/opentrons/config/modules/95-opentrons-modules.rules
+++ b/api/opentrons/config/modules/95-opentrons-modules.rules
@@ -1,2 +1,2 @@
-SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="ttyTempDeck"
-SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="ttyMagDeck"
+KERNEL=="ttyACM[0-9]*" SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
+KERNEL=="ttyACM[0-9]*" SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"

--- a/api/opentrons/modules/__init__.py
+++ b/api/opentrons/modules/__init__.py
@@ -23,12 +23,12 @@ def load(name, slot):
 
 def discover_devices(module_prefix):
     if os.environ.get('RUNNING_ON_PI'):
-        devices = os.listdir('/dev')
+        devices = os.listdir('/dev/modules')
     else:
         devices = []
     matches = filter(
-        lambda x: x.startswith('tty{}'.format(module_prefix)), devices)
-    res = list(map(lambda x: '/dev/{}'.format(x), matches))
+        lambda x: x.endswith('_{}'.format(module_prefix)), devices)
+    res = list(map(lambda x: '/dev/modules/{}'.format(x), matches))
     log.debug('Discovered devices for prefix {}: {}'.format(
         module_prefix, res))
     return res
@@ -77,7 +77,7 @@ class MagDeck:
         MagDecks
         """
         if not robot.is_simulating():
-            ports = discover_devices('MagDeck')
+            ports = discover_devices('magdeck')
             # Connect to the first module. Need more advanced selector to
             # support more than one of the same type of module
             port = ports[0] if len(ports) > 0 else None
@@ -152,7 +152,7 @@ class TempDeck:
         TempDecks
         """
         if not robot.is_simulating():
-            ports = discover_devices('TempDeck')
+            ports = discover_devices('tempdeck')
             # Connect to the first module. Need more advanced selector to
             # support more than one of the same type of module
             port = ports[0] if len(ports) > 0 else None


### PR DESCRIPTION

## overview

This PR changes the way a module node is created in /dev
All modules will be symlinked to `/dev/modules/` with a naming standard of `/ttyN_tempdeck`, `/ttyN_magdeck`, etc where N will be the number corresponding to the original port name assigned by the os. So, a magdeck at path `/dev/ttyACM1` will have a symlink at `/dev/modules/tty1_magdeck`

## changelog

- Changed udev rules file in `/config/modules`
- Made appropriate changes to modules api objects to switch to above change

