### PR TITLE
chore(build): Make push-api fail if no usb host was found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ install-types:
 .PHONY: push-api
 push-api: export host = $(usb_host)
 push-api:
+	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
 	$(MAKE) -C $(API_DIR) push
 	$(MAKE) -C $(API_DIR) restart
 
@@ -76,6 +77,7 @@ api-local-container:
 .PHONY: term
 term: export host = $(usb_host)
 term:
+	$(if $(host),@echo "Connecting to $(host)",$(error host variable required))
 	$(MAKE) -C $(API_DIR) term
 
 # all tests


### PR DESCRIPTION
Previously, because the robot finding mechanism was not actually in a target, if no robot was found
in push-api then the makefile would proceed to build the wheel and only fail when it tried to
connect to :31950 (note the lack of actual IP address there). By instead invoking the discovery
client directly in a target and using a file intermediate we can fail fast if no robot is found.

## Review requests

Check it on windows just to be sure.