### PR TITLE
feat(compute,api,update): Add system version to health, allow resin pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN pipenv install /tmp/api-server-lib --system && \
     pipenv install /tmp/api --system && \
     pipenv install /tmp/update-server --system && \
     pip install /tmp/avahi_tools && \
+    echo "export OT_SYSTEM_VERSION=`python -c \"import json; print(json.load(open('/tmp/api/opentrons/package.json'))['version'])\"`" | tee -a /etc/profile.d/opentrons.sh && \
     rm -rf /tmp/api && \
     rm -rf /tmp/api-server-lib && \
     rm -rf /tmp/update-server && \

--- a/api/opentrons/server/endpoints/__init__.py
+++ b/api/opentrons/server/endpoints/__init__.py
@@ -18,7 +18,8 @@ async def health(request: web.Request) -> web.Response:
         'name': NAME,
         'api_version': __version__,
         'fw_version': robot.fw_version,
-        'logs': static_paths
+        'logs': static_paths,
+        'system_version': os.environ.get('OT_SYSTEM_VERSION', 'unknown')
     }
     return web.json_response(
         headers={'Access-Control-Allow-Origin': '*'},

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -4,7 +4,6 @@ import sys
 import logging
 import os
 import traceback
-import atexit
 from aiohttp import web
 from opentrons import robot, __version__
 from opentrons.api import MainRouter
@@ -302,8 +301,8 @@ def main():
 
     if not os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"):
         setup_udev_rules_file()
-    atexit.register(unlock_resin_updates)
-    lock_resin_updates()
+    # Explicitly unlock resin updates in case a prior server left them locked
+    unlock_resin_updates()
     web.run_app(init(), host=args.hostname, port=args.port, path=args.path)
     arg_parser.exit(message="Stopped\n")
 

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -11,7 +11,8 @@ async def test_health(virtual_smoothie_env, loop, test_client):
         'name': 'opentrons-dev',
         'api_version': __version__,
         'fw_version': 'Virtual Smoothie',
-        'logs': ['/logs/serial.log', '/logs/api.log']
+        'logs': ['/logs/serial.log', '/logs/api.log'],
+        'system_version': 'unknown'
     })
     resp = await cli.get('/health')
     text = await resp.text()

--- a/update-server/otupdate/__init__.py
+++ b/update-server/otupdate/__init__.py
@@ -44,17 +44,20 @@ def get_app(
     api_server_version = get_version(api_package)
     update_server_version = get_version(update_package)
     device_name = get_name()
+    system_version = os.environ.get('OT_SYSTEM_VERSION', 'unknown')
     log.info("  Device name:            {}".format(device_name))
     log.info("  Update server version:  {}".format(update_server_version))
     log.info("  API server version:     {}".format(api_server_version))
     log.info("  Smoothie FW version:    {}".format(smoothie_version))
+    log.info("  System Version:         {}".format(system_version))
     log.info("  Test mode:              {}".format(test))
 
     health = bootstrap_endp.build_health_endpoint(
         name=device_name,
         update_server_version=update_server_version,
         api_server_version=api_server_version,
-        smoothie_version=smoothie_version
+        smoothie_version=smoothie_version,
+        system_version=system_version
     )
     bootstrap_fn = partial(
         bootstrap_endp.bootstrap_update_server, test_flag=test)

--- a/update-server/otupdate/endpoints.py
+++ b/update-server/otupdate/endpoints.py
@@ -9,14 +9,16 @@ log = logging.getLogger(__name__)
 
 
 def build_health_endpoint(
-        name, update_server_version, api_server_version, smoothie_version):
+        name, update_server_version, api_server_version, smoothie_version,
+        system_version):
     async def health(request: web.Request) -> web.Response:
         return web.json_response(
             {
                 'name': name,
                 'updateServerVersion': update_server_version,
                 'apiServerVersion': api_server_version,
-                'smoothieVersion': smoothie_version
+                'smoothieVersion': smoothie_version,
+                'systemVersion': system_version
             },
             headers={'Access-Control-Allow-Origin': '*'}
         )


### PR DESCRIPTION
## overview

This commit adds an environment variable in the 3.3.0 dockerfile that is parsed from the api's package.json at build time. This is sent in the /health endpoints of both the api server and
update server:

```
GET /health
200 OK
{
    "name": "opentrons-moon-moon",
    "api_version": "3.3.0-beta.1",
    "fw_version": "edge-6168d32",
    "logs": [
        "/logs/serial.log",
        "/logs/api.log"
    ],
    "system_version": "3.3.0-beta.1"
}
```
```
GET /server/update/health
200 OK
{
    "name": "opentrons-moon-moon",
    "updateServerVersion": "3.3.0-beta.1",
    "apiServerVersion": "3.3.0-beta.1",
    "smoothieVersion": "edge-6168d32",
    "systemVersion": "3.3.0-beta.1"
}
```
The environment variable `OT_SYSTEM_VERSION` is set up by adding to `/etc/profile` rather than either an `ENV` directive or addition to `to-environ.sh` because
- Variables specified in `ENV` directives are not properly loaded when the container is "restarted" by killing PID 1
- Variables in ot-environ.sh are actually associated with the api server post 3.3.0 (or really post #2073 ) rather than the container.

In addition, this commit removes the resin-updates.lock file that prevents the host
OS from pulling container changes.


## changelog

- add `OT_SYSTEM_VERSION` flag to root profile
- add system version entries to the dicts returned by the `GET /health` and `GET /server/update/health` that use the above flag
- Remove the resin lock file

## testing

- [x] Make sure the run app on 3.2 doesn't crash from the extra info in the system version
- [x] Ditto with 3.3

Closes #2091 
