### PR TITLE
feat(app): Add reset robot UI with options

### DIFF
--- a/api/opentrons/server/endpoints/settings.py
+++ b/api/opentrons/server/endpoints/settings.py
@@ -100,4 +100,4 @@ async def reset(request: web.Request) -> web.Response:
 async def available_resets(request: web.Request) -> web.Response:
     """ Indicate what parts of the user configuration are available for reset.
     """
-    return web.json_response(_settings_reset_options, status=200)
+    return web.json_response({'options': _settings_reset_options}, status=200)

--- a/api/opentrons/server/endpoints/settings.py
+++ b/api/opentrons/server/endpoints/settings.py
@@ -12,22 +12,22 @@ _settings_reset_options = [
     {
         'id': 'deckCalibration',
         'name': 'Deck Calibration',
-        'description': 'Reset calibration of pipette to deck'
+        'description': 'Reset pipette-to-deck alignment calibration'
     },
     {
         'id': 'tipProbe',
-        'name': 'Tip Probe Calibration',
-        'description': 'Erase tip probe data'
+        'name': 'Tip Length',
+        'description': 'Clear tip probe data'
     },
     {
         'id': 'labwareCalibration',
         'name': 'Labware Calibration',
-        'description': 'Erase custom labware calibration'
+        'description': 'Clear labware calibration'
     },
     {
         'id': 'bootScripts',
         'name': 'Boot Scripts',
-        'description': 'Erase custom boot scripts'
+        'description': 'Clear custom boot scripts'
     }
 ]
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -50,10 +50,11 @@ async def test_available_resets(virtual_smoothie_env, loop, test_client):
 
     resp = await cli.get('/settings/reset/options')
     body = await resp.json()
+    options_list = body.get('options')
     assert resp.status == 200
     for key in ['deckCalibration', 'tipProbe',
                 'labwareCalibration', 'bootScripts']:
-        for opt in body:
+        for opt in options_list:
             if opt['id'] == key:
                 assert 'name' in opt
                 assert 'description' in opt

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -37,7 +37,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(AdvancedSettingsCard
 
 function AdvancedSettingsCard (props: Props) {
   return (
-    <Card title={TITLE} column>
+    <Card title={TITLE}>
       <LabeledSelect
         label='Update Channel'
         value={props.channel}

--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -12,7 +12,6 @@ type Props = {
   checkForUpdates: () => mixed
 }
 
-const TITLE = 'Information'
 const VERSION_LABEL = 'Software Version'
 
 export default function AppInfoCard (props: Props) {
@@ -23,7 +22,6 @@ export default function AppInfoCard (props: Props) {
 
   return (
     <RefreshCard
-      title={TITLE}
       refreshing={checkInProgress}
       refresh={checkForUpdates}
     >

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -2,12 +2,14 @@
 // app info card with version and updated
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
 
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
 import type {Setting, RobotHealth} from '../../http-api-client'
 import {fetchSettings, setSettings, makeGetRobotSettings, makeGetRobotHealth} from '../../http-api-client'
 import {downloadLogs} from '../../shell'
+import {getConfig} from '../../config'
 
 import {RefreshCard} from '@opentrons/components'
 import {LabeledButton, LabeledToggle} from '../controls'
@@ -17,12 +19,14 @@ type OP = Robot
 type SP = {
   health: ?RobotHealth,
   settings: Array<Setting>,
+  resetEnabled: boolean,
 }
 
 type DP = {
   fetch: () => mixed,
   set: (id: string, value: boolean) => mixed,
   download: () => mixed,
+  reset: () => mixed,
 }
 
 type Props = OP & SP & DP
@@ -59,7 +63,7 @@ class BooleanSettingToggle extends React.Component<BooleanSettingProps> {
 }
 
 function AdvancedSettingsCard (props: Props) {
-  const {name, settings, set, fetch, download, health} = props
+  const {name, settings, set, fetch, download, health, resetEnabled, reset} = props
   const logsAvailable = health && health.response && health.response.logs
   return (
     <RefreshCard watch={name} refresh={fetch} title={TITLE} column>
@@ -76,6 +80,18 @@ function AdvancedSettingsCard (props: Props) {
       >
         <p>Access logs from this robot.</p>
       </LabeledButton>
+      {resetEnabled && (
+        <LabeledButton
+          label='Factory Reset'
+          buttonProps={{
+            disabled: !logsAvailable,
+            onClick: reset,
+            children: 'Reset'
+          }}
+        >
+          <p>Restore robot to factory configuration</p>
+        </LabeledButton>
+      )}
     </RefreshCard>
   )
 }
@@ -88,17 +104,23 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const settingsRequest = getRobotSettings(state, ownProps)
     const settings = settingsRequest && settingsRequest.response && settingsRequest.response.settings
     const health = getRobotHealth(state, ownProps)
+    const config = getConfig(state)
+
     return {
       health,
-      settings: settings || []
+      settings: settings || [],
+      resetEnabled: config.reset
     }
   }
 }
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  const resetUrl = `/robots/${ownProps.name}/reset`
+
   return {
     fetch: () => dispatch(fetchSettings(ownProps)),
     set: (id, value) => dispatch(setSettings(ownProps, id, value)),
-    download: () => dispatch(downloadLogs(ownProps))
+    download: () => dispatch(downloadLogs(ownProps)),
+    reset: () => dispatch(push(resetUrl))
   }
 }

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -78,7 +78,7 @@ function AdvancedSettingsCard (props: Props) {
       <LabeledButton
         label='Factory Reset'
         buttonProps={{
-          component: Link,
+          Component: Link,
           to: resetUrl,
           children: 'Reset'
         }}

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -9,7 +9,6 @@ import type {Robot} from '../../robot'
 import type {Setting, RobotHealth} from '../../http-api-client'
 import {fetchSettings, setSettings, makeGetRobotSettings, makeGetRobotHealth} from '../../http-api-client'
 import {downloadLogs} from '../../shell'
-import {getConfig} from '../../config'
 
 import {RefreshCard} from '@opentrons/components'
 import {LabeledButton, LabeledToggle} from '../controls'
@@ -19,7 +18,6 @@ type OP = Robot
 type SP = {
   health: ?RobotHealth,
   settings: Array<Setting>,
-  resetEnabled: boolean,
 }
 
 type DP = {
@@ -63,7 +61,7 @@ class BooleanSettingToggle extends React.Component<BooleanSettingProps> {
 }
 
 function AdvancedSettingsCard (props: Props) {
-  const {name, settings, set, fetch, download, health, resetEnabled, reset} = props
+  const {name, settings, set, fetch, download, health, reset} = props
   const logsAvailable = health && health.response && health.response.logs
   return (
     <RefreshCard watch={name} refresh={fetch} title={TITLE} column>
@@ -80,18 +78,16 @@ function AdvancedSettingsCard (props: Props) {
       >
         <p>Access logs from this robot.</p>
       </LabeledButton>
-      {resetEnabled && (
-        <LabeledButton
-          label='Factory Reset'
-          buttonProps={{
-            disabled: !logsAvailable,
-            onClick: reset,
-            children: 'Reset'
-          }}
-        >
-          <p>Restore robot to factory configuration</p>
-        </LabeledButton>
-      )}
+      <LabeledButton
+        label='Factory Reset'
+        buttonProps={{
+          disabled: !logsAvailable,
+          onClick: reset,
+          children: 'Reset'
+        }}
+      >
+        <p>Restore robot to factory configuration</p>
+      </LabeledButton>
     </RefreshCard>
   )
 }
@@ -104,12 +100,10 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const settingsRequest = getRobotSettings(state, ownProps)
     const settings = settingsRequest && settingsRequest.response && settingsRequest.response.settings
     const health = getRobotHealth(state, ownProps)
-    const config = getConfig(state)
 
     return {
       health,
-      settings: settings || [],
-      resetEnabled: config.reset
+      settings: settings || []
     }
   }
 }

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -2,7 +2,7 @@
 // app info card with version and updated
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {push} from 'react-router-redux'
+import {Link} from 'react-router-dom'
 
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
@@ -24,7 +24,6 @@ type DP = {
   fetch: () => mixed,
   set: (id: string, value: boolean) => mixed,
   download: () => mixed,
-  reset: () => mixed,
 }
 
 type Props = OP & SP & DP
@@ -61,13 +60,11 @@ class BooleanSettingToggle extends React.Component<BooleanSettingProps> {
 }
 
 function AdvancedSettingsCard (props: Props) {
-  const {name, settings, set, fetch, download, health, reset} = props
+  const {name, settings, set, fetch, download, health} = props
   const logsAvailable = health && health.response && health.response.logs
+  const resetUrl = `/robots/${name}/reset`
   return (
     <RefreshCard watch={name} refresh={fetch} title={TITLE} column>
-      {settings.map(s => (
-        <BooleanSettingToggle {...s} key={s.id} set={set} />
-      ))}
       <LabeledButton
         label='Download Logs'
         buttonProps={{
@@ -81,13 +78,16 @@ function AdvancedSettingsCard (props: Props) {
       <LabeledButton
         label='Factory Reset'
         buttonProps={{
-          disabled: !logsAvailable,
-          onClick: reset,
+          component: Link,
+          to: resetUrl,
           children: 'Reset'
         }}
       >
         <p>Restore robot to factory configuration</p>
       </LabeledButton>
+      {settings.map(s => (
+        <BooleanSettingToggle {...s} key={s.id} set={set} />
+      ))}
     </RefreshCard>
   )
 }
@@ -109,12 +109,9 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
 }
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
-  const resetUrl = `/robots/${ownProps.name}/reset`
-
   return {
     fetch: () => dispatch(fetchSettings(ownProps)),
     set: (id, value) => dispatch(setSettings(ownProps, id, value)),
-    download: () => dispatch(downloadLogs(ownProps)),
-    reset: () => dispatch(push(resetUrl))
+    download: () => dispatch(downloadLogs(ownProps))
   }
 }

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -1,0 +1,104 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {goBack} from 'react-router-redux'
+import type {Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+
+import {AlertModal} from '@opentrons/components'
+import {Portal} from '../portal'
+import {LabeledToggle} from '../controls'
+
+type OP = {
+  robot: Robot
+}
+
+type DP = {
+  cancel: () => mixed,
+  reset: () => mixed,
+}
+
+type State = {
+  deckCalibration: boolean,
+  labwareCalibration: boolean,
+  tipCalibration: boolean,
+  bootScripts: boolean,
+}
+
+const TITLE = 'Robot Factory Reset'
+
+class ResetRobotModal extends React.Component<DP, State> {
+  constructor (props: DP) {
+    super(props)
+
+    this.state = {
+      deckCalibration: false,
+      labwareCalibration: false,
+      tipCalibration: false,
+      bootScripts: false
+    }
+  }
+
+  toggle = (name) => {
+    return () => this.setState({[name]: !this.state[name]})
+  }
+
+  render () {
+    return (
+      <Portal>
+        <AlertModal
+          heading={TITLE}
+          buttons={[
+            {onClick: this.props.cancel, children: 'cancel'},
+            {onClick: this.props.reset, children: 'reset'}
+          ]}
+          alertOverlay
+        >
+        <p>Warning! Clicking <strong>reset</strong> will erase your selected configurations and restore your robot to factory settings. This cannot be undone</p>
+        {/* TODO (ka 2018-8-17): Rebuild toggles with mock data from #1885 */}
+        <LabeledToggle
+          label='Deck Calibration'
+          onClick={this.toggle('deckCalibration')}
+          toggledOn={this.state.deckCalibration}
+        >
+          <p>Reset calibration of pipette to deck</p>
+        </LabeledToggle>
+
+        <LabeledToggle
+          label='Labware'
+          onClick={this.toggle('labwareCalibration')}
+          toggledOn={this.state.labwareCalibration}
+        >
+          <p>Erase custom labware calibration</p>
+        </LabeledToggle>
+
+        <LabeledToggle
+          label='Tip Length'
+          onClick={this.toggle('tipCalibration')}
+          toggledOn={this.state.tipCalibration}
+        >
+          <p>Erase tip probe data</p>
+        </LabeledToggle>
+
+        <LabeledToggle
+          label='Boot Scripts'
+          onClick={this.toggle('bootScripts')}
+          toggledOn={this.state.bootScripts}
+        >
+          <p>Erase custom boot scripts</p>
+        </LabeledToggle>
+
+        </AlertModal>
+      </Portal>
+    )
+  }
+}
+
+export default connect(null, mapDispatchToProps)(ResetRobotModal)
+
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  return {
+    cancel: () => dispatch(goBack()),
+    reset: () => dispatch(goBack())
+  }
+}

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -21,11 +21,34 @@ type DP = {
 type State = {
   deckCalibration: boolean,
   labwareCalibration: boolean,
-  tipCalibration: boolean,
+  tipProbe: boolean,
   bootScripts: boolean,
 }
 
 const TITLE = 'Robot Factory Reset'
+
+const MOCK_RESET_OPTIONS = [
+  {
+    id: 'deckCalibration',
+    title: 'Deck Calibration',
+    description: 'Reset calibration of pipette to deck'
+  },
+  {
+    id: 'tipProbe',
+    title: 'Tip Length',
+    description: 'Erase tip probe data'
+  },
+  {
+    id: 'labwareCalibration',
+    title: 'Labware Calibration',
+    description: 'Erase custom labware calibration'
+  },
+  {
+    id: 'bootScripts',
+    title: 'Boot Scripts',
+    description: 'Erase custom boot scripts'
+  }
+]
 
 class ResetRobotModal extends React.Component<DP, State> {
   constructor (props: DP) {
@@ -34,7 +57,7 @@ class ResetRobotModal extends React.Component<DP, State> {
     this.state = {
       deckCalibration: false,
       labwareCalibration: false,
-      tipCalibration: false,
+      tipProbe: false,
       bootScripts: false
     }
   }
@@ -55,39 +78,15 @@ class ResetRobotModal extends React.Component<DP, State> {
           alertOverlay
         >
         <p>Warning! Clicking <strong>reset</strong> will erase your selected configurations and restore your robot to factory settings. This cannot be undone</p>
-        {/* TODO (ka 2018-8-17): Rebuild toggles with mock data from #1885 */}
-        <LabeledToggle
-          label='Deck Calibration'
-          onClick={this.toggle('deckCalibration')}
-          toggledOn={this.state.deckCalibration}
-        >
-          <p>Reset calibration of pipette to deck</p>
-        </LabeledToggle>
-
-        <LabeledToggle
-          label='Labware'
-          onClick={this.toggle('labwareCalibration')}
-          toggledOn={this.state.labwareCalibration}
-        >
-          <p>Erase custom labware calibration</p>
-        </LabeledToggle>
-
-        <LabeledToggle
-          label='Tip Length'
-          onClick={this.toggle('tipCalibration')}
-          toggledOn={this.state.tipCalibration}
-        >
-          <p>Erase tip probe data</p>
-        </LabeledToggle>
-
-        <LabeledToggle
-          label='Boot Scripts'
-          onClick={this.toggle('bootScripts')}
-          toggledOn={this.state.bootScripts}
-        >
-          <p>Erase custom boot scripts</p>
-        </LabeledToggle>
-
+        {MOCK_RESET_OPTIONS.map(o => (
+          <LabeledToggle
+            label= {o.title}
+            onClick= {this.toggle(o.id)}
+            toggledOn={this.state[o.id]}
+            key={o.id}>
+            <p>{o.description}</p>
+          </LabeledToggle>
+        ))}
         </AlertModal>
       </Portal>
     )

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -1,15 +1,16 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {goBack} from 'react-router-redux'
+import {push} from 'react-router-redux'
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
-import type {Option, ResetRobotRequest} from '../../http-api-client'
+import type {Option, ResetRobotRequest, RobotServerRestart} from '../../http-api-client'
 import {
   fetchResetOptions,
   makeGetRobotResetOptions,
   resetRobotData,
   makeGetRobotResetRequest,
+  makeGetRobotRestartRequest,
   restartRobotServer
 } from '../../http-api-client'
 import {AlertModal} from '@opentrons/components'
@@ -23,6 +24,7 @@ type OP = {
 type SP = {
   options: ?Array<Option>,
   resetRequest: ResetRobotRequest,
+  restartRequest: RobotServerRestart,
 }
 
 type DP = {
@@ -69,8 +71,22 @@ class ResetRobotModal extends React.Component<Props, OptionsState> {
   }
 
   render () {
-    const {resetRequest} = this.props
-    if (resetRequest && resetRequest.response) {
+    const {resetRequest, restartRequest} = this.props
+    if (restartRequest.response) {
+      return (
+        <Portal>
+          <AlertModal
+            heading={TITLE}
+            buttons={[
+              {onClick: this.props.close, children: 'close'}
+            ]}
+            alertOverlay
+          >
+            <p>Your robot has been updated. Please wait for your robot to fully restart, which may take several minutes.</p>
+          </AlertModal>
+        </Portal>
+      )
+    } else if (resetRequest.response) {
       return (
         <Portal>
           <AlertModal
@@ -84,31 +100,32 @@ class ResetRobotModal extends React.Component<Props, OptionsState> {
           </AlertModal>
         </Portal>
       )
+    } else {
+      return (
+        <Portal>
+          <AlertModal
+            heading={TITLE}
+            buttons={[
+              {onClick: this.props.close, children: 'close'},
+              {onClick: this.handleReset, children: 'reset'}
+            ]}
+            alertOverlay
+          >
+          <p>Warning! Clicking <strong>reset</strong> will erase your selected configurations and restore your robot to factory settings. This cannot be undone</p>
+          {this.props.options && this.props.options.map(o => (
+            <LabeledCheckbox
+              label= {o.name}
+              onChange= {this.toggle(o.id)}
+              name={o.id}
+              value={this.state[o.id]}
+              key={o.id}>
+              <p>{o.description}</p>
+            </LabeledCheckbox>
+          ))}
+          </AlertModal>
+        </Portal>
+      )
     }
-    return (
-      <Portal>
-        <AlertModal
-          heading={TITLE}
-          buttons={[
-            {onClick: this.props.close, children: 'close'},
-            {onClick: this.handleReset, children: 'reset'}
-          ]}
-          alertOverlay
-        >
-        <p>Warning! Clicking <strong>reset</strong> will erase your selected configurations and restore your robot to factory settings. This cannot be undone</p>
-        {this.props.options && this.props.options.map(o => (
-          <LabeledCheckbox
-            label= {o.name}
-            onChange= {this.toggle(o.id)}
-            name={o.id}
-            value={this.state[o.id]}
-            key={o.id}>
-            <p>{o.description}</p>
-          </LabeledCheckbox>
-        ))}
-        </AlertModal>
-      </Portal>
-    )
   }
 }
 
@@ -117,13 +134,14 @@ export default connect(makeMapStateToProps, mapDispatchToProps)(ResetRobotModal)
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getResetOptions = makeGetRobotResetOptions()
   const getResetRequest = makeGetRobotResetRequest()
+  const getRobotRestartRequest = makeGetRobotRestartRequest()
   return (state, ownProps) => {
     const {robot} = ownProps
     const optionsRequest = getResetOptions(state, robot)
-    const resetRequest = getResetRequest(state, robot)
     return {
       options: optionsRequest && optionsRequest.response,
-      resetRequest
+      resetRequest: getResetRequest(state, robot),
+      restartRequest: getRobotRestartRequest(state, robot)
     }
   }
 }
@@ -132,7 +150,7 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {robot} = ownProps
   return {
     fetchOptions: () => dispatch(fetchResetOptions(robot)),
-    close: () => dispatch(goBack()),
+    close: () => dispatch(push(`/robots/${robot.name}`)),
     reset: (options) => dispatch(resetRobotData(robot, options)),
     restart: () => dispatch(restartRobotServer(robot))
   }

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -33,13 +33,6 @@ type SP = {
 
 type DP = {dispatch: Dispatch}
 
-type OptionsState = {
-  deckCalibration: boolean,
-  labwareCalibration: boolean,
-  tipProbe: boolean,
-  bootScripts: boolean,
-}
-
 type Props = SP & {
   fetchOptions: () => mixed,
   closeModal: () => mixed,
@@ -49,16 +42,11 @@ type Props = SP & {
 
 const TITLE = 'Robot Factory Reset'
 
-class ResetRobotModal extends React.Component<Props, OptionsState> {
+class ResetRobotModal extends React.Component<Props, ResetRobotRequest> {
   constructor (props: Props) {
     super(props)
 
-    this.state = {
-      deckCalibration: false,
-      labwareCalibration: false,
-      tipProbe: false,
-      bootScripts: false
-    }
+    this.state = {}
   }
 
   toggle = (name) => {
@@ -133,8 +121,10 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   return (state, ownProps) => {
     const {robot} = ownProps
     const optionsRequest = getResetOptions(state, robot)
+    const optionsResponse = optionsRequest.response
+    console.log('OPTIONS', {optionsResponse})
     return {
-      options: optionsRequest && optionsRequest.response,
+      options: optionsResponse && optionsResponse.options,
       resetRequest: getResetRequest(state, robot),
       restartRequest: getRobotRestartRequest(state, robot)
     }
@@ -154,13 +144,17 @@ function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
     ))
     : close
 
+  let fetchOptions = restartRequest
+    ? () => dispatch(chainActions(
+      clearRestartResponse(robot),
+      fetchResetOptions(robot)
+    ))
+    : () => dispatch(fetchResetOptions(robot))
+
   return {
     ...stateProps,
     closeModal,
-    fetchOptions: () => dispatch(chainActions(
-      clearRestartResponse(robot),
-      fetchResetOptions(robot))
-    ),
+    fetchOptions,
     reset: (options) => dispatch(resetRobotData(robot, options)),
     restart: () => dispatch(chainActions(
       restartRobotServer(robot),

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -157,7 +157,10 @@ function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   return {
     ...stateProps,
     closeModal,
-    fetchOptions: () => dispatch(fetchResetOptions(robot)),
+    fetchOptions: () => dispatch(chainActions(
+      clearRestartResponse(robot),
+      fetchResetOptions(robot))
+    ),
     reset: (options) => dispatch(resetRobotData(robot, options)),
     restart: () => dispatch(chainActions(
       restartRobotServer(robot),

--- a/app/src/components/controls/LabeledCheckbox.js
+++ b/app/src/components/controls/LabeledCheckbox.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+
+import {CheckboxField} from '@opentrons/components'
+import LabeledControl from './LabeledControl'
+import styles from './styles.css'
+
+type Props = {
+  label: string,
+  name: string,
+  value: boolean,
+  className?: string,
+  children: React.Node,
+  onChange: (event: SyntheticInputEvent<*>) => mixed,
+}
+
+export default function LabeledCheckbox (props: Props) {
+  const {label, value, name, onChange} = props
+  const checkboxClass = cx(styles.labeled_checkbox, props.className)
+  return (
+    <LabeledControl
+      label={label}
+      control={(
+        <CheckboxField
+          className={checkboxClass}
+          name={name}
+          value={value}
+          onChange={onChange}
+        />
+      )}
+    >
+      {props.children}
+    </LabeledControl>
+  )
+}

--- a/app/src/components/controls/index.js
+++ b/app/src/components/controls/index.js
@@ -3,5 +3,6 @@ import ToggleButton from './ToggleButton'
 import LabeledToggle from './LabeledToggle'
 import LabeledButton from './LabeledButton'
 import LabeledSelect from './LabeledSelect'
+import LabeledCheckbox from './LabeledCheckbox'
 
-export {ToggleButton, LabeledToggle, LabeledButton, LabeledSelect}
+export {ToggleButton, LabeledToggle, LabeledButton, LabeledSelect, LabeledCheckbox}

--- a/app/src/components/controls/styles.css
+++ b/app/src/components/controls/styles.css
@@ -57,6 +57,10 @@
   @apply --font-body-2-dark;
 }
 
+.labeled_checkbox {
+  float: right;
+}
+
 .control_info {
   @apply --font-body-1-dark;
 

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -7,7 +7,7 @@
 import type {BaseRobot} from '../robot'
 import type {ApiRequestError} from './types'
 
-export type ApiRequestAction<Path: string, Body: ?{}> = {|
+export type ApiRequestAction<Path: string, Body> = {|
   type: 'api:REQUEST',
   payload: {|
     robot: BaseRobot,
@@ -16,7 +16,7 @@ export type ApiRequestAction<Path: string, Body: ?{}> = {|
   |},
 |}
 
-export type ApiSuccessAction<Path: string, Body: {}> = {|
+export type ApiSuccessAction<Path: string, Body> = {|
   type: 'api:SUCCESS',
   payload: {|
     robot: BaseRobot,
@@ -42,13 +42,13 @@ export type ClearApiResponseAction<Path: string> = {|
   |}
 |}
 
-export type ApiAction<Path: string, Request: ?{}, Response: {}> =
+export type ApiAction<Path: string, Request, Response> =
   | ApiRequestAction<Path, Request>
   | ApiSuccessAction<Path, Response>
   | ApiFailureAction<Path>
   | ClearApiResponseAction<Path>
 
-export function apiRequest<Path: string, Body: ?{}> (
+export function apiRequest<Path: string, Body> (
   robot: BaseRobot,
   path: Path,
   request: Body
@@ -56,7 +56,7 @@ export function apiRequest<Path: string, Body: ?{}> (
   return {type: 'api:REQUEST', payload: {robot, path, request}}
 }
 
-export function apiSuccess<Path: string, Body: {}> (
+export function apiSuccess<Path: string, Body> (
   robot: BaseRobot,
   path: Path,
   response: Body

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -7,7 +7,7 @@
 import type {BaseRobot} from '../robot'
 import type {ApiRequestError} from './types'
 
-export type ApiRequestAction<Path: string, Body> = {|
+export type ApiRequestAction<Path: string, Body: ?{}> = {|
   type: 'api:REQUEST',
   payload: {|
     robot: BaseRobot,
@@ -16,7 +16,7 @@ export type ApiRequestAction<Path: string, Body> = {|
   |},
 |}
 
-export type ApiSuccessAction<Path: string, Body> = {|
+export type ApiSuccessAction<Path: string, Body: {}> = {|
   type: 'api:SUCCESS',
   payload: {|
     robot: BaseRobot,
@@ -42,13 +42,13 @@ export type ClearApiResponseAction<Path: string> = {|
   |}
 |}
 
-export type ApiAction<Path: string, Request, Response> =
+export type ApiAction<Path: string, Request: ?{}, Response: {}> =
   | ApiRequestAction<Path, Request>
   | ApiSuccessAction<Path, Response>
   | ApiFailureAction<Path>
   | ClearApiResponseAction<Path>
 
-export function apiRequest<Path: string, Body> (
+export function apiRequest<Path: string, Body: ?{}> (
   robot: BaseRobot,
   path: Path,
   request: Body
@@ -56,7 +56,7 @@ export function apiRequest<Path: string, Body> (
   return {type: 'api:REQUEST', payload: {robot, path, request}}
 }
 
-export function apiSuccess<Path: string, Body> (
+export function apiSuccess<Path: string, Body: {}> (
   robot: BaseRobot,
   path: Path,
   response: Body

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -7,6 +7,7 @@ import {healthReducer, type HealthAction} from './health'
 import type {ModulesAction} from './modules'
 import {motorsReducer, type MotorsAction} from './motors'
 import {pipettesReducer, type PipettesAction} from './pipettes'
+import type {ResetAction} from './reset'
 import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
 import {settingsReducer, type SettingsAction} from './settings'
@@ -86,6 +87,7 @@ export type Action =
   | ModulesAction
   | MotorsAction
   | PipettesAction
+  | ResetAction
   | RobotAction
   | ServerAction
   | SettingsAction
@@ -138,7 +140,8 @@ export {
   fetchHealthAndIgnored,
   fetchIgnoredUpdate,
   setIgnoredUpdate,
-  makeGetRobotIgnoredUpdateRequest
+  makeGetRobotIgnoredUpdateRequest,
+  clearRestartResponse
 } from './server'
 
 export {

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -105,6 +105,8 @@ export {
 
 export * from './modules'
 
+export * from './reset'
+
 export {
   disengagePipetteMotors
 } from './motors'

--- a/app/src/http-api-client/reducer.js
+++ b/app/src/http-api-client/reducer.js
@@ -53,6 +53,18 @@ export default function apiReducer (
         }
       }
     }
+
+    case 'api:CLEAR_RESPONSE': {
+      const {name, path, stateByName, stateByPath} = getUpdateInfo(state, action)
+
+      return {
+        ...state,
+        [name]: {
+          ...stateByName,
+          [path]: {...stateByPath, response: null, inProgress: false, error: null}
+        }
+      }
+    }
   }
 
   return state

--- a/app/src/http-api-client/reset.js
+++ b/app/src/http-api-client/reset.js
@@ -19,7 +19,9 @@ export type ResetOption = {
   description: string,
 }
 
-type FetchResetOptionsResponse = Array<ResetOption>
+type FetchResetOptionsResponse = {
+  options: Array<ResetOption>
+}
 
 export type ResetRobotRequest = {
   [OptionId]: boolean,
@@ -46,7 +48,7 @@ export function fetchResetOptions (robot: RobotService): ThunkPromiseAction {
 
     return client(robot, 'GET', OPTIONS_PATH)
       .then(
-        (resp) => apiSuccess(robot, OPTIONS_PATH, resp),
+        (resp: FetchResetOptionsResponse) => apiSuccess(robot, OPTIONS_PATH, resp),
         (err: ApiRequestError) => apiFailure(robot, OPTIONS_PATH, err)
       )
       .then(dispatch)
@@ -76,14 +78,14 @@ export function resetRobotData (robot: RobotService, options: ResetRobotRequest)
   }
 }
 
-export function clearResetResponse (robot: RobotService): ResetAction {
-  return clearApiResponse(robot, RESET_PATH)
-}
-
 export function makeGetRobotResetRequest () {
   const selector: Selector<State, BaseRobot, ResetRobotRequest> = createSelector(
     getRobotApiState,
     (state) => state[RESET_PATH] || {inProgress: false}
   )
   return selector
+}
+
+export function clearResetResponse (robot: RobotService): ResetAction {
+  return clearApiResponse(robot, RESET_PATH)
 }

--- a/app/src/http-api-client/reset.js
+++ b/app/src/http-api-client/reset.js
@@ -55,15 +55,6 @@ export function fetchResetOptions (robot: RobotService): ThunkPromiseAction {
   }
 }
 
-export function makeGetRobotResetOptions () {
-  const selector: Selector<State, BaseRobot, FetchResetOptionsCall> = createSelector(
-    getRobotApiState,
-    (state) => state[OPTIONS_PATH] || {inProgress: false}
-  )
-
-  return selector
-}
-
 export function resetRobotData (robot: RobotService, options: ResetRobotRequest): ThunkPromiseAction {
   const request: ResetRobotRequest = options
   return (dispatch) => {
@@ -76,6 +67,15 @@ export function resetRobotData (robot: RobotService, options: ResetRobotRequest)
       )
       .then(dispatch)
   }
+}
+
+export function makeGetRobotResetOptions () {
+  const selector: Selector<State, BaseRobot, FetchResetOptionsCall> = createSelector(
+    getRobotApiState,
+    (state) => state[OPTIONS_PATH] || {inProgress: false}
+  )
+
+  return selector
 }
 
 export function makeGetRobotResetRequest () {

--- a/app/src/http-api-client/reset.js
+++ b/app/src/http-api-client/reset.js
@@ -11,27 +11,21 @@ import {apiRequest, apiSuccess, apiFailure, clearApiResponse} from './actions'
 import {getRobotApiState} from './reducer'
 import client from './client'
 
-type Id = string
+type OptionId = string
 
-export type Option = {
-  id: Id,
+export type ResetOption = {
+  id: OptionId,
   name: string,
   description: string,
 }
 
-type FetchResetOptionsResponse = Array<Option>
+type FetchResetOptionsResponse = Array<ResetOption>
 
 export type ResetRobotRequest = {
-  [Id]: boolean,
+  [OptionId]: boolean,
 }
 
-type ResetRobotSuccess = {|
-  type: 'api:SERVER_SUCCESS',
-  payload: {|
-    robot: RobotService,
-    path: string,
-  |}
-|}
+type ResetRobotResponse = {}
 
 type FetchResetOptionsCall = ApiCall<null, FetchResetOptionsResponse>
 
@@ -44,6 +38,7 @@ export const RESET_PATH: 'settings/reset' = 'settings/reset'
 
 export type ResetAction =
   | ApiAction<'settings/reset/options', null, FetchResetOptionsResponse>
+  | ApiAction<'settings/reset', ResetRobotRequest, ResetRobotResponse>
 
 export function fetchResetOptions (robot: RobotService): ThunkPromiseAction {
   return (dispatch) => {
@@ -74,17 +69,15 @@ export function resetRobotData (robot: RobotService, options: ResetRobotRequest)
 
     return client(robot, 'POST', RESET_PATH, request)
       .then(
-        (resp: ResetRobotSuccess) => apiSuccess(robot, RESET_PATH, resp),
+        (resp: ResetRobotResponse) => apiSuccess(robot, RESET_PATH, resp),
         (err: ApiRequestError) => apiFailure(robot, RESET_PATH, err)
       )
       .then(dispatch)
   }
 }
 
-export function clearResetResponse (robot: RobotService): ThunkPromiseAction {
-  return (dispatch) => {
-    return dispatch(clearApiResponse(robot, RESET_PATH))
-  }
+export function clearResetResponse (robot: RobotService): ResetAction {
+  return clearApiResponse(robot, RESET_PATH)
 }
 
 export function makeGetRobotResetRequest () {

--- a/app/src/http-api-client/reset.js
+++ b/app/src/http-api-client/reset.js
@@ -1,0 +1,58 @@
+// @flow
+// API client for getting reset options and resetting robot config files
+import {createSelector, type Selector} from 'reselect'
+
+import type {State, ThunkPromiseAction} from '../types'
+import type {BaseRobot, RobotService} from '../robot'
+import type {ApiCall, ApiRequestError} from './types'
+import type {ApiAction} from './actions'
+
+import {apiRequest, apiSuccess, apiFailure} from './actions'
+import {getRobotApiState} from './reducer'
+import client from './client'
+
+type Id = string
+
+export type Option = {
+  id: Id,
+  title: string,
+  description: string,
+}
+
+type FetchResetOptionsResponse = {
+  options: Array<Option>,
+}
+
+type FetchResetOptionsCall = ApiCall<null, FetchResetOptionsResponse>
+
+export type OptionsState = {
+  [robotName: string]: ?FetchResetOptionsCall,
+}
+
+export type ResetAction =
+  | ApiAction<'OPTIONS_PATH', null, FetchResetOptionsResponse>
+
+const OPTIONS_PATH: 'settings/reset/options' = 'settings/reset/options'
+// const RESET_PATH: 'settings/reset' = 'settings/reset'
+
+export function fetchResetOptions (robot: RobotService): ThunkPromiseAction {
+  return (dispatch) => {
+    dispatch(apiRequest(robot, OPTIONS_PATH, null))
+
+    return client(robot, 'GET', OPTIONS_PATH)
+      .then(
+        (resp: FetchResetOptionsResponse) => apiSuccess(robot, OPTIONS_PATH, resp),
+        (err: ApiRequestError) => apiFailure(robot, OPTIONS_PATH, err)
+      )
+      .then(dispatch)
+  }
+}
+
+export function makeGetRobotResetOptions () {
+  const selector: Selector<State, BaseRobot, FetchResetOptionsCall> = createSelector(
+    getRobotApiState,
+    (state) => state[OPTIONS_PATH] || {inProgress: false}
+  )
+
+  return selector
+}

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -59,10 +59,19 @@ export type ServerFailureAction = {|
   |}
 |}
 
+export type ClearServerAction = {|
+  type: 'api:CLEAR_SERVER_RESPONSE',
+  payload: {|
+    robot: RobotService,
+    path: RequestPath,
+  |}
+|}
+
 export type ServerAction =
   | ServerRequestAction
   | ServerSuccessAction
   | ServerFailureAction
+  | ClearServerAction
 
 export type RobotServerUpdate = ApiCall<void, ServerUpdateResponse>
 export type RobotServerRestart = ApiCall<void, ServerRestartResponse>
@@ -114,6 +123,10 @@ export function restartRobotServer (
           dispatch(serverFailure(robot, RESTART, error))
       )
   }
+}
+
+export function clearRestartResponse (robot: RobotService): * {
+  return clearServerResponse(robot, RESTART)
 }
 
 export function fetchHealthAndIgnored (robot: RobotService): * {
@@ -196,6 +209,20 @@ export function serverReducer (
           ...state[name],
           [path]: {
             error: action.payload.error,
+            inProgress: false,
+            response: null
+          }
+        }
+      }
+
+    case 'api:CLEAR_SERVER_RESPONSE':
+      ({path, robot: {name}} = action.payload)
+      return {
+        ...state,
+        [name]: {
+          ...state[name],
+          [path]: {
+            error: null,
             inProgress: false,
             response: null
           }
@@ -311,4 +338,11 @@ function serverFailure (
   error: ApiRequestError
 ): ServerFailureAction {
   return {type: 'api:SERVER_FAILURE', payload: {robot, path, error}}
+}
+
+function clearServerResponse (
+  robot: RobotService,
+  path: RequestPath
+): ClearServerAction {
+  return {type: 'api:CLEAR_SERVER_RESPONSE', payload: {robot, path}}
 }

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -23,6 +23,7 @@ import RobotSettings, {
 } from '../../components/RobotSettings'
 import CalibrateDeck from '../../components/CalibrateDeck'
 import ConnectBanner from '../../components/RobotSettings/ConnectBanner'
+import ResetRobotModal from '../../components/RobotSettings/ResetRobotModal'
 
 type SP = {
   showUpdateModal: boolean,
@@ -75,6 +76,10 @@ function RobotSettingsPage (props: Props) {
 
         <Route path={`${path}/calibrate-deck`} render={(props) => (
           <CalibrateDeck match={props.match} robot={robot} parentUrl={url} />
+        )} />
+
+        <Route path={`${path}/reset`} render={(props) => (
+          <ResetRobotModal robot={robot} />
         )} />
 
         <Route exact path={path} render={() => {

--- a/components/src/styles/typography.css
+++ b/components/src/styles/typography.css
@@ -61,4 +61,11 @@
     font-weight: var(--fw-regular);
     color: var(--c-font-light);
   };
+
+  --font-card-title: {
+    @apply --font-header-dark;
+
+    margin: 0.5rem 1rem;
+    font-weight: var(--fw-regular);
+  };
 }


### PR DESCRIPTION
## overview

This PR adds reset robot button to advanced settings and reset robot with options modal(s)

Closes #2030

<img width="1026" alt="screen shot 2018-08-22 at 3 30 01 pm" src="https://user-images.githubusercontent.com/3430313/44486098-b0ca1c80-a620-11e8-9ae8-10a721396f9b.png">
<img width="1023" alt="screen shot 2018-08-22 at 3 30 16 pm" src="https://user-images.githubusercontent.com/3430313/44486099-b0ca1c80-a620-11e8-8205-754bf9aa5516.png">
<img width="1024" alt="screen shot 2018-08-22 at 3 30 27 pm" src="https://user-images.githubusercontent.com/3430313/44486100-b0ca1c80-a620-11e8-8131-bd27e6640676.png">
<img width="1026" alt="screen shot 2018-08-22 at 3 30 36 pm" src="https://user-images.githubusercontent.com/3430313/44486101-b0ca1c80-a620-11e8-91b9-e87c791f4ec2.png">



## changelog

- feat(app): Add reset robot UI with options

## review requests

Please make sure it works on actual robots.
