### PR TITLE
feat(protocol-designer): flow rate field more dependent on pipette

### DIFF
--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -5,8 +5,9 @@ import {Icon} from '../icons'
 // import globalStyles from '../styles/index.css'
 import styles from './forms.css'
 
-// TODO(mc, 2018-02-22): disabled prop
 type Props = {
+  /** field is disabled if value is true */
+  disabled?: boolean,
   /** change handler */
   onChange?: (event: SyntheticInputEvent<*>) => mixed,
   /** classes to apply */
@@ -40,7 +41,8 @@ type Props = {
 export default function InputField (props: Props) {
   const error = props.error != null
   const labelClass = cx(styles.form_field, props.className, {
-    [styles.error]: error
+    [styles.error]: error,
+    [styles.disabled]: props.disabled
   })
 
   if (!props.label) {
@@ -77,10 +79,10 @@ function Input (props: Props) {
           type={props.type || 'text'}
           value={props.value || ''}
           placeholder={props.placeholder}
-          onChange={props.onChange}
-          onFocus={props.onFocus}
+          onChange={props.disabled ? undefined : props.onChange}
+          onFocus={props.disabled ? undefined : props.onFocus}
           onBlur={props.onBlur}
-          onClick={props.onClick}
+          onClick={props.disabled ? undefined : props.onClick}
           readOnly={props.readOnly}
         />
         {props.units && <div className={styles.suffix}>{props.units}</div>}

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -179,4 +179,8 @@
   & .form_group_label {
     color: var(--c-light-gray);
   }
+
+  & input { /* stylelint-disable no-descending-specificity */
+    color: var(--c-med-gray);
+  }
 }

--- a/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
+++ b/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
@@ -16,13 +16,14 @@ const DECIMALS_ALLOWED = 1
 type Props = {
   /** When flow rate is falsey (including 0), it means 'use default' */
   defaultFlowRate: ?number,
+  disabled?: boolean,
   formFlowRate: ?number,
   flowRateType: 'aspirate' | 'dispense',
   label: ?string,
   minFlowRate: number,
   maxFlowRate: number,
   updateValue: (flowRate: ?number) => mixed,
-  pipetteModelDisplayName: string
+  pipetteModelDisplayName: ?string
 }
 
 type State = {
@@ -101,6 +102,7 @@ export default class FlowRateField extends React.Component<Props, State> {
 
     const {
       defaultFlowRate,
+      disabled,
       formFlowRate,
       flowRateType,
       label,
@@ -141,7 +143,7 @@ export default class FlowRateField extends React.Component<Props, State> {
       />
     )
 
-    const FlowRateModal = (
+    const FlowRateModal = pipetteModelDisplayName && (
       <Portal>
         <AlertModal
           className={modalStyles.modal}
@@ -186,9 +188,10 @@ export default class FlowRateField extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <FormGroup label={label || DEFAULT_LABEL}>
+        <FormGroup label={label || DEFAULT_LABEL} disabled={disabled}>
           <InputField
             readOnly
+            disabled={disabled}
             onClick={this.openModal}
             value={(formFlowRate) ? `${formFlowRate} μL/s` : 'Default'}
           />

--- a/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
+++ b/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
@@ -112,7 +112,10 @@ export default class FlowRateField extends React.Component<Props, State> {
     } = this.props
 
     const modalFlowRateNum = Number(this.state.modalFlowRate)
-    const rangeDescription = `between ${minFlowRate} and ${maxFlowRate}`
+
+    // show 0.1 not 0 as minimum, since bottom of range is non-inclusive
+    const displayMinFlowRate = minFlowRate || Math.pow(10, -DECIMALS_ALLOWED)
+    const rangeDescription = `between ${displayMinFlowRate} and ${maxFlowRate}`
     const outOfBounds = (
       modalFlowRateNum === 0 ||
       minFlowRate > modalFlowRateNum ||
@@ -129,7 +132,7 @@ export default class FlowRateField extends React.Component<Props, State> {
         errorMessage = `a max of ${DECIMALS_ALLOWED} decimal place${
           DECIMALS_ALLOWED > 1 ? 's' : ''} is allowed`
       } else if (!pristine && outOfBounds) {
-        errorMessage = rangeDescription
+        errorMessage = `accepted range is ${displayMinFlowRate} to ${maxFlowRate}`
       }
     }
 
@@ -190,10 +193,11 @@ export default class FlowRateField extends React.Component<Props, State> {
       <React.Fragment>
         <FormGroup label={label || DEFAULT_LABEL} disabled={disabled}>
           <InputField
+            units='μL/s'
             readOnly
             disabled={disabled}
             onClick={this.openModal}
-            value={(formFlowRate) ? `${formFlowRate} μL/s` : 'Default'}
+            value={formFlowRate ? `${formFlowRate}` : 'Default'}
           />
         </FormGroup>
 

--- a/protocol-designer/src/components/StepEditForm/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/FlowRateField/index.js
@@ -44,15 +44,13 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const pipetteConfig = pipette && getPipette(pipette.model)
   const pipetteModelDisplayName = pipetteConfig ? pipetteConfig.displayName : 'pipette'
 
-  let defaultFlowRate = null
+  let defaultFlowRate
   if (pipetteConfig) {
     if (flowRateType === 'aspirate') {
       defaultFlowRate = pipetteConfig.aspirateFlowRate
     } else if (flowRateType === 'dispense') {
       defaultFlowRate = pipetteConfig.dispenseFlowRate
     }
-  } else {
-    console.warn('FlowRateField mapStateToProps expected pipetteConfig', ownProps)
   }
 
   const formFlowRate = formData && formData[name]
@@ -63,6 +61,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   return {
     innerKey,
     defaultFlowRate,
+    disabled: pipette == null,
     formFlowRate,
     flowRateType,
     label: ownProps.label,


### PR DESCRIPTION
# overview

1. Clear flow rate when pipette is changed
2. On a form with no pipette selected (new form), flow rate field is disabled.

Yet another part of #1323  :)

# changelog

- refactor handleFormChange to support multiple transformations
- add `disabled` prop to `InputField` component
- disable flow rate field when no pipette is selected

# review requests

- changing pipette should reset flow rate to "Default" (falsey). Should work in all Steps (except Pause)
- on a form with no pipette selected (new form), flow rate field is always disabled. Disabled: label & input field text is grayed out, and clicking does nothing. When you select a pipette, it becomes enabled