### PR TITLE
refactor(app): Consolidate /settings calls into common API state

### DIFF
--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -111,7 +111,7 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   return {
     fetch: () => dispatch(fetchSettings(ownProps)),
-    set: (id, value) => dispatch(setSettings(ownProps, id, value)),
+    set: (id, value) => dispatch(setSettings(ownProps, {id, value})),
     download: () => dispatch(downloadLogs(ownProps))
   }
 }

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -51,11 +51,15 @@ export type ApiAction<Path: string, Request: ?{}, Response: {}> =
   | ApiFailureAction<Path>
   | ClearApiResponseAction<Path>
 
-type RequestMaker = (robot: RobotService, request: ?{}) => ThunkPromiseAction
+export type RequestMaker<Request: ?{} = void> =
+  (robot: RobotService, request: Request) => ThunkPromiseAction
 
 // thunk action creator creator (sorry) for making API calls
 // e.g. export const fetchHealth = buildRequestMaker('GET', 'health')
-export function buildRequestMaker (method: Method, path: string): RequestMaker {
+export function buildRequestMaker<Request: ?{}> (
+  method: Method,
+  path: string
+): RequestMaker<Request> {
   return (robot, request = null) => (dispatch) => {
     dispatch(apiRequest(robot, path, request))
 

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -17,8 +17,7 @@ type FetchHealthResponse = {
   logs: ?Array<string>,
 }
 
-export type HealthAction =
-  | ApiAction<'health', null, FetchHealthResponse>
+export type HealthAction = ApiAction<'health', null, FetchHealthResponse>
 
 export type FetchHealthCall = ApiCall<void, FetchHealthResponse>
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -10,7 +10,7 @@ import {pipettesReducer, type PipettesAction} from './pipettes'
 import type {ResetAction} from './reset'
 import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
-import {settingsReducer, type SettingsAction} from './settings'
+import type {SettingsAction} from './settings'
 import {wifiReducer, type WifiAction} from './wifi'
 
 export const reducer = combineReducers({
@@ -19,7 +19,6 @@ export const reducer = combineReducers({
   pipettes: pipettesReducer,
   robot: robotReducer,
   server: serverReducer,
-  settings: settingsReducer,
   wifi: wifiReducer,
   // TODO(mc, 2018-07-09): api subreducer will become the sole reducer
   api: apiReducer
@@ -62,10 +61,6 @@ export type {
 } from './server'
 
 export type {
-  Setting
-} from './settings'
-
-export type {
   WifiListResponse,
   WifiStatusResponse,
   WifiConfigureResponse,
@@ -101,6 +96,8 @@ export * from './modules'
 
 export * from './reset'
 
+export * from './settings'
+
 export {
   disengagePipetteMotors
 } from './motors'
@@ -135,12 +132,6 @@ export {
   makeGetRobotIgnoredUpdateRequest,
   clearRestartResponse
 } from './server'
-
-export {
-  fetchSettings,
-  setSettings,
-  makeGetRobotSettings
-} from './settings'
 
 export {
   fetchWifiList,

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -2,13 +2,13 @@
 // robot settings endpoints
 import {createSelector, type Selector} from 'reselect'
 
-import type {State, Action, ThunkPromiseAction} from '../types'
-import type {BaseRobot, RobotService} from '../robot'
-import type {ApiCall, ApiRequestError} from './types'
-import client from './client'
+import {buildRequestMaker} from './actions'
+import {getRobotApiState} from './reducer'
 
-import {apiRequest, apiSuccess, apiFailure} from './actions'
-import type {ApiRequestAction, ApiSuccessAction, ApiFailureAction} from './actions'
+import type {State} from '../types'
+import type {BaseRobot} from '../robot'
+import type {ApiCall} from './types'
+import type {ApiAction, RequestMaker} from './actions'
 
 type Id = string
 
@@ -22,147 +22,37 @@ export type Setting = {
   value: Value,
 }
 
-type SettingsPath = 'settings'
-
 type SettingsRequest = ?{id: Id, value: Value}
 
 type SettingsResponse = {settings: Array<Setting>}
 
 export type SettingsAction =
-  | ApiRequestAction<SettingsPath, SettingsRequest>
-  | ApiSuccessAction<SettingsPath, SettingsResponse>
-  | ApiFailureAction<SettingsPath>
+  ApiAction<'settings', SettingsRequest, SettingsResponse>
 
-type RobotSettingsRequestState = ApiCall<SettingsRequest, SettingsResponse>
+export type RobotSettingsCall = ApiCall<SettingsRequest, SettingsResponse>
 
-type RobotSettingsState = {
-  settings?: RobotSettingsRequestState
-}
-
-export type SettingsState = {
-  [robotName: string]: ?RobotSettingsState,
+export type RobotSettingsState = {
+  settings?: RobotSettingsCall
 }
 
 const SETTINGS: 'settings' = 'settings'
 
-// TODO(mc, 2018-07-03): flow helper until we have one reducer, since
-// p === 'constant' checks but p === CONSTANT does not, even if
-// CONSTANT is defined as `const CONSTANT: 'constant' = 'constant'`
-function getSettingsPath (p: string): ?SettingsPath {
-  if (p === 'settings') return p
+type SettingsRequestMaker = RequestMaker<SettingsRequest>
 
-  return null
-}
+export const fetchSettings: SettingsRequestMaker =
+  buildRequestMaker('GET', SETTINGS)
 
-export function fetchSettings (robot: RobotService): ThunkPromiseAction {
-  const request: SettingsRequest = null
-
-  return (dispatch) => {
-    dispatch(apiRequest(robot, SETTINGS, request))
-
-    return client(robot, 'GET', SETTINGS)
-      .then(
-        (res: SettingsResponse) => apiSuccess(robot, SETTINGS, res),
-        (err: ApiRequestError) => apiFailure(robot, SETTINGS, err)
-      )
-      .then(dispatch)
-  }
-}
-
-export function setSettings (
-  robot: RobotService,
-  id: Id,
-  value: Value
-): ThunkPromiseAction {
-  const request: SettingsRequest = {id, value}
-
-  return (dispatch) => {
-    dispatch(apiRequest(robot, SETTINGS, request))
-
-    return client(robot, 'POST', SETTINGS, request)
-      .then(
-        (res: SettingsResponse) => apiSuccess(robot, SETTINGS, res),
-        (err: ApiRequestError) => apiFailure(robot, SETTINGS, err)
-      )
-      .then(dispatch)
-  }
-}
-
-// TODO(mc, 2018-07-03): remove in favor of single HTTP API reducer
-export function settingsReducer (
-  state: SettingsState = {},
-  action: Action
-): SettingsState {
-  switch (action.type) {
-    case 'api:REQUEST': {
-      const path = getSettingsPath(action.payload.path)
-      if (!path) return state
-      const {payload: {request, robot: {name}}} = action
-      const stateByName = state[name] || {}
-      const stateByPath = stateByName[path] || {}
-
-      return {
-        ...state,
-        [name]: {
-          ...stateByName,
-          [path]: {...stateByPath, request, inProgress: true, error: null}
-        }
-      }
-    }
-
-    case 'api:SUCCESS': {
-      const path = getSettingsPath(action.payload.path)
-      if (!path) return state
-      const {payload: {response, robot: {name}}} = action
-      const stateByName = state[name] || {}
-      const stateByPath = stateByName[path] || {}
-
-      return {
-        ...state,
-        [name]: {
-          ...stateByName,
-          [path]: {...stateByPath, response, inProgress: false, error: null}
-        }
-      }
-    }
-
-    case 'api:FAILURE': {
-      const path = getSettingsPath(action.payload.path)
-      if (!path) return state
-      const {payload: {error, robot: {name}}} = action
-      const stateByName = state[name] || {}
-      const stateByPath = stateByName[path] || {}
-
-      return {
-        ...state,
-        [name]: {
-          ...stateByName,
-          [path]: {...stateByPath, error, inProgress: false}
-        }
-      }
-    }
-  }
-
-  return state
-}
+export const setSettings: SettingsRequestMaker =
+  buildRequestMaker('POST', SETTINGS)
 
 export function makeGetRobotSettings () {
-  const selector: Selector<State, BaseRobot, RobotSettingsRequestState> =
-    createSelector(getRobotSettingsState, getSettingsRequest)
+  const selector: Selector<State, BaseRobot, RobotSettingsCall> =
+    createSelector(getRobotApiState, getSettingsRequest)
 
   return selector
 }
 
-function getRobotSettingsState (
-  state: State,
-  props: BaseRobot
-): RobotSettingsState {
-  return state.api.settings[props.name] || {}
-}
-
-function getSettingsRequest (
-  state: RobotSettingsState
-): RobotSettingsRequestState {
+function getSettingsRequest (state: RobotSettingsState): RobotSettingsCall {
   let requestState = state[SETTINGS] || {inProgress: false}
 
   // guard against an older version of GET /settings


### PR DESCRIPTION
## overview

Small refactor PR in the same vein as #2215 to make future API work around connectivity state easier with regards to #2100.

## changelog

- refactor(app): Consolidate /settings calls into common API state

## review requests

Ensure robot advanced settings still report correctly and can still be changed correctly.
