### PR TITLE
feat(shared-data): Add generator function to create regular labware defs

### DIFF
--- a/protocol-designer/src/utils/index.js
+++ b/protocol-designer/src/utils/index.js
@@ -1,6 +1,5 @@
 // @flow
 import uuidv1 from 'uuid/v1'
-import {wellNameSplit} from '@opentrons/components'
 import type {BoundingRect, GenericRect} from '../collision-types'
 import type {Wells} from '../labware-ingred/types'
 
@@ -24,28 +23,6 @@ export const formConnectorFactory = (
 })
 
 export const uuid: () => string = uuidv1
-
-export const intToAlphabetLetter = (i: number, lowerCase: boolean = false) =>
-  String.fromCharCode((lowerCase ? 96 : 65) + i)
-
-// These utils are great candidates for unit tests
-export const toWellName = ({rowNum, colNum}: {rowNum: number, colNum: number}) => (
-  String.fromCharCode(colNum + 65) + (rowNum + 1)
-)
-
-export const wellKeyToXYList = (wellKey: string) => {
-  const [x, y] = wellKey.split(',').map(s => parseInt(s, 10))
-  return toWellName({rowNum: parseInt(y), colNum: x})
-}
-
-export const wellNameToXY = (wellName: string) => {
-  // Eg B9 => [1, 8]
-  const [letters, numbers] = wellNameSplit(wellName)
-
-  const letterNum = letters.toUpperCase().charCodeAt(0) - 65
-  const numberNum = parseInt(numbers, 10) - 1
-  return [letterNum, numberNum]
-}
 
 // Collision detection for SelectionRect / SelectablePlate
 

--- a/shared-data/js/helpers/index.js
+++ b/shared-data/js/helpers/index.js
@@ -5,6 +5,14 @@ import computeWellAccess from './computeWellAccess'
 import getWellTotalVolume from './getWellTotalVolume'
 import wellIsRect from './wellIsRect'
 
+export const intToAlphabetLetter = (i: number, lowerCase: boolean = false) =>
+  String.fromCharCode((lowerCase ? 96 : 65) + i)
+
+// These utils are great candidates for unit tests
+export const toWellName = ({rowNum, colNum}: {rowNum: number, colNum: number}) => (
+  String.fromCharCode(rowNum + 65) + (colNum + 1)
+)
+
 export {
   canPipetteUseLabware,
   computeWellAccess,

--- a/shared-data/js/index.js
+++ b/shared-data/js/index.js
@@ -11,7 +11,7 @@ export * from './constants'
 export * from './helpers'
 export * from './pipettes'
 export * from './types'
-// export * from './labwareTools'
+export * from './labwareTools'
 
 export {
   getLabware,

--- a/shared-data/js/index.js
+++ b/shared-data/js/index.js
@@ -11,6 +11,7 @@ export * from './constants'
 export * from './helpers'
 export * from './pipettes'
 export * from './types'
+// export * from './labwareTools'
 
 export {
   getLabware,

--- a/shared-data/js/labwareTools/__tests__/createLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.js
@@ -1,0 +1,77 @@
+import Ajv from 'ajv'
+import exampleLabware from './example.json'
+import exampleLabware2 from './example2.json'
+import labwareSchema from '../../../labware-json-schema/labware-schema.json'
+import omit from 'lodash/omit'
+import {createRegularLabware} from '../index.js'
+import roundTo from 'round-to'
+import assignId from '../assignId'
+jest.mock('../assignId', () => {
+  return jest.fn().mockImplementation(() => 1)
+})
+
+const ajv = new Ajv({
+  allErrors: true,
+  jsonPointers: true,
+})
+
+const validate = ajv.compile(labwareSchema)
+
+// Test a minimal labware definition
+const well = omit(exampleLabware['wells']['A1'], ['x', 'y', 'z'])
+const labware = createRegularLabware(exampleLabware['metadata'], exampleLabware['parameters'], exampleLabware['dimensions'], [1, 2], [10, 10], well, exampleLabware['vendor'])
+
+const well2 = omit(exampleLabware2['wells']['A1'], ['x', 'y', 'z'])
+const labware2 = createRegularLabware(exampleLabware2['metadata'], exampleLabware2['parameters'], exampleLabware2['dimensions'], [3, 2], [9, 9], well2)
+
+describe('test the schema against a minimalist fixture', () => {
+  test('...', () => {
+    const valid = validate(exampleLabware)
+    const validationErrors = validate.errors
+
+    expect(validationErrors).toBe(null)
+    expect(valid).toBe(true)
+  })
+})
+
+describe('test fields generate correctly', () => {
+  test('...', () => {
+    expect(exampleLabware).toEqual(labware)
+    expect(exampleLabware2).toEqual(labware2)
+  })
+  test('id is from assignId', () => {
+    expect(assignId).toHaveBeenCalled()
+  })
+  test('ordering generates as expected', () => {
+    expect(exampleLabware2.ordering).toEqual(labware2.ordering)
+  })
+  test('well XYZ generates correctly', () => {
+    const spacing = [11.8, 12.1]
+    const grid = [8, 12]
+    const labware3 = createRegularLabware(
+      exampleLabware2['metadata'],
+      exampleLabware2['parameters'],
+      exampleLabware2['dimensions'],
+      grid,
+      spacing,
+      well2)
+
+    var col = 0
+    var row = 0
+    var c
+    var r
+    for (c in labware3.ordering) {
+      var columns = labware3.ordering[c]
+      row = columns.length - 1
+      for (r in columns) {
+        var index = labware3.ordering[c][r]
+        var well = labware3.wells[index]
+        expect(well.x).toEqual(roundTo(col * spacing[1], 2))
+        expect(well.y).toEqual(roundTo(row * spacing[0], 2))
+        expect(well.z).toEqual(0)
+        row = row - 1
+      }
+      col = col + 1
+    }
+  })
+})

--- a/shared-data/js/labwareTools/__tests__/example.json
+++ b/shared-data/js/labwareTools/__tests__/example.json
@@ -1,0 +1,48 @@
+{
+ "otId": 1,
+ "deprecated": false,
+ "metadata": {
+   "name": "fake labware",
+   "displayCategory": "wellPlate",
+   "displayVolumeUnits": "uL",
+   "displayLengthUnits": "mm"
+ },
+ "vendor": {
+   "sku": "t40u9sernisofsea",
+   "vendor": "opentrons"
+ },
+ "parameters": {
+   "format": "96Standard",
+   "isTiprack": false,
+   "wellShape": "circular"
+ },
+ "dimensions": {
+   "overallLength": 50,
+   "overallWidth": 50,
+   "overallHeight": 50,
+   "offsetX":10,
+   "offsetY":10,
+   "offsetZ":5
+ },
+ "ordering": [["A1"], ["A2"]],
+ "wells": {
+   "A1":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 0,
+     "y": 0,
+     "z": 0
+
+   },
+   "A2":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 10,
+     "y": 0,
+     "z": 0
+     }}
+
+
+}

--- a/shared-data/js/labwareTools/__tests__/example.json
+++ b/shared-data/js/labwareTools/__tests__/example.json
@@ -1,48 +1,49 @@
 {
- "otId": 1,
- "deprecated": false,
- "metadata": {
-   "name": "fake labware",
-   "displayCategory": "wellPlate",
-   "displayVolumeUnits": "uL",
-   "displayLengthUnits": "mm"
- },
- "vendor": {
-   "sku": "t40u9sernisofsea",
-   "vendor": "opentrons"
- },
- "parameters": {
-   "format": "96Standard",
-   "isTiprack": false,
-   "wellShape": "circular"
- },
- "dimensions": {
-   "overallLength": 50,
-   "overallWidth": 50,
-   "overallHeight": 50,
-   "offsetX":10,
-   "offsetY":10,
-   "offsetZ":5
- },
- "ordering": [["A1"], ["A2"]],
- "wells": {
-   "A1":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 0,
-     "y": 0,
-     "z": 0
-
-   },
-   "A2":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 10,
-     "y": 0,
-     "z": 0
-     }}
-
-
+  "otId": "mock-id",
+  "deprecated": false,
+  "metadata": {
+    "name": "fake labware",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "uL",
+    "displayLengthUnits": "mm"
+  },
+  "vendor": {
+    "sku": "t40u9sernisofsea",
+    "vendor": "opentrons"
+  },
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": false
+  },
+  "cornerOffsetFromSlot": {
+    "x": 10,
+    "y": 10,
+    "z": 5
+  },
+  "dimensions": {
+    "overallLength": 50,
+    "overallWidth": 50,
+    "overallHeight": 50
+  },
+  "ordering": [["A1"], ["A2"]],
+  "wells": {
+    "A1": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    },
+    "A2": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 10,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    }
+  }
 }

--- a/shared-data/js/labwareTools/__tests__/example2.json
+++ b/shared-data/js/labwareTools/__tests__/example2.json
@@ -1,0 +1,79 @@
+{
+ "otId": 1,
+ "deprecated": false,
+ "metadata": {
+   "name": "fake labware 2",
+   "displayCategory": "wellPlate",
+   "displayVolumeUnits": "uL",
+   "displayLengthUnits": "mm"
+ },
+ "parameters": {
+   "format": "irregular",
+   "isTiprack": false,
+   "wellShape": "circular"
+ },
+ "dimensions": {
+   "overallLength": 50,
+   "overallWidth": 50,
+   "overallHeight": 50,
+   "offsetX":10,
+   "offsetY":10,
+   "offsetZ":5
+ },
+ "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
+ "wells": {
+   "A1":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 0,
+     "y": 18,
+     "z": 0
+
+   },
+   "B1":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 0,
+     "y": 9,
+     "z": 0
+
+   },
+   "C1":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 0,
+     "y": 0,
+     "z": 0
+
+   },
+   "A2":{
+     "depth": 40,
+     "totalLiquidVolume": 100,
+     "diameter": 30,
+     "x": 9,
+     "y": 18,
+     "z": 0
+     },
+     "B2":{
+       "depth": 40,
+       "totalLiquidVolume": 100,
+       "diameter": 30,
+       "x": 9,
+       "y": 9,
+       "z": 0
+     },
+     "C2":{
+       "depth": 40,
+       "totalLiquidVolume": 100,
+       "diameter": 30,
+       "x": 9,
+       "y": 0,
+       "z": 0
+       }
+   }
+
+
+}

--- a/shared-data/js/labwareTools/__tests__/example2.json
+++ b/shared-data/js/labwareTools/__tests__/example2.json
@@ -1,79 +1,81 @@
 {
- "otId": 1,
- "deprecated": false,
- "metadata": {
-   "name": "fake labware 2",
-   "displayCategory": "wellPlate",
-   "displayVolumeUnits": "uL",
-   "displayLengthUnits": "mm"
- },
- "parameters": {
-   "format": "irregular",
-   "isTiprack": false,
-   "wellShape": "circular"
- },
- "dimensions": {
-   "overallLength": 50,
-   "overallWidth": 50,
-   "overallHeight": 50,
-   "offsetX":10,
-   "offsetY":10,
-   "offsetZ":5
- },
- "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
- "wells": {
-   "A1":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 0,
-     "y": 18,
-     "z": 0
-
-   },
-   "B1":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 0,
-     "y": 9,
-     "z": 0
-
-   },
-   "C1":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 0,
-     "y": 0,
-     "z": 0
-
-   },
-   "A2":{
-     "depth": 40,
-     "totalLiquidVolume": 100,
-     "diameter": 30,
-     "x": 9,
-     "y": 18,
-     "z": 0
-     },
-     "B2":{
-       "depth": 40,
-       "totalLiquidVolume": 100,
-       "diameter": 30,
-       "x": 9,
-       "y": 9,
-       "z": 0
-     },
-     "C2":{
-       "depth": 40,
-       "totalLiquidVolume": 100,
-       "diameter": 30,
-       "x": 9,
-       "y": 0,
-       "z": 0
-       }
-   }
-
-
+  "otId": "mock-id",
+  "deprecated": false,
+  "metadata": {
+    "name": "fake labware 2",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "uL",
+    "displayLengthUnits": "mm"
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false
+  },
+  "cornerOffsetFromSlot": {
+    "x": 10,
+    "y": 10,
+    "z": 5
+  },
+  "dimensions": {
+    "overallLength": 50,
+    "overallWidth": 50,
+    "overallHeight": 50
+  },
+  "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
+  "wells": {
+    "A1": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 0,
+      "y": 18,
+      "z": 0,
+      "shape": "circular"
+    },
+    "B1": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 0,
+      "y": 9,
+      "z": 0,
+      "shape": "circular"
+    },
+    "C1": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    },
+    "A2": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 9,
+      "y": 18,
+      "z": 0,
+      "shape": "circular"
+    },
+    "B2": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 9,
+      "y": 9,
+      "z": 0,
+      "shape": "circular"
+    },
+    "C2": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 9,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    }
+  }
 }

--- a/shared-data/js/labwareTools/assignId.js
+++ b/shared-data/js/labwareTools/assignId.js
@@ -1,3 +1,4 @@
+// @flow
 import uuidv1 from 'uuid/v1'
 
 function assignId () {

--- a/shared-data/js/labwareTools/assignId.js
+++ b/shared-data/js/labwareTools/assignId.js
@@ -1,0 +1,7 @@
+import uuidv1 from 'uuid/v1'
+
+function assignId () {
+  return uuidv1()
+}
+
+export default assignId

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -1,0 +1,114 @@
+// @flow
+import assignId from './assignId'
+import roundTo from 'round-to'
+
+type Metadata = {
+  name: string,
+  displayCategory: string,
+  displayVolumeUnits?: string,
+  displayLengthUnits?: string,
+}
+
+type Dimensions = {
+  overallLength: number,
+  overallWidth: number,
+  overallHeight: number,
+  offsetX: number,
+  offsetY: number,
+  offsetZ: number,
+}
+
+type Vendor = {
+  sku?: string,
+  vendor?: string,
+}
+
+// 1. Valid pipette type for a container (i.e. is there multi channel access?)
+// 2. Is the container a tiprack?
+type Params = {
+  format: string,
+  isTiprack: boolean,
+  tipLength?: number,
+  wellShape?: string,
+}
+
+type Well = {
+  depth: number,
+  diameter?: number,
+  length?: number,
+  width?: number,
+  totalLiquidVolume?: number,
+}
+
+type Schema = {
+  otId: number,
+  deprecated: boolean,
+  metadata: Metadata,
+  dimensions: Dimensions,
+  parameters: Params,
+  vendor?: Vendor,
+  ordering: Array<Array<string>>,
+  wells: {[wellName: string]: Well},
+}
+
+function determineOrdering (grid: Array<number>): Array<Array<string>> {
+  var ordering = []
+  var rows = grid[0]
+  var cols = grid[1]
+  var A = 'A'
+
+  var r
+  var c
+
+  for (c = 0; c < cols; c++) {
+    let colOrdering = []
+    for (r = 0; r < rows; r++) {
+      var char = String.fromCharCode(A.charCodeAt(0) + r)
+      var wellName = char + (1 + c).toString()
+      colOrdering.push(wellName)
+    }
+    ordering.push(colOrdering)
+  }
+
+  return ordering
+}
+// Private helper function to return individual well output
+function calculateCoordinates (well: Well, ordering: Array<Array<string>>, spacing: Array<number>): {[wellName: string]: Well} {
+  let wells = {}
+  var rowSpacing = spacing[0]
+  var colSpacing = spacing[1]
+  var col
+  var row
+
+  for (col = 0; col < ordering.length; col++) {
+    var rowLength = ordering[col].length
+    for (row = 0; row < rowLength; row++) {
+      var x = roundTo(col * colSpacing, 2)
+      var y = roundTo((rowLength - row - 1) * rowSpacing, 2)
+      var z = 0
+      wells[ordering[col][row]] = {...well, x, y, z}
+    }
+  }
+
+  return wells
+}
+
+// Make function public via export function
+// Need slot offset
+// well spacing
+// use display category to do logic checks (tiprack has tip length etc)
+// rows/cols
+// customization can contain nothing OR ??
+export function createRegularLabware (metadata: Metadata, parameters: Params, dimensions: Dimensions, grid: Array<number>, spacing: Array<number>, well: Well, vendor?: Vendor): Schema {
+  const otId = assignId()
+  const ordering = determineOrdering(grid)
+  var definition = null
+
+  const wells = calculateCoordinates(well, ordering, spacing)
+  if (vendor) {
+    definition = {otId, deprecated: false, metadata, dimensions, parameters, ordering, wells, vendor}
+  } else {
+    definition = {otId, deprecated: false, metadata, dimensions, parameters, ordering, wells}
+  }
+  return definition
+}

--- a/shared-data/js/schema.js
+++ b/shared-data/js/schema.js
@@ -15,6 +15,8 @@ const LabwareFormats = [
   'irregular',
 ]
 
+// TODO (9/21/2018): This will be deprecated and
+// replaced with labware-json-schema
 const schema = {
   type: 'object',
   required: ['metadata', 'ordering', 'wells'],

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -9,10 +9,10 @@
 
   "type": "object",
   "additionalProperties": false,
-  "required": ["otId", "deprecated", "metadata","parameters", "ordering", "dimensions", "wells"],
+  "required": ["otId","deprecated","metadata","parameters","cornerOffsetFromSlot","ordering","dimensions","wells"],
   "properties": {
     "otId": {
-      "type": "number"
+      "type": "string"
     },
     "deprecated": {
       "type": "boolean"
@@ -52,7 +52,7 @@
     "parameters": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["format", "isTiprack", "wellShape"],
+      "required": ["format", "isTiprack"],
       "properties": {
         "format": {
           "type": "string"
@@ -62,10 +62,6 @@
         },
         "tipLength": {
           "$ref": "#/definitions/positiveNumber"
-        },
-        "wellShape": {
-          "type": "string",
-          "enum": ["rectangular", "circular"]
         }
       }
 
@@ -80,10 +76,21 @@
         }
       }
     },
+    "cornerOffsetFromSlot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "z"],
+      "properties": {
+        "x": {"type": "number"},
+        "y": {"type": "number"},
+        "z": {"type": "number"}
+      }
+
+    },
     "dimensions": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["overallWidth", "overallHeight", "overallLength", "offsetX", "offsetY", "offsetZ"],
+      "required": ["overallWidth", "overallHeight", "overallLength"],
       "properties": {
         "overallWidth": {
           "$ref": "#/definitions/positiveNumber"
@@ -93,15 +100,6 @@
         },
         "overallLength": {
           "$ref": "#/definitions/positiveNumber"
-        },
-        "offsetX": {
-          "$ref": "#/definitions/positiveNumber"
-        },
-        "offsetY": {
-          "$ref": "#/definitions/positiveNumber"
-        },
-        "offsetZ": {
-          "$ref": "#/definitions/positiveNumber"
         }
       }
 
@@ -109,10 +107,10 @@
     "wells": {
       "type": "object",
       "patternProperties": {
-        ".*": {
+        "['A' - 'Z'][*]": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["depth", "x", "y", "z"],
+          "required": ["depth", "x", "y", "z", "shape"],
           "oneOf": [
             {"required": ["width", "length"]},
             {"required": ["diameter"]}
@@ -129,7 +127,11 @@
             "totalLiquidVolume": {"$ref": "#/definitions/positiveNumber"},
             "width": {"$ref": "#/definitions/positiveNumber"},
             "length": {"$ref": "#/definitions/positiveNumber"},
-            "diameter": {"$ref": "#/definitions/positiveNumber"}
+            "diameter": {"$ref": "#/definitions/positiveNumber"},
+            "shape": {
+              "type": "string",
+              "enum": ["rectangular", "circular"]
+            }
 
           }
         }

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "positiveNumber": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["otId", "deprecated", "metadata","parameters", "ordering", "dimensions", "wells"],
+  "properties": {
+    "otId": {
+      "type": "number"
+    },
+    "deprecated": {
+      "type": "boolean"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "displayCategory"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayCategory": {
+          "type": "string"
+        },
+        "displayLengthUnits": {
+          "type": "string"
+        },
+        "displayVolumeUnits": {
+          "type": "string"
+        }
+      }
+    },
+    "vendor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sku": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        }
+      }
+
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format", "isTiprack", "wellShape"],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "isTiprack": {
+          "type": "boolean"
+        },
+        "tipLength": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "wellShape": {
+          "type": "string",
+          "enum": ["rectangular", "circular"]
+        }
+      }
+
+    },
+    "ordering": {
+      "type": "array",
+      "description": "",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["overallWidth", "overallHeight", "overallLength", "offsetX", "offsetY", "offsetZ"],
+      "properties": {
+        "overallWidth": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "overallHeight": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "overallLength": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "offsetX": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "offsetY": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "offsetZ": {
+          "$ref": "#/definitions/positiveNumber"
+        }
+      }
+
+    },
+    "wells": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["depth", "x", "y", "z"],
+          "oneOf": [
+            {"required": ["width", "length"]},
+            {"required": ["diameter"]}
+          ],
+          "not": {"anyOf": [
+                    {"required": ["diameter", "width"]},
+                    {"required": ["diameter", "length"]}
+          ]},
+          "properties": {
+            "depth": {"$ref": "#/definitions/positiveNumber"},
+            "x": {"$ref": "#/definitions/positiveNumber"},
+            "y": {"$ref": "#/definitions/positiveNumber"},
+            "z": {"$ref": "#/definitions/positiveNumber"},
+            "totalLiquidVolume": {"$ref": "#/definitions/positiveNumber"},
+            "width": {"$ref": "#/definitions/positiveNumber"},
+            "length": {"$ref": "#/definitions/positiveNumber"},
+            "diameter": {"$ref": "#/definitions/positiveNumber"}
+
+          }
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -12,5 +12,9 @@
   "devDependencies": {
     "flow-bin": "^0.76.0",
     "flow-typed": "^2.5.1"
+  },
+  "dependencies": {
+    "round-to": "^3.0.0",
+    "uuid": "3.3.2"
   }
 }

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -14,7 +14,6 @@
     "flow-typed": "^2.5.1"
   },
   "dependencies": {
-    "round-to": "^3.0.0",
     "uuid": "3.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9933,6 +9933,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+round-to@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/round-to/-/round-to-3.0.0.tgz#f457177d68e5a1d9d55796528cd03daea0bb4fb9"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -11511,13 +11515,13 @@ uuid@3.1.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
+uuid@3.3.2, uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8flags@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9933,10 +9933,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
-round-to@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/round-to/-/round-to-3.0.0.tgz#f457177d68e5a1d9d55796528cd03daea0bb4fb9"
-
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"


### PR DESCRIPTION
## overview

Closes #2175. This is the base work for creating a tool which will correctly format a labware definition for you so that we will _never_ have to handcraft a definition again 🔮. 

## changelog
- Add updated JSON Schema for labware definitions 
- Add generator function to make JSON defs for regularly shaped containers (i.e. symmetric grid)
- Add in `round-to` package which is a simple way to round decimals -- may want to use this for all js projects moving forward?

## TODO
- Put in ability to use function in a browser
- Remove `schema.js` and update any other files associated with old shared-data schema
- Add in labware defs with the new generator function (need to solidify new JSON schema before this can be done)

## review requests

Let me know if further comments are needed in either test or the function itself. Also if there is a better way to do certain type checking also let me know!