### PR TITLE
feat(app): Populate FileInfo page with JSON protocol metadata

### DIFF
--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -1,32 +1,74 @@
 // @flow
 import * as React from 'react'
+import {connect} from 'react-redux'
+import moment from 'moment'
+
+import {
+  getProtocolName,
+  getProtocolAuthor,
+  getProtocolLastUpdated,
+  getProtocolMethod,
+  getProtocolDescription,
+} from '../../protocol'
 import {LabeledValue} from '@opentrons/components'
 import InfoSection from './InfoSection'
-import {SectionContentHalf} from '../layout'
+import {SectionContentHalf, CardRow} from '../layout'
 
-import styles from './styles.css'
+import type {State} from '../../types'
 
 type Props = {
-  name: string,
+  name: ?string,
+  author: ?string,
+  lastUpdated: ?number,
+  method: ?string,
+  description: ?string,
 }
-const TITLE = 'Information'
 
-export default function InformationCard (props: Props) {
-  const {name} = props
+const INFO_TITLE = 'Information'
+const DESCRIPTION_TITLE = 'Description'
+const DATE_FORMAT = 'DD MMM Y, hh:mmA'
 
-  let createdBy = 'Opentrons API'
-  if (name.endsWith('.json')) {
-    createdBy = 'Protocol Designer'
-  }
+export default connect(mapStateToProps)(InformationCard)
+
+function InformationCard (props: Props) {
+  const {name, author, method, description} = props
+  const lastUpdated = props.lastUpdated
+    ? moment(props.lastUpdated).format(DATE_FORMAT)
+    : '-'
 
   return (
-    <InfoSection title={TITLE}>
-      <SectionContentHalf>
-        <LabeledValue label={'Protocol Name'} value={name} />
-      </SectionContentHalf>
-      <SectionContentHalf className={styles.align_left}>
-        <LabeledValue label={'Creation Method'} value={createdBy} />
-      </SectionContentHalf>
-    </InfoSection>
+    <React.Fragment>
+      <InfoSection title={INFO_TITLE}>
+        <CardRow>
+          <SectionContentHalf>
+            <LabeledValue label="Protocol Name" value={name || '-'} />
+          </SectionContentHalf>
+          <SectionContentHalf>
+            <LabeledValue label="Organization/Author" value={author || '-'} />
+          </SectionContentHalf>
+        </CardRow>
+        <SectionContentHalf>
+          <LabeledValue label="Last Updated" value={lastUpdated} />
+        </SectionContentHalf>
+        <SectionContentHalf>
+          <LabeledValue label="Creation Method" value={method || '-'} />
+        </SectionContentHalf>
+      </InfoSection>
+      {description && (
+        <InfoSection title={DESCRIPTION_TITLE}>
+          <p>{description}</p>
+        </InfoSection>
+      )}
+    </React.Fragment>
   )
+}
+
+function mapStateToProps (state: State): Props {
+  return {
+    name: getProtocolName(state),
+    author: getProtocolAuthor(state),
+    lastUpdated: getProtocolLastUpdated(state),
+    method: getProtocolMethod(state),
+    description: getProtocolDescription(state),
+  }
 }

--- a/app/src/components/FileInfo/LabwareTable.js
+++ b/app/src/components/FileInfo/LabwareTable.js
@@ -3,14 +3,11 @@ import * as React from 'react'
 import styles from './styles.css'
 
 type Props = {
-  title: string,
   children: React.Node,
 }
 
 export default function LabwareTable (props: Props) {
   return (
-    <div>
-    <h3 className={styles.title}>{props.title}</h3>
     <table className={styles.labware_table}>
       <tbody>
         <tr>
@@ -20,6 +17,5 @@ export default function LabwareTable (props: Props) {
         {props.children}
       </tbody>
     </table>
-    </div>
   )
 }

--- a/app/src/components/FileInfo/ProtocolLabwareCard.js
+++ b/app/src/components/FileInfo/ProtocolLabwareCard.js
@@ -3,10 +3,13 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import countBy from 'lodash/countBy'
+
+import {selectors as robotSelectors} from '../../robot'
+import InfoSection from './InfoSection'
+import LabwareTable from './LabwareTable'
+
 import type {State} from '../../types'
 import type {Labware} from '../../robot'
-import {selectors as robotSelectors} from '../../robot'
-import LabwareTable from './LabwareTable'
 
 type Props = {
   labware: Array<Labware>,
@@ -14,12 +17,14 @@ type Props = {
 
 const TITLE = 'Required Labware'
 
-export default connect(mapStateToProps, null)(ProtocolLabwareCard)
+export default connect(mapStateToProps)(ProtocolLabwareCard)
 
 function ProtocolLabwareCard (props: Props) {
   const {labware} = props
-  const labwareCount = countBy(labware, 'name')
 
+  if (labware.length === 0) return null
+
+  const labwareCount = countBy(labware, 'name')
   const labwareList = Object.keys(labwareCount).map(type => (
     <tr key={type}>
       <td>{type}</td>
@@ -28,9 +33,9 @@ function ProtocolLabwareCard (props: Props) {
   ))
 
   return (
-    <LabwareTable title={TITLE}>
-      {labwareList}
-    </LabwareTable>
+    <InfoSection title={TITLE}>
+      <LabwareTable>{labwareList}</LabwareTable>
+    </InfoSection>
   )
 }
 function mapStateToProps (state: State): Props {

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -16,36 +16,37 @@ import {SectionContentHalf} from '../layout'
 import InfoSection from './InfoSection'
 import InstrumentWarning from './InstrumentWarning'
 
+type OP = {
+  robot: Robot,
+}
+
 type SP = {
   pipettes: Array<Pipette>,
   actualPipettes: ?PipettesResponse,
-  _robot: ?Robot,
 }
 
-type DP = {dispatch: Dispatch}
-
-type Props = SP & {
+type DP = {
   fetchPipettes: () => mixed,
   changePipetteUrl: string,
 }
 
+type Props = OP & SP & DP
+
 const TITLE = 'Required Pipettes'
 
-export default connect(makeMapStateToProps, null, mergeProps)(ProtocolPipettesCard)
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(ProtocolPipettes)
 
-function ProtocolPipettesCard (props: Props) {
-  const {
-    pipettes,
-    actualPipettes,
-    fetchPipettes,
-    changePipetteUrl,
-  } = props
+function ProtocolPipettes (props: Props) {
+  const {pipettes, actualPipettes, fetchPipettes, changePipetteUrl} = props
 
-  const pipetteInfo = pipettes.map((p) => {
+  if (pipettes.length === 0) return null
+
+  const pipetteInfo = pipettes.map(p => {
     const pipetteConfig = getPipette(p.name)
-    const displayName = !pipetteConfig
-      ? 'N/A'
-      : pipetteConfig.displayName
+    const displayName = !pipetteConfig ? 'N/A' : pipetteConfig.displayName
 
     const actualModel = actualPipettes && actualPipettes[p.mount].model
     let pipettesMatch = true
@@ -61,49 +62,49 @@ function ProtocolPipettesCard (props: Props) {
     }
   })
 
-  const pipettesMatch = pipetteInfo.every((p) => p.pipettesMatch)
+  const pipettesMatch = pipetteInfo.every(p => p.pipettesMatch)
 
   return (
-    <RefreshWrapper
-      refresh={fetchPipettes}
-    >
+    <RefreshWrapper refresh={fetchPipettes}>
       <InfoSection title={TITLE}>
         <SectionContentHalf>
-          {pipetteInfo.map((p) => (
-            <InstrumentItem key={p.mount} match={p.pipettesMatch} mount={p.mount}>{p.displayName}</InstrumentItem>
+          {pipetteInfo.map(p => (
+            <InstrumentItem
+              key={p.mount}
+              match={p.pipettesMatch}
+              mount={p.mount}
+            >
+              {p.displayName}
+            </InstrumentItem>
           ))}
         </SectionContentHalf>
         {!pipettesMatch && (
-          <InstrumentWarning instrumentType='pipette' url={changePipetteUrl}/>
+          <InstrumentWarning instrumentType="pipette" url={changePipetteUrl} />
         )}
       </InfoSection>
     </RefreshWrapper>
   )
 }
 
-function makeMapStateToProps (): (state: State) => SP {
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getAttachedPipettes = makeGetRobotPipettes()
 
-  return (state, props) => {
-    const _robot = robotSelectors.getConnectedRobot(state)
-    const pipettesCall = _robot && getAttachedPipettes(state, _robot)
+  return (state, ownProps) => {
+    const pipettesCall = getAttachedPipettes(state, ownProps.robot)
 
     return {
-      _robot,
       pipettes: robotSelectors.getPipettes(state),
       actualPipettes: pipettesCall && pipettesCall.response,
     }
   }
 }
 
-function mergeProps (stateProps: SP, dispatchProps: DP): Props {
-  const {dispatch} = dispatchProps
-  const {_robot} = stateProps
-  const changePipetteUrl = _robot ? `/robots/${_robot.name}/instruments` : '/robots'
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  const {robot} = ownProps
+  const changePipetteUrl = `/robots/${robot.name}/instruments`
 
   return {
-    ...stateProps,
     changePipetteUrl,
-    fetchPipettes: () => _robot && dispatch(fetchPipettes(_robot)),
+    fetchPipettes: () => dispatch(fetchPipettes(robot)),
   }
 }

--- a/app/src/components/FileInfo/index.js
+++ b/app/src/components/FileInfo/index.js
@@ -3,38 +3,33 @@ import * as React from 'react'
 
 import type {Robot} from '../../robot'
 
+// TODO(mc, 2018-09-13): these aren't cards; rename
 import InformationCard from './InformationCard'
 import ProtocolPipettesCard from './ProtocolPipettesCard'
 import ProtocolModulesCard from './ProtocolModulesCard'
 import ProtocolLabwareCard from './ProtocolLabwareCard'
 import Continue from './Continue'
-import {CardRow} from '../layout'
+import UploadError from '../UploadError'
 
 import styles from './styles.css'
 
 type Props = {
-  name: string,
   robot: Robot,
+  sessionLoaded: ?boolean,
+  uploadError: ?{message: string},
 }
 
 export default function FileInfo (props: Props) {
+  const {robot, sessionLoaded, uploadError} = props
+
   return (
     <div className={styles.file_info_container}>
-      <CardRow>
-        <InformationCard {...props}/>
-      </CardRow>
-      <CardRow>
-        <ProtocolPipettesCard />
-      </CardRow>
-      <CardRow>
-        <ProtocolModulesCard />
-      </CardRow>
-      <CardRow>
-        <ProtocolLabwareCard />
-      </CardRow>
-      <CardRow>
-        <Continue />
-      </CardRow>
+      <InformationCard />
+      <ProtocolPipettesCard robot={robot} />
+      <ProtocolModulesCard robot={robot} />
+      <ProtocolLabwareCard />
+      {uploadError && <UploadError uploadError={uploadError} />}
+      {sessionLoaded && <Continue />}
     </div>
   )
 }

--- a/app/src/components/FileInfo/styles.css
+++ b/app/src/components/FileInfo/styles.css
@@ -6,13 +6,23 @@
 }
 
 .info_section {
-  border-bottom: 1px solid var(--c-light-gray);
+  width: 100%;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+
+  & > p {
+    @apply --font-body-2-dark;
+  }
+
+  &:not(:last-of-type) {
+    border-bottom: 1px solid var(--c-light-gray);
+  }
 }
 
 .title {
   @apply --font-header-dark;
 
-  margin: 1rem 0;
+  margin: 0 0 1rem;
   font-weight: var(--fw-regular);
   text-transform: capitalize;
 }
@@ -85,5 +95,5 @@
 .continue_button {
   display: inline-block;
   width: 16.5rem;
-  margin-top: 1rem;
+  margin-bottom: 1rem;
 }

--- a/app/src/components/UploadError/index.js
+++ b/app/src/components/UploadError/index.js
@@ -1,7 +1,6 @@
 // @flow
 // upload summary component
 import * as React from 'react'
-import cx from 'classnames'
 import {Icon} from '@opentrons/components'
 
 import styles from './styles.css'
@@ -9,48 +8,27 @@ import styles from './styles.css'
 const UPLOAD_ERROR_MESSAGE = 'Your protocol could not be opened.'
 
 type Props = {
-  name: string,
-  uploadError: ?{message: string},
+  uploadError: {message: string},
 }
 
-export default function UploadStatus (props: Props) {
-  const {name, uploadError} = props
+export default function UploadError (props: Props) {
+  const {uploadError} = props
 
   return (
-    <div className={styles.container}>
-    <div className={styles.results}>
-      <StatusIcon />
+    <section className={styles.results}>
+      <Icon name="alert" className={styles.error_icon} />
       <div className={styles.status}>
-        <p className={styles.status_message}>
-          {UPLOAD_ERROR_MESSAGE}
-        </p>
+        <p className={styles.status_message}>{UPLOAD_ERROR_MESSAGE}</p>
         <div className={styles.details}>
-          <h3 className={styles.file_details_title}>
-            File details:
-          </h3>
+          <p className={styles.error_message}>{uploadError.message}</p>
           <p>
-            Filename: {name}
-          </p>
-        </div>
-        <div className={styles.details}>
-          <p className={styles.error_message}>
-            {uploadError && (uploadError.message)}
-          </p>
-          <p>
-            Looks like there might be a problem with your protocol file. Please
-            check your file for errors. If you need help, contact support
-            and provide them with your protocol file and the error message above.
+            It looks like there might be a problem with your protocol file.
+            Please check your file for errors. If you need help, contact support
+            and provide them with your protocol file and the error message
+            above.
           </p>
         </div>
       </div>
-    </div>
-    </div>
-  )
-}
-
-function StatusIcon () {
-  const iconClassName = cx(styles.status_icon, styles.error)
-  return (
-    <Icon name='alert' className={iconClassName} />
+    </section>
   )
 }

--- a/app/src/components/UploadError/styles.css
+++ b/app/src/components/UploadError/styles.css
@@ -1,67 +1,31 @@
-/* TODO(mc, 2018-02-09): fix lint errors and remove this ignore */
-/* stylelint-disable no-duplicate-selectors  */
-
 /* Upload component styles */
 @import '@opentrons/components';
 
-.container {
+.results {
   @apply --center-children;
 
   width: 100%;
-  height: 100%;
+  margin-top: 1.25rem;
 }
 
-.results {
-  display: flex;
-  align-items: center;
-}
-
-.status_icon {
+.error_icon {
   width: 6rem;
 }
 
 .status {
+  @apply --font-body-2-dark;
+
   margin-left: 2rem;
   max-width: 24rem;
-
-  & > *:not(:last-child) {
-    margin-bottom: 1rem;
-  }
 }
 
-.status_message {
-  @apply --font-header-dark;
-
-  margin-bottom: 1rem;
+.status_message,
+.error_message {
+  font-weight: var(--fw-semibold);
+  margin-bottom: 0.75rem;
 }
 
-.success {
-  color: var(--c-green);
-}
-
-.error,
+.error_icon,
 .error_message {
   color: var(--c-red);
-}
-
-.details {
-  @apply --font-body-2-dark;
-}
-
-.error_message {
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-}
-
-.file_details_title {
-  @apply --font-header-dark;
-
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  font-weight: var(--fw-regular);
-}
-
-.open_setup_link {
-  cursor: pointer;
-  color: var(--c-blue);
 }

--- a/app/src/components/UploadPanel/Upload.js
+++ b/app/src/components/UploadPanel/Upload.js
@@ -5,8 +5,8 @@ import ConfirmUploadModal from './ConfirmUploadModal'
 import UploadMenu from './UploadMenu'
 
 type Props = {
+  filename: ?string,
   sessionLoaded: ?boolean,
-  uploadError: ? {message: string},
   createSession: (file: File) => mixed,
 }
 
@@ -41,7 +41,7 @@ export default class Upload extends React.Component<Props, State> {
   }
 
   confirmUpload = () => {
-    const { uploadedFile } = this.state
+    const {uploadedFile} = this.state
 
     if (uploadedFile) {
       this.props.createSession(uploadedFile)
@@ -55,12 +55,14 @@ export default class Upload extends React.Component<Props, State> {
 
   render () {
     const {uploadedFile} = this.state
-    const {sessionLoaded, uploadError} = this.props
+    const {filename} = this.props
+
     return (
       <React.Fragment>
-        {sessionLoaded && !uploadError && (<UploadMenu />)}
+        {filename && <UploadMenu />}
         <UploadInput onUpload={this.onUpload} isButton />
         <UploadInput onUpload={this.onUpload} />
+
         {uploadedFile && (
           <ConfirmUploadModal
             confirm={this.confirmUpload}

--- a/app/src/components/UploadPanel/index.js
+++ b/app/src/components/UploadPanel/index.js
@@ -1,41 +1,50 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {connect} from 'react-redux'
-import {push} from 'react-router-redux'
 
 import {selectors as robotSelectors} from '../../robot'
-import {openProtocol} from '../../protocol'
+import {openProtocol, getProtocolFilename} from '../../protocol'
 
 import {SidePanel} from '@opentrons/components'
 import Upload from './Upload'
 
-type Props = {
+import type {State, Dispatch} from '../../types'
+
+type SP = {
+  filename: ?string,
   sessionLoaded: ?boolean,
-  uploadError: ? {message: string},
-  confirmUpload: () => mixed,
-  createSession: () => mixed,
+  uploadError: ?{message: string},
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UploadPanel)
+type DP = {
+  createSession: File => mixed,
+}
+
+type Props = SP & DP
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UploadPanel)
 
 function UploadPanel (props: Props) {
   return (
-    <SidePanel title='Open Protocol'>
+    <SidePanel title="Protocol File">
       <Upload {...props} />
     </SidePanel>
   )
 }
 
-function mapStateToProps (state) {
+function mapStateToProps (state: State): SP {
   return {
+    filename: getProtocolFilename(state),
     sessionLoaded: robotSelectors.getSessionIsLoaded(state),
     uploadError: robotSelectors.getUploadError(state),
   }
 }
 
-function mapDispatchToProps (dispatch) {
+function mapDispatchToProps (dispatch: Dispatch): DP {
   return {
-    confirmUpload: () => dispatch(push('/upload/confirm')),
-    createSession: (file) => dispatch(openProtocol(file)),
+    createSession: (file: File) => dispatch(openProtocol(file)),
   }
 }

--- a/app/src/components/layout/styles.css
+++ b/app/src/components/layout/styles.css
@@ -66,12 +66,10 @@
 .section_content_full {
   width: 100%;
   overflow-y: auto;
-  padding-bottom: 1rem;
 }
 
 .section_content_50 {
   display: inline-block;
   vertical-align: top;
   width: 50%;
-  padding-bottom: 1rem;
 }

--- a/app/src/pages/Upload/FileInfo.js
+++ b/app/src/pages/Upload/FileInfo.js
@@ -1,23 +1,36 @@
 // @flow
 import * as React from 'react'
-import type {Robot} from '../../robot'
+
+import {SpinnerModal} from '@opentrons/components'
 import Page from '../../components/Page'
 import FileInfo from '../../components/FileInfo'
 
+import type {Robot} from '../../robot'
+
 type Props = {
-  name: string,
   robot: Robot,
+  filename: string,
+  uploadInProgress: boolean,
+  uploadError: ?{message: string},
+  sessionLoaded: boolean,
 }
 
 export default function FileInfoPage (props: Props) {
+  const {robot, filename, uploadInProgress, uploadError, sessionLoaded} = props
+
   return (
     <Page
-      titleBarProps = {{
-        title: props.name,
+      titleBarProps={{
+        title: filename,
         subtitle: 'overview',
       }}
     >
-      <FileInfo {...props} />
+      <FileInfo
+        robot={robot}
+        sessionLoaded={sessionLoaded}
+        uploadError={uploadError}
+      />
+      {uploadInProgress && <SpinnerModal message="Upload in Progress" />}
     </Page>
   )
 }

--- a/app/src/protocol/__tests__/selectors.test.js
+++ b/app/src/protocol/__tests__/selectors.test.js
@@ -10,6 +10,24 @@ const SPECS = [
     expected: {name: 'proto.json'},
   },
   {
+    name: 'getProtocolContents',
+    selector: protocol.getProtocolContents,
+    state: {protocol: {file: {name: 'proto.json'}, contents: 'fizzbuzz'}},
+    expected: 'fizzbuzz',
+  },
+  {
+    name: 'getProtocolData',
+    selector: protocol.getProtocolData,
+    state: {
+      protocol: {
+        file: {name: 'proto.json'},
+        contents: 'fizzbuzz',
+        data: {metadata: {}},
+      },
+    },
+    expected: {metadata: {}},
+  },
+  {
     name: 'getProtocolFilename with no file',
     selector: protocol.getProtocolFilename,
     state: {protocol: {file: null}},
@@ -20,6 +38,215 @@ const SPECS = [
     selector: protocol.getProtocolFilename,
     state: {protocol: {file: {name: 'proto.json'}}},
     expected: 'proto.json',
+  },
+  {
+    name: 'getProtocolName with nothing loaded',
+    selector: protocol.getProtocolName,
+    state: {protocol: {file: null, contents: null, data: null}},
+    expected: null,
+  },
+  {
+    name: 'getProtocolName from filename if no data',
+    selector: protocol.getProtocolName,
+    state: {
+      protocol: {file: {name: 'proto.json'}, contents: null, data: null},
+    },
+    expected: 'proto',
+  },
+  {
+    name: 'getProtocolName from filename if data does not include name',
+    selector: protocol.getProtocolName,
+    state: {
+      protocol: {
+        file: {name: 'proto.json'},
+        contents: 'fizzbuzz',
+        data: {metadata: {}},
+      },
+    },
+    expected: 'proto',
+  },
+  {
+    name: 'getProtocolName from metadata',
+    selector: protocol.getProtocolName,
+    state: {
+      protocol: {
+        file: {name: 'proto.json'},
+        contents: 'fizzbuzz',
+        data: {metadata: {'protocol-name': 'A Protocol'}},
+      },
+    },
+    expected: 'A Protocol',
+  },
+  {
+    name: 'getProtocolAuthor if no data',
+    selector: protocol.getProtocolAuthor,
+    state: {protocol: {data: null}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolAuthor if author not in metadata',
+    selector: protocol.getProtocolAuthor,
+    state: {protocol: {data: {metadata: {}}}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolAuthor if author in metadata',
+    selector: protocol.getProtocolAuthor,
+    state: {protocol: {data: {metadata: {author: 'Fizz Buzz'}}}},
+    expected: 'Fizz Buzz',
+  },
+  {
+    name: 'getProtocolDescription if no data',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {data: null}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolDescription if description not in metadata',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {data: {metadata: {}}}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolDescription if description in metadata',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {data: {metadata: {description: 'Fizzes buzzes'}}}},
+    expected: 'Fizzes buzzes',
+  },
+  {
+    name: 'getProtocolLastUpdated falls back to file if no data',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {file: {lastModifieddata: null}}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolDescription if description not in metadata',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {data: {metadata: {}}}},
+    expected: undefined,
+  },
+  {
+    name: 'getProtocolDescription if description in metadata',
+    selector: protocol.getProtocolDescription,
+    state: {protocol: {data: {metadata: {description: 'Fizzes buzzes'}}}},
+    expected: 'Fizzes buzzes',
+  },
+  {
+    name: 'getProtocolLastUpdated if nothing loaded',
+    selector: protocol.getProtocolLastUpdated,
+    state: {protocol: {file: null, contents: null, data: null}},
+    expected: null,
+  },
+  {
+    name: 'getProtocolLastUpdated from file.lastModified',
+    selector: protocol.getProtocolLastUpdated,
+    state: {protocol: {file: {lastModified: 1}}},
+    expected: 1,
+  },
+  {
+    name: 'getProtocolLastUpdated from metadata.created',
+    selector: protocol.getProtocolLastUpdated,
+    state: {
+      protocol: {
+        file: {lastModified: 1},
+        data: {metadata: {created: 2}},
+      },
+    },
+    expected: 2,
+  },
+  {
+    name: 'getProtocolLastUpdated from metadata.last-modified',
+    selector: protocol.getProtocolLastUpdated,
+    state: {
+      protocol: {
+        file: {lastModified: 1},
+        data: {metadata: {created: 2, 'last-modified': 3}},
+      },
+    },
+    expected: 3,
+  },
+  {
+    name: 'getProtocolMethod if nothing loaded',
+    selector: protocol.getProtocolMethod,
+    state: {protocol: {file: null, contents: null, data: null}},
+    expected: null,
+  },
+  {
+    name: 'getProtocolMethod if file not yet read',
+    selector: protocol.getProtocolMethod,
+    state: {protocol: {file: {name: 'proto.py'}, contents: null, data: null}},
+    expected: null,
+  },
+  {
+    name: 'getProtocolMethod if non-JSON file has been read',
+    selector: protocol.getProtocolMethod,
+    state: {
+      protocol: {
+        file: {name: 'proto.py'},
+        contents: 'fizzbuzz',
+        data: null,
+      },
+    },
+    expected: 'Opentrons API',
+  },
+  {
+    name: 'getProtocolMethod if JSON file read but no data',
+    selector: protocol.getProtocolMethod,
+    state: {
+      protocol: {
+        file: {name: 'proto.json', type: 'application/json'},
+        contents: 'fizzbuzz',
+        data: null,
+      },
+    },
+    expected: 'Unknown Application',
+  },
+  {
+    name: 'getProtocolMethod if JSON file read but no name in data',
+    selector: protocol.getProtocolMethod,
+    state: {
+      protocol: {
+        file: {name: 'proto.py', type: 'application/json'},
+        contents: 'fizzbuzz',
+        data: {metadata: {}},
+      },
+    },
+    expected: 'Unknown Application',
+  },
+  {
+    name: 'getProtocolMethod if JSON file read with name in data',
+    selector: protocol.getProtocolMethod,
+    state: {
+      protocol: {
+        file: {name: 'proto.py', type: 'application/json'},
+        contents: 'fizzbuzz',
+        data: {
+          metadata: {},
+          'designer-application': {
+            'application-name': 'opentrons/protocol-designer',
+          },
+        },
+      },
+    },
+    expected: 'Opentrons Protocol Designer',
+  },
+  {
+    name: 'getProtocolMethod if JSON file read with name and version in data',
+    selector: protocol.getProtocolMethod,
+    state: {
+      protocol: {
+        file: {name: 'proto.py', type: 'application/json'},
+        contents: 'fizzbuzz',
+        data: {
+          metadata: {},
+          'designer-application': {
+            'application-name': 'opentrons/protocol-designer',
+            'application-version': 'v1.2.3',
+          },
+        },
+      },
+    },
+    expected: 'Opentrons Protocol Designer v1.2.3',
   },
 ]
 

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -1,28 +1,31 @@
 // @flow
 // protocol state and loading actions
-import { createSelector } from 'reselect'
-
+import path from 'path'
+import startCase from 'lodash/startCase'
+import {createSelector} from 'reselect'
+import {getter} from '@thi.ng/paths'
 import {
   fileToProtocolFile,
   parseProtocolData,
+  fileIsJson,
   filenameToType,
 } from './protocol-data'
 
-import type { Selector } from 'reselect'
-import type { State, Action, ThunkAction } from '../types'
-import type { ProtocolState, ProtocolFile, ProtocolData } from './types'
+import type {Selector} from 'reselect'
+import type {State, Action, ThunkAction} from '../types'
+import type {ProtocolState, ProtocolFile, ProtocolData} from './types'
 
 export * from './types'
 
 type OpenProtocolAction = {|
   type: 'protocol:OPEN',
-  payload: {| file: ProtocolFile |},
+  payload: {|file: ProtocolFile|},
 |}
 
 type UploadProtocolAction = {|
   type: 'protocol:UPLOAD',
-  payload: {| contents: string, data: ?ProtocolData |},
-  meta: {| robot: true |},
+  payload: {|contents: string, data: ?ProtocolData|},
+  meta: {|robot: true|},
 |}
 
 export type ProtocolAction = OpenProtocolAction | UploadProtocolAction
@@ -33,7 +36,7 @@ export function openProtocol (file: File): ThunkAction {
     const protocolFile = fileToProtocolFile(file)
     const openAction: OpenProtocolAction = {
       type: 'protocol:OPEN',
-      payload: { file: protocolFile },
+      payload: {file: protocolFile},
     }
 
     reader.onload = () => {
@@ -41,8 +44,8 @@ export function openProtocol (file: File): ThunkAction {
       const contents: string = (reader.result: any)
       const uploadAction: UploadProtocolAction = {
         type: 'protocol:UPLOAD',
-        payload: { contents, data: parseProtocolData(protocolFile, contents) },
-        meta: { robot: true },
+        payload: {contents, data: parseProtocolData(protocolFile, contents)},
+        meta: {robot: true},
       }
 
       dispatch(uploadAction)
@@ -53,7 +56,7 @@ export function openProtocol (file: File): ThunkAction {
   }
 }
 
-const INITIAL_STATE = { file: null, contents: null, data: null }
+const INITIAL_STATE = {file: null, contents: null, data: null}
 
 export function protocolReducer (
   state: ProtocolState = INITIAL_STATE,
@@ -61,19 +64,21 @@ export function protocolReducer (
 ): ProtocolState {
   switch (action.type) {
     case 'protocol:OPEN':
-      return { ...INITIAL_STATE, ...action.payload }
+      return {...INITIAL_STATE, ...action.payload}
 
     case 'protocol:UPLOAD':
-      return { ...state, ...action.payload }
+      return {...state, ...action.payload}
 
     case 'robot:SESSION_RESPONSE': {
       const {name, protocolText: contents} = action.payload
-      const file = !state.file || name !== state.file.name
-        ? {name, type: filenameToType(name), lastModified: null}
-        : state.file
-      const data = !state.contents || contents !== state.contents
-        ? parseProtocolData(file, contents)
-        : state.data
+      const file =
+        !state.file || name !== state.file.name
+          ? {name, type: filenameToType(name), lastModified: null}
+          : state.file
+      const data =
+        !state.contents || contents !== state.contents
+          ? parseProtocolData(file, contents)
+          : state.data
 
       return {file, contents, data}
     }
@@ -85,11 +90,76 @@ export function protocolReducer (
   return state
 }
 
+type StringGetter = (?ProtocolData) => ?string
+type NumberGetter = (?ProtocolData) => ?number
 type StringSelector = Selector<State, void, ?string>
+type NumberSelector = Selector<State, void, ?number>
+
+const getName: StringGetter = getter('metadata.protocol-name')
+const getAuthor: StringGetter = getter('metadata.author')
+const getDesc: StringGetter = getter('metadata.description')
+const getCreated: NumberGetter = getter('metadata.created')
+const getLastModified: NumberGetter = getter('metadata.last-modified')
+const getAppName: StringGetter = getter('designer-application.application-name')
+const getAppVersion: StringGetter = getter(
+  'designer-application.application-version'
+)
+const stripDirAndExtension = f => path.basename(f, path.extname(f))
 
 export const getProtocolFile = (state: State) => state.protocol.file
+export const getProtocolContents = (state: State) => state.protocol.contents
+export const getProtocolData = (state: State) => state.protocol.data
 
 export const getProtocolFilename: StringSelector = createSelector(
   getProtocolFile,
   file => file && file.name
+)
+
+export const getProtocolLastModified: NumberSelector = createSelector(
+  getProtocolFile,
+  file => file && file.lastModified
+)
+
+export const getProtocolName: StringSelector = createSelector(
+  getProtocolFilename,
+  getProtocolData,
+  (name, data) => getName(data) || (name && stripDirAndExtension(name))
+)
+
+export const getProtocolAuthor: StringSelector = createSelector(
+  getProtocolData,
+  data => getAuthor(data)
+)
+
+export const getProtocolDescription: StringSelector = createSelector(
+  getProtocolData,
+  data => getDesc(data)
+)
+
+export const getProtocolLastUpdated: NumberSelector = createSelector(
+  getProtocolFile,
+  getProtocolData,
+  (file, data) =>
+    getLastModified(data) || getCreated(data) || (file && file.lastModified)
+)
+
+const METHOD_OT_API = 'Opentrons API'
+const METHOD_UNKNOWN = 'Unknown Application'
+
+export const getProtocolMethod: StringSelector = createSelector(
+  getProtocolFile,
+  getProtocolContents,
+  getProtocolData,
+  (file, contents, data) => {
+    const isJson = file && fileIsJson(file)
+    const appName = getAppName(data)
+    const appVersion = getAppVersion(data)
+    const readableName = appName && startCase(appName)
+
+    if (!file || !contents) return null
+    if (isJson === true && !readableName) return METHOD_UNKNOWN
+    if (!isJson) return METHOD_OT_API
+    if (readableName && appVersion) return `${readableName} ${appVersion}`
+    return readableName
+  }
 )

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -14,7 +14,7 @@ import type {
   SessionStatus,
 } from '../types'
 
-import type {DisconnectResponseAction, SessionUpdateAction} from '../actions'
+import type {SessionUpdateAction} from '../actions'
 
 type Request = {
   inProgress: boolean,
@@ -88,12 +88,14 @@ export default function sessionReducer (
 ): State {
   switch (action.type) {
     case 'robot:DISCONNECT_RESPONSE':
-      return handleDisconnectResponse(state, action)
+      return INITIAL_STATE
 
     case 'robot:SESSION_UPDATE':
       return handleSessionUpdate(state, action)
 
     case 'protocol:UPLOAD':
+      return handleSessionInProgress(INITIAL_STATE)
+
     case 'robot:REFRESH_SESSION':
       return handleSessionInProgress(state)
 
@@ -101,32 +103,33 @@ export default function sessionReducer (
     case 'robot:SESSION_ERROR':
       return handleSessionResponse(state, action)
 
-    case RUN: return handleRun(state, action)
-    case RUN_RESPONSE: return handleRunResponse(state, action)
-    case PAUSE: return handlePause(state, action)
-    case PAUSE_RESPONSE: return handlePauseResponse(state, action)
-    case RESUME: return handleResume(state, action)
-    case RESUME_RESPONSE: return handleResumeResponse(state, action)
-    case CANCEL: return handleCancel(state, action)
-    case CANCEL_RESPONSE: return handleCancelResponse(state, action)
-    case TICK_RUN_TIME: return handleTickRunTime(state, action)
+    case RUN:
+      return handleRun(state, action)
+    case RUN_RESPONSE:
+      return handleRunResponse(state, action)
+    case PAUSE:
+      return handlePause(state, action)
+    case PAUSE_RESPONSE:
+      return handlePauseResponse(state, action)
+    case RESUME:
+      return handleResume(state, action)
+    case RESUME_RESPONSE:
+      return handleResumeResponse(state, action)
+    case CANCEL:
+      return handleCancel(state, action)
+    case CANCEL_RESPONSE:
+      return handleCancelResponse(state, action)
+    case TICK_RUN_TIME:
+      return handleTickRunTime(state, action)
   }
 
   return state
 }
 
-function handleDisconnectResponse (
-  state: State,
-  action: DisconnectResponseAction
-): State {
-  return INITIAL_STATE
-}
-
-function handleSessionUpdate (
-  state: State,
-  action: SessionUpdateAction
-): State {
-  const {payload: {state: sessionState, startTime, lastCommand}} = action
+function handleSessionUpdate (state: State, action: SessionUpdateAction): State {
+  const {
+    payload: {state: sessionState, startTime, lastCommand},
+  } = action
   let {protocolCommandsById} = state
 
   if (lastCommand) {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -109,7 +109,7 @@ export const getConnectionStatus: Selector<State, void, ConnectionStatus> =
     }
   )
 
-export function getSessionLoadInProgress (state: State) {
+export function getSessionLoadInProgress (state: State): boolean {
   return sessionRequest(state).inProgress
 }
 

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -44,6 +44,7 @@ describe('robot reducer - session', () => {
   })
 
   test('handles protocol:UPLOAD action', () => {
+    const initialState = reducer(undefined, {}).session
     const state = {
       session: {
         sessionRequest: {inProgress: false, error: new Error('AH')},
@@ -57,9 +58,8 @@ describe('robot reducer - session', () => {
     }
 
     expect(reducer(state, action).session).toEqual({
+      ...initialState,
       sessionRequest: {inProgress: true, error: null},
-      startTime: null,
-      runTime: 0,
     })
   })
 


### PR DESCRIPTION
## overview

Closes #2129

This PR adds selectors for JSON protocol metadata and wires them up into the File Info page. It also tweaks the error message to show up on the file info page (because protocol metadata would be useful to debug a JSON protocol that was valid JSON but failed during simulation).

![2018-09-13 23 30 36](https://user-images.githubusercontent.com/2963448/45566243-12e2ff80-b824-11e8-85f3-567b4f58169d.gif)

## changelog

- feat(app): Populate FileInfo page with JSON protocol metadata 

## review requests

Please test this out with:

- [x] Good JSON protocol
- [x] Bad JSON protocol
- [x] Good Python protocol
- [x] Bad Python protocol