### PR TITLE
Pd fix transfer tip use

### DIFF
--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -160,8 +160,8 @@ describe('single transfer exceeding pipette max', () => {
   beforeEach(() => {
     transferArgs = {
       ...transferArgs,
-      sourceWells: ['A1'],
-      destWells: ['B2'],
+      sourceWells: ['A1', 'B1'],
+      destWells: ['A3', 'B3'],
       volume: 350,
     }
     // tip setup: tiprack's A1 has tip, pipette has no tip
@@ -169,6 +169,7 @@ describe('single transfer exceeding pipette max', () => {
     robotInitialState.tipState.pipettes.p300SingleId = false
     // liquid setup
     robotInitialState.liquidState.labware.sourcePlateId.A1 = {'0': {volume: 400}}
+    robotInitialState.liquidState.labware.sourcePlateId.B1 = {'1': {volume: 400}}
   })
 
   test('changeTip="once"', () => {
@@ -181,9 +182,13 @@ describe('single transfer exceeding pipette max', () => {
     expect(result.commands).toEqual([
       cmd.pickUpTip('A1'),
       cmd.aspirate('A1', 300),
-      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 300, {labware: 'destPlateId'}),
       cmd.aspirate('A1', 50),
-      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 50, {labware: 'destPlateId'}),
+      cmd.aspirate('B1', 300),
+      cmd.dispense('B3', 300, {labware: 'destPlateId'}),
+      cmd.aspirate('B1', 50),
+      cmd.dispense('B3', 50, {labware: 'destPlateId'}),
     ])
 
     expect(result.robotState.liquidState).toEqual(merge(
@@ -191,11 +196,26 @@ describe('single transfer exceeding pipette max', () => {
       robotInitialState.liquidState,
       {
         labware: {
-          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
-          destPlateId: {B2: {'0': {volume: 350}}},
+          sourcePlateId: {
+            A1: {'0': {volume: 400 - 350}},
+            B1: {'1': {volume: 400 - 350}},
+          },
+          destPlateId: {
+            A3: {'0': {volume: 350}},
+            B3: {
+              '0': {volume: 0}, // contaminant volume
+              '1': {volume: 350},
+            },
+          },
         },
         pipettes: {
-          p300SingleId: {'0': {'0': {volume: 0}}}, // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+          p300SingleId: {
+            // pipette's Tip 0 has 0uL of Ingred 0 & 1 (contamination)
+            '0': {
+              '0': {volume: 0},
+              '1': {volume: 0},
+            },
+          },
         },
       }
     ))
@@ -212,14 +232,28 @@ describe('single transfer exceeding pipette max', () => {
       cmd.pickUpTip('A1'),
 
       cmd.aspirate('A1', 300),
-      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 300, {labware: 'destPlateId'}),
 
       // replace tip before next asp-disp chunk
       cmd.dropTip('A1'),
       cmd.pickUpTip('B1'),
 
       cmd.aspirate('A1', 50),
-      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 50, {labware: 'destPlateId'}),
+
+      // replace tip before next source-dest well pair
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('C1'),
+
+      cmd.aspirate('B1', 300),
+      cmd.dispense('B3', 300, {labware: 'destPlateId'}),
+
+      // replace tip before next asp-disp chunk
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('D1'),
+
+      cmd.aspirate('B1', 50),
+      cmd.dispense('B3', 50, {labware: 'destPlateId'}),
     ])
 
     expect(result.robotState.liquidState).toEqual(merge(
@@ -227,12 +261,24 @@ describe('single transfer exceeding pipette max', () => {
       robotInitialState.liquidState,
       {
         labware: {
-          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
-          destPlateId: {B2: {'0': {volume: 350}}},
+          sourcePlateId: {
+            A1: {'0': {volume: 400 - 350}},
+            B1: {'1': {volume: 400 - 350}},
+          },
+          destPlateId: {
+            A3: {'0': {volume: 350}},
+            B3: {'0': {volume: 0}, '1': {volume: 350}},
+          },
           [FIXED_TRASH_ID]: result.robotState.liquidState.labware[FIXED_TRASH_ID], // Ignore liquid contents of trash. TODO LATER make this more elegant
         },
         pipettes: {
-          p300SingleId: {'0': {'0': {volume: 0}}}, // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+          p300SingleId: {
+            '0': {
+              // pipette's Tip 0 has 0uL of Ingred 0 and 1 (contamination)
+              '0': {volume: 0},
+              '1': {volume: 0},
+            },
+          },
         },
       }
     ))
@@ -250,10 +296,16 @@ describe('single transfer exceeding pipette max', () => {
     expect(result.commands).toEqual([
       // no pick up tip
       cmd.aspirate('A1', 300),
-      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 300, {labware: 'destPlateId'}),
 
       cmd.aspirate('A1', 50),
-      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+      cmd.dispense('A3', 50, {labware: 'destPlateId'}),
+
+      cmd.aspirate('B1', 300),
+      cmd.dispense('B3', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('B1', 50),
+      cmd.dispense('B3', 50, {labware: 'destPlateId'}),
     ])
 
     expect(result.robotState.liquidState).toEqual(merge(
@@ -261,11 +313,23 @@ describe('single transfer exceeding pipette max', () => {
       robotInitialState.liquidState,
       {
         labware: {
-          sourcePlateId: {A1: {'0': {volume: 400 - 350}}},
-          destPlateId: {B2: {'0': {volume: 350}}},
+          sourcePlateId: {
+            A1: {'0': {volume: 400 - 350}},
+            B1: {'1': {volume: 400 - 350}},
+          },
+          destPlateId: {
+            A3: {'0': {volume: 350}},
+            B3: {'0': {volume: 0}, '1': {volume: 350}},
+          },
         },
         pipettes: {
-          p300SingleId: {'0': {'0': {volume: 0}}}, // pipette's Tip 0 has 0uL of Ingred 0 (contamination)
+          p300SingleId: {
+            // pipette's Tip 0 has 0uL of Ingred 0 and 1 (contamination)
+            '0': {
+              '0': {volume: 0},
+              '1': {volume: 0},
+            },
+          },
         },
       }
     ))

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -74,7 +74,7 @@ const transfer = (data: TransferFormData): CommandCreator => (prevRobotState: Ro
         (subTransferVol: number, chunkIdx: number): Array<CommandCreator> => {
           // TODO IMMEDIATELY disposal vol ^^^
           const tipCommands: Array<CommandCreator> = (
-            (data.changeTip === 'once' && chunkIdx === 0) ||
+            (data.changeTip === 'once' && pairIdx === 0 && chunkIdx === 0) ||
             data.changeTip === 'always')
               ? [replaceTip(data.pipette)]
               : []


### PR DESCRIPTION
## overview

Fixes bug #2287 where Transfer with change tip: "only the first aspirate" (aka, "once") would change tips too eagerly (for cases where the transfer volume <= pipette max vol, it would change them every time and look the same as if "always" had been selected)

The diff is really 1 line, but I also expanded the tests to catch a wider range of behaviors with tip use.

## changelog

- fix changeTip="once" behavior for transfer

## review requests

Transfer tip use works as expected (hover over the saved Transfer step and look at what tips in the tiprack are highlighted)

Does not affect other step types, it's just Transfer.