### PR TITLE
fix(api): When reseting the robot singleton, clear added tips

### DIFF
--- a/api/opentrons/api/session.py
+++ b/api/opentrons/api/session.py
@@ -177,6 +177,12 @@ class Session(object):
             self._modules.extend(_dedupe(modules))
             self._interactions.extend(_dedupe(interactions))
 
+            # Labware calibration happens after simulation and before run, so
+            # we have to clear the tips if they are left on after simulation
+            # to ensure that the instruments are in the expected state at the
+            # beginning of the labware calibration flow
+            robot.clear_tips()
+
         return res
 
     def refresh(self):

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -102,6 +102,7 @@ class Robot(object):
         self.fw_version = self._driver.get_fw_version()
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
+        self._instruments = {}
         self.model_by_mount = {'left': None, 'right': None}
 
         # TODO (artyom, 09182017): once protocol development experience
@@ -173,6 +174,16 @@ class Robot(object):
                     axis_mapping={'x': 'C'})
             }
         }
+        # If reset is called with a tip attached, the tip must be removed
+        # before the poses and _instruments members are cleared. If the tip is
+        # not removed, the effective length of the pipette remains increased by
+        # the length of the tip, and subsequent `_add_tip` calls will increase
+        # the length in addition to this. This should be fixed by changing pose
+        # tracking to that it tracks the tip as a separate node rather than
+        # adding and subtracting the tip length to the pipette length.
+        for instrument in self._instruments.values():
+            if instrument.tip_attached:
+                instrument._remove_tip(instrument._tip_length)
 
         self.poses = pose_tracker.init()
 

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -134,6 +134,20 @@ class Robot(object):
         else:
             return True
 
+    def clear_tips(self):
+        """
+        If reset is called with a tip attached, the tip must be removed
+        before the poses and _instruments members are cleared. If the tip is
+        not removed, the effective length of the pipette remains increased by
+        the length of the tip, and subsequent `_add_tip` calls will increase
+        the length in addition to this. This should be fixed by changing pose
+        tracking to that it tracks the tip as a separate node rather than
+        adding and subtracting the tip length to the pipette length.
+        """
+        for instrument in self._instruments.values():
+            if instrument.tip_attached:
+                instrument._remove_tip(instrument._tip_length)
+
     def reset(self):
         """
         Resets the state of the robot and clears:
@@ -174,16 +188,7 @@ class Robot(object):
                     axis_mapping={'x': 'C'})
             }
         }
-        # If reset is called with a tip attached, the tip must be removed
-        # before the poses and _instruments members are cleared. If the tip is
-        # not removed, the effective length of the pipette remains increased by
-        # the length of the tip, and subsequent `_add_tip` calls will increase
-        # the length in addition to this. This should be fixed by changing pose
-        # tracking to that it tracks the tip as a separate node rather than
-        # adding and subtracting the tip length to the pipette length.
-        for instrument in self._instruments.values():
-            if instrument.tip_attached:
-                instrument._remove_tip(instrument._tip_length)
+        self.clear_tips()
 
         self.poses = pose_tracker.init()
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -58,6 +58,15 @@ async def test_load_from_text(session_manager, protocol):
     assert len(acc) == 75
 
 
+async def test_clear_tips(session_manager, tip_clear_protocol):
+    session = session_manager.create(
+        name='<blank>', text=tip_clear_protocol.text)
+
+    assert len(session._instruments) == 1
+    for instrument in session._instruments:
+        assert not instrument.tip_attached
+
+
 async def test_async_notifications(main_router):
     publish('session', {'name': 'foo', 'payload': {'bar': 'baz'}})
     # Get async iterator

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -223,6 +223,20 @@ def protocol(request):
         return Protocol(text=text, filename=filename)
 
 
+@pytest.fixture(params=["no_clear_tips.py"])
+def tip_clear_protocol(request):
+    try:
+        root = request.getfuncargvalue('protocol_file')
+    except Exception:
+        root = request.param
+
+    filename = os.path.join(os.path.dirname(__file__), 'data', root)
+
+    with open(filename) as file:
+        text = ''.join(list(file))
+        return Protocol(text=text, filename=filename)
+
+
 @pytest.fixture
 def session_manager(main_router):
     return main_router.session_manager

--- a/api/tests/opentrons/data/no_clear_tips.py
+++ b/api/tests/opentrons/data/no_clear_tips.py
@@ -1,0 +1,17 @@
+from opentrons import containers, instruments
+
+
+# a 12 row trough for sources, and 96 well plate for output
+trough = containers.load('trough-12row', '3', 'trough')
+plate = containers.load('96-PCR-flat', '1', 'plate')
+
+# a tip rack for our pipette
+p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
+
+# create a p200 pipette on robot axis B
+p200 = instruments.P300_Single(mount="left", tip_racks=[p200rack])
+
+# simple, atomic commands to control fine details
+p200.pick_up_tip()
+p200.aspirate(50, trough.wells('A1'))
+p200.dispense(plate.wells('D1'))

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -7,6 +7,26 @@ from unittest import mock
 import pytest
 
 
+def test_reset(virtual_smoothie_env):
+    """
+    This test may need to be expanded to include various other conditions that
+    should be reset.
+
+    :param virtual_smoothie_env: pytest fixture to simulate Smoothie connection
+    """
+    # Not testing this one--this is needed to clean the robot singleton from
+    # other tests. This is an inherent problem with the use of the singleton--
+    # it entangles both runtime code and tests in unpredictable ways.
+    robot.reset()
+
+    lw = labware.load('opentrons-tiprack-300ul', '1')
+    p = instruments.P300_Single(mount='right', tip_racks=[lw])
+    p.pick_up_tip()
+    assert p.tip_attached
+    robot.reset()
+    assert not p.tip_attached
+
+
 def test_configurable_mount_offsets():
     def _test_offset(x, y, z):
         robot.reset()


### PR DESCRIPTION
## overview

When `Robot.reset` is called, any instruments with tips attached should have the tips removed before clearing the singleton state (including both the instruments dict and pose tracker). Closes #2322.

## changelog

- fix: clear tip lengths if present before clearing instruments
