### PR TITLE
fix(compute): Include opentrons/audio in the docker image again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN pip install --force-reinstall \
 # file, or you will encounter a copy error
 
 COPY ./compute/container_setup.sh /usr/local/bin/container_setup.sh
-
+COPY ./audio/ /etc/audio
 COPY ./shared-data/robot-data /etc/robot-data
 COPY ./shared-data/definitions /etc/labware
 COPY ./api /tmp/api


### PR DESCRIPTION
This got removed in the previous dockerfile changes; the factory relies on it, so add it again.

This is required for 3.3