### PR TITLE
feat(app): Add robot name to intercom on connect

### DIFF
--- a/app/src/support.js
+++ b/app/src/support.js
@@ -32,8 +32,9 @@ export const supportMiddleware: Middleware = (store) => (next) => (action) => {
   if (action.type === 'robot:CONNECT_RESPONSE') {
     const state = store.getState()
     const robot = state.robot.connection.connectRequest.name
-    log.debug('Updating intercom data', {user_id: userId, robot})
-    intercom('update', {user_id: userId, 'Robot Name': robot})
+    const data = {user_id: userId, 'Robot Name': robot}
+    log.debug('Updating intercom data', {data})
+    intercom('update', {data})
   }
 
   return next(action)

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -1,17 +1,12 @@
 // @flow
 // user support module
 import noop from 'lodash/noop'
-import {LOCATION_CHANGE} from 'react-router-redux'
 
 import {version} from './../package.json'
 import createLogger from './logger'
 
 import type {ThunkAction, Middleware} from './types'
 import type {Config} from './config'
-
-// import {
-//   selectors as robotSelectors
-// } from './robot'
 
 type SupportConfig = $PropertyType<Config, 'support'>
 
@@ -23,7 +18,7 @@ const INTERCOM_ID = process.env.OT_APP_INTERCOM_ID
 // intercom handler (default noop)
 let intercom = noop
 let userId
-let robot = ''
+let robot
 
 export function initializeSupport (): ThunkAction {
   return (_, getState) => {
@@ -35,12 +30,6 @@ export function initializeSupport (): ThunkAction {
 }
 
 export const supportMiddleware: Middleware = (store) => (next) => (action) => {
-  // update intercom on page change
-  // TODO(mc, 2018-08-02): this is likely to hit intercom throttle limit
-  if (action.type === LOCATION_CHANGE) {
-    intercom('update')
-  }
-
   if (action.type === 'robot:CONNECT_RESPONSE') {
     const state = store.getState()
     robot = state.robot.connection.connectRequest.name

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -22,6 +22,8 @@ const INTERCOM_ID = process.env.OT_APP_INTERCOM_ID
 
 // intercom handler (default noop)
 let intercom = noop
+let userId
+let robot = ''
 
 export function initializeSupport (): ThunkAction {
   return (_, getState) => {
@@ -41,9 +43,9 @@ export const supportMiddleware: Middleware = (store) => (next) => (action) => {
 
   if (action.type === 'robot:CONNECT_RESPONSE') {
     const state = store.getState()
-    const robot = state.robot.connection.connectRequest.name
-    log.debug('Updating intercom data', {robot})
-    intercom('update', {robot})
+    robot = state.robot.connection.connectRequest.name
+    log.debug('Updating intercom data', {user_id: userId, robot})
+    intercom('update', {user_id: userId, 'Robot Name': robot})
   }
 
   return next(action)
@@ -51,13 +53,15 @@ export const supportMiddleware: Middleware = (store) => (next) => (action) => {
 
 function initializeIntercom (config: SupportConfig) {
   if (INTERCOM_ID) {
+    userId = config.userId
+
     const data = {
       app_id: INTERCOM_ID,
-      user_id: config.userId,
+      user_id: userId,
       created_at: config.createdAt,
       name: config.name,
-      email: config.email,
-      'App Version': version
+      'App Version': version,
+      'Robot Name': robot
     }
 
     log.debug('Initializing Intercom', {data})

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -9,6 +9,10 @@ import createLogger from './logger'
 import type {ThunkAction, Middleware} from './types'
 import type {Config} from './config'
 
+// import {
+//   selectors as robotSelectors
+// } from './robot'
+
 type SupportConfig = $PropertyType<Config, 'support'>
 
 const log = createLogger(__filename)
@@ -31,7 +35,16 @@ export function initializeSupport (): ThunkAction {
 export const supportMiddleware: Middleware = (store) => (next) => (action) => {
   // update intercom on page change
   // TODO(mc, 2018-08-02): this is likely to hit intercom throttle limit
-  if (action.type === LOCATION_CHANGE) intercom('update')
+  if (action.type === LOCATION_CHANGE) {
+    intercom('update')
+  }
+
+  if (action.type === 'robot:CONNECT_RESPONSE') {
+    const state = store.getState()
+    const robot = state.robot.connection.connectRequest.name
+    log.debug('Updating intercom data', {robot})
+    intercom('update', {robot})
+  }
 
   return next(action)
 }

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -18,7 +18,6 @@ const INTERCOM_ID = process.env.OT_APP_INTERCOM_ID
 // intercom handler (default noop)
 let intercom = noop
 let userId
-let robot
 
 export function initializeSupport (): ThunkAction {
   return (_, getState) => {
@@ -32,7 +31,7 @@ export function initializeSupport (): ThunkAction {
 export const supportMiddleware: Middleware = (store) => (next) => (action) => {
   if (action.type === 'robot:CONNECT_RESPONSE') {
     const state = store.getState()
-    robot = state.robot.connection.connectRequest.name
+    const robot = state.robot.connection.connectRequest.name
     log.debug('Updating intercom data', {user_id: userId, robot})
     intercom('update', {user_id: userId, 'Robot Name': robot})
   }
@@ -49,8 +48,7 @@ function initializeIntercom (config: SupportConfig) {
       user_id: userId,
       created_at: config.createdAt,
       name: config.name,
-      'App Version': version,
-      'Robot Name': robot
+      'App Version': version
     }
 
     log.debug('Initializing Intercom', {data})


### PR DESCRIPTION
## overview

This PR functions as a fix for an intercom throttling problem. Calling `intercom('update')` on every route change results in us far surpassing our 20 calls per 30 minutes rule.

This PR addresses the first checkbox of #2019. On robot connect, send the robot name to intercom. This is code correct but will not function properly until the fix above clears out our throttling.

## changelog

- fix(app): Remove intercom update on route change
- feat(app): Add robot name to intercom on connect

## review requests

Standard review. 🎙 
