### PR TITLE
fix(api): Update definitions for tuberacks

### DIFF
--- a/api/opentrons/config/containers/default-containers.json
+++ b/api/opentrons/config/containers/default-containers.json
@@ -23964,7 +23964,7 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23972,7 +23972,7 @@
                     "B1": {
                          "x": 25,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23980,7 +23980,7 @@
                     "C1": {
                          "x": 50,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23988,7 +23988,7 @@
                     "A2": {
                          "x": 0,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23996,7 +23996,7 @@
                     "B2": {
                          "x": 25,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24004,7 +24004,7 @@
                     "C2": {
                          "x": 50,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24012,7 +24012,7 @@
                     "A3": {
                          "x": 0,
                          "y": 50,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24020,7 +24020,7 @@
                     "B3": {
                          "x": 25,
                          "y": 50,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24028,7 +24028,7 @@
                     "C3": {
                          "x": 50,
                          "y": 50,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24036,7 +24036,7 @@
                     "A4": {
                          "x": 0,
                          "y": 75,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24044,7 +24044,7 @@
                     "B4": {
                          "x": 25,
                          "y": 75,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24052,7 +24052,7 @@
                     "C4": {
                          "x": 50,
                          "y": 75,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24060,7 +24060,7 @@
                     "A5": {
                          "x": 0,
                          "y": 100,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24068,7 +24068,7 @@
                     "B5": {
                          "x": 25,
                          "y": 100,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24076,7 +24076,7 @@
                     "C5": {
                          "x": 50,
                          "y": 100,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24093,48 +24093,48 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B1": {
                          "x": 35,
                          "y": 0,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "A2": {
                          "x": 0,
                          "y": 35,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B2": {
                          "x": 35,
                          "y": 35,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "A3": {
                          "x": 0,
                          "y": 70,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B3": {
                          "x": 35,
                          "y": 70,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     }
@@ -24150,7 +24150,7 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24158,7 +24158,7 @@
                     "B1": {
                          "x": 25,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24166,7 +24166,7 @@
                     "C1": {
                          "x": 50,
                          "y": 0,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24174,7 +24174,7 @@
                     "A2": {
                          "x": 0,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24182,7 +24182,7 @@
                     "B2": {
                          "x": 25,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24190,7 +24190,7 @@
                     "C2": {
                          "x": 50,
                          "y": 25,
-                         "z": 5.78,
+                         "z": 6.78,
                          "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
@@ -24198,32 +24198,32 @@
                     "A3": {
                          "x": 18.25,
                          "y": 57.5,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "B3": {
                          "x": 53.25,
                          "y": 57.5,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "A4": {
                          "x": 18.25,
                          "y": 92.5,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "B4": {
                          "x": 53.25,
                          "y": 92.5,
-                         "z": 5.95,
-                         "depth": 113.85,
+                         "z": 6.95,
+                         "depth": 112.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     }

--- a/api/opentrons/config/containers/default-containers.json
+++ b/api/opentrons/config/containers/default-containers.json
@@ -23964,7 +23964,7 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23972,7 +23972,7 @@
                     "B1": {
                          "x": 25,
                          "y": 0,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23980,7 +23980,7 @@
                     "C1": {
                          "x": 50,
                          "y": 0,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23988,7 +23988,7 @@
                     "A2": {
                          "x": 0,
                          "y": 25,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -23996,7 +23996,7 @@
                     "B2": {
                          "x": 25,
                          "y": 25,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24004,7 +24004,7 @@
                     "C2": {
                          "x": 50,
                          "y": 25,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24012,7 +24012,7 @@
                     "A3": {
                          "x": 0,
                          "y": 50,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24020,7 +24020,7 @@
                     "B3": {
                          "x": 25,
                          "y": 50,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24028,7 +24028,7 @@
                     "C3": {
                          "x": 50,
                          "y": 50,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24036,7 +24036,7 @@
                     "A4": {
                          "x": 0,
                          "y": 75,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24044,7 +24044,7 @@
                     "B4": {
                          "x": 25,
                          "y": 75,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24052,7 +24052,7 @@
                     "C4": {
                          "x": 50,
                          "y": 75,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24060,7 +24060,7 @@
                     "A5": {
                          "x": 0,
                          "y": 100,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24068,7 +24068,7 @@
                     "B5": {
                          "x": 25,
                          "y": 100,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24076,7 +24076,7 @@
                     "C5": {
                          "x": 50,
                          "y": 100,
-                         "z": 11.78,
+                         "z": 5.78,
                          "depth": 117.98,
                          "diameter": 17,
                          "total-liquid-volume": 15000
@@ -24093,48 +24093,48 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B1": {
                          "x": 35,
                          "y": 0,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "A2": {
                          "x": 0,
                          "y": 35,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B2": {
                          "x": 35,
                          "y": 35,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "A3": {
                          "x": 0,
                          "y": 70,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     },
                     "B3": {
                          "x": 35,
                          "y": 70,
-                         "z": 7.78,
-                         "depth": 117.98,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 17,
                          "total-liquid-volume": 15000
                     }
@@ -24150,80 +24150,80 @@
                     "A1": {
                          "x": 0,
                          "y": 0,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "B1": {
                          "x": 25,
                          "y": 0,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "C1": {
                          "x": 50,
                          "y": 0,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "A2": {
                          "x": 0,
                          "y": 25,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "B2": {
                          "x": 25,
                          "y": 25,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "C2": {
                          "x": 50,
                          "y": 25,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.78,
+                         "depth": 117.98,
                          "diameter": 14.5,
                          "total-liquid-volume": 15000
                     },
                     "A3": {
                          "x": 18.25,
                          "y": 57.5,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "B3": {
                          "x": 53.25,
                          "y": 57.5,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "A4": {
                          "x": 18.25,
                          "y": 92.5,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     },
                     "B4": {
                          "x": 53.25,
                          "y": 92.5,
-                         "z": 10.78,
-                         "depth": 120,
+                         "z": 5.95,
+                         "depth": 113.85,
                          "diameter": 26.45,
                          "total-liquid-volume": 50000
                     }


### PR DESCRIPTION
## overview

Update labware definitions for 15ml, 50ml, and 15/50ml tuberacks to match actual well heights. Closes #2290 

Combined drawing for modular tube rack with tubes:

![0503 6x15ml 4x50ml tube insert simplified picture](https://user-images.githubusercontent.com/5034659/45760439-13024700-bbf8-11e8-8524-6dde7e29a6d0.PNG)

## review requests

Please test thoroughly on a robot

- [ ] Verify that the deck calibration is correct (add tip and then move_to the x,y,z point on the deck of a calibration cross)
- Move to .top() and .bottom() of every well in
  - [ ] at least one tube in the 15ml tuberack
  - [ ] at least one tube in the 50ml tuberack
  - [ ] at least one 15ml tube in the 15/50ml tuberack
  - [ ] at least one 50ml tube in the 15/50ml tuberack

If you wish to use a protocol to do this:

```
from opentrons import robot, instruments, labware

# Select whatever pipette and tiprack you wish to use
tr = labware.load('opentrons-tiprack-300ul', '1')
tuberack_15_50 = labware.load('opentrons-tuberack-15_50ml', '2')
tuberack_15 = labware.load('opentrons-tuberack-15ml', '5')
tuberack_50 = labware.load('opentrons-tuberack-50ml', '8')
pipette = instruments.P300_Single(mount='right', tip_racks=[tr])
pipette.pick_up_tip()

# Validate deck calibration using crosses in slots 3 and 7
pipette.move_to((robot.deck, (380.87, 9.0, 0.0)), strategy='arc')
robot.pause()
pipette.move_to((robot.deck, (12.13, 258.0, 0.0)), strategy='arc')
robot.pause()
# If either of the above misses, recalibrate your deck

pipette.aspirate(50, tuberack_15['A1'])
robot.pause()
pipette.dispense(tuberack_15['C5'])
robot.pause()

pipette.aspirate(50, tuberack_50['A1'])
robot.pause()
pipette.dispense(tuberack_50['B3'])
robot.pause()

pipette.aspirate(50, tuberack_15_50['A1'])
robot.pause()
pipette.dispense(tuberack_15_50['C2'])
robot.pause()
pipette.aspirate(50, tuberack_15_50['A3'])
robot.pause()
pipette.dispense(tuberack_15_50['B4'])
robot.pause()
```