### PR TITLE
feat(app): Add upgrade and downgrade logic to robot updates

### DIFF
--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -33,7 +33,6 @@
     "electron-updater": "^3.1.2",
     "fs-extra": "^6.0.1",
     "merge-options": "^1.0.1",
-    "semver": "^5.5.0",
     "uuid": "^3.2.1",
     "winston": "^3.1.0",
     "yargs-parser": "^10.0.0"

--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "remark": "^9.0.0",
     "remark-react": "^4.0.3",
     "reselect": "^3.0.1",
+    "semver": "^5.5.0",
     "winston": "^2.2.0"
   }
 }

--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -6,14 +6,14 @@ import {withRouter} from 'react-router'
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
 import {actions as robotActions} from '../../robot'
-import {makeGetAvailableRobotUpdate} from '../../http-api-client'
+import {makeGetRobotUpdateInfo} from '../../http-api-client'
 
 import {RobotListItem} from './RobotList.js'
 
 type OP = Robot
 
 type SP = {
-  availableUpdate: ?string,
+  upgradable: boolean,
 }
 
 type DP = {
@@ -26,10 +26,10 @@ export default withRouter(
 )
 
 function makeMapStateToProps () {
-  const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
+  const getUpdateInfo = makeGetRobotUpdateInfo()
 
   return (state: State, ownProps: OP): SP => ({
-    availableUpdate: getAvailableRobotUpdate(state, ownProps),
+    upgradable: getUpdateInfo(state, ownProps).type === 'upgrade',
   })
 }
 

--- a/app/src/components/ConnectPanel/RobotList.js
+++ b/app/src/components/ConnectPanel/RobotList.js
@@ -17,7 +17,7 @@ type ListProps = {
 }
 
 type ItemProps = Robot & {
-  availableUpdate: ?string,
+  upgradable: ?string,
   connect: () => mixed,
   disconnect: () => mixed,
 }
@@ -31,7 +31,7 @@ export default function RobotList (props: ListProps) {
 }
 
 export function RobotListItem (props: ItemProps) {
-  const {name, wired, isConnected, availableUpdate, connect, disconnect} = props
+  const {name, wired, isConnected, upgradable, connect, disconnect} = props
   const onClick = isConnected
     ? disconnect
     : connect
@@ -46,7 +46,7 @@ export function RobotListItem (props: ItemProps) {
         <NotificationIcon
           name={wired ? 'usb' : 'wifi'}
           className={styles.robot_item_icon}
-          childName={availableUpdate ? 'circle' : null}
+          childName={upgradable ? 'circle' : null}
           childClassName={styles.notification}
         />
 

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -6,12 +6,12 @@ import {Link} from 'react-router-dom'
 
 import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
-import type {FetchHealthCall} from '../../http-api-client'
+import type {FetchHealthCall, RobotUpdateInfo} from '../../http-api-client'
 
 import {
   fetchHealthAndIgnored,
   makeGetRobotHealth,
-  makeGetAvailableRobotUpdate,
+  makeGetRobotUpdateInfo,
 } from '../../http-api-client'
 
 import {RefreshCard, LabeledValue, OutlineButton} from '@opentrons/components'
@@ -23,7 +23,7 @@ type OwnProps = Robot & {
 
 type StateProps = {
   healthRequest: FetchHealthCall,
-  availableUpdate: ?string,
+  updateInfo: RobotUpdateInfo,
 }
 
 type DispatchProps = {
@@ -42,7 +42,7 @@ export default connect(makeMapStateToProps, mapDispatchToProps)(InformationCard)
 function InformationCard (props: Props) {
   const {
     name,
-    availableUpdate,
+    updateInfo,
     fetchHealth,
     updateUrl,
     healthRequest: {inProgress, response: health},
@@ -51,9 +51,8 @@ function InformationCard (props: Props) {
   const realName = (health && health.name) || name
   const version = (health && health.api_version) || 'Unknown'
   const firmwareVersion = (health && health.fw_version) || 'Unknown'
-  const updateText = availableUpdate
-    ? 'Update'
-    : 'Updated'
+  const updateText = updateInfo.type || 'Reinstall'
+
   return (
     <RefreshCard
       watch={name}
@@ -93,11 +92,11 @@ function InformationCard (props: Props) {
 
 function makeMapStateToProps () {
   const getRobotHealth = makeGetRobotHealth()
-  const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
+  const getUpdateInfo = makeGetRobotUpdateInfo()
 
   return (state: State, ownProps: OwnProps): StateProps => ({
     healthRequest: getRobotHealth(state, ownProps),
-    availableUpdate: getAvailableRobotUpdate(state, ownProps),
+    updateInfo: getUpdateInfo(state, ownProps),
   })
 }
 

--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -109,7 +109,7 @@ function mergeProps (stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   const {dispatch} = dispatchProps
 
   const close = () => dispatch(push(`/robots/${ownProps.name}`))
-  let ignoreUpdate = updateInfo
+  let ignoreUpdate = updateInfo.type
     ? () => dispatch(setIgnoredUpdate(ownProps, updateInfo.version)).then(close)
     : close
 

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -47,12 +47,6 @@ export type {
 } from './robot'
 
 export type {
-  RobotServerUpdate,
-  RobotServerRestart,
-  RobotServerUpdateIgnore,
-} from './server'
-
-export type {
   WifiListResponse,
   WifiStatusResponse,
   WifiConfigureResponse,
@@ -94,6 +88,8 @@ export * from './pipettes'
 
 export * from './motors'
 
+export * from './server'
+
 export {
   home,
   clearHomeResponse,
@@ -105,20 +101,6 @@ export {
   makeGetRobotHome,
   makeGetRobotLights,
 } from './robot'
-
-export {
-  updateRobotServer,
-  restartRobotServer,
-  makeGetAvailableRobotUpdate,
-  makeGetRobotUpdateRequest,
-  makeGetRobotRestartRequest,
-  getAnyRobotUpdateAvailable,
-  fetchHealthAndIgnored,
-  fetchIgnoredUpdate,
-  setIgnoredUpdate,
-  makeGetRobotIgnoredUpdateRequest,
-  clearRestartResponse,
-} from './server'
 
 export {
   fetchWifiList,

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -241,21 +241,6 @@ export function serverReducer (
   return state
 }
 
-export const makeGetAvailableRobotUpdate = () => {
-  const selector: Selector<State, RobotService, ?string> = createSelector(
-    makeGetRobotHealth(),
-    getApiUpdateVersion,
-    (health, updateVersion) => {
-      const currentVersion = health.response && health.response.api_version
-      return currentVersion && currentVersion !== updateVersion
-        ? updateVersion
-        : null
-    }
-  )
-
-  return selector
-}
-
 export type RobotUpdateType = 'upgrade' | 'downgrade' | null
 
 export type RobotUpdateInfo = {version: string, type: RobotUpdateType}

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -1,6 +1,7 @@
 // @flow
 // server endpoints http api module
 import {createSelector, type Selector} from 'reselect'
+import semver from 'semver'
 import {chainActions} from '../util'
 import type {State, ThunkPromiseAction, Action} from '../types'
 import type {RobotService} from '../robot'
@@ -108,6 +109,10 @@ export function updateRobotServer (robot: RobotService): ThunkPromiseAction {
   }
 }
 
+export function clearUpdateResponse (robot: RobotService): * {
+  return clearServerResponse(robot, UPDATE)
+}
+
 export function restartRobotServer (robot: RobotService): ThunkPromiseAction {
   return dispatch => {
     dispatch(serverRequest(robot, RESTART))
@@ -132,7 +137,7 @@ export function fetchIgnoredUpdate (robot: RobotService): ThunkPromiseAction {
   return dispatch => {
     dispatch(serverRequest(robot, IGNORE))
 
-    return client(robot, 'GET', 'server/update/ignore').then(
+    return client(robot, 'GET', 'update/ignore').then(
       (response: ServerRestartResponse) =>
         dispatch(serverSuccess(robot, IGNORE, response)),
       (error: ApiRequestError) => dispatch(serverFailure(robot, IGNORE, error))
@@ -148,7 +153,7 @@ export function setIgnoredUpdate (
     const body = {version}
     dispatch(serverRequest(robot, IGNORE))
 
-    return client(robot, 'POST', 'server/update/ignore', body).then(
+    return client(robot, 'POST', 'update/ignore', body).then(
       (response: ServerRestartResponse) =>
         dispatch(serverSuccess(robot, IGNORE, response)),
       (error: ApiRequestError) => dispatch(serverFailure(robot, IGNORE, error))
@@ -245,6 +250,33 @@ export const makeGetAvailableRobotUpdate = () => {
       return currentVersion && currentVersion !== updateVersion
         ? updateVersion
         : null
+    }
+  )
+
+  return selector
+}
+
+export type RobotUpdateType = 'upgrade' | 'downgrade' | null
+
+export type RobotUpdateInfo = {version: string, type: RobotUpdateType}
+
+export const makeGetRobotUpdateInfo = () => {
+  const selector: Selector<State, RobotService, RobotUpdateInfo> = createSelector(
+    makeGetRobotHealth(),
+    getApiUpdateVersion,
+    (health, updateVersion) => {
+      const current = health.response && health.response.api_version
+      const upgrade = current && semver.gt(updateVersion, current)
+      const downgrade = current && semver.lt(updateVersion, current)
+      let type
+      if (!current || (!upgrade && !downgrade)) {
+        type = null
+      } else {
+        type = upgrade
+          ? 'upgrade'
+          : 'downgrade'
+      }
+      return {version: updateVersion, type: type}
     }
   )
 

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -11,7 +11,7 @@ import {
   makeGetRobotHome,
   clearHomeResponse,
   makeGetRobotIgnoredUpdateRequest,
-  makeGetAvailableRobotUpdate,
+  makeGetRobotUpdateInfo,
 } from '../../http-api-client'
 
 import {SpinnerModalPage} from '@opentrons/components'
@@ -121,19 +121,19 @@ function RobotSettingsPage (props: Props) {
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getHomeRequest = makeGetRobotHome()
   const getUpdateIgnoredRequest = makeGetRobotIgnoredUpdateRequest()
-  const getAvailableRobotUpdate = makeGetAvailableRobotUpdate()
+  const getRobotUpdateInfo = makeGetRobotUpdateInfo()
 
   return (state, ownProps) => {
     const {robot} = ownProps
     const connectRequest = robotSelectors.getConnectRequest(state)
     const homeRequest = getHomeRequest(state, robot)
     const ignoredRequest = getUpdateIgnoredRequest(state, robot)
-    const availableUpdate = getAvailableRobotUpdate(state, robot)
+    const updateInfo = getRobotUpdateInfo(state, robot)
     const showUpdateModal = (
-      availableUpdate &&
+      updateInfo.type === 'upgrade' &&
       ignoredRequest &&
       ignoredRequest.response &&
-      ignoredRequest.response.version !== availableUpdate
+      ignoredRequest.response.version !== updateInfo.version
     )
 
     return {

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -11,6 +11,7 @@ import {
   makeGetRobotHome,
   clearHomeResponse,
   makeGetRobotIgnoredUpdateRequest,
+  makeGetRobotRestartRequest,
   makeGetRobotUpdateInfo,
 } from '../../http-api-client'
 
@@ -121,6 +122,7 @@ function RobotSettingsPage (props: Props) {
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getHomeRequest = makeGetRobotHome()
   const getUpdateIgnoredRequest = makeGetRobotIgnoredUpdateRequest()
+  const getRestartRequest = makeGetRobotRestartRequest()
   const getRobotUpdateInfo = makeGetRobotUpdateInfo()
 
   return (state, ownProps) => {
@@ -128,12 +130,20 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const connectRequest = robotSelectors.getConnectRequest(state)
     const homeRequest = getHomeRequest(state, robot)
     const ignoredRequest = getUpdateIgnoredRequest(state, robot)
+    const restartRequest = getRestartRequest(state, robot)
     const updateInfo = getRobotUpdateInfo(state, robot)
     const showUpdateModal = (
+      // only show the alert modal if there's an upgrade available
       updateInfo.type === 'upgrade' &&
-      ignoredRequest &&
+      // and we haven't already ignored the upgrade
       ignoredRequest.response &&
-      ignoredRequest.response.version !== updateInfo.version
+      ignoredRequest.response.version !== updateInfo.version &&
+      // and we're not actively restarting
+      !restartRequest.inProgress &&
+      // TODO(mc, 2018-09-27): clear this state out on disconnect otherwise
+      // restartRequest.response latches this modal closed (which is fine,
+      // but only for this specific modal)
+      !restartRequest.response
     )
 
     return {


### PR DESCRIPTION
## overview

This PR addresses #2354 by checking if the available robot update is an `upgrade` `downgrade` or reinstall. UI changes include:

- only show a `NotificationIcon` in the `RobotListItem` if the available install is an upgrade
- Robot Settings page `InformationCard` button text is [upgrade] [reinstall] or [downgrade]
- More informative text about the type of install in the UpdateModal

## changelog

- feat(app): Add upgrade and downgrade logic to robot updates

## review requests
To test on VS, run `make -C api wheel`

### app version and api version match
  - [ ] no notification icon in robot list
  - [ ] `InformationCard` in `RobotSettings` button text = [REINSTALL]
  - [ ] opening the update modal informs you that your robot version is up to date, but you can reinstall

### robot version is ahead of app version. downgrade available
change the version of 
`api/dist/opentrons-3.4.0-py2.py3-none-any.whl` 
to 
`api/dist/opentrons-3.3.0-py2.py3-none-any.whl`
  - [ ] no notification icon in robot list
  - [ ] `InformationCard` in `RobotSettings` button text = [DOWNGRADE]
  - [ ] opening the update modal informs you that your robot version ahead of the app, and you can downgrade to ensure both are on the same version (update the app prompt will come in follow up PR)

### robot version is behind app version. upgrade available
change the version of 
`api/dist/opentrons-3.4.0-py2.py3-none-any.whl` 
to 
`api/dist/opentrons-3.5.0-py2.py3-none-any.whl`
  - [ ]  notification icon in robot list (yellow dot)
  - [ ] `InformationCard` in `RobotSettings` button text = [UPGRADE]
  - [ ] opening the update modal informs you an upgrade is available and recommends upgrading to ensure compatibility with the app version