### PR TITLE
feat(protocol-designer): display tip use across step timeline

### DIFF
--- a/components/src/deck/Labware.js
+++ b/components/src/deck/Labware.js
@@ -15,11 +15,14 @@ import styles from './Labware.css'
 type WellProps = $Diff<React.ElementProps<typeof Well>,
   {wellDef: *, svgOffset: *}>
 
+type TipProps = $Diff<React.ElementProps<typeof Tip>,
+  {wellDef: *, tipVolume: *}>
+
 export type Props = {
   /** labware type, to get definition from shared-data */
   labwareType: string,
   /** optional getter for tip props by wellName (tipracks only) */
-  getTipProps?: (wellName: string) => ?React.ElementProps<typeof Tip>,
+  getTipProps?: (wellName: string) => ?TipProps,
   /** optional getter for well props by wellName (non-tiprack labware only ) */
   getWellProps?: (wellName: string) => ?WellProps
 }

--- a/components/src/deck/Tip.js
+++ b/components/src/deck/Tip.js
@@ -36,12 +36,9 @@ export default function Tip (props: Props) {
     />
   }
 
-  const outerCircleClassName = cx(
-    styles.tip_border,
-    {
-      [styles.highlighted]: highlighted
-    }
-  )
+  const outerCircleClassName = (highlighted)
+    ? styles.highlighted
+    : styles.tip_border
 
   return (
     <g>

--- a/components/src/deck/Well.css
+++ b/components/src/deck/Well.css
@@ -23,6 +23,7 @@
 .highlighted {
   stroke-width: 1;
   stroke: var(--c-highlight);
+  fill: transparent;
 }
 
 .error {

--- a/protocol-designer/src/components/SelectablePlate.js
+++ b/protocol-designer/src/components/SelectablePlate.js
@@ -13,8 +13,11 @@ import SelectionRect from '../components/SelectionRect.js'
 import type {ContentsByWell} from '../labware-ingred/types'
 import type {RectEvent} from '../collision-types'
 
+type LabwareProps = React.ElementProps<typeof Labware>
+
 export type Props = {
   wellContents: ContentsByWell,
+  getTipProps?: $PropertyType<LabwareProps, 'getTipProps'>,
   containerType: string,
 
   selectable?: boolean,
@@ -45,6 +48,7 @@ function getFillColor (groupIds: Array<string>): ?string {
 export default function SelectablePlate (props: Props) {
   const {
     wellContents,
+    getTipProps,
     containerType,
     onSelectionMove,
     onSelectionDone,
@@ -74,6 +78,7 @@ export default function SelectablePlate (props: Props) {
   const labwareComponent = <Labware
     labwareType={containerType}
     getWellProps={getWellProps}
+    getTipProps={getTipProps}
   />
 
   if (!selectable) return labwareComponent // don't wrap labwareComponent with SelectionRect

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -53,111 +53,101 @@ type MP = {
 
 type SP = $Diff<Props, MP>
 
-function makeMapStateToProps (): * {
-  const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
-    const {selectable} = ownProps
-    const selectedContainerId = selectors.getSelectedContainerId(state)
-    const containerId = ownProps.containerId || selectedContainerId
+function mapStateToProps (state: BaseState, ownProps: OP): SP {
+  const {selectable} = ownProps
+  const selectedContainerId = selectors.getSelectedContainerId(state)
+  const containerId = ownProps.containerId || selectedContainerId
 
-    if (containerId === null) {
-      console.error('SelectablePlate: No container is selected, and no containerId was given to Connected SelectablePlate')
-      return {
-        containerId: '',
-        wellContents: {},
-        containerType: '',
-        selectable: selectable
-      }
-    }
-
-    const getTipsPerStep = tipContentsSelectors.makeGetTipsPerStep(containerId)
-    const getInitialTips = tipContentsSelectors.makeGetTerminalTips(START_TERMINAL_ITEM_ID, containerId)
-    const getEndTips = tipContentsSelectors.makeGetTerminalTips(END_TERMINAL_ITEM_ID, containerId)
-
-    const labware = selectors.getLabware(state)[containerId]
-    const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
-    const wellSelectionModeForLabware = selectedContainerId === containerId
-    let wellContents: ContentsByWell = {}
-    let getTipProps
-
-    const activeItem = steplistSelectors.getActiveItem(state)
-    if (
-      !activeItem.isStep && activeItem.id === START_TERMINAL_ITEM_ID
-    ) {
-      // selection for deck setup: shows initial state of liquids
-      wellContents = wellContentsSelectors.wellContentsAllLabware(state)[containerId]
-      getTipProps = getInitialTips(state)
-    } else if (
-      !activeItem.isStep && activeItem.id === END_TERMINAL_ITEM_ID
-    ) {
-      // "end" terminal
-      wellContents = wellContentsSelectors.lastValidWellContents(state)[containerId]
-      getTipProps = getEndTips(state)
-    } else if (!activeItem.isStep) {
-      console.warn(`SelectablePlate got unhandled terminal id: "${activeItem.id}"`)
-    } else {
-      const stepId = activeItem.id
-      // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
-      const orderedSteps = steplistSelectors.orderedSteps(state)
-      const timelineIdx = orderedSteps.includes(stepId)
-        ? orderedSteps.findIndex(id => id === stepId)
-        : null
-
-      // shows liquids the current step in timeline
-      const selectedWells = wellSelectionSelectors.getSelectedWells(state)
-      let wellContentsWithoutHighlight = null
-      let highlightedWells
-
-      if ((timelineIdx != null)) {
-        wellContentsWithoutHighlight = (allWellContentsForSteps[timelineIdx])
-          // Valid non-end step
-          ? allWellContentsForSteps[timelineIdx][containerId]
-          // Erroring step: show last valid well contents in timeline
-          : wellContentsSelectors.lastValidWellContents(state)[containerId]
-      }
-
-      if (wellSelectionModeForLabware) {
-        // we're in the well selection modal, highlight hovered/selected wells
-        highlightedWells = wellSelectionSelectors.getHighlightedWells(state)
-      } else {
-        // wells are highlighted for steps / substep hover
-
-        // TODO Ian 2018-05-02: Should wellHighlightsForSteps return well highlights
-        // even when prev step isn't processed (due to encountering an upstream error
-        // in the timeline reduce op)
-        const highlightedWellsForSteps = highlightSelectors.wellHighlightsForSteps(state)
-        highlightedWells = (
-          timelineIdx != null &&
-          highlightedWellsForSteps &&
-          highlightedWellsForSteps[timelineIdx] &&
-          highlightedWellsForSteps[timelineIdx][containerId]
-        ) || {}
-      }
-
-      // TODO: Ian 2018-07-31 some sets of wells are {[wellName]: true},
-      // others {[wellName]: wellName}. Use Set instead!
-      // TODO: Ian 2018-08-16 pass getWellProps instead of wellContents,
-      // and make getWellProps a plain old selector (move that logic out of this STP)
-      wellContents = (mapValues(
-        wellContentsWithoutHighlight,
-        (wellContentsForWell: WellContents, well: string): WellContents => ({
-          ...wellContentsForWell,
-          highlighted: Boolean(highlightedWells[well]),
-          selected: Boolean(selectedWells[well])
-        })
-      ): ContentsByWell)
-
-      getTipProps = getTipsPerStep && getTipsPerStep(state)[stepId]
-    }
-
+  if (containerId === null) {
+    console.error('SelectablePlate: No container is selected, and no containerId was given to Connected SelectablePlate')
     return {
-      containerId,
-      wellContents,
-      getTipProps: getTipProps || noop,
-      containerType: labware.type,
-      selectable
+      containerId: '',
+      wellContents: {},
+      containerType: '',
+      selectable: selectable
     }
   }
-  return mapStateToProps
+
+  const labware = selectors.getLabware(state)[containerId]
+  const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
+  const wellSelectionModeForLabware = selectedContainerId === containerId
+  let wellContents: ContentsByWell = {}
+
+  const activeItem = steplistSelectors.getActiveItem(state)
+  if (
+    !activeItem.isStep && activeItem.id === START_TERMINAL_ITEM_ID
+  ) {
+    // selection for deck setup: shows initial state of liquids
+    wellContents = wellContentsSelectors.wellContentsAllLabware(state)[containerId]
+  } else if (
+    !activeItem.isStep && activeItem.id === END_TERMINAL_ITEM_ID
+  ) {
+    // "end" terminal
+    wellContents = wellContentsSelectors.lastValidWellContents(state)[containerId]
+  } else if (!activeItem.isStep) {
+    console.warn(`SelectablePlate got unhandled terminal id: "${activeItem.id}"`)
+  } else {
+    const stepId = activeItem.id
+    // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
+    const orderedSteps = steplistSelectors.orderedSteps(state)
+    const timelineIdx = orderedSteps.includes(stepId)
+      ? orderedSteps.findIndex(id => id === stepId)
+      : null
+
+    // shows liquids the current step in timeline
+    const selectedWells = wellSelectionSelectors.getSelectedWells(state)
+    let wellContentsWithoutHighlight = null
+    let highlightedWells
+
+    if ((timelineIdx != null)) {
+      wellContentsWithoutHighlight = (allWellContentsForSteps[timelineIdx])
+        // Valid non-end step
+        ? allWellContentsForSteps[timelineIdx][containerId]
+        // Erroring step: show last valid well contents in timeline
+        : wellContentsSelectors.lastValidWellContents(state)[containerId]
+    }
+
+    if (wellSelectionModeForLabware) {
+      // we're in the well selection modal, highlight hovered/selected wells
+      highlightedWells = wellSelectionSelectors.getHighlightedWells(state)
+    } else {
+      // wells are highlighted for steps / substep hover
+
+      // TODO Ian 2018-05-02: Should wellHighlightsForSteps return well highlights
+      // even when prev step isn't processed (due to encountering an upstream error
+      // in the timeline reduce op)
+      const highlightedWellsForSteps = highlightSelectors.wellHighlightsForSteps(state)
+      highlightedWells = (
+        timelineIdx != null &&
+        highlightedWellsForSteps &&
+        highlightedWellsForSteps[timelineIdx] &&
+        highlightedWellsForSteps[timelineIdx][containerId]
+      ) || {}
+    }
+
+    // TODO: Ian 2018-07-31 some sets of wells are {[wellName]: true},
+    // others {[wellName]: wellName}. Use Set instead!
+    // TODO: Ian 2018-08-16 pass getWellProps instead of wellContents,
+    // and make getWellProps a plain old selector (move that logic out of this STP)
+    wellContents = (mapValues(
+      wellContentsWithoutHighlight,
+      (wellContentsForWell: WellContents, well: string): WellContents => ({
+        ...wellContentsForWell,
+        highlighted: Boolean(highlightedWells[well]),
+        selected: Boolean(selectedWells[well])
+      })
+    ): ContentsByWell)
+  }
+
+  const getTipProps = tipContentsSelectors.getTipsForCurrentStep(state, {labwareId: containerId})
+
+  return {
+    containerId,
+    wellContents,
+    getTipProps: getTipProps || noop,
+    containerType: labware.type,
+    selectable
+  }
 }
 
 function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
@@ -228,4 +218,4 @@ function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   }
 }
 
-export default connect(makeMapStateToProps, null, mergeProps)(SelectablePlate)
+export default connect(mapStateToProps, null, mergeProps)(SelectablePlate)

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -1,0 +1,86 @@
+// @flow
+import {createSelector} from 'reselect'
+import noop from 'lodash/noop'
+import * as StepGeneration from '../../step-generation'
+import {
+  selectors as steplistSelectors,
+  START_TERMINAL_ITEM_ID,
+  END_TERMINAL_ITEM_ID,
+  type TerminalItemId
+} from '../../steplist'
+import {selectors as fileDataSelectors} from '../../file-data'
+
+import type {Selector} from '../../types'
+import type {ElementProps} from 'react'
+import {typeof Labware} from '@opentrons/components'
+type GetTipProps = $PropertyType<ElementProps<Labware>, 'getTipProps'>
+
+function getTipEmpty (
+  wellName: string,
+  labwareId: string,
+  robotState: StepGeneration.RobotState
+) {
+  return !(
+    robotState.tipState.tipracks[labwareId] &&
+    robotState.tipState.tipracks[labwareId][wellName]
+  )
+}
+
+export const makeGetTerminalTips = (terminalId: TerminalItemId, labwareId: string) => {
+  let robotStateSelector
+  if (terminalId === START_TERMINAL_ITEM_ID) {
+    robotStateSelector = fileDataSelectors.getInitialRobotState
+  } else if (terminalId === END_TERMINAL_ITEM_ID) {
+    robotStateSelector = fileDataSelectors.lastValidRobotState
+  } else {
+    console.error(`Invalid terminalId ${terminalId}, could not makeGetTerminalTips`)
+    return noop
+  }
+  const getInitialTips: Selector<GetTipProps> = createSelector(
+    robotStateSelector,
+    (initialRobotState) => (wellName: string) => ({
+      empty: getTipEmpty(wellName, labwareId, initialRobotState),
+      highlighted: false
+    })
+  )
+  return getInitialTips
+}
+
+type TipsPerStep = {[stepId: number]: GetTipProps}
+export const makeGetTipsPerStep = (labwareId: string) => {
+  const getTipsPerStep: Selector<TipsPerStep> = createSelector(
+    steplistSelectors.orderedSteps,
+    fileDataSelectors.robotStateTimeline,
+    (orderedSteps, robotStateTimeline) => {
+      const timeline = robotStateTimeline.timeline
+      return orderedSteps.reduce((acc: TipsPerStep, stepId, timelineIdx) => {
+        const prevFrame: ?* = timeline[timelineIdx - 1]
+        const currentFrame: ?* = timeline[timelineIdx]
+
+        return {
+          ...acc,
+          [stepId]: (wellName: string) => {
+            // show empty/present tip state at end of previous frame
+            const empty = (prevFrame)
+              ? getTipEmpty(wellName, labwareId, prevFrame.robotState)
+              : false
+
+            // show highlights of tips used by current frame
+            const highlighted = (currentFrame)
+              ? currentFrame.commands.some(c =>
+                c.command === 'pick-up-tip' &&
+                c.params.labware === labwareId &&
+                c.params.well === wellName)
+              : false
+
+            return {
+              empty,
+              highlighted
+            }
+          }
+        }
+      }, {})
+    }
+  )
+  return getTipsPerStep
+}

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -5,8 +5,7 @@ import * as StepGeneration from '../../step-generation'
 import {
   selectors as steplistSelectors,
   START_TERMINAL_ITEM_ID,
-  END_TERMINAL_ITEM_ID,
-  type TerminalItemId
+  END_TERMINAL_ITEM_ID
 } from '../../steplist'
 import {selectors as fileDataSelectors} from '../../file-data'
 import {getWellSetForMultichannel} from '../../well-selection/utils'
@@ -15,6 +14,10 @@ import type {Selector} from '../../types'
 import type {ElementProps} from 'react'
 import {typeof Labware} from '@opentrons/components'
 type GetTipProps = $PropertyType<ElementProps<Labware>, 'getTipProps'>
+
+function getLabwareIdProp (state, props: {labwareId: string}) {
+  return props.labwareId
+}
 
 function getTipHighlighted (
   labwareId: string,
@@ -59,58 +62,77 @@ function getTipEmpty (
   )
 }
 
-export const makeGetTerminalTips = (terminalId: TerminalItemId, labwareId: string) => {
-  let robotStateSelector
-  if (terminalId === START_TERMINAL_ITEM_ID) {
-    robotStateSelector = fileDataSelectors.getInitialRobotState
-  } else if (terminalId === END_TERMINAL_ITEM_ID) {
-    robotStateSelector = fileDataSelectors.lastValidRobotState
-  } else {
-    console.error(`Invalid terminalId ${terminalId}, could not makeGetTerminalTips`)
-    return noop
-  }
-  const getInitialTips: Selector<GetTipProps> = createSelector(
-    robotStateSelector,
-    (initialRobotState) => (wellName: string) => ({
+const getInitialTips: Selector<GetTipProps> = createSelector(
+  fileDataSelectors.getInitialRobotState,
+  getLabwareIdProp,
+  (initialRobotState, labwareId) =>
+    (wellName: string) => ({
       empty: getTipEmpty(wellName, labwareId, initialRobotState),
       highlighted: false
     })
-  )
-  return getInitialTips
-}
+)
 
-type TipsPerStep = {[stepId: number]: GetTipProps}
-export const makeGetTipsPerStep = (labwareId: string) => {
-  const getTipsPerStep: Selector<TipsPerStep> = createSelector(
-    steplistSelectors.orderedSteps,
-    fileDataSelectors.robotStateTimeline,
-    (orderedSteps, robotStateTimeline) => {
-      const timeline = robotStateTimeline.timeline
-      return orderedSteps.reduce((acc: TipsPerStep, stepId, timelineIdx) => {
-        const prevFrame: ?* = timeline[timelineIdx - 1]
-        const currentFrame: ?* = timeline[timelineIdx]
+const getLastValidTips: Selector<GetTipProps> = createSelector(
+  fileDataSelectors.lastValidRobotState,
+  getLabwareIdProp,
+  (lastValidRobotState, labwareId) =>
+    (wellName: string) => ({
+      empty: getTipEmpty(wellName, labwareId, lastValidRobotState),
+      highlighted: false
+    })
+)
 
-        return {
-          ...acc,
-          [stepId]: (wellName: string) => {
-            // show empty/present tip state at end of previous frame
-            const empty = (prevFrame)
-              ? getTipEmpty(wellName, labwareId, prevFrame.robotState)
-              : false
-
-            // show highlights of tips used by current frame
-            const highlighted = (currentFrame)
-              ? getTipHighlighted(labwareId, wellName, currentFrame)
-              : false
-
-            return {
-              empty,
-              highlighted
-            }
-          }
-        }
-      }, {})
+export const getTipsForCurrentStep: Selector<GetTipProps> = createSelector(
+  steplistSelectors.orderedSteps,
+  fileDataSelectors.robotStateTimeline,
+  steplistSelectors.getHoveredStepId,
+  steplistSelectors.getActiveItem,
+  getInitialTips,
+  getLastValidTips,
+  getLabwareIdProp,
+  (orderedSteps, robotStateTimeline, hoveredStepId, activeItem, initialTips, lastValidTips, labwareId) => {
+    if (!activeItem.isStep) {
+      const terminalId = activeItem.id
+      if (terminalId === START_TERMINAL_ITEM_ID) {
+        return initialTips
+      } else if (terminalId === END_TERMINAL_ITEM_ID) {
+        return lastValidTips
+      } else {
+        console.error(`Invalid terminalId ${terminalId}, could not getTipsForCurrentStep`)
+        return noop
+      }
     }
-  )
-  return getTipsPerStep
-}
+
+    const stepId = activeItem.id
+    const hovered = stepId === hoveredStepId
+    const timeline = robotStateTimeline.timeline
+    const timelineIdx = orderedSteps.includes(stepId)
+      ? orderedSteps.findIndex(id => id === stepId)
+      : null
+
+    if (timelineIdx == null) {
+      console.error(`Expected non-null timelineIdx for step ${stepId}`)
+      return noop
+    }
+
+    const prevFrame = timeline[timelineIdx - 1]
+    const currentFrame = timeline[timelineIdx]
+
+    return (wellName: string) => {
+      // show empty/present tip state at end of previous frame
+      const empty = (prevFrame)
+        ? getTipEmpty(wellName, labwareId, prevFrame.robotState)
+        : false
+
+      // show highlights of tips used by current frame, if user is hovering
+      const highlighted = (hovered && currentFrame)
+        ? getTipHighlighted(labwareId, wellName, currentFrame)
+        : false
+
+      return {
+        empty,
+        highlighted
+      }
+    }
+  }
+)

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {createSelector} from 'reselect'
+import {createSelector, type Selector} from 'reselect'
 import noop from 'lodash/noop'
 import * as StepGeneration from '../../step-generation'
 import {
@@ -10,10 +10,12 @@ import {
 import {selectors as fileDataSelectors} from '../../file-data'
 import {getWellSetForMultichannel} from '../../well-selection/utils'
 
-import type {Selector} from '../../types'
+import type {BaseState} from '../../types'
 import type {ElementProps} from 'react'
 import {typeof Labware} from '@opentrons/components'
+
 type GetTipProps = $PropertyType<ElementProps<Labware>, 'getTipProps'>
+type GetTipSelector = Selector<BaseState, {labwareId: string}, GetTipProps>
 
 function getLabwareIdProp (state, props: {labwareId: string}) {
   return props.labwareId
@@ -62,7 +64,7 @@ function getTipEmpty (
   )
 }
 
-const getInitialTips: Selector<GetTipProps> = createSelector(
+const getInitialTips: GetTipSelector = createSelector(
   fileDataSelectors.getInitialRobotState,
   getLabwareIdProp,
   (initialRobotState, labwareId) =>
@@ -72,7 +74,7 @@ const getInitialTips: Selector<GetTipProps> = createSelector(
     })
 )
 
-const getLastValidTips: Selector<GetTipProps> = createSelector(
+const getLastValidTips: GetTipSelector = createSelector(
   fileDataSelectors.lastValidRobotState,
   getLabwareIdProp,
   (lastValidRobotState, labwareId) =>
@@ -82,7 +84,7 @@ const getLastValidTips: Selector<GetTipProps> = createSelector(
     })
 )
 
-export const getTipsForCurrentStep: Selector<GetTipProps> = createSelector(
+export const getTipsForCurrentStep: GetTipSelector = createSelector(
   steplistSelectors.orderedSteps,
   fileDataSelectors.robotStateTimeline,
   steplistSelectors.getHoveredStepId,


### PR DESCRIPTION
## overview

Tip tracking made visual!

Closes #1094

Tip tracking right now works only for whole steps, substeps don't show an additional level of detail. If we do want substep-grain tip tracking viz, I want to refactor the well substeps first and maybe the timeline shape itself, because there is a lot of complexity that I don't want to duplicate/expand.

![2018-08-16--tip-tracking-timetravel](https://user-images.githubusercontent.com/11590381/44229058-e1afda80-a164-11e8-9779-45478361ee20.gif)

## changelog

- show tips on deck

## review requests

:beetle: It looks like there are some bugs with tip use (eg 'once' seems to work like 'always' in some cases). I don't believe they are tip tracking viz bugs, I think what you see is what the robot will do. So, fixing what the robot will do with "once" vs "always" will be another PR. But at least we can see what's happening!

## tips
<img src="https://c1.staticflickr.com/9/8383/8590666880_c4f83d285e_b.jpg"></img>