### PR TITLE
feat(api): Add hidden ssid wifi support

### DIFF
--- a/api/opentrons/server/endpoints/wifi.py
+++ b/api/opentrons/server/endpoints/wifi.py
@@ -41,6 +41,8 @@ async def configure(request):
                        - psk is also not specified: assumed to be 'none'
                        - psk is specified: assumed to be 'wpa2-psk'
     psk: str Optional. The password for the network, if there is one.
+    hidden: bool Optional. True if the network is not broadcasting its
+                           SSID. If not specified, assumed to be False.
     """
     result = {}
 
@@ -48,6 +50,7 @@ async def configure(request):
         body = await request.json()
         ssid = body.get('ssid')
         psk = body.get('psk')
+        hidden = body.get('hidden')
         security = body.get('security_type')
 
         if ssid is None:
@@ -56,7 +59,8 @@ async def configure(request):
         else:
             ok, message = await nmcli.configure(ssid,
                                                 security_type=security,
-                                                psk=psk)
+                                                psk=psk,
+                                                hidden=hidden)
             status = 201 if ok else 401
             result['ssid'] = ssid
 

--- a/api/opentrons/system/nmcli.py
+++ b/api/opentrons/system/nmcli.py
@@ -170,7 +170,7 @@ async def configure(ssid, # noqa(C901) There is a lot of work that will be done
     if psk:
         configure_cmd += ['wifi-sec.psk', psk]
     if hidden:
-        configure_cmd += ['hidden', 'true']
+        configure_cmd += ['wifi.hidden', 'true']
     res, err = await _call(configure_cmd)
     # nmcli connection add returns a string that looks like
     # "Connection ’connection-name’ (connection-uuid) successfully added."

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -62,7 +62,7 @@ async def test_wifi_configure(
 
     msg = "Device 'wlan0' successfully activated with '076aa998-0275-4aa0-bf85-e9629021e267'."  # noqa
 
-    async def mock_configure(ssid, security_type=None, psk=None):
+    async def mock_configure(ssid, security_type=None, psk=None, hidden=False):
         # Command: nmcli device wifi connect "{ssid}" password "{psk}"
         return True, msg
 


### PR DESCRIPTION
Fix the hidden flag in the nmcli module and expose it to the REST interface.

Closes #2137 

If anybody wants a router to test with I have an el clasico WRT54G that can be set up to do so.