### PR TITLE
fix(shared-data): fix tube-rack-15_50ml labware def

### DIFF
--- a/shared-data/definitions/tube-rack-15_50ml.json
+++ b/shared-data/definitions/tube-rack-15_50ml.json
@@ -26,113 +26,113 @@
   ],
   "wells": {
     "A1": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 10.5,
-      "y": 47.26,
-      "z": 0
+      "x": 17.1,
+      "y": 74.25,
+      "z": 5
     },
     "A2": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 33.2,
-      "y": 47.26,
-      "z": 0
+      "x": 39.8,
+      "y": 74.25,
+      "z": 5
     },
     "A3": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 30,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 30,
       "total-liquid-volume": 50000,
       "width": 30,
-      "x": 55.26,
-      "y": 65.5,
-      "z": 0
+      "x": 68.36,
+      "y": 68.35,
+      "z": 5
     },
     "A4": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 30,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 30,
       "total-liquid-volume": 50000,
       "width": 30,
-      "x": 91.1,
-      "y": 65.5,
-      "z": 0
+      "x": 104.2,
+      "y": 68.35,
+      "z": 5
     },
     "B1": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 10.5,
-      "y": 34.0,
-      "z": 0
+      "x": 17.1,
+      "y": 42.75,
+      "z": 5
     },
     "B2": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 33.2,
-      "y": 34.0,
-      "z": 0
+      "x": 39.8,
+      "y": 42.75,
+      "z": 5
     },
     "B3": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 30,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 30,
       "total-liquid-volume": 50000,
       "width": 30,
-      "x": 55.26,
-      "y": 2.5,
-      "z": 0
+      "x": 68.36,
+      "y": 22.99,
+      "z": 5
     },
     "B4": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 30,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 30,
       "total-liquid-volume": 50000,
       "width": 30,
-      "x": 91.1,
-      "y": 2.5,
-      "z": 0
+      "x": 104.2,
+      "y": 22.99,
+      "z": 5
     },
     "C1": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 10.5,
-      "y": 1.9,
-      "z": 0
+      "x": 17.1,
+      "y": 11.25,
+      "z": 5
     },
     "C2": {
-      "depth": 76.81281249999999,
+      "depth": 76.81,
       "diameter": 17,
-      "height": 76.81281249999999,
+      "height": 76.81,
       "length": 17,
       "total-liquid-volume": 15000,
       "width": 17,
-      "x": 33.2,
-      "y": 1.9,
+      "x": 39.8,
+      "y": 11.25,
       "z": 0
     }
   }


### PR DESCRIPTION
## overview

Fixed labware def in shared-data for `tube-rack-15_50ml` -- before, wells were all messed up and overlapping!

![image](https://user-images.githubusercontent.com/11590381/44161601-d63cb080-a08b-11e8-8eca-193dde0fbb85.png)

## changelog

- Fix def! Used `default-containers.json` for x/y/diameter, but kept the updated depth (but rounded to 2 decimal places)

## review requests

- `make -c shared-data/ build` then you can view the updated definition in PD on the deck. Note that all defs have a hard-coded offset `svgOffset` in `Plate` component, so it will be off, but if you zero out `svgOffset`, then the labware will be centered :sob: 