### PR TITLE
feat(app): Add release notes to app update modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **api:** Add container definitions for opentrons alumnium block setaluminum block ([#2205](https://github.com/Opentrons/opentrons/issues/2205)) ([107d6b0](https://github.com/Opentrons/opentrons/commit/107d6b0))
+* **api:** Add container definitions for opentrons alumnium block set ([#2205](https://github.com/Opentrons/opentrons/issues/2205)) ([107d6b0](https://github.com/Opentrons/opentrons/commit/107d6b0))
 * **api:** Add definitions for the modular tuberack ([#2167](https://github.com/Opentrons/opentrons/issues/2167)) ([be902f6](https://github.com/Opentrons/opentrons/commit/be902f6))
 * **api:** add engage custom height and offset params ([#2171](https://github.com/Opentrons/opentrons/issues/2171)) ([4b1f8bd](https://github.com/Opentrons/opentrons/commit/4b1f8bd)), closes [#2155](https://github.com/Opentrons/opentrons/issues/2155)
 * **api:** Add hidden ssid wifi support ([#2193](https://github.com/Opentrons/opentrons/issues/2193)) ([ffc702f](https://github.com/Opentrons/opentrons/commit/ffc702f))

--- a/app-shell/.gitignore
+++ b/app-shell/.gitignore
@@ -1,2 +1,3 @@
 # lib is compiled by babel
 lib
+!build

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -1,0 +1,50 @@
+# Changes since 3.3.0
+
+<!-- start:@opentrons/app -->
+## Opentrons App
+
+We've updated the app to give you information about your protocols _before_ you start calibrating and running your robot. We hope you like the update!
+
+### Bug fixes
+
+- Fixed support chat so required configuration information is properly sent
+
+### New features
+
+- We've got a shiny new protocol summary page to give you more information about your protocol at a glance after you upload it
+- The app now automatically provides pipette configuration to support chat so our wonderful staff can better help you
+<!-- end:@opentrons/app -->
+
+
+<!-- start:@opentrons/api -->
+## OT2 and Protocol API
+
+This update is all about new and updated labware definitions! Remember to update your robot after you update your app to get these changes onto your OT2.
+
+### Bug fixes
+
+- Fixed some problems with the Biorad PCR and 10µL tiprack definitions
+- Fixed a problem with how the robot launches its API server
+- Ensured that factory reset really does clear the labware database every time
+
+### New features
+
+- Added a bunch of new labware definitions
+    - [Opentrons modular tuberack set][tuberacks]
+    - [Opentrons aluminum block set][blocks]
+    - Enjoy using your shiny new tube rack sets and [Temperature Module][tempdeck]!
+- The min. and max. volumes of the default pipette constructors in the protocol API can now be optionally overridden (thanks [@rvinzent][rvinzent]!)
+
+    ```
+    p300 = instruments.P300_Single(
+        mount='right',
+        min_volume=42,
+        max_volume=240,
+    )
+    ```
+
+[tuberacks]: https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1
+[blocks]: https://shop.opentrons.com/products/aluminum-block-set
+[tempdeck]: https://shop.opentrons.com/products/tempdeck
+[rvinzent]: https://github.com/Opentrons/opentrons/pull/2084
+<!-- end:@opentrons/api -->

--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -8,6 +8,7 @@
       "to": "./ui",
       "filter": ["**/*"]
     },
+    "build/release-notes.md",
     "!Makefile"
   ],
   "extraResources": [
@@ -49,20 +50,14 @@
     "fpm": ["--name=Opentrons"]
   },
   "mac": {
-    "target": [
-      "zip"
-    ],
+    "target": ["zip"],
     "category": "public.app-category.productivity"
   },
   "win": {
-    "target": [
-      "nsis"
-    ]
+    "target": ["nsis"]
   },
   "linux": {
-    "target": [
-      "deb"
-    ],
+    "target": ["deb"],
     "executableName": "opentrons",
     "category": "Science"
   },

--- a/app-shell/src/update.js
+++ b/app-shell/src/update.js
@@ -1,5 +1,7 @@
 // @flow
 // app updater
+import path from 'path'
+import fs from 'fs'
 import {autoUpdater as updater} from 'electron-updater'
 
 import createLogger from './log'
@@ -15,6 +17,10 @@ updater.logger = createLogger(__filename)
 updater.autoDownload = false
 
 export const CURRENT_VERSION = updater.currentVersion
+export const CURRENT_RELEASE_NOTES = fs.readFileSync(
+  path.join(__dirname, '../build/release-notes.md'),
+  'utf8'
+)
 
 export function registerUpdate (dispatch: Dispatch) {
   return function handleAction (action: Action) {

--- a/app/package.json
+++ b/app/package.json
@@ -40,6 +40,8 @@
     "react-router-redux": "^5.0.0-alpha.6",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
+    "remark": "^9.0.0",
+    "remark-react": "^4.0.3",
     "reselect": "^3.0.1",
     "winston": "^2.2.0"
   }

--- a/app/src/components/AppSettings/AppInfoCard.js
+++ b/app/src/components/AppSettings/AppInfoCard.js
@@ -7,38 +7,35 @@ import {CURRENT_VERSION} from '../../shell'
 import {RefreshCard, LabeledValue, OutlineButton} from '@opentrons/components'
 import {CardContentHalf} from '../layout'
 
-import type {ShellUpdateState} from '../../shell'
+import styles from './styles.css'
 
 type Props = {
-  update: ShellUpdateState,
+  availableVersion: ?string,
   checkUpdate: () => mixed,
 }
 
 const TITLE = 'Information'
 const VERSION_LABEL = 'Software Version'
 
+const UPDATE_AVAILABLE = 'view available update'
+const UPDATE_NOT_AVAILABLE = 'up to date'
+
 export default function AppInfoCard (props: Props) {
-  const {checkUpdate, update: {available, checking}} = props
+  const {checkUpdate, availableVersion} = props
 
   return (
-    <RefreshCard
-      refreshing={checking}
-      refresh={checkUpdate}
-      title={TITLE}
-    >
+    <RefreshCard refresh={checkUpdate} title={TITLE}>
       <CardContentHalf>
-        <LabeledValue
-          label={VERSION_LABEL}
-          value={CURRENT_VERSION}
-        />
+        <LabeledValue label={VERSION_LABEL} value={CURRENT_VERSION} />
       </CardContentHalf>
       <CardContentHalf>
         <OutlineButton
           Component={Link}
-          to='/menu/app/update'
-          disabled={!available}
+          to="/menu/app/update"
+          disabled={!availableVersion}
+          className={styles.show_update_button}
         >
-          {available ? 'update' : 'updated'}
+          {availableVersion ? UPDATE_AVAILABLE : UPDATE_NOT_AVAILABLE}
         </OutlineButton>
       </CardContentHalf>
     </RefreshCard>

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -2,71 +2,78 @@
 // AlertModal for updating to newest app version
 import * as React from 'react'
 
-import type {ShellUpdateState} from '../../shell'
 import {Icon, AlertModal, type ButtonProps} from '@opentrons/components'
 import {Portal} from '../portal'
+import {BottomButtonBar} from '../modals'
+import ReleaseNotes from './ReleaseNotes'
+import styles from './styles.css'
+
+import type {ShellUpdateState} from '../../shell'
 
 type Props = {
   update: ShellUpdateState,
   availableVersion: ?string,
   downloadUpdate: () => mixed,
   applyUpdate: () => mixed,
-  close: () => mixed,
+  closeModal: () => mixed,
 }
 
 // TODO(mc, 2018-03-19): prop or component for text-height icons
-const Spinner = () => (<Icon name='ot-spinner' height='1em' spin />)
+const Spinner = () => <Icon name="ot-spinner" height="1em" spin />
 
 export default function AppUpdateModal (props: Props) {
-  const {close, availableVersion, update: {error, downloading}} = props
-  const {button, message} = mapPropsToButtonPropsAndMessage(props)
-  const closeButtonChildren = error || downloading
-    ? 'close'
-    : 'not now'
+  const {
+    closeModal,
+    availableVersion,
+    update: {downloading, info},
+  } = props
+  const buttonProps = mapPropsToButtonProps(props)
+  const closeButtonChildren = downloading ? 'close' : 'not now'
 
   return (
     <Portal>
       <AlertModal
-        heading={`App Version ${availableVersion || ''} Available`}
-        onCloseClick={close}
-        buttons={[
-          {onClick: close, children: closeButtonChildren},
-          button,
-        ]}
+        heading={`Version ${availableVersion || ''} Available`}
+        onCloseClick={closeModal}
+        className={styles.update_modal}
+        contentsClassName={styles.update_modal_contents}
         alertOverlay
       >
-        {message}
+        {info && <ReleaseNotes source={info.releaseNotes} />}
+        <BottomButtonBar
+          buttons={[
+            {onClick: closeModal, children: closeButtonChildren},
+            buttonProps,
+          ]}
+        />
       </AlertModal>
     </Portal>
   )
 }
 
-function mapPropsToButtonPropsAndMessage (props: Props) {
-  const {error, downloaded, checking, downloading} = props.update
+const DOWNLOAD = 'download'
+const DOWNLOAD_IN_PROGRESS = 'downloading'
+const RESTART = 'restart app'
 
-  if (error) {
-    return {
-      button: null,
-      message: 'Something went wrong retrieving the update. Please try restarting the app and trying again. If the problem persists, contact Opentrons support.',
-    }
-  }
-
-  const disabled = error || checking || downloading
+function mapPropsToButtonProps (props: Props): ButtonProps {
+  const {downloaded, checking, downloading} = props.update
+  const disabled = checking || downloading
   const onClick = downloaded ? props.applyUpdate : props.downloadUpdate
 
-  let message
-  let button: ButtonProps = {onClick, disabled}
+  let buttonProps: ButtonProps = {onClick, disabled}
 
   if (downloaded) {
-    message = 'Restart the app to finish the update'
-    button.children = 'Restart'
+    buttonProps.children = RESTART
   } else if (downloading) {
-    message = 'Update is downloading.'
-    button.children = (<Spinner />)
+    buttonProps.children = (
+      <React.Fragment>
+        {`${DOWNLOAD_IN_PROGRESS} `}
+        <Spinner />
+      </React.Fragment>
+    )
   } else {
-    message = 'We recommend updating your app to the latest version'
-    button.children = 'Download'
+    buttonProps.children = DOWNLOAD
   }
 
-  return {message, button}
+  return buttonProps
 }

--- a/app/src/components/AppSettings/AppUpdateModal.js
+++ b/app/src/components/AppSettings/AppUpdateModal.js
@@ -39,7 +39,7 @@ export default function AppUpdateModal (props: Props) {
         contentsClassName={styles.update_modal_contents}
         alertOverlay
       >
-        {info && <ReleaseNotes source={info.releaseNotes} />}
+        <ReleaseNotes source={info && info.releaseNotes} />
         <BottomButtonBar
           buttons={[
             {onClick: closeModal, children: closeButtonChildren},

--- a/app/src/components/AppSettings/ReleaseNotes.js
+++ b/app/src/components/AppSettings/ReleaseNotes.js
@@ -10,13 +10,18 @@ const renderer = remark().use(reactRenderer, {
   remarkReactComponents: {div: React.Fragment},
 })
 
+const DEFAULT_RELEASE_NOTES = 'We recommend upgrading to the latest version.'
+
 export default function ReleaseNotes (props: Props) {
   const {source} = props
-  if (!source) return null
 
   return (
     <div className={styles.release_notes}>
-      {renderer.processSync(source).contents}
+      {source ? (
+        renderer.processSync(source).contents
+      ) : (
+        <p>{DEFAULT_RELEASE_NOTES}</p>
+      )}
     </div>
   )
 }

--- a/app/src/components/AppSettings/ReleaseNotes.js
+++ b/app/src/components/AppSettings/ReleaseNotes.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react'
+import remark from 'remark'
+import reactRenderer from 'remark-react'
+import styles from './styles.css'
+
+type Props = {source: ?string}
+
+const renderer = remark().use(reactRenderer, {
+  remarkReactComponents: {div: React.Fragment},
+})
+
+export default function ReleaseNotes (props: Props) {
+  const {source} = props
+  if (!source) return null
+
+  return (
+    <div className={styles.release_notes}>
+      {renderer.processSync(source).contents}
+    </div>
+  )
+}

--- a/app/src/components/AppSettings/index.js
+++ b/app/src/components/AppSettings/index.js
@@ -8,10 +8,8 @@ import AppInfoCard from './AppInfoCard'
 import AppUpdateModal from './AppUpdateModal'
 import {CardContainer, CardRow} from '../layout'
 
-import type {ShellUpdateState} from '../../shell'
-
 type Props = {
-  update: ShellUpdateState,
+  availableVersion: ?string,
   checkUpdate: () => mixed,
 }
 
@@ -19,10 +17,13 @@ export default function AppSettings (props: Props) {
   return (
     <CardContainer>
       <CardRow>
-        <AppInfoCard {...props}/>
+        <AppInfoCard
+          availableVersion={props.availableVersion}
+          checkUpdate={props.checkUpdate}
+        />
       </CardRow>
       <CardRow>
-        <AnalyticsSettingsCard {...props} />
+        <AnalyticsSettingsCard />
       </CardRow>
       <CardRow>
         <AdvancedSettingsCard checkUpdate={props.checkUpdate} />

--- a/app/src/components/AppSettings/styles.css
+++ b/app/src/components/AppSettings/styles.css
@@ -1,0 +1,72 @@
+@import '@opentrons/components';
+
+.show_update_button {
+  width: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.update_modal {
+  max-height: 100%;
+}
+
+.update_modal_contents {
+  display: flex;
+}
+
+.release_notes {
+  max-height: 100%;
+  padding-bottom: 3rem;
+  overflow-y: auto;
+
+  /* push the scrollbar out to the right */
+  padding-right: 1.5rem;
+  margin-right: -1.5rem;
+
+  & > h1 {
+    @apply --font-header-dark;
+
+    margin-bottom: 1rem;
+  }
+
+  & > h2 {
+    @apply --font-header-dark;
+
+    font-weight: var(--fw-regular);
+    margin-top: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  & > h3 {
+    @apply --font-body-2-dark;
+
+    font-weight: var(--fw-semibold);
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  & ul,
+  & ol {
+    margin-left: 1.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  & li {
+    margin: 0.25rem 0;
+  }
+
+  & pre {
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--c-font-dark);
+  }
+
+  & code {
+    font-family: monospace;
+    color: var(--c-font-light);
+  }
+
+  & p {
+    @apply --font-body-2-dark;
+  }
+}

--- a/app/src/components/modals/BottomButtonBar.js
+++ b/app/src/components/modals/BottomButtonBar.js
@@ -1,0 +1,32 @@
+// @flow
+// bottom button bar for modals
+// TODO(mc, 2018-08-18): maybe make this the default AlertModal behavior
+import * as React from 'react'
+import cx from 'classnames'
+
+import {OutlineButton} from '@opentrons/components'
+import styles from './styles.css'
+
+import type {ButtonProps} from '@opentrons/components'
+
+type Props = {
+  buttons: Array<?ButtonProps>,
+  className?: string,
+}
+
+export default function BottomButtonBar (props: Props) {
+  const buttons = props.buttons.filter(Boolean)
+  const className = cx(styles.bottom_button_bar, props.className)
+
+  return (
+    <div className={className}>
+      {buttons.map((button, index) => (
+        <OutlineButton
+          {...button}
+          key={index}
+          className={cx(styles.bottom_button, button.className)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/modals/ErrorModal.js
+++ b/app/src/components/modals/ErrorModal.js
@@ -33,19 +33,13 @@ export default function ErrorModal (props: Props) {
 
   return (
     <Portal>
-      <AlertModal
-        heading={heading}
-        buttons={[closeButtonProps]}
-        alertOverlay
-      >
-        <p className={styles.error_modal_message}>
-          {error.message}
-        </p>
+      <AlertModal heading={heading} buttons={[closeButtonProps]} alertOverlay>
+        <p className={styles.error_modal_message}>{error.message}</p>
+        <p>{description}</p>
         <p>
-          {description}
-        </p>
-        <p>
-          If you keep getting this message, try restarting your robot. If this does not resolve the issue please contact Opentrons Support.
+          If you keep getting this message, try restarting your app and/or
+          robot. If this does not resolve the issue please contact Opentrons
+          Support.
         </p>
       </AlertModal>
     </Portal>

--- a/app/src/components/modals/index.js
+++ b/app/src/components/modals/index.js
@@ -2,5 +2,6 @@
 // app specific modals
 import Modal from './Modal'
 import ErrorModal from './ErrorModal'
+import BottomButtonBar from './BottomButtonBar'
 
-export {Modal, ErrorModal}
+export {Modal, ErrorModal, BottomButtonBar}

--- a/app/src/components/modals/styles.css
+++ b/app/src/components/modals/styles.css
@@ -22,3 +22,19 @@
   left: 0;
   right: 0;
 }
+
+.bottom_button_bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem 1.5rem 1rem;
+  text-align: right;
+  background-color: white;
+  box-shadow: 0 -8px 8px -4px white;
+}
+
+.bottom_button {
+  margin-left: 1rem;
+  width: 10rem;
+}

--- a/app/src/shell/__tests__/update.test.js
+++ b/app/src/shell/__tests__/update.test.js
@@ -96,8 +96,8 @@ describe('shell/update', () => {
       {
         name: 'handles shell:SET_UPDATE_SEEN',
         action: {type: 'shell:SET_UPDATE_SEEN'},
-        initialState: {seen: false},
-        expected: {seen: true},
+        initialState: {seen: false, error: {message: 'AH'}},
+        expected: {seen: true, error: null},
       },
     ]
 

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -15,7 +15,7 @@ import type {ShellUpdateAction} from './update'
 
 export type ShellAction = ShellUpdateAction
 
-const {CURRENT_VERSION} = remote.require('./update')
+const {CURRENT_VERSION, CURRENT_RELEASE_NOTES} = remote.require('./update')
 const {getConfig} = remote.require('./config')
 const {getRobots} = remote.require('./discovery')
 
@@ -23,7 +23,7 @@ const log = createLogger(__filename)
 
 export * from './update'
 
-export {CURRENT_VERSION}
+export {CURRENT_VERSION, CURRENT_RELEASE_NOTES}
 
 export const shellReducer = combineReducers({update: updateReducer})
 

--- a/app/src/shell/update.js
+++ b/app/src/shell/update.js
@@ -85,7 +85,7 @@ export function updateReducer (
       }
 
     case 'shell:SET_UPDATE_SEEN':
-      return {...state, seen: true}
+      return {...state, seen: true, error: null}
   }
 
   return state

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -18,6 +18,8 @@ type Props = {
   children: React.Node,
   /** optional classes to apply */
   className?: string,
+  /** optional classes to apply */
+  contentsClassName?: string,
   /** lightens overlay (alert modal over existing modal)**/
   alertOverlay?: boolean,
 }
@@ -27,9 +29,9 @@ type Props = {
  */
 export default function AlertModal (props: Props) {
   const {heading, buttons, className, onCloseClick, alertOverlay} = props
-  const wrapperStyle = heading
-    ? styles.alert_modal_wrapper
-    : cx(styles.alert_modal_wrapper, styles.no_alert_header)
+  const wrapperStyle = cx(styles.alert_modal_wrapper, {
+    [styles.no_alert_header]: !heading,
+  }, props.contentsClassName)
 
   return (
     <Modal

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -66,9 +66,10 @@
 }
 
 .alert_modal_wrapper {
-  border-radius: 0;
   position: relative;
+  max-height: 100%;
   padding-top: 4rem;
+  border-radius: 0;
 }
 
 .no_alert_header {
@@ -109,6 +110,7 @@
 .alert_modal_contents {
   @apply --font-body-2-dark;
 
+  max-height: 100%;
   padding: 1rem;
 
   & > p {

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,6 +488,12 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@mapbox/hast-util-table-cell-style@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz#5b7166ae01297d72216932b245e4b2f0b642dca6"
+  dependencies:
+    unist-util-visit "^1.3.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2472,6 +2478,10 @@ codemirror@^5.32.0:
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.33.0.tgz#462ad9a6fe8d38b541a9536a3997e1ef93b40c6a"
 
+collapse-white-space@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
+
 collapse-white-space@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
@@ -2586,6 +2596,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz#b13793131d9ea2d2431cf5b507ddec258f0ce0db"
+  dependencies:
+    trim "0.0.1"
 
 commander@2.12.x, commander@~2.12.1:
   version "2.12.2"
@@ -3266,6 +3282,12 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-properties@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  dependencies:
+    object-keys "^1.0.12"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -3345,6 +3367,12 @@ des.js@^1.0.0:
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+detab@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detab/-/detab-2.0.1.tgz#531f5e326620e2fd4f03264a905fb3bcc8af4df4"
+  dependencies:
+    repeat-string "^1.5.4"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -5240,6 +5268,24 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
+hast-to-hyperscript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz#3eb25483ec72a8e9a71e4b1ad7eb8f7c86f755db"
+  dependencies:
+    comma-separated-tokens "^1.0.0"
+    is-nan "^1.2.1"
+    kebab-case "^1.0.0"
+    property-information "^3.0.0"
+    space-separated-tokens "^1.0.0"
+    trim "0.0.1"
+    unist-util-is "^2.0.0"
+
+hast-util-sanitize@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-1.2.0.tgz#1a46bc8e8554f4747d219dd1d85f9cb245b1b08d"
+  dependencies:
+    xtend "^4.0.1"
+
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -5833,6 +5879,12 @@ is-my-json-valid@^2.10.0:
     generate-object-property "^1.1.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-nan@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.2.1.tgz#9faf65b6fb6db24b7f5c0628475ea71f988401e2"
+  dependencies:
+    define-properties "^1.1.1"
 
 is-npm@^1.0.0:
   version "1.0.0"
@@ -6522,6 +6574,10 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+kebab-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
+
 kefir@^3.7.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.3.tgz#8e0ab10084ed8a01cbb5d4f7f18a0b859f7b9bd9"
@@ -6927,6 +6983,28 @@ mdast-util-compact@^1.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit "^1.1.0"
 
+mdast-util-definitions@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz#49f936b09207c45b438db19551652934312f04f0"
+  dependencies:
+    unist-util-visit "^1.0.0"
+
+mdast-util-to-hast@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.2.tgz#26b1971f49d6db1e3428463a12e66c89db5021cb"
+  dependencies:
+    collapse-white-space "^1.0.0"
+    detab "^2.0.0"
+    mdast-util-definitions "^1.2.0"
+    mdurl "^1.0.1"
+    trim "0.0.1"
+    trim-lines "^1.0.0"
+    unist-builder "^1.0.1"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.0"
+    xtend "^4.0.1"
+
 mdns-js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdns-js/-/mdns-js-1.0.1.tgz#89a0fd4d85dc6c7630da39d56fc88420bb357867"
@@ -6934,6 +7012,10 @@ mdns-js@^1.0.1:
     debug "^3.1.0"
     dns-js "~0.2.1"
     semver "^5.4.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -7533,6 +7615,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -7801,6 +7887,17 @@ parse-color@^1.0.0:
 parse-entities@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
+parse-entities@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -8676,6 +8773,10 @@ prop-types@^15.6.1, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+property-information@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -9447,9 +9548,57 @@ remark-parse@^4.0.0:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-react@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/remark-react/-/remark-react-4.0.3.tgz#980938f3bcc93bef220215b26b0b0a80f3158c7d"
+  dependencies:
+    "@mapbox/hast-util-table-cell-style" "^0.1.3"
+    hast-to-hyperscript "^4.0.0"
+    hast-util-sanitize "^1.0.0"
+    mdast-util-to-hast "^3.0.0"
+
 remark-stringify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-4.0.0.tgz#4431884c0418f112da44991b4e356cfe37facd87"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark-stringify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-5.0.0.tgz#336d3a4d4a6a3390d933eeba62e8de4bd280afba"
   dependencies:
     ccount "^1.0.0"
     is-alphanumeric "^1.0.0"
@@ -9472,6 +9621,14 @@ remark@^8.0.0:
   dependencies:
     remark-parse "^4.0.0"
     remark-stringify "^4.0.0"
+    unified "^6.0.0"
+
+remark@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-9.0.0.tgz#c5cfa8ec535c73a67c4b0f12bfdbd3a67d8b2f60"
+  dependencies:
+    remark-parse "^5.0.0"
+    remark-stringify "^5.0.0"
     unified "^6.0.0"
 
 remove-trailing-separator@^1.0.1:
@@ -10150,6 +10307,12 @@ sourcemapped-stacktrace@^1.1.6:
   resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.8.tgz#6b7a3f1a6fb15f6d40e701e23ce404553480d688"
   dependencies:
     source-map "0.5.6"
+
+space-separated-tokens@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz#e95ab9d19ae841e200808cd96bc7bd0adbbb3412"
+  dependencies:
+    trim "0.0.1"
 
 sparkles@^1.0.0:
   version "1.0.0"
@@ -10831,6 +10994,10 @@ tree-kill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
 
+trim-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -11036,21 +11203,39 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+unist-builder@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-1.0.3.tgz#ab0f9d0f10936b74f3e913521955b0478e0ff036"
+  dependencies:
+    object-assign "^4.1.0"
+
 unist-util-find-all-after@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.1.tgz#4e5512abfef7e0616781aecf7b1ed751c00af908"
   dependencies:
     unist-util-is "^2.0.0"
 
+unist-util-generated@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.2.tgz#8b993f9239d8e560be6ee6e91c3f7b7208e5ce25"
+
 unist-util-is@^2.0.0, unist-util-is@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+
+unist-util-is@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
 
 unist-util-modify-children@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz#66d7e6a449e6f67220b976ab3cb8b5ebac39e51d"
   dependencies:
     array-iterate "^1.0.0"
+
+unist-util-position@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.1.tgz#8e220c24658239bf7ddafada5725ed0ea1ebbc26"
 
 unist-util-remove-position@^1.0.0:
   version "1.1.1"
@@ -11061,6 +11246,18 @@ unist-util-remove-position@^1.0.0:
 unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
+
+unist-util-visit-parents@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
+  dependencies:
+    unist-util-is "^2.1.2"
+
+unist-util-visit@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## overview

This PR addresses the app update portion of #2028 

![2018-09-18 16 13 13](https://user-images.githubusercontent.com/2963448/45714253-1269a200-bb5f-11e8-9083-c786d786b5da.gif)

## changelog

- feat(app): Add release notes to app update modal 

## review requests

App update is hard to test. Hit me up if you'd like a modified build of the app that has an incorrect version so that it thinks it's out of data.

- [ ] App updates to latest **beta** (use modified build from @mcous)
- [ ] If app update fails, error message is displayed (this will happen if you try to update from a dev build)

@umbhau and @pantslakz (and anyone else) let me know what you think of these release notes! I'm thinking we keep the release notes as a summary from the last major release, and we add to it prior to beta releases.

@IanLondon and @b-cooper I added max-height rules to some children of the AlertModal. I didn't see it change anything in PD (because the top level modal doesn't have a height or max-height by default) but please double check for me.