### PR TITLE
docs(api): Corrected the documentation of parameters in labware.create

### DIFF
--- a/api/docs/source/labware.rst
+++ b/api/docs/source/labware.rst
@@ -342,8 +342,8 @@ Through the API's call labware.create(), you can create simple grid containers, 
 
     custom_plate = labware.create(
         '3x6_plate',                    # name of you container
-        grid=(3, 6),                    # specify amount of (rows, columns)
-        spacing=(12, 12),               # distances (mm) between each (row, column)
+        grid=(3, 6),                    # specify amount of (columns, rows)
+        spacing=(12, 12),               # distances (mm) between each (column, row)
         diameter=5,                     # diameter (mm) of each well on the plate
         depth=10,                       # depth (mm) of each well on the plate
         volume=200)


### PR DESCRIPTION
Switched columns and rows in the  documentation of grid and spacing parameters in labware.create

Closes #2058 

## overview

The documentation on the `labware.create` method was incorrect, saying the `grid` and `spacing` tuple was to be declared as `(rows, cols)` when it should have been `(cols, rows)`.

## changelog
- Fixed `labware.create` documentaion

## review requests

<!--
  Describe any requests for your reviewers here.
-->
