### PR TITLE
refactor(api): Generate empty log files if not found

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -3,7 +3,6 @@
 import sys
 import logging
 import os
-import tempfile
 import traceback
 import atexit
 from aiohttp import web
@@ -25,12 +24,8 @@ except ModuleNotFoundError:
 from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
-lock_file_path = '/tmp/resin/resin-updates.lock'
-if os.environ.get('RUNNING_ON_PI'):
-    log_file_path = '/data/user_storage/opentrons_data/logs'
-else:
-    tmpdir = tempfile.mkdtemp("logs")
-    log_file_path = os.path.abspath(tmpdir)
+lock_file_path = 'tmp/resin/resin-updates.lock'
+log_file_path = environment.get_path('LOG_DIR')
 
 
 def lock_resin_updates():
@@ -66,6 +61,7 @@ def log_init():
     level_value = logging._nameToLevel[ot_log_level]
 
     serial_log_filename = environment.get_path('SERIAL_LOG_FILE')
+    api_log_filename = environment.get_path('LOG_FILE')
 
     logging_config = dict(
         version=1,
@@ -88,31 +84,40 @@ def log_init():
                 'maxBytes': 5000000,
                 'level': logging.DEBUG,
                 'backupCount': 3
+            },
+            'api': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'basic',
+                'filename': api_log_filename,
+                'maxBytes': 1000000,
+                'level': logging.DEBUG,
+                'backupCount': 5
             }
+
         },
         loggers={
             '__main__': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': logging.INFO
             },
             'opentrons.server': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': level_value
             },
             'opentrons.api': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': level_value
             },
             'opentrons.instruments': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': level_value
             },
             'opentrons.robot.robot_configs': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': level_value
             },
             'opentrons.drivers.smoothie_drivers.driver_3_0': {
-                'handlers': ['debug'],
+                'handlers': ['debug', 'api'],
                 'level': level_value
             },
             'opentrons.drivers.serial_communication': {

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError:
 from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
-lock_file_path = 'tmp/resin/resin-updates.lock'
+lock_file_path = '/tmp/resin/resin-updates.lock'
 log_file_path = environment.get_path('LOG_DIR')
 
 

--- a/api/tests/opentrons/server/test_logs_endpoints.py
+++ b/api/tests/opentrons/server/test_logs_endpoints.py
@@ -9,13 +9,6 @@ async def test_log_endpoints(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    # Test no log file(s) found
-    s0 = await cli.get('/logs/serial.log')
-    assert s0.status == 404
-    #
-    a0 = await cli.get('/logs/api.log')
-    assert a0.status == 404
-
     # # Test that values are set correctly
     serial_name = "serial.log"
     serial_file = os.path.join(main.log_file_path, serial_name)


### PR DESCRIPTION
## overview
The logs endpoint did not take into account creating empty log files if they did not exist. This created weird behavior on front-end side where a user would be prompted to save a file, but nothing actually saved. Closes #2040 .

## changelog

- Add empty files if either api or serial log(s) do not exist.

## review requests

@btmorr did I do this in the right place?
