### PR TITLE
feat(protocol-designer): add tooltips for step creation button

### DIFF
--- a/components/src/tooltips/HoverTooltip.js
+++ b/components/src/tooltips/HoverTooltip.js
@@ -17,6 +17,8 @@ type PopperProps = React.ElementProps<typeof Popper>
 type Props = {
   tooltipComponent: React.Node,
   placement?: $PropertyType<PopperProps, 'placement'>,
+  positionFixed?: $PropertyType<PopperProps, 'positionFixed'>,
+  modifiers?: $PropertyType<PopperProps, 'modifiers'>,
   children: (HoverTooltipHandlers) => React.Node
 }
 type State = {isOpen: boolean}
@@ -48,7 +50,11 @@ class HoverTooltip extends React.Component<Props, State> {
         </Reference>
         {
           this.state.isOpen &&
-          <Popper placement={this.props.placement} modifiers={{offset: {offset: `0, ${DISTANCE_FROM_REFERENCE}`}}}>
+          <Popper
+            placement={this.props.placement}
+            modifiers={{offset: {offset: `0, ${DISTANCE_FROM_REFERENCE}`}, ...this.props.modifiers}}
+            positionFixed={this.props.positionFixed}
+          >
             {({ref, style, placement}) => (
               <div ref={ref} className={styles.tooltip_box} style={style} data-placement={placement}>
                 {this.props.tooltipComponent}

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -1,56 +1,55 @@
 // @flow
 import * as React from 'react'
 import styles from './StepCreationButton.css'
+import i18n from '../localization'
 
-import {PrimaryButton} from '@opentrons/components'
+import {HoverTooltip, PrimaryButton} from '@opentrons/components'
 import {stepIconsByType, type StepType} from '../form-types'
 
-type StepCreationButtonProps = {
+type Props = {
   onStepClick?: StepType => (event?: SyntheticEvent<*>) => mixed,
   onExpandClick?: (event?: SyntheticEvent<*>) => mixed,
-  onClickAway?: (event?: MouseEvent | SyntheticEvent<*>) => mixed, // TODO is there away around this 2-event union?
+  onClickAway?: (event?: SyntheticEvent<*>) => mixed,
   expanded?: boolean
 }
 
-class StepCreationButton extends React.Component<StepCreationButtonProps> {
-  ref: ?HTMLDivElement
-  handleAllClicks = (e: MouseEvent) => {
-    // TODO Ian 2018-03-23 this isn't working correctly now,
-    // but should onMouseLeave take care of this behavior instead, anyway?
-    if (this.ref && (e.currentTarget instanceof HTMLElement) && !this.ref.contains(e.currentTarget)) {
-      this.props.expanded && this.props.onClickAway && this.props.onClickAway(e)
-    }
-  }
+function StepCreationButton (props: Props) {
+  const {expanded, onExpandClick, onStepClick, onClickAway} = props
+  const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause']
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleAllClicks, true)
-  }
+  const buttons = expanded && supportedSteps.map(stepType =>
+    <HoverTooltip
+      key={stepType}
+      placement='right'
+      modifiers={{preventOverflow: {enabled: false}}}
+      positionFixed
+      tooltipComponent={i18n.t(`tooltip.step_description.${stepType}`)}
+    >
+      {(hoverTooltipHandlers) => (
+      <PrimaryButton
+        hoverTooltipHandlers={hoverTooltipHandlers}
+        onClick={onStepClick && onStepClick(stepType)}
+        iconName={stepIconsByType[stepType]}
+      >
+        {stepType}
+      </PrimaryButton>
+    )}
+  </HoverTooltip>
+  )
 
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleAllClicks, true)
-  }
+  return (
+    <div className={styles.step_creation_button} onMouseLeave={onClickAway}>
+      <PrimaryButton
+        onClick={expanded ? onClickAway : onExpandClick}
+      >
+        {i18n.t('button.add_step')}
+      </PrimaryButton>
 
-  render () {
-    const {expanded, onExpandClick, onStepClick, onClickAway} = this.props
-    const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause']
-
-    return (
-      <div className={styles.step_creation_button} ref={ref => { this.ref = ref }} onMouseLeave={onClickAway}>
-        <PrimaryButton onClick={expanded ? onClickAway : onExpandClick}>+ Add Step</PrimaryButton>
-        <div className={styles.buttons_popover}>
-          {expanded && supportedSteps.map(stepType =>
-            <PrimaryButton
-              key={stepType}
-              onClick={onStepClick && onStepClick(stepType)}
-              iconName={stepIconsByType[stepType]}
-            >
-              {stepType}
-            </PrimaryButton>
-          )}
-        </div>
+      <div className={styles.buttons_popover}>
+        {buttons}
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 export default StepCreationButton

--- a/protocol-designer/src/localization/en/button.json
+++ b/protocol-designer/src/localization/en/button.json
@@ -1,5 +1,6 @@
 {
   "cancel": "cancel",
   "done": "done",
-  "reset": "reset"
+  "reset": "reset",
+  "add_step": "+ Add Step"
 }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -1,3 +1,11 @@
 {
-  "not_in_beta": "This feature is not available in Beta"
+  "not_in_beta": "This feature is not available in Beta",
+
+  "step_description": {
+    "transfer": "Move liquid from wells to an equal number of wells",
+    "distribute": "One well to multiple wells",
+    "consolidate": "Multiple wells to one well",
+    "mix": "Mix content of wells",
+    "pause": "OT-2 will pause before proceeding"
+  }
 }


### PR DESCRIPTION
## overview

Tooltips! For step creation button (aka "Add Step" button)

![image](https://user-images.githubusercontent.com/11590381/44867655-741ca780-ac56-11e8-9904-337c0b95838c.png)

Closes #1979

## changelog

* pare down StepCreationButton to simpler functional component
* add 'positionFixed' & 'modifiers' props to HoverTooltip

## review requests

- :computer_mouse: 