### PR TITLE
feat(protocol-designer): warn changes will be lost on import/create

### DIFF
--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {actions, selectors} from '../../navigation'
 import {selectors as fileDataSelectors} from '../../file-data'
-import {actions as loadFileActions} from '../../load-file'
+import {actions as loadFileActions, selectors as loadFileSelectors} from '../../load-file'
 import FileSidebar from './FileSidebar'
 import type {BaseState, ThunkDispatch} from '../../types'
 
@@ -14,7 +14,8 @@ type SP = {
 }
 
 type MP = {
-  _canCreateNew: ?boolean
+  _canCreateNew: ?boolean,
+  _hasUnsavedChanges: ?boolean
 }
 
 export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
@@ -32,19 +33,22 @@ function mapStateToProps (state: BaseState): SP & MP {
       }
       : null,
     // Ignore clicking 'CREATE NEW' button in these cases
-    _canCreateNew: !selectors.newProtocolModal(state)
+    _canCreateNew: !selectors.newProtocolModal(state),
+    _hasUnsavedChanges: loadFileSelectors.hasUnsavedChanges(state)
   }
 }
 
 function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: ThunkDispatch<*>}): Props {
-  const {_canCreateNew, downloadData} = stateProps
+  const {_canCreateNew, _hasUnsavedChanges, downloadData} = stateProps
   const {dispatch} = dispatchProps
   return {
     downloadData,
-    loadFile: (fileChangeEvent) => dispatch(loadFileActions.loadProtocolFile(fileChangeEvent)),
-    createNewFile: _canCreateNew
-      ? () => dispatch(actions.toggleNewProtocolModal(true))
-      : undefined,
+    loadFile: (fileChangeEvent) => {
+      if (!_hasUnsavedChanges || confirm('TEST')) {
+        dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
+      }
+    },
+    createNewFile: _canCreateNew ? () => dispatch(actions.toggleNewProtocolModal(true)) : undefined,
     onDownload: () => dispatch(loadFileActions.saveProtocolFile())
   }
 }

--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
+import i18n from '../../localization'
 import {actions, selectors} from '../../navigation'
 import {selectors as fileDataSelectors} from '../../file-data'
 import {actions as loadFileActions, selectors as loadFileSelectors} from '../../load-file'
@@ -44,7 +45,7 @@ function mergeProps (stateProps: SP & MP, dispatchProps: {dispatch: ThunkDispatc
   return {
     downloadData,
     loadFile: (fileChangeEvent) => {
-      if (!_hasUnsavedChanges || confirm('TEST')) {
+      if (!_hasUnsavedChanges || window.confirm(i18n.t('alert.window.confirm_import'))) {
         dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
       }
     },

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
 import type {BaseState} from '../types'
+import i18n from '../localization'
 import {selectors, actions as navigationActions} from '../navigation'
 import {actions as fileActions, selectors as loadFileSelectors} from '../load-file'
 import type {NewProtocolFields} from '../load-file'
@@ -41,7 +42,7 @@ function mergeProps (stateProps: SP, dispatchProps: DP): Props {
     hideModal: stateProps.hideModal,
     onCancel: dispatchProps.onCancel,
     onSave: (fields) => {
-      if (!stateProps._hasUnsavedChanges || confirm('TEST')) {
+      if (!stateProps._hasUnsavedChanges || window.confirm(i18n.t('alert.window.confirm_create_new'))) {
         dispatchProps._createNewProtocol(fields)
       }
     }

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -4,30 +4,46 @@ import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
 import type {BaseState} from '../types'
 import {selectors, actions as navigationActions} from '../navigation'
-import {actions as fileActions} from '../load-file'
+import {actions as fileActions, selectors as loadFileSelectors} from '../load-file'
+import type {NewProtocolFields} from '../load-file'
 
 import NewFileModal from '../components/modals/NewFileModal'
 
-export default connect(mapStateToProps, mapDispatchToProps)(NewFileModal)
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(NewFileModal)
 
 type Props = React.ElementProps<typeof NewFileModal>
 
-type StateProps = {
-  hideModal: $PropertyType<Props, 'hideModal'>
+type SP = {
+  hideModal: $PropertyType<Props, 'hideModal'>,
+  _hasUnsavedChanges: ?boolean
 }
-type DispatchProps = $Diff<Props, StateProps>
+type DP = {
+  onCancel: () => mixed,
+  _createNewProtocol: (NewProtocolFields) => mixed
+}
 
-function mapStateToProps (state: BaseState): StateProps {
+function mapStateToProps (state: BaseState): SP {
   return {
-    hideModal: !selectors.newProtocolModal(state)
+    hideModal: !selectors.newProtocolModal(state),
+    _hasUnsavedChanges: loadFileSelectors.hasUnsavedChanges(state)
   }
 }
 
-function mapDispatchToProps (dispatch: Dispatch<*>): DispatchProps {
+function mapDispatchToProps (dispatch: Dispatch<*>): DP {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
-    onSave: fields => {
-      dispatch(fileActions.createNewProtocol(fields))
+    _createNewProtocol: fields => { dispatch(fileActions.createNewProtocol(fields)) }
+  }
+}
+
+function mergeProps (stateProps: SP, dispatchProps: DP): Props {
+  return {
+    hideModal: stateProps.hideModal,
+    onCancel: dispatchProps.onCancel,
+    onSave: (fields) => {
+      if (!stateProps._hasUnsavedChanges || confirm('TEST')) {
+        dispatchProps._createNewProtocol(fields)
+      }
     }
   }
 }

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux'
 import { AppContainer } from 'react-hot-loader'
 
 import configureStore from './configureStore.js'
+import i18n from './localization'
 import App from './components/App'
 import {selectors as loadFileSelectors} from './load-file'
 const store = configureStore()
@@ -11,9 +12,7 @@ const store = configureStore()
 if (process.env.NODE_ENV === 'production') {
   window.onbeforeunload = (e) => {
     // NOTE: the custom text will be ignored in modern browsers
-    return loadFileSelectors.hasUnsavedChanges(store.getState())
-      ? 'Are you sure you want to leave? You have may unsaved changes.'
-      : undefined
+    return loadFileSelectors.hasUnsavedChanges(store.getState()) ? i18n.t('alert.window.confirm_leave') : undefined
   }
 }
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -22,5 +22,10 @@
         "body": "The well(s) you're trying to aspirate from are empty. Hover over labware in Starting Deck State to add liquids."
       }
     }
+  },
+  "window": {
+    "confirm_create_new": "Are you sure you want to create a new file? Any unsaved changes will be discarded.",
+    "confirm_import": "Are you sure you want to import this file? You will lose any current unsaved changes.",
+    "confirm_leave": "Are you sure you want to leave? You will lose any unsaved changes."
   }
 }


### PR DESCRIPTION

## overview

If a user attempts to import an existing file or create a new one, their current protocol will be
nuked upon completing that action. We now give people a confirmation step.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->


<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
