### PR TITLE
refactor(app): Incorporate discovery-client into app-shell behind flag (1 of 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PATH := $(shell yarn bin):$(PATH)
 
 API_DIR := api
 API_LIB_DIR := api-server-lib
+DISCOVERY_CLIENT_DIR := discovery-client
 SHARED_DATA_DIR := shared-data
 UPDATE_SERVER_DIR := update-server
 
@@ -30,6 +31,7 @@ install:
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 	yarn
 	$(MAKE) -C $(SHARED_DATA_DIR) build
+	$(MAKE) -C $(DISCOVERY_CLIENT_DIR)
 
 # uninstall all project dependencies
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile

--- a/app-shell/.babelrc
+++ b/app-shell/.babelrc
@@ -4,6 +4,11 @@
       "plugins": [
         "transform-es2015-modules-commonjs"
       ]
+    },
+    "production": {
+      "plugins": [
+        "unassert"
+      ]
     }
   },
   "plugins": [

--- a/app-shell/.babelrc
+++ b/app-shell/.babelrc
@@ -1,5 +1,11 @@
 {
-  "extends": "../.babelrc",
+  "env": {
+    "test": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  },
   "plugins": [
     "transform-object-rest-spread",
     "transform-class-properties"

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,7 +8,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__@(tests|mocks)__/**'
+src_ignore := "**/__@(tests|mocks)__/**"
+babel := babel $(src_dir) --out-dir $(lib_dir) --ignore $(src_ignore)
 
 # dep directories for production build
 # TODO(mc, 2018-08-07): figure out a better way to do this

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,7 +8,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-babel := babel $(src_dir) --out-dir $(lib_dir)
+babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__tests__/**'
 
 # dep directories for production build
 # TODO(mc, 2018-08-07): figure out a better way to do this

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -8,7 +8,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__tests__/**'
+babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__@(tests|mocks)__/**'
 
 # dep directories for production build
 # TODO(mc, 2018-08-07): figure out a better way to do this

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -24,7 +24,11 @@
     "flow-bin": "^0.76.0",
     "flow-typed": "^2.5.1"
   },
+  "devDependencies": {
+    "@opentrons/app": "3.3.0-beta.1"
+  },
   "dependencies": {
+    "@opentrons/discovery-client": "3.3.0-beta.1",
     "@thi.ng/paths": "^1.3.8",
     "dateformat": "^3.0.3",
     "electron-debug": "^1.1.0",

--- a/app-shell/src/__mocks__/config.js
+++ b/app-shell/src/__mocks__/config.js
@@ -1,0 +1,2 @@
+// mock config
+module.exports = jest.genMockFromModule('../config')

--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -1,0 +1,129 @@
+// tests for the app-shell's discovery module
+import EventEmitter from 'events'
+import DiscoveryClient from '@opentrons/discovery-client'
+import {registerDiscovery} from '../discovery'
+import {getConfig} from '../config'
+
+jest.mock('@opentrons/discovery-client')
+jest.mock('../log')
+jest.mock('../config')
+
+describe('app-shell/discovery', () => {
+  let dispatch
+  let mockClient
+
+  beforeEach(() => {
+    mockClient = Object.assign(new EventEmitter(), {
+      services: [],
+      candidates: [],
+      start: jest.fn().mockReturnThis(),
+      stop: jest.fn().mockReturnThis(),
+      add: jest.fn().mockReturnThis(),
+      remove: jest.fn().mockReturnThis(),
+      setPollInterval: jest.fn().mockReturnThis()
+    })
+
+    getConfig.mockReturnValue({
+      candidates: []
+    })
+
+    dispatch = jest.fn()
+    DiscoveryClient.mockReturnValue(mockClient)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('registerDiscovery creates a DiscoveryClient', () => {
+    registerDiscovery(dispatch)
+
+    expect(DiscoveryClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nameFilter: /^opentrons/i,
+        pollInterval: 5000,
+        candidates: []
+      })
+    )
+  })
+
+  test('calls client.start on "discovery:START"', () => {
+    registerDiscovery(dispatch)({type: 'discovery:START'})
+    expect(mockClient.start).toHaveBeenCalled()
+  })
+
+  test('sets client to slow poll on "discovery:FINISH"', () => {
+    registerDiscovery(dispatch)({type: 'discovery:FINISH'})
+    expect(mockClient.setPollInterval).toHaveBeenCalledWith(15000)
+  })
+
+  describe('"service" event handling', () => {
+    beforeEach(() => registerDiscovery(dispatch))
+
+    const SPECS = [
+      {
+        name: 'dispatches discovery:UPDATE_LIST on "service" event',
+        services: [
+          {name: 'opentrons-dev', ip: '192.168.1.42', port: 31950, ok: true}
+        ],
+        expected: [
+          {
+            name: 'opentrons-dev',
+            ok: true,
+            connections: [{ip: '192.168.1.42', port: 31950, ok: true, local: false}]
+          }
+        ]
+      },
+      {
+        name: 'handles multiple services',
+        services: [
+          {name: 'opentrons-1', ip: '192.168.1.42', port: 31950, ok: false},
+          {name: 'opentrons-2', ip: '169.254.9.8', port: 31950, ok: true}
+        ],
+        expected: [
+          {
+            name: 'opentrons-1',
+            ok: false,
+            connections: [
+              {ip: '192.168.1.42', port: 31950, ok: false, local: false}
+            ]
+          },
+          {
+            name: 'opentrons-2',
+            ok: true,
+            connections: [
+              {ip: '169.254.9.8', port: 31950, ok: true, local: true}
+            ]
+          }
+        ]
+      },
+      {
+        name: 'combines multiple services into one robot',
+        services: [
+          {name: 'opentrons-dev', ip: '192.168.1.42', port: 31950, ok: true},
+          {name: 'opentrons-dev', ip: '169.254.9.8', port: 31950, ok: true}
+        ],
+        expected: [
+          {
+            name: 'opentrons-dev',
+            ok: true,
+            connections: [
+              {ip: '192.168.1.42', port: 31950, ok: true, local: false},
+              {ip: '169.254.9.8', port: 31950, ok: true, local: true}
+            ]
+          }
+        ]
+      }
+    ]
+
+    SPECS.forEach(spec => test(spec.name, () => {
+      mockClient.services = spec.services
+
+      mockClient.emit('service')
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'discovery:UPDATE_LIST',
+        payload: {robots: spec.expected}
+      })
+    }))
+  })
+})

--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -69,7 +69,6 @@ describe('app-shell/discovery', () => {
         expected: [
           {
             name: 'opentrons-dev',
-            ok: true,
             connections: [{ip: '192.168.1.42', port: 31950, ok: true, local: false}]
           }
         ]
@@ -83,14 +82,12 @@ describe('app-shell/discovery', () => {
         expected: [
           {
             name: 'opentrons-1',
-            ok: false,
             connections: [
               {ip: '192.168.1.42', port: 31950, ok: false, local: false}
             ]
           },
           {
             name: 'opentrons-2',
-            ok: true,
             connections: [
               {ip: '169.254.9.8', port: 31950, ok: true, local: true}
             ]
@@ -106,7 +103,6 @@ describe('app-shell/discovery', () => {
         expected: [
           {
             name: 'opentrons-dev',
-            ok: true,
             connections: [
               {ip: '192.168.1.42', port: 31950, ok: true, local: false},
               {ip: '169.254.9.8', port: 31950, ok: true, local: true}

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -65,6 +65,13 @@ const DEFAULTS = {
     createdAt: Math.floor(Date.now() / 1000),
     name: 'Unknown User',
     email: null
+  },
+
+  // robot discovery
+  discovery: {
+    // new discovery client feature flag
+    enabled: false,
+    candidates: []
   }
 }
 

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -1,0 +1,94 @@
+// @flow
+// app shell discovery module
+import assert from 'assert'
+import groupBy from 'lodash/groupBy'
+import map from 'lodash/map'
+import uniqBy from 'lodash/uniqBy'
+
+import DiscoveryClient, {
+  DEFAULT_PORT,
+  SERVICE_EVENT
+} from '@opentrons/discovery-client'
+
+import {getConfig} from './config'
+import createLogger from './log'
+
+// TODO(mc, 2018-08-08): figure out type exports thru compilation
+import type {Service} from '@opentrons/discovery-client/src/types'
+import type {Action} from '@opentrons/app/src/types'
+import type {DiscoveredRobot, Connection} from '@opentrons/app/src/discovery/types'
+
+const log = createLogger(__filename)
+
+const NAME_FILTER = /^opentrons/i
+
+// TODO(mc, 2018-08-09): values picked arbitrarily and should be researched
+const FAST_POLL_INTERVAL = 5000
+const SLOW_POLL_INTERVAL = 15000
+
+let config
+let client
+
+export function registerDiscovery (dispatch: Action => void) {
+  config = getConfig('discovery')
+
+  client = DiscoveryClient({
+    nameFilter: NAME_FILTER,
+    pollInterval: FAST_POLL_INTERVAL,
+    logger: log,
+    candidates: config.candidates
+  })
+
+  client
+    .on(SERVICE_EVENT, () => dispatch({
+      type: 'discovery:UPDATE_LIST',
+      payload: {robots: servicesToRobots(client.services)}
+    }))
+    .on('error', error => log.error('discovery error', {error}))
+
+  return function handleIncomingAction (action: Action) {
+    log.debug('handling action in discovery', {action})
+
+    switch (action.type) {
+      case 'discovery:START': return client.start()
+      case 'discovery:FINISH': return client.setPollInterval(SLOW_POLL_INTERVAL)
+    }
+  }
+}
+
+// TODO(mc, 2018-08-09): exploring moving this to DiscoveryClient
+function servicesToRobots (services: Array<Service>): Array<DiscoveredRobot> {
+  const servicesByName = groupBy(services, 'name')
+
+  return map(servicesByName, (services: Array<Service>, name) => ({
+    name,
+    ok: services.reduce((ok, s) => ok || s.ok, null),
+    connections: servicesToConnections(services)
+  }))
+}
+
+function servicesToConnections (services: Array<Service>): Array<Connection> {
+  assert(uniqBy(services, 'name').length <= 1, 'services should have same name')
+
+  return services.map(serviceToConnection).filter(Boolean)
+}
+
+function serviceToConnection (service: Service): ?Connection {
+  if (!service.ip) return null
+
+  return {
+    ip: service.ip,
+    ok: service.ok,
+    port: service.port || DEFAULT_PORT,
+    local: isLocal(service.ip)
+  }
+}
+
+function isLocal (ip: string): boolean {
+  // TODO(mc, 2018-08-09): remove `fd00` check for legacy IPv6 robots
+  return (
+    ip.startsWith('169.254') ||
+    ip.startsWith('fe80') ||
+    ip.startsWith('fd00')
+  )
+}

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -13,8 +13,9 @@ import DiscoveryClient, {
 import {getConfig} from './config'
 import createLogger from './log'
 
-// TODO(mc, 2018-08-08): figure out type exports thru compilation
-import type {Service} from '@opentrons/discovery-client/src/types'
+import type {Service} from '@opentrons/discovery-client'
+
+// TODO(mc, 2018-08-08): figure out type exports from app
 import type {Action} from '@opentrons/app/src/types'
 import type {DiscoveredRobot, Connection} from '@opentrons/app/src/discovery/types'
 

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -63,7 +63,6 @@ function servicesToRobots (services: Array<Service>): Array<DiscoveredRobot> {
 
   return map(servicesByName, (services: Array<Service>, name) => ({
     name,
-    ok: services.reduce((ok, s) => ok || s.ok, null),
     connections: servicesToConnections(services)
   }))
 }

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -7,6 +7,7 @@ import {initialize as initializeApiUpdate} from './api-update'
 import createLogger from './log'
 import {getConfig, getStore, getOverrides, registerConfig} from './config'
 import {registerRobotLogs} from './robot-logs'
+import {registerDiscovery} from './discovery'
 
 const config = getConfig()
 const log = createLogger(__filename)
@@ -45,10 +46,13 @@ function startUp () {
 
   const configHandler = registerConfig(dispatch)
   const downloadHandler = registerRobotLogs(dispatch, mainWindow)
+  const discoveryHandler = registerDiscovery(dispatch)
+
   ipcMain.on('dispatch', (_, action) => {
     log.debug('Received action via IPC from renderer', {action})
     configHandler(action)
     downloadHandler(action)
+    discoveryHandler(action)
   })
 
   if (config.devtools) {

--- a/app-shell/src/robot-logs.js
+++ b/app-shell/src/robot-logs.js
@@ -2,11 +2,9 @@
 
 export function registerRobotLogs (dispatch, mainWindow) {
   return function handleIncomingAction (action) {
-    const {type, payload: {logUrls}} = action
-    if (type === 'shell:DOWNLOAD_LOGS') {
-      logUrls.forEach((url) => {
-        mainWindow.webContents.downloadURL(url)
-      })
+    if (action.type === 'shell:DOWNLOAD_LOGS') {
+      const {payload: {logUrls}} = action
+      logUrls.forEach(url => mainWindow.webContents.downloadURL(url))
     }
   }
 }

--- a/app/Makefile
+++ b/app/Makefile
@@ -57,4 +57,4 @@ dev-mdns:
 .PHONY: dev-shell
 dev-shell:
 	wait-on http-get://localhost:$(port) && \
-	$(MAKE) -C $(shell_dir) dev port=$(port)
+	$(MAKE) -C $(shell_dir) lib dev port=$(port)

--- a/app/src/discovery/__tests__/actions.test.js
+++ b/app/src/discovery/__tests__/actions.test.js
@@ -1,0 +1,33 @@
+// discovery actions test
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import {startDiscovery} from '..'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+
+describe('discovery actions', () => {
+  let store
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    store = mockStore({})
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  test('startDiscovery', () => {
+    const expectedTimeout = 30000
+    const expectedStart = {type: 'discovery:START', meta: {shell: true}}
+    const expectedFinish = {type: 'discovery:FINISH', meta: {shell: true}}
+
+    store.dispatch(startDiscovery())
+    expect(store.getActions()).toEqual([expectedStart])
+    jest.runTimersToTime(expectedTimeout)
+    expect(store.getActions()).toEqual([expectedStart, expectedFinish])
+  })
+})

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,0 +1,63 @@
+// @flow
+// robot discovery state
+import type {Action, ThunkAction} from '../types'
+import type {DiscoveredRobot} from './types'
+
+type DiscoveryState = {
+  scanning: boolean,
+  robotsByName: {[name: string]: DiscoveredRobot}
+}
+
+type StartAction = {|
+  type: 'discovery:START',
+  meta: {| shell: true |},
+|}
+
+type FinishAction = {|
+  type: 'discovery:FINISH',
+  meta: {| shell: true |},
+|}
+
+type UpdateListAction = {|
+  type: 'discovery:UPDATE_LIST',
+  payload: {| robots: Array<DiscoveredRobot> |},
+|}
+
+export type DiscoveryAction =
+  | StartAction
+  | FinishAction
+  | UpdateListAction
+
+const DISCOVERY_TIMEOUT = 30000
+
+export function startDiscovery (): ThunkAction {
+  const start: StartAction = {type: 'discovery:START', meta: {shell: true}}
+  const finish: FinishAction = {type: 'discovery:FINISH', meta: {shell: true}}
+
+  return dispatch => {
+    dispatch(start)
+    setTimeout(() => dispatch(finish), DISCOVERY_TIMEOUT)
+  }
+}
+
+// TODO(mc, 2018-08-09): uncomment when we figure out how to get this
+// to the app shell
+// export function updateDiscoveryList (
+//   robots: Array<DiscoveredRobot>
+// ): UpdateListAction {
+//   return {type: 'discovery:UPDATE_LIST', payload: {robots}}
+// }
+
+// TODO(mc, 2018-08-09): implement this reducer
+export function discoveryReducer (
+  state: DiscoveryState = {scanning: false, robotsByName: {}},
+  action: Action
+): DiscoveryState {
+  switch (action.type) {
+    case 'discovery:START': return state
+    case 'discovery:FINISH': return state
+    case 'discovery:UPDATE_LIST': return state
+  }
+
+  return state
+}

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -1,0 +1,13 @@
+// @flow
+export type Connection = {
+  ip: string,
+  port: number,
+  local: boolean,
+  ok: ?boolean,
+}
+
+export type DiscoveredRobot = {
+  name: string,
+  ok: ?boolean,
+  connections: Array<Connection>,
+}

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -8,6 +8,5 @@ export type Connection = {
 
 export type DiscoveredRobot = {
   name: string,
-  ok: ?boolean,
   connections: Array<Connection>,
 }

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -12,9 +12,13 @@ import createLogger from './logger'
 import {checkForShellUpdates, shellMiddleware} from './shell'
 
 import {healthCheckMiddleware} from './health-check'
-import {apiClientMiddleware as robotApiMiddleware} from './robot'
+import {
+  apiClientMiddleware as robotApiMiddleware,
+  actions as robotActions
+} from './robot'
 import {initializeAnalytics, analyticsMiddleware} from './analytics'
 import {initializeSupport, supportMiddleware} from './support'
+import {startDiscovery} from './discovery'
 
 import reducer from './reducer'
 
@@ -61,8 +65,10 @@ if (module.hot) {
   module.hot.accept('./components/App', renderApp)
 }
 
+const {config} = store.getState()
+
 // attach store to window if devtools are on
-if (store.getState().config.devtools) global.store = store
+if (config.devtools) global.store = store
 
 // initialize analytics and support after first render
 store.dispatch(initializeAnalytics())
@@ -70,6 +76,13 @@ store.dispatch(initializeSupport())
 
 // kickoff an initial update check at launch
 store.dispatch(checkForShellUpdates())
+
+// kickoff a discovery run immediately
+// TODO(mc, 2018-08-09): remove feature flag chack after switchover
+store.dispatch(config.discovery.enabled
+  ? startDiscovery()
+  : robotActions.discover()
+)
 
 log.info('Rendering app UI')
 renderApp()

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -4,11 +4,12 @@ import {combineReducers} from 'redux'
 import {routerReducer} from 'react-router-redux'
 
 // robot state
-import {NAME as ROBOT_NAME, reducer as robotReducer} from './robot'
+import {reducer as robotReducer} from './robot'
 
 // api state
 import {reducer as httpApiReducer} from './http-api-client'
 
+// health check state
 import {healthCheckReducer} from './health-check'
 
 // app shell state
@@ -17,10 +18,14 @@ import {shellReducer} from './shell'
 // config state
 import {configReducer} from './config'
 
+// discovery state
+import {discoveryReducer} from './discovery'
+
 export default combineReducers({
-  [ROBOT_NAME]: robotReducer,
+  robot: robotReducer,
   api: httpApiReducer,
   config: configReducer,
+  discovery: discoveryReducer,
   healthCheck: healthCheckReducer,
   shell: shellReducer,
   router: routerReducer

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -21,11 +21,6 @@ export default function client (dispatch) {
   // TODO(mc, 2017-09-22): build some sort of timer middleware instead?
   let runTimerInterval = NO_INTERVAL
 
-  // kickoff a discovery run immediately
-  // dispatching a discover action (rather than calling handleDiscover) ensures
-  // proper state handling (action will run thru the full middleware pipeline)
-  dispatch(actions.discover())
-
   // return an action handler
   return function receive (state = {}, action = {}) {
     const {type} = action

--- a/app/src/robot/test/api-client-discovery.test.js
+++ b/app/src/robot/test/api-client-discovery.test.js
@@ -58,10 +58,6 @@ describe('api client - discovery', () => {
 
   afterEach(() => delay(EXPECTED_DISCOVERY_MS))
 
-  test('kicks off a discovery run immediately', () => {
-    expect(dispatch).toHaveBeenCalledWith(actions.discover())
-  })
-
   test('searches for HTTP services', () => {
     return sendToClient(notScanningState, actions.discover())
       .then(() => expect(bonjour.find).toHaveBeenCalledWith({type: 'http'}))

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -36,7 +36,6 @@ export type BaseRobot = {
 
 // robot MDNS service for connectivity
 export type RobotService = BaseRobot & {
-  host: string,
   ip: string,
   port: number,
   wired?: boolean,

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -14,6 +14,7 @@ import type {HealthCheckAction} from './health-check'
 import type {Action as HttpApiAction} from './http-api-client'
 import type {ShellAction} from './shell'
 import type {ConfigAction} from './config'
+import type {DiscoveryAction} from './discovery'
 
 export type State = $Call<reducer>
 
@@ -26,6 +27,7 @@ export type Action =
   | ShellAction
   | ConfigAction
   | RouterAction
+  | DiscoveryAction
 
 export type ActionType = $PropertyType<Action, 'type'>
 

--- a/discovery-client/.babelrc
+++ b/discovery-client/.babelrc
@@ -1,5 +1,11 @@
 {
-  "extends": "../.babelrc",
+  "env": {
+    "test": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  },
   "plugins": [
     "transform-object-rest-spread",
     "transform-class-properties"

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -8,8 +8,9 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__tests__/**'
-flow_copy := flow-copy-source --ignore '**/__tests__/**' $(src_dir) $(lib_dir)
+src_ignore := '**/__@(tests|mocks)__/**'
+babel := babel $(src_dir) --ignore $(src_ignore) --out-dir $(lib_dir) 
+flow_copy := flow-copy-source --ignore $(src_ignore) $(src_dir) $(lib_dir)
 
 # set NODE_ENV for a command with $(env)=environment
 env := cross-env NODE_ENV

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -1,4 +1,4 @@
-# opentrons app desktop shell makefile
+# opentrons discovery-client makefile
 
 SHELL := /bin/bash
 
@@ -8,8 +8,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-src_ignore := '**/__@(tests|mocks)__/**'
-babel := babel $(src_dir) --ignore $(src_ignore) --out-dir $(lib_dir) 
+src_ignore := "**/__@(tests|mocks)__/**"
+babel := babel $(src_dir) --ignore $(src_ignore) --out-dir $(lib_dir)
 flow_copy := flow-copy-source --ignore $(src_ignore) $(src_dir) $(lib_dir)
 
 # set NODE_ENV for a command with $(env)=environment

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -9,6 +9,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 src_dir := src
 lib_dir := lib
 babel := babel $(src_dir) --out-dir $(lib_dir) --ignore '**/__tests__/**'
+flow_copy := flow-copy-source --ignore '**/__tests__/**' $(src_dir) $(lib_dir)
 
 # set NODE_ENV for a command with $(env)=environment
 env := cross-env NODE_ENV
@@ -33,3 +34,4 @@ clean:
 .PHONY: lib
 lib:
 	$(env)=production $(babel)
+	$(flow_copy)

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -42,11 +42,10 @@ describe('discovery client', () => {
     expect(mdns.__mockBrowser.discover).not.toHaveBeenCalled()
   })
 
-  test('calls start on existing browser', () => {
+  test('mdns browser started on ready', () => {
     const client = DiscoveryClient()
 
     client.start()
-    expect(mdns.createBrowser).toHaveBeenCalledTimes(1)
     expect(mdns.__mockBrowser.discover).toHaveBeenCalledTimes(0)
     mdns.__mockBrowser.emit('ready')
     expect(mdns.__mockBrowser.discover).toHaveBeenCalledTimes(1)
@@ -59,6 +58,17 @@ describe('discovery client', () => {
     const result = client.stop()
     expect(result).toBe(client)
     expect(mdns.__mockBrowser.stop).toHaveBeenCalled()
+  })
+
+  test('stops browser and creates new one on repeated client.start', () => {
+    const client = DiscoveryClient()
+
+    client.start()
+    expect(mdns.createBrowser).toHaveBeenCalledTimes(1)
+    expect(mdns.__mockBrowser.stop).toHaveBeenCalledTimes(0)
+    client.start()
+    expect(mdns.createBrowser).toHaveBeenCalledTimes(2)
+    expect(mdns.__mockBrowser.stop).toHaveBeenCalledTimes(1)
   })
 
   test(

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -27,6 +27,8 @@ import type {
   Logger
 } from './types'
 
+export * from './types'
+
 type Options = {
   pollInterval?: number,
   services?: Array<Service>,

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -27,8 +27,6 @@ import type {
   Logger
 } from './types'
 
-export * from './types'
-
 type Options = {
   pollInterval?: number,
   services?: Array<Service>,
@@ -38,6 +36,9 @@ type Options = {
   logger?: Logger
 }
 
+const log = (logger: ?Logger, level: LogLevel, msg: string, meta?: {}) =>
+  logger && typeof logger[level] === 'function' && logger[level](msg, meta)
+
 export default function DiscoveryClientFactory (options?: Options) {
   return new DiscoveryClient(options || {})
 }
@@ -45,9 +46,7 @@ export default function DiscoveryClientFactory (options?: Options) {
 export const SERVICE_EVENT: 'service' = 'service'
 export const SERVICE_REMOVED_EVENT: 'serviceRemoved' = 'serviceRemoved'
 export const DEFAULT_POLL_INTERVAL = 5000
-
-const log = (logger: ?Logger, level: LogLevel, msg: string, meta?: {}) =>
-  logger && typeof logger[level] === 'function' && logger[level](msg, meta)
+export {DEFAULT_PORT}
 
 export class DiscoveryClient extends EventEmitter {
   services: Array<Service>
@@ -146,7 +145,7 @@ export class DiscoveryClient extends EventEmitter {
   }
 
   _startBrowser (): void {
-    if (this._browser) return this._browser.discover()
+    this._stopBrowser()
 
     const browser = mdns
       .createBrowser(mdns.tcp('http'))
@@ -227,7 +226,7 @@ export class DiscoveryClient extends EventEmitter {
     if (poll) this._poll()
     if (updated.length) {
       updated.forEach(s => this.emit(SERVICE_EVENT, s))
-      log(this._logger, 'debug', 'updated services', {services: this.services})
+      log(this._logger, 'debug', 'updated services', {updated})
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.5",
     "flow-bin": "^0.76.0",
+    "flow-copy-source": "^2.0.2",
     "flow-mono-cli": "^1.3.4",
     "flow-typed": "^2.5.1",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-unassert": "^2.1.2",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -12,6 +12,10 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   eval "$(pyenv init -)"
 fi
 
+# upgrade yarn
+curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
+export PATH=$HOME/.yarn/bin:$PATH
+
 # report versions for sanity
 echo "make --version"
 make --version

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -12,10 +12,6 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   eval "$(pyenv init -)"
 fi
 
-# upgrade yarn
-curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
-export PATH=$HOME/.yarn/bin:$PATH
-
 # report versions for sanity
 echo "make --version"
 make --version

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,6 +3222,12 @@ decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decamelize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  dependencies:
+    xregexp "4.0.0"
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -4558,6 +4564,12 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
+
 findup@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
@@ -4581,6 +4593,16 @@ flatten@^1.0.2:
 flow-bin@^0.76.0:
   version "0.76.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.76.0.tgz#eb00036991c3abc106743fcbc7ee321f02aa4faa"
+
+flow-copy-source@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-2.0.2.tgz#096e579a9bb63a38afc5d4dd68ac847a5be27594"
+  dependencies:
+    chokidar "^2.0.0"
+    fs-extra "^7.0.0"
+    glob "^7.0.0"
+    kefir "^3.7.3"
+    yargs "^12.0.1"
 
 flow-mono-cli@^1.3.4:
   version "1.3.4"
@@ -4719,6 +4741,14 @@ fs-extra@^5.0.0:
 fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -6495,6 +6525,12 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+kefir@^3.7.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.3.tgz#8e0ab10084ed8a01cbb5d4f7f18a0b859f7b9bd9"
+  dependencies:
+    symbol-observable "1.0.4"
+
 keyboardevent-from-electron-accelerator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-1.1.0.tgz#324614f6e33490c37ffc5be5876b3e85fe223c84"
@@ -6658,6 +6694,13 @@ locate-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
@@ -7663,11 +7706,23 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -7692,6 +7747,10 @@ p-timeout@^1.1.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 p-waterfall@^1.0.0:
   version "1.0.0"
@@ -10541,6 +10600,10 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
+symbol-observable@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
 symbol-observable@^1.0.3, symbol-observable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
@@ -11661,6 +11724,10 @@ xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
+
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -11675,6 +11742,10 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -11682,6 +11753,12 @@ yallist@^2.1.2:
 yargs-parser@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz#c737c93de2567657750cb1f2c00be639fd19c994"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   dependencies:
     camelcase "^4.1.0"
 
@@ -11750,6 +11827,23 @@ yargs@6.6.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
+
+yargs@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^2.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.1.0"
 
 yargs@^4.2.0:
   version "4.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,10 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-plugin-unassert@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-unassert/-/babel-plugin-unassert-2.1.2.tgz#a1ea61811726db747079443ec1b15c4b06c6b944"
+
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
## overview

This PR is part 1 of a 2 part change:

- #2036: Incorporate discovery-client into app-shell behind flag (this one)
- #2045: Move discovery / optionally enable discovery-client (2 of 2)

This PR pulls the `DiscoveryClient` into the app-shell enough to dispatch redux actions when the client finds / updates robots. It **does not** do anything with those actions nor drive any UI from them just yet.

Work is for #990 and #1964

## changelog

- refactor(app): Incorporate discovery-client into app-shell behind flag

## review requests

If you're gonna run this from your dev environment (rather than a Slack build), make sure your environment is good:

0. `yarn` (or `make install` if you're feeling it)
1. `make -C discovery-client` to build the non-babel DiscoveryClient for the app-shell

Then, do a normal `make -C app dev` to make sure if the feature flag is unset, everything works like it used to:

- [x] Wifi robots show up
- [x] "Legacy" USB robots (i.e. IPv6 `[fd00:0:cafe:fefe::1]`) show up (or not depending on if your machine is affected by #1964)

Then, flip the flag on:

```shell
# note the **double-underscore** between DISCOVERY and ENABLED
make -C app dev OT_APP_DISCOVERY__ENABLED=1
```

With the flag on, the robot list **will not populate**. That's fine and why this is behind a flag. Go to the Redux devtools:

- [x] Wifi robots show up in an action called `discovery:UPDATE_LIST`
- [x] "New" USB robots (IPv4 `169.254.etc`) show up as `local: true` in `connections`
- [x] If robot has both USB and WiFi, it shows up as one entry with multiple entries in `connections`

Please note that `[fd00:0:cafe:fefe::1]` is not expected to show up at this time.

![screenshot 2018-08-09 16 06 49](https://user-images.githubusercontent.com/2963448/43922937-3c04b4be-9bee-11e8-843b-f5ac41352694.png)
