### PR TITLE
refactor(api): invert control of system and server

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -56,7 +56,7 @@ publish:
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev:
-	$(python) opentrons/server/main.py -P 31950
+	$(python) opentrons/main.py -P 31950
 
 .PHONY: wheel
 wheel: clean

--- a/api/opentrons/main.py
+++ b/api/opentrons/main.py
@@ -1,0 +1,198 @@
+import os
+import logging
+import asyncio
+import re
+from opentrons import HERE
+from opentrons import server
+from opentrons.server.main import build_arg_parser
+from opentrons.server.endpoints import update
+from argparse import ArgumentParser
+from opentrons import robot, __version__
+from opentrons.config import feature_flags as ff
+from logging.config import dictConfig
+from opentrons.util import environment
+from opentrons.system import udev, resin
+
+log = logging.getLogger(__name__)
+log_file_path = environment.get_path('LOG_DIR')
+
+
+def log_init():
+    """
+    Function that sets log levels and format strings. Checks for the
+    OT_LOG_LEVEL environment variable otherwise defaults to DEBUG.
+    """
+    fallback_log_level = 'INFO'
+    ot_log_level = robot.config.log_level
+    if ot_log_level not in logging._nameToLevel:
+        log.info("OT Log Level {} not found. Defaulting to {}".format(
+            ot_log_level, fallback_log_level))
+        ot_log_level = fallback_log_level
+
+    level_value = logging._nameToLevel[ot_log_level]
+
+    serial_log_filename = environment.get_path('SERIAL_LOG_FILE')
+    api_log_filename = environment.get_path('LOG_FILE')
+
+    logging_config = dict(
+        version=1,
+        formatters={
+            'basic': {
+                'format':
+                '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'  # noqa: E501
+            }
+        },
+        handlers={
+            'debug': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'basic',
+                'level': level_value
+            },
+            'serial': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'basic',
+                'filename': serial_log_filename,
+                'maxBytes': 5000000,
+                'level': logging.DEBUG,
+                'backupCount': 3
+            },
+            'api': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'basic',
+                'filename': api_log_filename,
+                'maxBytes': 1000000,
+                'level': logging.DEBUG,
+                'backupCount': 5
+            }
+
+        },
+        loggers={
+            '__main__': {
+                'handlers': ['debug', 'api'],
+                'level': logging.INFO
+            },
+            'opentrons.server': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
+            },
+            'opentrons.api': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
+            },
+            'opentrons.instruments': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
+            },
+            'opentrons.robot.robot_configs': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
+            },
+            'opentrons.drivers.smoothie_drivers.driver_3_0': {
+                'handlers': ['debug', 'api'],
+                'level': level_value
+            },
+            'opentrons.drivers.serial_communication': {
+                'handlers': ['serial'],
+                'level': logging.DEBUG
+            }
+        }
+    )
+    dictConfig(logging_config)
+
+
+def _find_smoothie_file():
+    resources = os.listdir(os.path.join(HERE, 'resources'))
+    for fi in resources:
+        matches = re.search('smoothie-(.*).hex', fi)
+        if matches:
+            branch_plus_ref = matches.group(1)
+            return os.path.join(HERE, 'resources', fi), branch_plus_ref
+    raise OSError("Could not find smoothie firmware file in {}"
+                  .format(os.path.join(HERE, 'resources')))
+
+
+def _sync_do_smoothie_install(explicit_modeset, filename):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(update._update_firmware(filename,
+                                                    loop,
+                                                    explicit_modeset))
+
+
+def initialize_robot():
+    packed_smoothie_fw_file, packed_smoothie_fw_ver = _find_smoothie_file()
+    try:
+        robot.connect()
+    except Exception as e:
+        # The most common reason for this exception (aside from hardware
+        # failures such as a disconnected smoothie) is that the smoothie
+        # is in programming mode. If it is, then we still want to update
+        # it (so it can boot again), but we don’t have to do the GPIO
+        # manipulations that _put_ it in programming mode
+        log.exception("Error while connecting to motor driver: {}".format(e))
+        explicit_modeset = False
+        fw_version = None
+    else:
+        explicit_modeset = True
+        fw_version = robot.fw_version
+
+    if fw_version != packed_smoothie_fw_ver:
+        log.info("Executing smoothie update: current vers {}, packed vers {}"
+                 .format(fw_version, packed_smoothie_fw_ver))
+        _sync_do_smoothie_install(explicit_modeset, packed_smoothie_fw_file)
+
+        if robot.is_connected():
+            robot.fw_version = robot._driver.get_fw_version()
+            log.info("FW Update complete!")
+        else:
+            raise RuntimeError(
+                "Could not connect to motor driver after fw update")
+
+    else:
+        log.info("FW version OK: {}".format(packed_smoothie_fw_ver))
+
+
+def run(**kwargs):
+    """
+    This function was necessary to separate from main() to accommodate for
+    server startup path on system 3.0, which is server.main. In the case where
+    the api is on system 3.0, server.main will redirect to this function with
+    an additional argument of 'patch_old_init'. kwargs are hence used to allow
+    the use of different length args
+    """
+    log_init()
+    try:
+        robot.connect()
+    except Exception as e:
+        log.exception("Error while connecting to motor-driver: {}".format(e))
+
+    log.info("API server version:  {}".format(__version__))
+    log.info("Smoothie FW version: {}".format(robot.fw_version))
+
+    if not os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"):
+        initialize_robot()
+
+        if not ff.disable_home_on_boot():
+            log.info("Homing Z axes")
+            robot.home_z()
+        udev.setup_rules_file()
+    # Explicitly unlock resin updates in case a prior server left them locked
+    resin.unlock_updates()
+
+    server.run(kwargs.get('hostname'), kwargs.get('port'), kwargs.get('path'))
+
+
+def main():
+    """This application creates and starts the server for both the RPC routes
+    handled by opentrons.server.rpc and HTTP endpoints defined here
+    """
+
+    arg_parser = ArgumentParser(
+        description="Opentrons robot software",
+        parents=[build_arg_parser()])
+    args = arg_parser.parse_args()
+    run(**vars(args))
+    arg_parser.exit(message="Stopped\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/api/opentrons/resources/scripts/start.sh
+++ b/api/opentrons/resources/scripts/start.sh
@@ -37,6 +37,6 @@ fi
 
 export ENABLE_NETWORKING_ENDPOINTS=true
 echo "[ $0 ] Starting Opentrons API server"
-python -m opentrons.server.main -U $OT_SERVER_UNIX_SOCKET_PATH opentrons.server.main:init
+python -m opentrons.main -U $OT_SERVER_UNIX_SOCKET_PATH
 echo "[ $0 ] Server exited unexpectedly. Please power-cycle the machine, and contact Opentrons support."
 while true; do sleep 1; done

--- a/api/opentrons/server/__init__.py
+++ b/api/opentrons/server/__init__.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import logging
+import traceback
+from opentrons.util import environment
+from aiohttp import web
+from .rpc import RPCServer
+from .http import HTTPServer
+from opentrons.api.routers import MainRouter
+
+log = logging.getLogger(__name__)
+log_file_path = environment.get_path('LOG_DIR')
+
+
+@web.middleware
+async def error_middleware(request, handler):
+    try:
+        response = await handler(request)
+    except web.HTTPNotFound:
+        log.exception("Exception handler for request {}".format(request))
+        data = {
+            'message': 'File was not found at {}'.format(request)
+        }
+        response = web.json_response(data, status=404)
+    except Exception as e:
+        log.exception("Exception in handler for request {}".format(request))
+        data = {
+            'message': 'An unexpected error occured - {}'.format(e),
+            'traceback': traceback.format_exc()
+        }
+        response = web.json_response(data, status=500)
+
+    return response
+
+
+# Support for running using aiohttp CLI.
+# See: https://docs.aiohttp.org/en/stable/web.html#command-line-interface-cli  # NOQA
+def init(loop=None):
+    """
+    Builds an application and sets up RPC and HTTP servers with it
+    """
+
+    app = web.Application(loop=loop, middlewares=[error_middleware])
+    app['opentronsRpc'] = RPCServer(app, MainRouter())
+    app['opentronsHttp'] = HTTPServer(app, log_file_path)
+
+    return app
+
+
+def run(hostname=None, port=None, path=None):
+    """
+    The arguments are not all optional. Either a path or hostname+port should
+    be specified; you have to specify one.
+    """
+    if path:
+        log.debug("Starting Opentrons server application on {}".format(
+            path))
+        hostname, port = None, None
+    else:
+        log.debug("Starting Opentrons server application on {}:{}".format(
+            hostname, port))
+        path = None
+
+    web.run_app(init(), host=hostname, port=port, path=path)

--- a/api/opentrons/server/http.py
+++ b/api/opentrons/server/http.py
@@ -1,0 +1,78 @@
+import logging
+from . import endpoints as endp
+from .endpoints import (wifi, control, settings, update)
+from opentrons.deck_calibration import endpoints as dc_endp
+
+
+from .endpoints import serverlib_fallback as endpoints
+log = logging.getLogger(__name__)
+
+
+class HTTPServer(object):
+    def __init__(self, app, log_file_path):
+        self.app = app
+        self.log_file_path = log_file_path
+
+        self.app.router.add_get(
+            '/health', endp.health)
+        self.app.router.add_get(
+            '/wifi/list', wifi.list_networks)
+        self.app.router.add_post(
+            '/wifi/configure', wifi.configure)
+        self.app.router.add_get(
+            '/wifi/status', wifi.status)
+        self.app.router.add_post('/wifi/keys', wifi.add_key)
+        self.app.router.add_get('/wifi/keys', wifi.list_keys)
+        self.app.router.add_delete('/wifi/keys/{key_uuid}', wifi.remove_key)
+        self.app.router.add_get(
+            '/wifi/eap-options', wifi.eap_options)
+        self.app.router.add_post(
+            '/identify', control.identify)
+        self.app.router.add_get(
+            '/modules', control.get_attached_modules)
+        self.app.router.add_get(
+            '/modules/{serial}/data', control.get_module_data)
+        self.app.router.add_post(
+            '/camera/picture', control.take_picture)
+        self.app.router.add_post(
+            '/server/update', endpoints.update_api)
+        self.app.router.add_post(
+            '/server/update/firmware', endpoints.update_firmware)
+        self.app.router.add_post(
+            '/modules/{serial}/update', update.update_module_firmware)
+        self.app.router.add_get(
+            '/server/update/ignore', endpoints.get_ignore_version)
+        self.app.router.add_post(
+            '/server/update/ignore', endpoints.set_ignore_version)
+        self.app.router.add_static(
+            '/logs', self.log_file_path, show_index=True)
+        self.app.router.add_post(
+            '/server/restart', endpoints.restart)
+        self.app.router.add_post(
+            '/calibration/deck/start', dc_endp.start)
+        self.app.router.add_post(
+            '/calibration/deck', dc_endp.dispatch)
+        self.app.router.add_get(
+            '/pipettes', control.get_attached_pipettes)
+        self.app.router.add_get(
+            '/motors/engaged', control.get_engaged_axes)
+        self.app.router.add_post(
+            '/motors/disengage', control.disengage_axes)
+        self.app.router.add_get(
+            '/robot/positions', control.position_info)
+        self.app.router.add_post(
+            '/robot/move', control.move)
+        self.app.router.add_post(
+            '/robot/home', control.home)
+        self.app.router.add_get(
+            '/robot/lights', control.get_rail_lights)
+        self.app.router.add_post(
+            '/robot/lights', control.set_rail_lights)
+        self.app.router.add_get(
+            '/settings', settings.get_advanced_settings)
+        self.app.router.add_post(
+            '/settings', settings.set_advanced_setting)
+        self.app.router.add_post(
+            '/settings/reset', settings.reset)
+        self.app.router.add_get(
+            '/settings/reset/options', settings.available_resets)

--- a/api/opentrons/server/rpc.py
+++ b/api/opentrons/server/rpc.py
@@ -11,6 +11,7 @@ from asyncio import Queue
 from opentrons.server import serialize
 from concurrent.futures import ThreadPoolExecutor
 
+
 log = logging.getLogger(__name__)
 
 # Number of executor threads
@@ -25,10 +26,11 @@ CALL_NACK_MESSAGE = 4
 PONG_MESSAGE = 5
 
 
-class Server(object):
-    def __init__(self, root=None, loop=None, middlewares=()):
+class RPCServer(object):
+    def __init__(self, app, root=None):
         self.monitor_events_task = None
-        self.loop = loop or asyncio.get_event_loop()
+        self.app = app
+        self.loop = app.loop or asyncio.get_event_loop()
         self.objects = {}
         self.system = SystemCalls(self.objects)
 
@@ -40,7 +42,6 @@ class Server(object):
         self.clients = {}
         self.tasks = []
 
-        self.app = web.Application(loop=loop, middlewares=middlewares)
         self.app.router.add_get('/', self.handler)
         self.app.on_shutdown.append(self.on_shutdown)
 

--- a/api/opentrons/system/resin.py
+++ b/api/opentrons/system/resin.py
@@ -1,0 +1,23 @@
+import os
+import logging
+
+log = logging.getLogger(__name__)
+lock_file_path = '/tmp/resin/resin-updates.lock'
+
+
+def lock_updates():
+    if os.environ.get('RUNNING_ON_PI'):
+        import fcntl
+
+        try:
+            with open(lock_file_path, 'w') as fd:
+                fd.write('a')
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                fd.close()
+        except OSError:
+            log.warning('Unable to create resin-update lock file')
+
+
+def unlock_updates():
+    if os.environ.get('RUNNING_ON_PI') and os.path.exists(lock_file_path):
+        os.remove(lock_file_path)

--- a/api/opentrons/system/udev.py
+++ b/api/opentrons/system/udev.py
@@ -1,0 +1,35 @@
+import os
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def setup_rules_file():
+    """
+    Copy the udev rules file for Opentrons Modules to opentrons_data directory
+    and trigger the new rules.
+    This rules file in opentrons_data is symlinked into udev rules directory
+
+    TODO: Move this file to resources and move the symlink to point to
+    /data/system/
+    """
+    import shutil
+    import subprocess
+
+    rules_file = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), '..',
+        'config', 'modules', '95-opentrons-modules.rules')
+
+    shutil.copy2(
+        rules_file,
+        '/data/user_storage/opentrons_data/95-opentrons-modules.rules')
+
+    res0 = subprocess.run('udevadm control --reload-rules',
+                          shell=True, stdout=subprocess.PIPE).stdout.decode()
+    if res0 is not '':
+        log.warning(res0.strip())
+
+    res1 = subprocess.run('udevadm trigger',
+                          shell=True, stdout=subprocess.PIPE).stdout.decode()
+    if res1 is not '':
+        log.warning(res1.strip())

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -18,7 +18,7 @@ from opentrons.data_storage import database
 from opentrons.server import rpc
 from opentrons import config
 from opentrons.config import advanced_settings as advs
-from opentrons.server.main import init
+from opentrons.server import init
 from opentrons.deck_calibration import endpoints
 from opentrons.util import environment
 
@@ -249,6 +249,8 @@ def session(loop, test_client, request, main_router):
     to have @pytest.mark.parametrize('root', [value]) decorator set.
     If not set root will be defaulted to None
     """
+    from aiohttp import web
+    from opentrons.server import error_middleware
     root = None
     try:
         root = request.getfuncargvalue('root')
@@ -259,7 +261,8 @@ def session(loop, test_client, request, main_router):
     except Exception:
         pass
 
-    server = rpc.Server(loop=loop, root=root)
+    app = web.Application(loop=loop, middlewares=[error_middleware])
+    server = rpc.RPCServer(app, root)
     client = loop.run_until_complete(test_client(server.app))
     socket = loop.run_until_complete(client.ws_connect('/'))
     token = str(uuid())

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy
 from opentrons import robot, modules
-from opentrons.server.main import init
+from opentrons.server import init
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons import instruments
 from opentrons.instruments import pipette_config

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -1,6 +1,6 @@
 import json
 from opentrons import __version__
-from opentrons.server.main import init
+from opentrons.server import init
 
 
 async def test_health(virtual_smoothie_env, loop, test_client):

--- a/api/tests/opentrons/server/test_logs_endpoints.py
+++ b/api/tests/opentrons/server/test_logs_endpoints.py
@@ -1,7 +1,7 @@
 import os
 import json
-from opentrons.server import main
-from opentrons.server.main import init
+from opentrons import main
+from opentrons.server import init
 
 
 async def test_log_endpoints(

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 
-from opentrons.server.main import init
+from opentrons.server import init
 from opentrons.data_storage import database as db
 from opentrons.robot import robot_configs as rc
 

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -4,7 +4,7 @@ import tempfile
 import asyncio
 import pytest
 from aiohttp import web
-from opentrons.server.main import init
+from opentrons.server import init
 from opentrons.server.endpoints import update
 from opentrons.server.endpoints import serverlib_fallback
 from opentrons import modules

--- a/api/tests/opentrons/server/test_wifi_endpoints.py
+++ b/api/tests/opentrons/server/test_wifi_endpoints.py
@@ -3,8 +3,8 @@ import os
 import random
 import tempfile
 import pytest
-from opentrons.server.main import init
 from opentrons.system import nmcli
+from opentrons.server import init
 from opentrons.server.endpoints import wifi
 
 """


### PR DESCRIPTION
## overview

This PR separates out the previously entangled server and system functions so that `opentrons.main` handles system configuration while `server.main` only configures and runs the server

## changelog
- Entrypoint of the system is changed to `opentrons.main`
- Server is restructured to hold the REST (`http.py`) and rpc(`rpc.py`) sides as siblings, so either can be run without the other
- udev and resin configuration moved to `/system`

## review requests

- Check if the system and server functions have been sufficiently disentangled

### Test on a robot to verify everything still works (esp communication with the app):
- [ ] Run the system on a robot
- [ ] Check all HTTP endpoints
- [ ] Check RPC functionality
    - [ ] Upload protocol that uses module
    - [ ] Run labware calibration
    - [ ] Run protocol
    - [ ] Pause/resume/cancel
    - [ ] Reset after run
- [ ] Check regressions
    - [ ] Check server not binding on localhost
    - [ ] Check server runs properly on system 3.0
    - [ ] Check server reflashes out of date smoothie or programming mode smoothie on boot
    - [ ] Check server installs properly from windows runapp

