### PR TITLE
feat(protocol-designer): allow tenths of µl pipette volumes

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -8,6 +8,7 @@ import {
 } from './errors'
 import {
   castToNumber,
+  castToFloat,
   onlyPositiveNumbers,
   onlyIntegers,
   defaultTo,
@@ -29,10 +30,12 @@ type StepFieldHelpers = {
   hydrate?: (state: BaseState, id: string) => mixed
 }
 const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
+  'aspirate_airGap_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
   'aspirate_labware': {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware
   },
+  'aspirate_mix_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
   'dispense_delayMinutes': {
     processValue: composeProcessors(castToNumber, defaultTo(0))
   },
@@ -43,12 +46,13 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware
   },
+  'dispense_mix_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
   'dispense_wells': {
     getErrors: composeErrors(minimumWellCount(1)),
     processValue: defaultTo([])
   },
   'aspirate_disposalVol_volume': {
-    processValue: composeProcessors(castToNumber, onlyPositiveNumbers, onlyIntegers)
+    processValue: composeProcessors(castToFloat, onlyPositiveNumbers)
   },
   'labware': {
     getErrors: composeErrors(requiredField),
@@ -73,7 +77,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   },
   'volume': {
     getErrors: composeErrors(requiredField),
-    processValue: composeProcessors(castToNumber, onlyPositiveNumbers, defaultTo(0))
+    processValue: composeProcessors(castToFloat, onlyPositiveNumbers, defaultTo(0))
   },
   'wells': {
     getErrors: composeErrors(minimumWellCount(1)),

--- a/protocol-designer/src/steplist/fieldLevel/processing.js
+++ b/protocol-designer/src/steplist/fieldLevel/processing.js
@@ -18,6 +18,14 @@ export const castToNumber = (rawValue: mixed): ?number => {
   }
 }
 
+const DEFAULT_DECIMAL_PLACES = 1
+export const castToFloat = (rawValue: mixed): ?number => {
+  if (!rawValue) return Number(rawValue)
+  const rawNumericValue = typeof rawValue === 'string' ? rawValue.replace(/[^.0-9]/, '') : String(rawValue)
+  const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${DEFAULT_DECIMAL_PLACES}})(\\d*)`)
+  return Number(rawNumericValue.replace(trimRegex, (match, group1) => group1))
+}
+
 /*********************
 **  Value Limiters  **
 **********************/
@@ -25,7 +33,7 @@ export const castToNumber = (rawValue: mixed): ?number => {
 // in practive they will always take parameters of one type (e.g. `(value: number)`)
 // For the sake of simplicity and flow happiness, they are equiped to deal with parameters of type `mixed`
 
-export const onlyPositiveNumbers = (value: mixed) => (value && Number(value) > 0) ? value : null
+export const onlyPositiveNumbers = (value: mixed) => (value && Number(value) >= 0) ? value : null
 export const onlyIntegers = (value: mixed) => (value && Number.isInteger(value)) ? value : null
 export const defaultTo = (defaultValue: mixed) => (value: mixed) => (value || defaultValue)
 


### PR DESCRIPTION
## overview

Allow users to input volumes in step forms with precision down to the tenth of a µl.

Closes #2120

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->


<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->

Try setting any volume in the Step Forms to a precision of a tenth of a µl.
