### PR TITLE
fix(compute): Make RUNNING_ON_PI available in env again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,17 +97,17 @@ COPY ./compute/find_ot_resources.py /usr/local/bin
 RUN ln -sf /data/system/ot-environ.sh /etc/profile.d/00-persistent-ot-environ.sh &&\
     ln -sf `find_ot_resources.py`/ot-environ.sh /etc/profile.d/01-builtin-ot-environ.sh
 
-# Note: the quoting that defines the PATH echo is very specifically set up to
-# get $PATH in the script literally so it is evaluated at container runtime.
-RUN echo "export CONTAINER_ID=$(uuidgen)" | tee -a /etc/profile.d/opentrons.sh\
-    && echo 'export PATH=$PATH:'"`find_ot_resources.py`/scripts" | tee -a /etc/profile.d/opentrons.sh
-
-
 # This configuration is used both by both the build and runtime so it has to
 # be here. When building a container for local use, set this to 0. If set to
 # 0, ENABLE_VIRTUAL_SMOOTHIE will be set at runtime automatically
-ARG running_on_pi=1
-ENV RUNNING_ON_PI=$running_on_pi
+ARG running_on_pi='export RUNNING_ON_PI=1'
+
+# Note: the quoting that defines the PATH echo is very specifically set up to
+# get $PATH in the script literally so it is evaluated at container runtime.
+RUN echo "export CONTAINER_ID=$(uuidgen)" | tee -a /etc/profile.d/opentrons.sh\
+    && echo 'export PATH=$PATH:'"`find_ot_resources.py`/scripts" | tee -a /etc/profile.d/opentrons.sh\
+    && echo $running_on_pi | tee -a /etc/profile.d/opentrons.sh
+
 
 ARG data_mkdir_path_slash_if_none=/
 RUN mkdir -p $data_mkdir_path_slash_if_none

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ api-local-container:
 	docker build . \
 		--no-cache \
 		--build-arg base_image=resin/amd64-alpine-python:3.6-slim-20180123 \
-		--build-arg running_on_pi=0 \
+		--build-arg running_on_pi="" \
 		--build-arg data_mkdir_path_slash_if_none=/data/system
 
 .PHONY: term


### PR DESCRIPTION
## overview

When this was only a Dockerfile variable, it was only available in the environ of the original pid 1
of the system (and children). This means it works fine in the API server, but logging in remotely -
even with a login shell - won't have it set. Now it will.

## Testing

Without this commit, RUNNING_ON_PI is only available in /proc/1/environ (and only if it hasn't previously been "restarted" by killing pid 1):
```
296f25b:~# env | grep RUNNING_ON_PI
296f25b:~# bash -lc "env | grep RUNNING_ON_PI"
[ bash ] Environment already configured
[ bash ] Environment already configured
296f25b:~# cat /proc/1/environ | grep RUNNING_ON_PI
RUNNING_ON_PI=1
```

After, it is available in any login shell:

```
bash-4.3# bash -l
[ bash ] Configuring environment
[ bash ] Environment configuration done
[ bash ] Environment already configured
b0e09c3:/# env | grep RUNNING_ON_PI
RUNNING_ON_PI=1
```

## Review Requests
Put this on a machine (via resin) and check that RUNNING_ON_PI is set in a login shell - either the shell you get through SSH, or by running "bash -l" in a resin terminal.

