### PR TITLE
 feat(api): bind labware instance to module on load when not simulating

### DIFF
--- a/api/opentrons/modules/__init__.py
+++ b/api/opentrons/modules/__init__.py
@@ -41,6 +41,8 @@ def load(name, slot):
             ]
             if matching_modules:
                 module_instance = matching_modules[0]
+                labware_instance = labware.load(name, slot)
+                module_instance.labware = labware_instance
             else:
                 raise AbsentModuleError(
                     "no module of name {} is currently connected".format(name)

--- a/api/opentrons/modules/__init__.py
+++ b/api/opentrons/modules/__init__.py
@@ -19,9 +19,6 @@ class AbsentModuleError(Exception):
 
 
 def load(name, slot):
-    # TODO: if robot.is_simulating create class without setting up
-    # it will be out of scope and gc'ed at end of simulation exec
-    # if not simnulating grab from list of modules on robot
     module_instance = None
     if name in SUPPORTED_MODULES:
         if robot.is_simulating():


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This is just a follow-up addition to the module.load changes from the set of changes to the Module API objects and their interface to the robot.  The proper instance of placeable was only being attached to the module object instance when the robot was simulating.

In a quick test run on @sanni-t 's robot, this was clearly contributing to the improper pipette positioning that we've been encountering on protocols that include modules.  This doesn't necessarily solve the whole problem, but I figured, as we're still troubleshooting, we might as well eliminate any weird behavior that was just associated with this omission.    