### PR TITLE
fix(api): Change api update ignore route to be accessible to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ target/
 api/tests/opentrons/data/configs/
 api/opentrons/config/*.json
 sample_protocol.py
+api/opentrons/server/endpoints/ignore.json
 
 # Local Calibration Data
 calibrations/

--- a/api/opentrons/server/endpoints/serverlib_fallback.py
+++ b/api/opentrons/server/endpoints/serverlib_fallback.py
@@ -9,8 +9,12 @@ from aiohttp import web
 from threading import Thread
 
 log = logging.getLogger(__name__)
-PATH = os.path.abspath(os.path.dirname(__file__))
-filepath = os.path.join(PATH, 'ignore.json')
+ignore_file = 'ignore.json'
+if os.environ.get('RUNNING_ON_PI'):
+    filedir = '/data/user_storage/opentrons_data'
+else:
+    filedir = os.path.abspath(os.path.dirname(__file__))
+filepath = os.path.join(filedir, ignore_file)
 
 
 async def _install(filename, loop):

--- a/api/opentrons/server/http.py
+++ b/api/opentrons/server/http.py
@@ -41,9 +41,9 @@ class HTTPServer(object):
         self.app.router.add_post(
             '/modules/{serial}/update', update.update_module_firmware)
         self.app.router.add_get(
-            '/server/update/ignore', endpoints.get_ignore_version)
+            '/update/ignore', endpoints.get_ignore_version)
         self.app.router.add_post(
-            '/server/update/ignore', endpoints.set_ignore_version)
+            '/update/ignore', endpoints.set_ignore_version)
         self.app.router.add_static(
             '/logs', self.log_file_path, show_index=True)
         self.app.router.add_post(

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -212,7 +212,7 @@ def robot(dummy_db):
 @pytest.fixture(params=["dinosaur.py"])
 def protocol(request):
     try:
-        root = request.getfuncargvalue('protocol_file')
+        root = request.getfixturevalue('protocol_file')
     except Exception:
         root = request.param
 
@@ -226,7 +226,7 @@ def protocol(request):
 @pytest.fixture(params=["no_clear_tips.py"])
 def tip_clear_protocol(request):
     try:
-        root = request.getfuncargvalue('protocol_file')
+        root = request.getfixturevalue('protocol_file')
     except Exception:
         root = request.param
 
@@ -253,7 +253,7 @@ def session(loop, test_client, request, main_router):
     from opentrons.server import error_middleware
     root = None
     try:
-        root = request.getfuncargvalue('root')
+        root = request.getfixturevalue('root')
         if not root:
             root = main_router
         # Assume test fixture has init to attach test loop

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -27,7 +27,7 @@ class ContainerTestCase(unittest.TestCase):
         slot = '1'
         containers_load(self.robot, container_name, slot)
         # 2018-1-30 Incremented number of containers based on fixed trash
-        self.assertEquals(len(self.robot.get_containers()), 2)
+        self.assertEqual(len(self.robot.get_containers()), 2)
 
         self.assertRaises(
             RuntimeWarning, containers_load,
@@ -47,11 +47,11 @@ class ContainerTestCase(unittest.TestCase):
 
         containers_load(
             self.robot, container_name, slot, 'custom-name', share=True)
-        self.assertEquals(len(self.robot.get_containers()), 3)
+        self.assertEqual(len(self.robot.get_containers()), 3)
 
         containers_load(
             self.robot, 'trough-12row', slot, share=True)
-        self.assertEquals(len(self.robot.get_containers()), 4)
+        self.assertEqual(len(self.robot.get_containers()), 4)
 
     def test_load_legacy_slot_names(self):
         slots_old = [

--- a/api/tests/opentrons/containers/test_old_container_loading.py
+++ b/api/tests/opentrons/containers/test_old_container_loading.py
@@ -48,14 +48,14 @@ if not ff.split_labware_definitions():
             old_container_loading.get_persisted_container("container-2")
 
             # Skip container-3 is defined in .secret/containers-3.json.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 ValueError,
                 'Container type "container-3" not found in files: .*'
             ):
                 old_container_loading.get_persisted_container("container-3")
 
             # Skip container-4 is defined in .containers-4.json.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 ValueError,
                 'Container type "container-4" not found in files: .*'
             ):

--- a/api/tests/opentrons/containers/test_placeable_unittest.py
+++ b/api/tests/opentrons/containers/test_placeable_unittest.py
@@ -25,7 +25,7 @@ class PlaceableTestCase(unittest.TestCase):
                     print(w2)
                     assert False
         else:
-            self.assertEquals(w1, w2)
+            self.assertEqual(w1, w2)
 
     def test_get_name(self):
         c = generate_plate(4, 2, (5, 5), (0, 0), 5)

--- a/api/tests/opentrons/helpers/test_helpers.py
+++ b/api/tests/opentrons/helpers/test_helpers.py
@@ -21,8 +21,8 @@ class HelpersTest(unittest.TestCase):
         p2 = Vector(10, -12, 14)
         res = helpers.break_down_travel(
             p1, p2, increment=5, mode='absolute')
-        self.assertEquals(res[-1], p2)
-        self.assertEquals(len(res), 5)
+        self.assertEqual(res[-1], p2)
+        self.assertEqual(len(res), 5)
 
         p1 = Vector(10, -12, 14)
         res = helpers.break_down_travel(Vector(0, 0, 0), p1, mode='relative')
@@ -30,5 +30,5 @@ class HelpersTest(unittest.TestCase):
             0.46537410754407676,
             -0.5584489290528921,
             0.6515237505617075)
-        self.assertEquals(res[-1], expected)
-        self.assertEquals(len(res), 5)
+        self.assertEqual(res[-1], expected)
+        self.assertEqual(len(res), 5)

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -57,10 +57,10 @@ class PipetteTest(unittest.TestCase):
 
     def test_get_plunger_position(self):
 
-        self.assertEquals(self.p200._get_plunger_position('top'), 0)
-        self.assertEquals(self.p200._get_plunger_position('bottom'), 10)
-        self.assertEquals(self.p200._get_plunger_position('blow_out'), 12)
-        self.assertEquals(self.p200._get_plunger_position('drop_tip'), 13)
+        self.assertEqual(self.p200._get_plunger_position('top'), 0)
+        self.assertEqual(self.p200._get_plunger_position('bottom'), 10)
+        self.assertEqual(self.p200._get_plunger_position('blow_out'), 12)
+        self.assertEqual(self.p200._get_plunger_position('drop_tip'), 13)
 
         self.p200.plunger_positions['drop_tip'] = None
         self.assertRaises(
@@ -112,7 +112,7 @@ class PipetteTest(unittest.TestCase):
             self.plate[1]
         ]
 
-        self.assertEquals(self.p200.placeables, expected)
+        self.assertEqual(self.p200.placeables, expected)
 
     def test_unpack_location(self):
 
@@ -133,10 +133,10 @@ class PipetteTest(unittest.TestCase):
     def test_volume_percentage(self):
         self.assertRaises(RuntimeError, self.p200._volume_percentage, -1)
         self.assertRaises(RuntimeError, self.p200._volume_percentage, 300)
-        self.assertEquals(self.p200._volume_percentage(100), 0.5)
-        self.assertEquals(len(self.robot.get_warnings()), 0)
+        self.assertEqual(self.p200._volume_percentage(100), 0.5)
+        self.assertEqual(len(self.robot.get_warnings()), 0)
         self.p200._volume_percentage(self.p200.min_volume / 2)
-        self.assertEquals(len(self.robot.get_warnings()), 1)
+        self.assertEqual(len(self.robot.get_warnings()), 1)
 
     def test_add_tip(self):
         """
@@ -922,7 +922,7 @@ class PipetteTest(unittest.TestCase):
                 strategy='direct')
         ]
 
-        self.assertEquals(expected, self.p200.robot.move_to.mock_calls)
+        self.assertEqual(expected, self.p200.robot.move_to.mock_calls)
 
     def test_mix(self):
         # It is necessary to aspirate before it is mocked out
@@ -950,26 +950,26 @@ class PipetteTest(unittest.TestCase):
         self.p200.pick_up_tip()
         self.p200.aspirate(50, self.plate[0])
         self.p200.air_gap()
-        self.assertEquals(self.p200.current_volume, 200)
+        self.assertEqual(self.p200.current_volume, 200)
 
         self.p200.dispense()
         self.p200.aspirate(50, self.plate[1])
         self.p200.air_gap(10)
-        self.assertEquals(self.p200.current_volume, 60)
+        self.assertEqual(self.p200.current_volume, 60)
 
         self.p200.dispense()
         self.p200.aspirate(50, self.plate[2])
         self.p200.air_gap(10, 10)
-        self.assertEquals(self.p200.current_volume, 60)
+        self.assertEqual(self.p200.current_volume, 60)
 
         self.p200.dispense()
         self.p200.aspirate(50, self.plate[2])
         self.p200.air_gap(0)
-        self.assertEquals(self.p200.current_volume, 50)
+        self.assertEqual(self.p200.current_volume, 50)
 
     def test_pipette_home(self):
         self.p200.home()
-        self.assertEquals(len(self.robot.commands()), 1)
+        self.assertEqual(len(self.robot.commands()), 1)
 
     def test_mix_with_named_args(self):
         self.p200.current_volume = 100
@@ -1008,22 +1008,22 @@ class PipetteTest(unittest.TestCase):
     def test_simulate_plunger_while_enqueing(self):
 
         self.p200.pick_up_tip()
-        self.assertEquals(self.p200.current_volume, 0)
+        self.assertEqual(self.p200.current_volume, 0)
 
         self.p200.aspirate(200)
-        self.assertEquals(self.p200.current_volume, 200)
+        self.assertEqual(self.p200.current_volume, 200)
 
         self.p200.dispense(20)
-        self.assertEquals(self.p200.current_volume, 180)
+        self.assertEqual(self.p200.current_volume, 180)
 
         self.p200.dispense(20)
-        self.assertEquals(self.p200.current_volume, 160)
+        self.assertEqual(self.p200.current_volume, 160)
 
         self.p200.dispense(60)
-        self.assertEquals(self.p200.current_volume, 100)
+        self.assertEqual(self.p200.current_volume, 100)
 
         self.p200.dispense(100)
-        self.assertEquals(self.p200.current_volume, 0)
+        self.assertEqual(self.p200.current_volume, 0)
 
         self.p200.drop_tip()
 
@@ -1113,7 +1113,7 @@ class PipetteTest(unittest.TestCase):
     def test_tip_tracking_start_at_tip(self):
         self.p200.start_at_tip(self.tiprack1['B2'])
         self.p200.pick_up_tip()
-        self.assertEquals(self.tiprack1['B2'], self.p200.current_tip())
+        self.assertEqual(self.tiprack1['B2'], self.p200.current_tip())
 
     def test_tip_tracking_return(self):
         # Note: because this test mocks out `drop_tip`, as a side-effect

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -74,23 +74,23 @@ async def test_ignore_updates(
     app = init(loop)
     cli = await loop.create_task(test_client(app))
     # Test no ignore file found
-    r0 = await cli.get('/server/update/ignore')
+    r0 = await cli.get('/update/ignore')
     r0body = await r0.text()
     assert json.loads(r0body) == {'version': None}
 
     # Test that values are set correctly
 
     ignore = {'version': '3.1.3'}
-    r1 = await cli.post('server/update/ignore', json=ignore)
+    r1 = await cli.post('/update/ignore', json=ignore)
     assert r1.status == 200
 
     # Test that you cannot pass an empty version
     ignore2 = {'version': ''}
-    r2 = await cli.post('server/update/ignore', json=ignore2)
+    r2 = await cli.post('/update/ignore', json=ignore2)
     assert r2.status == 400
 
     # Test that version in the temporary directory is still '3.1.3'
-    r3 = await cli.get('/server/update/ignore')
+    r3 = await cli.get('/update/ignore')
     r3body = await r3.text()
     assert json.loads(r3body) == {'version': '3.1.3'}
 

--- a/api/tests/opentrons/util/test_vector.py
+++ b/api/tests/opentrons/util/test_vector.py
@@ -20,7 +20,7 @@ class VectorTestCase(unittest.TestCase):
 
     def test_repr(self):
         v1 = Vector(1, 2, 3)
-        self.assertEquals(str(v1), '(x=1.00, y=2.00, z=3.00)')
+        self.assertEqual(str(v1), '(x=1.00, y=2.00, z=3.00)')
 
     def test_add(self):
         v1 = Vector(1, 2, 3)
@@ -38,7 +38,7 @@ class VectorTestCase(unittest.TestCase):
     def test_zero_coordinates(self):
 
         zero_coords = Vector(1, 2, 3).zero_coordinates()
-        self.assertEquals(zero_coords, VectorValue(0, 0, 0))
+        self.assertEqual(zero_coords, VectorValue(0, 0, 0))
 
     def test_substract(self):
         v1 = Vector(1, 2, 3)


### PR DESCRIPTION
## overview

Change api update ignore route to be accessible to client. Other changes are renames for deprecation warnings (get API warnings in test down to 0). Closes #2367 

## changelog

- Change API update ignore route to "/update/ignore"
- Rename functions in test to clear deprecation warnings

## review requests

Talked with @mcous about the route change. Ping @Kadee80 
