### PR TITLE
chore(chore): add exception in gitattributes for our hex files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+api/opentrons/resources/smoothie*.hex -text


### PR DESCRIPTION
## overview

With our current .gitattributes settings, the hex file with CRLF endings keeps popping up as "modified" whenever I check out a branch.

This should remove the text=auto from applying to the hex files.

## changelog


## review requests

Works on Windows?