### PR TITLE
fix(app): Add missing title to app info card

### DIFF
--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -11,7 +11,7 @@ type Props = {
   update: ShellUpdate,
   checkForUpdates: () => mixed
 }
-
+const TITLE = 'Information'
 const VERSION_LABEL = 'Software Version'
 
 export default function AppInfoCard (props: Props) {
@@ -24,6 +24,7 @@ export default function AppInfoCard (props: Props) {
     <RefreshCard
       refreshing={checkInProgress}
       refresh={checkForUpdates}
+      title={TITLE}
     >
       <CardContentHalf>
         <LabeledValue


### PR DESCRIPTION
## overview

Somewhere between the last release and 3.3.0 the the title 'Information' was removed from the app info card in the more section of the app.

<img width="628" alt="screen shot 2018-08-28 at 11 17 12 am" src="https://user-images.githubusercontent.com/3430313/44737365-ca0b1700-aabf-11e8-97e0-3f374d37ef5d.png">
<img width="634" alt="screen shot 2018-08-28 at 12 41 58 pm" src="https://user-images.githubusercontent.com/3430313/44737367-cbd4da80-aabf-11e8-8fdd-39dbbccf1918.png">

## changelog

-fix(app): Add missing title to app info card

## review requests

Open app, click more tab, confirm Information title renders in top app info card.