### PR TITLE
feat(api): Remove deck calibration from reset options

### DIFF
--- a/api/opentrons/server/endpoints/settings.py
+++ b/api/opentrons/server/endpoints/settings.py
@@ -10,11 +10,6 @@ log = logging.getLogger(__name__)
 
 _settings_reset_options = [
     {
-        'id': 'deckCalibration',
-        'name': 'Deck Calibration',
-        'description': 'Reset pipette-to-deck alignment calibration'
-    },
-    {
         'id': 'tipProbe',
         'name': 'Tip Length',
         'description': 'Clear tip probe data'
@@ -80,8 +75,6 @@ async def reset(request: web.Request) -> web.Response:
                  .format(requested_reset)},
                 status=400)
     log.info("Reset requested for {}".format(', '.join(data.keys())))
-    if data.get('deckCalibration'):
-        rc.clear(calibration=True, robot=False)
     if data.get('tipProbe'):
         config = rc.load()
         config.tip_length.clear()

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -52,8 +52,7 @@ async def test_available_resets(virtual_smoothie_env, loop, test_client):
     body = await resp.json()
     options_list = body.get('options')
     assert resp.status == 200
-    for key in ['deckCalibration', 'tipProbe',
-                'labwareCalibration', 'bootScripts']:
+    for key in ['tipProbe', 'labwareCalibration', 'bootScripts']:
         for opt in options_list:
             if opt['id'] == key:
                 assert 'name' in opt
@@ -88,21 +87,6 @@ async def execute_reset_tests(cli):
     with open(robot_settings, 'r') as f:
         data = json.load(f)
     assert data['tip_length'] == {}
-
-    # Check that we delete the entire deck calibration file
-    resp = await cli.post('/settings/reset', json={'deckCalibration': True})
-    body = await resp.json()
-    assert resp.status == 200
-    assert body == {}
-
-    deck_cal = index['deckCalibrationFile']
-    assert not os.path.exists(deck_cal)
-
-    # Check that this endpoint is idempotent
-    resp = await cli.post('/settings/reset', json={'deckCalibration': True})
-    body = await resp.json()
-    assert resp.status == 200
-    assert body == {}
 
     # Check the inpost validation
     resp = await cli.post('/settings/reset', json={'aksgjajhadjasl': False})


### PR DESCRIPTION
## overview

Remove deck calibration from factory reset options, as deck calibration reset should not be done
outside of the context of recalibration. Closes #2331 

## review requests

Ensure that factory reset options still appear as expected