### PR TITLE
refactor(app): Consolidate /pipettes calls into common API

### DIFF
--- a/app/src/http-api-client/__tests__/motors.test.js
+++ b/app/src/http-api-client/__tests__/motors.test.js
@@ -23,8 +23,12 @@ describe('/motors/**', () => {
     robot = {name: NAME, ip: '1.2.3.4', port: '1234'}
     state = {
       api: {
-        pipettes: {},
-        motors: {},
+        api: {
+          [NAME]: {
+            pipettes: {},
+            motors: {},
+          },
+        },
       },
     }
 
@@ -55,7 +59,7 @@ describe('/motors/**', () => {
     test('skips GET /pipettes call if axes are in state', () => {
       const expected = {axes: ['z', 'b']}
 
-      state.api.pipettes = {[NAME]: {response: mockPipettesResponse}}
+      state.api.api[NAME].pipettes = {response: mockPipettesResponse}
       client.__setMockResponse(response)
 
       // use mock.calls to verify call order

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -4,9 +4,9 @@ import {combineReducers} from 'redux'
 import apiReducer from './reducer'
 import {calibrationReducer, type CalibrationAction} from './calibration'
 import type {HealthAction} from './health'
+import type {PipettesAction} from './pipettes'
 import type {ModulesAction} from './modules'
 import {motorsReducer, type MotorsAction} from './motors'
-import {pipettesReducer, type PipettesAction} from './pipettes'
 import type {ResetAction} from './reset'
 import {robotReducer, type RobotAction} from './robot'
 import {serverReducer, type ServerAction} from './server'
@@ -16,7 +16,6 @@ import {wifiReducer, type WifiAction} from './wifi'
 export const reducer = combineReducers({
   calibration: calibrationReducer,
   motors: motorsReducer,
-  pipettes: pipettesReducer,
   robot: robotReducer,
   server: serverReducer,
   wifi: wifiReducer,
@@ -41,12 +40,6 @@ export type {
   JogStep,
   DeckCalPoint,
 } from './calibration'
-
-export type {
-  Pipette,
-  PipettesResponse,
-  RobotPipettes,
-} from './pipettes'
 
 export type {
   RobotMove,
@@ -98,14 +91,11 @@ export * from './reset'
 
 export * from './settings'
 
+export * from './pipettes'
+
 export {
   disengagePipetteMotors,
 } from './motors'
-
-export {
-  fetchPipettes,
-  makeGetRobotPipettes,
-} from './pipettes'
 
 export {
   home,

--- a/app/src/http-api-client/motors.js
+++ b/app/src/http-api-client/motors.js
@@ -62,7 +62,7 @@ export function disengagePipetteMotors (
   ...mounts: Array<Mount>
 ): ThunkPromiseAction {
   return (dispatch, getState) => {
-    const pipettesState = getState().api.pipettes[robot.name]
+    const pipettesState = getState().api.api[robot.name].pipettes
 
     dispatch(motorsRequest(robot, DISENGAGE, {mounts}))
 

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -2,10 +2,14 @@
 // pipette state from api
 import {createSelector, type Selector} from 'reselect'
 
-import type {State, Action, ThunkPromiseAction} from '../types'
+import type {State, ThunkPromiseAction} from '../types'
 import type {BaseRobot, RobotService} from '../robot'
 
+import {apiRequest, apiSuccess, apiFailure} from './actions'
 import type {ApiCall} from './types'
+import type {ApiAction} from './actions'
+import {getRobotApiState} from './reducer'
+
 import type {MotorAxis} from './motors'
 import client, {type ApiRequestError} from './client'
 
@@ -21,104 +25,42 @@ export type PipettesResponse = {
   left: Pipette,
 }
 
-export type PipettesRequestAction = {|
-  type: 'api:PIPETTES_REQUEST',
-  payload: {|
-    robot: RobotService,
-  |},
-|}
+type FetchPipettesCall = ApiCall<null, PipettesResponse>
 
-export type PipettesSuccessAction = {|
-  type: 'api:PIPETTES_SUCCESS',
-  payload: {|
-    robot: RobotService,
-    pipettes: PipettesResponse,
-  |},
-|}
-
-export type PipettesFailureAction = {|
-  type: 'api:PIPETTES_FAILURE',
-  payload: {|
-    robot: RobotService,
-    error: ApiRequestError,
-  |},
-|}
-
-export type PipettesAction =
-  | PipettesRequestAction
-  | PipettesSuccessAction
-  | PipettesFailureAction
+export type PipettesAction = ApiAction<'pipette', null, PipettesResponse>
 
 export type RobotPipettes = ApiCall<void, PipettesResponse>
 
-type PipettesState = {
-  [robotName: string]: ?RobotPipettes,
+export type PipettesState = {
+  pipettes?: FetchPipettesCall,
 }
+
+const PIPETTES: 'pipettes' = 'pipettes'
 
 export function fetchPipettes (
   robot: RobotService,
   refresh: boolean = false
 ): ThunkPromiseAction {
-  let path = 'pipettes'
+  let path = PIPETTES
   if (refresh) path += '?refresh=true'
 
   return (dispatch) => {
-    dispatch({type: 'api:PIPETTES_REQUEST', payload: {robot}})
+    dispatch(apiRequest(robot, path, null))
 
     return client(robot, 'GET', path)
-      .then((pipettes) => (
-        {type: 'api:PIPETTES_SUCCESS', payload: {robot, pipettes}}
-      )).catch((error) => (
-        {type: 'api:PIPETTES_FAILURE', payload: {robot, error}}
-      )).then((action) => dispatch(action))
+      .then(
+        (resp: PipettesResponse) => apiSuccess(robot, PIPETTES, resp),
+        (err: ApiRequestError) => apiFailure(robot, PIPETTES, err)
+      )
+      .then(dispatch)
   }
-}
-
-export function pipettesReducer (
-  state: ?PipettesState,
-  action: Action
-): PipettesState {
-  if (state == null) return {}
-
-  let name
-  let pipettes
-  let error
-
-  switch (action.type) {
-    case 'api:PIPETTES_REQUEST':
-      ({robot: {name}} = action.payload)
-      return {
-        ...state,
-        [name]: {...state[name], error: null, inProgress: true},
-      }
-
-    case 'api:PIPETTES_SUCCESS':
-      ({pipettes, robot: {name}} = action.payload)
-      return {
-        ...state,
-        [name]: {error: null, response: pipettes, inProgress: false},
-      }
-
-    case 'api:PIPETTES_FAILURE':
-      ({error, robot: {name}} = action.payload)
-      return {
-        ...state,
-        [name]: {...state[name], error, inProgress: false},
-      }
-  }
-
-  return state
 }
 
 export const makeGetRobotPipettes = () => {
   const selector: Selector<State, BaseRobot, RobotPipettes> = createSelector(
-    selectRobotPipettesState,
-    (state) => state || {inProgress: false, error: null, response: null}
+    getRobotApiState,
+    (state) => state[PIPETTES] || {inProgress: false}
   )
 
   return selector
-}
-
-function selectRobotPipettesState (state: State, props: BaseRobot) {
-  return state.api.pipettes[props.name]
 }

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -26,8 +26,7 @@ type SettingsRequest = ?{id: Id, value: Value}
 
 type SettingsResponse = {settings: Array<Setting>}
 
-export type SettingsAction =
-  ApiAction<'settings', SettingsRequest, SettingsResponse>
+export type SettingsAction = ApiAction<'settings', SettingsRequest, SettingsResponse>
 
 export type RobotSettingsCall = ApiCall<SettingsRequest, SettingsResponse>
 

--- a/app/src/support.js
+++ b/app/src/support.js
@@ -51,15 +51,16 @@ export const supportMiddleware: Middleware = (store) => (next) => (action) => {
     const robot = state.robot.connection.connectRequest.name
 
     update = {[ROBOT_NAME]: robot}
-  } else if (action.type === 'api:PIPETTES_SUCCESS') {
+  } else if (action.type === 'api:SUCCESS') {
     const state = store.getState()
-
     if (state.robot.connection.connectedTo === action.payload.robot.name) {
-      const {left, right} = action.payload.pipettes
+      if (action.payload.path === 'pipettes') {
+        const {left, right} = action.payload.response
 
-      update = {
-        [PIPETTE_MODEL_LEFT]: left.model,
-        [PIPETTE_MODEL_RIGHT]: right.model,
+        update = {
+          [PIPETTE_MODEL_LEFT]: left.model,
+          [PIPETTE_MODEL_RIGHT]: right.model,
+        }
       }
     }
   }


### PR DESCRIPTION
## overview

Small refactor PR in to make future API work around connectivity state easier with regards to #2100. 

Since pipettes is a one off case with refresh it does not implement `buildRequestMaker`.

This pr touches motors as well since they depend on pipettes. Theres a TODO about storing motors in state that might require further discussion.

## changelog

- refactor(app): Consolidate /pipettes calls into common API

## review requests

tests pass and everything looks cool on VS but please test all pipette related pages on an actual robot with pipettes to ensure everything still works!

- [ ] `InstrumentSettings` page pipettes card
- [ ] `FileInfo` page pipettes section
- [ ] Pipette calibration pages
