### PR TITLE
refactor(api): Remove log.exception() in _parse_instrument_data()

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -156,7 +156,6 @@ def _parse_instrument_data(smoothie_response):
         # because of how Smoothieware handles GCODE messages
         data = bytearray.fromhex(items[1])
     except (ValueError, IndexError, TypeError, AttributeError):
-        log.exception('Unexpected argument to _parse_instrument_data:')
         raise ParseError(
             'Unexpected argument to _parse_instrument_data: {}'.format(
                 smoothie_response))


### PR DESCRIPTION
## overview

This logging fills up the screen when running factory tests, which can be confusing for testers. And
it is not that useful of a log because this error is expected when no pipette is attached