### PR TITLE
feat(protocol-library-kludge): support modules and nicknames

### DIFF
--- a/components/src/deck/ContainerNameOverlay.js
+++ b/components/src/deck/ContainerNameOverlay.js
@@ -5,7 +5,7 @@ import styles from './LabwareContainer.css'
 
 type Props = {
   title: string,
-  subtitle?: string,
+  subtitle?: ?string,
 }
 
 export function ContainerNameOverlay (props: Props) {

--- a/protocol-library-kludge/src/URLDeck.css
+++ b/protocol-library-kludge/src/URLDeck.css
@@ -1,0 +1,3 @@
+.url_deck {
+  margin: 0 4rem; /* horizontal space for module overhang */
+}

--- a/protocol-library-kludge/src/URLDeck.js
+++ b/protocol-library-kludge/src/URLDeck.js
@@ -1,31 +1,92 @@
 // @flow
 import React from 'react'
+import startCase from 'lodash/startCase'
+import styles from './URLDeck.css'
 import {
+  ContainerNameOverlay,
   Deck,
   Labware,
-  type LabwareComponentProps
+  Module
+} from '@opentrons/components'
+import type {
+  DeckSlot,
+  LabwareComponentProps,
+  ModuleType
 } from '@opentrons/components'
 
-// Expects slot: labwareType URL params, eg `?11=96-flat&10=tiprack-200ul`
+// URI-encoded JSON expected as URL param "data" (eg `?data=...`)
+type UrlData = {
+  labware: {
+    [DeckSlot]: {
+      labwareType: string,
+      name: ?string
+    }
+  },
+  modules: {
+    [DeckSlot]: ModuleType
+  }
+}
+
+function getDataFromUrl (): ?UrlData {
+  try {
+    const urlData = JSON.parse(new URLSearchParams(window.location.search).get('data'))
+    return urlData
+  } catch (e) {
+    console.error('Failed to parse "data" URL param.', e)
+    return null
+  }
+}
+
 export default class URLDeck extends React.Component<{}> {
-  urlParams: ?URLSearchParams
+  urlData: ?UrlData
 
   constructor () {
     super()
-    this.urlParams = new URLSearchParams(window.location.search)
+    this.urlData = getDataFromUrl()
   }
 
-  getLabware = (args: LabwareComponentProps) => {
+  getLabwareComponent = (args: LabwareComponentProps) => {
     const {slot} = args
-    const labwareType = this.urlParams && this.urlParams.get(slot)
-    return (labwareType)
-      ? <Labware labwareType={labwareType} />
-      : null
+    const {urlData} = this
+    if (!urlData) return null
+
+    const labwareData = urlData.labware && urlData.labware[slot]
+    const moduleData = urlData.modules && urlData.modules[slot]
+    let labware = null
+    let module = null
+
+    if (labwareData) {
+      const {name, labwareType} = labwareData
+      const displayLabwareType = startCase(labwareType)
+      labware = (
+        <React.Fragment>
+          <Labware labwareType={labwareType} />
+          <ContainerNameOverlay
+            title={name || displayLabwareType}
+            subtitle={name ? displayLabwareType : null}
+          />
+        </React.Fragment>
+      )
+    }
+
+    if (moduleData) {
+      module = <Module mode='default' name='tempdeck' />
+    }
+
+    return (
+      <React.Fragment>
+        {module}
+        {labware}
+      </React.Fragment>
+    )
   }
 
   render () {
     return (
-      <Deck LabwareComponent={this.getLabware} />
+      <Deck
+        className={styles.url_deck}
+        LabwareComponent={this.getLabwareComponent}
+      />
     )
   }
 }


### PR DESCRIPTION
## overview

Support modules and nicknames for labware in OT2 deckmap kludge for Protocol Library!

## changelog

* support modules & nicknames
* url-encoded JSON in `data` param

## review requests

- You'd have to test this locally. URLs will look like http://localhost:8080/?data=%7B%22labware%22:%7B%224%22:%7B%22name%22:%22nickname%22,%22labwareType%22:%2296-flat%22%7D%7D,%22modules%22:%7B%224%22:%22tempdeck%22%7D%7D The joy of passing JSON via URL params into iframes :grimacing: 