### PR TITLE
feat(protocol-designer): support mm from bottom offset in JSON protocols

### DIFF
--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -72,7 +72,7 @@ def get_location(loaded_labware, command_type, params, default_values):
 
     # optional command-specific value, fallback to default
     offset_from_bottom = params.get(
-        'offset-from-bottom-mm', offset_default)
+        'offsetFromBottomMm', offset_default)
 
     if offset_from_bottom is None:
         # not all commands use offsets

--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -54,7 +54,7 @@ def load_labware(protocol_data):
     return loaded_labware
 
 
-def get_location(loaded_labware, command_type, params, default_values):
+def _get_location(loaded_labware, command_type, params, default_values):
     labwareId = params.get('labware')
     if not labwareId:
         # not all commands use labware param
@@ -81,14 +81,14 @@ def get_location(loaded_labware, command_type, params, default_values):
     return labware.wells(well).bottom(offset_from_bottom)
 
 
-def get_pipette(command_params, loaded_pipettes):
+def _get_pipette(command_params, loaded_pipettes):
     pipetteId = command_params.get('pipette')
     return loaded_pipettes.get(pipetteId)
 
 
 # TODO (Ian 2018-08-22) once Pipette has more sensible way of managing
 # flow rate value (eg as an argument in aspirate/dispense fns), remove this
-def set_flow_rate(
+def _set_flow_rate(
         pipette_model, pipette, command_type, params, default_values):
     """
     Set flow rate in uL/mm, to value obtained from command's params,
@@ -133,13 +133,13 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: 
         command_type = command_item.get('command')
         params = command_item.get('params', {})
 
-        pipette = get_pipette(params, loaded_pipettes)
+        pipette = _get_pipette(params, loaded_pipettes)
         pipette_model = protocol_data\
             .get('pipettes', {})\
             .get(params.get('pipette'), {})\
             .get('model')
 
-        location = get_location(
+        location = _get_location(
             loaded_labware, command_type, params, default_values)
         volume = params.get('volume')
 
@@ -148,7 +148,7 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: 
             # which use pipettes right now.
             # Flow rate is persisted inside the Pipette object
             # and is settable but not easily gettable
-            set_flow_rate(
+            _set_flow_rate(
                 pipette_model, pipette, command_type, params, default_values)
 
         if command_type == 'delay':

--- a/api/tests/opentrons/protocols/test_load_json_protocol.py
+++ b/api/tests/opentrons/protocols/test_load_json_protocol.py
@@ -43,7 +43,7 @@ def test_get_location():
             "well": well,
             "offsetFromBottomMm": offset
         }
-        result = protocols.get_location(
+        result = protocols._get_location(
             loaded_labware, command_type, command_params, default_values)
         assert result == plate.well(well).bottom(offset)
 
@@ -53,7 +53,7 @@ def test_get_location():
     }
 
     # no command-specific offset, use default
-    result = protocols.get_location(
+    result = protocols._get_location(
         loaded_labware, command_type, command_params, default_values)
     assert result == plate.well(well).bottom(
         default_values['aspirate-mm-from-bottom'])

--- a/api/tests/opentrons/protocols/test_load_json_protocol.py
+++ b/api/tests/opentrons/protocols/test_load_json_protocol.py
@@ -21,6 +21,44 @@ def test_load_pipettes():
     assert pipette == loaded_pipettes['leftPipetteHere']
 
 
+def test_get_location():
+    robot.reset()
+
+    command_type = 'aspirate'
+    plate = labware.load("96-flat", 1)
+    well = "B2"
+
+    default_values = {
+        'aspirate-mm-from-bottom': 2
+    }
+
+    loaded_labware = {
+        "someLabwareId": plate
+    }
+
+    # test with nonzero and with zero command-specific offset
+    for offset in [5, 0]:
+        command_params = {
+            "labware": "someLabwareId",
+            "well": well,
+            "offset-from-bottom-mm": offset
+        }
+        result = protocols.get_location(
+            loaded_labware, command_type, command_params, default_values)
+        assert result == plate.well(well).bottom(offset)
+
+    command_params = {
+        "labware": "someLabwareId",
+        "well": well
+    }
+
+    # no command-specific offset, use default
+    result = protocols.get_location(
+        loaded_labware, command_type, command_params, default_values)
+    assert result == plate.well(well).bottom(
+        default_values['aspirate-mm-from-bottom'])
+
+
 def test_load_labware():
     robot.reset()
     data = {

--- a/api/tests/opentrons/protocols/test_load_json_protocol.py
+++ b/api/tests/opentrons/protocols/test_load_json_protocol.py
@@ -41,7 +41,7 @@ def test_get_location():
         command_params = {
             "labware": "someLabwareId",
             "well": well,
-            "offset-from-bottom-mm": offset
+            "offsetFromBottomMm": offset
         }
         result = protocols.get_location(
             loaded_labware, command_type, command_params, default_values)

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -12,7 +12,10 @@ import {
   HandleKeypress
 } from '@opentrons/components'
 import i18n from '../../../localization'
-import { DEFAULT_MM_FROM_BOTTOM } from '../../../constants'
+import {
+  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  DEFAULT_MM_FROM_BOTTOM_DISPENSE
+} from '../../../constants'
 import {Portal} from '../../portals/MainPageModalPortal'
 import modalStyles from '../../modals/modal.css'
 import {actions} from '../../../steplist'
@@ -54,7 +57,10 @@ class TipPositionModal extends React.Component<Props, State> {
     this.props.updateValue(formatValue(this.state.value || 0))
   }
   handleReset = () => {
-    this.setState({value: formatValue(DEFAULT_MM_FROM_BOTTOM)}, this.applyChanges)
+    const defaultMm = this.props.prefix === 'aspirate'
+      ? DEFAULT_MM_FROM_BOTTOM_ASPIRATE
+      : DEFAULT_MM_FROM_BOTTOM_DISPENSE
+    this.setState({value: formatValue(defaultMm)}, this.applyChanges)
     this.props.closeModal()
   }
   handleCancel = () => {

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -57,6 +57,8 @@ class TipPositionModal extends React.Component<Props, State> {
     this.props.updateValue(formatValue(this.state.value || 0))
   }
   handleReset = () => {
+    // NOTE: when `prefix` isn't set (eg in the Mix form), we'll use
+    // the value `DEFAULT_MM_FROM_BOTTOM_DISPENSE` (since we gotta pick something :/)
     const defaultMm = this.props.prefix === 'aspirate'
       ? DEFAULT_MM_FROM_BOTTOM_ASPIRATE
       : DEFAULT_MM_FROM_BOTTOM_DISPENSE

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -49,6 +49,7 @@ export const START_TERMINAL_TITLE = 'STARTING DECK STATE'
 export const END_TERMINAL_TITLE = 'FINAL DECK STATE'
 
 export const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'
-export const DEFAULT_MM_FROM_BOTTOM: 1 = 1
+export const DEFAULT_MM_FROM_BOTTOM_ASPIRATE = 1
+export const DEFAULT_MM_FROM_BOTTOM_DISPENSE = 0.5
 export const DEFAULT_WELL_ORDER_FIRST_OPTION: 't2b' = 't2b'
 export const DEFAULT_WELL_ORDER_SECOND_OPTION: 'l2r' = 'l2r'

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -7,6 +7,10 @@ import {getInitialRobotState, robotStateTimeline} from './commands'
 import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../../steplist'
+import {
+  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  DEFAULT_MM_FROM_BOTTOM_DISPENSE
+} from '../../constants'
 import type {BaseState} from '../../types'
 import type {ProtocolFile, FilePipette, FileLabware} from '../../file-types'
 import type {LabwareData, PipetteData} from '../../step-generation'
@@ -17,7 +21,9 @@ const applicationVersion = process.env.OT_PD_VERSION || 'unknown version'
 
 const executionDefaults = {
   'aspirate-flow-rate': getPropertyAllPipettes('aspirateFlowRate'),
-  'dispense-flow-rate': getPropertyAllPipettes('dispenseFlowRate')
+  'dispense-flow-rate': getPropertyAllPipettes('dispenseFlowRate'),
+  'aspirate-mm-from-bottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  'dispense-mm-from-bottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
 }
 
 export const createFile: BaseState => ProtocolFile = createSelector(

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -5,7 +5,7 @@ import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseAr
 
 /** Aspirate with given args. Requires tip. */
 const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
-  const {pipette, volume, labware, well} = args
+  const {pipette, volume, labware, well, offsetFromBottomMm} = args
 
   const actionName = 'aspirate'
   let errors: Array<CommandCreatorError> = []
@@ -32,14 +32,21 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     return {errors}
   }
 
+  const params: {offsetFromBottomMm?: number} & AspirateDispenseArgs = {
+    pipette,
+    volume,
+    labware,
+    well
+  }
+
+  if (offsetFromBottomMm != null) {
+    // only include 'offsetFromBottomMm' key if value is not void
+    params.offsetFromBottomMm = offsetFromBottomMm
+  }
+
   const commands = [{
     command: 'aspirate',
-    params: {
-      pipette,
-      volume,
-      labware,
-      well
-    }
+    params
   }]
 
   const liquidStateAndWarnings = updateLiquidState({

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -32,21 +32,17 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     return {errors}
   }
 
-  const params: {offsetFromBottomMm?: number} & AspirateDispenseArgs = {
-    pipette,
-    volume,
-    labware,
-    well
-  }
-
-  if (offsetFromBottomMm != null) {
-    // only include 'offsetFromBottomMm' key if value is not void
-    params.offsetFromBottomMm = offsetFromBottomMm
-  }
-
   const commands = [{
     command: 'aspirate',
-    params
+    params: {
+      pipette,
+      volume,
+      labware,
+      well,
+      offsetFromBottomMm: offsetFromBottomMm == null
+        ? undefined
+        : offsetFromBottomMm
+    }
   }]
 
   const liquidStateAndWarnings = updateLiquidState({

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -34,6 +34,11 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
     }
   }
 
+  const {
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm
+  } = data
+
   // TODO error on negative data.disposalVolume?
   const disposalVolume = (data.disposalVolume && data.disposalVolume > 0)
     ? data.disposalVolume
@@ -63,7 +68,8 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
             pipette: data.pipette,
             volume: data.volume + (isFirstWellInChunk ? disposalVolume : 0),
             labware: data.sourceLabware,
-            well: sourceWell
+            well: sourceWell,
+            offsetFromBottomMm: aspirateOffsetFromBottomMm
           }),
           ...touchTipAfterAspirateCommand
         ]
@@ -102,7 +108,9 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
           data.sourceLabware,
           sourceWellChunk[0],
           data.mixFirstAspirate.volume,
-          data.mixFirstAspirate.times
+          data.mixFirstAspirate.times,
+          aspirateOffsetFromBottomMm,
+          dispenseOffsetFromBottomMm
         )
         : []
 
@@ -113,7 +121,9 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
           data.sourceLabware,
           sourceWellChunk[0],
           data.volume,
-          1
+          1,
+          aspirateOffsetFromBottomMm,
+          dispenseOffsetFromBottomMm
         )
         : []
 
@@ -123,7 +133,9 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
           data.destLabware,
           data.destWell,
           data.mixInDestination.volume,
-          data.mixInDestination.times
+          data.mixInDestination.times,
+          aspirateOffsetFromBottomMm,
+          dispenseOffsetFromBottomMm
         )
         : []
 
@@ -146,7 +158,8 @@ const consolidate = (data: ConsolidateFormData): CommandCreator => (prevRobotSta
           pipette: data.pipette,
           volume: data.volume * sourceWellChunk.length,
           labware: data.destLabware,
-          well: data.destWell
+          well: data.destWell,
+          offsetFromBottomMm: dispenseOffsetFromBottomMm
         }),
         ...touchTipAfterDispenseCommands,
         ...trashTheDisposalVol,

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -22,21 +22,17 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     return {errors}
   }
 
-  const params: {offsetFromBottomMm?: number} & AspirateDispenseArgs = {
-    pipette,
-    volume,
-    labware,
-    well
-  }
-
-  if (offsetFromBottomMm != null) {
-    // only include 'offsetFromBottomMm' key if value is not void
-    params.offsetFromBottomMm = offsetFromBottomMm
-  }
-
   const commands = [{
     command: 'dispense',
-    params
+    params: {
+      pipette,
+      volume,
+      labware,
+      well,
+      offsetFromBottomMm: offsetFromBottomMm == null
+        ? undefined
+        : offsetFromBottomMm
+    }
   }]
 
   return {

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -5,7 +5,7 @@ import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseAr
 
 /** Dispense with given args. Requires tip. */
 const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
-  const {pipette, volume, labware, well} = args
+  const {pipette, volume, labware, well, offsetFromBottomMm} = args
 
   const actionName = 'dispense'
   let errors: Array<CommandCreatorError> = []
@@ -22,14 +22,21 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     return {errors}
   }
 
+  const params: {offsetFromBottomMm?: number} & AspirateDispenseArgs = {
+    pipette,
+    volume,
+    labware,
+    well
+  }
+
+  if (offsetFromBottomMm != null) {
+    // only include 'offsetFromBottomMm' key if value is not void
+    params.offsetFromBottomMm = offsetFromBottomMm
+  }
+
   const commands = [{
     command: 'dispense',
-    params: {
-      pipette,
-      volume,
-      labware,
-      well
-    }
+    params
   }]
 
   return {

--- a/protocol-designer/src/step-generation/distribute.js
+++ b/protocol-designer/src/step-generation/distribute.js
@@ -37,6 +37,11 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
     }
   }
 
+  const {
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm
+  } = data
+
   // TODO error on negative data.disposalVolume?
   const disposalVolume = (data.disposalVolume && data.disposalVolume > 0)
     ? data.disposalVolume
@@ -86,7 +91,8 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
               pipette,
               volume: data.volume,
               labware: data.destLabware,
-              well: destWell
+              well: destWell,
+              offsetFromBottomMm: dispenseOffsetFromBottomMm
             }),
             ...touchTipAfterDispenseCommand
           ]
@@ -124,7 +130,9 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
           data.sourceLabware,
           data.sourceWell,
           data.mixBeforeAspirate.volume,
-          data.mixBeforeAspirate.times
+          data.mixBeforeAspirate.times,
+          aspirateOffsetFromBottomMm,
+          dispenseOffsetFromBottomMm
         )
         : []
 
@@ -135,7 +143,8 @@ const distribute = (data: DistributeFormData): CommandCreator => (prevRobotState
           pipette,
           volume: data.volume * destWellChunk.length + disposalVolume,
           labware: data.sourceLabware,
-          well: data.sourceWell
+          well: data.sourceWell,
+          offsetFromBottomMm: aspirateOffsetFromBottomMm
         }),
         ...touchTipAfterAspirateCommand,
 

--- a/protocol-designer/src/step-generation/mix.js
+++ b/protocol-designer/src/step-generation/mix.js
@@ -15,11 +15,13 @@ export function mixUtil (
   labware: string,
   well: string,
   volume: number,
-  times: number
+  times: number,
+  aspirateOffsetFromBottomMm?: ?number,
+  dispenseOffsetFromBottomMm?: ?number
 ): Array<CommandCreator> {
   return repeatArray([
-    aspirate({pipette, volume, labware, well}),
-    dispense({pipette, volume, labware, well})
+    aspirate({pipette, volume, labware, well, offsetFromBottomMm: aspirateOffsetFromBottomMm}),
+    dispense({pipette, volume, labware, well, offsetFromBottomMm: dispenseOffsetFromBottomMm})
   ], times)
 }
 
@@ -36,7 +38,16 @@ const mix = (data: MixFormData): CommandCreator => (prevRobotState: RobotState) 
     * 'never': reuse the tip from the last step
   */
   const actionName = 'mix'
-  const {pipette, labware, wells, volume, times, changeTip} = data
+  const {
+    pipette,
+    labware,
+    wells,
+    volume,
+    times,
+    changeTip,
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm
+  } = data
 
   // Errors
   if (!prevRobotState.instruments[pipette]) {
@@ -77,7 +88,15 @@ const mix = (data: MixFormData): CommandCreator => (prevRobotState: RobotState) 
       })]
       : []
 
-      const mixCommands = mixUtil(pipette, labware, well, volume, times)
+      const mixCommands = mixUtil(
+        pipette,
+        labware,
+        well,
+        volume,
+        times,
+        aspirateOffsetFromBottomMm,
+        dispenseOffsetFromBottomMm
+      )
 
       return [
         ...tipCommands,

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -41,6 +41,11 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
     }
   }
 
+  const {
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm
+  } = data
+
   // TODO error on negative data.disposalVolume?
   const disposalVolume = (data.disposalVolume && data.disposalVolume > 0)
     ? data.disposalVolume
@@ -75,7 +80,15 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
               : []
 
           const preWetTipCommands = (data.preWetTip && chunkIdx === 0)
-            ? mixUtil(data.pipette, data.sourceLabware, sourceWell, Math.max(subTransferVol), 1)
+            ? mixUtil(
+              data.pipette,
+              data.sourceLabware,
+              sourceWell,
+              Math.max(subTransferVol),
+              1,
+              aspirateOffsetFromBottomMm,
+              dispenseOffsetFromBottomMm
+            )
             : []
 
           const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
@@ -84,7 +97,9 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
               data.sourceLabware,
               sourceWell,
               data.mixBeforeAspirate.volume,
-              data.mixBeforeAspirate.times
+              data.mixBeforeAspirate.times,
+              aspirateOffsetFromBottomMm,
+              dispenseOffsetFromBottomMm
             )
             : []
 
@@ -110,7 +125,9 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
               data.destLabware,
               destWell,
               data.mixInDestination.volume,
-              data.mixInDestination.times
+              data.mixInDestination.times,
+              aspirateOffsetFromBottomMm,
+              dispenseOffsetFromBottomMm
             )
             : []
 
@@ -122,14 +139,16 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
               pipette: data.pipette,
               volume: subTransferVol,
               labware: data.sourceLabware,
-              well: sourceWell
+              well: sourceWell,
+              offsetFromBottomMm: aspirateOffsetFromBottomMm
             }),
             ...touchTipAfterAspirateCommands,
             dispense({
               pipette: data.pipette,
               volume: subTransferVol,
               labware: data.destLabware,
-              well: destWell
+              well: destWell,
+              offsetFromBottomMm: dispenseOffsetFromBottomMm
             }),
             ...touchTipAfterDispenseCommands,
             ...mixInDestinationCommands

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -38,6 +38,8 @@ export type TransferLikeFormDataFields = {
   changeTip: ChangeTipOptions,
   /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
   disposalVolume: ?number,
+  /** offset from bottom of well in mm */
+  aspirateOffsetFromBottomMm?: ?number,
 
   // ===== DISPENSE SETTINGS =====
   /** Touch tip in destination well after dispense */
@@ -45,7 +47,9 @@ export type TransferLikeFormDataFields = {
   /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
   delayAfterDispense: ?number,
   /** If given, blow out in the specified labware after dispense at the end of each asp-asp-dispense cycle */
-  blowout: ?string // TODO LATER LabwareId export type here instead of string?
+  blowout: ?string, // TODO LATER LabwareId export type here instead of string?
+  /** offset from bottom of well in mm */
+  dispenseOffsetFromBottomMm?: ?number
 }
 
 export type ConsolidateFormData = {
@@ -99,7 +103,10 @@ export type MixFormData = {
   /** change tip: see comments in step-generation/mix.js */
   changeTip: ChangeTipOptions,
   /** If given, blow out in the specified labware after mixing each well */
-  blowout?: string
+  blowout?: string,
+  /** offset from bottom of well in mm */
+  aspirateOffsetFromBottomMm?: ?number,
+  dispenseOffsetFromBottomMm?: ?number,
 }
 
 export type PauseFormData = {|
@@ -194,7 +201,8 @@ export type PipetteLabwareFields = {|
 
 export type AspirateDispenseArgs = {|
   ...PipetteLabwareFields,
-  volume: number
+  volume: number,
+  offsetFromBottomMm?: ?number
 |}
 
 export type Command = {|

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -3,7 +3,10 @@ import uniq from 'lodash/uniq'
 import {getWellSetForMultichannel} from '../../well-selection/utils'
 import {selectors} from '../index'
 import {selectors as pipetteSelectors} from '../../pipettes'
-import { DEFAULT_MM_FROM_BOTTOM } from '../../constants'
+import {
+  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  DEFAULT_MM_FROM_BOTTOM_DISPENSE
+} from '../../constants'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {BaseState, GetState} from '../../types'
@@ -59,7 +62,7 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
     updateOverrides = {
       ...updateOverrides,
       'aspirate_wells': null,
-      'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+      'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE
     }
   }
 
@@ -68,7 +71,7 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
     updateOverrides = {
       ...updateOverrides,
       'dispense_wells': null,
-      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
     }
   }
 
@@ -77,7 +80,9 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
     updateOverrides = {
       ...updateOverrides,
       'wells': null,
-      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+      // TODO: Ian 2018-09-03 should we have both asp/disp for Mix?
+      // if not, is dispense the right choice vs aspirate?
+      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
     }
   }
 

--- a/protocol-designer/src/steplist/formLevel/generateNewForm.js
+++ b/protocol-designer/src/steplist/formLevel/generateNewForm.js
@@ -9,7 +9,8 @@ import type {
 
 import {
   DEFAULT_CHANGE_TIP_OPTION,
-  DEFAULT_MM_FROM_BOTTOM,
+  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  DEFAULT_MM_FROM_BOTTOM_DISPENSE,
   DEFAULT_WELL_ORDER_FIRST_OPTION,
   DEFAULT_WELL_ORDER_SECOND_OPTION,
   FIXED_TRASH_ID
@@ -33,36 +34,36 @@ export const getDefaultsForStepType = (stepType: StepType) => {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
-        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM,
+        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
-        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
       }
     case 'consolidate':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
-        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM,
+        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
-        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
       }
     case 'mix':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
-        'mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+        'mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE // NOTE: mix uses dispense for both asp + disp, for now
       }
     case 'distribute':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
         'aspirate_disposalVol_checkbox': true,
-        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM,
+        'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_blowout_checkbox': true,
         'dispense_blowout_labware': FIXED_TRASH_ID,
-        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM
+        'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -44,6 +44,10 @@ const mixFormToArgs = (formData: FormData, context: StepFormContext): Validation
 
   const volume = Number(formData.volume) || 0
   const times = Number(formData.times) || 0
+  // NOTE: for mix, there is only one tip offset field,
+  // and it applies to both aspirate and dispense
+  const aspirateOffsetFromBottomMm = Number(formData['mmFromBottom'])
+  const dispenseOffsetFromBottomMm = Number(formData['mmFromBottom'])
 
   // It's radiobutton, so one should always be selected.
   const changeTip = formData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
@@ -86,7 +90,9 @@ const mixFormToArgs = (formData: FormData, context: StepFormContext): Validation
         delay,
         changeTip,
         blowout,
-        pipette
+        pipette,
+        aspirateOffsetFromBottomMm,
+        dispenseOffsetFromBottomMm
       }
       : null
   }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -40,8 +40,8 @@ const transferLikeFormToArgs = (formData: FormData, context: StepFormContext): T
   const destLabware = formData['dispense_labware']
   const blowout = formData['dispense_blowout_labware']
 
-  const aspirateOffsetFromBottomMm = formData['aspirate_mmFromBottom']
-  const dispenseOffsetFromBottomMm = formData['dispense_mmFromBottom']
+  const aspirateOffsetFromBottomMm = Number(formData['aspirate_mmFromBottom'])
+  const dispenseOffsetFromBottomMm = Number(formData['dispense_mmFromBottom'])
 
   const delayAfterDispense = formData['dispense_delay_checkbox']
     ? ((Number(formData['dispense_delayMinutes']) || 0) * 60) +

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -40,6 +40,9 @@ const transferLikeFormToArgs = (formData: FormData, context: StepFormContext): T
   const destLabware = formData['dispense_labware']
   const blowout = formData['dispense_blowout_labware']
 
+  const aspirateOffsetFromBottomMm = formData['aspirate_mmFromBottom']
+  const dispenseOffsetFromBottomMm = formData['dispense_mmFromBottom']
+
   const delayAfterDispense = formData['dispense_delay_checkbox']
     ? ((Number(formData['dispense_delayMinutes']) || 0) * 60) +
       (Number(formData['dispense_delaySeconds'] || 0))
@@ -78,6 +81,9 @@ const transferLikeFormToArgs = (formData: FormData, context: StepFormContext): T
 
     sourceLabware,
     destLabware,
+
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm,
 
     blowout, // TODO allow user to blowout
     changeTip,

--- a/shared-data/protocol-json-schema/protocol-schema.json
+++ b/shared-data/protocol-json-schema/protocol-schema.json
@@ -48,32 +48,12 @@
       }
     },
 
-    "well-position-params": {
-      "description": "Optional params for well position offsets",
-      "type": "object",
+    "offset-from-bottom-mm": {
+      "description": "Offset from bottom of well in millimeters",
       "properties": {
-        "position": {
-          "required": ["anchor"],
-          "additionalProperties": false,
-          "properties": {
-            "anchor": {
-              "description": "The anchor, or origin point at which the offsets are applied. (It's always in the X/Y center of the well, but varies the Z)",
-              "type": "string",
-              "enum": ["top", "bottom", "center"]
-            },
-            "offset": {
-              "description": "Optional x, y, and z offsets from the anchor point in millimeters. Negative values are allowed",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "x": {"$ref": "#/definitions/mm-offset"},
-                "y": {"$ref": "#/definitions/mm-offset"},
-                "z": {"$ref": "#/definitions/mm-offset"}
-              }
-            }
-          }
-        }
-      }
+        "offset-from-bottom-mm": {"$ref": "#/definitions/mm-offset"}
+      },
+      "additionalProperties": false
     },
 
     "pipette-access-params": {
@@ -166,11 +146,15 @@
       "type": "object",
       "required": [
         "aspirate-flow-rate",
-        "dispense-flow-rate"
+        "dispense-flow-rate",
+        "aspirate-mm-from-bottom",
+        "dispense-mm-from-bottom"
       ],
       "properties": {
         "aspirate-flow-rate": {"$ref": "#/definitions/flow-rate-for-pipettes"},
-        "dispense-flow-rate": {"$ref": "#/definitions/flow-rate-for-pipettes"}
+        "dispense-flow-rate": {"$ref": "#/definitions/flow-rate-for-pipettes"},
+        "aspirate-mm-from-bottom": {"$ref": "#/definitions/mm-offset"},
+        "dispense-mm-from-bottom": {"$ref": "#/definitions/mm-offset"}
       }
     },
 
@@ -292,7 +276,7 @@
                         {"$ref": "#/definitions/flow-rate-params"},
                         {"$ref": "#/definitions/pipette-access-params"},
                         {"$ref": "#/definitions/volume-params"},
-                        {"$ref": "#/definitions/well-position-params"}
+                        {"$ref": "#/definitions/offset-from-bottom-mm"}
                       ]
                     }
                   }
@@ -309,8 +293,7 @@
                     },
                     "params": {
                       "allOf": [
-                        {"$ref": "#/definitions/pipette-access-params"},
-                        {"$ref": "#/definitions/well-position-params"}
+                        {"$ref": "#/definitions/pipette-access-params"}
                       ]
                     }
                   }

--- a/shared-data/protocol-json-schema/protocol-schema.json
+++ b/shared-data/protocol-json-schema/protocol-schema.json
@@ -48,12 +48,11 @@
       }
     },
 
-    "offset-from-bottom-mm": {
+    "offsetFromBottomMm": {
       "description": "Offset from bottom of well in millimeters",
       "properties": {
-        "offset-from-bottom-mm": {"$ref": "#/definitions/mm-offset"}
-      },
-      "additionalProperties": false
+        "offsetFromBottomMm": {"$ref": "#/definitions/mm-offset"}
+      }
     },
 
     "pipette-access-params": {
@@ -276,7 +275,7 @@
                         {"$ref": "#/definitions/flow-rate-params"},
                         {"$ref": "#/definitions/pipette-access-params"},
                         {"$ref": "#/definitions/volume-params"},
-                        {"$ref": "#/definitions/offset-from-bottom-mm"}
+                        {"$ref": "#/definitions/offsetFromBottomMm"}
                       ]
                     }
                   }


### PR DESCRIPTION
## overview

Closes #2157

- JSON protocols store default mm from bottom, for aspirate and for dispense, in "default-values" key
- Aspirate and dispense commands have optional parameter to offset mm from bottom, which when specified is used instead of the "default-values" offset
- API defaults for mm from bottom on aspirate/dispense are never used (unless the JSON doesn't include the new "default-values")

## changelog

- PD: split out generic "offset from bottom" into 2: one for aspirate and one for dispense. I copied over the defaults that the API is using now: 1mm and 0.5mm for asp/disp respectively.
- Hook up tip positioning fields from form to step generation fns so they're saved into the commands list and thus the JSON file
- API's JSON executor, and JSON schema, updated to support explicit mm from bottom (should be backwards-compatible)

## review requests

- [ ] Test on updated robot with new protocol build in this version of PD. You'll need to `make push` to the robot to get the updated JSON executor code in there. (As of tuesday sept 4, bitter-wood has this pushed to it, but please double-check.) Transfer/consolidate/distribute should use given tip positioning, and mix should too (mix is a little different b/c it sets aspirate and dispense offsets together in one field, the others have separate aspirate/dispense offset fields).