### PR TITLE
feat(protocol-designer): add 'drop tip' to 'dispense' section of form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -94,6 +94,7 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
         <div className={formStyles.row_wrapper}>
           <div className={styles.left_settings_column}>
             <FormGroup label='TECHNIQUE'>
+              <StepCheckboxRow name="dispense_touchTip" label="Touch tip" />
               <StepCheckboxRow name="dispense_mix_checkbox" label='Mix'>
                 <StepInputField name="dispense_mix_volume" units="μL" {...focusHandlers} />
                 <StepInputField name="dispense_mix_times" units="Times" {...focusHandlers} />

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -69,6 +69,7 @@ export type TransferLikeForm = {|
   'volume'?: string,
   'dispense_labware'?: string,
   'dispense_wells'?: Array<string>,
+  'dispense_touchTip'?: boolean,
   'dispense_mix_checkbox'?: boolean,
   'dispense_mix_volume'?: string,
   'dispense_mix_times'?: string

--- a/protocol-designer/src/steplist/fieldLevel/types.js
+++ b/protocol-designer/src/steplist/fieldLevel/types.js
@@ -20,6 +20,7 @@ export type StepFieldName =
   | 'dispense_delayMinutes'
   | 'dispense_delaySeconds'
   | 'dispense_labware'
+  | 'dispense_touchTip'
   | 'dispense_mix_checkbox'
   | 'dispense_mix_times'
   | 'dispense_mix_volume'

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -157,7 +157,7 @@ function _vapTransferLike (
     mixInDestination,
     preWetTip: formData['aspirate_preWetTip'] || false,
     touchTipAfterAspirate: formData['aspirate_touchTip'] || false,
-    touchTipAfterDispense: false, // TODO Ian 2018-03-01 Not in form
+    touchTipAfterDispense: formData['dispense_touchTip'] || false,
     description: 'description would be here 2018-03-01' // TODO get from form
   }
 


### PR DESCRIPTION
## overview

Closes #1689

Command creators & tests already are set up for this! Just needed to hook up the form.

## changelog

- Add "drop tip" to "Dispense" section of transfer-like forms

## review requests

Check that this is working in transfer/distribute/consolidate -- inspect the JSON for drop-tip commands after dispense commands.