### PR TITLE
Api add network info endpoint

### DIFF
--- a/api/opentrons/server/endpoints/wifi.py
+++ b/api/opentrons/server/endpoints/wifi.py
@@ -80,17 +80,28 @@ async def status(request):
     Get request will return the status of the wifi connection from the
     RaspberryPi to the internet.
 
-    Options are:
+    The body of the response is a json dict containing
+
+    'status': connectivity status, where the options are:
       "none" - no connection to router or network
       "portal" - device behind a captive portal and cannot reach full internet
       "limited" - connection to router but not internet
       "full" - connection to router and internet
       "unknown" - an exception occured while trying to determine status
-
+    'ipAddress': the ip address, if it exists (null otherwise); this also
+                 contains the subnet mask in CIDR notation, e.g. 10.2.12.120/16
+    'macAddress': the mac address
+    'gatewayAddress': the address of the current gateway, if it exists (null
+                      otherwise)
     """
-    connectivity = {"status": "unknown"}
+    connectivity = {'status': 'none',
+                    'ipAddress': None,
+                    'macAddress': 'unknown',
+                    'gatewayAddress': None}
     try:
         connectivity['status'] = await nmcli.is_connected()
+        net_info = await nmcli.iface_info('wlan0')
+        connectivity.update(net_info)
         log.debug("Connectivity: {}".format(connectivity['status']))
         status = 200
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## overview

Adds additional network information to the `GET /wifi/status` endpoint. In particular, this now returns
- The IP address of the interface, with its subnet in CIDR format
- The IP address of the interface's gateway
- The MAC address of the interface

If any of these fields aren't found (e.g. if the interface is disconnected, or has a setup where there's no gateway somehow) they'll be null.

For instance, a robot connected to a wifi network might look like:

`GET /wifi/status`

```
200 OK
{
    "status": "full",
    "ipAddress": "192.168.1.137/24",
    "macAddress": "3A:1A:4A:5E:D4:66",
    "gatewayAddress": "192.168.1.1"
}
```

while a robot that is not connected might return

```
200 OK
{
    "status": "none",
    "ipAddress": null,
    "macAddress": "3A:1A:4A:5E:D4:66",
    "gatewayAddress": null
}
```

## review requests

Frontend people, please let me know if you'd like any changes to the shape of this endpoint.

Closes #2136 