### PR TITLE
feat(app): Add update channel selector to advanced settings

### DIFF
--- a/app-shell/dev-app-update.yml
+++ b/app-shell/dev-app-update.yml
@@ -1,5 +1,4 @@
 provider: s3
 bucket: opentrons-app
 path: builds
-# TODO(mc, 2018-03-28): switch to latest when we have a "latest" release
-channel: beta
+channel: latest

--- a/app-shell/lib/config.js
+++ b/app-shell/lib/config.js
@@ -7,6 +7,8 @@ const {getIn} = require('@thi.ng/paths')
 const uuid = require('uuid/v4')
 const yargsParser = require('yargs-parser')
 
+const {version} = require('../package.json')
+
 // make sure all arguments are included in production
 const argv = process.defaultApp
   ? process.argv.slice(2)
@@ -19,10 +21,16 @@ const PARSE_ARGS_OPTS = {
   }
 }
 
-// TODO(mc, 2018-05-25): future config changes will require migration strategy
+// TODO(mc, 2018-05-25): future config changes may require migration strategy
 const DEFAULTS = {
   devtools: false,
+
   modules: false,
+
+  // app update config
+  update: {
+    channel: version.includes('beta') ? 'beta' : 'latest'
+  },
 
   // logging config
   log: {

--- a/app-shell/lib/update.js
+++ b/app-shell/lib/update.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const {autoUpdater: updater} = require('electron-updater')
+const {getConfig} = require('./config')
 const log = require('./log')(__filename)
 
 updater.logger = log
@@ -19,6 +20,7 @@ function checkForUpdates () {
     updater.once('update-available', handleUpdateAvailable)
     updater.once('update-not-available', handleUpdateNotAvailable)
     updater.once('error', handleError)
+    updater.channel = getConfig('update.channel')
     updater.checkForUpdates()
 
     function handleUpdateAvailable (info) {

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -3,34 +3,63 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
-import type {State, Dispatch} from '../../types'
-import {getDevToolsOn, toggleDevTools} from '../../config'
+import {getConfig, updateConfig, toggleDevTools} from '../../config'
 import {Card} from '@opentrons/components'
-import {LabeledToggle} from '../controls'
+import {LabeledToggle, LabeledSelect} from '../controls'
+
+import type {State, Dispatch} from '../../types'
+import type {UpdateChannel} from '../../config'
+
+type OP = {
+  checkForUpdates: () => mixed
+}
 
 type SP = {
   devToolsOn: boolean,
+  channel: UpdateChannel
 }
 
 type DP = {
-  toggleDevTools: () => mixed
+  toggleDevTools: () => mixed,
+  handleChannel: (event: SyntheticInputEvent<HTMLSelectElement>) => mixed
 }
 type Props = SP & DP
 
 const TITLE = 'Advanced Settings'
+
+// TODO(mc, 2018-08-03): enable "alpha" option
+const CHANNEL_OPTIONS = [
+  {name: 'Stable', value: (('latest': UpdateChannel): string)},
+  {name: 'Beta', value: (('beta': UpdateChannel): string)}
+]
 
 export default connect(mapStateToProps, mapDispatchToProps)(AdvancedSettingsCard)
 
 function AdvancedSettingsCard (props: Props) {
   return (
     <Card title={TITLE} column>
+      <LabeledSelect
+        label='Update Channel'
+        value={props.channel}
+        options={CHANNEL_OPTIONS}
+        onChange={props.handleChannel}
+      >
+        <p>
+          Sets the update channel of your app. &quot;Stable&quot; will keep
+          you on the latest stable release. The &quot;Beta&quot; channel will
+          recieve updates more frequently so you can try out new features, but
+          the releases may be less well tested than &quot;Stable&quot;.
+        </p>
+      </LabeledSelect>
       <LabeledToggle
         label='Enable Developer Tools'
         toggledOn={props.devToolsOn}
         onClick={props.toggleDevTools}
       >
         <p>
-          Requires restart. Turns on the app&#39;s developer tools, which provide access to the inner workings of the app and additional logging.
+          Requires restart. Turns on the app&#39;s developer tools, which
+          provide access to the inner workings of the app and additional
+          logging.
         </p>
       </LabeledToggle>
     </Card>
@@ -38,13 +67,23 @@ function AdvancedSettingsCard (props: Props) {
 }
 
 function mapStateToProps (state: State): SP {
+  const config = getConfig(state)
+
   return {
-    devToolsOn: getDevToolsOn(state)
+    devToolsOn: config.devtools,
+    channel: config.update.channel
   }
 }
 
-function mapDispatchToProps (dispatch: Dispatch) {
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP) {
   return {
-    toggleDevTools: () => dispatch(toggleDevTools())
+    toggleDevTools: () => dispatch(toggleDevTools()),
+    handleChannel: (event) => {
+      dispatch(updateConfig('update.channel', event.target.value))
+
+      // TODO(mc, 2018-08-03): refactor app update interface to be more
+      // reactive and teach it to re-check on release channel change
+      setTimeout(ownProps.checkForUpdates, 500)
+    }
   }
 }

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -45,10 +45,10 @@ function AdvancedSettingsCard (props: Props) {
         onChange={props.handleChannel}
       >
         <p>
-          Sets the update channel of your app. &quot;Stable&quot; will keep
-          you on the latest stable release. The &quot;Beta&quot; channel will
-          recieve updates more frequently so you can try out new features, but
-          the releases may be less well tested than &quot;Stable&quot;.
+          Sets the update channel of your app. &quot;Stable&quot; receives the
+          latest stable releases. &quot;Beta&quot; is updated more frequently
+          so you can try out new features, but the releases may be less well
+          tested than &quot;Stable&quot;.
         </p>
       </LabeledSelect>
       <LabeledToggle

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -24,7 +24,7 @@ export default function AppSettings (props: Props) {
         <AnalyticsSettingsCard {...props} />
       </CardRow>
       <CardRow>
-        <AdvancedSettingsCard />
+        <AdvancedSettingsCard checkForUpdates={props.checkForUpdates} />
       </CardRow>
     </CardContainer>
   )

--- a/app/src/components/controls/LabeledButton.js
+++ b/app/src/components/controls/LabeledButton.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 
 import {OutlineButton, type ButtonProps} from '@opentrons/components'
-import ControlInfo from './ControlInfo'
+import LabeledControl from './LabeledControl'
 import styles from './styles.css'
 
 type Props = {
@@ -17,16 +17,13 @@ export default function LabeledButton (props: Props) {
   const buttonClass = cx(styles.labeled_button, buttonProps.className)
 
   return (
-    <div className={styles.labeled_control_wrapper}>
-      <div className={styles.labeled_control}>
-        <p className={styles.labeled_control_label}>
-          {label}
-        </p>
+    <LabeledControl
+      label={label}
+      control={(
         <OutlineButton {...buttonProps} className={buttonClass} />
-      </div>
-      <ControlInfo>
-        {props.children}
-      </ControlInfo>
-    </div>
+      )}
+    >
+      {props.children}
+    </LabeledControl>
   )
 }

--- a/app/src/components/controls/LabeledControl.js
+++ b/app/src/components/controls/LabeledControl.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react'
+
+import ControlInfo from './ControlInfo'
+import styles from './styles.css'
+
+type Props = {
+  label: string,
+  control: React.Node,
+  children?: React.Node,
+}
+
+export default function LabeledControl (props: Props) {
+  const {label, control, children} = props
+
+  return (
+    <div className={styles.labeled_control_wrapper}>
+      <div className={styles.labeled_control}>
+        <p className={styles.labeled_control_label}>
+          {label}
+        </p>
+        {control}
+      </div>
+      <ControlInfo>
+        {children}
+      </ControlInfo>
+    </div>
+  )
+}

--- a/app/src/components/controls/LabeledSelect.js
+++ b/app/src/components/controls/LabeledSelect.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from 'react'
+
+import {DropdownField} from '@opentrons/components'
+import LabeledControl from './LabeledControl'
+import styles from './styles.css'
+
+type Props = React.ElementProps<typeof DropdownField> & {
+  label: string,
+  children: React.Node,
+}
+
+export default function LabeledSelect (props: Props) {
+  const {label, value, options, onChange} = props
+
+  return (
+    <LabeledControl
+      label={label}
+      control={(
+        <DropdownField
+          className={styles.labeled_select}
+          value={value}
+          options={options}
+          onChange={onChange}
+        />
+      )}
+    >
+      {props.children}
+    </LabeledControl>
+  )
+}

--- a/app/src/components/controls/LabeledToggle.js
+++ b/app/src/components/controls/LabeledToggle.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 
-import ControlInfo from './ControlInfo'
+import LabeledControl from './LabeledControl'
 import ToggleButton from './ToggleButton'
 import styles from './styles.css'
 
@@ -16,20 +16,17 @@ export default function LabeledToggle (props: Props) {
   const {label, toggledOn, onClick} = props
 
   return (
-    <div className={styles.labeled_control_wrapper}>
-      <label className={styles.labeled_control}>
-        <p className={styles.labeled_control_label}>
-          {label}
-        </p>
+    <LabeledControl
+      label={label}
+      control={(
         <ToggleButton
           className={styles.labeled_toggle_button}
           toggledOn={toggledOn}
           onClick={onClick}
         />
-      </label>
-      <ControlInfo>
-        {props.children}
-      </ControlInfo>
-    </div>
+      )}
+    >
+      {props.children}
+    </LabeledControl>
   )
 }

--- a/app/src/components/controls/index.js
+++ b/app/src/components/controls/index.js
@@ -2,5 +2,6 @@
 import ToggleButton from './ToggleButton'
 import LabeledToggle from './LabeledToggle'
 import LabeledButton from './LabeledButton'
+import LabeledSelect from './LabeledSelect'
 
-export {ToggleButton, LabeledToggle, LabeledButton}
+export {ToggleButton, LabeledToggle, LabeledButton, LabeledSelect}

--- a/app/src/components/controls/styles.css
+++ b/app/src/components/controls/styles.css
@@ -22,10 +22,6 @@
   display: block;
 }
 
-label.labeled_control {
-  @apply --clickable;
-}
-
 .labeled_control_label {
   @apply --font-body-1-dark;
 
@@ -45,10 +41,15 @@ label.labeled_control {
   }
 }
 
-.labeled_button {
+.labeled_button,
+.labeled_select {
   float: right;
-  width: 7.5rem;
+  width: 8rem;
   margin-top: 0.25rem;
+}
+
+.labeled_select {
+  @apply --font-body-2-dark;
 }
 
 .control_info {

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -7,10 +7,17 @@ import type {LogLevel} from '../logger'
 
 type UrlProtocol = 'file:' | 'http:'
 
+export type UpdateChannel = 'latest' | 'beta' | 'alpha'
+
 // TODO(mc, 2018-05-17): put this type somewhere common to app and app-shell
 export type Config = {
   devtools: boolean,
   modules: boolean,
+
+  // app update config
+  update: {
+    channel: UpdateChannel,
+  },
 
   // logging config
   log: {
@@ -87,17 +94,13 @@ export function getConfig (state: State): Config {
   return state.config
 }
 
-export function getDevToolsOn (state: State): boolean {
-  return state.config.devtools
-}
-
 export function getModulesOn (state: State): boolean {
   return state.config.modules
 }
 
 export function toggleDevTools (): ThunkAction {
   return (dispatch, getState) => {
-    const devToolsOn = getDevToolsOn(getState())
+    const devToolsOn = getConfig(getState()).devtools
     return dispatch(updateConfig('devtools', !devToolsOn))
   }
 }


### PR DESCRIPTION
## overview

This PR also serving as the feature request ticket.

The support team is having trouble keeping track of which users are on beta and how best to support users who are encountering bugs that are present in "stable" but may have been fixed in "beta". This PR adds an option to the app's advanced settings to allow a user to switch between update channels on the fly using the app's existing self-update mechanisms so the support team doesn't need to wrangle a bunch of links all the time

## changelog

- feat(app): Add update channel selector to advanced settings 

## review requests

1. Open the app
2. Go to App Settings
3. Change the release channel and notice how the update button state changes
4. Download a prod build from Slack and ensure the updates (and downgrades) actually work
    - On mac, it probably won't work because the branch builds from Slack aren't signed
    - If you'd like to test out on mac, hit me up and I'll get you a signed build from my machine

I also slipped in some consolidation work for advanced settings control components, so give those a glance in both app settings and robot settings to ensure those aren't broken.
