### PR TITLE
feat(app,api): Add opt-in ping/pong monitoring to RPC websocket

### DIFF
--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -97,7 +97,8 @@ async def test_init(session, root):
             'v': {'value': 0}
         },
         'type': serialized_type,
-        '$': {'type': rpc.CONTROL_MESSAGE}}
+        '$': {'type': rpc.CONTROL_MESSAGE, 'monitor': True}
+    }
 
     assert serialized_type['v']['STATIC'] == 'static', \
         'Class attributes are serialized correctly'
@@ -113,7 +114,7 @@ async def test_exception_during_call(session):
         'type': rpc.CALL_NACK_MESSAGE,
         'token': session.token
     }
-    assert res.pop('reason').startswith('TypeError: build_call()')
+    assert res.pop('reason').startswith('TypeError:')
     assert res == {}
 
 
@@ -419,7 +420,7 @@ async def test_concurrent_and_disconnect(loop, root, session, connect):  # noqa 
 
     for res in results:
         # First message is root info
-        assert res.pop(0)['$'] == {'type': 3}
+        assert res.pop(0)['$'] == {'type': 3, 'monitor': True}
         expected = []
         # All acks received
         expected.extend([ack_message(token) for token in tokens])

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -57,9 +57,10 @@ function makeMapStateToProps () {
 
   return (state: State) => {
     const robot = robotSelectors.getConnectedRobot(state)
+    const unexpectedDisconnect = state.robot.connection.unexpectedDisconnect
 
     return {
-      ok: robot && getHealthOk(state, robot)
+      ok: robot && !unexpectedDisconnect && getHealthOk(state, robot)
     }
   }
 }

--- a/app/src/health-check/__tests__/health-check.test.js
+++ b/app/src/health-check/__tests__/health-check.test.js
@@ -154,7 +154,7 @@ describe('health check', () => {
 
     test('CONNECT_RESPONSE success dispatches START_HEALTH_CHECK', () => {
       state.robot.connection.connectedTo = ''
-      invoke(robotActions.connectResponse())
+      invoke(robotActions.connectResponse(null, true))
       // middleware should pull `robot` from the connection request state
       expect(store.dispatch).toHaveBeenCalledWith(
         startHealthCheck(expect.objectContaining({
@@ -166,6 +166,12 @@ describe('health check', () => {
 
     test('CONNECT_RESPONSE failure noops', () => {
       invoke(robotActions.connectResponse(new Error('AH')))
+      expect(store.dispatch).toHaveBeenCalledTimes(0)
+    })
+
+    test('CONNECT_RESPONSE with pollHealth: false noops', () => {
+      state.robot.connection.connectedTo = ''
+      invoke(robotActions.connectResponse(null, false))
       expect(store.dispatch).toHaveBeenCalledTimes(0)
     })
 

--- a/app/src/health-check/index.js
+++ b/app/src/health-check/index.js
@@ -122,7 +122,7 @@ export const healthCheckMiddleware: Middleware =
         break
 
       case 'robot:CONNECT_RESPONSE':
-        if (!action.payload.error) {
+        if (!action.payload.error && action.payload.pollHealth) {
           const state = store.getState()
           const name = getConnectRequest(state).name
           const robot = getDiscovered(state).find(r => r.name === name)

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -51,7 +51,8 @@ export type ConnectAction = {|
 export type ConnectResponseAction = {|
   type: 'robot:CONNECT_RESPONSE',
   payload: {|
-    error: ?{message: string}
+    error: ?{message: string},
+    pollHealth: ?boolean,
   |},
 |}
 
@@ -76,6 +77,10 @@ export type DisconnectAction = {|
 export type DisconnectResponseAction = {|
   type: 'robot:DISCONNECT_RESPONSE',
   payload: {},
+|}
+
+export type UnexpectedDisconnectAction = {|
+  type: 'robot:UNEXPECTED_DISCONNECT',
 |}
 
 export type ConfirmProbedAction = {|
@@ -222,6 +227,7 @@ export type Action =
   | DisconnectAction
   | DisconnectResponseAction
   | ClearConnectResponseAction
+  | UnexpectedDisconnectAction
   | ConfirmProbedAction
   | PipetteCalibrationAction
   | LabwareCalibrationAction
@@ -253,10 +259,10 @@ export const actions = {
     }
   },
 
-  connectResponse (error: ?Error): ConnectResponseAction {
+  connectResponse (error: ?Error, pollHealth: ?boolean): ConnectResponseAction {
     return {
       type: 'robot:CONNECT_RESPONSE',
-      payload: {error}
+      payload: {error, pollHealth}
     }
   },
 
@@ -273,6 +279,10 @@ export const actions = {
       type: 'robot:DISCONNECT_RESPONSE',
       payload: {}
     }
+  },
+
+  unexpectedDisconnect (): UnexpectedDisconnectAction {
+    return {type: 'robot:UNEXPECTED_DISCONNECT'}
   },
 
   // TODO(mc, 2018-08-10): remove

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -21,12 +21,14 @@ type State = {
     inProgress: boolean,
     error: ?{message: string}
   },
+  unexpectedDisconnect: boolean,
 }
 
 const INITIAL_STATE: State = {
   connectedTo: '',
   connectRequest: {inProgress: false, error: null, name: ''},
-  disconnectRequest: {inProgress: false, error: null}
+  disconnectRequest: {inProgress: false, error: null},
+  unexpectedDisconnect: false
 }
 
 export default function connectionReducer (
@@ -50,6 +52,9 @@ export default function connectionReducer (
 
     case 'robot:DISCONNECT_RESPONSE':
       return handleDisconnectResponse(state, action)
+
+    case 'robot:UNEXPECTED_DISCONNECT':
+      return {...state, unexpectedDisconnect: true}
   }
 
   return state
@@ -92,7 +97,8 @@ function handleDisconnectResponse (
   return {
     ...state,
     connectedTo: '',
-    disconnectRequest: {error: null, inProgress: false}
+    disconnectRequest: {error: null, inProgress: false},
+    unexpectedDisconnect: false
   }
 }
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -48,6 +48,7 @@ describe('api client', () => {
       // rejection warnings. These warnings are Jest's fault for nextTick stuff
       // http://clarkdave.net/2016/09/node-v6-6-and-asynchronously-handled-promise-rejections/
       on: jest.fn(() => rpcClient),
+      removeAllListeners: jest.fn(() => rpcClient),
       close: jest.fn(),
       remote: {
         session_manager: sessionManager,
@@ -106,7 +107,7 @@ describe('api client', () => {
 
   describe('connect and disconnect', () => {
     test('connect RpcClient on CONNECT message', () => {
-      const expectedResponse = actions.connectResponse()
+      const expectedResponse = actions.connectResponse(null, true)
 
       expect(RpcClient).toHaveBeenCalledTimes(0)
 
@@ -125,6 +126,18 @@ describe('api client', () => {
 
       return sendConnect()
         .then(() => expect(dispatch).toHaveBeenCalledWith(expectedResponse))
+    })
+
+    test('send CONNECT_RESPONSE w pollHealth: false if RPC.monitoring', () => {
+      const expectedResponse = actions.connectResponse(null, false)
+
+      rpcClient.monitoring = true
+
+      return sendConnect()
+        .then(() => {
+          expect(RpcClient).toHaveBeenCalledWith(`ws://${ROBOT_IP}:31950`)
+          expect(dispatch).toHaveBeenCalledWith(expectedResponse)
+        })
     })
 
     test('dispatch DISCONNECT_RESPONSE if already disconnected', () => {

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -10,7 +10,8 @@ describe('robot reducer - connection', () => {
     expect(getState(state)).toEqual({
       connectedTo: '',
       connectRequest: {inProgress: false, error: null, name: ''},
-      disconnectRequest: {inProgress: false, error: null}
+      disconnectRequest: {inProgress: false, error: null},
+      unexpectedDisconnect: false
     })
   })
 
@@ -124,14 +125,16 @@ describe('robot reducer - connection', () => {
     const state = {
       connection: {
         connectedTo: 'ot',
-        disconnectRequest: {inProgress: true, error: null}
+        disconnectRequest: {inProgress: true, error: null},
+        unexpectedDisconnect: true
       }
     }
     const action = {type: 'robot:DISCONNECT_RESPONSE', payload: {}}
 
     expect(getState(reducer(state, action))).toEqual({
       connectedTo: '',
-      disconnectRequest: {inProgress: false, error: null}
+      disconnectRequest: {inProgress: false, error: null},
+      unexpectedDisconnect: false
     })
   })
 })

--- a/app/src/rpc/client.js
+++ b/app/src/rpc/client.js
@@ -13,7 +13,8 @@ import {
   ACK,
   NACK,
   NOTIFICATION,
-  CONTROL_MESSAGE
+  CONTROL_MESSAGE,
+  PONG
 } from './message-types'
 
 // TODO(mc, 2017-08-29): see note about uuid above
@@ -25,6 +26,10 @@ const HANDSHAKE_TIMEOUT = 10000
 const RECEIVE_CONTROL_TIMEOUT = 10000
 const CALL_ACK_TIMEOUT = 10000
 // const CALL_RESULT_TIMEOUT = 240000
+
+// ping pong
+const PING_INTERVAL_MS = 3000
+const MISSED_PING_THRESHOLD = 2
 
 // metadata constants
 const REMOTE_TARGET_OBJECT = 0
@@ -44,6 +49,10 @@ class RpcContext extends EventEmitter {
     this._ws = ws
     this._resultTypes = new Map()
     this._typeObjectCache = new Map()
+    this._pingInterval = null
+    this._missedPings = 0
+
+    this.monitoring = false
     this.remote = null
     // default max listeners is 10, we need more than that
     // keeping this at a finite number just in case we get a leak later
@@ -51,7 +60,7 @@ class RpcContext extends EventEmitter {
 
     ws.on('error', this._handleError.bind(this))
     ws.on('message', this._handleMessage.bind(this))
-    ws.on('close', this._handleClose.bind(this))
+    ws.once('close', this.close.bind(this))
   }
 
   callRemote (id, name, args = []) {
@@ -137,11 +146,16 @@ class RpcContext extends EventEmitter {
     return this.callRemote(null, 'get_object_by_id', [typeId])
   }
 
-  // remove all event listeners and close the websocket
+  // close the websocket and cleanup self
   close () {
-    this.removeAllListeners()
+    clearInterval(this._pingInterval)
     this._ws.removeAllListeners()
     this._ws.close()
+    this.eventNames()
+      .filter(n => n !== 'close')
+      .forEach(n => this.removeAllListeners(n))
+
+    this.emit('close')
   }
 
   // cache required metadata from call results
@@ -169,13 +183,25 @@ class RpcContext extends EventEmitter {
     }
   }
 
+  _startMonitoring () {
+    this.monitoring = true
+    this._pingInterval = setInterval(this._ping.bind(this), PING_INTERVAL_MS)
+  }
+
+  _ping () {
+    if (this._missedPings > MISSED_PING_THRESHOLD) return this.close()
+
+    this._send({$: {ping: true}})
+    this._missedPings = this._missedPings + 1
+  }
+
+  _handlePong () {
+    this._missedPings = 0
+  }
+
   _send (message) {
     // log.debug('Sending: %j', message)
     this._ws.send(message)
-  }
-
-  _handleClose () {
-    this.emit('close')
   }
 
   _handleError (error) {
@@ -184,8 +210,6 @@ class RpcContext extends EventEmitter {
 
   // TODO(mc): split this method up
   _handleMessage (message) {
-    // log.debug('Received message %j', message)
-
     const {$: meta, data} = message
     const type = meta.type
 
@@ -197,6 +221,8 @@ class RpcContext extends EventEmitter {
         // then cache its type object
         this._cacheCallResultMetadata(root)
         this._cacheCallResultMetadata(rootType)
+
+        if (meta.monitor) this._startMonitoring()
 
         RemoteObject(this, root)
           .then((remote) => {
@@ -232,6 +258,10 @@ class RpcContext extends EventEmitter {
           .then((remote) => this.emit('notification', remote))
           // .catch((e) => log.error('Error creating notification remote', e))
 
+        break
+
+      case PONG:
+        this._handlePong()
         break
 
       default:

--- a/app/src/rpc/message-types.js
+++ b/app/src/rpc/message-types.js
@@ -7,6 +7,7 @@ export const ACK = 1
 export const NOTIFICATION = 2
 export const CONTROL_MESSAGE = 3
 export const NACK = 4
+export const PONG = 5
 
 // statuses
 export const statuses = {


### PR DESCRIPTION
## overview

This PR adds opt-in ping/pong monitoring to the RPC websocket. It also improves/adds WebSocket closure handling to surface socket closure to the UI more reliably.

Closes #2052

## changelog

- feat(app,api): Add opt-in ping/pong monitoring to RPC websocket 

## review requests

Checking on the currently connected robot via polling `GET /health` has proven unreliable (socket can fail even when the health endpoint is fine) and is kind of a mess in terms of app state. Also, now that the app can combine multiple IP addresses into one robot (if `$OT_APP_DISCOVERY__ENABLED` is set), **the existing health-check implementation doesn't know what to do if the currently connected IP goes down but the robot is still accessible via another IP**. For the purposes of switching to new discovery by default, this is blocking.

Rather than getting crazy with the existing health-check stuff, this PR implements a very simple (and battle-tested) ping/pong routine where the client sends a ping and the server responds with a pong on an interval. If too many pings go by without a pong, the client will close the socket and signal the UI.

If the RPC server the app connects to supports ping/pong, the app will *not* spin up a `GET /health` poll routine for that robot. We can build auto-reconnect attempts on top of this, and eventually remove the `http-api-client/health-check` module entirely in favor of the `/health` polling in `discovery-client` and the socket ping/pong here.

I didn't even attempt to build unit tests for this because the server-side RPC tests are completely unworkable (it seems like raises in the code cause indefinite hangs rather than test failures) and the client-side code isn't much better. I'm sorry.

### test plan

Tests can be run with real robot or virtual smoothie, provided at least a few people test on real robots.

#### regression testing

On a robot **without** ping/pong RPC:

- [x] App starts `GET /health` poll on connect
- [x] App stops `GET /health` poll on disconnect
- [x] Websocket close triggers LostConnectionAlert
    - Simulate this by killing the server process
- [x] Health poll failures trigger LostConnectionAlert
    - I'm not sure, but I think you can simluate this by disabling your WiFi / pulling the ethernet cable

#### new feature testing

On a robot **with** ping/pong RPC (`sunset` has been loaded with this branch):

- [x] App **does not** start `GET /health` poll on connect
- [x] Ping/pong routine works through / does not interfere with protocol run
- [x] Websocket close triggers LostConnectionAlert
    - Simulate this by killing the server process
- [x] Missed pongs trigger LostConnectionAlert
    - Simulate this by killing your laptop's WiFi and/or:
    - Editing lines 312-317 in `api/opentrons/server/rpc.py`
        - This will cause the server to never send a pong
        - Client should close out the socket itself after ~9 seconds (3 pings * 3 seconds per ping)
        ```py
        # before
        def send_pong(self):
            self.send({
                '$': {
                    'type': PONG_MESSAGE
                }
            })
    
        # after
        def send_pong(self):
            pass
        ```

