### PR TITLE
fix(api): Fix pipette volume params and revert change in param order

### DIFF
--- a/api/docs/source/pipettes.rst
+++ b/api/docs/source/pipettes.rst
@@ -60,42 +60,79 @@ The values are in microliters/seconds, and have varying defaults depending on th
         dispense_flow_rate=600)
 
 
+Minimum and Maximum Volume
+==================
+
+The minimum and maximum volume of the pipette may be set using
+``min_volume`` and ``max_volume``. The values are in microliters and have
+varying defaults depending on the model.
+
+
+.. code-block:: python
+
+    pipette = instruments.P10_Single(
+        mount='right',
+        min_volume=2,
+        max_volume=8)
+
+
 The given defaults for every pipette model is the following:
-p10_Single
+
+P10_Single
 ==========
-Aspirate Default: 5ul/sec
-Dispense Default: 10ul/sec
 
-p10_Multi
+- Aspirate Default: 5 μl/s
+- Dispense Default: 10 μl/s
+- Minimum Volume: 1 μl
+- Maximum Volume: 10 μl
+
+P10_Multi
 =========
-Aspirate Default: 5ul/sec
-Dispense Default: 10ul/sec
 
-p50_Single
+- Aspirate Default: 5 μl/s
+- Dispense Default: 10 μl/s
+- Minimum Volume: 1 μl
+- Maximum Volume: 10 μl
+
+P50_Single
 ==========
-Aspirate Default: 25ul/sec
-Dispense Default: 50ul/sec
 
-p50_Multi
+- Aspirate Default: 25 μl/s
+- Dispense Default: 50 μl/s
+- Minimum Volume: 5 μl
+- Maximum Volume: 50 μl
+
+P50_Multi
 =========
-Aspirate Default: 25ul/sec
-Dispense Default: 50ul/sec
 
-p300_Single
+- Aspirate Default: 25 μl/s
+- Dispense Default: 50 μl/s
+- Minimum Volume: 5 μl
+- Maximum Volume: 50 μl
+
+P300_Single
 ===========
-Aspirate Default: 150
-Dispense Default: 300
 
-p300_Multi
+- Aspirate Default: 150 μl/s
+- Dispense Default: 300 μl/s
+- Minimum Volume: 30 μl
+- Maximum Volume: 300 μl
+
+P300_Multi
 ==========
-Aspirate Default: 150
-Dispense Default: 300
 
-p1000_Single
+- Aspirate Default: 150 μl/s
+- Dispense Default: 300 μl/s
+- Minimum Volume: 30 μl
+- Maximum Volume: 300 μl
+
+P1000_Single
 ============
-Aspirate Default: 500
-Dispense Default: 1000
 
+- Aspirate Default: 500 μl/s
+- Dispense Default: 1000 μl/s
+- Minimum Volume: 100 μl
+- Maximum Volume: 1000 μl
 
 Old Pipette Constructor
 =======================

--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -63,10 +63,10 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p10_single')
@@ -77,20 +77,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P10_Multi(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p10_multi')
@@ -101,20 +101,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P50_Single(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p50_single')
@@ -125,20 +125,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P50_Multi(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p50_multi')
@@ -149,20 +149,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P300_Single(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p300_single')
@@ -173,20 +173,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P300_Multi(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p300_multi')
@@ -197,20 +197,20 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def P1000_Single(
             self,
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         pipette_model_version = self._retrieve_version_number(
             mount, 'p1000_single')
@@ -221,10 +221,10 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
-            min_volume=min_volume,
-            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate)
+            dispense_flow_rate=dispense_flow_rate,
+            min_volume=min_volume,
+            max_volume=max_volume)
 
     def _create_pipette_from_config(
             self,
@@ -232,10 +232,10 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
-            min_volume=None,
-            max_volume=None,
             aspirate_flow_rate=None,
-            dispense_flow_rate=None):
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
 
         if aspirate_flow_rate is not None:
             config = config._replace(aspirate_flow_rate=aspirate_flow_rate)
@@ -243,9 +243,9 @@ class InstrumentsWrapper(object):
             config = config._replace(dispense_flow_rate=dispense_flow_rate)
 
         if min_volume is not None:
-            config._replace(min_volume=min_volume)
+            config = config._replace(min_volume=min_volume)
         if max_volume is not None:
-            config._replace(max_volume=max_volume)
+            config = config._replace(max_volume=max_volume)
 
         p = self.Pipette(
             model_offset=config.model_offset,

--- a/api/tests/opentrons/labware/test_pipette_constructors.py
+++ b/api/tests/opentrons/labware/test_pipette_constructors.py
@@ -1,0 +1,51 @@
+import pytest
+from opentrons import robot, instruments
+from opentrons.instruments import Pipette
+
+factories = [
+    ('p10_single', instruments.P10_Single),
+    ('p10_multi', instruments.P10_Multi),
+    ('p50_single', instruments.P50_Single),
+    ('p50_multi', instruments.P50_Multi),
+    ('p300_single', instruments.P300_Single),
+    ('p300_multi', instruments.P300_Multi),
+    ('p1000_single', instruments.P1000_Single),
+]
+
+
+@pytest.mark.parametrize('factory', factories)
+def test_pipette_contructors(factory, monkeypatch):
+    expected_name, make_pipette = factory
+
+    aspirate_flow_rate = None
+    dispense_flow_rate = None
+
+    def mock_set_flow_rate(self, aspirate, dispense):
+        nonlocal aspirate_flow_rate
+        nonlocal dispense_flow_rate
+        aspirate_flow_rate = aspirate
+        dispense_flow_rate = dispense
+
+    monkeypatch.setattr(Pipette, 'set_flow_rate', mock_set_flow_rate)
+    robot.reset()
+
+    # note: not using named parameters here to catch any breakage due to
+    # argument reordering
+    pipette = make_pipette(
+        'left',  # mount
+        '',      # trash_container
+        [],      # tip_racks
+        21,      # aspirate_flow_rate
+        42,      # dispense_flow_rate
+        7,       # min_volume
+        8        # max_volume
+    )
+
+    assert pipette.name.startswith(expected_name) is True
+    assert pipette.mount == 'left'
+    assert pipette.trash_container == robot.fixed_trash[0]
+    assert pipette.tip_racks == []
+    assert aspirate_flow_rate == 21
+    assert dispense_flow_rate == 42
+    assert pipette.min_volume == 7
+    assert pipette.max_volume == 8


### PR DESCRIPTION
## overview

Bug report + fix. This PR fixes up a couple problems with #2084:

- The change in parameter order of the pipette factories was a **breaking change**
    - New parameters were moved to the end of the constructors where all new parameters should be added to avoid breakage
- The new volume parameters weren't actually passed to the pipette config
    - Fixed

This PR also:

- Adds tests to sanity check the behavior of the factories and ensure this sort of break isn't introduced again
- Adds `min_volume` and `max_volume` to the documentation

## changelog

- fix(api): Fix pipette volume params and revert change in param order 

## review requests

Please make sure the pipette constructors still work! Unit tests pretty much cover everything so this shouldn't be too risky.
