### PR TITLE
feat(components): make titlebar stick to top on scroll

### DIFF
--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -16,9 +16,6 @@
   height: 3rem;
   text-transform: uppercase;
   background-color: var(--c-dark-gray);
-  position: sticky;
-  top: 0;
-  z-index: 101;
 }
 
 .title_bar,

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -16,6 +16,9 @@
   height: 3rem;
   text-transform: uppercase;
   background-color: var(--c-dark-gray);
+  position: sticky;
+  top: 0;
+  z-index: 101;
 }
 
 .title_bar,

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -116,4 +116,8 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
   }
 }
 
-export default connect(mapStateToProps, null, mergeProps)(TitleBar)
+const StickyTitleBar = (props) => (
+  <TitleBar {...props} className={styles.sticky_bar} />
+)
+
+export default connect(mapStateToProps, null, mergeProps)(StickyTitleBar)

--- a/protocol-designer/src/containers/TitleBar.css
+++ b/protocol-designer/src/containers/TitleBar.css
@@ -8,3 +8,9 @@
   display: inline-block;
   vertical-align: middle;
 }
+
+.sticky_bar {
+  position: sticky;
+  top: 0;
+  z-index: 101;
+}


### PR DESCRIPTION
Titlebars now stay in view despite scrolling, which allows users to always see possible navigation
options.

Closes #2195