### PR TITLE
refactor(app): Move discovery / optionally enable discovery-client (2 of 2)

### DIFF
--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -20,10 +20,18 @@ describe('analytics events map', () => {
     const state = (name) => ({
       robot: {
         connection: {
-          connectRequest: {name},
-          discoveredByName: {
-            wired: {wired: true},
-            wireless: {}
+          connectRequest: {name}
+        }
+      },
+      discovery: {
+        robotsByName: {
+          wired: {
+            name: 'wired',
+            connections: [{ip: 'foo', port: 123, ok: true, local: true}]
+          },
+          wireless: {
+            name: 'wireless',
+            connections: [{ip: 'bar', port: 456, ok: true, local: false}]
           }
         }
       }

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -19,7 +19,8 @@ export default function makeEvent (state: State, action: Action): ?Event {
 
     case 'robot:CONNECT_RESPONSE':
       const name = state.robot.connection.connectRequest.name
-      const robot = state.robot.connection.discoveredByName[name]
+      const robot = robotSelectors.getDiscovered(state)
+        .find(r => r.name === name)
 
       if (!robot) {
         log.warn('No robot found for connect response')

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -5,10 +5,8 @@ import {connect} from 'react-redux'
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
 
-import {
-  selectors as robotSelectors,
-  actions as robotActions
-} from '../../robot'
+import {selectors as robotSelectors} from '../../robot'
+import {startDiscovery, getScanning} from '../../discovery'
 
 import {SidePanel} from '@opentrons/components'
 import RobotList from './RobotList'
@@ -51,12 +49,12 @@ function mapStateToProps (state: State): StateProps {
   return {
     robots,
     found: robots.length > 0,
-    isScanning: robotSelectors.getIsScanning(state)
+    isScanning: getScanning(state)
   }
 }
 
 function mapDispatchToProps (dispatch: Dispatch): DispatchProps {
   return {
-    onScanClick: () => dispatch(robotActions.discover())
+    onScanClick: () => dispatch(startDiscovery())
   }
 }

--- a/app/src/components/RobotSettings/ConnectivityCard.js
+++ b/app/src/components/RobotSettings/ConnectivityCard.js
@@ -3,9 +3,7 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
-import type {State, Dispatch} from '../../types'
-import {actions as robotActions, type Robot} from '../../robot'
-
+import {startDiscovery} from '../../discovery'
 import {
   fetchWifiList,
   configureWifi,
@@ -20,6 +18,9 @@ import {RefreshCard, LabeledValue} from '@opentrons/components'
 import {CardContentFull} from '../layout'
 import WifiConnectForm from './WifiConnectForm'
 import WifiConnectModal from './WifiConnectModal'
+
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
 
 type OwnProps = Robot
 
@@ -137,7 +138,7 @@ function mapDispatchToProps (
   const clearConfigureAction = clearConfigureWifiResponse(ownProps)
   const clearFailedConfigure = () => dispatch(clearConfigureAction)
   const clearSuccessfulConfigure = () => fetchList()
-    .then(() => dispatch(robotActions.discover()))
+    .then(() => dispatch(startDiscovery()))
     .then(() => dispatch(clearConfigureAction))
 
   return {

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -52,6 +52,10 @@ export type Config = {
     name: string,
     email: ?string,
   },
+
+  discovery: {
+    enabled: boolean,
+  },
 }
 
 type UpdateConfigAction = {|

--- a/app/src/discovery/__tests__/actions.test.js
+++ b/app/src/discovery/__tests__/actions.test.js
@@ -12,7 +12,7 @@ describe('discovery actions', () => {
 
   beforeEach(() => {
     jest.useFakeTimers()
-    store = mockStore({})
+    store = mockStore({config: {discovery: {enabled: true}}})
   })
 
   afterEach(() => {
@@ -29,5 +29,18 @@ describe('discovery actions', () => {
     expect(store.getActions()).toEqual([expectedStart])
     jest.runTimersToTime(expectedTimeout)
     expect(store.getActions()).toEqual([expectedStart, expectedFinish])
+  })
+
+  // TODO(mc, 2018-08-10): legacy discovery support; remove
+  test('startDiscovery with discovery disabled', () => {
+    store = mockStore({config: {discovery: {enabled: false}}})
+
+    const expectedStart = {
+      type: 'robot:DISCOVER',
+      meta: {robotCommand: true}
+    }
+
+    store.dispatch(startDiscovery())
+    expect(store.getActions()).toEqual([expectedStart])
   })
 })

--- a/app/src/discovery/__tests__/reducer.test.js
+++ b/app/src/discovery/__tests__/reducer.test.js
@@ -1,0 +1,97 @@
+// discovery reducer test
+import {discoveryReducer} from '..'
+
+describe('discoveryReducer', () => {
+  const SPECS = [
+    // TODO(mc, 2018-08-10): legacy; remove when DC enabled by default
+    {
+      name: 'robot:DISCOVER sets scanning: true',
+      action: {type: 'robot:DISCOVER'},
+      initialState: {scanning: false},
+      expectedState: {scanning: true}
+    },
+    // TODO(mc, 2018-08-10): legacy; remove when DC enabled by default
+    {
+      name: 'robot:DISCOVER_FINISH sets scanning: false',
+      action: {type: 'robot:DISCOVER_FINISH'},
+      initialState: {scanning: true},
+      expectedState: {scanning: false}
+    },
+    {
+      name: 'discovery:START sets scanning: true',
+      action: {type: 'discovery:START'},
+      initialState: {scanning: false},
+      expectedState: {scanning: true}
+    },
+    {
+      name: 'discovery:FINISH sets scanning: false',
+      action: {type: 'discovery:FINISH'},
+      initialState: {scanning: true},
+      expectedState: {scanning: false}
+    },
+    // TODO(mc, 2018-08-10): legacy; remove when DC enabled by default
+    {
+      name: 'robot:ADD_DISCOVERED adds robot to list',
+      action: {
+        type: 'robot:ADD_DISCOVERED',
+        payload: {name: 'foo', ip: '192.168.1.42', port: 31950, wired: false}
+      },
+      initialState: {robotsByName: {}},
+      expectedState: {
+        robotsByName: {
+          foo: {
+            name: 'foo',
+            connections: [
+              {ip: '192.168.1.42', port: 31950, ok: true, local: false}
+            ]
+          }
+        }
+      }
+    },
+    // TODO(mc, 2018-08-10): legacy; remove when DC enabled by default
+    {
+      name: 'robot:REMOVE_DISCOVERED sets ok to false',
+      action: {
+        type: 'robot:REMOVE_DISCOVERED',
+        payload: {name: 'foo', ip: '192.168.1.42', port: 31950, wired: false}
+      },
+      initialState: {robotsByName: {}},
+      expectedState: {
+        robotsByName: {
+          foo: {
+            name: 'foo',
+            connections: [
+              {ip: '192.168.1.42', port: 31950, ok: false, local: false}
+            ]
+          }
+        }
+      }
+    },
+    {
+      name: 'discovery:UPDATE_LIST resets discovered list',
+      action: {
+        type: 'discovery:UPDATE_LIST',
+        payload: {
+          robots: [
+            {name: 'foo', connections: []},
+            {name: 'bar', connections: []}
+          ]
+        }
+      },
+      initialState: {robotsByName: {}},
+      expectedState: {
+        robotsByName: {
+          foo: {name: 'foo', connections: []},
+          bar: {name: 'bar', connections: []}
+        }
+      }
+    }
+  ]
+
+  SPECS.forEach(spec => {
+    const {name, action, initialState, expectedState} = spec
+    test(name, () =>
+      expect(discoveryReducer(initialState, action)).toEqual(expectedState)
+    )
+  })
+})

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -1,0 +1,24 @@
+// discovery selectors tests
+import * as discovery from '..'
+
+describe('discovery selectors', () => {
+  const SPECS = [
+    {
+      name: 'getScanning when true',
+      selector: discovery.getScanning,
+      state: {discovery: {scanning: true}},
+      expected: true
+    },
+    {
+      name: 'getScanning when false',
+      selector: discovery.getScanning,
+      state: {discovery: {scanning: false}},
+      expected: false
+    }
+  ]
+
+  SPECS.forEach(spec => {
+    const {name, selector, state, expected} = spec
+    test(name, () => expect(selector(state)).toEqual(expected))
+  })
+})

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,6 +1,7 @@
 // @flow
 // robot discovery state
-import type {Action, ThunkAction} from '../types'
+import type {State, Action, ThunkAction} from '../types'
+import type {RobotService} from '../robot'
 import type {DiscoveredRobot} from './types'
 
 type DiscoveryState = {
@@ -34,9 +35,14 @@ export function startDiscovery (): ThunkAction {
   const start: StartAction = {type: 'discovery:START', meta: {shell: true}}
   const finish: FinishAction = {type: 'discovery:FINISH', meta: {shell: true}}
 
-  return dispatch => {
-    dispatch(start)
+  return (dispatch, getState) => {
+    // TODO(mc, 2018-08-10): remove legacy discovery
+    if (!getState().config.discovery.enabled) {
+      return dispatch({type: 'robot:DISCOVER', meta: {robotCommand: true}})
+    }
+
     setTimeout(() => dispatch(finish), DISCOVERY_TIMEOUT)
+    return dispatch(start)
   }
 }
 
@@ -48,16 +54,77 @@ export function startDiscovery (): ThunkAction {
 //   return {type: 'discovery:UPDATE_LIST', payload: {robots}}
 // }
 
+export function getScanning (state: State) {
+  return state.discovery.scanning
+}
+
+export function getDiscoveredRobotsByName (state: State) {
+  return state.discovery.robotsByName
+}
+
+// TODO(mc, 2018-08-10): implement
+// export function getRobots (state: State) {
+//
+// }
+
 // TODO(mc, 2018-08-09): implement this reducer
 export function discoveryReducer (
   state: DiscoveryState = {scanning: false, robotsByName: {}},
   action: Action
 ): DiscoveryState {
   switch (action.type) {
-    case 'discovery:START': return state
-    case 'discovery:FINISH': return state
-    case 'discovery:UPDATE_LIST': return state
+    // TODO(mc, 2018-08-10): remove robot:DISCOVER
+    case 'robot:DISCOVER':
+    case 'discovery:START':
+      return {...state, scanning: true}
+
+    // TODO(mc, 2018-08-10): remove robot:DISCOVER_FINISH
+    case 'robot:DISCOVER_FINISH':
+    case 'discovery:FINISH':
+      return {...state, scanning: false}
+
+    // TODO(mc, 2018-08-10): remove robot:ADD_DISCOVERED
+    case 'robot:ADD_DISCOVERED':
+      return {
+        ...state,
+        robotsByName: {
+          ...state.robotsByName,
+          [action.payload.name]: robotServiceToDiscoveredRobot(action.payload, true)
+        }
+      }
+
+    // TODO(mc, 2018-08-10): remove robot:REMOVE_DISCOVERED
+    case 'robot:REMOVE_DISCOVERED':
+      return {
+        ...state,
+        robotsByName: {
+          ...state.robotsByName,
+          [action.payload.name]: robotServiceToDiscoveredRobot(action.payload, false)
+        }
+      }
+
+    case 'discovery:UPDATE_LIST':
+      return {
+        ...state,
+        robotsByName: action.payload.robots.reduce((robotsMap, robot) => ({
+          ...robotsMap,
+          [robot.name]: robot
+        }), {})
+      }
   }
 
   return state
+}
+
+// TODO(mc, 2018-08-10): remove this function when no longer needed
+function robotServiceToDiscoveredRobot (
+  robot: RobotService,
+  ok: boolean
+): DiscoveredRobot {
+  return {
+    name: robot.name,
+    connections: [
+      {ip: robot.ip, port: robot.port, local: !!robot.wired, ok}
+    ]
+  }
 }

--- a/app/src/health-check/__tests__/health-check.test.js
+++ b/app/src/health-check/__tests__/health-check.test.js
@@ -16,7 +16,9 @@ import {
 jest.mock('../../http-api-client/health')
 
 const name = 'opentrons-dev'
-const robot = {name, ip: '1.2.3.4', port: '1234'}
+const ip = '1.2.3.4'
+const port = '1234'
+const robot = {name, ip, port}
 
 describe('health check', () => {
   let state
@@ -26,8 +28,13 @@ describe('health check', () => {
       robot: {
         connection: {
           connectedTo: name,
-          connectRequest: {name},
-          discoveredByName: {[name]: robot}}
+          connectRequest: {name}
+        }
+      },
+      discovery: {
+        robotsByName: {
+          [name]: {name, connections: [{ip, port, ok: true}]}
+        }
       },
       healthCheck: {
         alreadyRunning: {id: 1, missed: 0},
@@ -149,7 +156,12 @@ describe('health check', () => {
       state.robot.connection.connectedTo = ''
       invoke(robotActions.connectResponse())
       // middleware should pull `robot` from the connection request state
-      expect(store.dispatch).toHaveBeenCalledWith(startHealthCheck(robot))
+      expect(store.dispatch).toHaveBeenCalledWith(
+        startHealthCheck(expect.objectContaining({
+          ip: robot.ip,
+          port: robot.port
+        }))
+      )
     })
 
     test('CONNECT_RESPONSE failure noops', () => {

--- a/app/src/health-check/index.js
+++ b/app/src/health-check/index.js
@@ -7,7 +7,7 @@ import type {BaseRobot, RobotService} from '../robot'
 
 // TODO(mc, 2018-02-26): figure out this circular dependency
 import {
-  getDiscoveredByName,
+  getDiscovered,
   getConnectRequest,
   getConnectedRobotName
 } from '../robot/selectors'
@@ -125,7 +125,7 @@ export const healthCheckMiddleware: Middleware =
         if (!action.payload.error) {
           const state = store.getState()
           const name = getConnectRequest(state).name
-          const robot = getDiscoveredByName(state)[name]
+          const robot = getDiscovered(state).find(r => r.name === name)
           if (robot) store.dispatch(startHealthCheck(robot))
         }
         break

--- a/app/src/http-api-client/__mocks__/health.js
+++ b/app/src/http-api-client/__mocks__/health.js
@@ -1,12 +1,10 @@
 // mock health module
 'use strict'
 
+const {mockResolvedValue} = require('../../../__util__/mock-promise')
 const health = module.exports = jest.genMockFromModule('../health')
 
-health.__mockThunk = jest.fn(() => new Promise((resolve) => {
-  process.nextTick(resolve)
-}))
-
+health.__mockThunk = jest.fn()
+health.__setResponse = action => mockResolvedValue(health.__mockThunk, action)
 health.fetchHealth = jest.fn(() => health.__mockThunk)
-
 health.healthReducer.mockReturnValue({})

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -12,10 +12,7 @@ import createLogger from './logger'
 import {checkForShellUpdates, shellMiddleware} from './shell'
 
 import {healthCheckMiddleware} from './health-check'
-import {
-  apiClientMiddleware as robotApiMiddleware,
-  actions as robotActions
-} from './robot'
+import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {initializeAnalytics, analyticsMiddleware} from './analytics'
 import {initializeSupport, supportMiddleware} from './support'
 import {startDiscovery} from './discovery'
@@ -78,11 +75,7 @@ store.dispatch(initializeSupport())
 store.dispatch(checkForShellUpdates())
 
 // kickoff a discovery run immediately
-// TODO(mc, 2018-08-09): remove feature flag chack after switchover
-store.dispatch(config.discovery.enabled
-  ? startDiscovery()
-  : robotActions.discover()
-)
+store.dispatch(startDiscovery())
 
 log.info('Rendering app UI')
 renderApp()

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -6,7 +6,6 @@ import type {
   Slot,
   Axis,
   Direction,
-  BaseRobot,
   RobotService,
   ProtocolFile,
   SessionUpdate
@@ -36,7 +35,7 @@ export type AddDiscoveredAction = {|
 
 export type RemoveDiscoveredAction = {|
   type: 'robot:REMOVE_DISCOVERED',
-  payload: BaseRobot,
+  payload: RobotService,
 |}
 
 export type ConnectAction = {|
@@ -236,10 +235,12 @@ export type Action =
   | ClearSessionAction
 
 export const actions = {
+  // TODO(mc, 2018-08-10): remove
   discover (): DiscoverAction {
     return {type: 'robot:DISCOVER', meta: {robotCommand: true}}
   },
 
+  // TODO(mc, 2018-08-10): remove
   discoverFinish (): DiscoverFinishAction {
     return {type: 'robot:DISCOVER_FINISH'}
   },
@@ -274,10 +275,12 @@ export const actions = {
     }
   },
 
+  // TODO(mc, 2018-08-10): remove
   addDiscovered (service: RobotService): AddDiscoveredAction {
     return {type: 'robot:ADD_DISCOVERED', payload: service}
   },
 
+  // TODO(mc, 2018-08-10): remove
   removeDiscovered (service: RobotService): RemoveDiscoveredAction {
     return {type: 'robot:REMOVE_DISCOVERED', payload: service}
   },

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -52,7 +52,15 @@ export default function client (dispatch) {
     if (rpcClient) disconnect()
 
     const name = action.payload.name
-    const target = state[constants._NAME].connection.discoveredByName[name]
+    const target = selectors.getDiscovered(state)
+      .find(r => r.name === name)
+
+    if (!target) {
+      return dispatch(
+        actions.connectResponse(new Error(`Robot "${name}" not found`))
+      )
+    }
+
     const {ip, port} = target
 
     RpcClient(`ws://${ip}:${port}`)

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -1,15 +1,8 @@
 // @flow
 // robot connection state and reducer
-import omit from 'lodash/omit'
-import without from 'lodash/without'
-
 import type {Action} from '../../types'
 
-import type {RobotService} from '../types'
-
 import type {
-  AddDiscoveredAction,
-  RemoveDiscoveredAction,
   ConnectAction,
   ConnectResponseAction,
   ClearConnectResponseAction,
@@ -18,11 +11,6 @@ import type {
 } from '../actions'
 
 type State = {
-  isScanning: boolean,
-  discovered: string[],
-  discoveredByName: {
-    [string]: RobotService
-  },
   connectedTo: string,
   connectRequest: {
     inProgress: boolean,
@@ -36,9 +24,6 @@ type State = {
 }
 
 const INITIAL_STATE: State = {
-  isScanning: false,
-  discovered: [],
-  discoveredByName: {},
   connectedTo: '',
   connectRequest: {inProgress: false, error: null, name: ''},
   disconnectRequest: {inProgress: false, error: null}
@@ -51,18 +36,6 @@ export default function connectionReducer (
   if (state == null) return INITIAL_STATE
 
   switch (action.type) {
-    case 'robot:DISCOVER':
-      return handleDiscover(state)
-
-    case 'robot:DISCOVER_FINISH':
-      return handleDiscoverFinish(state)
-
-    case 'robot:ADD_DISCOVERED':
-      return handleAddDiscovered(state, action)
-
-    case 'robot:REMOVE_DISCOVERED':
-      return handleRemoveDiscovered(state, action)
-
     case 'robot:CONNECT':
       return handleConnect(state, action)
 
@@ -77,82 +50,9 @@ export default function connectionReducer (
 
     case 'robot:DISCONNECT_RESPONSE':
       return handleDisconnectResponse(state, action)
-
-    case 'api:SUCCESS': {
-      const {robot, path} = action.payload
-      if (path === 'health') {
-        // $FlowFixMe: api:_ actions use BaseRobot, discovery needs RobotService
-        return maybeDiscoverWired(state, robot)
-      }
-
-      break
-    }
-
-    case 'api:FAILURE': {
-      const {robot, path} = action.payload
-      if (path === 'health') {
-        // $FlowFixMe: api:_ actions use BaseRobot, discovery needs RobotService
-        return maybeRemoveWired(state, robot)
-      }
-      break
-    }
   }
 
   return state
-}
-
-function handleDiscover (state: State): State {
-  return {
-    ...state,
-    isScanning: true
-  }
-}
-
-function handleDiscoverFinish (state: State): State {
-  return {
-    ...state,
-    isScanning: false
-  }
-}
-
-function handleAddDiscovered (
-  state: State,
-  action: {payload: $PropertyType<AddDiscoveredAction, 'payload'>}
-): State {
-  const {payload} = action
-  const {name} = payload
-  let {discovered, discoveredByName} = state
-
-  if (discovered.indexOf(name) < 0) {
-    discovered = discovered.concat(name)
-  }
-
-  discoveredByName = {
-    ...discoveredByName,
-    [name]: {
-      ...discoveredByName[name],
-      ...payload
-    }
-  }
-
-  return {...state, discovered, discoveredByName}
-}
-
-function handleRemoveDiscovered (
-  state: State,
-  action: {payload: $PropertyType<RemoveDiscoveredAction, 'payload'>}
-): State {
-  if (state.connectedTo === action.payload.name) {
-    return state
-  }
-
-  const {payload: {name}} = action
-
-  return {
-    ...state,
-    discovered: without(state.discovered, name),
-    discoveredByName: omit(state.discoveredByName, name)
-  }
 }
 
 function handleConnect (state: State, action: ConnectAction): State {
@@ -201,16 +101,4 @@ function handleClearConnectResponse (
   action: ClearConnectResponseAction
 ): State {
   return {...state, connectRequest: INITIAL_STATE.connectRequest}
-}
-
-function maybeDiscoverWired (state: State, robot: RobotService): State {
-  if (!robot.wired) return state
-
-  return handleAddDiscovered(state, {payload: robot})
-}
-
-function maybeRemoveWired (state: State, robot: RobotService): State {
-  if (!robot.wired) return state
-
-  return handleRemoveDiscovered(state, {payload: robot})
 }

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -75,8 +75,14 @@ describe('api client', () => {
   const STATE = {
     [NAME]: {
       connection: {
-        discoveredByName: {
-          [ROBOT_NAME]: {ip: ROBOT_IP, port: 31950}
+        connectedTo: ''
+      }
+    },
+    discovery: {
+      robotsByName: {
+        [ROBOT_NAME]: {
+          name: ROBOT_NAME,
+          connections: [{ip: ROBOT_IP, port: 31950, ok: true}]
         }
       }
     }

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -8,34 +8,9 @@ describe('robot reducer - connection', () => {
     const state = reducer(undefined, {})
 
     expect(getState(state)).toEqual({
-      isScanning: false,
-      discovered: [],
-      discoveredByName: {},
       connectedTo: '',
       connectRequest: {inProgress: false, error: null, name: ''},
       disconnectRequest: {inProgress: false, error: null}
-    })
-  })
-
-  test('handles DISCOVER action', () => {
-    const state = {
-      connection: {isScanning: false}
-    }
-    const action = {type: 'robot:DISCOVER'}
-
-    expect(getState(reducer(state, action))).toEqual({
-      isScanning: true
-    })
-  })
-
-  test('handles DISCOVER_FINISH action', () => {
-    const state = {
-      connection: {isScanning: true}
-    }
-    const action = {type: 'robot:DISCOVER_FINISH'}
-
-    expect(getState(reducer(state, action))).toEqual({
-      isScanning: false
     })
   })
 
@@ -157,128 +132,6 @@ describe('robot reducer - connection', () => {
     expect(getState(reducer(state, action))).toEqual({
       connectedTo: '',
       disconnectRequest: {inProgress: false, error: null}
-    })
-  })
-
-  test('handles ADD_DISCOVERED action', () => {
-    const state = {
-      connection: {
-        discovered: ['foo'],
-        discoveredByName: {
-          foo: {host: 'abcdef.local', name: 'foo'}
-        }
-      }
-    }
-    const action = {
-      type: 'robot:ADD_DISCOVERED',
-      payload: {host: '123456.local', name: 'bar'}
-    }
-
-    expect(getState(reducer(state, action))).toEqual({
-      discovered: ['foo', 'bar'],
-      discoveredByName: {
-        foo: {host: 'abcdef.local', name: 'foo'},
-        bar: {host: '123456.local', name: 'bar'}
-      }
-    })
-  })
-
-  test('handles ADD_DISCOVERED action when robot is already present', () => {
-    const state = {
-      connection: {
-        discovered: ['foo'],
-        discoveredByName: {
-          foo: {host: 'abcdef.local', name: 'foo'}
-        }
-      }
-    }
-    const action = {
-      type: 'robot:ADD_DISCOVERED',
-      payload: {host: 'abcdef.local', name: 'foo'}
-    }
-
-    expect(getState(reducer(state, action))).toEqual({
-      discovered: ['foo'],
-      discoveredByName: {
-        foo: {host: 'abcdef.local', name: 'foo'}
-      }
-    })
-  })
-
-  test('handles REMOVE_DISCOVERED action', () => {
-    const state = {
-      connection: {
-        discovered: ['foo', 'bar'],
-        discoveredByName: {
-          foo: {host: 'abcdef.local', name: 'foo'},
-          bar: {host: '123456.local', name: 'bar'}
-        }
-      }
-    }
-    const action = {
-      type: 'robot:REMOVE_DISCOVERED',
-      payload: {name: 'foo'}
-    }
-
-    expect(getState(reducer(state, action))).toEqual({
-      discovered: ['bar'],
-      discoveredByName: {
-        bar: {host: '123456.local', name: 'bar'}
-      }
-    })
-  })
-
-  test('adds wired robot to discovered on /health api:SUCCESS', () => {
-    const state = {
-      connection: {
-        discovered: ['foo'],
-        discoveredByName: {
-          foo: {name: 'foo', host: 'abcdef.local'}
-        }
-      }
-    }
-
-    const action = {
-      type: 'api:SUCCESS',
-      payload: {
-        robot: {name: 'bar', host: 'ghijkl.local', wired: true},
-        path: 'health'
-      }
-    }
-
-    expect(getState(reducer(state, action))).toEqual({
-      discovered: ['foo', 'bar'],
-      discoveredByName: {
-        foo: {name: 'foo', host: 'abcdef.local'},
-        bar: {name: 'bar', host: 'ghijkl.local', wired: true}
-      }
-    })
-  })
-
-  test('removes wired robot from discovered on /health api:FAILURE', () => {
-    const state = {
-      connection: {
-        discovered: ['foo', 'bar'],
-        discoveredByName: {
-          foo: {name: 'foo', host: 'abcdef.local'},
-          bar: {name: 'bar', host: 'ghijkl.local', wired: true}
-        }
-      }
-    }
-
-    const action = {
-      type: 'api:FAILURE',
-      payload: {
-        robot: {name: 'bar', host: 'ghijkl.local', wired: true},
-        path: 'health'
-      }
-    }
-
-    expect(getState(reducer(state, action))).toEqual({
-      discovered: ['foo'],
-      discoveredByName: {
-        foo: {name: 'foo', host: 'abcdef.local'}
-      }
     })
   })
 })

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -4,7 +4,6 @@ import {NAME, selectors, constants} from '../'
 const makeState = (state) => ({[NAME]: state})
 
 const {
-  getIsScanning,
   getDiscovered,
   getConnectionStatus,
   getSessionLoadInProgress,
@@ -32,25 +31,36 @@ const {
 } = selectors
 
 describe('robot selectors', () => {
-  test('getIsScanning', () => {
-    let state = {connection: {isScanning: true}}
-    expect(getIsScanning(makeState(state))).toBe(true)
-
-    state = {connection: {isScanning: false}}
-    expect(getIsScanning(makeState(state))).toBe(false)
-  })
-
   test('getDiscovered', () => {
     const state = {
-      robot: {
-        connection: {
-          connectedTo: 'bar',
-          discovered: ['foo', 'bar', 'baz', 'qux'],
-          discoveredByName: {
-            foo: {host: 'abcdef.local', name: 'foo'},
-            bar: {host: '123456.local', name: 'bar'},
-            baz: {host: 'qwerty.local', name: 'baz'},
-            qux: {host: 'dvorak.local', name: 'qux', wired: true}
+      robot: {connection: {connectedTo: 'bar'}},
+      discovery: {
+        robotsByName: {
+          foo: {
+            name: 'foo',
+            connections: [
+              {ip: '10.10.1.2', port: 31950, ok: true, local: false}
+            ]
+          },
+          bar: {
+            name: 'bar',
+            connections: [
+              {ip: '10.10.3.4', port: 31950, ok: true, local: false},
+              {ip: '169.254.3.4', port: 31950, ok: true, local: true}
+            ]
+          },
+          baz: {
+            name: 'baz',
+            connections: [
+              {ip: '10.10.5.6', port: 31950, ok: true, local: false},
+              {ip: '169.254.5.6', port: 31950, ok: false, local: true}
+            ]
+          },
+          qux: {
+            name: 'qux',
+            connections: [
+              {ip: '169.254.7.8', port: 31950, ok: true, local: true}
+            ]
           }
         }
       }
@@ -59,17 +69,32 @@ describe('robot selectors', () => {
     expect(getDiscovered(state)).toEqual([
       {
         name: 'bar',
-        host: '123456.local',
+        ip: '169.254.3.4',
+        port: 31950,
+        wired: true,
         isConnected: true
       },
       {
         name: 'qux',
-        host: 'dvorak.local',
+        ip: '169.254.7.8',
+        port: 31950,
         isConnected: false,
         wired: true
       },
-      {name: 'baz', host: 'qwerty.local', isConnected: false},
-      {name: 'foo', host: 'abcdef.local', isConnected: false}
+      {
+        name: 'baz',
+        ip: '10.10.5.6',
+        port: 31950,
+        wired: false,
+        isConnected: false
+      },
+      {
+        name: 'foo',
+        ip: '10.10.1.2',
+        port: 31950,
+        wired: false,
+        isConnected: false
+      }
     ])
   })
 


### PR DESCRIPTION
## overview

This PR is part 2 of a 2 part change:

- #2036: Incorporate discovery-client into app-shell behind flag (1 of 2)
- #2045: Move discovery / optionally enable discovery-client (this one)

It continues the work in 2036 by moving the app's discovery state out of the giant `robot` state subtree and into its own top-level `discovery` subtree. It also wires up the app to the new `DiscoveryClient` + `app-shell/discovery` module.

With this PR, the discovery refactor reaches feature parity with the existing system except for IPv6 wired robots. Remaining planned work:

- Support "legacy" (IPv6) wired robots (hit parity)
- Wire-up robot list persistence across boots
- Add UI for unhealthy but known robots
- Tweak UI for single robot item that is connected over ethernet but is also reachable on WiFi
- Remove feature flag to enable by default

## changelog

- refactor(app): Move discovery state to top-level `discovery` tree
- refactor(app): Optionally enable discovery-client to drive `discovery` state in the app

## review requests

### existing discovery

New discovery is behind a feature flag. Old discovery should still work.

```shell
make -C app dev
```

- [x] List population should work (almost, see below) the same as it was working before
    - None of the actions nor underlying mechanisms have been removed
    - The existing actions drive a new reducer

**Known change for legacy discovery** An IPv6 wired robot could previous be removed by _any_ failed `GET /health`, regardless of if that fetch was discovery related or not (e.g. a refresh of the robot info card could cause the robot to disappear if it was not responding). This behavior has been removed from the legacy discovery module; un-reachable IPv6 wired robots will only be removed if the are found to be unreachable during a refresh period.

### new discovery - OT_APP_DISCOVERY__ENABLED=1

To test out the new plumbing:

```shell
make -C app dev OT_APP_DISCOVERY__ENABLED=1
```

- [x] Robot list populates with WiFi robots
- [x] Robot list populates with wired robots (IPv4 necessary)
    - Testable with wandering-katie, sunset, moon-moon, and any other robot on Resin app TempBots
- [x] If a robot is on WiFi and USB, shows up in list as USB robot
- [x] If a robot on WiFi and USB is unplugged, it will (eventually) update to a WiFi robot

**Known limitations / TODOs**

- Local VS API (`make -C api dev ENABLE_VIRTUAL_SMOOTHIE=true`) isn't working yet
- IPv6 ethernet robot support isn't working yet
- Clicking refresh button clears the list
    - This is a UI limitation; happens because underlying `ok` health check flags go from `true` (good) to `null` (unknown)
- List population/update for a given robot can be slow
    - List pre-population is a TODO
    - Polling intervals probably need to be tweaked
    - Current implementation of UI is to only display robots that are `ok === true`