### PR TITLE
fix(app): Prevent wrong keypress combo from changing jog jump size

### DIFF
--- a/app/src/components/JogControls/index.js
+++ b/app/src/components/JogControls/index.js
@@ -68,6 +68,7 @@ export default class JogControls extends React.Component<Props, State> {
 
   handleStepSelect = (event: SyntheticInputEvent<*>) => {
     this.setState({step: Number(event.target.value)})
+    event.target.blur()
   }
 
   getJogHandlers () {


### PR DESCRIPTION
## overview

This PR closes #2300. Clicking on a jog increment radio button caused an onFocus event which allowed an unused combination of our arrow keys + shift to change the jump size. The solution was to setState and then immediately `.blur()` the clicked element.

## changelog

- fix(app): Prevent wrong keypress combo from changing jog jump size

## review requests

Try it out on VS or a Robot. Open up deck calibration or labware calibration (some screen with jog buttons)

- [ ] expected key combos jog the robot or change the jog increment

Click on a radio button to choose a jog increment (focus the form element)
- [ ] shift + left/right arrow keys does NOT change the jog increment
- [ ] + or - keys still changes jog increment

