### PR TITLE
fix(api): throw early error on bad json delay cmd

### DIFF
--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -152,9 +152,15 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: 
                 pipette_model, pipette, command_type, params, default_values)
 
         if command_type == 'delay':
-            wait = params.get('wait', 0)
-            if wait is True:
-                # TODO Ian 2018-05-14 pass message
+            wait = params.get('wait')
+            if wait is None:
+                raise ValueError('Delay cannot be null')
+            elif wait is True:
+                # TODO: Ian 2018-09-11 this causes Run App command list to
+                # indent, un-comment when there's a path to fix:
+
+                # message = params.get('message', 'Pausing until user resumes')
+                # robot.comment(message)
                 robot.pause()
             else:
                 _sleep(wait)


### PR DESCRIPTION
## overview

fix strange behavior where a malformed delay 'wait' param loads/simulates fine, but stalls during
real protocol execution

## changelog


## review requests

- test on robot with a JSON protocol where `"wait": null` if you want. You gotta `make push host=xxxx`. I tested on sunset

Not sure who to request reviews on this so I just added a buncha people, if there are a few :heavy_check_mark: s you can skip reviewing if you want