### PR TITLE
feat(app): Enable modules by default

### DIFF
--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -30,8 +30,6 @@ const PARSE_ARGS_OPTS = {
 const DEFAULTS: Config = {
   devtools: false,
 
-  modules: false,
-
   // app update config
   update: {
     channel: pkg.version.includes('beta') ? 'beta' : 'latest'

--- a/app/src/components/DeckMap/ConnectedSlotItem.js
+++ b/app/src/components/DeckMap/ConnectedSlotItem.js
@@ -12,7 +12,6 @@ import {
   type SessionModule
 } from '../../robot'
 
-import {getModulesOn} from '../../config'
 import type {LabwareComponentProps} from '@opentrons/components'
 import LabwareItem, {type LabwareItemProps} from './LabwareItem'
 import ModuleItem from './ModuleItem'
@@ -61,10 +60,7 @@ function mapStateToProps (state: State, ownProps: OP): SP {
   const tipracksConfirmed = robotSelectors.getTipracksConfirmed(state)
   const labware = allLabware.find((lw) => lw.slot === slot)
   const highlighted = slot === selectedSlot
-  const modulesEnabled = getModulesOn(state)
-  const module = modulesEnabled
-    ? robotSelectors.getModulesBySlot(state)[slot]
-    : null
+  const module = robotSelectors.getModulesBySlot(state)[slot]
 
   const stateProps: SP = {}
 

--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -8,14 +8,12 @@ import type {Module} from '../../http-api-client'
 import type {Robot} from '../../robot'
 
 import {RefreshCard} from '@opentrons/components'
-import {getModulesOn} from '../../config'
 import {fetchModules, makeGetRobotModules} from '../../http-api-client'
 import ModulesCardContents from './ModulesCardContents'
 
 type OP = Robot
 
 type SP = {
-  modulesFlag: ?boolean,
   modules: ?Array<Module>,
   refreshing: boolean
 }
@@ -29,20 +27,17 @@ const TITLE = 'Modules'
 export default connect(makeSTP, DTP)(AttachedModulesCard)
 
 function AttachedModulesCard (props: Props) {
-  if (props.modulesFlag) {
-    return (
-      <RefreshCard
-        title={TITLE}
-        watch={props.name}
-        refreshing={props.refreshing}
-        refresh={props.refresh}
-        column
-      >
-        <ModulesCardContents modules={props.modules} />
-      </RefreshCard>
-    )
-  }
-  return null
+  return (
+    <RefreshCard
+      title={TITLE}
+      watch={props.name}
+      refreshing={props.refreshing}
+      refresh={props.refresh}
+      column
+    >
+      <ModulesCardContents modules={props.modules} />
+    </RefreshCard>
+  )
 }
 
 function makeSTP (): (state: State, ownProps: OP) => SP {
@@ -54,7 +49,6 @@ function makeSTP (): (state: State, ownProps: OP) => SP {
     const modules = modulesResponse && modulesResponse.modules
 
     return {
-      modulesFlag: getModulesOn(state),
       modules: modules,
       refreshing: modulesCall.inProgress
     }

--- a/app/src/components/ReviewDeckModal/LabwareComponent.js
+++ b/app/src/components/ReviewDeckModal/LabwareComponent.js
@@ -4,7 +4,6 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 
 import {selectors as robotSelectors, type SessionModule} from '../../robot'
-import {getModulesOn} from '../../config'
 
 import type {LabwareComponentProps} from '@opentrons/components'
 import type {LabwareItemProps} from '../DeckMap'
@@ -49,8 +48,6 @@ function mapStateToProps (state, ownProps: OP): SP {
 
   return {
     labware: allLabware.find((lw) => lw.slot === slot),
-    module: getModulesOn(state)
-      ? robotSelectors.getModulesBySlot(state)[slot]
-      : null
+    module: robotSelectors.getModulesBySlot(state)[slot]
   }
 }

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -6,14 +6,12 @@ import {
   actions as robotActions,
   selectors as robotSelectors
 } from '../../robot'
-import {getModulesOn} from '../../config'
 import {SidePanel, SidePanelGroup} from '@opentrons/components'
 import RunTimer from './RunTimer'
 import RunControls from './RunControls'
 import TempDeckStatusCard from '../TempDeckStatusCard'
 
 const mapStateToProps = (state) => ({
-  modulesFlag: getModulesOn(state),
   isRunning: robotSelectors.getIsRunning(state),
   isPaused: robotSelectors.getIsPaused(state),
   startTime: robotSelectors.getStartTime(state),
@@ -36,13 +34,11 @@ const mapDispatchToProps = (dispatch) => ({
 function RunPanel (props) {
   return (
     <SidePanel title='Execute Run'>
-        <SidePanelGroup>
-          <RunTimer startTime={props.startTime} runTime={props.runTime} />
-          <RunControls {...props} />
-        </SidePanelGroup>
-        {props.modulesFlag && (
-          <TempDeckStatusCard />
-        )}
+      <SidePanelGroup>
+        <RunTimer startTime={props.startTime} runTime={props.runTime} />
+        <RunControls {...props} />
+      </SidePanelGroup>
+      <TempDeckStatusCard />
     </SidePanel>
   )
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -13,7 +13,6 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 // TODO(mc, 2018-05-17): put this type somewhere common to app and app-shell
 export type Config = {
   devtools: boolean,
-  modules: boolean,
 
   // app update config
   update: {
@@ -104,10 +103,6 @@ export function configReducer (
 
 export function getConfig (state: State): Config {
   return state.config
-}
-
-export function getModulesOn (state: State): boolean {
-  return state.config.modules
 }
 
 export function toggleDevTools (): ThunkAction {

--- a/app/src/pages/Calibrate/Labware.js
+++ b/app/src/pages/Calibrate/Labware.js
@@ -10,7 +10,6 @@ import type {Labware, Robot} from '../../robot'
 
 import {selectors as robotSelectors} from '../../robot'
 import {makeGetRobotSettings} from '../../http-api-client'
-import {getModulesOn} from '../../config'
 
 import Page from '../../components/Page'
 import CalibrateLabware from '../../components/CalibrateLabware'
@@ -94,10 +93,9 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const calToBottomFlag = settings && settings.find(s => s.id === 'calibrateToBottom')
     const calibrateToBottom = !!calToBottomFlag && calToBottomFlag.value
 
-    const modulesEnabled = getModulesOn(state)
     const modulesRequired = robotSelectors.getModules(state).length > 0
     const modulesReviewed = robotSelectors.getModulesReviewed(state)
-    const reviewModules = modulesEnabled && modulesRequired && !modulesReviewed
+    const reviewModules = modulesRequired && !modulesReviewed
 
     return {
       slot,


### PR DESCRIPTION
## overview

This PR removes the modules feature flag to enable modules by default

## changelog

- feat(app): Enable modules by default 

## review requests

Make sure modules work without having to set a feature flag
