### PR TITLE
fix(protocol-designer): correct alignment of form fields

### DIFF
--- a/components/src/forms/InputField.js
+++ b/components/src/forms/InputField.js
@@ -2,8 +2,9 @@
 import * as React from 'react'
 import cx from 'classnames'
 import {Icon} from '../icons'
-// import globalStyles from '../styles/index.css'
 import styles from './forms.css'
+
+// TODO: Ian 2018-09-14 remove 'label' prop when IngredientPropertiesForm gets updated
 
 type Props = {
   /** field is disabled if value is true */
@@ -12,7 +13,7 @@ type Props = {
   onChange?: (event: SyntheticInputEvent<*>) => mixed,
   /** classes to apply */
   className?: string,
-  /** inline label text */
+  /** inline label text. DEPRECATED */
   label?: string,
   /** placeholder text */
   placeholder?: string,

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -74,9 +74,14 @@
     flex: 1 1 auto;
     color: var(--c-dark-gray);
     width: 100%;
+    font-size: 1rem;
 
-    /* add 1px padding that is present in chrome but not ff */
-    padding: 1px;
+    /* TODO: Ian 2018-09-14 Firefox has 1px padding on input element,
+    * but I can't figure out how to fix it in Firefox without breaking it in Chrome.
+    * Better CSS reset for inputs needed?
+    */
+
+    /* padding: 1px; */
   }
 
   & input:focus {

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -102,6 +102,7 @@
     flex: 1 0;
     font-weight: var(--fw-semibold);
     text-align: right;
+    align-self: center;
     color: var(--c-dark-gray);
   }
 }

--- a/protocol-designer/src/components/StepEditForm/WellOrderInput/WellOrderInput.css
+++ b/protocol-designer/src/components/StepEditForm/WellOrderInput/WellOrderInput.css
@@ -4,6 +4,7 @@
   height: 30px;
   width: 30px;
   cursor: pointer;
+  margin: 0.25rem;
 }
 
 .well_order_icon:hover {


### PR DESCRIPTION
## overview

Closes #2196

InputField wasn't tall enough, and WellOrderInput needed a little vertical padding so that the rows in the form still line up.

## changelog

* consistent vertical padding for InputField and WellOrderInput

## review requests

- Looks OK
- You're OK with the 1px padding mis-alignment in Firefox on input field (@mcous fixed it, I'm breaking it again, b/c I spent too much time messing trying to reset it with no progress and PD doesn't support FF anyway)
- Run App should not be affected. I'm pretty sure the only thing that could be affected is the wifi password field, I don't see any other uses of InputField in run app -- and that wifi password field looks unchanged to me. Please double-check @Kadee80 @mcous 