### PR TITLE
feat(api): Add container definitions for opentrons alumnium block set

### DIFF
--- a/api/opentrons/config/containers/default-containers.json
+++ b/api/opentrons/config/containers/default-containers.json
@@ -24630,6 +24630,1958 @@
                          "total-liquid-volume": 2000
                     }
                }
+          },
+          "opentrons-aluminum-block-2ml-eppendorf": {
+               "origin-offset": {
+                    "x": 25.88,
+                    "y": 20.75
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B1": {
+                         "x": 17.25,
+                         "y": 0,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C1": {
+                         "x": 34.5,
+                         "y": 0,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D1": {
+                         "x": 51.75,
+                         "y": 0,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A2": {
+                         "x": 0,
+                         "y": 17.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B2": {
+                         "x": 17.25,
+                         "y": 17.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C2": {
+                         "x": 34.5,
+                         "y": 17.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D2": {
+                         "x": 51.75,
+                         "y": 17.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A3": {
+                         "x": 0,
+                         "y": 34.5,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B3": {
+                         "x": 17.25,
+                         "y": 34.5,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C3": {
+                         "x": 34.5,
+                         "y": 34.5,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D3": {
+                         "x": 51.75,
+                         "y": 34.5,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A4": {
+                         "x": 0,
+                         "y": 51.75,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B4": {
+                         "x": 17.25,
+                         "y": 51.75,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C4": {
+                         "x": 34.5,
+                         "y": 51.75,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D4": {
+                         "x": 51.75,
+                         "y": 51.75,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A5": {
+                         "x": 0,
+                         "y": 69,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B5": {
+                         "x": 17.25,
+                         "y": 69,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C5": {
+                         "x": 34.5,
+                         "y": 69,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D5": {
+                         "x": 51.75,
+                         "y": 69,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A6": {
+                         "x": 0,
+                         "y": 86.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B6": {
+                         "x": 17.25,
+                         "y": 86.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C6": {
+                         "x": 34.5,
+                         "y": 86.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D6": {
+                         "x": 51.75,
+                         "y": 86.25,
+                         "z": 5.5,
+                         "depth": 38.5,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    }
+               }
+          },
+       "opentrons-aluminum-block-2ml-screwcap": {
+               "origin-offset": {
+                    "x": 25.88,
+                    "y": 20.75
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B1": {
+                         "x": 17.25,
+                         "y": 0,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C1": {
+                         "x": 34.5,
+                         "y": 0,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D1": {
+                         "x": 51.75,
+                         "y": 0,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A2": {
+                         "x": 0,
+                         "y": 17.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B2": {
+                         "x": 17.25,
+                         "y": 17.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C2": {
+                         "x": 34.5,
+                         "y": 17.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D2": {
+                         "x": 51.75,
+                         "y": 17.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A3": {
+                         "x": 0,
+                         "y": 34.5,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B3": {
+                         "x": 17.25,
+                         "y": 34.5,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C3": {
+                         "x": 34.5,
+                         "y": 34.5,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D3": {
+                         "x": 51.75,
+                         "y": 34.5,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A4": {
+                         "x": 0,
+                         "y": 51.75,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B4": {
+                         "x": 17.25,
+                         "y": 51.75,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C4": {
+                         "x": 34.5,
+                         "y": 51.75,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D4": {
+                         "x": 51.75,
+                         "y": 51.75,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A5": {
+                         "x": 0,
+                         "y": 69,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B5": {
+                         "x": 17.25,
+                         "y": 69,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C5": {
+                         "x": 34.5,
+                         "y": 69,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D5": {
+                         "x": 51.75,
+                         "y": 69,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "A6": {
+                         "x": 0,
+                         "y": 86.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "B6": {
+                         "x": 17.25,
+                         "y": 86.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "C6": {
+                         "x": 34.5,
+                         "y": 86.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    },
+                    "D6": {
+                         "x": 51.75,
+                         "y": 86.25,
+                         "z": 6.5,
+                         "depth": 42,
+                         "diameter": 9,
+                         "total-liquid-volume": 2000
+                    }
+               }
+          },
+          "opentrons-aluminum-block-96-PCR-plate": {
+               "origin-offset": {
+                    "x": 11.25,
+                    "y": 14.38
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B1": {
+                         "x": 9,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C1": {
+                         "x": 18,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D1": {
+                         "x": 27,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E1": {
+                         "x": 36,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F1": {
+                         "x": 45,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G1": {
+                         "x": 54,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H1": {
+                         "x": 63,
+                         "y": 0,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A2": {
+                         "x": 0,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B2": {
+                         "x": 9,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C2": {
+                         "x": 18,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D2": {
+                         "x": 27,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E2": {
+                         "x": 36,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F2": {
+                         "x": 45,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G2": {
+                         "x": 54,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H2": {
+                         "x": 63,
+                         "y": 9,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A3": {
+                         "x": 0,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B3": {
+                         "x": 9,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C3": {
+                         "x": 18,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D3": {
+                         "x": 27,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E3": {
+                         "x": 36,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F3": {
+                         "x": 45,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G3": {
+                         "x": 54,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H3": {
+                         "x": 63,
+                         "y": 18,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A4": {
+                         "x": 0,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B4": {
+                         "x": 9,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C4": {
+                         "x": 18,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D4": {
+                         "x": 27,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E4": {
+                         "x": 36,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F4": {
+                         "x": 45,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G4": {
+                         "x": 54,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H4": {
+                         "x": 63,
+                         "y": 27,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A5": {
+                         "x": 0,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B5": {
+                         "x": 9,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C5": {
+                         "x": 18,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D5": {
+                         "x": 27,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E5": {
+                         "x": 36,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F5": {
+                         "x": 45,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G5": {
+                         "x": 54,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H5": {
+                         "x": 63,
+                         "y": 36,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A6": {
+                         "x": 0,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B6": {
+                         "x": 9,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C6": {
+                         "x": 18,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D6": {
+                         "x": 27,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E6": {
+                         "x": 36,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F6": {
+                         "x": 45,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G6": {
+                         "x": 54,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H6": {
+                         "x": 63,
+                         "y": 45,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A7": {
+                         "x": 0,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B7": {
+                         "x": 9,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C7": {
+                         "x": 18,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D7": {
+                         "x": 27,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E7": {
+                         "x": 36,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F7": {
+                         "x": 45,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G7": {
+                         "x": 54,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H7": {
+                         "x": 63,
+                         "y": 54,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A8": {
+                         "x": 0,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B8": {
+                         "x": 9,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C8": {
+                         "x": 18,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D8": {
+                         "x": 27,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E8": {
+                         "x": 36,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F8": {
+                         "x": 45,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G8": {
+                         "x": 54,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H8": {
+                         "x": 63,
+                         "y": 63,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A9": {
+                         "x": 0,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B9": {
+                         "x": 9,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C9": {
+                         "x": 18,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D9": {
+                         "x": 27,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E9": {
+                         "x": 36,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F9": {
+                         "x": 45,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G9": {
+                         "x": 54,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H9": {
+                         "x": 63,
+                         "y": 72,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A10": {
+                         "x": 0,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B10": {
+                         "x": 9,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C10": {
+                         "x": 18,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D10": {
+                         "x": 27,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E10": {
+                         "x": 36,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F10": {
+                         "x": 45,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G10": {
+                         "x": 54,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H10": {
+                         "x": 63,
+                         "y": 81,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A11": {
+                         "x": 0,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B11": {
+                         "x": 9,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C11": {
+                         "x": 18,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D11": {
+                         "x": 27,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E11": {
+                         "x": 36,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F11": {
+                         "x": 45,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G11": {
+                         "x": 54,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H11": {
+                         "x": 63,
+                         "y": 90,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A12": {
+                         "x": 0,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B12": {
+                         "x": 9,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C12": {
+                         "x": 18,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D12": {
+                         "x": 27,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E12": {
+                         "x": 36,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F12": {
+                         "x": 45,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G12": {
+                         "x": 54,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H12": {
+                         "x": 63,
+                         "y": 99,
+                         "z": 7.44,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    }
+               }
+          },
+           "opentrons-aluminum-block-PCR-strips": {
+               "origin-offset": {
+                    "x": 11.25,
+                    "y": 14.38
+               },
+               "locations": {
+                    "A1": {
+                         "x": 0,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B1": {
+                         "x": 9,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C1": {
+                         "x": 18,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D1": {
+                         "x": 27,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E1": {
+                         "x": 36,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F1": {
+                         "x": 45,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G1": {
+                         "x": 54,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H1": {
+                         "x": 63,
+                         "y": 0,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A2": {
+                         "x": 0,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B2": {
+                         "x": 9,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C2": {
+                         "x": 18,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D2": {
+                         "x": 27,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E2": {
+                         "x": 36,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F2": {
+                         "x": 45,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G2": {
+                         "x": 54,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H2": {
+                         "x": 63,
+                         "y": 9,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A3": {
+                         "x": 0,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B3": {
+                         "x": 9,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C3": {
+                         "x": 18,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D3": {
+                         "x": 27,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E3": {
+                         "x": 36,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F3": {
+                         "x": 45,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G3": {
+                         "x": 54,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H3": {
+                         "x": 63,
+                         "y": 18,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A4": {
+                         "x": 0,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B4": {
+                         "x": 9,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C4": {
+                         "x": 18,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D4": {
+                         "x": 27,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E4": {
+                         "x": 36,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F4": {
+                         "x": 45,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G4": {
+                         "x": 54,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H4": {
+                         "x": 63,
+                         "y": 27,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A5": {
+                         "x": 0,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B5": {
+                         "x": 9,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C5": {
+                         "x": 18,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D5": {
+                         "x": 27,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E5": {
+                         "x": 36,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F5": {
+                         "x": 45,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G5": {
+                         "x": 54,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H5": {
+                         "x": 63,
+                         "y": 36,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A6": {
+                         "x": 0,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B6": {
+                         "x": 9,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C6": {
+                         "x": 18,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D6": {
+                         "x": 27,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E6": {
+                         "x": 36,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F6": {
+                         "x": 45,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G6": {
+                         "x": 54,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H6": {
+                         "x": 63,
+                         "y": 45,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A7": {
+                         "x": 0,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B7": {
+                         "x": 9,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C7": {
+                         "x": 18,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D7": {
+                         "x": 27,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E7": {
+                         "x": 36,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F7": {
+                         "x": 45,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G7": {
+                         "x": 54,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H7": {
+                         "x": 63,
+                         "y": 54,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A8": {
+                         "x": 0,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B8": {
+                         "x": 9,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C8": {
+                         "x": 18,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D8": {
+                         "x": 27,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E8": {
+                         "x": 36,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F8": {
+                         "x": 45,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G8": {
+                         "x": 54,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H8": {
+                         "x": 63,
+                         "y": 63,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A9": {
+                         "x": 0,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B9": {
+                         "x": 9,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C9": {
+                         "x": 18,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D9": {
+                         "x": 27,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E9": {
+                         "x": 36,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F9": {
+                         "x": 45,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G9": {
+                         "x": 54,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H9": {
+                         "x": 63,
+                         "y": 72,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A10": {
+                         "x": 0,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B10": {
+                         "x": 9,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C10": {
+                         "x": 18,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D10": {
+                         "x": 27,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E10": {
+                         "x": 36,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F10": {
+                         "x": 45,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G10": {
+                         "x": 54,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H10": {
+                         "x": 63,
+                         "y": 81,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A11": {
+                         "x": 0,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B11": {
+                         "x": 9,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C11": {
+                         "x": 18,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D11": {
+                         "x": 27,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E11": {
+                         "x": 36,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F11": {
+                         "x": 45,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G11": {
+                         "x": 54,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H11": {
+                         "x": 63,
+                         "y": 90,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "A12": {
+                         "x": 0,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "B12": {
+                         "x": 9,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "C12": {
+                         "x": 18,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "D12": {
+                         "x": 27,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "E12": {
+                         "x": 36,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "F12": {
+                         "x": 45,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "G12": {
+                         "x": 54,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    },
+                    "H12": {
+                         "x": 63,
+                         "y": 99,
+                         "z": 9.69,
+                         "depth": 14.81,
+                         "diameter": 5.4,
+                         "total-liquid-volume": 300
+                    }
+               }
           }
      }
 }


### PR DESCRIPTION
## overview

Closes #2184. 

## changelog

- Adds container definitions for the following:
`opentrons-aluminum-block-2ml-eppendorf`
`opentrons-aluminum-block-2ml-screwcap`
`opentrons-aluminum-block-96-PCR-plate`
`opentrons-aluminum-block-PCR-strips`

## review requests

Pls test on your robot (pre- and post calibration behaviors) with this protocol:
```
from opentrons import labware, instruments, robot

pcr_plate = labware.load('opentrons-aluminum-block-96-PCR-plate', '1')
pcr_tube = labware.load('opentrons-aluminum-block-PCR-strips', '2')
tubes_eppendorf = labware.load('opentrons-aluminum-block-2ml-eppendorf', '3')
tubes_screwcap = labware.load('opentrons-aluminum-block-2ml-screwcap', '4')
tiprack = labware.load('tiprack-10ul', '6')
pipette = instruments.P10_Single(mount='right', tip_racks=[tiprack])

pipette.pick_up_tip()
pipette.distribute(1, pcr_plate.wells('A1'), pcr_plate.wells('B1', to='H12'), new_tip='never')
robot.pause()
pipette.distribute(1, pcr_tube.wells('A1'), pcr_tube.wells('B1', to='H12'), new_tip='never')
robot.pause()
pipette.distribute(1, tubes_eppendorf.wells('A1'), tubes_eppendorf.wells('B1', to='D6'), new_tip='never')
robot.pause()
pipette.distribute(1, tubes_screwcap.wells('A1'), tubes_screwcap.wells('B1', to='D6'), new_tip='never')
robot.pause()
pipette.return_tip()
```
Check that it is..
1. Roughly center in well A1 for pre-calibration
2. After calibration adjustments, nothing crazy happens