### PR TITLE
ci: Parallelize `make install` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - source scripts/travis-install.sh
 
 install:
-  - make install
+  - make -j 2 install
 
 before_script:
   # Get all branches to allow comparison for mono-repo management tools

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,19 @@ endif
 usb_host = $(shell yarn run -s discovery find -i 169.254 fd00 -c "[fd00:0:cafe:fefe::1]")
 
 # install all project dependencies
-# front-end dependecies handled by yarn
 .PHONY: install
-install:
+install: install-py install-js
+
+.PHONY: install-py
+install-py:
 	$(OT_PYTHON) -m pip install pipenv==11.6.8
 	$(MAKE) -C $(API_LIB_DIR) install
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
+
+# front-end dependecies handled by yarn
+.PHONY: install-js
+install-js:
 	yarn
 	$(MAKE) -C $(SHARED_DATA_DIR) build
 	$(MAKE) -C $(DISCOVERY_CLIENT_DIR)
@@ -45,7 +51,7 @@ install:
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile
 .PHONY: uninstall
 uninstall:
-	lerna clean
+	shx rm -rf '**/node_modules'
 
 # install flow typed definitions for all JS projects that use flow
 # typedefs are commited, so only needs to be run when we want to update

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - ps: $env:nodejs_version = (Get-Content -Path .nvmrc)[0]
   - ps: Install-Product node $env:nodejs_version x64
   # install dev dependencies
-  - cmd: '%MAKE% install'
+  - cmd: '%MAKE% -j 2 install'
 
 # do not run MSBuild
 build: false


### PR DESCRIPTION
## overview

This PR runs `pipenv` and `yarn` in parallel on CI to speed up the builds during the `make install` stage. It also gives users the option to run `make install` in parallel on their own machines.

## changelog

- ci: Parallelize `make install` in CI 

## review requests

`make` has an option `-j, --jobs` that lets you specify how many jobs can run in parallel. By default, `--jobs` is set to `1`. However, by passing `-j 2` (or, just `-j` to let your computer figure out how many jobs to run based on number of cores your CPU has), you can tell `make` to run more jobs.

By splitting `make install` into `install-py` and `install-js` and adding them as task dependencies of `install` (rather than part of the task body), `make` will run them in parallel when you tell it `-j 2`.

Compared to the build immediately before this one (so relatively unscientifically):

|   | Travis | AppVeyor |
| --- | --- | --- |
| `make install` | 150 seconds | 275 seconds |
| `make -j 2 install` | 141 seconds | 190 seconds |
|   | 6% faster | 30% faster |

Also give `make -j install` a try on your own machine