### PR TITLE
feat(api): support optional pause message

### DIFF
--- a/api/opentrons/commands/commands.py
+++ b/api/opentrons/commands/commands.py
@@ -302,11 +302,14 @@ def delay(seconds, minutes):
     )
 
 
-def pause():
+def pause(msg):
+    text = 'Pausing robot operation'
+    if msg:
+        text = text + ': {}'.format(msg)
     return make_command(
         name=types.PAUSE,
         payload={
-            'text': 'Pausing robot operation'
+            'text': text
         }
     )
 

--- a/api/opentrons/protocols/__init__.py
+++ b/api/opentrons/protocols/__init__.py
@@ -156,12 +156,8 @@ def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: 
             if wait is None:
                 raise ValueError('Delay cannot be null')
             elif wait is True:
-                # TODO: Ian 2018-09-11 this causes Run App command list to
-                # indent, un-comment when there's a path to fix:
-
-                # message = params.get('message', 'Pausing until user resumes')
-                # robot.comment(message)
-                robot.pause()
+                message = params.get('message', 'Pausing until user resumes')
+                robot.pause(msg=message)
             else:
                 _sleep(wait)
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -741,7 +741,7 @@ class Robot(object):
             )
 
     @commands.publish.both(command=commands.pause)
-    def pause(self):
+    def pause(self, msg=None):
         """
         Pauses execution of the protocol. Use :meth:`resume` to resume
         """
@@ -817,7 +817,7 @@ class Robot(object):
             return False
         return self._driver.simulating
 
-    @commands.publish.before(command=commands.comment)
+    @commands.publish.both(command=commands.comment)
     def comment(self, msg):
         pass
 


### PR DESCRIPTION
## overview

Closes #1694 - `robot.pause` supports optional message param. Also fixes unticketed issue where robot.comment causes commands list in Run App to indent.

JSON example (nothing is indented in JSON b/c only low-level methods used):
![image](https://user-images.githubusercontent.com/11590381/45700099-afb1df80-bb39-11e8-9d87-248255c28ffb.png)

.py example (.py uses indentation b/c it uses distribute, etc high-level methods):
![image](https://user-images.githubusercontent.com/11590381/45700245-fd2e4c80-bb39-11e8-8136-424033313722.png)

## changelog

* support optional robot.pause message
* fix indentation issue with robot.comment in Run App command log

## review requests

Not sure who to include in a PR like this so I just tagged a handful of ppl...

- [ ] Should not break existing protocols -- `robot.pause()` with no args should still work the same and generate the same messages. This should not be a breaking change to the API
- [ ] Protocols made with Protocol Designer show messages for Pause steps that use "pause until resume"
- [ ] Python protocols using `robot.pause` and `robot.comment` show appropriately (no indent) in the command list in Run App