### PR TITLE
fix(api): Bind jupyter notebook to 0.0.0.0

### DIFF
--- a/api/opentrons/resources/jupyter/jupyter_notebook_config.py
+++ b/api/opentrons/resources/jupyter/jupyter_notebook_config.py
@@ -171,7 +171,7 @@ c.NotebookApp.allow_origin = '*'
 #c.NotebookApp.iopub_msg_rate_limit = 1000
 
 ## The IP address the notebook server will listen on.
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 
 ## Supply extra arguments that will be passed to Jinja environment.
 #c.NotebookApp.jinja_environment_options = {}


### PR DESCRIPTION
The jupyter notebook package has a bug in 5.7.0 where specifying the notebook
application’s listening ip as ’*’ causes it to fail to boot:
https://github.com/jupyter/notebook/issues/3946

The workaround listed there is to bind the server to 0.0.0.0 instead, so we do
that here.

Closes #2394

## review requests

Run on a robot and check that jupyter comes up. Already done on wolf-wolf-wolf-moon (which has notebook 5.6.0, so checking back compat) and divine-night which has 5.7.0.
