### PR TITLE
fix(api): support touch-tip for JSON protocols

### DIFF
--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -65,7 +65,8 @@ def get_pipette(command_params, loaded_pipettes):
     return loaded_pipettes.get(pipetteId)
 
 
-def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):
+# C901 code complexity is due to long elif block, ok in this case (Ian+Ben)
+def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: C901 E501
     subprocedures = [
         p.get('subprocedure', [])
         for p in protocol_data.get('procedure', [])]

--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -103,6 +103,9 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):
         elif command_type == 'dispense':
             pipette.dispense(volume, location)
 
+        elif command_type == 'touch-tip':
+            pipette.touch_tip(location)
+
 
 def execute_protocol(protocol):
     loaded_pipettes = load_pipettes(protocol)


### PR DESCRIPTION
## overview

Closes #1997 -- oops...

## changelog

- adds "touch-tip" command support for JSON protocols

## review requests

Code review

I tested on Sunset, if you feel like it you can test too. Requires `make push`

Latest PD artifact https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/edge/index.html should work fine with this for a test protocol. Or I'll Slack you a .json protocol with some "touch-tip" commands for testing this if you want.