### PR TITLE
feat(api): Use the resin supervisor restart endpoint to restart

### DIFF
--- a/api-server-lib/ot2serverlib/endpoints.py
+++ b/api-server-lib/ot2serverlib/endpoints.py
@@ -1,6 +1,8 @@
+import asyncio
 import os
 import logging
 from time import sleep
+import aiohttp
 from aiohttp import web
 from threading import Thread
 import ot2serverlib
@@ -110,15 +112,55 @@ async def update_firmware(request):
     return web.json_response(res, status=status)
 
 
+def do_restart():
+    """ This is the (somewhat) synchronous method to use to do a restart.
+
+    It actually starts a thread that does the restart. `__wait_and_restart`,
+    on the other hand, should not be called directly, because it will block
+    until the system restarts.
+    """
+    Thread(target=__wait_and_restart).start()
+
+
 def __wait_and_restart():
+    """ Delay and then execute the restart. Do not call directly. Instead, call
+    `do_restart()`.
+    """
     log.info('Restarting server')
     sleep(1)
-    os.system('kill 1')
+    # We can use the default event loop here because this
+    # is actually running in a thread. We use aiohttp here because urllib is
+    # painful and we don’t have `requests`.
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_resin_supervisor_restart())
+
+
+async def _resin_supervisor_restart():
+    """ Execute a container restart by requesting it from the supervisor.
+
+    Note that failures here are returned but most likely will not be
+    sent back to the caller, since this is run in a separate workthread.
+    If the system is not responding, look for these log messages.
+    """
+    supervisor = os.environ.get('RESIN_SUPERVISOR_ADDRESS',
+                                'http://127.0.0.1:48484')
+    restart_url = supervisor + '/v1/restart'
+    api = os.environ.get('RESIN_SUPERVISOR_API_KEY', 'unknown')
+    app_id = os.environ.get('RESIN_APP_ID', 'unknown')
+    async with aiohttp.ClientSession() as session:
+        async with session.post(restart_url,
+                                params={'apikey': api},
+                                json={'appId': app_id,
+                                      'force': True}) as resp:
+            body = await resp.read()
+            if resp.status != 202:
+                log.error("Could not shut down: {}: {}"
+                          .format(resp.status, body))
 
 
 async def restart(request):
     """
     Returns OK, then waits approximately 1 second and restarts container
     """
-    Thread(target=__wait_and_restart).start()
+    do_restart()
     return web.json_response({"message": "restarting"})


### PR DESCRIPTION
## overview

Right now we restart our system by killing pid 1. When this happens, changes that the resin
supervisor and container make to the environment (like environment variables specified in the
Dockerfile) are not persisted across the restart. By using the Resin supervisor's /restart endpoint
(https://docs.resin.io/reference/supervisor/supervisor-api/#post-v1-restart) we can avoid this.

Closes #2092 

## Testing

- Changing a machine's name in the resin UI does not take effect until the machine's container is restarted (e.g. with the restart button in the Resin UI). Now, hitting the server /restart endpoint causes the change to take effect.