### PR TITLE
feat(protocol-designer): add "app build date" field to PD saved files

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -19,6 +19,11 @@ import type {LabwareData, PipetteData} from '../../step-generation'
 const protocolSchemaVersion = '1.0.0'
 const applicationVersion = process.env.OT_PD_VERSION || 'unknown version'
 
+// Internal release date: this should never be read programatically,
+// it just helps us humans quickly identify what build a user was using
+// when we look at saved protocols (without requiring us to trace thru git logs)
+const _internalAppBuildDate = process.env.OT_PD_BUILD_DATE
+
 const executionDefaults = {
   'aspirate-flow-rate': getPropertyAllPipettes('aspirateFlowRate'),
   'dispense-flow-rate': getPropertyAllPipettes('dispenseFlowRate'),
@@ -90,6 +95,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
       'designer-application': {
         'application-name': 'opentrons/protocol-designer',
         'application-version': applicationVersion,
+        _internalAppBuildDate,
         data: {
           pipetteTiprackAssignments: mapValues(
             initialRobotState.instruments,

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -12,12 +12,13 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 
 const gitInfo = gitDescribeSync()
 const OT_PD_VERSION = gitInfo && gitInfo.raw
+const OT_PD_BUILD_DATE = (new Date()).toUTCString()
 
 const passThruEnvVars = Object.keys(process.env)
   .filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX))
   .concat(['NODE_ENV'])
 
-const envVarsWithDefaults = {OT_PD_VERSION}
+const envVarsWithDefaults = {OT_PD_VERSION, OT_PD_BUILD_DATE}
 
 const envVars = passThruEnvVars.reduce((acc, envVar) =>
   ({[envVar]: '', ...acc}),


### PR DESCRIPTION
## overview

It's annoying to have to look up a commit hash from the git-describe version that we have saved in right now, so this PR introduces an additional field in PD protocols (still conforms with the protocol schema, it's an additional field)

Serves as its own ticket.

## changelog


## review requests

Check out the Travis build, save a file, open it in a text editor, and confirm that the `"_internalAppBuildDate"` is the time that the build was made, not the time you opened PD.
