### PR TITLE
fix(protocol-designer): fix whitescreen on deleting blowout labware

### DIFF
--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -191,15 +191,24 @@ export const LabwareDropdown = connect(LabwareDropdownSTP)((props: LabwareDropdo
       name={name}
       focusedField={focusedField}
       dirtyFields={dirtyFields}
-      render={({value, updateValue}) => (
-        <DropdownField
-          className={className}
-          options={labwareOptions}
-          onBlur={() => { onFieldBlur(name) }}
-          onFocus={() => { onFieldFocus(name) }}
-          value={value ? String(value) : null}
-          onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
-      )} />
+      render={({value, updateValue}) => {
+        // blank out the dropdown if labware id does not exist
+        const availableLabwareIds = labwareOptions.map(opt => opt.value)
+        const fieldValue = availableLabwareIds.includes(value)
+          ? String(value)
+          : null
+        return (
+          <DropdownField
+            className={className}
+            options={labwareOptions}
+            onBlur={() => { onFieldBlur(name) }}
+            onFocus={() => { onFieldFocus(name) }}
+            value={fieldValue}
+            onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } }
+          />
+        )
+      }}
+    />
   )
 })
 

--- a/protocol-designer/src/step-generation/blowout.js
+++ b/protocol-designer/src/step-generation/blowout.js
@@ -24,6 +24,10 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
   }
 
+  if (!labware || !prevRobotState.labware[labware]) {
+    errors.push(errorCreators.labwareDoesNotExist({actionName, labware}))
+  }
+
   if (errors.length > 0) {
     return {errors}
   }

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -71,6 +71,19 @@ describe('blowout', () => {
     })
   })
 
+  test('blowout with invalid labware ID should throw error', () => {
+    const result = blowoutWithErrors({
+      pipette: 'p300SingleId',
+      labware: 'badLabware',
+      well: 'A1',
+    })(robotStateWithTip)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'LABWARE_DOES_NOT_EXIST',
+    })
+  })
+
   test('blowout with no tip should throw error', () => {
     const result = blowoutWithErrors({
       pipette: 'p300SingleId',

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -46,6 +46,10 @@ const getChannels = (pipetteId: string, state: BaseState): PipetteChannels => {
   return pipette.channels
 }
 
+// TODO: Ian 2018-09-20 this is only usable by 'unsavedForm'.
+// Eventually we gotta allow arbitrary actions like DELETE_LABWARE
+// (or more speculatively, CHANGE_PIPETTE etc), which affect saved forms from
+// 'outside', to cause changes that run thru all the logic in this block
 function handleFormChange (payload: ChangeFormPayload, getState: GetState): ChangeFormPayload {
   // Use state to handle form changes
   const baseState = getState()


### PR DESCRIPTION
## overview

Addresses #2161 but I can't find a clean way to totally close it - added a comment to `handleFormChange` and commented on that ticket with more info.

This PR makes it so labware dropdown shows up as blank instead of just showing the first thing in the list, when the previously selected labware was deleted.

This PR also fixes a bug, for which this PR serves as the ticket:

WHITESCREEN BUG:
* Create a Distribute step that blows out to a `trash-box` labware on the deck
* Delete that trash-box
* Whitescreen!

## changelog

* fix unticketed bug: setting blowout to a trash-box in a step and deleting the trash box caused whitescreen
*make labware dropdown blank when nonexistent labware selected

## review requests

* No whitescreen on deleting labware, even in blowout
* Even if it's not all the way to where we wanna be, is the labware field going blank still a positive improvement, better than leaving as is?