### PR TITLE
feat(api): Consolidate pipette configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ target/
 
 # Testing
 api/tests/opentrons/data/configs/
+api/opentrons/config/*.json
 sample_protocol.py
 
 # Local Calibration Data

--- a/api/MANIFEST.in
+++ b/api/MANIFEST.in
@@ -4,3 +4,4 @@ include opentrons/config/smoothie/smoothie-defaults.ini
 include opentrons/config/smoothie/config_one_pro_plus
 include opentrons/config/modules/avrdude.conf
 include opentrons/config/modules/95-opentrons-modules.rules
+include opentrons/config/pipette-config.json

--- a/api/Makefile
+++ b/api/Makefile
@@ -53,8 +53,9 @@ publish:
 	cd scripts && publish.sh && doc-deploy.sh
 
 .PHONY: dev
+dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev:
-	ENABLE_VIRTUAL_SMOOTHIE=true $(python) opentrons/server/main.py -P 31950 opentrons.server.main:init
+	$(python) opentrons/server/main.py -P 31950 opentrons.server.main:init
 
 .PHONY: wheel
 wheel: clean

--- a/api/Makefile
+++ b/api/Makefile
@@ -54,7 +54,7 @@ publish:
 
 .PHONY: dev
 dev:
-	$(python) opentrons/server/main.py -P 31950 opentrons.server.main:init
+	ENABLE_VIRTUAL_SMOOTHIE=true $(python) opentrons/server/main.py -P 31950 opentrons.server.main:init
 
 .PHONY: wheel
 wheel: clean

--- a/api/opentrons/deck_calibration/endpoints.py
+++ b/api/opentrons/deck_calibration/endpoints.py
@@ -122,12 +122,12 @@ def set_current_mount(attached_pipettes):
     pipette = None
     model = None
 
-    if left['model'] in pipette_config.configs.keys():
+    if left['model'] in pipette_config.configs:
         pip_config = pipette_config.load(left['model'])
         left_pipette = instruments._create_pipette_from_config(
             mount='left', config=pip_config)
 
-    if right['model'] in pipette_config.configs.keys():
+    if right['model'] in pipette_config.configs:
         pip_config = pipette_config.load(right['model'])
         right_pipette = instruments._create_pipette_from_config(
             mount='right', config=pip_config)

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -2,17 +2,12 @@ import logging
 import os
 import json
 from collections import namedtuple
-from opentrons.config import get_config_index
+from opentrons import __file__ as root_file
 
-FILE_DIR = os.path.abspath(os.path.dirname(__file__))
 
+root_dir = os.path.abspath(os.path.dirname(root_file))
+config_file = os.path.join(root_dir, 'config', 'pipette-config.json')
 log = logging.getLogger(__name__)
-
-
-def pipette_config_path():
-    index = get_config_index()
-    return index.get('pipetteConfigFile', './settings.json')
-
 
 pipette_config = namedtuple(
     'pipette_config',
@@ -32,84 +27,16 @@ pipette_config = namedtuple(
 )
 
 
-def _create_config_from_dict(cfg: dict, model: str) -> pipette_config:
+# Notes:
+# - multi-channel pipettes share the same dimensional offsets
+# - single-channel pipettes have different lengths
+# - Default number of seconds to aspirate/dispense a pipette's full volume,
+#     and these times were chosen to mimic normal human-pipetting motions.
+#     However, accurate speeds are dependent on environment (ex: liquid
+#     viscosity), therefore a pipette's flow-rates (ul/sec) should be set by
+#     protocol writer
 
-    def _dict_key_to_config_attribute(key: str) -> str:
-        '''
-        Converts the JSON key syntax (eg: "plungerPositions"), to the format
-        used in the namedtuple `plunger_config` (eg: "plunger_positions")
-        '''
-        return ''.join([
-                '_{}'.format(c.lower()) if c.isupper() else c
-                for c in key
-            ])
-
-    def _load_config_value(config_dict: dict, key: str):
-        '''
-        Retrieves a given key from the loaded JSON config dict. If that key is
-        not present in the dictionary, it falls back to the value from
-        the namedtuple `plunger_config`, named "fallback"
-        '''
-        nonlocal model
-        fallback_cfg = fallback_configs.get(model)
-        fallback_key = _dict_key_to_config_attribute(key)
-        fallback_value = getattr(fallback_cfg, fallback_key)
-        return config_dict.get(key, fallback_value)
-
-    res = None
-
-    try:
-        plunger_pos = _load_config_value(cfg, 'plungerPositions')
-        res = pipette_config(
-            plunger_positions={
-                'top': plunger_pos['top'],
-                'bottom': plunger_pos['bottom'],
-                'blow_out': plunger_pos.get(
-                    'blowOut', plunger_pos.get('blow_out')),
-                'drop_tip': plunger_pos.get(
-                    'dropTip', plunger_pos.get('drop_tip')),
-            },
-            pick_up_current=_load_config_value(cfg, 'pickUpCurrent'),
-            aspirate_flow_rate=_load_config_value(
-                cfg, 'aspirateFlowRate'),
-            dispense_flow_rate=_load_config_value(
-                cfg, 'dispenseFlowRate'),
-            channels=_load_config_value(cfg, 'channels'),
-            name=model,
-            model_offset=_load_config_value(cfg, 'modelOffset'),
-            plunger_current=_load_config_value(cfg, 'plungerCurrent'),
-            drop_tip_current=_load_config_value(cfg, 'dropTipCurrent'),
-            max_volume=_load_config_value(cfg, 'max_volume'),
-            tip_length=_load_config_value(cfg, 'tipLength')
-        )
-    except (KeyError, json.decoder.JSONDecodeError) as e:
-        log.error('Error when loading pipette config: {}'.format(e))
-
-    return res
-
-
-def _load_config_dict_from_file(pipette_model: str) -> dict:
-    config_file = pipette_config_path()
-    cfg = {}
-    if os.path.exists(config_file):
-        with open(config_file) as conf:
-            all_configs = json.load(conf)
-            cfg = all_configs.get(pipette_model, cfg)
-    return cfg
-
-
-# ------------------------- deprecated data ---------------------------
-# This section is left in as a fall-back until the settings file is
-# available on all robots. Currently, getting the settings file onto
-# the robots requires a Resin push, which involves some pain to users
-# because it restarts the robot--even if a protocol run is in progress.
-# The preferred solution is to implement a server endpoint that will
-# accept a data packet and save it in the robot, the same way that API
-# server updates are currently done. Once that is in place, the app can
-# ship the required data to the robot and this fallback data can be
-# removed from server code. Delete from here to "end deprecated data"
-# below, and remove the `select_config` call from the `config` dict
-# comprehension.
+# Multi-channel y offset caluclations:
 DISTANCE_BETWEEN_NOZZLES = 9
 NUM_MULTI_CHANNEL_NOZZLES = 8
 MULTI_LENGTH = (NUM_MULTI_CHANNEL_NOZZLES - 1) * DISTANCE_BETWEEN_NOZZLES
@@ -121,320 +48,9 @@ Z_OFFSET_P50 = 0
 Z_OFFSET_P300 = 0
 Z_OFFSET_P1000 = 20  # shortest single-channel pipette
 
-DEFAULT_ASPIRATE_SECONDS = 2
-DEFAULT_DISPENSE_SECONDS = 1
 
-# TODO (ben 20180511): should we read these values from
-# TODO                 /shared-data/robot-data/pipette-config.json ? Unclear,
-# TODO                 because this is the backup in case that behavior fails,
-# TODO                 but we could make it more reliable if we start bundling
-# TODO                 config data into the wheel file perhaps. Needs research.
-p10_single_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2,
-        'blow_out': -1,
-        'drop_tip': -4.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p10_single_v1',
-    model_offset=[0.0, 0.0, Z_OFFSET_P10],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=10,
-    tip_length=33
-)
-
-p10_single_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 0.5,
-        'blow_out': -2.5,
-        'drop_tip': -6
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p10_single_v1.3',
-    model_offset=[0.0, 0.0, Z_OFFSET_P10],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=10,
-    tip_length=33
-)
-
-p10_multi_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2,
-        'blow_out': -1,
-        'drop_tip': -4
-    },
-    pick_up_current=0.2,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p10_multi_v1',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=10,
-    tip_length=33
-)
-
-p10_multi_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 0.5,
-        'blow_out': -2.5,
-        'drop_tip': -5.5
-    },
-    pick_up_current=0.2,
-    aspirate_flow_rate=10 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=10 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p10_multi_v1.3',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=10,
-    tip_length=33
-)
-
-p50_single_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2.01,
-        'blow_out': 2,
-        'drop_tip': -4.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p50_single_v1',
-    model_offset=[0.0, 0.0, Z_OFFSET_P50],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=50,
-    tip_length=51.7
-)
-
-p50_single_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2,
-        'blow_out': 0.5,
-        'drop_tip': -6
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p50_single_v1.3',
-    model_offset=[0.0, 0.0, Z_OFFSET_P50],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=50,
-    tip_length=51.7
-)
-
-p50_multi_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2.5,
-        'blow_out': 2,
-        'drop_tip': -3.5
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p50_multi_v1',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=50,
-    tip_length=51.7
-)
-
-p50_multi_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2,
-        'blow_out': 0.5,
-        'drop_tip': -5
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=50 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=50 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p50_multi_v1.3',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=50,
-    tip_length=51.7
-)
-
-p300_single_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 1.5,
-        'blow_out': 0,
-        'drop_tip': -4
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p300_single_v1',
-    model_offset=[0.0, 0.0, Z_OFFSET_P300],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=300,
-    tip_length=51.7
-)
-
-p300_single_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 1.5,
-        'blow_out': -1.5,
-        'drop_tip': -5.5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p300_single_v1.3',
-    model_offset=[0.0, 0.0, Z_OFFSET_P300],
-    plunger_current=0.3,
-    drop_tip_current=0.5,
-    max_volume=300,
-    tip_length=51.7
-)
-
-p300_multi_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 3.5,
-        'blow_out': 3,
-        'drop_tip': -2
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p300_multi_v1',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=300,
-    tip_length=51.7
-)
-
-p300_multi_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 3.5,
-        'blow_out': 1.5,
-        'drop_tip': -3.5
-    },
-    pick_up_current=0.3,
-    aspirate_flow_rate=300 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=300 / DEFAULT_DISPENSE_SECONDS,
-    channels=8,
-    name='p300_multi_v1.3',
-    model_offset=[0.0, Y_OFFSET_MULTI, Z_OFFSET_MULTI],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=300,
-    tip_length=51.7
-)
-
-p1000_single_v1 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 3,
-        'blow_out': 1,
-        'drop_tip': -5
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p1000_single_v1',
-    model_offset=[0.0, 0.0, Z_OFFSET_P1000],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=1000,
-    tip_length=76.7
-)
-
-p1000_single_v1_3 = pipette_config(
-    plunger_positions={
-        'top': 19.5,
-        'bottom': 2.5,
-        'blow_out': -0.5,
-        'drop_tip': -4
-    },
-    pick_up_current=0.1,
-    aspirate_flow_rate=1000 / DEFAULT_ASPIRATE_SECONDS,
-    dispense_flow_rate=1000 / DEFAULT_DISPENSE_SECONDS,
-    channels=1,
-    name='p1000_single_v1.3',
-    model_offset=[0.0, 0.0, Z_OFFSET_P1000],
-    plunger_current=0.5,
-    drop_tip_current=0.5,
-    max_volume=1000,
-    tip_length=76.7
-)
-
-fallback_configs = {
-    'p10_single_v1': p10_single_v1,
-    'p10_single_v1.3': p10_single_v1_3,
-    'p10_multi_v1': p10_multi_v1,
-    'p10_multi_v1.3': p10_multi_v1_3,
-    'p50_single_v1': p50_single_v1,
-    'p50_single_v1.3': p50_single_v1_3,
-    'p50_multi_v1': p50_multi_v1,
-    'p50_multi_v1.3': p50_multi_v1_3,
-    'p300_single_v1': p300_single_v1,
-    'p300_single_v1.3': p300_single_v1_3,
-    'p300_multi_v1': p300_multi_v1,
-    'p300_multi_v1.3': p300_multi_v1_3,
-    'p1000_single_v1': p1000_single_v1,
-    'p1000_single_v1.3': p1000_single_v1_3,
-}
-
-
-def select_config(model: str):
-    cfg_dict = _load_config_dict_from_file(model)
-    cfg = _create_config_from_dict(cfg_dict, model)
-    if not cfg:
-        cfg = fallback_configs.get(model)
-    return cfg
-# ----------------------- end deprecated data -------------------------
-
-
-# Notes:
-# - multi-channel pipettes share the same dimensional offsets
-# - single-channel pipettes have different lengths
-# - Default number of seconds to aspirate/dispense a pipette's full volume,
-#     and these times were chosen to mimic normal human-pipetting motions.
-#     However, accurate speeds are dependent on environment (ex: liquid
-#     viscosity), therefore a pipette's flow-rates (ul/sec) should be set by
-#     protocol writer
-
-
-configs = {
-    model: select_config(model)
-    for model in fallback_configs.keys()}
+with open(config_file) as cfg_file:
+    configs = json.load(cfg_file).keys()
 
 
 def load(pipette_model: str) -> pipette_config:
@@ -448,4 +64,45 @@ def load(pipette_model: str) -> pipette_config:
         key in the "pipette-config.json" file
     :return: a `pipette_config` instance
     """
-    return select_config(pipette_model)
+    with open(config_file) as cfg_file:
+        cfg = json.load(cfg_file).get(pipette_model, {})
+
+        plunger_pos = cfg.get('plungerPositions')
+
+        res = pipette_config(
+            plunger_positions={
+                'top': plunger_pos.get('top'),
+                'bottom': plunger_pos.get('bottom'),
+                'blow_out': plunger_pos.get('blowOut'),
+                'drop_tip': plunger_pos.get('dropTip'),
+            },
+            pick_up_current=cfg.get('pickUpCurrent'),
+            aspirate_flow_rate=cfg.get('aspirateFlowRate'),
+            dispense_flow_rate=cfg.get('dispenseFlowRate'),
+            channels=cfg.get('channels'),
+            name=pipette_model,
+            model_offset=cfg.get('modelOffset'),
+            plunger_current=cfg.get('plungerCurrent'),
+            drop_tip_current=cfg.get('dropTipCurrent'),
+            max_volume=cfg.get('maxVolume'),
+            tip_length=cfg.get('tipLength')
+        )
+
+    # Verify that stored values agree with calculations
+    if 'multi' in pipette_model:
+        assert res.model_offset[1] == Y_OFFSET_MULTI
+        assert res.model_offset[2] == Z_OFFSET_MULTI
+    elif 'p1000' in pipette_model:
+        assert res.model_offset[1] == 0.0
+        assert res.model_offset[2] == Z_OFFSET_P1000
+    elif 'p10' in pipette_model:
+        assert res.model_offset[1] == 0.0
+        assert res.model_offset[2] == Z_OFFSET_P10
+    elif 'p300' in pipette_model:
+        assert res.model_offset[1] == 0.0
+        assert res.model_offset[2] == Z_OFFSET_P300
+    else:
+        assert res.model_offset[1] == 0.0
+        assert res.model_offset[2] == Z_OFFSET_P50
+
+    return res

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -791,7 +791,7 @@ class Robot(object):
             }
         left_model = left_data.get('model')
         if left_model:
-            tip_length = pipette_config.configs[left_model].tip_length
+            tip_length = pipette_config.load(left_model).tip_length
             left_data.update({'tip_length': tip_length})
 
         right_data = {
@@ -801,7 +801,7 @@ class Robot(object):
             }
         right_model = right_data.get('model')
         if right_model:
-            tip_length = pipette_config.configs[right_model].tip_length
+            tip_length = pipette_config.load(right_model).tip_length
             right_data.update({'tip_length': tip_length})
         return {
             'left': left_data,

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -204,17 +204,18 @@ def backup_configuration(config: robot_config, tag=None):
     save_robot_settings(config, tag=tag)
 
 
-def clear(filename=None):
-    if filename:
-        files = [filename]
-    else:
-        dc_filename = get_config_index().get('deckCalibrationFile')
-        rs_filename = get_config_index().get('robotSettingsFile')
-        files = [dc_filename, rs_filename]
-    log.info('Deleting config file: {}'.format(filename))
-    for file in files:
-        if os.path.exists(file):
-            os.remove(file)
+def clear():
+    files = [
+        get_config_index().get('deckCalibrationFile'),
+        get_config_index().get('robotSettingsFile')]
+    for filename in files:
+        _clear_file(filename)
+
+
+def _clear_file(filename):
+    log.debug('Deleting {}'.format(filename))
+    if os.path.exists(filename):
+        os.remove(filename)
 
 
 def _load_json(filename) -> dict:

--- a/api/opentrons/server/endpoints/control.py
+++ b/api/opentrons/server/endpoints/control.py
@@ -174,9 +174,9 @@ def _validate_move_data(data):
         error = True
     if target == 'pipette':
         model = data.get('model')
-        if model not in pipette_config.configs.keys():
+        if model not in pipette_config.configs:
             message = "Model '{}' not recognized, must be one " \
-                      "of {}".format(model, pipette_config.configs.keys())
+                      "of {}".format(model, pipette_config.configs)
             error = True
     else:
         model = None

--- a/api/setup.py
+++ b/api/setup.py
@@ -2,6 +2,7 @@
 # https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
 import codecs
 import os
+import shutil
 from setuptools import setup, find_packages
 import json
 
@@ -54,6 +55,18 @@ def read(*parts):
 
 
 if __name__ == "__main__":
+    pipette_config_filename = 'pipette-config.json'
+    config_src = os.path.join(
+        '..', 'shared-data', 'robot-data', pipette_config_filename)
+    config_dst = os.path.join('opentrons', 'config')
+    try:
+        pipette_config_file = os.path.join(config_dst, pipette_config_filename)
+        if os.path.exists(pipette_config_file):
+            os.remove(pipette_config_file)
+        shutil.copy2(config_src, config_dst)
+    except OSError:
+        print('Unable to copy shared data directory due to exception:')
+
     setup(
         python_requires='>=3.6',
         name=DISTNAME,

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -60,7 +60,8 @@ def test_all_pipette_models_can_transfer():
 def test_pipette_models_reach_max_volume():
     from opentrons.instruments import pipette_config
 
-    for model, config in pipette_config.configs.items():
+    for model in pipette_config.configs:
+        config = pipette_config.load(model)
         robot.reset()
         pipette = instruments._create_pipette_from_config(
             config=config,
@@ -293,30 +294,3 @@ def test_drop_tip_in_trash(virtual_smoothie_env, monkeypatch):
     y_offset = movelog[0][1][1]
     assert base_obj == robot.fixed_trash[0]
     assert y_offset == 111.5
-
-
-def test_fallback_config_file():
-    from opentrons.instruments.pipette_config import \
-        _create_config_from_dict, fallback_configs
-
-    pipette_dict = {
-        'tipLength': 321,
-        'channels': 4
-    }
-
-    for model, config in fallback_configs.items():
-        new_config = _create_config_from_dict(pipette_dict, model)
-        assert new_config.tip_length == 321
-        assert new_config.channels == 4
-        assert new_config.name == config.name
-        assert new_config.pick_up_current == config.pick_up_current
-        assert new_config.plunger_positions == config.plunger_positions
-
-
-def test_json_and_fallback_configs_match():
-    from opentrons.instruments.pipette_config import \
-        select_config, fallback_configs
-
-    for model, config_fallback in fallback_configs.items():
-        config_from_json = select_config(model)
-        assert config_from_json == config_fallback

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from opentrons import robot, modules
 from opentrons.server.main import init
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
-from opentrons.instruments.pipette_config import configs
+from opentrons.instruments import pipette_config
 
 
 async def test_get_pipettes_uncommissioned(
@@ -51,7 +51,7 @@ async def test_get_pipettes(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = configs[test_model]
+    model = pipette_config.load(test_model)
     expected = {
         'left': {
             'model': model.name,
@@ -110,7 +110,7 @@ async def test_get_cached_pipettes(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    model = configs[test_model]
+    model = pipette_config.load(test_model)
     expected = {
         'left': {
             'model': model.name,
@@ -131,7 +131,7 @@ async def test_get_cached_pipettes(
     assert resp.status == 200
     assert json.loads(text) == expected
 
-    model1 = list(configs.values())[1]
+    model1 = pipette_config.load('p10_single_v1.3')
 
     def dummy_model(mount):
         return model1.name

--- a/shared-data/robot-data/pipette-config.json
+++ b/shared-data/robot-data/pipette-config.json
@@ -46,7 +46,7 @@
       "blowOut": -1,
       "dropTip": -4
     },
-    "pickUpCurrent": 0.2,
+    "pickUpCurrent": 0.4,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
     "channels": 8,
@@ -65,7 +65,7 @@
       "blowOut": -2.5,
       "dropTip": -5.5
     },
-    "pickUpCurrent": 0.2,
+    "pickUpCurrent": 0.4,
     "aspirateFlowRate": 5,
     "dispenseFlowRate": 10,
     "channels": 8,
@@ -122,7 +122,7 @@
       "blowOut": 2,
       "dropTip": -3.5
     },
-    "pickUpCurrent": 0.3,
+    "pickUpCurrent": 0.6,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
     "channels": 8,
@@ -141,7 +141,7 @@
       "blowOut": 0.5,
       "dropTip": -5
     },
-    "pickUpCurrent": 0.3,
+    "pickUpCurrent": 0.6,
     "aspirateFlowRate": 25,
     "dispenseFlowRate": 50,
     "channels": 8,
@@ -198,7 +198,7 @@
       "blowOut": 3,
       "dropTip": -2
     },
-    "pickUpCurrent": 0.3,
+    "pickUpCurrent": 0.6,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
     "channels": 8,
@@ -217,7 +217,7 @@
       "blowOut": 1.5,
       "dropTip": -3.5
     },
-    "pickUpCurrent": 0.3,
+    "pickUpCurrent": 0.6,
     "aspirateFlowRate": 150,
     "dispenseFlowRate": 300,
     "channels": 8,


### PR DESCRIPTION
## overview

This PR is also acting as a ticket. Pipette configuration data is duplicated in several places in both data and code, and the config loading system is unnecessarily complex. 

This PR will consolidate pipette configuration to only use the version from shared-data, and update multi-channel pick up currents based on test data from @Carlos-fernandez. 

## changelog

- Bundle pipette-config.json from shared-data into the api wheel
- Use bundled pipette-config.json for pipette configs (no other copies of data)
- Update multi-channel pick up current values based on test data

## review requests

Tested on 🌔 🌔 --loads correctly with different pipettes (p300_multi_v1 and p300_single_v1).  @Carlos-fernandez please verify the new current values.