### PR TITLE
feat(app): Add persistent unique user ID to intercom data

### DIFF
--- a/app-shell/lib/config.js
+++ b/app-shell/lib/config.js
@@ -45,13 +45,20 @@ const DEFAULTS = {
     }
   },
 
-  // analytics
+  // analytics (mixpanel)
   analytics: {
     appId: uuid(),
     optedIn: false,
     seenOptIn: false
-  }
+  },
 
+  // user support (intercom)
+  support: {
+    userId: uuid(),
+    createdAt: Math.floor(Date.now() / 1000),
+    name: 'App User',
+    email: null
+  }
 }
 
 // lazy load store, overrides, and log because of config/log interdependency

--- a/app-shell/lib/config.js
+++ b/app-shell/lib/config.js
@@ -56,7 +56,7 @@ const DEFAULTS = {
   support: {
     userId: uuid(),
     createdAt: Math.floor(Date.now() / 1000),
-    name: 'App User',
+    name: 'Unknown User',
     email: null
   }
 }

--- a/app/src/analytics/index.js
+++ b/app/src/analytics/index.js
@@ -1,7 +1,6 @@
 // @flow
 // analytics module
 import noop from 'lodash/noop'
-import {LOCATION_CHANGE} from 'react-router-redux'
 import mixpanel from 'mixpanel-browser'
 
 import type {State, ThunkAction, Middleware} from '../types'
@@ -17,7 +16,6 @@ type AnalyticsConfig = $PropertyType<Config, 'analytics'>
 const log = createLogger(__filename)
 
 // pulled in from environment at build time
-const INTERCOM_ID = process.env.OT_APP_INTERCOM_ID
 const MIXPANEL_ID = process.env.OT_APP_MIXPANEL_ID
 
 const MIXPANEL_OPTS = {
@@ -29,8 +27,7 @@ const MIXPANEL_OPTS = {
   track_pageview: false
 }
 
-// intercom and mixpanel.track handlers (noop)
-let intercom = noop
+// mixpanel.track handler (default noop)
 let track = noop
 
 export function initializeAnalytics (): ThunkAction {
@@ -38,7 +35,6 @@ export function initializeAnalytics (): ThunkAction {
     const config = getState().config.analytics
 
     log.debug('Analytics config', {config})
-    initializeIntercom(config)
     initializeMixpanel(config)
   }
 }
@@ -64,11 +60,6 @@ export const analyticsMiddleware: Middleware =
       track(event.name, event.properties)
     }
 
-    // update intercom on page change
-    if (action.type === LOCATION_CHANGE) {
-      intercom('update')
-    }
-
     // enable mixpanel tracking if optedIn goes to true
     if (
       action.type === 'config:SET' &&
@@ -92,17 +83,6 @@ export function getAnalyticsOptedIn (state: State) {
 
 export function getAnalyticsSeen (state: State) {
   return state.config.analytics.seenOptIn
-}
-
-function initializeIntercom (config: AnalyticsConfig) {
-  if (INTERCOM_ID) {
-    log.debug('Initializing Intercom')
-
-    const data = {app_id: INTERCOM_ID, 'App Version': version}
-
-    intercom = global.Intercom || intercom
-    intercom('boot', data)
-  }
 }
 
 function initializeMixpanel (config: AnalyticsConfig) {

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -38,6 +38,13 @@ export type Config = {
     optedIn: boolean,
     seenOptIn: boolean,
   },
+
+  support: {
+    userId: string,
+    createdAt: number,
+    name: string,
+    email: ?string,
+  },
 }
 
 type UpdateConfigAction = {|

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -14,6 +14,7 @@ import {checkForShellUpdates, shellMiddleware} from './shell'
 import {healthCheckMiddleware} from './health-check'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {initializeAnalytics, analyticsMiddleware} from './analytics'
+import {initializeSupport, supportMiddleware} from './support'
 
 import reducer from './reducer'
 
@@ -30,6 +31,7 @@ const middleware = applyMiddleware(
   shellMiddleware,
   healthCheckMiddleware,
   analyticsMiddleware,
+  supportMiddleware,
   routerMiddleware(history)
 )
 
@@ -59,13 +61,12 @@ if (module.hot) {
   module.hot.accept('./components/App', renderApp)
 }
 
-// TODO(mc, 2018-03-29): developer mode in app settings
-if (process.env.NODE_ENV === 'development') {
-  global.store = store
-}
+// attach store to window if devtools are on
+if (store.getState().config.devtools) global.store = store
 
-// initialize analytics after first render
+// initialize analytics and support after first render
 store.dispatch(initializeAnalytics())
+store.dispatch(initializeSupport())
 
 // kickoff an initial update check at launch
 store.dispatch(checkForShellUpdates())

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -1,0 +1,54 @@
+// @flow
+// user support module
+import noop from 'lodash/noop'
+import {LOCATION_CHANGE} from 'react-router-redux'
+
+import {version} from './../package.json'
+import createLogger from './logger'
+
+import type {ThunkAction, Middleware} from './types'
+import type {Config} from './config'
+
+type SupportConfig = $PropertyType<Config, 'support'>
+
+const log = createLogger(__filename)
+
+// pulled in from environment at build time
+const INTERCOM_ID = process.env.OT_APP_INTERCOM_ID
+
+// intercom handler (default noop)
+let intercom = noop
+
+export function initializeSupport (): ThunkAction {
+  return (_, getState) => {
+    const config = getState().config.support
+
+    log.debug('Support config', {config})
+    initializeIntercom(config)
+  }
+}
+
+export const supportMiddleware: Middleware = (store) => (next) => (action) => {
+  // update intercom on page change
+  // TODO(mc, 2018-08-02): this is likely to hit intercom throttle limit
+  if (action.type === LOCATION_CHANGE) intercom('update')
+
+  return next(action)
+}
+
+function initializeIntercom (config: SupportConfig) {
+  if (INTERCOM_ID) {
+    const data = {
+      app_id: INTERCOM_ID,
+      user_id: config.userId,
+      created_at: config.createdAt,
+      name: config.name,
+      email: config.email,
+      'App Version': version
+    }
+
+    log.debug('Initializing Intercom', {data})
+    intercom = global.Intercom || intercom
+    intercom('boot', data)
+  }
+}


### PR DESCRIPTION
## overview

This PR updates the intercom configuration to attach a unique user ID (generated on first open of the app) that is stored on the filesystem to persist between app openings and re-installs. This _should_ allow users to keep their conversations going.

It also lays a little bit of groundwork for users to be able to input their name and email for support purposes.

Closes #1999

## changelog

- feat(app): Add persistent unique user ID to intercom data 

## review requests

I separated support from analytics to make sure we don't leak data between the too and keep our modules (the code kind) more focused.

- [x] App still initializes MixPanel and sends analytics events
    - Remember to set `OT_APP_MIXPANEL_ID`
- [x] New conversation shows up with unique `user_id` and generic "App User" name in intercom
    - Remember to set `OT_APP_INTERCOM_ID`
    - Ask me for a testing environment ID to avoid confusing our support folks