### PR TITLE
refactor(components, app): Standardize modal titles

### DIFF
--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -15,7 +15,7 @@ const ATTACH_CONFIRM = 'have robot check connection'
 const DETACH_CONFIRM = 'confirm pipette is detached'
 
 export default function Instructions (props: ChangePipetteProps) {
-  const {wantedPipetteName, actualPipette} = props
+  const {wantedPipetteName, actualPipette, direction, displayName} = props
 
   const titleBar = {
     ...props,
@@ -24,9 +24,14 @@ export default function Instructions (props: ChangePipetteProps) {
       : {Component: Link, to: props.exitUrl, children: 'exit'}
   }
 
+  const heading = `${capitalize(direction)} ${displayName} Pipette`
+
   return (
-    <ModalPage titleBar={titleBar} contentsClassName={styles.modal_contents}>
-      <Title {...props} />
+    <ModalPage
+      titleBar={titleBar}
+      heading={heading}
+      contentsClassName={styles.modal_contents}
+    >
 
       {!actualPipette && !wantedPipetteName && (
         <PipetteSelection onChange={props.onPipetteSelect} />
@@ -41,17 +46,6 @@ export default function Instructions (props: ChangePipetteProps) {
         </div>
       )}
     </ModalPage>
-  )
-}
-
-function Title (props: ChangePipetteProps) {
-  const {direction, displayName} = props
-  const title = `${capitalize(direction)} ${displayName} Pipette`
-
-  return (
-    <h3 className={styles.attach_pipette_title}>
-      {title}
-    </h3>
   )
 }
 

--- a/app/src/components/layout/CardContentFlex.js
+++ b/app/src/components/layout/CardContentFlex.js
@@ -1,13 +1,15 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import styles from './styles.css'
 
 type Props = {
   children: React.Node,
+  className: string,
 }
 export default function CardContentFlex (props: Props) {
   return (
-    <div className={styles.card_content_flex}>
+    <div className={cx(styles.card_content_flex, props.className)}>
       {props.children}
     </div>
   )

--- a/app/src/components/layout/CardContentFull.js
+++ b/app/src/components/layout/CardContentFull.js
@@ -1,13 +1,15 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import styles from './styles.css'
 
 type Props = {
   children: React.Node,
+  className: string,
 }
 export default function CardContentFull (props: Props) {
   return (
-    <div className={styles.card_content_full}>
+    <div className={cx(styles.card_content_full, props.className)}>
       {props.children}
     </div>
   )

--- a/app/src/components/layout/CardContentHalf.js
+++ b/app/src/components/layout/CardContentHalf.js
@@ -1,13 +1,15 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import styles from './styles.css'
 
 type Props = {
   children: React.Node,
+  className: string,
 }
 export default function CardContentHalf (props: Props) {
   return (
-    <div className={styles.card_content_50}>
+    <div className={cx(styles.card_content_50, props.className)}>
       {props.children}
     </div>
   )

--- a/app/src/components/layout/CardContentQuarter.js
+++ b/app/src/components/layout/CardContentQuarter.js
@@ -1,13 +1,15 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import styles from './styles.css'
 
 type Props = {
   children: React.Node,
+  className: string,
 }
 export default function CardContentQuarter (props: Props) {
   return (
-    <div className={styles.card_content_25}>
+    <div className={cx(styles.card_content_25, props.className)}>
       {props.children}
     </div>
   )

--- a/app/src/components/layout/styles.css
+++ b/app/src/components/layout/styles.css
@@ -30,7 +30,6 @@
   width: 100%;
   overflow-y: auto;
   padding: 1rem;
-  font-size: var(--fs-body-2);
 }
 
 .card_content_50 {

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -134,7 +134,7 @@ exports[`modals Modal renders correctly with optional heading 1`] = `
     className="modal_contents"
   >
     <h3
-      className="modal_page_heading"
+      className="modal_heading"
     >
       Heading Visible
     </h3>

--- a/components/src/modals/Modal.js
+++ b/components/src/modals/Modal.js
@@ -30,7 +30,7 @@ export default function Modal (props: ModalProps) {
       <Overlay onClick={onCloseClick} alertOverlay={alertOverlay}/>
        <div className={cx(styles.modal_contents, contentsClassName)}>
          {heading && (
-           <h3 className={styles.modal_page_heading}>{heading}</h3>
+           <h3 className={styles.modal_heading}>{heading}</h3>
          )}
         {props.children}
       </div>

--- a/components/src/modals/ModalPage.js
+++ b/components/src/modals/ModalPage.js
@@ -24,7 +24,7 @@ export default function ModalPage (props: Props) {
       <TitleBar {...titleBar} className={styles.title_bar} />
       <div className={cx(styles.modal_page_contents, props.contentsClassName)}>
         {heading && (
-          <h3 className={styles.modal_page_heading}>{heading}</h3>
+          <h3 className={styles.modal_heading}>{heading}</h3>
         )}
         {props.children}
       </div>

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -57,12 +57,12 @@
   padding-top: 1rem;
 }
 
-.modal_page_heading {
+.modal_heading {
   @apply --font-header-dark;
 
   margin-top: 0;
   margin-bottom: 1rem;
-  text-transform: uppercase;
+  text-transform: capitalize;
 }
 
 .alert_modal_wrapper {

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -81,6 +81,7 @@
   position: relative;
   overflow: auto;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.33);
+  font-size: var(--fs-body-2);
 }
 
 .card_title {


### PR DESCRIPTION
## overview

This PR closes #2029.

## changelog
- refactor(components, app): Standardize modal titles

## review requests
Standard review. Please note due to changes in comp lib designs, some of the app modal screens are out of date (modal page headings in particular). I implemented titles based on @howisthisnamenottakenyet feedback.

I tried to implement any lingering comments from #2035 while I was in there.

To avoid any one offs - the headings for the attach/change pipette are now handled via the heading prop.