### PR TITLE
fix(protocol-designer): fix bug with well access for rect wells

### DIFF
--- a/shared-data/js/helpers/computeWellAccess.js
+++ b/shared-data/js/helpers/computeWellAccess.js
@@ -24,8 +24,12 @@ function findWellAt (labwareName: string, x: number, y: number): ?string {
     // Not circular, must be a rectangular well
     // For rectangular wells, (x, y) is at the center.
     // Here we calculate 'wellOriginX/Y', at the bottom left point (lowest x y values)
-    const wellOriginX = well.x - (well.width / 2)
-    const wellOriginY = well.y - (well.length / 2)
+
+    // TODO: Ian 2018-09-17 un-comment the below when definitions update to center
+    // (right now defs are bottom-left bounding box)
+
+    const wellOriginX = well.x // - (well.width / 2)
+    const wellOriginY = well.y // - (well.length / 2)
 
     return Math.abs(x - wellOriginX) <= well.width &&
       Math.abs(y - wellOriginY) <= well.length


### PR DESCRIPTION
## overview

Fixes #2081

When I wrote this, I thought `shared-data/` labware definitions worked like `default-containers.json` definitions -- that rectangular well x/y point was located in the center. However, in `shared-data/` right now, all well x/y points are located at the bottom left bounding box around the well.

In `shared-data/`, this will soon be changed to well center, so I kept the logic and just commented it out until `shared-data/` x/y matches what this code was written for, x/y in well center.

## changelog

- fix bug in findWellAt fn

## review requests

- Can select well 9 of trough
- Other labware selection still works (the only other rectangular-well labware is Trash Box, so that's worth testing, works for me)