### PR TITLE
feat(discovery-client): Add /server/update/health check to poller

### DIFF
--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -383,6 +383,35 @@ describe('discovery client', () => {
   )
 
   test(
+    'if both polls comes back bad, oks should be flagged false',
+    done => {
+      const client = DiscoveryClient({
+        services: [
+          {
+            name: 'opentrons-dev',
+            ip: '192.168.1.42',
+            port: 31950,
+            ok: null,
+            serverOk: null
+          }
+        ]
+      })
+
+      client.once('service', () => {
+        expect(client.services).toHaveLength(1)
+        expect(client.services[0].ok).toBe(false)
+        expect(client.services[0].serverOk).toBe(false)
+        done()
+      })
+
+      client.start()
+      const onHealth = poller.poll.mock.calls[0][2]
+      onHealth({ ip: '192.168.1.42', port: 31950 }, null, null)
+    },
+    10
+  )
+
+  test(
     'if names come back conflicting, prefer /server and set ok to false',
     done => {
       const client = DiscoveryClient({

--- a/discovery-client/src/__tests__/poller.test.js
+++ b/discovery-client/src/__tests__/poller.test.js
@@ -79,9 +79,9 @@ describe('discovery poller', () => {
     expect(fetch).toHaveBeenCalledWith(`http://foo:31950/health`)
     expect(fetch).toHaveBeenCalledWith(`http://bar:31950/health`)
     expect(fetch).toHaveBeenCalledWith(`http://baz:31950/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/server/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/server/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/server/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/server/update/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/server/update/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/server/update/health`)
   })
 
   test(

--- a/discovery-client/src/__tests__/poller.test.js
+++ b/discovery-client/src/__tests__/poller.test.js
@@ -1,12 +1,12 @@
 import fetch from 'node-fetch'
-import {poll, stop} from '../poller'
+import { poll, stop } from '../poller'
 
 jest.mock('node-fetch')
 
 describe('discovery poller', () => {
   beforeEach(() => {
     jest.useFakeTimers()
-    fetch.__setMockResponse({ok: false})
+    fetch.__setMockResponse({ ok: false })
   })
 
   afterEach(() => {
@@ -21,16 +21,20 @@ describe('discovery poller', () => {
   })
 
   test('sets an interval to poll candidates evenly', () => {
-    poll([{ip: 'foo', port: 31950}, {ip: 'bar', port: 31950}], 6000, jest.fn())
+    poll(
+      [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
+      6000,
+      jest.fn()
+    )
 
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 3000)
     setInterval.mockClear()
 
     poll(
       [
-        {ip: 'foo', port: 31950},
-        {ip: 'bar', port: 31950},
-        {ip: 'baz', port: 31950}
+        { ip: 'foo', port: 31950 },
+        { ip: 'bar', port: 31950 },
+        { ip: 'baz', port: 31950 }
       ],
       6000,
       jest.fn()
@@ -44,7 +48,7 @@ describe('discovery poller', () => {
     setInterval.mockReturnValueOnce(intervalId)
 
     const request = poll(
-      [{ip: 'foo', port: 31950}, {ip: 'bar', port: 31950}],
+      [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
       6000,
       jest.fn()
     )
@@ -53,7 +57,7 @@ describe('discovery poller', () => {
   })
 
   test('can stop polling', () => {
-    const request = {id: 1234}
+    const request = { id: 1234 }
 
     stop(request)
     expect(clearInterval).toHaveBeenCalledWith(1234)
@@ -62,60 +66,114 @@ describe('discovery poller', () => {
   test('calls fetch health for all candidates in an interval', () => {
     poll(
       [
-        {ip: 'foo', port: 31950},
-        {ip: 'bar', port: 31950},
-        {ip: 'baz', port: 31950}
+        { ip: 'foo', port: 31950 },
+        { ip: 'bar', port: 31950 },
+        { ip: 'baz', port: 31950 }
       ],
       6000,
       jest.fn()
     )
 
     jest.runTimersToTime(6000)
-    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(fetch).toHaveBeenCalledTimes(6)
     expect(fetch).toHaveBeenCalledWith(`http://foo:31950/health`)
     expect(fetch).toHaveBeenCalledWith(`http://bar:31950/health`)
     expect(fetch).toHaveBeenCalledWith(`http://baz:31950/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/server/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/server/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/server/health`)
   })
 
-  test('calls onHealth with health response if successful', done => {
-    fetch.__setMockResponse({
-      ok: true,
-      json: () => Promise.resolve({name: 'foo'})
-    })
+  test(
+    'calls onHealth with health response if successful',
+    done => {
+      fetch.__setMockResponse({
+        ok: true,
+        json: () => Promise.resolve({ name: 'foo' })
+      })
 
-    poll([{ip: 'foo', port: 31950}], 1000, (candidate, response) => {
-      expect(candidate).toEqual({ip: 'foo', port: 31950})
-      expect(response).toEqual({name: 'foo'})
-      done()
-    })
+      poll(
+        [{ ip: 'foo', port: 31950 }],
+        1000,
+        (candidate, apiRes, serverRes) => {
+          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
+          expect(apiRes).toEqual({ name: 'foo' })
+          expect(serverRes).toEqual({ name: 'foo' })
+          done()
+        }
+      )
 
-    jest.runTimersToTime(1000)
-  })
+      jest.runTimersToTime(1000)
+    },
+    10
+  )
 
-  test('calls onHealth with null response if fetch not ok', done => {
-    fetch.__setMockResponse({
-      ok: false,
-      json: () => Promise.resolve({message: 'oh no!'})
-    })
+  test(
+    'calls onHealth with null response if fetch not ok',
+    done => {
+      fetch.__setMockResponse({
+        ok: false,
+        json: () => Promise.resolve({ message: 'oh no!' })
+      })
 
-    poll([{ip: 'foo', port: 31950}], 1000, (candidate, response) => {
-      expect(candidate).toEqual({ip: 'foo', port: 31950})
-      expect(response).toEqual(null)
-      done()
-    })
+      poll(
+        [{ ip: 'foo', port: 31950 }],
+        1000,
+        (candidate, apiRes, serverRes) => {
+          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
+          expect(apiRes).toEqual(null)
+          expect(serverRes).toEqual(null)
+          done()
+        }
+      )
 
-    jest.runTimersToTime(1000)
-  })
+      jest.runTimersToTime(1000)
+    },
+    10
+  )
 
-  test('calls onHealth with null response if fetch rejects', done => {
-    fetch.__setMockError(new Error('failed to fetch'))
+  test(
+    'calls onHealth with null response if fetch rejects',
+    done => {
+      fetch.__setMockError(new Error('failed to fetch'))
 
-    poll([{ip: 'foo', port: 31950}], 1000, (candidate, response) => {
-      expect(candidate).toEqual({ip: 'foo', port: 31950})
-      expect(response).toEqual(null)
-      done()
-    })
+      poll(
+        [{ ip: 'foo', port: 31950 }],
+        1000,
+        (candidate, apiRes, serverRes) => {
+          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
+          expect(apiRes).toEqual(null)
+          expect(serverRes).toEqual(null)
+          done()
+        }
+      )
 
-    jest.runTimersToTime(1000)
-  })
+      jest.runTimersToTime(1000)
+    },
+    10
+  )
+
+  test(
+    'calls onHealth with null response if JSON parse rejects',
+    done => {
+      fetch.__setMockResponse({
+        ok: true,
+        json: () => Promise.reject(new Error('oh no!'))
+      })
+
+      poll(
+        [{ ip: 'foo', port: 31950 }],
+        1000,
+        (candidate, apiRes, serverRes) => {
+          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
+          expect(apiRes).toEqual(null)
+          expect(serverRes).toEqual(null)
+          done()
+        }
+      )
+
+      jest.runTimersToTime(1000)
+    },
+    10
+  )
 })

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -208,7 +208,10 @@ export class DiscoveryClient extends EventEmitter {
     // else, response was not ok, so unset ok flag in all matching ips
     const { ip } = candidate
     const nextServices = this.services.map(
-      s => (s.ip === ip && s.ok !== false ? { ...s, ok: false } : s)
+      s =>
+        s.ip === ip && (s.ok !== false || s.serverOk !== false)
+          ? { ...s, ok: false, serverOk: false }
+          : s
     )
 
     this._updateServiceList(nextServices)

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -45,9 +45,9 @@ type Options = {
 const log = (logger: ?Logger, level: LogLevel, msg: string, meta?: {}) =>
   logger && typeof logger[level] === 'function' && logger[level](msg, meta)
 
-const santizeRe = (patterns: ?(Array<string | RegExp>)) => {
+const santizeRe = (patterns: ?Array<string | RegExp>) => {
   if (!patterns) return []
-  return patterns.map(p => typeof p === 'string' ? escape(p) : p)
+  return patterns.map(p => (typeof p === 'string' ? escape(p) : p))
 }
 
 export default function DiscoveryClientFactory (options?: Options) {
@@ -59,7 +59,7 @@ export const SERVICE_REMOVED_EVENT: 'serviceRemoved' = 'serviceRemoved'
 export const DEFAULT_POLL_INTERVAL = 5000
 export { DEFAULT_PORT }
 
-const TO_REGEX_OPTS = {contains: true, nocase: true, safe: true}
+const TO_REGEX_OPTS = { contains: true, nocase: true, safe: true }
 
 export class DiscoveryClient extends EventEmitter {
   services: Array<Service>
@@ -76,7 +76,11 @@ export class DiscoveryClient extends EventEmitter {
     super()
 
     // null out ok flag for pre-populated services
-    this.services = (options.services || []).map(s => ({ ...s, ok: null }))
+    this.services = (options.services || []).map(s => ({
+      ...s,
+      ok: null,
+      serverOk: null
+    }))
 
     // allow strings instead of full {ip: string, port: ?number} object
     this.candidates = (options.candidates || [])
@@ -192,8 +196,12 @@ export class DiscoveryClient extends EventEmitter {
     if (service) this._handleService(service)
   }
 
-  _handleHealth (candidate: Candidate, response: ?HealthResponse): mixed {
-    const service = fromResponse(candidate, response)
+  _handleHealth (
+    candidate: Candidate,
+    apiResponse: ?HealthResponse,
+    serverResponse: ?HealthResponse
+  ): mixed {
+    const service = fromResponse(candidate, apiResponse, serverResponse)
 
     if (service) return this._handleService(service)
 
@@ -207,12 +215,10 @@ export class DiscoveryClient extends EventEmitter {
   }
 
   _handleService (service: Service): mixed {
-    const { name, ip, port, ok } = service
-
     if (
-      !this._nameFilter.test(name) ||
-      !this._ipFilter.test(ip || '') ||
-      !this._portFilter.includes(port)
+      !this._nameFilter.test(service.name) ||
+      !this._ipFilter.test(service.ip || '') ||
+      !this._portFilter.includes(service.port)
     ) {
       log(this._logger, 'debug', 'Ignoring service', service)
       return
@@ -230,10 +236,19 @@ export class DiscoveryClient extends EventEmitter {
 
     // update existing services and null out conflics
     nextServices = nextServices.map(s => {
-      // if we have a service already, make sure not to reset ok to null
-      if (s === prevService && s.ok !== ok && ok !== null) return service
-      if (serviceConflicts.includes(s)) return { ...s, ip: null, ok: null }
-      return s
+      // if we have a service already, make sure not to reset oks to null
+      if (s === prevService) {
+        const newOk = s.ok == null ? service.ok : s.ok
+        const newServerOk = s.serverOk == null ? service.serverOk : s.serverOk
+
+        return newOk !== s.ok || newServerOk !== s.serverOk
+          ? { ...service, ok: newOk, serverOk: newServerOk }
+          : s
+      }
+
+      return serviceConflicts.includes(s)
+        ? { ...s, ip: null, ok: null, serverOk: null }
+        : s
     })
 
     // promote candidates and update service list

--- a/discovery-client/src/poller.js
+++ b/discovery-client/src/poller.js
@@ -62,7 +62,7 @@ export function stop (request: ?PollRequest, log: ?Logger) {
 
 function fetchHealth (cand: Candidate, log: ?Logger) {
   const apiHealthUrl = `http://${cand.ip}:${cand.port}/health`
-  const serverHealthUrl = `http://${cand.ip}:${cand.port}/server/health`
+  const serverHealthUrl = `http://${cand.ip}:${cand.port}/server/update/health`
 
   return Promise.all([
     fetchAndParseBody(apiHealthUrl, log),

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -2,14 +2,17 @@
 
 export type Candidate = {
   ip: string,
-  port: number
+  port: number,
 }
 
 export type Service = {
   name: string,
   ip: ?string,
   port: number,
-  ok: ?boolean
+  // GET /health response.ok === true
+  ok: ?boolean,
+  // GET /server/health response.ok === true
+  serverOk: ?boolean,
 }
 
 // TODO(mc, 2018-07-26): grab common logger type from app and app-shell
@@ -26,5 +29,5 @@ export type Logger = {[level: LogLevel]: (message: string, meta?: {}) => void}
 
 // note: the discovery module only cares about name
 export type HealthResponse = {
-  name: string
+  name: string,
 }


### PR DESCRIPTION
## overview

Feature ticket + PR.

Per connectivity discussions, this is a plumbing PR that adds an additional check to the discovery poller: `GET /server/update/health`. This will (eventually) help the app determine if a robot's update server is still up even if the primary API is not responding

## changelog

- feat(discovery-client): Add GET /server/health check to poller 

## review requests

Sorry for the large diff; it's mostly unit test changes though. Source changes themselves are small. Easiest way to test this is with the CLI:


```shell
make -C discovery-client
npx discovery browse
```

You will now see that discovered robots have an additional `serverOk` flag:

```
Browsing for services
service added or updated: { name: 'opentrons-dev',
  ip: 'localhost',
  port: 31950,
  ok: true,
  serverOk: false }
```