### PR TITLE
refactor(api): Use inspect.getfullargspec in commands

### DIFF
--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -331,15 +331,15 @@ def publish(before, after, command, meta=None):
             call_args = _get_args(f, args, kwargs)
             command_args = dict(
                 zip(
-                    reversed(inspect.getargspec(command).args),
-                    reversed(inspect.getargspec(command).defaults or [])))
+                    reversed(inspect.getfullargspec(command).args),
+                    reversed(inspect.getfullargspec(command).defaults or [])))
 
             # TODO (artyom, 20170927): we are doing this to be able to use
             # the decorator in Instrument class methods, in which case
             # self is effectively an instrument.
             # To narrow the scope of this hack, we are checking if the command
             # is expecting instrument first.
-            if 'instrument' in inspect.getargspec(command).args:
+            if 'instrument' in inspect.getfullargspec(command).args:
                 # We are also checking if call arguments have 'self' and
                 # don't have instruments specified, in which case instruments
                 # should take precedence.
@@ -349,7 +349,7 @@ def publish(before, after, command, meta=None):
             command_args.update({
                 key: call_args[key]
                 for key in
-                set(inspect.getargspec(command).args) & call_args.keys()
+                set(inspect.getfullargspec(command).args) & call_args.keys()
             })
 
             if meta:
@@ -377,14 +377,14 @@ def _get_args(f, args, kwargs):
     # Create the initial dictionary with args that have defaults
     res = {}
 
-    if inspect.getargspec(f).defaults:
+    if inspect.getfullargspec(f).defaults:
         res = dict(
             zip(
-                reversed(inspect.getargspec(f).args),
-                reversed(inspect.getargspec(f).defaults)))
+                reversed(inspect.getfullargspec(f).args),
+                reversed(inspect.getfullargspec(f).defaults)))
 
     # Update / insert values for positional args
-    res.update(dict(zip(inspect.getargspec(f).args, args)))
+    res.update(dict(zip(inspect.getfullargspec(f).args, args)))
 
     # Update it with values for named args
     res.update(kwargs)


### PR DESCRIPTION
inspect.getargspec has been deprecated since version 3.0 (see
https://docs.python.org/3.6/library/inspect.html#inspect.getargspec ) in favor of
inspect.getfullargspec. This doesn't have a behavior change, but on some platforms, like appveyor,
every single time inspect.getargspec is used you get a deprecation warning, which at the very least
adds around 10k lines of noise to an appveyor build log.
