### PR TITLE
feat(protocol-designer): restyle selected TitledList carat hover

### DIFF
--- a/components/src/__tests__/__snapshots__/lists.test.js.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.js.snap
@@ -205,7 +205,7 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
       className="title"
     />
     <div
-      className="title_bar_carat hoverable_carat"
+      className="title_bar_carat"
       onClick={[Function]}
     >
       <svg
@@ -244,7 +244,7 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
       className="title"
     />
     <div
-      className="title_bar_carat hoverable_carat"
+      className="title_bar_carat"
       onClick={[Function]}
     >
       <svg

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -85,7 +85,7 @@ export default function TitledList (props: ListProps) {
         {collapsible && (
           <div
             onClick={handleCollapseToggle}
-            className={cx(styles.title_bar_carat, {[styles.hoverable_carat]: !props.selected})}
+            className={styles.title_bar_carat}
           >
             <Icon
               className={styles.title_bar_icon}

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -83,8 +83,8 @@
   padding: calc(var(--list-padding-small) - var(--bd-width-default));
   padding-top: 1rem;
 
-  &.hoverable_carat:hover {
-    background-color: var(--c-bg-hover);
+  &:hover {
+    background-color: color(var(--c-black) alpha(5%));
   }
 }
 


### PR DESCRIPTION
## overview

Before, hovering over TitledList carat only showed a "hover state" (background color darkens) when the TitledList was NOT selected. This PR shows the carat "hover state" on both unselected and selected TitledLists.

And when I say TitledLists, I'm talking about how they're used by PD with all the fancy props, not the minimalistic use of TitledList in Run App (which should not be affected)

Closes #1977

## changelog

- show 'hover state' background color shift when user hovers over carat of a selected TitledList

^ uses black at 5% opacity instead of opaque 5% gray

## review requests

- Nothing weird in Run App's TitledLists
- :carrot: :mouse: 