### PR TITLE
feat(api): Robot Reset

### DIFF
--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -10,6 +10,7 @@ from opentrons.data_storage import labware_definitions as ldef
 from opentrons.data_storage import serializers
 from opentrons.config import feature_flags as fflags
 import logging
+import os
 
 SUPPORTED_MODULES = ['magdeck', 'tempdeck']
 
@@ -274,5 +275,11 @@ def set_version(version):
         pass
     db_conn = sqlite3.connect(database_path)
     db_queries.set_user_version(db_conn, version)
+
+
+def reset():
+    """ Unmount and remove the sqlite database (used in robot reset) """
+    if os.path.exists(database_path):
+        os.remove(database_path)
 
 # ======================== END Public Functions ======================== #

--- a/api/opentrons/robot/robot_configs.py
+++ b/api/opentrons/robot/robot_configs.py
@@ -204,12 +204,11 @@ def backup_configuration(config: robot_config, tag=None):
     save_robot_settings(config, tag=tag)
 
 
-def clear():
-    files = [
-        get_config_index().get('deckCalibrationFile'),
-        get_config_index().get('robotSettingsFile')]
-    for filename in files:
-        _clear_file(filename)
+def clear(calibration=True, robot=True):
+    if calibration:
+        _clear_file(get_config_index().get('deckCalibrationFile'))
+    if robot:
+        _clear_file(get_config_index().get('robotSettingsFile'))
 
 
 def _clear_file(filename):

--- a/api/opentrons/server/endpoints/__init__.py
+++ b/api/opentrons/server/endpoints/__init__.py
@@ -3,8 +3,6 @@ import json
 import logging
 from aiohttp import web
 from opentrons import robot, __version__
-from opentrons.config import advanced_settings as advs
-
 
 log = logging.getLogger(__name__)
 
@@ -25,38 +23,3 @@ async def health(request: web.Request) -> web.Response:
     return web.json_response(
         headers={'Access-Control-Allow-Origin': '*'},
         body=json.dumps(res))
-
-
-async def get_advanced_settings(request: web.Request) -> web.Response:
-    """
-    Handles a GET request and returns a json body with the key "settings" and a
-    value that is a list of objects where each object has keys "id", "title",
-    "description", and "value"
-    """
-    res = _get_adv_settings()
-    return web.json_response(res)
-
-
-def _get_adv_settings() -> dict:
-    data = advs.get_all_adv_settings()
-    return {"settings": list(data.values())}
-
-
-async def set_advanced_setting(request: web.Request) -> web.Response:
-    """
-    Handles a POST request with a json body that has keys "id" and "value",
-    where the value of "id" must correspond to an id field of a setting in
-    `opentrons.config.advanced_settings.settings`. Saves the value of "value"
-    for the setting that matches the supplied id.
-    """
-    data = await request.json()
-    key = data.get('id')
-    value = data.get('value')
-    if key and key in advs.settings_by_id.keys():
-        advs.set_adv_setting(key, value)
-        res = _get_adv_settings()
-        status = 200
-    else:
-        res = {'message': 'ID {} not found in settings list'.format(key)}
-        status = 400
-    return web.json_response(res, status=status)

--- a/api/opentrons/server/endpoints/settings.py
+++ b/api/opentrons/server/endpoints/settings.py
@@ -1,0 +1,52 @@
+import logging
+from aiohttp import web
+from opentrons.config import advanced_settings as advs
+
+log = logging.getLogger(__name__)
+
+
+async def get_advanced_settings(request: web.Request) -> web.Response:
+    """
+    Handles a GET request and returns a json body with the key "settings" and a
+    value that is a list of objects where each object has keys "id", "title",
+    "description", and "value"
+    """
+    res = _get_adv_settings()
+    return web.json_response(res)
+
+
+def _get_adv_settings() -> dict:
+    data = advs.get_all_adv_settings()
+    return {"settings": list(data.values())}
+
+
+async def set_advanced_setting(request: web.Request) -> web.Response:
+    """
+    Handles a POST request with a json body that has keys "id" and "value",
+    where the value of "id" must correspond to an id field of a setting in
+    `opentrons.config.advanced_settings.settings`. Saves the value of "value"
+    for the setting that matches the supplied id.
+    """
+    data = await request.json()
+    key = data.get('id')
+    value = data.get('value')
+    if key and key in advs.settings_by_id.keys():
+        advs.set_adv_setting(key, value)
+        res = _get_adv_settings()
+        status = 200
+    else:
+        res = {'message': 'ID {} not found in settings list'.format(key)}
+        status = 400
+    return web.json_response(res, status=status)
+
+
+async def reset(request: web.Request) -> web.Response:
+    """ Execute a reset of the requested parts of the user configuration.
+    """
+    return web.json_response({'message': 'Not implemented'}, status=501)
+
+
+async def available_resets(request: web.Request) -> web.Response:
+    """ Indicate what parts of the user configuration are available for reset.
+    """
+    return web.json_response({'message': 'Not implemented'}, status=501)

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -10,7 +10,7 @@ from opentrons import robot, __version__
 from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
 from opentrons.server import endpoints as endp
-from opentrons.server.endpoints import (wifi, control)
+from opentrons.server.endpoints import (wifi, control, settings)
 from opentrons.config import feature_flags as ff
 from opentrons.util import environment
 from opentrons.deck_calibration import endpoints as dc_endp
@@ -208,9 +208,13 @@ def init(loop=None):
     server.app.router.add_post(
         '/robot/lights', control.set_rail_lights)
     server.app.router.add_get(
-        '/settings', endp.get_advanced_settings)
+        '/settings', settings.get_advanced_settings)
     server.app.router.add_post(
-        '/settings', endp.set_advanced_setting)
+        '/settings', settings.set_advanced_setting)
+    server.app.router.add_post(
+        '/settings/reset', settings.reset)
+    server.app.router.add_get(
+        '/settings/reset/options', settings.available_resets)
 
     return server.app
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -1,4 +1,12 @@
+import contextlib
+import json
+import os
+import shutil
+import tempfile
+
 from opentrons.server.main import init
+from opentrons.data_storage import database as db
+from opentrons.robot import robot_configs as rc
 
 
 def validate_response_body(body):
@@ -34,3 +42,96 @@ async def test_set(virtual_smoothie_env, loop, test_client):
     test_setting = list(
         filter(lambda x: x.get('id') == test_id, body.get('settings')))[0]
     assert test_setting.get('value')
+
+
+async def test_available_resets(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    resp = await cli.get('/settings/reset/options')
+    body = await resp.json()
+    assert resp.status == 200
+    for key in ['deckCalibration', 'tipProbe',
+                'labwareCalibration', 'bootScripts']:
+        for opt in body:
+            if opt['id'] == key:
+                assert 'name' in opt
+                assert 'description' in opt
+                break
+        else:
+            raise KeyError(key)
+
+
+async def execute_reset_tests(cli):
+    # Make sure we actually delete the database
+    resp = await cli.post('/settings/reset', json={'labwareCalibration': True})
+    body = await resp.json()
+    assert not os.path.exists(db.database_path)
+    assert resp.status == 200
+    assert body == {}
+
+    # Make sure this one is idempotent
+    resp = await cli.post('/settings/reset', json={'labwareCalibration': True})
+    body = await resp.json()
+    assert resp.status == 200
+    assert body == {}
+
+    # Check that we properly delete only the tip length key
+    resp = await cli.post('/settings/reset', json={'tipProbe': True})
+    body = await resp.json()
+    assert resp.status == 200
+    assert body == {}
+
+    index = rc.get_config_index()
+    robot_settings = index['robotSettingsFile']
+    with open(robot_settings, 'r') as f:
+        data = json.load(f)
+    assert data['tip_length'] == {}
+
+    # Check that we delete the entire deck calibration file
+    resp = await cli.post('/settings/reset', json={'deckCalibration': True})
+    body = await resp.json()
+    assert resp.status == 200
+    assert body == {}
+
+    deck_cal = index['deckCalibrationFile']
+    assert not os.path.exists(deck_cal)
+
+    # Check that this endpoint is idempotent
+    resp = await cli.post('/settings/reset', json={'deckCalibration': True})
+    body = await resp.json()
+    assert resp.status == 200
+    assert body == {}
+
+    # Check the inpost validation
+    resp = await cli.post('/settings/reset', json={'aksgjajhadjasl': False})
+    body = await resp.json()
+    assert resp.status // 100 == 4
+    assert 'message' in body
+    assert 'aksgjajhadjasl' in body['message']
+
+
+@contextlib.contextmanager
+def restore_db(db_path):
+    db_name = os.path.basename(db_path)
+    with tempfile.TemporaryDirectory() as tempdir:
+        shutil.copy(db_path,
+                    os.path.join(tempdir, db_name))
+        try:
+            yield
+        finally:
+            shutil.copy(os.path.join(tempdir, db_name),
+                        db_path)
+
+
+async def test_reset(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+
+    # This test runs each reset individually (except /data/boot.d which won’t
+    # work locally) and checks the error handling
+
+    # precondition
+    assert os.path.exists(db.database_path)
+    with restore_db(db.database_path):
+        await execute_reset_tests(cli)


### PR DESCRIPTION
## overview

 Add endpoints at GET /settings/reset/options and POST /settings/reset to, respectively, query what reset options are available and reset any subset of those options to their factory configurations. This allows us to reset only the parts of the configuration that a user might want, and avoid resetting those configurations that are required for operation and difficult to change.

Closes #1885  

GET /settings/reset/options

```
200 OK
[
    {
        "id": "deckCalibration",
        "name": "Deck Calibration",
        "description": "Reset calibration of pipette to deck"
    },
    {
        "id": "tipProbe",
        "name": "Tip Probe Calibration",
        "description": "Erase tip probe data"
    },
    {
        "id": "labwareCalibration",
        "name": "Labware Calibration",
        "description": "Erase custom labware calibration"
    },
    {
        "id": "bootScripts",
        "name": "Boot Scripts",
        "description": "Erase custom boot scripts"
    }
]
```

POST /settings/reset with eg ` {"deckCalibration": true, "bootScripts":true}` (note the other options are unspecified):

```
200 OK
{}
```

POST /settings/reset with ` {"bad-option": true}` (note the other options are unspecified:
```
400 Bad Request
{
    "message": "bad is not a valid reset option"
}
```
## changelog

- Add and implement GET /settings/reset/options and PUT /settings/reset endpoints
- Move settings endpoints in the api server to their own file

## review requests

@Laura-Danielle @btmorr In addition to the general "is this good code" look over would you mind gut checking the files I'm resetting? It seems like this is all we need on 3.3.

@umbhau @Laura-Danielle  really anybody with more opinions or knowledge about calibration than me - is this good wording for the description fields?

Updated 8/20/2018 for results for changes noted by @Kadee80  on the issue.