### PR TITLE
fix(update-server): Set the cwd to the venv during an otupdate selftest

### DIFF
--- a/update-server/otupdate/endpoints.py
+++ b/update-server/otupdate/endpoints.py
@@ -55,8 +55,8 @@ async def bootstrap_update_server(
         log.debug('Bootstrapping update server {} [test mode: {}]'.format(
             filename, test_flag))
 
-        res, python, venv_site_pkgs = await bootstrap.install_sandboxed_update(
-            filename, request.loop)
+        res, python, venv_site_pkgs, venv\
+            = await bootstrap.install_sandboxed_update(filename, request.loop)
         log.debug('Install complete with status: {}'.format(res.get('status')))
 
     if python and res.get('status') != 'failure':
@@ -66,7 +66,7 @@ async def bootstrap_update_server(
         else:
             test_port = 34001
             res = await bootstrap.test_update_server(
-                python, test_port, filename, venv_site_pkgs)
+                python, test_port, filename, venv_site_pkgs, venv)
 
     if res.get('status') == 'failure':
         log.debug('Test failed, not installing update')

--- a/update-server/tests/test_bootstrap_fns.py
+++ b/update-server/tests/test_bootstrap_fns.py
@@ -18,8 +18,10 @@ wheel_data = namedtuple(
 
 
 async def test_create_virtual_environment(loop):
-    python, _ = await bootstrap.create_virtual_environment(loop=loop)
+    venv_dir, python, _ = await bootstrap.create_virtual_environment(loop=loop)
+    assert os.path.exists(venv_dir)
     assert os.path.exists(python)
+    assert python.startswith(venv_dir)
 
 
 async def test_install_fail(monkeypatch, loop):
@@ -30,7 +32,7 @@ async def test_install_fail(monkeypatch, loop):
 
     monkeypatch.setattr(bootstrap, '_install', mock_install)
 
-    res, python, _ = await bootstrap.install_sandboxed_update(
+    res, python, _, _2 = await bootstrap.install_sandboxed_update(
         test_data, loop=loop)
     assert res.get('status') == 'failure'
 
@@ -43,7 +45,7 @@ async def test_install_sandboxed_update(monkeypatch, loop):
 
     monkeypatch.setattr(bootstrap, '_install', mock_install)
 
-    res, python, _ = await bootstrap.install_sandboxed_update(
+    res, python, _, _2 = await bootstrap.install_sandboxed_update(
         test_data, loop=loop)
     assert res.get('status') == 'success'
 

--- a/update-server/tests/test_server_boot.py
+++ b/update-server/tests/test_server_boot.py
@@ -49,7 +49,7 @@ async def test_bootstrap_fail(monkeypatch, loop, test_client):
         to the system if the self-test passes and the bootstrap endpoint
         tries to actually install the package.
         """
-        return {'message': 'test msg', 'filename': filename}
+        return {'message': 'test msg', 'filename': filename}, 0
 
     monkeypatch.setattr(bootstrap, 'install_update', mock_install)
 


### PR DESCRIPTION
## overview

At least on a mac, on zsh, (this issue may be different depending on system and shell because of the
use of shell=True when invoking the server to selftest) the update server self test picks up the
code in the source directory rather than the module to self test. This breaks the unit tests. By
explicitly setting the cwd of the subshell used for the server under test to the root of the venv,
it all works. 

Specifically, this fixes an issue where the unit test checking the ability of the selftest to actually discover problems failed because it was implicitly running the main module.

## changelog

- Add plumbing to retrieve the venv root from otupdate.bootstrap.create_virtual_environment and pass it down all the way to otupdate.bootstrap._start_server
- Change otupdate.bootstrap._start_server to set the new subshell's cwd to the root of the virtual environment from above
- Change the monkey patched _install routine in test_server_boot.test_bootstrap_fail to return the same kind of object as the real thing

## review requests

Run the tests on environments other than osx