### PR TITLE
build(make): Add method to override python on which to install pipenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Individual projects may have additional instructions, so be sure to check out th
 Your computer will need the following tools installed to be able to develop with the Opentrons platform:
 
 *   macOS 10.11+, Linux, or Windows 10
-*   Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux)
+*   Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux. If `pyenv` is not available for your system or you do not want to use it, you can set the environment variable `OT_PYTHON` to the full path to the Python 3.6 executable)
 
     ```shell
     pyenv install 3.6.4

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ API_DIR := api
 API_LIB_DIR := api-server-lib
 SHARED_DATA_DIR := shared-data
 UPDATE_SERVER_DIR := update-server
+INSTALL_PYTHON ?= python
 
 # watch, coverage, and update snapshot variables for tests
 watch ?= false
@@ -24,7 +25,7 @@ endif
 # front-end dependecies handled by yarn
 .PHONY: install
 install:
-	pip install pipenv==11.6.8
+	$(INSTALL_PYTHON) -m pip install pipenv==11.6.8
 	$(MAKE) -C $(API_LIB_DIR) install
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ API_DIR := api
 API_LIB_DIR := api-server-lib
 SHARED_DATA_DIR := shared-data
 UPDATE_SERVER_DIR := update-server
-INSTALL_PYTHON ?= python
+
+# this may be set as an environment variable to select the version of
+# python to run if pyenv is not available. it should always be set to
+# point to a python3.6.
+OT_PYTHON ?= python
 
 # watch, coverage, and update snapshot variables for tests
 watch ?= false
@@ -25,7 +29,7 @@ endif
 # front-end dependecies handled by yarn
 .PHONY: install
 install:
-	$(INSTALL_PYTHON) -m pip install pipenv==11.6.8
+	$(OT_PYTHON) -m pip install pipenv==11.6.8
 	$(MAKE) -C $(API_LIB_DIR) install
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install


### PR DESCRIPTION
## overview

The install target in the root makefile installs pipenv, and was
therefore not using pipenv. Instead, it calls python directly, which is
mostly fine unless you have a default-set-up Mac, which has python
invoking the system's python2. Now, you can override the INSTALL_PYTHON
env var (for instance, by invoking make like `INSTALL_PYTHON=python3
make install`) to select the correct python.


## changelog

- Add method to override python used to install pipenv in `make install`