### PR TITLE
fix(app): Open external links in user's browser instead of app window

### DIFF
--- a/app-shell/src/ui.js
+++ b/app-shell/src/ui.js
@@ -1,5 +1,5 @@
 // sets up the main window ui
-import {app, BrowserWindow} from 'electron'
+import {app, shell, BrowserWindow} from 'electron'
 import path from 'path'
 import {getConfig} from './config'
 import createLogger from './log'
@@ -41,6 +41,13 @@ export default function createUi () {
 
   log.info(`Loading ${url}`)
   mainWindow.loadURL(url, {'extraHeaders': 'pragma: no-cache\n'})
+
+  // open new windows (<a target="_blank" ...) in browser windows
+  mainWindow.webContents.on('new-window', (event, url) => {
+    log.debug('Opening external link', {url})
+    event.preventDefault()
+    shell.openExternal(url)
+  })
 
   return mainWindow
 }

--- a/app/src/components/AppSettings/ReleaseNotes.js
+++ b/app/src/components/AppSettings/ReleaseNotes.js
@@ -7,7 +7,10 @@ import styles from './styles.css'
 type Props = {source: ?string}
 
 const renderer = remark().use(reactRenderer, {
-  remarkReactComponents: {div: React.Fragment},
+  remarkReactComponents: {
+    div: React.Fragment,
+    a: ExternalLink,
+  },
 })
 
 const DEFAULT_RELEASE_NOTES = 'We recommend upgrading to the latest version.'
@@ -24,4 +27,8 @@ export default function ReleaseNotes (props: Props) {
       )}
     </div>
   )
+}
+
+function ExternalLink (props) {
+  return <a {...props} target="_blank" rel="noopener noreferrer" />
 }

--- a/app/src/components/Resources/ResourceCard.js
+++ b/app/src/components/Resources/ResourceCard.js
@@ -22,6 +22,7 @@ export default function ResourceCard (props: Props) {
         Component="a"
         href={props.url}
         target="_blank"
+        rel="noopener noreferrer"
         className={styles.link_button}
       >
         View in Browser


### PR DESCRIPTION
## overview

Bug report + fix

The app was opening external links in the app rather than in the browser as expected

## changelog

- fix(app): Open external links in user's browser instead of app window 

## review requests

- [ ] External links open in browser
- [ ] Internal links navigate the app
