### PR TITLE
refactor(app): Add actual state for API update file

### DIFF
--- a/app-shell/src/api-update.js
+++ b/app-shell/src/api-update.js
@@ -1,3 +1,4 @@
+// @flow
 // api updater
 import assert from 'assert'
 import fse from 'fs-extra'
@@ -6,47 +7,52 @@ import path from 'path'
 import pkg from '../package.json'
 import createLogger from './log'
 
+import type {ApiUpdateInfo} from '@opentrons/app/src/shell'
+
 const log = createLogger(__filename)
 
-let updateFiles = []
+const DIRECTORY = path.join(__dirname, '../../api/dist')
+const EXTENSION = '.whl'
+const RE_VERSION = /.+-(\d+\.\d+\.\d+)([ab])?(\d+)?-.+/
+const SHORT_LABEL_TO_LABEL = {a: 'alpha', b: 'beta'}
+
+let updateFilename: string
+let updateVersion: string
 
 export const AVAILABLE_UPDATE = pkg.version
 
-export function initialize () {
-  updateFiles = [
-    // API update
-    {
-      id: 'whl',
-      directory: path.join(__dirname, '../../api/dist'),
-      ext: '.whl',
-    },
-  ].map(findUpdateFile)
+export function registerApiUpdate () {
+  initializeUpdateFileInfo()
+
+  // API update does not need to handle actions at the moment
+  return () => {}
 }
 
-export function getUpdateFiles () {
-  if (!updateFiles.length || !updateFiles.every(Boolean)) {
-    return Promise.reject(new Error('Update files were not all found'))
-  }
+export function getUpdateInfo (): ApiUpdateInfo {
+  assert(updateFilename && updateVersion, 'Update info was not initialized')
 
-  return Promise.all(updateFiles.map(readUpdateFile))
+  return {filename: path.basename(updateFilename), version: updateVersion}
 }
 
-function findUpdateFile (file) {
-  const {directory, ext} = file
+export function getUpdateFileContents (): Promise<Buffer> {
+  assert(updateFilename && updateVersion, 'Update info was not initialized')
 
+  return fse.readFile(updateFilename)
+}
+
+function initializeUpdateFileInfo () {
   try {
-    const results = fse.readdirSync(directory)
-    const files = results.filter(f => f.endsWith(ext))
+    const results = fse.readdirSync(DIRECTORY)
+    const files = results.filter(f => f.endsWith(EXTENSION))
 
     assert(
       files.length === 1,
-      `Expected 1 ${ext} file in ${directory}, found ${results.join(' ')}`
+      `Expected 1 ${EXTENSION} file in ${DIRECTORY}, found ${results.join(' ')}`
     )
 
-    const updateFile = Object.assign({name: files[0]}, file)
-    log.info(`Found update file`, updateFile)
-
-    return updateFile
+    log.info(`Found update file`, {filename: files[0]})
+    updateFilename = path.join(DIRECTORY, files[0])
+    updateVersion = getVersionFromFilename(updateFilename)
   } catch (error) {
     log.error('Unable to load API update files', {error})
   }
@@ -54,7 +60,17 @@ function findUpdateFile (file) {
   return null
 }
 
-function readUpdateFile (file) {
-  return fse.readFile(path.join(file.directory, file.name))
-    .then(contents => Object.assign({contents}, file))
+function getVersionFromFilename (filename: string): string {
+  const match = filename.toLowerCase().match(RE_VERSION)
+
+  assert(match, `could not parse version from "${filename}"`)
+
+  // $FlowFixMe: assert above means `match` exists here
+  const [baseVersion, shortLabel, labelVersion] = match.slice(1)
+  const label =
+    shortLabel && labelVersion
+      ? `-${SHORT_LABEL_TO_LABEL[shortLabel]}.${labelVersion}`
+      : ''
+
+  return `${baseVersion}${label}`
 }

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -3,9 +3,9 @@ import {app, dialog, ipcMain, Menu} from 'electron'
 
 import createUi from './ui'
 import initializeMenu from './menu'
-import {initialize as initializeApiUpdate} from './api-update'
 import createLogger from './log'
 import {getConfig, getStore, getOverrides, registerConfig} from './config'
+import {registerApiUpdate} from './api-update'
 import {registerDiscovery} from './discovery'
 import {registerRobotLogs} from './robot-logs'
 import {registerUpdate} from './update'
@@ -31,20 +31,20 @@ app.on('ready', startUp)
 
 function startUp () {
   log.info('Starting App')
-  process.on('uncaughtException', (error) => log.error('Uncaught: ', {error}))
+  process.on('uncaughtException', error => log.error('Uncaught: ', {error}))
 
   mainWindow = createUi()
   rendererLogger = createRendererLogger()
 
   initializeMenu()
-  initializeApiUpdate()
 
   // wire modules to UI dispatches
-  const dispatch = (action) => {
+  const dispatch = action => {
     log.debug('Sending action via IPC to renderer', {action})
     mainWindow.webContents.send('dispatch', action)
   }
 
+  const apiUpdateHandler = registerApiUpdate(dispatch)
   const configHandler = registerConfig(dispatch)
   const discoveryHandler = registerDiscovery(dispatch)
   const robotLogsHandler = registerRobotLogs(dispatch, mainWindow)
@@ -52,6 +52,7 @@ function startUp () {
 
   ipcMain.on('dispatch', (_, action) => {
     log.debug('Received action via IPC from renderer', {action})
+    apiUpdateHandler(action)
     configHandler(action)
     discoveryHandler(action)
     robotLogsHandler(action)
@@ -59,8 +60,9 @@ function startUp () {
   })
 
   if (config.devtools) {
-    installAndOpenExtensions()
-      .catch((error) => dialog.showErrorBox('Error opening dev tools', error))
+    installAndOpenExtensions().catch(error =>
+      dialog.showErrorBox('Error opening dev tools', error)
+    )
   }
 
   log.silly('Global references', {mainWindow, rendererLogger})
@@ -79,21 +81,20 @@ function installAndOpenExtensions () {
   const devtools = require('electron-devtools-installer')
   const forceDownload = !!process.env.UPGRADE_EXTENSIONS
   const install = devtools.default
-  const extensions = [
-    'REACT_DEVELOPER_TOOLS',
-    'REDUX_DEVTOOLS',
-  ]
+  const extensions = ['REACT_DEVELOPER_TOOLS', 'REDUX_DEVTOOLS']
 
-  return Promise
-    .all(extensions.map((name) => install(devtools[name], forceDownload)))
-    .then(() => mainWindow.webContents.on('context-menu', (_, props) => {
+  return Promise.all(
+    extensions.map(name => install(devtools[name], forceDownload))
+  ).then(() =>
+    mainWindow.webContents.on('context-menu', (_, props) => {
       const {x, y} = props
 
-      Menu
-        .buildFromTemplate([{
+      Menu.buildFromTemplate([
+        {
           label: 'Inspect element',
           click: () => mainWindow.inspectElement(x, y),
-        }])
-        .popup(mainWindow)
-    }))
+        },
+      ]).popup(mainWindow)
+    })
+  )
 }

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -29,7 +29,6 @@ const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 
 const robot = {name: 'opentrons', ip: '1.2.3.4', port: '1234'}
-const mockApiUpdate = electron.__mockRemotes['./api-update']
 const availableUpdate = '42.0.0'
 
 describe('server API client', () => {
@@ -46,11 +45,24 @@ describe('server API client', () => {
         api: {
           server: {
             [robot.name]: {
-              availableUpdate: '42.0.0',
               update: {inProgress: true, error: null, response: null},
               restart: {inProgress: true, error: null, response: null},
               'update/ignore': {inProgress: true, error: null, response: null},
             },
+          },
+          api: {
+            [robot.name]: {
+              health: {
+                response: {
+                  api_version: '3.0.0',
+                },
+              },
+            },
+          },
+        },
+        shell: {
+          apiUpdate: {
+            version: '4.0.0',
           },
         },
       }
@@ -59,36 +71,45 @@ describe('server API client', () => {
     test('makeGetRobotAvailableUpdate', () => {
       const getAvailableUpdate = makeGetAvailableRobotUpdate()
 
-      expect(getAvailableUpdate(state, robot)).toEqual('42.0.0')
+      expect(getAvailableUpdate(state, robot)).toEqual('4.0.0')
       expect(getAvailableUpdate(state, {name: 'foo'})).toEqual(null)
     })
 
     test('makeGetRobotUpdateRequest', () => {
       const getUpdateRequest = makeGetRobotUpdateRequest()
 
-      expect(getUpdateRequest(state, robot))
-        .toBe(state.api.server[robot.name].update)
-      expect(getUpdateRequest(state, {name: 'foo'}))
-        .toEqual({inProgress: false})
+      expect(getUpdateRequest(state, robot)).toBe(
+        state.api.server[robot.name].update
+      )
+      expect(getUpdateRequest(state, {name: 'foo'})).toEqual({
+        inProgress: false,
+      })
     })
 
     test('makeGetRobotUpdateRequest', () => {
       const getRestartRequest = makeGetRobotRestartRequest()
 
-      expect(getRestartRequest(state, robot))
-        .toBe(state.api.server[robot.name].restart)
-      expect(getRestartRequest(state, {name: 'foo'}))
-        .toEqual({inProgress: false})
+      expect(getRestartRequest(state, robot)).toBe(
+        state.api.server[robot.name].restart
+      )
+      expect(getRestartRequest(state, {name: 'foo'})).toEqual({
+        inProgress: false,
+      })
     })
 
     test('makeGetRobotIgnoredUpdateRequest', () => {
       const getIngoredUpdate = makeGetRobotIgnoredUpdateRequest()
 
-      expect(getIngoredUpdate(state, robot)).toEqual(state.api.server[robot.name]['update/ignore'])
-      expect(getIngoredUpdate(state, {name: 'foo'})).toEqual({inProgress: false})
+      expect(getIngoredUpdate(state, robot)).toEqual(
+        state.api.server[robot.name]['update/ignore']
+      )
+      expect(getIngoredUpdate(state, {name: 'foo'})).toEqual({
+        inProgress: false,
+      })
     })
 
-    test('getAnyRobotUpdateAvailable is true if any robot has update', () => {
+    // TODO(mc, 2018-09-25): re-evaluate this selector
+    test.skip('getAnyRobotUpdateAvailable is true if any robot has update', () => {
       state.api.server.anotherBot = {availableUpdate: null}
       expect(getAnyRobotUpdateAvailable(state)).toBe(true)
 
@@ -112,10 +133,9 @@ describe('server API client', () => {
     test('calls POST /server/restart', () => {
       client.__setMockResponse({message: 'restarting'})
 
-      return restartRobotServer(robot)(() => {})
-        .then(() => expect(client)
-          .toHaveBeenCalledWith(robot, 'POST', 'server/restart')
-        )
+      return restartRobotServer(robot)(() => {}).then(() =>
+        expect(client).toHaveBeenCalledWith(robot, 'POST', 'server/restart')
+      )
     })
 
     test('dispatches SERVER_REQUEST and SERVER_SUCCESS', () => {
@@ -131,7 +151,8 @@ describe('server API client', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(restartRobotServer(robot))
+      return store
+        .dispatch(restartRobotServer(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -148,19 +169,27 @@ describe('server API client', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(restartRobotServer(robot))
+      return store
+        .dispatch(restartRobotServer(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
 
   describe('fetchIgnoredUpdate action creator', () => {
     test('calls GET /server/update/ignore', () => {
-      client.__setMockResponse({inProgress: true, error: null, response: {version: '42.0.0'}})
+      client.__setMockResponse({
+        inProgress: true,
+        error: null,
+        response: {version: '42.0.0'},
+      })
 
-      return fetchIgnoredUpdate(robot)(() => {})
-        .then(() => expect(client)
-          .toHaveBeenCalledWith(robot, 'GET', 'server/update/ignore')
+      return fetchIgnoredUpdate(robot)(() => {}).then(() =>
+        expect(client).toHaveBeenCalledWith(
+          robot,
+          'GET',
+          'server/update/ignore'
         )
+      )
     })
 
     test('dispatches SERVER_REQUEST and SERVER_SUCCESS', () => {
@@ -176,7 +205,8 @@ describe('server API client', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(fetchIgnoredUpdate(robot))
+      return store
+        .dispatch(fetchIgnoredUpdate(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -193,19 +223,28 @@ describe('server API client', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(fetchIgnoredUpdate(robot))
+      return store
+        .dispatch(fetchIgnoredUpdate(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
 
   describe('setIgnoredUpdate action creator', () => {
     test('calls POST /server/update/ignore', () => {
-      client.__setMockResponse({inProgress: true, error: null, response: {version: '42.0.0'}})
+      client.__setMockResponse({
+        inProgress: true,
+        error: null,
+        response: {version: '42.0.0'},
+      })
 
-      return setIgnoredUpdate(robot, availableUpdate)(() => {})
-        .then(() => expect(client)
-          .toHaveBeenCalledWith(robot, 'POST', 'server/update/ignore', {version: availableUpdate})
+      return setIgnoredUpdate(robot, availableUpdate)(() => {}).then(() =>
+        expect(client).toHaveBeenCalledWith(
+          robot,
+          'POST',
+          'server/update/ignore',
+          {version: availableUpdate}
         )
+      )
     })
 
     test('dispatches SERVER_REQUEST and SERVER_SUCCESS', () => {
@@ -221,7 +260,8 @@ describe('server API client', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(setIgnoredUpdate(robot, availableUpdate))
+      return store
+        .dispatch(setIgnoredUpdate(robot, availableUpdate))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -238,7 +278,8 @@ describe('server API client', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(setIgnoredUpdate(robot, availableUpdate))
+      return store
+        .dispatch(setIgnoredUpdate(robot, availableUpdate))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
@@ -246,38 +287,14 @@ describe('server API client', () => {
   describe('reducer', () => {
     let state
 
-    beforeEach(() => (state = {
-      server: {
-        [robot.name]: {},
-      },
-    }))
-
-    test('sets availableUpdate on /health api:SUCCESS', () => {
-      const health = {name, api_version: 'foobar', fw_version: '7.8.9'}
-      const action = {
-        type: 'api:SUCCESS',
-        payload: {robot, path: 'health', response: health},
-      }
-
-      // test update available
-      state.server[robot.name].availableUpdate = null
-      expect(reducer(state, action).server).toEqual({
-        [robot.name]: {
-          availableUpdate: mockApiUpdate.AVAILABLE_UPDATE,
-          update: null,
-          restart: null,
+    beforeEach(() =>
+      (state = {
+        server: {
+          [robot.name]: {},
         },
-      })
+      }))
 
-      // test no update available
-      action.payload.response.api_version = mockApiUpdate.AVAILABLE_UPDATE
-      state.server[robot.name].availableUpdate = mockApiUpdate.AVAILABLE_UPDATE
-      expect(reducer(state, action).server).toEqual({
-        [robot.name]: {availableUpdate: null, update: null, restart: null},
-      })
-    })
-
-    REQUESTS_TO_TEST.forEach((request) => {
+    REQUESTS_TO_TEST.forEach(request => {
       const {path, response} = request
 
       test(`handles SERVER_REQUEST for /server/${path}`, () => {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -1,6 +1,5 @@
 // @flow
 // server endpoints http api module
-import {remote} from 'electron'
 import {createSelector, type Selector} from 'reselect'
 import {chainActions} from '../util'
 import type {State, ThunkPromiseAction, Action} from '../types'
@@ -8,10 +7,12 @@ import type {RobotService} from '../robot'
 
 import type {ApiCall} from './types'
 import client, {FetchError, type ApiRequestError} from './client'
-import {fetchHealth} from './health'
-
-// remote module paths relative to app-shell/lib/main.js
-const {AVAILABLE_UPDATE, getUpdateFiles} = remote.require('./api-update')
+import {fetchHealth, makeGetRobotHealth} from './health'
+import {
+  getApiUpdateVersion,
+  getApiUpdateFilename,
+  getApiUpdateContents,
+} from '../shell'
 
 type RequestPath = 'update' | 'restart' | 'update/ignore'
 
@@ -92,14 +93,12 @@ const UPDATE: RequestPath = 'update'
 const RESTART: RequestPath = 'restart'
 const IGNORE: RequestPath = 'update/ignore'
 
-export function updateRobotServer (
-  robot: RobotService
-): ThunkPromiseAction {
-  return (dispatch) => {
+export function updateRobotServer (robot: RobotService): ThunkPromiseAction {
+  return (dispatch, getState) => {
     dispatch(serverRequest(robot, UPDATE))
 
-    return getUpdateRequestBody()
-      .then((body) => client(robot, 'POST', 'server/update', body))
+    return getUpdateRequestBody(getState())
+      .then(body => client(robot, 'POST', 'server/update', body))
       .then(
         (response: ServerUpdateResponse) =>
           dispatch(serverSuccess(robot, UPDATE, response)),
@@ -109,19 +108,15 @@ export function updateRobotServer (
   }
 }
 
-export function restartRobotServer (
-  robot: RobotService
-): ThunkPromiseAction {
-  return (dispatch) => {
+export function restartRobotServer (robot: RobotService): ThunkPromiseAction {
+  return dispatch => {
     dispatch(serverRequest(robot, RESTART))
 
-    return client(robot, 'POST', 'server/restart')
-      .then(
-        (response: ServerRestartResponse) =>
-          dispatch(serverSuccess(robot, RESTART, response)),
-        (error: ApiRequestError) =>
-          dispatch(serverFailure(robot, RESTART, error))
-      )
+    return client(robot, 'POST', 'server/restart').then(
+      (response: ServerRestartResponse) =>
+        dispatch(serverSuccess(robot, RESTART, response)),
+      (error: ApiRequestError) => dispatch(serverFailure(robot, RESTART, error))
+    )
   }
 }
 
@@ -130,37 +125,33 @@ export function clearRestartResponse (robot: RobotService): * {
 }
 
 export function fetchHealthAndIgnored (robot: RobotService): * {
-  return chainActions(
-    fetchHealth(robot),
-    fetchIgnoredUpdate(robot)
-  )
+  return chainActions(fetchHealth(robot), fetchIgnoredUpdate(robot))
 }
 
 export function fetchIgnoredUpdate (robot: RobotService): ThunkPromiseAction {
-  return (dispatch) => {
+  return dispatch => {
     dispatch(serverRequest(robot, IGNORE))
 
-    return client(robot, 'GET', 'server/update/ignore')
-    .then(
+    return client(robot, 'GET', 'server/update/ignore').then(
       (response: ServerRestartResponse) =>
         dispatch(serverSuccess(robot, IGNORE, response)),
-      (error: ApiRequestError) =>
-        dispatch(serverFailure(robot, IGNORE, error))
+      (error: ApiRequestError) => dispatch(serverFailure(robot, IGNORE, error))
     )
   }
 }
 
-export function setIgnoredUpdate (robot: RobotService, version: ?string): ThunkPromiseAction {
-  return (dispatch) => {
+export function setIgnoredUpdate (
+  robot: RobotService,
+  version: ?string
+): ThunkPromiseAction {
+  return dispatch => {
     const body = {version}
     dispatch(serverRequest(robot, IGNORE))
 
-    return client(robot, 'POST', 'server/update/ignore', body)
-    .then(
+    return client(robot, 'POST', 'server/update/ignore', body).then(
       (response: ServerRestartResponse) =>
         dispatch(serverSuccess(robot, IGNORE, response)),
-      (error: ApiRequestError) =>
-        dispatch(serverFailure(robot, IGNORE, error))
+      (error: ApiRequestError) => dispatch(serverFailure(robot, IGNORE, error))
     )
   }
 }
@@ -175,7 +166,10 @@ export function serverReducer (
   let path
   switch (action.type) {
     case 'api:SERVER_REQUEST':
-      ({path, robot: {name}} = action.payload)
+      ;({
+        path,
+        robot: {name},
+      } = action.payload)
 
       return {
         ...state,
@@ -186,7 +180,10 @@ export function serverReducer (
       }
 
     case 'api:SERVER_SUCCESS':
-      ({path, robot: {name}} = action.payload)
+      ;({
+        path,
+        robot: {name},
+      } = action.payload)
 
       return {
         ...state,
@@ -201,7 +198,10 @@ export function serverReducer (
       }
 
     case 'api:SERVER_FAILURE':
-      ({path, robot: {name}} = action.payload)
+      ;({
+        path,
+        robot: {name},
+      } = action.payload)
 
       return {
         ...state,
@@ -216,7 +216,10 @@ export function serverReducer (
       }
 
     case 'api:CLEAR_SERVER_RESPONSE':
-      ({path, robot: {name}} = action.payload)
+      ;({
+        path,
+        robot: {name},
+      } = action.payload)
       return {
         ...state,
         [name]: {
@@ -228,24 +231,6 @@ export function serverReducer (
           },
         },
       }
-
-    // TODO(mc, 2018-07-05): this logic should live in a selector
-    case 'api:SUCCESS': {
-      if (action.payload.path !== 'health') return state
-      const name = action.payload.robot.name
-      let stateByName = state[name]
-      const previousUpdate = stateByName && stateByName.availableUpdate
-      const currentVersion = action.payload.response.api_version
-      const availableUpdate = currentVersion !== AVAILABLE_UPDATE
-        ? AVAILABLE_UPDATE
-        : null
-
-      if (availableUpdate !== previousUpdate) {
-        stateByName = {...stateByName, update: null, restart: null}
-      }
-
-      return {...state, [name]: {...stateByName, availableUpdate}}
-    }
   }
 
   return state
@@ -253,48 +238,59 @@ export function serverReducer (
 
 export const makeGetAvailableRobotUpdate = () => {
   const selector: Selector<State, RobotService, ?string> = createSelector(
-    selectRobotServerState,
-    (state) => (state && state.availableUpdate) || null
+    makeGetRobotHealth(),
+    getApiUpdateVersion,
+    (health, updateVersion) => {
+      const currentVersion = health.response && health.response.api_version
+      return currentVersion && currentVersion !== updateVersion
+        ? updateVersion
+        : null
+    }
   )
 
   return selector
 }
 
+// TODO(mc, 2018-09-25): this is broken until some planned discovery work is
+// done for https://github.com/Opentrons/opentrons/milestone/68
 export const makeGetRobotUpdateRequest = () => {
-  const selector: Selector<State, RobotService, RobotServerUpdate> =
-    createSelector(
-      selectRobotServerState,
-      (state) => (state && state.update) || {inProgress: false}
-    )
+  const selector: Selector<State,
+    RobotService,
+    RobotServerUpdate> = createSelector(
+    selectRobotServerState,
+    state => (state && state.update) || {inProgress: false}
+  )
 
   return selector
 }
 
 export const makeGetRobotRestartRequest = () => {
-  const selector: Selector<State, RobotService, RobotServerRestart> =
-    createSelector(
-      selectRobotServerState,
-      (state) => (state && state.restart) || {inProgress: false}
-    )
+  const selector: Selector<State,
+    RobotService,
+    RobotServerRestart> = createSelector(
+    selectRobotServerState,
+    state => (state && state.restart) || {inProgress: false}
+  )
 
   return selector
 }
 
 export const makeGetRobotIgnoredUpdateRequest = () => {
-  const selector: Selector<State, RobotService, RobotServerUpdateIgnore> =
-    createSelector(
-      selectRobotServerState,
-      (state) => (state && state['update/ignore']) || {inProgress: false}
-    )
+  const selector: Selector<State,
+    RobotService,
+    RobotServerUpdateIgnore> = createSelector(
+    selectRobotServerState,
+    state => (state && state['update/ignore']) || {inProgress: false}
+  )
 
   return selector
 }
 
-export const getAnyRobotUpdateAvailable: Selector<State, void, boolean> =
-  createSelector(
-    selectServerState,
-    (state) => Object.keys(state).some((name) => state[name].availableUpdate)
-  )
+export const getAnyRobotUpdateAvailable: Selector<State,
+  void,
+  boolean> = createSelector(selectServerState, state =>
+  Object.keys(state).some(name => state[name].availableUpdate)
+)
 
 function selectServerState (state: State) {
   return state.api.server
@@ -304,14 +300,16 @@ function selectRobotServerState (state: State, props: RobotService) {
   return selectServerState(state)[props.name]
 }
 
-function getUpdateRequestBody () {
-  return getUpdateFiles()
-    .then(files => {
+function getUpdateRequestBody (state: State) {
+  const filename = getApiUpdateFilename(state)
+
+  return getApiUpdateContents()
+    .then(contents => {
       const formData = new FormData()
-      files.forEach(f => formData.append(f.id, new Blob([f.contents]), f.name))
+      formData.append('whl', contents, filename)
       return formData
     })
-    .catch((error) => Promise.reject(FetchError(error)))
+    .catch(error => Promise.reject(FetchError(error)))
 }
 
 function serverRequest (

--- a/app/src/shell/__tests__/api-update.test.js
+++ b/app/src/shell/__tests__/api-update.test.js
@@ -1,0 +1,64 @@
+import electron from 'electron'
+import {mockResolvedValue} from '../../../__util__/mock-promise'
+import * as apiUpdate from '../api-update'
+
+jest.mock('electron')
+
+const {'./api-update': mockApiUpdate} = electron.__mockRemotes
+
+describe('shell/api-update', () => {
+  let _Blob
+
+  beforeEach(() => {
+    _Blob = global.Blob
+    global.Blob = jest.fn(input => ({blob: input}))
+  })
+
+  afterEach(() => {
+    global.Blob = _Blob
+  })
+
+  test('reducer puts update info in state', () => {
+    mockApiUpdate.getUpdateInfo.mockReturnValue({
+      filename: 'foo.whl',
+      version: '1.2.3',
+    })
+
+    expect(apiUpdate.apiUpdateReducer(undefined, {})).toEqual({
+      filename: 'foo.whl',
+      version: '1.2.3',
+    })
+  })
+
+  test('getApiUpdateContents puts file from app-shell into a Blob', () => {
+    const contents = 'update'
+
+    mockResolvedValue(mockApiUpdate.getUpdateFileContents, contents)
+
+    return expect(apiUpdate.getApiUpdateContents()).resolves.toEqual({
+      blob: ['update'],
+    })
+  })
+
+  describe('selectors', () => {
+    const SPECS = [
+      {
+        name: 'getApiUpdateVersion',
+        selector: apiUpdate.getApiUpdateVersion,
+        state: {shell: {apiUpdate: {version: '1.0.0'}}},
+        expected: '1.0.0',
+      },
+      {
+        name: 'getApiUpdateFilename',
+        selector: apiUpdate.getApiUpdateFilename,
+        state: {shell: {apiUpdate: {filename: 'foobar.whl', version: '1.0.0'}}},
+        expected: 'foobar.whl',
+      },
+    ]
+
+    SPECS.forEach(spec => {
+      const {name, selector, state, expected} = spec
+      test(name, () => expect(selector(state)).toEqual(expected))
+    })
+  })
+})

--- a/app/src/shell/api-update.js
+++ b/app/src/shell/api-update.js
@@ -1,0 +1,29 @@
+// @flow
+import {remote} from 'electron'
+
+import type {State} from '../types'
+
+export type ApiUpdateInfo = {
+  filename: string,
+  version: string,
+}
+
+const {getUpdateInfo, getUpdateFileContents} = remote.require('./api-update')
+
+export function apiUpdateReducer (state: ?ApiUpdateInfo) {
+  if (!state) return getUpdateInfo()
+  return state
+}
+
+export function getApiUpdateFilename (state: State): string {
+  return state.shell.apiUpdate.filename
+}
+
+export function getApiUpdateVersion (state: State): string {
+  return state.shell.apiUpdate.version
+}
+
+// caution: this calls an Electron RPC remote, so use sparingly
+export function getApiUpdateContents (): Promise<Blob> {
+  return getUpdateFileContents().then(contents => new Blob([contents]))
+}

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -6,6 +6,7 @@ import {combineReducers} from 'redux'
 import createLogger from '../logger'
 import {makeGetRobotHealth} from '../http-api-client'
 import {updateReducer} from './update'
+import {apiUpdateReducer} from './api-update'
 
 import type {Middleware, ThunkAction} from '../types'
 import type {RobotService} from '../robot'
@@ -22,10 +23,14 @@ const {getRobots} = remote.require('./discovery')
 const log = createLogger(__filename)
 
 export * from './update'
+export * from './api-update'
 
 export {CURRENT_VERSION, CURRENT_RELEASE_NOTES}
 
-export const shellReducer = combineReducers({update: updateReducer})
+export const shellReducer = combineReducers({
+  update: updateReducer,
+  apiUpdate: apiUpdateReducer,
+})
 
 export const shellMiddleware: Middleware = store => {
   const {dispatch} = store


### PR DESCRIPTION
## overview

The PR does work to address #2354 by putting information about the API update bundled with the app (most importantly: version) into the app state.

## changelog

- refactor(app): Add actual state for API update file 

## review requests

- [ ] Robot updates still work

### known issues

- The nav link notification dot for "Robots" is now broken
    - This should be fixed naturally or almost naturally by work for #2344
    - Would also like to confirm what our expected behavior actually is wrt this dot
