### PR TITLE
fix(api): Delete the labware database journal on reset

### DIFF
--- a/api/opentrons/data_storage/database.py
+++ b/api/opentrons/data_storage/database.py
@@ -281,5 +281,9 @@ def reset():
     """ Unmount and remove the sqlite database (used in robot reset) """
     if os.path.exists(database_path):
         os.remove(database_path)
+    # Not an os.path.join because it is a suffix to the full filename
+    journal_path = database_path + '-journal'
+    if os.path.exists(journal_path):
+        os.remove(journal_path)
 
 # ======================== END Public Functions ======================== #


### PR DESCRIPTION
## Overview

SQLite occasionally creates a journal file to ensure atomicity of transactions
(https://www.sqlite.org/tempfiles.html#rollback_journals). This is located at the path of the file
with -journal appended, e.g. opentrons.db-journal. This wouldn't normally be a problem except that
in addition to using the journal for transactions, SQLite uses it as a way to recover from a
catastrophic data loss like a loss of power, or, say, someone deleting the database backing store
out from under it. So to ensure that we remove the database, we also have to make sure that if a
journal exists we remove it as well.
