### PR TITLE
feat(protocol-library-kludge): set up OT2 deckmap mini-app kludge for…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "components",
     "discovery-client",
     "protocol-designer",
+    "protocol-library-kludge",
     "shared-data",
     "update-server/otupdate",
     "webpack-config"

--- a/protocol-library-kludge/Makefile
+++ b/protocol-library-kludge/Makefile
@@ -1,0 +1,41 @@
+# opentrons protocol-library-kludge makefile
+
+SHELL := /bin/bash
+
+# add node_modules/.bin to PATH
+PATH := $(shell cd .. && yarn bin):$(PATH)
+
+# set NODE_ENV for a command with $(env)=environment
+env := cross-env NODE_ENV
+
+# standard targets
+#####################################################################
+
+.PHONY: all
+all: clean build
+
+.PHONY: install
+install:
+	yarn
+
+.PHONY: clean
+clean:
+	shx rm -rf dist
+
+# artifacts
+#####################################################################
+
+.PHONY: build
+build:
+	$(env)=production webpack -p
+	shx cp index.html dist/
+
+# NOTE: Ian 2018-09-07 while this is a one-off OT2 deckmap iframe dealie,
+# it should be deployed MANUALLY to protocol-library-kludge/production/ on S3
+
+# development
+#####################################################################
+
+.PHONY: dev
+dev:
+	$(env)=development webpack-dev-server --hot

--- a/protocol-library-kludge/index.html
+++ b/protocol-library-kludge/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Opentrons Protocol Library</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i" rel="stylesheet">
+    <link href="./bundle.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./bundle.js"></script>
+  </body>
+</html>

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -1,0 +1,34 @@
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Opentrons/opentrons.git"
+  },
+  "author": {
+    "name": "Opentrons Labworks",
+    "email": "engineering@opentrons.com"
+  },
+  "name": "protocol-library-kludge",
+  "private": true,
+  "version": "3.3.0",
+  "description": "Protocol library stuff (WIP)",
+  "main": "src/index.js",
+  "bugs": {
+    "url": "https://github.com/Opentrons/opentrons/issues"
+  },
+  "homepage": "https://github.com/Opentrons/opentrons",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@opentrons/components": "3.3.0",
+    "classnames": "^2.2.5",
+    "lodash": "^4.17.4",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-hot-loader": "^3.0.0-beta.7",
+    "react-redux": "^5.0.6",
+    "react-router-dom": "^4.1.1"
+  },
+  "devDependencies": {
+    "flow-bin": "^0.76.0",
+    "flow-typed": "^2.5.1"
+  }
+}

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.3.0",
+    "@opentrons/components": "3.3.1-beta.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "react": "^16.2.0",

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -9,7 +9,7 @@
   },
   "name": "protocol-library-kludge",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1-beta.0",
   "description": "Protocol library stuff (WIP)",
   "main": "src/index.js",
   "bugs": {

--- a/protocol-library-kludge/src/App.js
+++ b/protocol-library-kludge/src/App.js
@@ -1,0 +1,9 @@
+// @flow
+import React from 'react'
+import URLDeck from './URLDeck'
+
+export default function App () {
+  return (
+    <URLDeck />
+  )
+}

--- a/protocol-library-kludge/src/App.js
+++ b/protocol-library-kludge/src/App.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import URLDeck from './URLDeck'
+import './globals.css'
 
 export default function App () {
   return (

--- a/protocol-library-kludge/src/URLDeck.js
+++ b/protocol-library-kludge/src/URLDeck.js
@@ -1,0 +1,31 @@
+// @flow
+import React from 'react'
+import {
+  Deck,
+  Labware,
+  type LabwareComponentProps
+} from '@opentrons/components'
+
+// Expects slot: labwareType URL params, eg `?11=96-flat&10=tiprack-200ul`
+export default class URLDeck extends React.Component<{}> {
+  urlParams: ?URLSearchParams
+
+  constructor () {
+    super()
+    this.urlParams = new URLSearchParams(window.location.search)
+  }
+
+  getLabware = (args: LabwareComponentProps) => {
+    const {slot} = args
+    const labwareType = this.urlParams && this.urlParams.get(slot)
+    return (labwareType)
+      ? <Labware labwareType={labwareType} />
+      : null
+  }
+
+  render () {
+    return (
+      <Deck LabwareComponent={this.getLabware} />
+    )
+  }
+}

--- a/protocol-library-kludge/src/globals.css
+++ b/protocol-library-kludge/src/globals.css
@@ -1,0 +1,3 @@
+* {
+  font-family: 'Open Sans', sans-serif;
+}

--- a/protocol-library-kludge/src/index.js
+++ b/protocol-library-kludge/src/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {AppContainer} from 'react-hot-loader'
+import App from './App'
+
+const render = (Component) => {
+  ReactDOM.render(
+    <AppContainer>
+      <Component />
+    </AppContainer>,
+    document.getElementById('root')
+  )
+}
+
+render(App)
+
+// Hot Module Replacement API
+if (module.hot) {
+  module.hot.accept('./App', () => {
+    render(App)
+  })
+}

--- a/protocol-library-kludge/webpack.config.js
+++ b/protocol-library-kludge/webpack.config.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const path = require('path')
+const webpack = require('webpack')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+const {rules} = require('@opentrons/webpack-config')
+
+const DEV = process.env.NODE_ENV !== 'production'
+
+module.exports = {
+  entry: [
+    './src/index.js'
+  ],
+
+  output: {
+    filename: 'bundle.js',
+    path: path.join(__dirname, 'dist')
+  },
+
+  module: {
+    rules: [
+      rules.js,
+      rules.localCss,
+      rules.images
+    ]
+  },
+
+  devServer: {
+    historyApiFallback: true
+  },
+
+  devtool: DEV ? 'eval-source-map' : 'source-map',
+
+  plugins: [
+    new ExtractTextPlugin({
+      filename: 'bundle.css',
+      disable: DEV,
+      ignoreOrder: true
+    })
+  ]
+}
+
+if (DEV) {
+  module.exports.entry.unshift(
+    'react-hot-loader/patch'
+  )
+
+  module.exports.plugins.push(
+    new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.NamedModulesPlugin()
+  )
+}


### PR DESCRIPTION
Moves towards #2145 (not quite closed)

This thing will not be long-lived, but will hang around some months. It is a kludge to be able to show the OT2 `Deck` component in the protocol library.

I don't know if it belongs in the monorepo, but it's a lot more convenient to `import {Deck, Labware} from '@opentrons/components` and also nice to use the same `webpack-config/` rules.

Non-monorepo solutions: 1) publishing `components/` to NPM or 2) cloning the monorepo during the build. The upside of the non-monorepo is that this kludge doesn't pollute the monorepo (and doesn't add noise to its GIT LOG / CHANGELOG!)

Thoughts?

This is a first step, it's also supposed to also show labware custom names just like Run App does (overlaid on top of the slots).

See it at http://staging-a.protocols.opentrons.com/protocol/384_plate_filling and other OT2 protocols (not all are working AFAIK, upstream issues)

# review requests

My big Q: should this go here, or in another repo (eg `parametric-protocol` private repo that's used for the old custom PCR iframe app in Protocol Library)?