### PR TITLE
feat(api): Add ability to connect to WPA2-Enterprise networks

### DIFF
--- a/api/opentrons/server/endpoints/wifi.py
+++ b/api/opentrons/server/endpoints/wifi.py
@@ -32,7 +32,27 @@ class ConfigureArgsError(Exception):
 
 async def list_networks(request: web.Request) -> web.Response:
     """
-    Get request will return a list of discovered ssids.
+    Get request will return a list of discovered ssids:
+
+    GET /wifi/list
+
+    200 OK
+    { "list": [
+        {
+           ssid: string // e.g. "linksys", name to connect to
+           signal: int // e.g. 100; arbitrary signal strength, more is better
+           active: boolean // e.g. true; whether there is a connection active
+           security: str // e.g. "WPA2 802.1X" raw nmcli security type output
+           securityType: str // e.g. "wpa-eap"; see blow
+        }
+      ]
+    }
+
+    The securityType field contains a value suitable for passing to the
+    securityType argument of /configure, or 'unsupported'. The security
+    field is mostly useful for debugging if you are unable to connect to
+    the network even though you think you are using the correct security
+    type.
     """
     try:
         networks = await nmcli.available_ssids()

--- a/api/opentrons/server/endpoints/wifi.py
+++ b/api/opentrons/server/endpoints/wifi.py
@@ -4,37 +4,214 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import Dict, List
+from typing import Dict, Any, List
 from aiohttp import web
 from opentrons.system import nmcli
 from opentrons.util import environment
 
 log = logging.getLogger(__name__)
 
+EAP_CONFIG_SHAPE = {
+    'options': [
+        {
+            'name': 'eapType',
+            'friendlyName': 'EAP Type',
+            'required': True,
+            'type': 'choice',
+            'choices': [t.qualified_name() for t in nmcli.EAP_TYPES]
+        }
+    ],
+    'methods': [
+        {'name': method.qualified_name(),
+         'options': [{k: v for k, v in arg.items()
+                      if k in ['name',
+                               'friendlyName',
+                               'required',
+                               'type',
+                               'choices',
+                               'fileType']}
+                     for arg in method.args()]}
+        for method in nmcli.EAP_TYPES]
+}
+
+
+class ConfigureArgsError(Exception):
+    def __init__(self, message):
+        self.msg = message
+        super().__init__()
+
 
 async def list_networks(request: web.Request) -> web.Response:
     """
     Get request will return a list of discovered ssids.
     """
-    res: Dict[str, List[str]] = {"list": []}
-
     try:
         networks = await nmcli.available_ssids()
-    except subprocess.CalledProcessError as e:
-        res = "CalledProcessError: {}".format(e.stdout)
-        status = 500
-    except FileNotFoundError as e:
-        res = "FileNotFoundError: {}".format(e)
-        status = 500
+    except RuntimeError as e:
+        return web.json_response({'message': ' '.join(e.args)}, status=500)
     else:
-        res["list"] = networks
-        status = 200
-
-    return web.json_response(res, status=status)
+        return web.json_response({'list': networks}, status=200)
 
 
-async def configure(request: web.Request) -> web.Response: # noqa(C901)
-    # Skipping complexity test due to planned work
+def _get_key_file(arg: str) -> str:
+    keys_dir = environment.get_path('WIFI_KEYS_DIR')
+    available_keys = os.listdir(keys_dir)
+    if arg not in available_keys:
+        raise ConfigureArgsError('Key ID {} is not valid on the system'
+                                 .format(arg))
+    files_in_dir = os.listdir(os.path.join(keys_dir, arg))
+    if len(files_in_dir) > 1:
+        raise OSError(
+            'Key ID {} has multiple files, try deleting and reuploading'
+            .format(arg))
+    return os.path.join(keys_dir, arg, files_in_dir[0])
+
+
+def _eap_check_no_extra_args(
+        config: Dict[str, Any], options: Any):
+    # options is an Any because the type annotation for EAP_CONFIG_SHAPE itself
+    # can’t quite express the type properly because of the inference from the
+    # dict annotation.
+    """Check for args that are not required for this method (to aid debugging)
+    ``config`` should be the user config.
+    ``options`` should be the options submember for the eap method.
+
+    Before this method is called, the validity of the 'eapType' key should be
+    established.
+    """
+    arg_names = [k for k in config.keys() if k != 'eapType']
+    valid_names = [o['name'] for o in options]
+    for an in arg_names:
+        if an not in valid_names:
+            raise ConfigureArgsError(
+                'Option {} is not valid for EAP method {}'
+                .format(an, config['eapType']))
+
+
+def _eap_check_option_ok(opt: Dict[str, str], config: Dict[str, Any]):
+    """ Check that a given EAP option is in the user config (if required)
+     and, if specified, is the right type.
+
+    ``opt`` should be an options dict from EAP_CONFIG_SHAPE.
+    ``config`` should be the user config dict.
+
+    Before this method is called, the validity of the eapType key should be
+    established.
+    """
+    if opt['name'] not in config:
+        if opt['required']:
+            raise ConfigureArgsError(
+                'Required argument {} for eap method {} not present'
+                .format(opt['friendlyName'], config['eapType']))
+        else:
+            return
+    name = opt['name']
+    o_type = opt['type']
+    arg = config[name]
+    if name in config:
+        if o_type in ('str', 'password') and not isinstance(arg, str):
+            raise ConfigureArgsError('Option {} should be a str'
+                                     .format(name))
+        elif o_type == 'choice' and arg not in opt['choices']:
+            raise ConfigureArgsError('Option {} must be one of {}'
+                                     .format(name,
+                                             ','.join(opt['choices'])))
+        elif o_type == 'bool' and not isinstance(arg, bool):
+            raise ConfigureArgsError('Option {} must be a bool'
+                                     .format(name))
+        elif o_type == 'file' and not isinstance(arg, str):
+            raise ConfigureArgsError('Option {} must be a str'
+                                     .format(name))
+
+
+def _eap_check_config(eap_config: Dict[str, Any]) -> Dict[str, Any]:
+    """ Check the eap specific args, and replace values where needed.
+
+    Similar to _check_configure_args but for only EAP.
+    """
+    eap_type = eap_config.get('eapType')
+    for method in EAP_CONFIG_SHAPE['methods']:
+        if method['name'] == eap_type:
+            options = method['options']
+            break
+    else:
+        raise ConfigureArgsError('EAP method {} is not valid'.format(eap_type))
+
+    _eap_check_no_extra_args(eap_config, options)
+
+    for opt in options:  # type: ignore
+        # Ignoring most types to do with EAP_CONFIG_SHAPE because of issues
+        # wth type inference for dict comprehensions
+        _eap_check_option_ok(opt, eap_config)
+        if opt['type'] == 'file' and opt['name'] in eap_config:
+            # Special work for file: rewrite from key id to path
+            eap_config[opt['name']] = _get_key_file(eap_config[opt['name']])
+    return eap_config
+
+
+def _deduce_security(kwargs) -> nmcli.SECURITY_TYPES:
+    """ Make sure that the security_type is known, or throw. """
+    # Security should be one of our valid strings
+    sec_translation = {
+        'wpa-psk': nmcli.SECURITY_TYPES.WPA_PSK,
+        'none': nmcli.SECURITY_TYPES.NONE,
+        'wpa-eap': nmcli.SECURITY_TYPES.WPA_EAP,
+    }
+    if not kwargs.get('security_type'):
+        if kwargs.get('psk') and kwargs.get('eap_config'):
+            raise ConfigureArgsError(
+                'Cannot deduce security type: psk and eap both passed')
+        elif kwargs.get('psk'):
+            kwargs['security_type'] = 'wpa-psk'
+        elif kwargs.get('eap_config'):
+            kwargs['security_type'] = 'wpa-eap'
+        else:
+            kwargs['security_type'] = 'none'
+    try:
+        return sec_translation[kwargs['security_type']]
+    except KeyError:
+        raise ConfigureArgsError('security_type must be one of {}'
+                                 .format(','.join(sec_translation.keys())))
+
+
+def _check_configure_args(**kwargs) -> Dict[str, Any]:
+    """ Check the arguments passed to configure.
+
+    Raises an exception on failure. On success, returns a dict of
+    kwargs with any necessary mutations.
+    """
+    # SSID must always be present
+    if not kwargs.get('ssid') or not isinstance(kwargs['ssid'], str):
+        raise ConfigureArgsError("SSID must be specified")
+    # If specified, hidden must be a bool
+    if not kwargs.get('hidden'):
+        kwargs['hidden'] = False
+    elif not isinstance(kwargs['hidden'], bool):
+        raise ConfigureArgsError('If specified, hidden must be a bool')
+
+    kwargs['security_type'] = _deduce_security(kwargs)
+
+    # If we have wpa2-personal, we need a psk
+    if kwargs['security_type'] == nmcli.SECURITY_TYPES.WPA_PSK:
+        if not kwargs.get('psk'):
+            raise ConfigureArgsError(
+                'If security_type is wpa-psk, psk must be specified')
+        return kwargs
+
+    # If we have wpa2-enterprise, we need eap config, and we need to check
+    # it
+    if kwargs['security_type'] == nmcli.SECURITY_TYPES.WPA_EAP:
+        if not kwargs.get('eap_config'):
+            raise ConfigureArgsError(
+                'If security_type is wpa-eap, eap_config must be specified')
+        kwargs['eap_config'] = _eap_check_config(kwargs['eap_config'])
+        return kwargs
+
+    # If we’re still here we have no security and we’re done
+    return kwargs
+
+
+async def configure(request: web.Request) -> web.Response:
     """
     Post request should include a json body specifying config information
     (see below). Robot will attempt to connect to this network and respond
@@ -42,63 +219,52 @@ async def configure(request: web.Request) -> web.Response: # noqa(C901)
 
     Fields in the body are:
     ssid: str Required. The SSID to connect to.
-    security_type: str Optional. one of 'none', 'wpa-psk'.
+    security_type: str Optional. one of 'none', 'wpa-psk', 'wpa-eap.
                        If not specified and
                        - psk is also not specified: assumed to be 'none'
                        - psk is specified: assumed to be 'wpa-psk'
     psk: str Optional. The password for the network, if there is one.
     hidden: bool Optional. True if the network is not broadcasting its
                            SSID. If not specified, assumed to be False.
+    eap_config: dict Optional. Configuration for WPA-EAP, required if
+                     security_type is wpa-eap. Should follow the format
+                     described by /wifi/eapoptions, e.g.
+                     {
+                         "method": <valid eap method>,
+                         "valid-eap-option1": arg,
+                         ...
+                         "valid-eap-optionN": arg
+                     }
+                     The types of the options should be as specified in
+                     /wifi/eapoptions. If the type is "file", the value
+                     should be a string containing the id of a previously
+                     uploaded key.
     """
-    result = {}
-    sec_translation = {
-        'wpa-psk': nmcli.SECURITY_TYPES.WPA_PSK,
-        'none': nmcli.SECURITY_TYPES.NONE,
-        None: nmcli.SECURITY_TYPES.NONE
-    }
     try:
         body = await request.json()
-        ssid = body.get('ssid')
-        psk = body.get('psk')
-        hidden = body.get('hidden')
-        security = body.get('security_type')
-        status = 200
-
-        if ssid is None:
-            status = 400
-            message = 'Error: "ssid" string is required'
-        try:
-            checked_sec = sec_translation[security]
-        except KeyError:
-            status = 400
-            message = 'Error: security type "{}" is invalid'.format(security)
-
-        if status == 200:
-            try:
-                ok, message = await nmcli.configure(ssid,
-                                                    security_type=checked_sec,
-                                                    psk=psk,
-                                                    hidden=hidden)
-            except ValueError as ve:
-                status = 400
-                message = str(ve)
-            else:
-                status = 201 if ok else 401
-            result['ssid'] = ssid
-
     except json.JSONDecodeError as e:
         log.debug("Error: JSONDecodeError in /wifi/configure: {}".format(e))
-        status = 400
-        message = e.msg
+        return web.json_response({'message': e.msg}, status=400)
 
-    except Exception as e:
-        log.warning("Error: {} in /wifi/configure': {}".format(type(e), e))
-        status = 500
-        message = 'An unexpected error occurred.'
+    try:
+        configure_kwargs = _check_configure_args(**body)
+    except ConfigureArgsError as e:
+        return web.json_response({'message': e.msg}, status=400)
+    except TypeError as te:  # Indicates an unexpected kwarg
+        return web.json_response({'message': str(te)}, status=400)
 
-    result['message'] = message
-    log.debug("Wifi configure result: {}".format(result))
-    return web.json_response(data=result, status=status)
+    try:
+        ok, message = await nmcli.configure(**configure_kwargs)
+        log.debug("Wifi configure result: {}".format(message))
+    except ValueError as ve:
+        return web.json_response({'message': str(ve)}, status=400)
+
+    if ok:
+        return web.json_response({'message': message,
+                                  'ssid': configure_kwargs['ssid']},
+                                 status=201)
+    else:
+        return web.json_response({'message': message}, status=401)
 
 
 async def status(request: web.Request) -> web.Response:
@@ -268,3 +434,83 @@ async def remove_key(request: web.Request) -> web.Response:
     return web.json_response(
         {'message': 'Key file {} deleted'.format(name)},
         status=200)
+
+
+async def eap_options(request: web.Request) -> web.Response:
+    """ Get request returns the available configuration options for WPA-EAP.
+
+    Because the options for connecting to WPA-EAP secured networks are quite
+    complex, to avoid duplicating logic this endpoint returns a json object
+    describing the structure of arguments and options for the eap_config arg to
+    /wifi/configure.
+
+    The object is shaped like this:
+    {
+        options: [  // top-level options valid for any EAP configuration method
+            {
+                  name: str // i.e. "identity"
+                  friendlyName: str // something human readable like "Username"
+                  required: bool,
+                  type: str,
+                  choices: optional list[str]
+            },
+        ],
+        methods: [ // Supported EAP methods and their options. One of these
+                   // method names must be passed in the eap_config dict
+            {
+                name: str // i.e. TTLS-EAPMSCHAPv2
+                options: [
+                    {
+                     name: str // i.e. "username"
+                     friendlyName: str // i.e. "Username"
+                     required: bool,
+                     type: str,
+                     choices: optional list[str]
+                   }
+                ]
+            }
+        ]
+    }
+
+
+    The ``type`` keys denore the semantic kind of the argument. Valid types
+    are:
+
+    password: This is some kind of password. It may be a psk for the network,
+              an Active Directory password, or the passphrase for a private key
+    str:      A generic string; perhaps a username, or a subject-matches
+              domain name for server validation
+    choice:   A string field with a limited number of options. If this is the
+              the type of an option, the option will also have a ``choices``
+              field presenting a list of valid options (as strings)
+    bool:     A boolean
+    file:     A file that the user must provide. This should be the id of a
+              file previously uploaded via POST /wifi/keys.
+
+
+    Although the arguments are described hierarchically, they should be
+    specified in eap_config as a flat dict. For instance, a /configure
+    invocation for TTLS/EAP-TLS might look like
+
+    ```
+    POST
+    {
+        ssid: "my-ssid",
+        securityType: "wpa-eap",
+        hidden: false,
+        eap_config : {
+            method: "TTLS/EAP-TLS",  // One of the method options
+            identity: "alice@example.com", // And then its arguments
+            anonymousIdentity: "anonymous@example.com",
+            password: "testing123",
+            caCert: "12d1f180f081b",
+            phase2CaCert: "12d1f180f081b",
+            phase2ClientCert: "009909fd9fa",
+            phase2PrivateKey: "081009fbcbc"
+            phase2PrivateKeyPassword: "testing321"
+        }
+    }
+    ```
+    """
+
+    return web.json_response(EAP_CONFIG_SHAPE, status=200)

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -170,7 +170,7 @@ def init(loop=None):
     server.app.router.add_get('/wifi/keys', wifi.list_keys)
     server.app.router.add_delete('/wifi/keys/{key_uuid}', wifi.remove_key)
     server.app.router.add_get(
-        '/wifi/eapoptions', wifi.eap_options)
+        '/wifi/eap-options', wifi.eap_options)
     server.app.router.add_post(
         '/identify', control.identify)
     server.app.router.add_get(

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -169,6 +169,8 @@ def init(loop=None):
     server.app.router.add_post('/wifi/keys', wifi.add_key)
     server.app.router.add_get('/wifi/keys', wifi.list_keys)
     server.app.router.add_delete('/wifi/keys/{key_uuid}', wifi.remove_key)
+    server.app.router.add_get(
+        '/wifi/eapoptions', wifi.eap_options)
     server.app.router.add_post(
         '/identify', control.identify)
     server.app.router.add_get(

--- a/api/opentrons/system/nmcli.py
+++ b/api/opentrons/system/nmcli.py
@@ -235,7 +235,7 @@ async def available_ssids() -> List[Dict[str, Any]]:
     Returns a list of the SSIDs. They may contain spaces and should be escaped
     if later passed to a shell.
     """
-    fields = ['ssid', 'signal', 'active']
+    fields = ['ssid', 'signal', 'active', 'security']
     cmd = ['--terse',
            '--fields',
            ','.join(fields),

--- a/api/opentrons/system/nmcli.py
+++ b/api/opentrons/system/nmcli.py
@@ -40,76 +40,76 @@ class _EAP_OUTER_TYPES(enum.Enum):
     TLS = EAPType(
         name='tls',
         args=[{'name': 'identity',
-               'friendlyName': 'Username',
+               'displayName': 'Username',
                'nmName': 'identity',
                'required': True,
-               'type': 'str'},
+               'type': 'string'},
               {'name': 'caCert',
-               'friendlyName': 'CA Certificate File',
+               'displayName': 'CA Certificate File',
                'nmName': 'ca-cert',
                'required': False,
                'type': 'file'},
               {'name': 'clientCert',
-               'friendlyName': 'Client Certificate File',
+               'displayName': 'Client Certificate File',
                'nmName': 'client-cert',
                'required': True,
                'type': 'file'},
               {'name': 'privateKey',
-               'friendlyName': 'Private Key File',
+               'displayName': 'Private Key File',
                'nmName': 'private-key',
                'required': True,
                'type': 'file'},
               {'name': 'privateKeyPassword',
-               'friendlyName': 'Private Key Password',
+               'displayName': 'Private Key Password',
                'nmName': 'private-key-password',
                'required': False,
                'type': 'password'}])
     PEAP = EAPType(
         name='peap',
         args=[{'name': 'identity',
-               'friendlyName': 'Username',
+               'displayName': 'Username',
                'nmName': 'identity',
                'required': True,
-               'type': 'str'},
+               'type': 'string'},
               {'name': 'anonymousIdentity',
-               'friendlyName': 'Anonymous Identity',
+               'displayName': 'Anonymous Identity',
                'nmName': 'anonymous-identity',
                'required': False,
-               'type': 'str'},
+               'type': 'string'},
               {'name': 'caCert',
-               'friendlyName': 'CA Certificate File',
+               'displayName': 'CA Certificate File',
                'nmName': 'ca-cert',
                'required': False,
                'type': 'file'}])
     TTLS = EAPType(
         name='ttls',
         args=[{'name': 'identity',
-               'friendlyName': 'Username',
+               'displayName': 'Username',
                'nmName': 'identity',
                'required': True,
-               'type': 'str'},
+               'type': 'string'},
               {'name': 'anonymousIdentity',
-               'friendlyName': 'Anonymous Identity',
+               'displayName': 'Anonymous Identity',
                'nmName': 'anonymous-identity',
                'required': False,
-               'type': 'str'},
+               'type': 'string'},
               {'name': 'caCert',
-               'friendlyName': 'CA Certificate File',
+               'displayName': 'CA Certificate File',
                'nmName': 'ca-cert',
                'required': False,
                'type': 'file'},
               {'name': 'clientCert',
-               'friendlyName': 'Client Certificate File',
+               'displayName': 'Client Certificate File',
                'nmName': 'client-cert',
                'required': False,
                'type': 'file'},
               {'name': 'privateKey',
-               'friendlyName': 'Private Key File',
+               'displayName': 'Private Key File',
                'nmName': 'private-key',
                'required': False,
                'type': 'file'},
               {'name': 'privateKeyPassword',
-               'friendlyName': 'Private Key Password',
+               'displayName': 'Private Key Password',
                'nmName': 'private-key-password',
                'required': False,
                'type': 'password'}])
@@ -128,36 +128,36 @@ class _EAP_PHASE2_TYPES(enum.Enum):
     MSCHAP_V2 = EAPType(
         name='mschapv2',
         args=[{'name': 'password',
-               'friendlyName': 'Password',
+               'displayName': 'Password',
                'nmName': 'password',
                'required': True,
                'type': 'password'}])
     MD5 = EAPType(
         name='md5',
         args=[{'name': 'password',
-               'friendlyName': 'Password',
+               'displayName': 'Password',
                'nmName': 'password',
                'required': True,
                'type': 'password'}])
     TLS = EAPType(
         name='tls',
         args=[{'name': 'phase2CaCert',
-               'friendlyName': 'Inner CA Certificate File',
+               'displayName': 'Inner CA Certificate File',
                'nmName': 'phase2-ca-cert',
                'required': False,
                'type': 'file'},
               {'name': 'phase2ClientCert',
-               'friendlyName': 'Inner Client Certificate File',
+               'displayName': 'Inner Client Certificate File',
                'nmName': 'phase2-client-cert',
                'required': True,
                'type': 'file'},
               {'name': 'phase2PrivateKey',
-               'friendlyName': 'Inner Private Key File',
+               'displayName': 'Inner Private Key File',
                'nmName': 'phase2-private-key',
                'required': True,
                'type': 'file'},
               {'name': 'phase2PrivateKeyPassword',
-               'friendlyName': 'Inner Private Key Password',
+               'displayName': 'Inner Private Key Password',
                'nmName': 'phase2-private-key-password',
                'required': False,
                'type': 'password'}])
@@ -391,11 +391,11 @@ def _build_con_add_cmd(ssid: str, security_type: SECURITY_TYPES,
 
 
 async def configure(ssid: str,
-                    security_type: SECURITY_TYPES,
+                    securityType: SECURITY_TYPES,
                     psk: Optional[str] = None,
                     hidden: bool = False,
-                    eap_config: Optional[Dict[str, Any]] = None,
-                    up_retries: int = 3) -> Tuple[bool, str]:
+                    eapConfig: Optional[Dict[str, Any]] = None,
+                    upRetries: int = 2) -> Tuple[bool, str]:
     """ Configure a connection but do not bring it up (though it is configured
     for autoconnect).
 
@@ -422,7 +422,7 @@ async def configure(ssid: str,
         _1, _2 = await _call(['connection', 'delete', already])
 
     configure_cmd = _build_con_add_cmd(
-        ssid, security_type, psk, hidden, eap_config)
+        ssid, securityType, psk, hidden, eapConfig)
     res, err = await _call(configure_cmd)
 
     # nmcli connection add returns a string that looks like
@@ -436,7 +436,7 @@ async def configure(ssid: str,
         return False, err.split('\r')[-1]
     name = uuid_matches.group(1)
     uuid = uuid_matches.group(2)
-    for _ in range(up_retries):
+    for _ in range(upRetries):
         res, err = await _call(['connection', 'up', 'uuid', uuid])
         if 'Connection successfully activated' in res:
             # If we successfully added the connection, remove other wifi

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -97,6 +97,12 @@ async def test_wifi_configure(
     assert resp.status == 201
     assert body == expected
 
+    resp = await cli.post(
+        '/wifi/configure', json={'ssid': 'asasd', 'foo': 'bar'})
+    assert resp.status == 400
+    body = await resp.json()
+    assert 'message' in body
+
 
 def test_deduce_security():
     with pytest.raises(wifi.ConfigureArgsError):

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -2,8 +2,10 @@ import json
 import os
 import random
 import tempfile
+import pytest
 from opentrons.server.main import init
 from opentrons.system import nmcli
+from opentrons.server.endpoints import wifi
 
 """
 All mocks in this test suite represent actual output from nmcli commands
@@ -96,6 +98,134 @@ async def test_wifi_configure(
     assert body == expected
 
 
+def test_deduce_security():
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._deduce_security({'psk': 'hi', 'eap_config': {'hi': 'nope'}})
+    assert wifi._deduce_security({'psk': 'test-psk'})\
+        == nmcli.SECURITY_TYPES.WPA_PSK
+    assert wifi._deduce_security({'eap_config': {'hi': 'this is bad'}})\
+        == nmcli.SECURITY_TYPES.WPA_EAP
+    assert wifi._deduce_security({}) == nmcli.SECURITY_TYPES.NONE
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._deduce_security({'security_type': 'this is invalid you fool'})
+
+
+def test_check_eap_config(wifi_keys_tempdir):
+    wifi_key_id = '88188cafcf'
+    os.mkdir(os.path.join(wifi_keys_tempdir, wifi_key_id))
+    with open(os.path.join(wifi_keys_tempdir,
+                           wifi_key_id,
+                           'test.pem'), 'w') as f:
+        f.write('what a terrible key')
+    # Bad eap types should fail
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_config({'eapType': 'afaosdasd'})
+    # Valid (if short) arguments should work
+    wifi._eap_check_config({'eapType': 'peap/eap-mschapv2',
+                            'identity': 'test@hi.com',
+                            'password': 'passwd'})
+    # Extra args should fail
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_config({'eapType': 'tls',
+                                'identity': 'test@example.com',
+                                'privateKey': wifi_key_id,
+                                'clientCert': wifi_key_id,
+                                'phase2CaCertf': 'foo'})
+    # Filenames should be rewritten
+    rewritten = wifi._eap_check_config({'eapType': 'ttls/eap-md5',
+                                        'identity': 'hello@example.com',
+                                        'password': 'hi',
+                                        'caCert': wifi_key_id})
+    assert rewritten['caCert'] == os.path.join(wifi_keys_tempdir,
+                                               wifi_key_id,
+                                               'test.pem')
+    # A config should be returned with the same keys
+    config = {'eapType': 'ttls/eap-tls',
+              'identity': "test@hello.com",
+              'phase2ClientCert': wifi_key_id,
+              'phase2PrivateKey': wifi_key_id}
+    out = wifi._eap_check_config(config)
+    for key in config.keys():
+        assert key in out
+
+
+def test_eap_check_option():
+    # Required arguments that are not specified should raise
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'test-opt', 'required': True,
+                                   'friendlyName': 'Test Option'},
+                                  {'eapType': 'test'})
+    # Non-required arguments that are not specified should not raise
+    wifi._eap_check_option_ok({'name': 'test-1',
+                               'required': False,
+                               'type': 'str',
+                               'friendlyName': 'Test Option'},
+                              {'eapType': 'test'})
+
+    # Check type mismatch detection pos and neg
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'identity',
+                                   'friendlyName': 'Username',
+                                   'required': True,
+                                   'type': 'str'},
+                                  {'identity': 2,
+                                  'eapType': 'test'})
+    wifi._eap_check_option_ok({'name': 'identity',
+                               'required': True,
+                               'friendlyName': 'Username',
+                               'type': 'str'},
+                              {'identity': 'hi',
+                              'eapType': 'test'})
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'password',
+                                   'required': True,
+                                   'friendlyName': 'Password',
+                                   'type': 'password'},
+                                  {'password': [2, 3],
+                                  'eapType': 'test'})
+    wifi._eap_check_option_ok({'name': 'password',
+                               'required': True,
+                               'friendlyName': 'password',
+                               'type': 'password'},
+                              {'password': 'secret',
+                              'eapType': 'test'})
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'phase2CaCert',
+                                   'friendlyName': 'some file who cares',
+                                   'required': True,
+                                   'type': 'file'},
+                                  {'phase2CaCert': 2,
+                                  'eapType': 'test'})
+    wifi._eap_check_option_ok({'name': 'phase2CaCert',
+                               'required': True,
+                               'friendlyName': 'hello',
+                               'type': 'file'},
+                              {'phase2CaCert': '82141cceaf',
+                              'eapType': 'test'})
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'some_flag',
+                                   'required': True,
+                                   'friendlyName': 'creative error',
+                                   'type': 'bool'},
+                                  {'some_flag': 'hi',
+                                  'eapType': 'test'})
+    with pytest.raises(wifi.ConfigureArgsError):
+        wifi._eap_check_option_ok({'name': 'some_choice',
+                                   'required': True,
+                                   'type': 'choice',
+                                   'friendlyName': 'Choice',
+                                   'choices': ['a', 'b', 'c']},
+                                  {'some_choice': 5,
+                                  'eapType': 'test'})
+    wifi._eap_check_option_ok({'name': 'some_choice',
+                               'required': True,
+                               'type': 'choice',
+                               'friendlyName': 'hi',
+                               'choices': ['a', 'b', 'c']},
+                              {'some_choice': 'a',
+                              'eapType': 'test'})
+
+
 async def test_list_keys(loop, test_client, wifi_keys_tempdir):
     dummy_names = ['ad12d1df199bc912', 'cbdda8124128cf', '812410990c5412']
     app = init(loop)
@@ -177,3 +307,35 @@ async def test_key_lifecycle(loop, test_client, wifi_keys_tempdir):
 
         dup_del_resp = await cli.delete(results['test1.pem']['uri'])
         assert dup_del_resp.status == 404
+
+
+async def test_eap_config_options(virtual_smoothie_env, loop, test_client):
+    app = init(loop)
+    cli = await loop.create_task(test_client(app))
+    resp = await cli.get('/wifi/eapoptions')
+
+    assert resp.status == 200
+
+    body = await resp.json()
+    # Check that the body is shaped correctly but ignore the actual content
+    assert 'options' in body
+    assert 'methods' in body
+    option_keys = ('name', 'friendlyName', 'required', 'type')
+    option_types = ('str', 'password', 'choice', 'file', 'bool')
+
+    def check_option(opt_dict):
+        for key in option_keys:
+            assert key in opt_dict
+        assert opt_dict['type'] in option_types
+        if opt_dict['type'] == 'choice':
+            assert 'choices' in opt_dict
+            assert isinstance(opt_dict['choices'], list)
+
+    for opt in body['options']:
+        check_option(opt)
+
+    for method in body['methods']:
+        assert 'name' in method
+        assert 'options' in method
+        for opt in method['options']:
+            check_option(opt)

--- a/update-server/otupdate/install.py
+++ b/update-server/otupdate/install.py
@@ -212,7 +212,6 @@ async def update_api(request: web.Request) -> web.Response:
     """
     log.debug('Update request received')
     data = await request.post()
-    # import pdb; pdb.set_trace()
     try:
         res0, rc0 = await install_py(
             sys.executable, data['whl'], request.loop)
@@ -228,7 +227,6 @@ async def update_api(request: web.Request) -> web.Response:
                 = (int(v) for v in version_re_res.group(1, 2, 3))
             if not _version_less((v_maj, v_min, v_pat),
                                  FIRST_PROVISIONED_VERSION):
-                # import pdb; pdb.set_trace()
                 resprov, rcprov = await _provision_container(
                     sys.executable, request.loop)
                 reslist.append(resprov)


### PR DESCRIPTION
This PR allows the system to connect to wireless networks that are secured
with WPA2-enterprise using

EAP-TLS
PEAP/EAP-MSCHAPv2 (eduroam)
TTLS/EAP-MSCHAPv2
TTLS/EAP-TLS
TTLS/MD5

These should be a good selection of the more popular EAP configurations.

There is also a framework for easily adding more configurations for EAP, by
adding elements to opentrons.system.nmcli._EAP_OUTER_TYPES,
opentrons.system.nmcli._EAP_PHASE2_TYPES, and opentrons.system.nmcli.EAP_TYPES.

Because eap configuration can become complex, the available configuration
options are exposed through a new endpoint, GET /wifi/eapoptions. The return
value describes the required structure for input to POST /wifi/configure.

The new endpoint has a lot of docs about it so check out the function `eap_options` in the wifi endpoints below.

# review requests

Testing, endpoint shapes. There are a couple different permutations to check out, all of which require a wireless AP and a RADIUS server. I've been using [freeradius](https://freeradius.org) which is a good FOSS implementation; I'd recommend installing it via homebrew or apt or whatever rather than using the docker container version of it, which is more intended for production and harder to configure.

Closes #2252, closes #2251, closes #2284 
