### PR TITLE
refactor(protocol-designer): refactor PD labware components for readability

### DIFF
--- a/components/interfaces/DeckSlot.js
+++ b/components/interfaces/DeckSlot.js
@@ -3,8 +3,6 @@ import * as React from 'react'
 
 export type DeckSlotProps = {
   slot: string,
-  width: number,
-  height: number,
   highlighted?: boolean,
   containerType?: string,
   children?: React.Node

--- a/components/src/deck/LabwareContainer.js
+++ b/components/src/deck/LabwareContainer.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import {SLOT_HEIGHT_MM, SLOT_WIDTH_MM} from '@opentrons/shared-data'
 import styles from './LabwareContainer.css'
 
 const defs = {roundSlotClipPath: 'roundSlotClipPath'} // TODO: import these defs instead of hard-coding in applications? Or should they be passed to children?
@@ -7,14 +8,16 @@ const defs = {roundSlotClipPath: 'roundSlotClipPath'} // TODO: import these defs
 type Props = {
   x?: number,
   y?: number,
-  height: number,
-  width: number,
+  height?: number,
+  width?: number,
   highlighted?: boolean,
   children?: React.Node,
 }
 
 export default function LabwareContainer (props: Props) {
-  const {x, y, height, width, highlighted, children} = props
+  const {x, y, highlighted, children} = props
+  const height = props.height || SLOT_HEIGHT_MM
+  const width = props.width || SLOT_WIDTH_MM
 
   return (
     <g>

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -17,7 +17,7 @@ type SP = {
 
 function mapStateToProps (state: BaseState): SP {
   return {
-    slot: labwareIngredSelectors.canAdd(state) || null,
+    slot: labwareIngredSelectors.selectedAddLabwareSlot(state) || null,
     permittedTipracks: pipetteSelectors.permittedTipracks(state),
   }
 }

--- a/protocol-designer/src/components/labware/ClickableText.js
+++ b/protocol-designer/src/components/labware/ClickableText.js
@@ -8,7 +8,7 @@ type Props = {
   height?: string | number,
   text?: string,
   iconName?: IconName,
-  onClick?: (e: SyntheticEvent<*>) => void,
+  onClick?: (e: SyntheticEvent<*>) => mixed,
 }
 
 const DEFAULT_HEIGHT = 15

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -1,17 +1,17 @@
 // @flow
 import React from 'react'
 import cx from 'classnames'
-import {HandleKeypress, type DeckSlot} from '@opentrons/components'
+import {HandleKeypress} from '@opentrons/components'
 import styles from './labware.css'
 
-type DisabledSelectSlotOverlayProps = {setMoveLabwareMode: (slot: ?DeckSlot) => void}
+type DisabledSelectSlotOverlayProps = {
+  cancelMove: () => mixed,
+}
+
 class DisabledSelectSlotOverlay extends React.Component<DisabledSelectSlotOverlayProps> {
-  cancelMove = () => {
-    this.props.setMoveLabwareMode()
-  }
   render () {
     return (
-      <HandleKeypress preventDefault handlers={[{key: 'Escape', onPress: this.cancelMove}]}>
+      <HandleKeypress preventDefault handlers={[{key: 'Escape', onPress: this.props.cancelMove}]}>
         <g className={cx(styles.slot_overlay, styles.disabled)}>
           <rect className={styles.overlay_panel} />
           <g className={styles.clickable_text}>

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -4,23 +4,22 @@ import cx from 'classnames'
 import {HandleKeypress} from '@opentrons/components'
 import styles from './labware.css'
 
-type DisabledSelectSlotOverlayProps = {
+type Props = {
   cancelMove: () => mixed,
 }
 
-class DisabledSelectSlotOverlay extends React.Component<DisabledSelectSlotOverlayProps> {
-  render () {
-    return (
-      <HandleKeypress preventDefault handlers={[{key: 'Escape', onPress: this.props.cancelMove}]}>
-        <g className={cx(styles.slot_overlay, styles.disabled)}>
-          <rect className={styles.overlay_panel} />
-          <g className={styles.clickable_text}>
-            <text x="0" y="40%">Select a slot</text>
-          </g>
+function DisabledSelectSlotOverlay (props: Props) {
+  const {cancelMove} = props
+  return (
+    <HandleKeypress preventDefault handlers={[{key: 'Escape', onPress: cancelMove}]}>
+      <g className={cx(styles.slot_overlay, styles.disabled)}>
+        <rect className={styles.overlay_panel} />
+        <g className={styles.clickable_text}>
+          <text x="0" y="40%">Select a slot</text>
         </g>
-      </HandleKeypress>
-    )
-  }
+      </g>
+    </HandleKeypress>
+  )
 }
 
 export default DisabledSelectSlotOverlay

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -179,25 +179,23 @@ export default function LabwareOnDeck (props: LabwareOnDeckProps) {
             onClickOutside={cancelMove}
             cancelMove={cancelMove} />
         : <EmptyDestinationSlotOverlay {...{moveLabwareDestination}}/>
+    } else if (showNameOverlay) {
+      overlay = <EnhancedNameThisLabwareOverlay {...{
+        setLabwareName,
+        deleteLabware,
+      }}
+      onClickOutside={setDefaultLabwareName} />
     } else {
-      if (showNameOverlay) {
-        overlay = <EnhancedNameThisLabwareOverlay {...{
-          setLabwareName,
+      overlay = (slotHasLabware)
+        ? <LabwareDeckSlotOverlay {...{
+          canAddIngreds,
           deleteLabware,
-        }}
-        onClickOutside={setDefaultLabwareName} />
-      } else {
-        overlay = (slotHasLabware)
-          ? <LabwareDeckSlotOverlay {...{
-            canAddIngreds,
-            deleteLabware,
-            editLiquids,
-            moveLabwareSource,
-          }} />
-          : <EmptyDeckSlotOverlay {...{
-            addLabware,
-          }} />
-      }
+          editLiquids,
+          moveLabwareSource,
+        }} />
+        : <EmptyDeckSlotOverlay {...{
+          addLabware,
+        }} />
     }
   }
 

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -1,13 +1,4 @@
 // @flow
-
-// On an empty slot:
-// * Renders a slot on the deck
-// * Renders Add Labware mouseover button
-//
-// On a slot with a container:
-// * Renders a SelectablePlate in the slot
-// * Renders Add Ingreds / Delete container mouseover buttons, and dispatches their actions
-
 import React from 'react'
 import cx from 'classnames'
 import {
@@ -20,7 +11,6 @@ import {
   clickOutside,
   type DeckSlot,
 } from '@opentrons/components'
-import {getLabware} from '@opentrons/shared-data'
 import styles from './labware.css'
 
 import ClickableText from './ClickableText'
@@ -30,32 +20,25 @@ import DisabledSelectSlotOverlay from './DisabledSelectSlotOverlay.js'
 
 const EnhancedNameThisLabwareOverlay = clickOutside(NameThisLabwareOverlay)
 
-function OccupiedDeckSlotOverlay ({
+function LabwareDeckSlotOverlay ({
   canAddIngreds,
-  containerId,
-  slot,
-  containerType,
-  containerName,
-  openIngredientSelector,
-  setMoveLabwareMode,
-  deleteContainer,
+  deleteLabware,
+  editLiquids,
+  moveLabwareSource,
 }) {
   return (
     <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
       <rect className={styles.overlay_panel} />
       {canAddIngreds &&
         <ClickableText
-          onClick={() => openIngredientSelector(containerId)}
+          onClick={editLiquids}
           iconName='pencil' y='15%' text='Name & Liquids' />
       }
       <ClickableText
-        onClick={() => setMoveLabwareMode(slot)}
+        onClick={moveLabwareSource}
         iconName='cursor-move' y='40%' text='Move' />
       <ClickableText
-        onClick={() => (
-          window.confirm(`Are you sure you want to permanently delete ${containerName || containerType} in slot ${slot}?`) &&
-          deleteContainer({containerId, slot, containerType})
-        )}
+        onClick={deleteLabware}
         iconName='close' y='65%' text='Delete' />
     </g>
   )
@@ -67,13 +50,13 @@ const labwareImages = {
   'trash-box': IMG_TRASH,
 }
 
-type SlotWithContainerProps = {
+type SlotWithLabwareProps = {
   containerType: string,
   displayName: string,
   containerId: string,
 }
 
-function SlotWithContainer (props: SlotWithContainerProps) {
+function SlotWithLabware (props: SlotWithLabwareProps) {
   const {containerType, displayName, containerId} = props
 
   return (
@@ -90,152 +73,145 @@ function SlotWithContainer (props: SlotWithContainerProps) {
   )
 }
 
-type LabwareOnDeckProps = {
-  slot: DeckSlot,
-
-  containerId: string,
-  containerType: string,
-  containerName: ?string,
-  showNameOverlay: ?boolean,
-
-  // canAdd: boolean,
-
-  activeModals: {
-    ingredientSelection: ?{
-      containerName: ?string,
-      slot: ?DeckSlot,
-    },
-    labwareSelection: boolean,
-  },
-  openIngredientSelector: (containerId: string) => void,
-
-  // createContainer: ({slot: string, containerType: string}) => mixed,
-  deleteContainer: ({containerId: string, slot: DeckSlot, containerType: string}) => void,
-  modifyContainer: ({containerId: string, modify: {[field: string]: mixed}}) => void, // eg modify = {name: 'newName'}
-
-  openLabwareSelector: ({slot: DeckSlot}) => void,
-  // closeLabwareSelector: ({slot: string}) => mixed,
-
-  setMoveLabwareMode: (slot: ?DeckSlot) => void,
-  slotToMoveFrom: ?DeckSlot,
-  moveLabware: (slot: DeckSlot) => void,
-
-  height?: number,
-  width?: number,
-  highlighted: boolean,
-
-  deckSetupMode: boolean,
+type EmptyDestinationSlotOverlayProps = {
+  moveLabwareDestination: (e?: SyntheticEvent<*>) => mixed,
 }
-
-export default function LabwareOnDeck (props: LabwareOnDeckProps) {
-  const {
-    slot,
-
-    containerId,
-    containerType,
-    containerName,
-    showNameOverlay,
-
-    // canAdd,
-
-    activeModals,
-    openIngredientSelector,
-
-    // createContainer,
-    deleteContainer,
-    modifyContainer,
-
-    openLabwareSelector,
-    // closeLabwareSelector,
-
-    setMoveLabwareMode,
-    slotToMoveFrom,
-    moveLabware,
-
-    height,
-    width,
-    highlighted,
-
-    deckSetupMode,
-  } = props
-
-  const slotIsOccupied = !!containerType
-
-  let canAddIngreds: boolean = !showNameOverlay
-
-  // labware definition's metadata.isValueSource defaults to true,
-  // only use it when it's defined as false
-  const labwareInfo = getLabware(containerType)
-  if (!labwareInfo || labwareInfo.metadata.isValidSource === false) {
-    canAddIngreds = false
-  }
-
-  const setDefaultLabwareName = () => modifyContainer({
-    containerId,
-    modify: {name: null},
-  })
+function EmptyDestinationSlotOverlay (props: EmptyDestinationSlotOverlayProps) {
+  const {moveLabwareDestination} = props
 
   const handleSelectMoveDestination = (e: SyntheticEvent<*>) => {
     e.preventDefault()
-    moveLabware(slot)
-  }
-  const cancelMove = () => {
-    setMoveLabwareMode()
+    moveLabwareDestination()
   }
 
   return (
-    <LabwareContainer {...{height, width, slot}} highlighted={highlighted}>
-      {/* The actual deck slot container: rendering of container, or rendering of empty slot */}
-      {slotIsOccupied
-        ? <SlotWithContainer displayName={containerName || containerType} {...{containerType, containerId}} />
-        : <EmptyDeckSlot {...{height, width, slot}} />
-      }
+    <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
+    <rect className={styles.overlay_panel} onClick={moveLabwareDestination} />
+    <ClickableText
+      onClick={handleSelectMoveDestination}
+      iconName='cursor-move'
+      y='40%'
+      text='Place Here'
+    />
+    </g>
+  )
+}
 
-      {(!deckSetupMode || activeModals.labwareSelection)
-        // "Add Labware" labware selection dropdown menu
-        ? null
-        : (slotToMoveFrom
-            // Mouseover empty slot -- Add (or Copy if in copy mode)
-            ? <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
-              <rect className={styles.overlay_panel} onClick={() => moveLabware(slot)} />
-              <ClickableText onClick={handleSelectMoveDestination} iconName='cursor-move' y='40%' text='Place Here' />
-            </g>
-            : <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
-              <rect className={styles.overlay_panel} />
-              <ClickableText onClick={e => openLabwareSelector({slot})}
-                iconName='plus' y='30%' text='Add Labware' />
-              <ClickableText onClick={e => window.alert('NOT YET IMPLEMENTED: Add Copy') /* TODO: New Copy feature */}
-                iconName='content-copy' y='55%' text='Add Copy' />
-            </g>
-        )
-      }
+type EmptyDeckSlotOverlayProps = {
+  addLabware: (e: SyntheticEvent<*>) => mixed,
+}
+function EmptyDeckSlotOverlay (props: EmptyDeckSlotOverlayProps) {
+  const {addLabware} = props
+  return (
+    <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
+      <rect className={styles.overlay_panel} />
+      <ClickableText onClick={addLabware}
+        iconName='plus' y='30%' text='Add Labware' />
+      <ClickableText
+        onClick={e => window.alert('NOT YET IMPLEMENTED: Add Copy') /* TODO: New Copy feature */}
+        iconName='content-copy' y='55%' text='Add Copy' />
+    </g>
+  )
+}
 
-      {slotToMoveFrom === slot &&
-        <DisabledSelectSlotOverlay onClickOutside={cancelMove} setMoveLabwareMode={setMoveLabwareMode} />}
+type LabwareOnDeckProps = {
+  slot: DeckSlot,
+  containerId: string,
+  containerName: ?string,
+  containerType: string,
 
-      {deckSetupMode && slotIsOccupied && !slotToMoveFrom && !showNameOverlay &&
-        <OccupiedDeckSlotOverlay {...{
-          canAddIngreds,
-          containerId,
-          slot,
-          containerType,
-          containerName,
-          openIngredientSelector,
-          setMoveLabwareMode,
-          deleteContainer,
-        }} />
-      }
+  showNameOverlay: ?boolean,
+  slotHasLabware: boolean,
+  highlighted: boolean,
 
-      {deckSetupMode && showNameOverlay &&
-        <EnhancedNameThisLabwareOverlay {...{
-          containerType,
-          containerId,
-          slot,
-          modifyContainer,
-          deleteContainer,
+  addLabwareMode: boolean,
+  canAddIngreds: boolean,
+  deckSetupMode: boolean,
+  moveLabwareMode: boolean,
+
+  addLabware: () => mixed,
+  editLiquids: () => mixed,
+  deleteLabware: () => mixed,
+
+  cancelMove: () => mixed,
+  moveLabwareDestination: () => mixed,
+  moveLabwareSource: () => mixed,
+  slotToMoveFrom: ?DeckSlot,
+
+  setLabwareName: (name: ?string) => mixed,
+  setDefaultLabwareName: () => mixed,
+}
+export default function LabwareOnDeck (props: LabwareOnDeckProps) {
+  const {
+    slot,
+    containerId,
+    containerName,
+    containerType,
+
+    showNameOverlay,
+    slotHasLabware,
+    highlighted,
+
+    addLabwareMode,
+    canAddIngreds,
+    deckSetupMode,
+    moveLabwareMode,
+
+    addLabware,
+    editLiquids,
+    deleteLabware,
+
+    cancelMove,
+    moveLabwareDestination,
+    moveLabwareSource,
+    slotToMoveFrom,
+
+    setDefaultLabwareName,
+    setLabwareName,
+  } = props
+
+  // determine what overlay to show
+  let overlay = null
+  if (deckSetupMode && !addLabwareMode) {
+    if (moveLabwareMode) {
+      overlay = (slotToMoveFrom === slot)
+        ? <DisabledSelectSlotOverlay
+            onClickOutside={cancelMove}
+            cancelMove={cancelMove} />
+        : <EmptyDestinationSlotOverlay {...{moveLabwareDestination}}/>
+    } else {
+      if (showNameOverlay) {
+        overlay = <EnhancedNameThisLabwareOverlay {...{
+          setLabwareName,
+          deleteLabware,
         }}
         onClickOutside={setDefaultLabwareName} />
+      } else {
+        overlay = (slotHasLabware)
+          ? <LabwareDeckSlotOverlay {...{
+            canAddIngreds,
+            deleteLabware,
+            editLiquids,
+            moveLabwareSource,
+          }} />
+          : <EmptyDeckSlotOverlay {...{
+            addLabware,
+          }} />
       }
+    }
+  }
+
+  const labwareOrSlot = (slotHasLabware)
+    ? <SlotWithLabware
+        {...{containerType, containerId}}
+        displayName={containerName || containerType}
+      />
+    : <EmptyDeckSlot slot={slot} />
+
+  return (
+    <LabwareContainer {...{slot, highlighted}}>
+      {labwareOrSlot}
+      {overlay}
     </LabwareContainer>
   )
 }

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -3,15 +3,12 @@ import * as React from 'react'
 import ForeignDiv from '../../components/ForeignDiv.js'
 import ClickableText from './ClickableText'
 import styles from './labware.css'
-import type {ClickOutsideInterface, DeckSlot} from '@opentrons/components'
+import type {ClickOutsideInterface} from '@opentrons/components'
 
 type Props = {
-  containerType: string,
-  containerId: string,
-  slot: DeckSlot,
+  setLabwareName: (name: ?string) => mixed,
   // TODO Ian 2018-02-16 type these fns elsewhere and import the type
-  modifyContainer: (args: {containerId: string, modify: {[field: string]: mixed}}) => void,
-  deleteContainer: (args: {containerId: string, slot: DeckSlot, containerType: string}) => void,
+  deleteLabware: () => mixed,
 } & ClickOutsideInterface
 
 type State = {
@@ -44,21 +41,13 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
   }
 
   onSubmit = () => {
-    const { containerId, modifyContainer } = this.props
     const containerName = this.state.inputValue || null
-
-    modifyContainer({
-      containerId,
-      modify: { name: containerName },
-    })
+    this.props.setLabwareName(containerName)
   }
 
   render () {
     const {
-      containerType,
-      containerId,
-      slot,
-      deleteContainer,
+      deleteLabware,
       passRef,
     } = this.props
 
@@ -79,7 +68,7 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
           <ClickableText onClick={this.onSubmit}
             iconName='check' y='60%' text='Save' />
 
-          <ClickableText onClick={() => deleteContainer({containerId, slot, containerType})}
+          <ClickableText onClick={deleteLabware}
             iconName='close' y='80%' text='Cancel' />
         </g>
       </g>

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -71,8 +71,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     modify: {name: null},
   })
 
-  // labware definition's metadata.isValueSource defaults to true,
-  // only use it when it's defined as false
+  // labware definition's metadata.isValidSource defaults to true,
+  // only use it when it is defined as false
   let canAddIngreds: boolean = !showNameOverlay
   const labwareInfo = getLabware(containerType)
   if (!labwareInfo || labwareInfo.metadata.isValidSource === false) {

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -12,7 +12,7 @@ import type {DeckSlot} from '@opentrons/components'
 
 // ===== Labware selector actions =====
 
-export const openLabwareSelector = createAction(
+export const openAddLabwareModal = createAction(
   'OPEN_LABWARE_SELECTOR',
   (args: {slot: DeckSlot}) => args
 )

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -13,7 +13,7 @@ import type {DeckSlot} from '@opentrons/components'
 // ===== Labware selector actions =====
 
 export const openAddLabwareModal = createAction(
-  'OPEN_LABWARE_SELECTOR',
+  'OPEN_ADD_LABWARE_MODAL',
   (args: {slot: DeckSlot}) => args
 )
 

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -48,7 +48,7 @@ const nextEmptySlot = loadedContainersSubstate => {
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
 // (this state just toggles a modal)
 const modeLabwareSelection = handleActions({
-  OPEN_LABWARE_SELECTOR: (state, action: ActionType<typeof actions.openAddLabwareModal>) =>
+  OPEN_ADD_LABWARE_MODAL: (state, action: ActionType<typeof actions.openAddLabwareModal>) =>
       action.payload.slot,
   CLOSE_LABWARE_SELECTOR: () => false,
   CREATE_CONTAINER: () => false,

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -48,7 +48,7 @@ const nextEmptySlot = loadedContainersSubstate => {
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
 // (this state just toggles a modal)
 const modeLabwareSelection = handleActions({
-  OPEN_LABWARE_SELECTOR: (state, action: ActionType<typeof actions.openLabwareSelector>) =>
+  OPEN_LABWARE_SELECTOR: (state, action: ActionType<typeof actions.openAddLabwareModal>) =>
       action.payload.slot,
   CLOSE_LABWARE_SELECTOR: () => false,
   CREATE_CONTAINER: () => false,
@@ -363,7 +363,8 @@ const disposalLabwareOptions: Selector<Options> = createSelector(
   }, [])
 )
 
-const canAdd = (state: BaseState) => rootSelector(state).modeLabwareSelection // false or selected slot to add labware to, eg 'A2'
+// false or selected slot to add labware to, eg 'A2'
+const selectedAddLabwareSlot = (state: BaseState) => rootSelector(state).modeLabwareSelection
 
 const getSavedLabware = (state: BaseState) => rootSelector(state).savedLabware
 
@@ -470,7 +471,7 @@ export const selectors = {
   allIngredientNamesIds,
   loadedContainersBySlot,
   containersBySlot,
-  canAdd,
+  selectedAddLabwareSlot,
   disposalLabwareOptions,
   labwareOptions,
   hasLiquid,


### PR DESCRIPTION
## overview

Refactor to clean up PD some labware components in preparation for #2335

Rename things for clarity, pass less props around, do business logic in container instead of component, etc

## changelog

* Simplify & clean up LabwareOnDeck, labware overlays, and related components & types

## review requests

Everything should act & appear the same.

Explicit list of things this PR touches and shouldn't change:

* Add labware, delete labware, and edit liquids still works the same
* Move labware still works the same, and causes the same changes in labware overlays
* "Copy" is still just as TODO as it was (ie,it's  not implemented and warns you that it's not implemented if you try it)
* When "Starting Deck State" is selected, the slots/labware show the editable overlays on hover, when anything else is selected (steps, or "Final Deck State"), no overlays but the labware name labels.
