### PR TITLE
feat(api): Handle read-only thumb drive mount on OT2

### DIFF
--- a/api/opentrons/config/__init__.py
+++ b/api/opentrons/config/__init__.py
@@ -185,7 +185,15 @@ def _generate_base_config(skip_usb=False) -> (str, dict):
     }
     usb_mount_available = os.path.ismount(usb_mount_point)
     if usb_mount_available and not skip_usb:
-        os.makedirs(usb_settings_dir, exist_ok=True)
+        try:
+            # TODO: it's not clear if this is required, or if the makedirs call
+            # TODO: under _move_settings_data is enough. Most of the settings
+            # TODO: covered by this module should be in code and configs should
+            # TODO: only be stored in one place anyway, so this should be
+            # TODO: simplified with that change
+            os.makedirs(usb_settings_dir, exist_ok=True)
+        except OSError:
+            log.exception('Failed to make directories with exception:')
         base_data_dir = usb_settings_dir
         new_cfg = usb_config
 
@@ -200,9 +208,12 @@ def _generate_base_config(skip_usb=False) -> (str, dict):
 
 
 def write_base_config(path: str, config_data: dict):
-    os.makedirs(path, exist_ok=True)
-    with open(os.path.join(path, index_filename), 'w') as base_f:
-        json.dump(config_data, base_f, indent=2)
+    try:
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, index_filename), 'w') as base_f:
+            json.dump(config_data, base_f, indent=2)
+    except OSError:
+        log.exception("Base config write failed with exception:")
 
 
 # ---- Utility functions ----

--- a/api/opentrons/instruments/instrument.py
+++ b/api/opentrons/instruments/instrument.py
@@ -85,8 +85,11 @@ class Instrument(object):
 
         last_persisted_data = self._strip_vector(last_persisted_data)
 
-        with open(self._get_calibration_file_path(), 'w') as f:
-            f.write(json.dumps(last_persisted_data, indent=4))
+        try:
+            with open(self._get_calibration_file_path(), 'w') as f:
+                json.dump(last_persisted_data, f, indent=4)
+        except OSError:
+            log.exception('Failed to save with exception:')
 
     def load_persisted_data(self):
         """
@@ -117,11 +120,15 @@ class Instrument(object):
 
     def _write_blank_calibrations_file(self):
         self._delete_calibration_file()
-        with open(self._get_calibration_file_path(), 'w') as f:
-            f.write(json.dumps({
-                'version': self.calibration_data_version,
-                'data': {}
-            }))
+        try:
+            with open(self._get_calibration_file_path(), 'w') as f:
+                default_data = {
+                    'version': self.calibration_data_version,
+                    'data': {}
+                }
+                json.dump(default_data, f, indent=2)
+        except OSError:
+            log.exception('Failed to write calibrations file with exception:')
 
     def _get_calibration_file_path(self):
         """

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -232,7 +232,10 @@ def _load_json(filename) -> dict:
 
 def _save_json(data, filename):
     # print("Saving json file at {}".format(filename))
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with open(filename, 'w') as file:
-        json.dump(data, file, sort_keys=True, indent=4)
-    return data
+    try:
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, 'w') as file:
+            json.dump(data, file, sort_keys=True, indent=4)
+        return data
+    except OSError:
+        log.exception('Write failed with exception:')

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
 from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
-lock_file_path = 'tmp/resin/resin-updates.lock'
+lock_file_path = '/tmp/resin/resin-updates.lock'
 if os.environ.get('RUNNING_ON_PI'):
     log_file_path = '/data/user_storage/opentrons_data/logs'
 else:


### PR DESCRIPTION
## overview

Sometimes the thumb drive where OT2 stores config data is mounted read-only (cause not yet known). When this happens, the server sometimes tries to write data or make directories on the thumb drive, and raises an unhandled exception that causes the server to fail to start. This PR adds exception handling around those write points to allow the server to boot and read previously written configs even if the mount is read-only.

Closes #1903

## changelog

- handle read-only thumb drive mount on OT2

## review requests

Needs to be tested on a robot.

- [ ] ssh into the robot
- [ ] `ps | grep python` to find the server process
- [ ] `kill -9 <proc_num>` to kill the existing server
- [ ] assuming the device is /dev/sda1: `mount -o remount,ro /dev/sda1 /mnt/usbdrive`
- [ ] `python -m opentrons.server.main -U $OT_SERVER_UNIX_SOCKET_PATH opentrons.server.main:init`
- [ ] check that the server boots and is available to the run app