### PR TITLE
feat(compute): Add openjdk8 to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --update \
       dropbear \
       dropbear-scp \
       gnupg \
+      openjdk8 \
       nginx \
       libstdc++ \
       g++ \


### PR DESCRIPTION
## overview

Add openjdk8 to the Dockerfile so that we or hacker users can write and run jvm-based software on the robot.

## changelog

- Add openjdk8 to Dockerfile

## review requests

Tested on :moon: :moon: