### PR TITLE
fix(app): Wrap run screen modals in portal

### DIFF
--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 
 import {SpinnerModal} from '@opentrons/components'
 import SessionAlert from './SessionAlert'
+import {Portal} from '../portal'
 
 import styles from './styles.css'
 
@@ -64,7 +65,9 @@ export default class CommandList extends Component {
     return (
       <div className={styles.run_page}>
       {showSpinner && (
-        <SpinnerModal />
+        <Portal>
+          <SpinnerModal />
+        </Portal>
       )}
       {!showSpinner && (
         <SessionAlert {...this.props} className={styles.alert} />


### PR DESCRIPTION
## overview

This PR is also serving as an issue.

**Issue:** Run screen `SpinnerModals` (after confirm cancel run or reset run) overlays did not cover the fill height of the page/screen since those modals were children of `CommandList`

**Fix:** Wrap run log modals in portal.

## changelog

- fix(app): Wrap run screen modals in portal

## review requests

Run a protocol - VS is fine, but the modals are very short lived
Cancel or Reset the run

- [ ] Spinner modal fills entire main page area of screen