### PR TITLE
feat(app): Add attached pipette info to intercom support

### DIFF
--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -122,7 +122,6 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const {robot} = ownProps
     const optionsRequest = getResetOptions(state, robot)
     const optionsResponse = optionsRequest.response
-    console.log('OPTIONS', {optionsResponse})
     return {
       options: optionsResponse && optionsResponse.options,
       resetRequest: getResetRequest(state, robot),


### PR DESCRIPTION
## overview

This PR closes #2019 by adding attached pipettes info to intercom data when a the api returns `'api:PIPETTES_SUCCESS'`

## changelog

- feat(app): Add attached pipette info to intercom support

## review requests

Unfortunately, the imported intercom handler always returned as a `noop` for `Intercom('update')` calls. So we had to do it the old fashioned way with `window.Intercom(...)`

Intercom does not accept arrays or objects for values in custom data fields. So rather than just have a single data attribute `Pipettes: {...}` with all of the apps info about the pipettes, it needed to be split up into `Left Pipette: model string` etc.

TODO: (in the future)
Add pipette serial numbers to intercom once they are exposed by the api

We have a test intercom app for these PRs so we can avoid confusing support with our nonsense messages. I will ping you with the intercom ID you need to set in app, and a link to the dashboard to view the user data

Open app (with the intercom ID set that I share via slack)

```shell
make -C app dev OT_APP_INTERCOM_ID=xyz123
```

Also go to your Intercom user in the intercom webapp. Look for the "Details" section on the left of the page. To see our custom properties, you will have to click "Show __ Hidden" link.

<img width="303" alt="screen shot 2018-09-04 at 3 26 18 pm" src="https://user-images.githubusercontent.com/2963448/45053102-f510e000-b056-11e8-8bd5-a3d9555be2a3.png">

1. Connect to a robot
2. View attached pipettes
    - [ ] "Robot Name" in Intercom user properties matches connected robot
    - [ ] "Pipette Model Left" and "Pipette Model Right" in user match connected pipettes
3. View attached pipettes of robot that you're **not connected** to
    - [ ] "Pipette Model Left" and "Pipette Model Right" remain unchanged
4. Connect to a robot with different (or empty) pipettes
    - [ ] "Pipette Model Left" and "Pipette Model Right" update or clear accordingly
