### PR TITLE
feat(api): add custom height and offset params to magdeck engage

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -314,9 +314,6 @@ class Session(object):
 
     def _pre_run_hooks(self):
         robot.home_z()
-        for module in robot.modules:
-            if hasattr(module, 'calibrate'):
-                module.calibrate()
 
 
 def _accumulate(iterable):


### PR DESCRIPTION
## overview
This PR switches out the magdeck calibration process and instead has the module `engage()` to:
- a default height for the labware, if it exists. e.g. `engage()`
- or a user-defined offset (+/- mm) to the default height. e.g. `engage(offset=2)`
- or a user-defined custom height, measured as mm from magdeck home position. e.g. `engage(height=10)`

## review requests
The `calibrate()` method still exists in the api for now, in case it's needed in future. Is this advisable?  
