### PR TITLE
fix(api-server-lib): Fix /server/restart failing in api-server-lib

### DIFF
--- a/api-server-lib/ot2serverlib/endpoints.py
+++ b/api-server-lib/ot2serverlib/endpoints.py
@@ -131,7 +131,7 @@ def __wait_and_restart():
     # We can use the default event loop here because this
     # is actually running in a thread. We use aiohttp here because urllib is
     # painful and we don’t have `requests`.
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(_resin_supervisor_restart())
 
 


### PR DESCRIPTION
## Overview

When /server/restart is provided by api-server-lib, there's a bug that was fixed in the
update-server version of /server/restart: a new thread has no asyncio event loop running and a new
one must be created.

## Testing

The issue can be seen when the robot fails to restart when /server/update is hit with current edge running on system 3.0:

From Resin logs, immediately after hitting restart
```
 main  Exception in thread Thread-1:
 main  Traceback (most recent call last):
 main    File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
 main      self.run()
 main    File "/usr/local/lib/python3.6/threading.py", line 864, in run
 main      self._target(*self._args, **self._kwargs)
 main    File "/data/packages/usr/local/lib/python3.6/site-packages/ot2serverlib/endpoints.py", line 134, in __wait_and_restart
 main      loop = asyncio.get_event_loop()
 main    File "/usr/local/lib/python3.6/asyncio/events.py", line 676, in get_event_loop
 main      return get_event_loop_policy().get_event_loop()
 main    File "/usr/local/lib/python3.6/asyncio/events.py", line 584, in get_event_loop
 main      % threading.current_thread().name)
 main  RuntimeError: There is no current event loop in thread 'Thread-1
```

The fix is to switch to creating a new event loop, and after updating to the fixed server lib wheel and restarting via resin, the restart now succeeds.

From resin logs, immediately after hitting restart with new version
```
Killing application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Application exited 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Killed application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Installing application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Installed application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Starting application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
Started application 'registry2.resin.io/v2/230045d40d12596d526cd5c71518f9bc'
```