### PR TITLE
feat(components): change default border width to 1px

### DIFF
--- a/components/src/styles/borders.css
+++ b/components/src/styles/borders.css
@@ -4,7 +4,7 @@
   /* borders */
   --bd-radius-default: 2px;
   --bd-radius-pill: 12px;
-  --bd-width-default: 2px;
+  --bd-width-default: 1px;
   --bd-light: var(--bd-width-default) solid var(--c-light-gray);
 
   /* outlines */


### PR DESCRIPTION
## overview

@howisthisnamenottakenyet wanted to try out changing the default border width from 2px to 1px. This most visibly changes the nav, and PD's list dividers.

## changelog


## review requests

It's a 1-character code difference, so this is mostly a design review. It affects both Protocol Designer and Run App.

Please note if the thinner border looks weird anywhere, or if any 2px borders are showing up where they shouldn't.

**Components:** https://s3-us-west-2.amazonaws.com/opentrons-components/components_change-default-border-width/index.html

**PD:** http://opentrons-protocol-designer.s3-website-us-west-2.amazonaws.com/components_change-default-border-width/

**Run App installer:**
* (Windows) https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.4.0-win-b7654-components_change-default-border-width.exe
* (Mac) https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.4.0-mac-b11623-components_change-default-border-width.zip
* (Linux) https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.4.0-linux-b11623-components_change-default-border-width.AppImage