### PR TITLE
fix(app): Increase RPC ping threshhold to work around API lock

### DIFF
--- a/app/src/rpc/client.js
+++ b/app/src/rpc/client.js
@@ -29,7 +29,7 @@ const CALL_ACK_TIMEOUT = 10000
 
 // ping pong
 const PING_INTERVAL_MS = 3000
-const MISSED_PING_THRESHOLD = 2
+const MISSED_PING_THRESHOLD = 10
 
 // metadata constants
 const REMOTE_TARGET_OBJECT = 0


### PR DESCRIPTION
## overview

Bug ticket + fix.

Long running HTTP requests (like POST /robot/home) lock up the webserver, preventing it from responding to the app's RPC pings. If the threshold is low enough, the app will close down the websocket before the API unlocks. #2083 introduced a threshold that was lower than the time it takes the robot to finish homing.

This PR works around that issue by increasing the missed-ping threshold until the system can be rearchitected.

## changelog

- fix(app): Increase RPC ping threshhold to workaround API lock during POST /robot/home

## review requests

Make sure clicking "Home" in the robot settings page doesn't cause the RPC connection to close
