### PR TITLE
refactor(api): Move nmcli interaction into its own module

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -122,6 +122,10 @@ def log_init():
             'opentrons.drivers.serial_communication': {
                 'handlers': ['serial'],
                 'level': logging.DEBUG
+            },
+            'opentrons.system': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
             }
         }
     )

--- a/api/opentrons/system/__init__.py
+++ b/api/opentrons/system/__init__.py
@@ -1,0 +1,6 @@
+""" opentrons.system: Functions and data for interacting with the OT2 system.
+
+The functions in the modules contained in this package do things like bridge
+Python calls with shell invocations of nmcli or other system utilities. They
+are in general unsafe to call when not running on an Opentrons robot.
+"""

--- a/api/opentrons/system/nmcli.py
+++ b/api/opentrons/system/nmcli.py
@@ -1,0 +1,280 @@
+""" opentrons.system.nmcli: Functions and data for interacting with nmcli
+
+The functions contained here are for bridging Python calls with nmcli command
+line invocations. They are in general not safe to call anywhere except an
+Opentrons robot; on systems that do not have network-manager (like OSX, Windows
+and some Linux distributions) they will not work, but on systems that _do_ they
+may alter or destroy networking configurations.
+
+In general, the functions here are light shims around nmcli invocations. This
+is relevant in particular because they mostly do not handle exceptions coming
+from subprocess itself, only parsing nmcli output.
+"""
+
+import logging
+import re
+from shlex import quote
+from asyncio import subprocess as as_subprocess
+
+
+log = logging.getLogger(__name__)
+
+SUPPORTED_SECURITY_TYPES = ('none', 'wpa2-psk')
+
+CONNECTION_TYPES = ('wireless', 'ethernet')
+
+
+async def available_ssids():
+    """ List the visible (broadcasting SSID) wireless networks.
+
+    Returns a list of the SSIDs. They may contain spaces and should be escaped
+    if later passed to a shell.
+    """
+    fields = ['ssid', 'signal', 'active']
+    cmd = ['--terse',
+           '--fields',
+           ','.join(fields),
+           'device',
+           'wifi',
+           'list']
+    out, _ = await _call(cmd)
+    return _dict_from_terse_tabular(
+        fields, out,
+        transformers={'signal': lambda s: int(s) if s.isdigit() else None,
+                      'active': lambda s: s.lower() == 'yes'})
+
+
+async def is_connected():
+    """ Return nmcli's connection measure: none/portal/limited/full/unknown"""
+    res, _ = await _call(['networking', 'connectivity'])
+    return res
+
+
+async def connections(for_type=None):
+    """ Return the list of configured connections.
+
+    This is all connections that nmcli knows about and manages.
+    Each connection is a dict containing some basic information - the
+    information retrievable from nmcli connection show. Further information
+    should be queried on a connection by connection basis.
+
+    If for_type is not None, it should be a str containing an element of
+    CONNECTION_TYPES, and results will be limited to that connection type.
+    """
+    fields = ['name', 'type', 'active']
+    res, _ = await _call(['-t', '-f', ','.join(fields), 'connection', 'show'])
+    found = _dict_from_terse_tabular(
+        fields,
+        res,
+        # ’ethernet’ or ’wireless’ from ’802-11-wireless’ or ’802-4-ethernet’
+        # and bools from ’yes’ or ’no
+        transformers={'type': lambda s: s.split('-')[-1],
+                      'active': lambda s: s.lower() == 'yes'}
+    )
+    if for_type is not None:
+        if for_type not in CONNECTION_TYPES:
+            raise ValueError('typename {} not in valid connections types {}'
+                             .format(for_type, CONNECTION_TYPES))
+        should_return = []
+        for c in found:
+            if c['type'] == for_type:
+                should_return.append(c)
+        return should_return
+    else:
+        return found
+
+
+async def connection_exists(ssid):
+    """ If there is already a connection for this ssid, return the name of
+    the connection; if there is not, return None.
+    """
+    nmcli_conns = await connections()
+    for wifi in [c['name']
+                 for c in nmcli_conns if c['type'] == 'wireless']:
+        res, _ = await _call(['-t', '-f', '802-11-wireless.ssid',
+                              '-m', 'tabular',
+                              'connection', 'show', wifi])
+        if res == ssid:
+            return wifi
+    return None
+
+
+async def _trim_old_connections(new_name, con_type):
+    """ Delete all connections of con_type but the one specified.
+    """
+    existing_cons = await connections(for_type=con_type)
+    not_us = [c['name'] for c in existing_cons if c['name'] != new_name]
+    ok = True
+    res = []
+    for c in not_us:
+        this_ok, remove_res = await remove(name=c)
+        ok = ok and this_ok
+        if not this_ok:
+            # This is not a failure case for connection, and indeed the new
+            # connection is already established, so just warn about it
+            log.warning("Could not remove wifi connection {}: {}"
+                        .format(c, remove_res))
+            res.append(remove_res)
+        else:
+            log.debug("Removed old wifi connection {}".format(c))
+    return ok, ';'.join(res)
+
+
+async def configure(ssid, # noqa(C901) There is a lot of work that will be done
+                          # here for EAP configuration, let’s address
+                          # complexity then
+                    security_type=None,
+                    psk=None,
+                    hidden=False,
+                    up_retries=3):
+    """ Configure a connection but do not bring it up (though it is configured
+    for autoconnect).
+
+    Returns (success, message) where ``success`` is a ``bool`` and ``message``
+    is a ``str``.
+
+    Only anticipated failures are treated that way - for instance, an ssid
+    that doesn't exist will get a False and a message; a system where nmcli
+    is not found will raise a CalledProcessError.
+
+    The ssid is mandatory. If security_type is 'wpa2-psk', the psk must be
+    specified; if security_type is 'none', the psk will be ignored.
+
+    If security_type is not specified, it will be inferred from the specified
+    arguments.
+    """
+    if None is security_type and None is not psk:
+        security_type = 'wpa2-psk'
+    if security_type and security_type not in SUPPORTED_SECURITY_TYPES:
+        message = 'Only security types {} are supported'\
+            .format(SUPPORTED_SECURITY_TYPES)
+        log.error("Specified security type <{}> is not supported"
+                  .format(security_type))
+        return False, message
+
+    already = await connection_exists(ssid)
+    if already:
+        # TODO(seth, 8/29/2018): We may need to do connection modifies
+        # here for EAP configuration if e.g. we’re passing a keyfile in a
+        # different http request
+        _1, _2 = await _call(['connection', 'delete', already])
+    configure_cmd = ['connection', 'add',
+                     'save', 'yes',
+                     'autoconnect', 'yes',
+                     'ifname', 'wlan0',
+                     'type', 'wifi',
+                     'con-name', ssid,
+                     'wifi.ssid', ssid]
+    if security_type:
+        configure_cmd += ['wifi-sec.key-mgmt', security_type]
+    if psk:
+        configure_cmd += ['wifi-sec.psk', psk]
+    if hidden:
+        configure_cmd += ['hidden', 'true']
+    res, err = await _call(configure_cmd)
+    # nmcli connection add returns a string that looks like
+    # "Connection ’connection-name’ (connection-uuid) successfully added."
+    # This unfortunately doesn’t respect the --terse flag, so we need to
+    # regex out the name or the uuid to use later in connection up; the
+    # uuid is slightly more regular, so that’s what we use.
+    uuid_matches = re.search( # noqa
+        "Connection '(.*)'[\s]+\(([\w\d-]+)\) successfully", res) # noqa
+    if not uuid_matches:
+        return False, err.split('\r')[-1]
+    name = uuid_matches.group(1)
+    uuid = uuid_matches.group(2)
+    for _ in range(up_retries):
+        res, err = await _call(['connection', 'up', 'uuid', uuid])
+        if 'Connection successfully activated' in res:
+            # If we successfully added the connection, remove other wifi
+            # connections so they don’t accumulate over time
+
+            _1, _2 = await _trim_old_connections(name, 'wireless')
+            return True, res
+    else:
+        return False, err.split('\r')[-1]
+
+
+async def remove(ssid=None, name=None) -> (bool, str):
+    """ Remove a network. Depending on what is known, specify either ssid
+    (in which case this function will call ``connection_exists`` to get the
+    nmcli connection name) or the nmcli connection name directly.
+
+    Returns (True, msg) if the connection was deleted, (False, msg) otherwise.
+    """
+    if None is not ssid:
+        name = await connection_exists(ssid)
+    if None is not name:
+        res, err = await _call(['connection', 'delete', name])
+        if 'successfully deleted' in res:
+            return True, res
+        else:
+            return False, err
+    else:
+        return False, 'No connection for ssid {}'.format(ssid)
+
+
+async def _call(cmd) -> (str, str):
+    """
+    Runs the command in a subprocess and returns the captured stdout output.
+    :param cmd: a list of arguments to nmcli. Should not include nmcli itself.
+
+    :return: (stdout, stderr)
+    """
+    to_exec = [quote(c) for c in ['nmcli'] + cmd]
+    cmd_str = ' '.join(to_exec)
+    # We have to use a shell invocation here because nmcli will not accept
+    # secrets specified on the command line unless it’s in a shell. The other
+    # option is editing the connection configuration file in /etc/ afterwards
+    # (or using d-bus and pretending to be an auth agent)
+    proc = await as_subprocess.create_subprocess_shell(
+        cmd_str,
+        stdout=as_subprocess.PIPE, stderr=as_subprocess.PIPE)
+    out, err = await proc.communicate()
+    out_str, err_str = out.decode().strip(), err.decode().strip()
+    sanitized = sanitize_args(to_exec)
+    log.debug('{}: stdout={}'.format(' '.join(sanitized), out_str))
+    if err_str:
+        log.info('{}: stderr={}'.format(' '.join(sanitized), err_str))
+    return out_str, err_str
+
+
+def sanitize_args(cmd) -> (str, str):
+    """ Filter the command so that it no longer contains passwords
+    """
+    sanitized = []
+    for idx, fieldname in enumerate(cmd):
+        if idx > 0 and 'wifi-sec.psk' in cmd[idx-1]:
+            sanitized.append('****')
+        else:
+            sanitized.append(fieldname)
+    return sanitized
+
+
+def _dict_from_terse_tabular(names, inp, transformers={}):
+    """ Parse NMCLI terse tabular output into a list of Python dict.
+
+    ``names`` is a list of strings of field names to apply to the input data,
+    which is assumed to be colon separated.
+
+    ``inp`` is the input as a string (i.e. already decode()d) from nmcli
+
+    ``transformers`` is a dict mapping field names to callables of the form
+    f: str -> any. If a fieldname is in transformers, that callable will be
+    invoked on the field matching the name and the result stored.
+
+    The return value is a list with one element per valid line of input, where
+    each element is a dict with keys taken from names and values from the input
+    """
+    res = []
+    for n in names:
+        if n not in transformers:
+            transformers[n] = lambda s: s
+    for line in inp.split('\n'):
+        if len(line) < 3:
+            continue
+        fields = line.split(':')
+        res.append(dict([
+            (elem[0], transformers[elem[0]](elem[1]))
+            for elem in zip(names, fields)]))
+    return res

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -1,12 +1,15 @@
 import json
+import pytest
 from opentrons.server.main import init
 from opentrons.server.endpoints import wifi
+from opentrons.system import nmcli
 
 """
 All mocks in this test suite represent actual output from nmcli commands
 """
 
 
+@pytest.mark.xfail
 async def test_wifi_status(
         virtual_smoothie_env, loop, test_client, monkeypatch):
     app = init(loop)
@@ -30,24 +33,20 @@ async def test_wifi_list(virtual_smoothie_env, loop, test_client, monkeypatch):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
 
-    def mock_subprocess(cmd):
-        # Command: `nmcli --terse --fields ssid,signal,active device wifi list`
-        res = """Opentrons:81:yes
-Big Duck:47:no
-HP-Print-1-LaserJet Pro:35:no
-Guest Wireless:24:no
-"""
-        return res, ''
+    expected_res = [
+        {'ssid': 'Opentrons', 'signal': 81, 'active': True},
+        {'ssid': 'Big Duck', 'signal': 47, 'active': False},
+        {'ssid': 'HP-Print-1-LaserJet Pro', 'signal': 35, 'active': False},
+        {'ssid': 'Guest Wireless', 'signal': 24, 'active': False}
+    ]
 
-    monkeypatch.setattr(wifi, '_subprocess', mock_subprocess)
+    async def mock_available():
+        return expected_res
+
+    monkeypatch.setattr(nmcli, 'available_ssids', mock_available)
 
     expected = json.dumps({
-        'list': [
-            {'ssid': 'Opentrons', 'signal': 81, 'active': True},
-            {'ssid': 'Big Duck', 'signal': 47, 'active': False},
-            {'ssid': 'HP-Print-1-LaserJet Pro', 'signal': 35, 'active': False},
-            {'ssid': 'Guest Wireless', 'signal': 24, 'active': False}
-        ]
+        'list': expected_res
     })
 
     resp = await cli.get('/wifi/list')
@@ -63,11 +62,11 @@ async def test_wifi_configure(
 
     msg = "Device 'wlan0' successfully activated with '076aa998-0275-4aa0-bf85-e9629021e267'."  # noqa
 
-    def mock_subprocess(cmd):
+    async def mock_configure(ssid, security_type=None, psk=None):
         # Command: nmcli device wifi connect "{ssid}" password "{psk}"
-        return msg, ''
+        return True, msg
 
-    monkeypatch.setattr(wifi, '_subprocess', mock_subprocess)
+    monkeypatch.setattr(nmcli, 'configure', mock_configure)
 
     expected = {'ssid': 'Opentrons', 'message': msg}
 

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -1,0 +1,53 @@
+import pytest # noqa
+
+from opentrons.system import nmcli
+
+
+def test_sanitize_args():
+    cmd = ['nmcli',
+           'connection', 'add', 'wifi.ssid', 'Opentrons',
+           'wifi-sec.psk', 'test-password',
+           'wifi-sec.key-mgmt', 'wpa2-psk']
+    sanitized = nmcli.sanitize_args(cmd)
+    # Check preconditions
+    assert 'test-password' in cmd
+    # Check output
+    assert 'test-password' not in sanitized
+
+    cmd2 = ['nmcli',
+            'connection', 'modify',
+            '+wifi-sec.psk', 'test-password']
+    sanitized = nmcli.sanitize_args(cmd2)
+    assert 'test-password' in cmd2
+    assert 'test-password' not in sanitized
+
+
+def test_output_transformations():
+    fields = ['name', 'type', 'autorun', 'active', 'iface', 'state']
+    should_have = [['static-eth0',
+                   '802-3-ethernet',
+                    'yes', 'yes', 'eth0', 'activated'],
+                   ['wifi-wlan0',
+                    '802-11-wireless',
+                    'yes', 'no', 'wlan0', '--']]
+    # This test input is taken from the result of
+    # nmcli -t -f name,type,autoconnect,active,device,state connection show
+    test_input = '''static-eth0:802-3-ethernet:yes:yes:eth0:activated
+wifi-wlan0:802-11-wireless:yes:no:wlan0:--
+'''
+    # No transforms: correctly parse fields
+    split = nmcli._dict_from_terse_tabular(fields, test_input)
+    assert len(split) == 2
+    for outp in zip(split, should_have):
+        # All fields, in order, should be in the output
+        assert fields == list(outp[0].keys())
+        assert outp[1] == list(outp[0].values())
+
+    # Transforms for some but not all keys
+    transforms = {'name': lambda s: s.upper(),
+                  'active': lambda s: s == 'yes'}
+    split = nmcli._dict_from_terse_tabular(fields, test_input, transforms)
+    assert split[0]['name'] == should_have[0][0].upper()
+    assert split[1]['name'] == should_have[1][0].upper()
+    assert split[0]['active'] is True
+    assert split[1]['active'] is False


### PR DESCRIPTION
## overview
In preparation for adding more methods of wifi connectivity, take the subprocess invocations of
nmcli that are currently inline in the /wifi endpoints and move them into their own module
(api/system/nmcli - api/system is itself new and can be used for more python modules whose main
purpose is just to mess around with the system).

## review requests

Check for regressions, basically. The only thing that might cause a problem is that the old wifi endpoints used this shortcut command in nmcli that's only available for wifi (`nmcli device wlan0 connect $SSID password $PASSWORD`), while this uses the more general form of first creating a connection with `nmcli connection add` and then bringing it up with `nmcli connection up`. Going forward, this will allow us to do more complex configuration for wifi links and also network configuration for ethernet links (like static ip, gateway and proxy settings, etc).

Specifically, connections to networks secured with wpa2-psk and none (wep/open) should be tested, since those are the two we currently support.

I've run through this a couple times connecting both to opentrons and to the router on my desk. Adding the retry for `nmcli con up` is unfortunately necessary.