### PR TITLE
fix(protocol-designer): hide pre-wet tip asp/disp from substeps

### DIFF
--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -96,14 +96,16 @@ function transferLikeSubsteps (args: {
     const commandCallArgs = {
       ...validatedForm,
       mixBeforeAspirate: null,
-      mixInDestination: null
+      mixInDestination: null,
+      preWetTip: false
     }
 
     result = transfer(commandCallArgs)(robotState)
   } else if (validatedForm.stepType === 'distribute') {
     const commandCallArgs = {
       ...validatedForm,
-      mixBeforeAspirate: null
+      mixBeforeAspirate: null,
+      preWetTip: false
     }
 
     result = distribute(commandCallArgs)(robotState)
@@ -111,7 +113,8 @@ function transferLikeSubsteps (args: {
     const commandCallArgs = {
       ...validatedForm,
       mixFirstAspirate: null,
-      mixInDestination: null
+      mixInDestination: null,
+      preWetTip: false
     }
 
     result = consolidate(commandCallArgs)(robotState)


### PR DESCRIPTION
Fixes #2151

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

In all steps that have it (transfer/distribute/consolidate), the "Pre-wet tip" option should no longer create its own extra substep row.