### PR TITLE
feat(app): Persist known robots to file-system when using new discovery

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -50,7 +50,8 @@ electron := electron . \
 	--log.level.console="debug" \
 	--disable_ui.webPreferences.webSecurity \
 	--ui.url.protocol="http:" \
-	--ui.url.path="localhost:$(port)"
+	--ui.url.path="localhost:$(port)" \
+	--discovery.candidates=localhost
 
 # standard targets
 #####################################################################

--- a/app-shell/__mocks__/electron-store.js
+++ b/app-shell/__mocks__/electron-store.js
@@ -1,0 +1,22 @@
+// mock electron-store
+'use strict'
+
+const Store = jest.fn()
+
+const mockStore = {
+  set: jest.fn(),
+  get: jest.fn(),
+  has: jest.fn(),
+  delete: jest.fn(),
+  clear: jest.fn(),
+  onDidChange: jest.fn(),
+  openInEditor: jest.fn()
+}
+
+module.exports = Store
+module.exports.__store = mockStore
+module.exports.__mockReset = () => {
+  Object.values(mockStore).forEach(m => m.mockReset())
+  Store.mockReset()
+  Store.mockImplementation(() => mockStore)
+}

--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -25,7 +25,7 @@ describe('app-shell/discovery', () => {
       setPollInterval: jest.fn().mockReturnThis()
     })
 
-    getConfig.mockReturnValue({candidates: []})
+    getConfig.mockReturnValue({enabled: true, candidates: []})
     getOverrides.mockReturnValue({})
 
     dispatch = jest.fn()
@@ -207,7 +207,7 @@ describe('app-shell/discovery', () => {
   })
 
   test('loads candidates from config on client initialization', () => {
-    getConfig.mockReturnValue({candidates: ['1.2.3.4']})
+    getConfig.mockReturnValue({enabled: true, candidates: ['1.2.3.4']})
     registerDiscovery(dispatch)
 
     expect(DiscoveryClient).toHaveBeenCalledWith(
@@ -219,7 +219,7 @@ describe('app-shell/discovery', () => {
 
   // ensures config override works with only one candidate specified
   test('canidates in config can be single value', () => {
-    getConfig.mockReturnValue({candidates: '1.2.3.4'})
+    getConfig.mockReturnValue({enabled: true, candidates: '1.2.3.4'})
     registerDiscovery(dispatch)
 
     expect(DiscoveryClient).toHaveBeenCalledWith(
@@ -230,7 +230,7 @@ describe('app-shell/discovery', () => {
   })
 
   test('services from overridden canidates are not persisted', () => {
-    getConfig.mockReturnValue({candidates: 'localhost'})
+    getConfig.mockReturnValue({enabled: true, candidates: 'localhost'})
     getOverrides.mockImplementation(key => {
       if (key === 'discovery.candidates') return ['1.2.3.4', '5.6.7.8']
       return null
@@ -244,7 +244,7 @@ describe('app-shell/discovery', () => {
   })
 
   test('service from overridden single candidate is not persisted', () => {
-    getConfig.mockReturnValue({candidates: 'localhost'})
+    getConfig.mockReturnValue({enabled: true, candidates: 'localhost'})
     getOverrides.mockImplementation(key => {
       if (key === 'discovery.candidates') return '1.2.3.4'
       return null

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -3,6 +3,7 @@
 import assert from 'assert'
 import groupBy from 'lodash/groupBy'
 import map from 'lodash/map'
+import noop from 'lodash/noop'
 import uniqBy from 'lodash/uniqBy'
 import Store from 'electron-store'
 
@@ -33,6 +34,9 @@ let client
 
 export function registerDiscovery (dispatch: Action => void) {
   config = getConfig('discovery')
+
+  if (!config.enabled) return noop
+
   store = new Store({name: 'discovery', defaults: {services: []}})
 
   client = DiscoveryClient({
@@ -70,7 +74,7 @@ export function registerDiscovery (dispatch: Action => void) {
 }
 
 export function getRobots () {
-  if (!client) return []
+  if (!client || !config || !config.enabled) return []
 
   return servicesToRobots(client.services)
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -2,6 +2,7 @@
 // config redux module
 import {setIn} from '@thi.ng/paths'
 import {getShellConfig} from '../shell'
+
 import type {State, Action, ThunkAction} from '../types'
 import type {LogLevel} from '../logger'
 
@@ -55,6 +56,7 @@ export type Config = {
 
   discovery: {
     enabled: boolean,
+    candidates: string | Array<string>
   },
 }
 

--- a/app/src/discovery/__tests__/reducer.test.js
+++ b/app/src/discovery/__tests__/reducer.test.js
@@ -1,8 +1,31 @@
 // discovery reducer test
 import {discoveryReducer} from '..'
 
+jest.mock('../../shell', () => ({
+  getShellRobots: () => ([
+    {name: 'foo', connections: []},
+    {name: 'bar', connections: []}
+  ])
+}))
+
 describe('discoveryReducer', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   const SPECS = [
+    {
+      name: 'pulls initial robot list from shell and sets scanning to false',
+      action: {},
+      initialState: undefined,
+      expectedState: {
+        scanning: false,
+        robotsByName: {
+          foo: {name: 'foo', connections: []},
+          bar: {name: 'bar', connections: []}
+        }
+      }
+    },
     // TODO(mc, 2018-08-10): legacy; remove when DC enabled by default
     {
       name: 'robot:DISCOVER sets scanning: true',

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,35 +1,38 @@
 // @flow
 // robot discovery state
+import {getShellRobots} from '../shell'
+
 import type {State, Action, ThunkAction} from '../types'
 import type {RobotService} from '../robot'
 import type {DiscoveredRobot} from './types'
 
+type RobotsMap = {[name: string]: DiscoveredRobot}
+
 type DiscoveryState = {
   scanning: boolean,
-  robotsByName: {[name: string]: DiscoveredRobot}
+  robotsByName: RobotsMap
 }
 
 type StartAction = {|
   type: 'discovery:START',
-  meta: {| shell: true |},
+  meta: {|shell: true|}
 |}
 
 type FinishAction = {|
   type: 'discovery:FINISH',
-  meta: {| shell: true |},
+  meta: {|shell: true|}
 |}
 
 type UpdateListAction = {|
   type: 'discovery:UPDATE_LIST',
-  payload: {| robots: Array<DiscoveredRobot> |},
+  payload: {|robots: Array<DiscoveredRobot>|}
 |}
 
-export type DiscoveryAction =
-  | StartAction
-  | FinishAction
-  | UpdateListAction
+export * from './types'
 
-const DISCOVERY_TIMEOUT = 30000
+export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
+
+const DISCOVERY_TIMEOUT = 15000
 
 export function startDiscovery (): ThunkAction {
   const start: StartAction = {type: 'discovery:START', meta: {shell: true}}
@@ -67,9 +70,15 @@ export function getDiscoveredRobotsByName (state: State) {
 //
 // }
 
+// getShellRobots makes a sync RPC call, so use sparingly
+const initialState: DiscoveryState = {
+  scanning: false,
+  robotsByName: flattenRobots(getShellRobots())
+}
+
 // TODO(mc, 2018-08-09): implement this reducer
 export function discoveryReducer (
-  state: DiscoveryState = {scanning: false, robotsByName: {}},
+  state: DiscoveryState = initialState,
   action: Action
 ): DiscoveryState {
   switch (action.type) {
@@ -89,7 +98,10 @@ export function discoveryReducer (
         ...state,
         robotsByName: {
           ...state.robotsByName,
-          [action.payload.name]: robotServiceToDiscoveredRobot(action.payload, true)
+          [action.payload.name]: robotServiceToDiscoveredRobot(
+            action.payload,
+            true
+          )
         }
       }
 
@@ -99,21 +111,31 @@ export function discoveryReducer (
         ...state,
         robotsByName: {
           ...state.robotsByName,
-          [action.payload.name]: robotServiceToDiscoveredRobot(action.payload, false)
+          [action.payload.name]: robotServiceToDiscoveredRobot(
+            action.payload,
+            false
+          )
         }
       }
 
     case 'discovery:UPDATE_LIST':
       return {
         ...state,
-        robotsByName: action.payload.robots.reduce((robotsMap, robot) => ({
-          ...robotsMap,
-          [robot.name]: robot
-        }), {})
+        robotsByName: flattenRobots(action.payload.robots)
       }
   }
 
   return state
+}
+
+function flattenRobots (robots: Array<DiscoveredRobot> = []): RobotsMap {
+  return robots.reduce(
+    (robotsMap, robot) => ({
+      ...robotsMap,
+      [robot.name]: robot
+    }),
+    {}
+  )
 }
 
 // TODO(mc, 2018-08-10): remove this function when no longer needed
@@ -123,8 +145,6 @@ function robotServiceToDiscoveredRobot (
 ): DiscoveredRobot {
   return {
     name: robot.name,
-    connections: [
-      {ip: robot.ip, port: robot.port, local: !!robot.wired, ok}
-    ]
+    connections: [{ip: robot.ip, port: robot.port, local: !!robot.wired, ok}]
   }
 }

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -73,7 +73,7 @@ export function getDiscoveredRobotsByName (state: State) {
 // getShellRobots makes a sync RPC call, so use sparingly
 const initialState: DiscoveryState = {
   scanning: false,
-  robotsByName: flattenRobots(getShellRobots())
+  robotsByName: normalizeRobots(getShellRobots())
 }
 
 // TODO(mc, 2018-08-09): implement this reducer
@@ -121,16 +121,16 @@ export function discoveryReducer (
     case 'discovery:UPDATE_LIST':
       return {
         ...state,
-        robotsByName: flattenRobots(action.payload.robots)
+        robotsByName: normalizeRobots(action.payload.robots)
       }
   }
 
   return state
 }
 
-function flattenRobots (robots: Array<DiscoveredRobot> = []): RobotsMap {
+function normalizeRobots (robots: Array<DiscoveredRobot> = []): RobotsMap {
   return robots.reduce(
-    (robotsMap, robot) => ({
+    (robotsMap: RobotsMap, robot: DiscoveredRobot) => ({
       ...robotsMap,
       [robot.name]: robot
     }),

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -38,7 +38,7 @@ const middleware = applyMiddleware(
 
 const composeEnhancers = (
   (
-    global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ && global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({maxAge: 200})
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({maxAge: 200})
   ) ||
   compose
 )
@@ -65,7 +65,7 @@ if (module.hot) {
 const {config} = store.getState()
 
 // attach store to window if devtools are on
-if (config.devtools) global.store = store
+if (config.devtools) window.store = store
 
 // initialize analytics and support after first render
 store.dispatch(initializeAnalytics())

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -6,12 +6,9 @@ import {createSelector, type Selector} from 'reselect'
 
 import {
   type ConnectionStatus,
-  _NAME,
   PIPETTE_MOUNTS,
   DECK_SLOTS
 } from './constants'
-
-import {getDiscoveredRobotsByName} from '../discovery'
 
 import type {ContextRouter} from 'react-router'
 import type {State} from '../types'
@@ -27,9 +24,9 @@ import type {
   SessionModule
 } from './types'
 
-const calibration = (state: State) => state[_NAME].calibration
-const connection = (state: State) => state[_NAME].connection
-const session = (state: State) => state[_NAME].session
+const calibration = (state: State) => state.robot.calibration
+const connection = (state: State) => state.robot.connection
+const session = (state: State) => state.robot.session
 const sessionRequest = (state: State) => session(state).sessionRequest
 const cancelRequest = (state: State) => session(state).cancelRequest
 
@@ -50,8 +47,10 @@ export function labwareType (labware: Labware): LabwareType {
 // TODO(mc, 2018-08-10): deprecate in favor of getRobots in discovery module
 export const getDiscovered: Selector<State, void, Array<Robot>> =
   createSelector(
-    getDiscoveredRobotsByName,
-    (state: State) => connection(state).connectedTo,
+    // TODO(mc, 2018-08-15): not using the selector in discovery right now
+    // because of dependency problem in WebWorker where this selector is used
+    state => state.discovery.robotsByName,
+    state => connection(state).connectedTo,
     (discoveredByName, connectedTo) => {
       const robots = Object.keys(discoveredByName)
         .map(name => {

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -3,9 +3,11 @@
 import {remote, ipcRenderer} from 'electron'
 import {createSelector, type Selector} from 'reselect'
 import createLogger from '../logger'
-import type {RobotService} from '../robot'
 import {makeGetRobotHealth} from '../http-api-client'
 import type {State, Action, Middleware, ThunkPromiseAction, ThunkAction, Error} from '../types'
+import type {RobotService} from '../robot'
+import type {Config} from '../config'
+import type {DiscoveredRobot} from '../discovery'
 
 const {
   CURRENT_VERSION,
@@ -17,6 +19,10 @@ const {
 const {
   getConfig
 } = remote.require('./config')
+
+const {
+  getRobots
+} = remote.require('./discovery')
 
 const log = createLogger(__filename)
 
@@ -176,8 +182,13 @@ export const getShellUpdate: Selector<State, void, ShellUpdate> =
   )
 
 // getShellConfig makes a sync RPC call, so use sparingly
-export function getShellConfig () {
+export function getShellConfig (): Config {
   return getConfig()
+}
+
+// getShellRobots makes a sync RPC call, so use sparingly
+export function getShellRobots (): Array<DiscoveredRobot> {
+  return getRobots()
 }
 
 function selectShellUpdateState (state: State) {

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -110,6 +110,31 @@ describe('discovery client', () => {
     10
   )
 
+  test('new mdns service does not null out ok of existing service', () => {
+    const client = DiscoveryClient()
+
+    client.services = [
+      {
+        name: 'opentrons-dev',
+        ip: '192.168.1.42',
+        port: 31950,
+        ok: true
+      }
+    ]
+
+    client.start()
+    mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+
+    expect(client.services).toEqual([
+      {
+        name: 'opentrons-dev',
+        ip: '192.168.1.42',
+        port: 31950,
+        ok: true
+      }
+    ])
+  })
+
   test(
     'selects IPv4 as ip from service.addresses',
     done => {

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -196,6 +196,7 @@ export class DiscoveryClient extends EventEmitter {
   }
 
   _handleService (service: Service): mixed {
+    const {ok} = service
     const candidateExists = this.candidates.some(matchCandidate(service))
     const serviceConflicts = this.services.filter(matchConflict(service))
     const prevService =
@@ -208,7 +209,8 @@ export class DiscoveryClient extends EventEmitter {
 
     // update existing services and null out conflics
     nextServices = nextServices.map(s => {
-      if (s === prevService && s.ok !== service.ok) return service
+      // if we have a service already, make sure not to reset ok to null
+      if (s === prevService && s.ok !== ok && ok !== null) return service
       if (serviceConflicts.includes(s)) return {...s, ip: null, ok: null}
       return s
     })


### PR DESCRIPTION
## overview

This PR adds robot persistence to file to the app and wires up the necessary state. It also includes some tweaks to various values and configurations based on how discovery behaves in the real world.

## changelog

- feat(app): Persist known robots to file-system when using new discovery

## review requests

Try this out on your machine!

0. `make -C discovery-client` (Re-build discovery client)
1. `make -C app dev OT_APP_DISCOVERY__ENABLED=1`

- [x] `discovery.robotsByName` state is prepopulated at app launch from file
- [x] App picks up virtual smoothie as `opentrons-dev`
- [x] App picks up IPv6 robots as their actual name
- [x] Unplugging an IPv6 robot from USB will get it to fall back to WiFi (faster if list is currently refreshing)
- [x] Ditto for IPv4 (should be unchanged from #2045)
- [x] RPC connection to robots still works

Known issues:

- RPC client and health-check module **do not** handle USB disconnections gracefully when RPC is connected
    - This may be a blocker for actual release of new discovery
    - For now though its enough for me to keep it behind the feature flag