### PR TITLE
feat(api): add instrument cache to hardware control

### DIFF
--- a/api/opentrons/hardware_control/controller.py
+++ b/api/opentrons/hardware_control/controller.py
@@ -72,3 +72,6 @@ class Controller:
 
     def home(self):
         return self._smoothie_driver.home()
+
+    def get_attached_instruments(self, mount):
+        return self._smoothie_driver.read_pipette_model(mount.name.lower())

--- a/api/opentrons/hardware_control/simulator.py
+++ b/api/opentrons/hardware_control/simulator.py
@@ -7,9 +7,10 @@ class Simulator:
     a robot with no smoothie connected.
     """
 
-    def __init__(self, config, loop):
+    def __init__(self, attached_instruments, config, loop):
         self._config = config
         self._loop = loop
+        self._attached_instruments = attached_instruments
 
     def move(self, target_position: Dict[str, float]):
         pass
@@ -17,3 +18,6 @@ class Simulator:
     def home(self):
         # driver_3_0-> HOMED_POSITION
         return {'X': 418, 'Y': 353, 'Z': 218, 'A': 218, 'B': 19, 'C': 19}
+
+    def get_attached_instruments(self, mount):
+        return self._attached_instruments[mount]

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -1,0 +1,30 @@
+import pytest
+from opentrons import types
+from opentrons import hardware_control as hc
+
+
+async def test_cache_instruments(loop):
+    dummy_instruments_attached = {types.Mount.LEFT: 'model_abc',
+                                  types.Mount.RIGHT: None}
+    hw_api = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments_attached, loop=loop)
+    await hw_api.cache_instrument_models()
+    assert hw_api._attached_instruments == dummy_instruments_attached
+
+
+@pytest.mark.skipif(not hc.controller,
+                    reason='hardware controller not available '
+                           '(probably windows)')
+async def test_cache_instruments_hc(monkeypatch, hardware_controller_lockfile,
+                                    running_on_pi, loop):
+    dummy_instruments_attached = {types.Mount.LEFT: 'model_abc',
+                                  types.Mount.RIGHT: None}
+    hw_api_cntrlr = hc.API.build_hardware_controller(loop=loop)
+
+    def mock_driver_method(mount):
+        attached_pipette = {'left': 'model_abc', 'right': None}
+        return attached_pipette[mount]
+    monkeypatch.setattr(hw_api_cntrlr._backend._smoothie_driver,
+                        'read_pipette_model', mock_driver_method)
+    await hw_api_cntrlr.cache_instrument_models()
+    assert hw_api_cntrlr._attached_instruments == dummy_instruments_attached

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -2,23 +2,22 @@ import pytest
 from opentrons import types
 from opentrons import hardware_control as hc
 
-if not hc.controller:
-    pytest.skip('hardware controller not available (probably windows)',
-                allow_module_level=True)
-
 
 @pytest.fixture
 def hardware_api(monkeypatch, loop):
     def mock_move(position):
         pass
-
-    hw_api = hc.API.build_hardware_simulator(loop=loop)
+    attached_pipettes = {types.Mount.LEFT: None, types.Mount.RIGHT: None}
+    hw_api = hc.API.build_hardware_simulator(
+        attached_instruments=attached_pipettes, loop=loop)
     monkeypatch.setattr(hw_api._backend, 'move', mock_move)
     return hw_api
 
 
 async def test_controller_home(loop):
-    c = hc.API.build_hardware_simulator(loop=loop)
+    attached_pipettes = {types.Mount.LEFT: None, types.Mount.RIGHT: None}
+    c = hc.API.build_hardware_simulator(
+        attached_instruments=attached_pipettes, loop=loop)
     await c.home()
     assert c._current_position == {'X': 418, 'Y': 353, 'Z': 218,
                                    'A': 218, 'B': 19, 'C': 19}


### PR DESCRIPTION
Closes #2236

## overview

This PR adds the `cache_instrument_models` method which would be used to keep track of attached pipettes. 
When in simulate mode, this method relies on the simulator knowing about the instruments attached to the robot (or mocked). The simulator needs this info while simulating a protocol in the Run app to check if correct pipettes are attached
