### PR TITLE
fix(protocol-designer): fix recurring deleted labware bug

### DIFF
--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
@@ -69,8 +69,8 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   let wellHeightMM = null
   if (formData && formData[labwareFieldName]) {
     const labwareById = labwareIngredsSelectors.getLabware(state)
-    // TODO: BC 2018-08-29 protect for the case where selected labware gets deleted
-    const labwareDef = getLabware(labwareById[formData[labwareFieldName]].type)
+    const labware = labwareById[formData[labwareFieldName]]
+    const labwareDef = labware && labware.type && getLabware(labware.type)
     if (labwareDef) {
       // NOTE: only taking depth of first well in labware def, UI not currently equipped for multiple depths
       const firstWell = labwareDef.wells['A1']

--- a/protocol-designer/src/containers/SelectablePlate.js
+++ b/protocol-designer/src/containers/SelectablePlate.js
@@ -145,7 +145,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     containerId,
     wellContents,
     getTipProps: getTipProps || noop,
-    containerType: labware.type,
+    containerType: labware ? labware.type : 'missing labware',
     selectable,
   }
 }

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -30,7 +30,8 @@ export const getLabwareLiquidState: Selector<StepGeneration.LabwareLiquidState> 
       acc: StepGeneration.LabwareLiquidState,
       labwareId
     ): StepGeneration.LabwareLiquidState => {
-      const allWells = getAllWellsForLabware(allLabware[labwareId].type)
+      const labwareType = allLabware[labwareId] && allLabware[labwareId].type
+      const allWells = labwareType ? getAllWellsForLabware(labwareType) : []
       const liquidStateForLabwareAllWells = allWells.reduce(
         (innerAcc: StepGeneration.SingleLabwareLiquidState, well) => ({
           ...innerAcc,
@@ -46,7 +47,7 @@ export const getLabwareLiquidState: Selector<StepGeneration.LabwareLiquidState> 
   }
 )
 
-function labwareConverter (labwareAppState: {[labwareId: string]: Labware}): {[labwareId: string]: StepGeneration.LabwareData} {
+function labwareConverter (labwareAppState: {[labwareId: string]: ?Labware}): {[labwareId: string]: StepGeneration.LabwareData} {
   // Convert internal PD labware objects into JSON spec labware objects
   // (just removes keys & makes flow happy)
   return mapValues(labwareAppState, (l: Labware): StepGeneration.LabwareData => ({

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -82,7 +82,7 @@ const renameLabwareFormMode = handleActions({
 }, false)
 
 type ContainersState = {
-  [id: string]: Labware,
+  [id: string]: ?Labware,
 }
 
 const initialLabwareState: ContainersState = {
@@ -95,10 +95,14 @@ const initialLabwareState: ContainersState = {
   },
 }
 
-function getNextDisambiguationNumber (allContainers: ContainersState, labwareType: string): number {
-  const allIds = Object.keys(allContainers)
-  const sameTypeLabware = allIds.filter(containerId => allContainers[containerId].type === labwareType)
-  const disambigNumbers = sameTypeLabware.map(containerId => allContainers[containerId].disambiguationNumber)
+function getNextDisambiguationNumber (allLabwareById: ContainersState, labwareType: string): number {
+  const allIds = Object.keys(allLabwareById)
+  const sameTypeLabware = allIds.filter(labwareId =>
+    allLabwareById[labwareId] &&
+    allLabwareById[labwareId].type === labwareType)
+  const disambigNumbers = sameTypeLabware.map(labwareId =>
+    (allLabwareById[labwareId] &&
+    allLabwareById[labwareId].disambiguationNumber) || 0)
 
   return disambigNumbers.length > 0
     ? Math.max(...disambigNumbers) + 1
@@ -282,7 +286,7 @@ const rootReducer = combineReducers({
 // SELECTORS
 const rootSelector = (state: BaseState): RootState => state.labwareIngred
 
-const getLabware: Selector<{[labwareId: string]: Labware}> = createSelector(
+const getLabware: Selector<{[labwareId: string]: ?Labware}> = createSelector(
   rootSelector,
   rootState => rootState.containers
 )
@@ -311,8 +315,8 @@ const getIngredientNames: Selector<{[ingredId: string]: string}> = createSelecto
 )
 
 const _loadedContainersBySlot = (containers: ContainersState) =>
-  reduce(containers, (acc, container: Labware, containerId) => (container.slot)
-    ? {...acc, [container.slot]: container.type}
+  reduce(containers, (acc, labware: ?Labware) => (labware && labware.slot)
+    ? {...acc, [labware.slot]: labware.type}
     : acc
   , {})
 

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -138,7 +138,8 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
       } else if (multiToSingle) {
         // multi-channel to single-channel: convert primary wells to all wells
         const labwareId = unsavedForm.labware
-        const labwareType = labwareId && labwareIngredSelectors.getLabware(baseState)[labwareId].type
+        const labware = labwareId && labwareIngredSelectors.getLabware(baseState)[labwareId]
+        const labwareType = labware && labware.type
 
         updateOverrides = {
           ...updateOverrides,
@@ -158,8 +159,10 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
         const sourceLabwareId = unsavedForm['aspirate_labware']
         const destLabwareId = unsavedForm['dispense_labware']
 
-        const sourceLabwareType = sourceLabwareId && labwareIngredSelectors.getLabware(baseState)[sourceLabwareId].type
-        const destLabwareType = destLabwareId && labwareIngredSelectors.getLabware(baseState)[destLabwareId].type
+        const sourceLabware = sourceLabwareId && labwareIngredSelectors.getLabware(baseState)[sourceLabwareId]
+        const sourceLabwareType = sourceLabware && sourceLabware.type
+        const destLabware = destLabwareId && labwareIngredSelectors.getLabware(baseState)[destLabwareId]
+        const destLabwareType = destLabware && destLabware.type
 
         updateOverrides = {
           ...updateOverrides,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -32,8 +32,7 @@ const mixFormToArgs = (formData: FormData, context: StepFormContext): Validation
   const orderSecond = formData.aspirate_wellOrder_second
   if (context && context.labware && labware) {
     const labwareById = context.labware
-    const labwareType = labwareById[labware].type
-    const labwareDef = getLabware(labwareType)
+    const labwareDef = labwareById[labware] && getLabware(labwareById[labware].type)
     if (labwareDef) {
       const allWellsOrdered = orderWells(labwareDef.ordering, orderFirst, orderSecond)
       wells = intersection(allWellsOrdered, wells)

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -110,7 +110,7 @@ const transferLikeFormToArgs = (formData: FormData, context: StepFormContext): T
   if (context && context.labware) {
     const labwareById = context.labware
     if (stepType !== 'distribute' && sourceLabware) {
-      const sourceLabwareDef = getLabware(labwareById[sourceLabware].type)
+      const sourceLabwareDef = labwareById[sourceLabware] && getLabware(labwareById[sourceLabware].type)
       if (sourceLabwareDef) {
         const allWellsOrdered = orderWells(sourceLabwareDef.ordering, aspirate_wellOrder_first, aspirate_wellOrder_second)
         sourceWells = intersection(allWellsOrdered, sourceWells)
@@ -119,7 +119,7 @@ const transferLikeFormToArgs = (formData: FormData, context: StepFormContext): T
       }
     }
     if (stepType !== 'consolidate' && destLabware) {
-      const destLabwareDef = getLabware(labwareById[destLabware].type)
+      const destLabwareDef = labwareById[destLabware] && getLabware(labwareById[destLabware].type)
       if (destLabwareDef) {
         const allWellsOrdered = orderWells(destLabwareDef.ordering, dispense_wellOrder_first, dispense_wellOrder_second)
         destWells = intersection(allWellsOrdered, destWells)

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/types.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/types.js
@@ -3,5 +3,5 @@
 import type { Labware } from '../../../labware-ingred/types'
 
 export type StepFormContext = {
-  labware?: ?{[labwareId: string]: Labware},
+  labware?: ?{[labwareId: string]: ?Labware},
 }

--- a/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/wellContentsAllLabware.js
@@ -70,7 +70,7 @@ const wellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
       return {
         ...acc,
         [labwareId]: _getWellContents(
-          _labware[labwareId].type,
+           _labware[labwareId] && _labware[labwareId].type,
           ingredsForLabware,
           // Only give _getWellContents the selection data if it's a selected container
           isSelectedLabware ? _selectedWells : null,


### PR DESCRIPTION
## overview

Fix our recurring deleting labware bug #1406 #1614 ...once and for all?

The problem is the worst when you delete a labware that one or more steps are using, in edge it whitescreens.

At least this will have Flow ensure that accessing labware by id will be safe, and not whitescreen due to` TypeError: ___ is undefined`.

## changelog

* make labware access by id always maybe typed (?Labware) so flow ensures safe access

## review requests

- Code review -- still sane?
- Test PD, deleted labware experience isn't fantastic, but at least it no longer whitescreens.

The UI won't whitescreen with this PR, but it'll be a little weird. #2161 will address the UI issues left in place by this PR.