### PR TITLE
fix(protocol-designer): fix tiprack diagram only displaying right

### DIFF
--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -160,7 +160,7 @@ export default class NewFileModal extends React.Component<Props, State> {
           </div>
 
           <div className={styles.diagrams}>
-            <TiprackDiagram containerType={this.state.right.tiprackModel} />
+            <TiprackDiagram containerType={this.state.left.tiprackModel} />
             <PipetteDiagram
               leftPipette={this.state.left.pipetteModel}
               rightPipette={this.state.right.pipetteModel}


### PR DESCRIPTION
## overview

Fix a small bug where the tiprack diagram in the new file modal would duplicate the diagram of the
selected right pipette tiprack instead of showing both selections.
