### PR TITLE
feat(protocol-designer): rename change tip options

### DIFF
--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -59,7 +59,7 @@ const MixForm = (props: MixFormProps): React.Element<React.Fragment> => {
           </FormGroup>
         </div>
         <div className={styles.right_settings_column}>
-          <ChangeTipField name="aspirate_changeTip" />
+          <ChangeTipField stepType="mix" name="aspirate_changeTip" />
           <FlowRateField />
           <TipPositionField />
         </div>

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -68,7 +68,7 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
             </FormGroup>
           </div>
           <div className={styles.right_settings_column}>
-            <ChangeTipField name="aspirate_changeTip" />
+            <ChangeTipField stepType={stepType} name="aspirate_changeTip" />
             <FlowRateField />
             <TipPositionField />
           </div>

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -181,22 +181,36 @@ export const FlowRateField = () => <FormGroup label='FLOW RATE'>Default</FormGro
 // this is a placeholder
 export const TipPositionField = () => <FormGroup label='TIP POSITION'>Bottom, center</FormGroup>
 
-const CHANGE_TIP_OPTIONS = [
-  {name: 'Always', value: 'always'},
-  {name: 'Once', value: 'once'},
+const getChangeTipOptions = () => [
+  {name: 'For each aspirate', value: 'always'},
+  {name: 'Only the first aspirate', value: 'once'},
   {name: 'Never', value: 'never'}
 ]
+
 // NOTE: ChangeTipField not validated as of 6/27/18 so no focusHandlers needed
-type ChangeTipFieldProps = {name: StepFieldName}
-export const ChangeTipField = (props: ChangeTipFieldProps) => (
-  <StepField
-    name={props.name}
-    render={({value, updateValue}) => (
-      <FormGroup label='CHANGE TIP'>
-        <DropdownField
-          options={CHANGE_TIP_OPTIONS}
-          value={value ? String(value) : null}
-          onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
-      </FormGroup>
-    )} />
-)
+type ChangeTipFieldProps = {name: StepFieldName, stepType: StepType}
+export const ChangeTipField = (props: ChangeTipFieldProps) => {
+  const {name, stepType} = props
+  let options = getChangeTipOptions()
+  // Override change tip option names for certain step types
+  switch (stepType) {
+    case 'consolidate':
+      options[0].name = 'For each dispense'
+      break
+    case 'mix':
+      options[0].name = 'For each well'
+      break
+  }
+  return (
+    <StepField
+      name={name}
+      render={({value, updateValue}) => (
+        <FormGroup label='Get new tip'>
+          <DropdownField
+            options={options}
+            value={value ? String(value) : null}
+            onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
+        </FormGroup>
+      )} />
+  )
+}

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -47,3 +47,5 @@ export const FIXED_TRASH_ID: 'trashId' = 'trashId'
 
 export const START_TERMINAL_TITLE = 'STARTING DECK STATE'
 export const END_TERMINAL_TITLE = 'FINAL DECK STATE'
+
+export const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -21,8 +21,6 @@ export type {
   StepFieldName
 }
 
-const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'
-
 const hydrateLabware = (state, id) => (labwareIngredSelectors.getLabware(state)[id])
 
 type StepFieldHelpers = {
@@ -34,9 +32,6 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   'aspirate_labware': {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware
-  },
-  'changeTip': {
-    processValue: defaultTo(DEFAULT_CHANGE_TIP_OPTION)
   },
   'dispense_delayMinutes': {
     processValue: composeProcessors(castToNumber, defaultTo(0))

--- a/protocol-designer/src/steplist/formProcessing.js
+++ b/protocol-designer/src/steplist/formProcessing.js
@@ -17,9 +17,10 @@ import type {
   CommandCreatorData
 } from '../step-generation'
 
-import {FIXED_TRASH_ID} from '../constants'
-
-const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'
+import {
+  DEFAULT_CHANGE_TIP_OPTION,
+  FIXED_TRASH_ID
+} from '../constants'
 
 // TODO LATER Ian 2018-03-01 remove or consolidate these 2 similar types?
 export type ValidFormAndErrors = {
@@ -55,13 +56,14 @@ export const generateNewForm = (stepId: StepIdType, stepType: StepType): BlankFo
   if (stepType === 'transfer' || stepType === 'consolidate' || stepType === 'mix') {
     return {
       ...baseForm,
-      'aspirate_changeTip': 'once'
+      'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION
     }
   }
 
   if (stepType === 'distribute') {
     return {
       ...baseForm,
+      'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
       'aspirate_disposalVol_checkbox': true,
       'dispense_blowout_checkbox': true,
       'dispense_blowout_labware': FIXED_TRASH_ID


### PR DESCRIPTION
## overview

Closes #1933 and addresses part of #1934 

![image](https://user-images.githubusercontent.com/11590381/43612735-3d480a7e-967b-11e8-8080-61bab0698cbd.png)

## changelog

- rename change tip options
- fix bug with forms defaulting to blank change tip option

## review requests

- make sure change tip options match #1933 
- for all step types, Change Tip should default to "Always" (the first option), and never default to being blank (as was previous behavior for everything but maybe Distribute)