### PR TITLE
fix(api): fix _poll_temperature() thread, deactivate before disconnect

### DIFF
--- a/api/opentrons/drivers/temp_deck/driver.py
+++ b/api/opentrons/drivers/temp_deck/driver.py
@@ -236,7 +236,6 @@ class TempDeck:
 
     @property
     def status(self) -> str:
-        self.update_temperature()
         current = self._temperature.get('current')
         target = self._temperature.get('target')
         delta = 0.7


### PR DESCRIPTION
## overview

This PR fixes the issue of multiple port access by tempdeck driver due to _poll_temperature() threads not terminating properly.
Also makes sure to deactivate the tempdeck before disconnecting (needed in case a user doesn't add deactivate() at the end of their protocol or if a run is canceled before deactivating the module)

## changelog
- Changed _poll_temperature() thread so that it terminates immediately upon disconnect
- All status and temperature properties of the tempdeck api object now depend on the _poll_temperature() thread to receive temperature updates from the module. If the thread is not active, then the driver's update_temperature() method will need to be called exclusively to get the latest tempdeck status

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

