### PR TITLE
fix(protocol-designer): ensure that timeline alert message defaults

### DIFF
--- a/protocol-designer/src/components/steplist/TimelineAlerts.js
+++ b/protocol-designer/src/components/steplist/TimelineAlerts.js
@@ -46,12 +46,12 @@ type Props = SP & DP
 
 const getErrorContent = (error: CommandCreatorError): AlertContent => ({
   title: i18n.t(`alert.timeline.error.${error.type}.title`, error.message),
-  body: i18n.t(`alert.timeline.error.${error.type}.body`, '')
+  body: i18n.t(`alert.timeline.error.${error.type}.body`, {defaultValue: ''})
 })
 
 const getWarningContent = (warning: CommandCreatorWarning): AlertContent => ({
   title: i18n.t(`alert.timeline.warning.${warning.type}.title`, warning.message),
-  body: i18n.t(`alert.timeline.warning.${warning.type}.body`, '')
+  body: i18n.t(`alert.timeline.warning.${warning.type}.body`, {defaultValue: ''})
 })
 
 function Alerts (props: Props) {

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -34,7 +34,7 @@ export function labwareDoesNotExist (args: {actionName: string, labware: string}
   const {actionName, labware} = args
   console.warn(`Attempted to ${actionName} with labware id "${labware}", this labware was not found under "labware"`)
   return {
-    message: 'This step involves labware that has been deleted',
+    message: 'A step involves labware that has been deleted',
     type: 'LABWARE_DOES_NOT_EXIST'
   }
 }


### PR DESCRIPTION
 if timeline alert doesn't have a verbose title and message, default to just the title

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
