### PR TITLE
refactor(app): Render AlertModals via portal

### DIFF
--- a/app/src/components/App.js
+++ b/app/src/components/App.js
@@ -10,6 +10,7 @@ import More from '../pages/More'
 import Upload from '../pages/Upload'
 import Calibrate from '../pages/Calibrate'
 import Run from '../pages/Run'
+import {PortalRoot as ModalPortalRoot} from './portal'
 
 import './App.global.css'
 import styles from './App.css'
@@ -29,6 +30,7 @@ export default function App () {
           <Route path='/calibrate' component={Calibrate} />
           <Route path='/run' component={Run} />
         </Switch>
+        <ModalPortalRoot />
       </PageWrapper>
     </div>
   )

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 
 import type {ShellUpdate} from '../../shell'
 import {Icon, AlertModal, type ButtonProps} from '@opentrons/components'
+import {Portal} from '../portal'
 
 type Props = {
   update: ShellUpdate,
@@ -23,17 +24,19 @@ export default function AppUpdateModal (props: Props) {
     : 'not now'
 
   return (
-    <AlertModal
-      heading={`App Version ${props.update.available || ''} Available`}
-      onCloseClick={close}
-      buttons={[
-        {onClick: close, children: closeButtonChildren},
-        button
-      ]}
-      alertOverlay
-    >
-      {message}
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={`App Version ${props.update.available || ''} Available`}
+        onCloseClick={close}
+        buttons={[
+          {onClick: close, children: closeButtonChildren},
+          button
+        ]}
+        alertOverlay
+      >
+        {message}
+      </AlertModal>
+    </Portal>
   )
 }
 

--- a/app/src/components/CalibrateDeck/NoPipetteModal.js
+++ b/app/src/components/CalibrateDeck/NoPipetteModal.js
@@ -15,6 +15,7 @@ export default function NoPipetteModal (props: Props) {
       buttons={[
         {children: 'close', Component: Link, to: props.parentUrl}
       ]}
+      alertOverlay
     >
       <p>Please attach a pipette before attempting to calibrate robot.</p>
     </AlertModal>

--- a/app/src/components/ChangePipette/ExitAlertModal.js
+++ b/app/src/components/ChangePipette/ExitAlertModal.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 
 import {AlertModal} from '@opentrons/components'
+import {Portal} from '../portal'
 
 type Props = {
   back: () => mixed,
@@ -16,15 +17,17 @@ export default function ExitAlertModal (props: Props) {
   const {back, exit} = props
 
   return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[
-        {children: CANCEL_TEXT, onClick: back},
-        {children: EXIT_TEXT, onClick: exit}
-      ]}
-      alertOverlay
-    >
-      <p>Doing so will exit pipette setup and home your robot.</p>
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={HEADING}
+        buttons={[
+          {children: CANCEL_TEXT, onClick: back},
+          {children: EXIT_TEXT, onClick: exit}
+        ]}
+        alertOverlay
+      >
+        <p>Doing so will exit pipette setup and home your robot.</p>
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/ClearDeckAlertModal/index.js
+++ b/app/src/components/ClearDeckAlertModal/index.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {Link} from 'react-router-dom'
 
 import {AlertModal} from '@opentrons/components'
+import {Portal} from '../portal'
 import styles from './styles.css'
 
 type Props = {
@@ -19,30 +20,33 @@ export default function ClearDeckAlertModal (props: Props) {
   const {onContinueClick, onCancelClick, parentUrl, cancelText, continueText} = props
 
   return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[
-        {children: `${cancelText}`, Component: Link, to: parentUrl, onClick: onCancelClick},
-        {
-          children: `${continueText}`,
-          className: styles.alert_button,
-          onClick: onContinueClick
+    <Portal>
+      <AlertModal
+        heading={HEADING}
+        buttons={[
+          {children: `${cancelText}`, Component: Link, to: parentUrl, onClick: onCancelClick},
+          {
+            children: `${continueText}`,
+            className: styles.alert_button,
+            onClick: onContinueClick
+          }
+        ]}
+        alertOverlay
+      >
+        <ul className={styles.alert_list}>
+          <li>All tipracks</li>
+          <li>All labware</li>
+        </ul>
+        {props.children && (
+          <div>
+            <p className={styles.alert_note_heading}>
+              Note:
+            </p>
+            {props.children}
+          </div>
+          )
         }
-      ]}
-    >
-      <ul className={styles.alert_list}>
-        <li>All tipracks</li>
-        <li>All labware</li>
-      </ul>
-      {props.children && (
-        <div>
-          <p className={styles.alert_note_heading}>
-            Note:
-          </p>
-          {props.children}
-        </div>
-        )
-      }
-    </AlertModal>
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/ConfirmTipProbeModal/index.js
+++ b/app/src/components/ConfirmTipProbeModal/index.js
@@ -7,6 +7,7 @@ import {push} from 'react-router-redux'
 
 import {actions as robotActions, type Mount} from '../../robot'
 import {ContinueModal} from '@opentrons/components'
+import {Portal} from '../portal'
 import Contents from './Contents'
 
 type OwnProps = {
@@ -23,12 +24,14 @@ export default connect(null, mapDispatchToProps)(ContinueTipProbeModal)
 
 function ContinueTipProbeModal (props: Props) {
   return (
-    <ContinueModal
-      onContinueClick={props.onContinueClick}
-      onCancelClick={props.onCancelClick}
-    >
-      <Contents />
-    </ContinueModal>
+    <Portal>
+      <ContinueModal
+        onContinueClick={props.onContinueClick}
+        onCancelClick={props.onCancelClick}
+      >
+        <Contents />
+      </ContinueModal>
+    </Portal>
   )
 }
 

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -14,7 +14,7 @@ import {
 import {makeGetHealthCheckOk} from '../../health-check'
 
 import {AlertModal} from '@opentrons/components'
-import {Portal} from '../Portal'
+import {Portal} from '../portal'
 import ModalCopy from './ModalCopy'
 
 type StateProps = {

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -14,6 +14,7 @@ import {
 import {makeGetHealthCheckOk} from '../../health-check'
 
 import {AlertModal} from '@opentrons/components'
+import {Portal} from '../Portal'
 import ModalCopy from './ModalCopy'
 
 type StateProps = {
@@ -36,16 +37,18 @@ function LostConnectionAlert (props: Props) {
   const {ok, disconnect} = props
 
   return ok === false && (
-    <AlertModal
-      onCloseClick={disconnect}
-      heading={'Connection to robot lost'}
-      buttons={[
-        {onClick: disconnect, children: 'close'}
-      ]}
-      alertOverlay
-    >
-      <ModalCopy />
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        onCloseClick={disconnect}
+        heading={'Connection to robot lost'}
+        buttons={[
+          {onClick: disconnect, children: 'close'}
+        ]}
+        alertOverlay
+      >
+        <ModalCopy />
+      </AlertModal>
+    </Portal>
   )
 }
 

--- a/app/src/components/RobotSettings/ConnectAlertModal.js
+++ b/app/src/components/RobotSettings/ConnectAlertModal.js
@@ -3,7 +3,7 @@
 import * as React from 'react'
 
 import {AlertModal} from '@opentrons/components'
-
+import {Portal} from '../portal'
 type Props = {
   onCloseClick: () => *
 }
@@ -18,17 +18,20 @@ export default function ConnectAlertModal (props: Props) {
   const {onCloseClick} = props
 
   return (
-    <AlertModal
-      heading={HEADING}
-      onCloseClick={onCloseClick}
-      buttons={[
-        {onClick: onCloseClick, children: 'close'}
-      ]}
-    >
-      <p>
-        {TRY_AGAIN_MESSAGE}
-        {CONTACT_SUPPORT_MESSAGE}
-      </p>
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={HEADING}
+        onCloseClick={onCloseClick}
+        buttons={[
+          {onClick: onCloseClick, children: 'close'}
+        ]}
+        alertOverlay
+      >
+        <p>
+          {TRY_AGAIN_MESSAGE}
+          {CONTACT_SUPPORT_MESSAGE}
+        </p>
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/RobotSettings/WifiConnectModal.js
+++ b/app/src/components/RobotSettings/WifiConnectModal.js
@@ -8,6 +8,7 @@ import type {
 } from '../../http-api-client'
 
 import {AlertModal} from '@opentrons/components'
+import {Portal} from '../portal'
 import {ErrorModal} from '../modals'
 
 type Props = {
@@ -42,14 +43,17 @@ export default function WifiConnectModal (props: Props) {
   }
 
   return (
-    <AlertModal
-      heading={`${SUCCESS_TITLE} ${response.ssid}`}
-      onCloseClick={close}
-      buttons={[
-        {onClick: close, children: 'close'}
-      ]}
-    >
-      {SUCCESS_MESSAGE}
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={`${SUCCESS_TITLE} ${response.ssid}`}
+        onCloseClick={close}
+        buttons={[
+          {onClick: close, children: 'close'}
+        ]}
+        alertOverlay
+      >
+        {SUCCESS_MESSAGE}
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/analytics-settings/AnalyticsSettingsModal.js
+++ b/app/src/components/analytics-settings/AnalyticsSettingsModal.js
@@ -7,7 +7,7 @@ import {getAnalyticsSeen, setAnalyticsSeen} from '../../analytics'
 import {Modal} from '@opentrons/components'
 import ModalButton from './ModalButton'
 import AnalyticsToggle from './AnalyticsToggle'
-
+import {Portal} from '../portal'
 import type {State, Dispatch} from '../../types'
 
 type SP = {
@@ -34,12 +34,14 @@ function AnalyticsSettingsModal (props: Props) {
   const {setSeen} = props
 
   return (
-    <Modal onCloseClick={setSeen} heading={TITLE} alertOverlay>
-      <AnalyticsToggle />
-      <ModalButton onClick={setSeen}>
-        {CONTINUE}
-      </ModalButton>
-    </Modal>
+    <Portal>
+      <Modal onCloseClick={setSeen} heading={TITLE} alertOverlay>
+        <AnalyticsToggle />
+        <ModalButton onClick={setSeen}>
+          {CONTINUE}
+        </ModalButton>
+      </Modal>
+    </Portal>
   )
 }
 

--- a/app/src/components/modals/ErrorModal.js
+++ b/app/src/components/modals/ErrorModal.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {Link} from 'react-router-dom'
 import {AlertModal} from '@opentrons/components'
+import {Portal} from '../portal'
 
 import type {Error} from '../../types'
 
@@ -31,20 +32,22 @@ export default function ErrorModal (props: Props) {
   }
 
   return (
-    <AlertModal
-      heading={heading}
-      buttons={[closeButtonProps]}
-      alertOverlay
-    >
-      <p className={styles.error_modal_message}>
-        {error.message}
-      </p>
-      <p>
-        {description}
-      </p>
-      <p>
-        If you keep getting this message, try restarting your robot. If this does not resolve the issue please contact Opentrons Support.
-      </p>
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={heading}
+        buttons={[closeButtonProps]}
+        alertOverlay
+      >
+        <p className={styles.error_modal_message}>
+          {error.message}
+        </p>
+        <p>
+          {description}
+        </p>
+        <p>
+          If you keep getting this message, try restarting your robot. If this does not resolve the issue please contact Opentrons Support.
+        </p>
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/portal/index.js
+++ b/app/src/components/portal/index.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react'
+import ReactDom from 'react-dom'
+
+const PORTAL_ROOT_ID = 'main-modal-portal-root'
+
+export function PortalRoot () {
+  return <div id={PORTAL_ROOT_ID} />
+}
+
+export function getPortalElem () {
+  return document.getElementById(PORTAL_ROOT_ID)
+}
+
+type Props = {children?: React.Node}
+/** The children of Portal are rendered into the
+  * PortalRoot, if the PortalRoot exists in the DOM */
+export function Portal (props: Props): React.Node {
+  const modalRootElem = getPortalElem()
+
+  if (!modalRootElem) {
+    console.error('Modal root is not present, could not render modal')
+    return null
+  }
+
+  return ReactDom.createPortal(
+    props.children,
+    modalRootElem
+  )
+}


### PR DESCRIPTION
## overview

This PR wraps all `AlertModal`s in a `Portal` to ensure modals are appended to the DOM within the PageWrapper of App.js. This fixes the weird scroll behavior seen in the Wifi Connect modals and should avoid any weirdness when implementing ResetRobotModal. I also too the liberty of adding the alertOverlay boolean to all instances of alertModals in the app.

<img width="1023" alt="screen shot 2018-08-15 at 2 35 49 pm" src="https://user-images.githubusercontent.com/3430313/44166226-d42d1e80-a098-11e8-864e-dea09c467b65.png">
<img width="1024" alt="screen shot 2018-08-15 at 2 36 35 pm" src="https://user-images.githubusercontent.com/3430313/44166227-d4c5b500-a098-11e8-8656-3c3e32eb7a1f.png">

## changelog

- refactor(app): Render AlertModals via portal

## review requests

Please check that all AlertModals render correctly. This PR did not affect Wizards/ModalPages.