### PR TITLE
fix(protocol-designer): fix gear size expanding with browser zoom

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormSection.css
+++ b/protocol-designer/src/components/StepEditForm/FormSection.css
@@ -26,4 +26,6 @@
   position: absolute;
   top: 0;
   right: 0;
+  height: 3rem;
+  width: 3rem;
 }

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -34,12 +34,10 @@ const FormSection = (props: FormSectionProps) => {
       </div>
 
       {props.collapsed !== undefined && // if doesn't exist in redux
-        <div onClick={props.onCollapseToggle}>
+        <div onClick={props.onCollapseToggle} className={styles.carat}>
           <IconButton
-            width='30px'
             name='settings'
             hover={!props.collapsed}
-            className={styles.carat}
           />
         </div>
       }


### PR DESCRIPTION
## overview

Closes #1769

## changelog

- fix gear size expanding with browser zoom in Step Forms

## review requests

Zooming (eg `Ctrl +`) shouldn't make the gear resize weirdly anymore