### PR TITLE
feat(api): add module firmware update endpoint

### DIFF
--- a/api/opentrons/config/modules/95-opentrons-modules.rules
+++ b/api/opentrons/config/modules/95-opentrons-modules.rules
@@ -1,2 +1,3 @@
-KERNEL=="ttyACM[0-9]*" SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
-KERNEL=="ttyACM[0-9]*" SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader"

--- a/api/opentrons/drivers/mag_deck/driver.py
+++ b/api/opentrons/drivers/mag_deck/driver.py
@@ -158,7 +158,7 @@ class MagDeck:
 
     def connect(self, port=None) -> str:
         '''
-        :param port: '/dev/ttyMagDeck'
+        :param port: '/dev/modules/ttyn_magdeck'
         NOTE: Using the symlink above to connect makes sure that the robot
         connects/reconnects to the module even after a device
         reset/reconnection

--- a/api/opentrons/server/endpoints/update.py
+++ b/api/opentrons/server/endpoints/update.py
@@ -2,10 +2,14 @@ import logging
 import asyncio
 import shutil
 import os
-
+import opentrons
+import tempfile
+from aiohttp import web
 from opentrons import robot
+from opentrons import modules
 
 log = logging.getLogger(__name__)
+UPDATE_TIMEOUT = 15
 
 
 def _ensure_programmer_executable():
@@ -67,4 +71,89 @@ async def _update_firmware(filename, loop, explicit_modeset=True):
     # run setup gcodes
     robot._driver._setup()
 
+    return res
+
+
+async def update_module_firmware(request):
+    """
+     This handler accepts a POST request with Content-Type: multipart/form-data
+     and a file field in the body named "module_firmware". The file should
+     be a valid HEX image to be flashed to the atmega32u4. The received file is
+     sent via USB to the board and flashed by the avr109 bootloader. The file
+     is then deleted and a success code is returned
+    """
+    log.debug('Update Firmware request received')
+    data = await request.post()
+    module_serial = request.match_info['serial']
+
+    res = await _update_module_firmware(module_serial,
+                                        data['module_firmware'],
+                                        request.loop)
+    if 'successful' not in res['message']:
+        if 'avrdudeResponse' in res and \
+                'checksum mismatch' in res['avrdudeResponse']:
+                status = 400
+        elif 'not found' in res['message']:
+            status = 404
+        else:
+            status = 500
+        log.error(res)
+    else:
+        status = 200
+        log.info(res)
+    return web.json_response(res, status=status)
+
+
+async def _update_module_firmware(module_serial, data, loop=None):
+
+    fw_filename = data.filename
+    content = data.file.read()
+    log.info('Preparing to flash firmware image {}'.format(fw_filename))
+    config_file_path = os.path.join(opentrons.HERE,
+                                    'config', 'modules', 'avrdude.conf')
+    with tempfile.NamedTemporaryFile(suffix=fw_filename) as fp:
+        fp.write(content)
+        # returns a dict of 'message' & 'avrdudeResponse'
+        res = await _upload_to_module(module_serial, fp.name,
+                                      config_file_path, loop=loop)
+    log.info('Firmware update complete')
+    res['filename'] = fw_filename
+    return res
+
+
+async def _upload_to_module(serialnum, fw_filename, config_file_path, loop):
+    """
+    This method remains in the API currently because of its use of the robot
+    singleton's copy of the api object & driver. This should move to the server
+    lib project eventually and use its own driver object (preferably involving
+    moving the drivers themselves to the serverlib)
+    """
+
+    # ensure there is a reference to the port
+    if not robot.is_connected():
+        robot.connect()
+    for module in robot.modules:
+        module.disconnect()
+    robot.modules = modules.discover_and_connect()
+    res = {}
+    for module in robot.modules:
+        if module.device_info.get('serial') == serialnum:
+            log.info("Module with serial {} found".format(serialnum))
+            bootloader_port = await modules.enter_bootloader(module)
+            if bootloader_port:
+                module._port = bootloader_port
+            # else assume old bootloader connection on existing module port
+            log.info("Uploading file to port:{} using config file {}".format(
+                module.port, config_file_path))
+            log.info("Flashing firmware. This will take a few seconds")
+            try:
+                res = await asyncio.wait_for(
+                    modules.update_firmware(
+                        module, fw_filename, config_file_path, loop),
+                    UPDATE_TIMEOUT)
+            except asyncio.TimeoutError:
+                return {'message': 'AVRDUDE not responding'}
+            break
+    if not res:
+        res = {'message': 'Module {} not found'.format(serialnum)}
     return res

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -11,12 +11,12 @@ from opentrons import robot, __version__, HERE
 from opentrons.api import MainRouter
 from opentrons.server.rpc import Server
 from opentrons.server import endpoints as endp
-from opentrons.server.endpoints import (wifi, control, settings)
+from opentrons.server.endpoints import (wifi, control, settings, update)
 from opentrons.config import feature_flags as ff
 from opentrons.util import environment
 from opentrons.deck_calibration import endpoints as dc_endp
 from logging.config import dictConfig
-from opentrons.server.endpoints import serverlib_fallback as endpoints, update
+from opentrons.server.endpoints import serverlib_fallback as endpoints
 
 from argparse import ArgumentParser
 
@@ -185,6 +185,8 @@ def init(loop=None):
         '/server/update', endpoints.update_api)
     server.app.router.add_post(
         '/server/update/firmware', endpoints.update_firmware)
+    server.app.router.add_post(
+        '/modules/{serial}/update', update.update_module_firmware)
     server.app.router.add_get(
         '/server/update/ignore', endpoints.get_ignore_version)
     server.app.router.add_post(

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -1,5 +1,6 @@
 # Test loading container onto a module
 import pytest
+import asyncio
 from opentrons import robot, labware, modules
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
@@ -93,3 +94,103 @@ def test_run_tempdeck_connected(
     robot.modules = [tempdeck]
     modules.load('tempdeck', '5')
     assert connected
+    tempdeck.disconnect()  # Necessary to kill the thread started by connect()
+
+
+@pytest.fixture
+def old_bootloader_module():
+    module = modules.TempDeck(port='/dev/modules/tty0_tempdeck')
+    module._device_info = {'model': 'temp_deck_v1'}
+    module._driver = TempDeckDriver()
+    return module
+
+
+@pytest.fixture
+def new_bootloader_module():
+    module = modules.TempDeck(port='/dev/modules/tty0_tempdeck')
+    module._device_info = {'model': 'temp_deck_v1.1'}
+    module._driver = TempDeckDriver()
+    return module
+
+
+async def test_enter_bootloader(
+        new_bootloader_module, virtual_smoothie_env, monkeypatch):
+
+    async def mock_discover_ports_before_dfu_mode():
+        return 'tty0_tempdeck'
+
+    def mock_enter_programming_mode(self):
+        return 'ok\n\rok\n\r'
+
+    async def mock_port_poll(_has_old_bootloader, ports_before_dfu_mode):
+        return '/dev/modules/tty0_bootloader'
+
+    monkeypatch.setattr(
+        TempDeckDriver, 'enter_programming_mode', mock_enter_programming_mode)
+    monkeypatch.setattr(
+        modules, '_discover_ports', mock_discover_ports_before_dfu_mode)
+    monkeypatch.setattr(modules, '_port_poll', mock_port_poll)
+
+    bootloader_port = await modules.enter_bootloader(new_bootloader_module)
+    assert bootloader_port == '/dev/modules/tty0_bootloader'
+
+
+def test_old_bootloader_check(
+        old_bootloader_module, new_bootloader_module, virtual_smoothie_env):
+    assert modules._has_old_bootloader(old_bootloader_module)
+    assert not modules._has_old_bootloader(new_bootloader_module)
+
+
+async def test_port_poll(virtual_smoothie_env, monkeypatch):
+    has_old_bootloader = False
+    timeout = 0.1
+    monkeypatch.setattr(modules, 'PORT_SEARCH_TIMEOUT', timeout)
+
+    # Case 1: Bootloader port is successfully opened on the module
+    async def mock_discover_ports1():
+        return ['tty0_magdeck', 'tty1_bootloader']
+    monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports1)
+
+    port_found = await asyncio.wait_for(
+        modules._port_poll(has_old_bootloader, None),
+        modules.PORT_SEARCH_TIMEOUT)
+    assert port_found == '/dev/modules/tty1_bootloader'
+
+    # Case 2: Switching to bootloader mode failed
+    async def mock_discover_ports2():
+        return ['tty0_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports2)
+
+    with pytest.raises(asyncio.TimeoutError):
+        port_found = await asyncio.wait_for(
+            modules._port_poll(has_old_bootloader, None),
+            modules.PORT_SEARCH_TIMEOUT)
+        assert not port_found
+
+
+async def test_old_bootloader_port_poll(virtual_smoothie_env, monkeypatch):
+    ports_before_switch = ['tty0_magdeck', 'tty1_tempdeck']
+    has_old_bootloader = True
+    timeout = 0.1
+    monkeypatch.setattr(modules, 'PORT_SEARCH_TIMEOUT', timeout)
+
+    # Case 1: Bootloader is opened on same port
+    async def mock_discover_ports():
+        return ['tty0_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports)
+
+    with pytest.raises(asyncio.TimeoutError):
+        port_found = await asyncio.wait_for(
+            modules._port_poll(has_old_bootloader, ports_before_switch),
+            modules.PORT_SEARCH_TIMEOUT)
+        assert not port_found
+
+    # Case 2: Bootloader is opened on a different port
+    async def mock_discover_ports():
+        return ['tty2_magdeck', 'tty1_tempdeck']
+    monkeypatch.setattr(modules, '_discover_ports', mock_discover_ports)
+
+    port_found = await asyncio.wait_for(
+        modules._port_poll(has_old_bootloader, ports_before_switch),
+        modules.PORT_SEARCH_TIMEOUT)
+    assert port_found == '/dev/modules/tty2_magdeck'

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -1,10 +1,13 @@
 import os
 import json
 import tempfile
+import asyncio
+import pytest
 from aiohttp import web
 from opentrons.server.main import init
 from opentrons.server.endpoints import update
 from opentrons.server.endpoints import serverlib_fallback
+from opentrons import modules
 
 
 async def test_restart(virtual_smoothie_env, monkeypatch, loop, test_client):
@@ -90,3 +93,153 @@ async def test_ignore_updates(
     r3 = await cli.get('/server/update/ignore')
     r3body = await r3.text()
     assert json.loads(r3body) == {'version': '3.1.3'}
+
+
+@pytest.fixture
+def dummy_modules():
+    temp_module = modules.TempDeck()
+    temp_module._device_info = {'serial': 'tdYYYYMMDD987'}
+    mag_module = modules.MagDeck()
+    mag_module._device_info = {'serial': 'mdYYYYMMDD123'}
+    return [temp_module, mag_module]
+
+
+async def test_update_module_firmware(
+        dummy_modules, virtual_smoothie_env, loop, test_client, monkeypatch):
+
+    app = init(loop)
+    client = await loop.create_task(test_client(app))
+    serial_num = 'mdYYYYMMDD123'
+    fw_filename = 'dummyFirmware.hex'
+    tmpdir = tempfile.mkdtemp("files")
+
+    with open(os.path.join(tmpdir, fw_filename), 'wb') as fd:
+        fd.write(bytes(0x1234))
+
+    def mock_discover_and_connect():
+        return dummy_modules
+
+    async def mock_enter_bootloader(module):
+        return '/dev/modules/tty0_bootloader'
+
+    monkeypatch.setattr(modules,
+                        'discover_and_connect', mock_discover_and_connect)
+    monkeypatch.setattr(modules, 'enter_bootloader', mock_enter_bootloader)
+
+    # ========= Happy path ==========
+    res_msg = {'message': 'Firmware update successful',
+               'avrdudeResponse': '1234 bytes of flash verified',
+               'filename': fw_filename}
+
+    async def mock_successful_upload_to_module(
+            module, fw_file, config_file, loop):
+        return res_msg
+
+    expected_res = res_msg
+
+    monkeypatch.setattr(modules,
+                        'update_firmware', mock_successful_upload_to_module)
+    resp = await client.post(
+        '/modules/{}/update'.format(serial_num),
+        data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
+
+    assert resp.status == 200
+    res = await resp.json()
+    assert res == expected_res
+
+
+async def test_fail_update_module_firmware(
+        dummy_modules, virtual_smoothie_env, loop, test_client, monkeypatch):
+    app = init(loop)
+    client = await loop.create_task(test_client(app))
+    serial_num = 'mdYYYYMMDD123'
+    fw_filename = 'dummyFirmware.hex'
+    tmpdir = tempfile.mkdtemp("files")
+
+    with open(os.path.join(tmpdir, fw_filename), 'wb') as fd:
+        fd.write(bytes(0x1234))
+
+    def mock_discover_and_connect():
+        return dummy_modules
+
+    async def mock_enter_bootloader(module):
+        return '/dev/modules/tty0_bootloader'
+
+    monkeypatch.setattr(modules,
+                        'discover_and_connect', mock_discover_and_connect)
+    monkeypatch.setattr(modules, 'enter_bootloader', mock_enter_bootloader)
+
+    # ========= Case 1: Port not accessible =========
+    res_msg1 = {'message': 'Firmware update failed',
+                'avrdudeResponse': 'ser_open(): can\'t open device',
+                'filename': fw_filename}
+
+    async def mock_failed_upload_to_module1(
+            serialnum, fw_file, config_file, loop):
+        return res_msg1
+
+    expected_res1 = res_msg1
+
+    monkeypatch.setattr(modules,
+                        'update_firmware', mock_failed_upload_to_module1)
+    resp1 = await client.post(
+        '/modules/{}/update'.format(serial_num),
+        data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
+
+    assert resp1.status == 500
+    j1 = await resp1.json()
+    assert j1 == expected_res1
+
+    # ========= Case 2: Corrupted file =========
+    res_msg2 = {'message': 'Firmware update failed',
+                'avrdudeResponse': 'checksum mismatch in line 1234',
+                'filename': fw_filename}
+
+    async def mock_failed_upload_to_module2(
+            serialnum, fw_file, config_file, loop):
+        return res_msg2
+
+    expected_res2 = res_msg2
+
+    monkeypatch.setattr(modules,
+                        'update_firmware', mock_failed_upload_to_module2)
+    resp2 = await client.post(
+        '/modules/{}/update'.format(serial_num),
+        data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
+
+    assert resp2.status == 400
+    j2 = await resp2.json()
+    assert j2 == expected_res2
+
+    # ========= Case 3: AVRDUDE not responding =========
+    expected_res3 = {'message': 'AVRDUDE not responding',
+                     'filename': fw_filename}
+
+    async def mock_failed_upload_to_module3(
+            serialnum, fw_file, config_file, loop):
+        await asyncio.sleep(2)
+
+    monkeypatch.setattr(modules,
+                        'update_firmware', mock_failed_upload_to_module3)
+    update.UPDATE_TIMEOUT = 0.1
+
+    resp3 = await client.post(
+        '/modules/{}/update'.format(serial_num),
+        data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
+
+    assert resp3.status == 500
+    j3 = await resp3.json()
+    assert j3 == expected_res3
+
+    # ========= Case 4: No module/ incorrect serial =========
+    wrong_serial = 'abcdef'
+    expected_res4 = {'message': 'Module {} not found'.format(wrong_serial),
+                     'filename': fw_filename}
+
+    resp4 = await client.post(
+        '/modules/{}/update'.format(wrong_serial),
+        data={'module_firmware': open(os.path.join(tmpdir, fw_filename))})
+
+    assert resp4.status == 404
+    j4 = await resp4.json()
+    assert j4 == expected_res4


### PR DESCRIPTION
## overview
This PR adds the firmware update endpoint for modules. 

The update process:
- The update methods use module serial number from POST request to find the module to be updated. 
- Once the matching module is found, it initiates firmware upload by first switching to dfu mode on the atmega32u4 and then selecting the bootloader port opened by dfu mode. The process of searching for this port is different depending on if the module has an older bootloader on it (all iGEM tempdecks have older bootloader)
- The `update_firmware` api method uses this port to upload firmware using avrdude command and returns a success or fail message to the endpoint

## changelog
- Added firmware update api methods and update server functions
- Added a udev rule for new bootloader
- Added tests for modules and update_server endpoint
