### PR TITLE
feat(app): Prompt user to update app in robot update modal

### DIFF
--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -14,6 +14,10 @@ import {
   makeGetRobotUpdateInfo,
 } from '../../http-api-client'
 
+import {
+  checkShellUpdate,
+} from '../../shell'
+
 import {RefreshCard, LabeledValue, OutlineButton} from '@opentrons/components'
 import {CardContentQuarter} from '../layout'
 
@@ -28,6 +32,7 @@ type StateProps = {
 
 type DispatchProps = {
   fetchHealth: () => mixed,
+  checkAppUpdate: () => mixed,
 }
 
 type Props = OwnProps & StateProps & DispatchProps
@@ -45,6 +50,7 @@ function InformationCard (props: Props) {
     updateInfo,
     fetchHealth,
     updateUrl,
+    checkAppUpdate,
     healthRequest: {inProgress, response: health},
   } = props
 
@@ -82,6 +88,7 @@ function InformationCard (props: Props) {
         <OutlineButton
           Component={Link}
           to={updateUrl}
+          onClick={checkAppUpdate}
         >
           {updateText}
         </OutlineButton>
@@ -106,5 +113,6 @@ function mapDispatchToProps (
 ): DispatchProps {
   return {
     fetchHealth: () => dispatch(fetchHealthAndIgnored(ownProps)),
+    checkAppUpdate: () => dispatch(checkShellUpdate()),
   }
 }

--- a/app/src/components/RobotSettings/UpdateAppMessage.js
+++ b/app/src/components/RobotSettings/UpdateAppMessage.js
@@ -1,0 +1,11 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+export default function UpdateAppMessage () {
+  return (
+    <p>
+      There is an app update available. Please <Link to={'/menu/app/update'}>update your app</Link> to receive the latest robot updates.
+    </p>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateAppMessage.js
+++ b/app/src/components/RobotSettings/UpdateAppMessage.js
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom'
 export default function UpdateAppMessage () {
   return (
     <p>
-      There is an app update available. Please <Link to={'/menu/app/update'}>update your app</Link> to receive the latest robot updates.
+      <strong>A newer version of the robot software is available.</strong> To update your robot to the latest version, please <Link to={'/menu/app/update'}>update your app software</Link> before updating your robot software.
     </p>
   )
 }

--- a/app/src/components/RobotSettings/UpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateModal.js
@@ -16,11 +16,19 @@ import {
   setIgnoredUpdate,
 } from '../../http-api-client'
 
+import {
+  getShellUpdateState,
+} from '../../shell'
+
+import type {ShellUpdateState} from '../../shell'
+
 import {AlertModal, Icon} from '@opentrons/components'
+import UpdateAppMessage from './UpdateAppMessage'
 
 type OP = Robot
 
 type SP = {
+  appUpdate: ShellUpdateState,
   updateInfo: RobotUpdateInfo,
   updateRequest: RobotServerUpdate,
   restartRequest: RobotServerRestart,
@@ -45,7 +53,15 @@ const Spinner = () => (<Icon name='ot-spinner' height='1em' spin />)
 export default connect(makeMapStateToProps, null, mergeProps)(UpdateModal)
 
 function UpdateModal (props: Props) {
-  const {updateInfo, ignoreUpdate, update, restart, updateRequest, restartRequest} = props
+  const {
+    updateInfo,
+    ignoreUpdate,
+    update,
+    restart,
+    updateRequest,
+    restartRequest,
+    appUpdate: {available},
+  } = props
   const inProgress = updateRequest.inProgress || restartRequest.inProgress
   let closeButtonText = 'not now'
   let message
@@ -87,7 +103,8 @@ function UpdateModal (props: Props) {
       ]}
       alertOverlay
     >
-      {message}
+      {available && <UpdateAppMessage />}
+      <p>{message}</p>
     </AlertModal>
   )
 }
@@ -98,6 +115,7 @@ function makeMapStateToProps (): (State, OP) => SP {
   const getRobotRestartRequest = makeGetRobotRestartRequest()
 
   return (state, ownProps) => ({
+    appUpdate: getShellUpdateState(state),
     updateInfo: getRobotUpdateInfo(state, ownProps),
     updateRequest: getRobotUpdateRequest(state, ownProps),
     restartRequest: getRobotRestartRequest(state, ownProps),


### PR DESCRIPTION
## overview

This PR closes #2354 by prompting user to update thier app in the update robot modal if there is an app update available.

## changelog

- feat(app): Prompt user to update app in robot update modal

## review requests

### app and robot are equal
- [ ] robot update buttons  = [reinstall]
- [ ] update robot modal displays update app message

### app is behind robot version
change app and app-shell package.json version to 3.3.0
- [ ] update robot modal displays update app message

### app is ahead of robot
change app and app-shell package.json version to 3.5.0
- [ ] update robot modal displays update app message