### PR TITLE
fix(discovery-client): Ensure IPs are actually de-duped

### DIFF
--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -182,14 +182,20 @@ describe('app-shell/discovery', () => {
 
     mockClient.services = [{name: 'foo'}, {name: 'bar'}]
     mockClient.emit('service')
-    expect(Store.__store.set).toHaveBeenCalledWith('services', [
+    expect(Store.__store.set).toHaveBeenLastCalledWith('services', [
       {name: 'foo'},
       {name: 'bar'},
     ])
+  })
+
+  test('stores services to file on serviceRemoved events', () => {
+    registerDiscovery(dispatch)
 
     mockClient.services = [{name: 'foo'}]
     mockClient.emit('serviceRemoved')
-    expect(Store.__store.set).toHaveBeenCalledWith('services', [{name: 'foo'}])
+    expect(Store.__store.set).toHaveBeenLastCalledWith('services', [
+      {name: 'foo'},
+    ])
   })
 
   test('loads services from file on client initialization', () => {

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -19,7 +19,10 @@ import type {Service} from '@opentrons/discovery-client'
 
 // TODO(mc, 2018-08-08): figure out type exports from app
 import type {Action} from '@opentrons/app/src/types'
-import type {DiscoveredRobot, Connection} from '@opentrons/app/src/discovery/types'
+import type {
+  DiscoveredRobot,
+  Connection,
+} from '@opentrons/app/src/discovery/types'
 
 const log = createLogger(__filename)
 

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -31,7 +31,7 @@ export * from './types'
 
 export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
 
-const DISCOVERY_TIMEOUT = 15000
+const DISCOVERY_TIMEOUT = 20000
 
 export function startDiscovery (): ThunkAction {
   const start: StartAction = {type: 'discovery:START', meta: {shell: true}}

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -8,12 +8,9 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # source and output directories for main process code
 src_dir := src
 lib_dir := lib
-src_ignore := "**/__@(tests|mocks)__/**"
+src_ignore := "**/__@(tests|mocks|fixtures)__/**"
 babel := babel $(src_dir) --ignore $(src_ignore) --out-dir $(lib_dir)
 flow_copy := flow-copy-source --ignore $(src_ignore) $(src_dir) $(lib_dir)
-
-# set NODE_ENV for a command with $(env)=environment
-env := cross-env NODE_ENV
 
 # standard targets
 #####################################################################
@@ -33,8 +30,9 @@ clean:
 #####################################################################
 
 .PHONY: lib
+lib: export NODE_ENV := production
 lib:
-	$(env)=production $(babel)
+	$(babel)
 	$(flow_copy)
 
 .PHONY: dist

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "escape-string-regexp": "^1.0.5",
+    "lodash": "^4.17.4",
     "mdns-js": "^1.0.1",
     "node-fetch": "^2.1.2",
     "to-regex": "^3.0.2",

--- a/discovery-client/src/__fixtures__/mdns-browser-service.js
+++ b/discovery-client/src/__fixtures__/mdns-browser-service.js
@@ -1,0 +1,18 @@
+export default {
+  addresses: ['192.168.1.42'],
+  query: ['_http._tcp.local'],
+  type: [
+    {
+      name: 'http',
+      protocol: 'tcp',
+      subtypes: [],
+      description: 'Web Site',
+    },
+  ],
+  txt: [''],
+  port: 31950,
+  fullname: 'opentrons-dev._http._tcp.local',
+  host: 'opentrons-dev.local',
+  interfaceIndex: 0,
+  networkInterface: 'en0',
+}

--- a/discovery-client/src/__fixtures__/service.js
+++ b/discovery-client/src/__fixtures__/service.js
@@ -1,0 +1,7 @@
+export default {
+  name: 'opentrons-dev',
+  ip: '192.168.1.42',
+  port: 31950,
+  ok: null,
+  serverOk: null,
+}

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -1,35 +1,24 @@
 import mdns from 'mdns-js'
+
 import DiscoveryClient from '..'
 import * as poller from '../poller'
+import * as service from '../service'
+import * as serviceList from '../service-list'
+import MOCK_BROWSER_SERVICE from '../__fixtures__/mdns-browser-service'
+import MOCK_SERVICE from '../__fixtures__/service'
 
 jest.mock('mdns-js')
 jest.mock('../poller')
 
-const BROWSER_SERVICE = {
-  addresses: ['192.168.1.42'],
-  query: ['_http._tcp.local'],
-  type: [
-    {
-      name: 'http',
-      protocol: 'tcp',
-      subtypes: [],
-      description: 'Web Site',
-    },
-  ],
-  txt: [''],
-  port: 31950,
-  fullname: 'opentrons-dev._http._tcp.local',
-  host: 'opentrons-dev.local',
-  interfaceIndex: 0,
-  networkInterface: 'en0',
-}
-
 describe('discovery client', () => {
-  beforeEach(() => {
-    mdns.__mockReset()
+  beforeAll(() => {
+    // spies
+    service.fromMdnsBrowser = jest.fn(service.fromMdnsBrowser)
+    serviceList.createServiceList = jest.fn(serviceList.createServiceList)
   })
 
-  afterEach(() => {
+  beforeEach(() => {
+    mdns.__mockReset()
     jest.clearAllMocks()
   })
 
@@ -78,18 +67,14 @@ describe('discovery client', () => {
 
       client.start()
       client.once('service', robot => {
-        expect(robot).toEqual({
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        })
-
+        expect(service.fromMdnsBrowser).toHaveBeenCalledWith(
+          MOCK_BROWSER_SERVICE
+        )
+        expect(robot).toEqual(MOCK_SERVICE)
         done()
       })
 
-      mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+      mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
     },
     10
   )
@@ -106,7 +91,7 @@ describe('discovery client', () => {
         done()
       })
 
-      mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+      mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
     },
     10
   )
@@ -116,103 +101,40 @@ describe('discovery client', () => {
 
     client.services = [
       {
-        name: 'opentrons-dev',
-        ip: '192.168.1.42',
-        port: 31950,
+        ...MOCK_SERVICE,
         ok: true,
         serverOk: true,
       },
     ]
 
     client.start()
-    mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+    mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
 
     expect(client.services).toEqual([
       {
-        name: 'opentrons-dev',
-        ip: '192.168.1.42',
-        port: 31950,
+        ...MOCK_SERVICE,
         ok: true,
         serverOk: true,
       },
     ])
   })
 
-  test('selects IPv4 as ip from service.addresses', () => {
-    const client = DiscoveryClient()
-    const service = {
-      ...BROWSER_SERVICE,
-      addresses: ['fe80::caf4:6db4:4652:e975', ...BROWSER_SERVICE.addresses],
-    }
-
-    client.start()
-    mdns.__mockBrowser.emit('update', service)
-    expect(client.services[0].ip).toBe('192.168.1.42')
-  })
-
-  test('ip falls back to IPv6 if no IPv4', () => {
-    const client = DiscoveryClient()
-    const service = {
-      ...BROWSER_SERVICE,
-      addresses: ['fe80::caf4:6db4:4652:e975'],
-    }
-
-    client.start()
-    mdns.__mockBrowser.emit('update', service)
-    expect(client.services[0].ip).toBe('[fe80::caf4:6db4:4652:e975]')
-  })
-
-  test('ip falls back to host if no IPv6 nor IPv4', () => {
-    const client = DiscoveryClient()
-    const service = {
-      ...BROWSER_SERVICE,
-      addresses: [],
-    }
-
-    client.start()
-    mdns.__mockBrowser.emit('update', service)
-    expect(client.services[0].ip).toBe('opentrons-dev.local')
-  })
-
   test('services and candidates can be prepopulated', () => {
+    const cachedServices = [MOCK_SERVICE]
     const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: true,
-          serverOk: true,
-        },
-      ],
+      services: cachedServices,
       candidates: [{ip: '192.168.1.43', port: 31950}],
     })
 
-    expect(client.services).toEqual([
-      {
-        name: 'opentrons-dev',
-        ip: '192.168.1.42',
-        port: 31950,
-        // ok flags should be nulled out
-        ok: null,
-        serverOk: null,
-      },
-    ])
+    expect(serviceList.createServiceList).toHaveBeenCalledWith(cachedServices)
+    expect(client.services).toEqual(cachedServices)
     expect(client.candidates).toEqual([{ip: '192.168.1.43', port: 31950}])
   })
 
   test('candidates should be deduped by services', () => {
     const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: true,
-          serverOk: true,
-        },
-      ],
-      candidates: [{ip: '192.168.1.42', port: 31950}],
+      services: [MOCK_SERVICE],
+      candidates: [{ip: MOCK_SERVICE.ip, port: 31950}],
     })
 
     expect(client.candidates).toEqual([])
@@ -222,7 +144,7 @@ describe('discovery client', () => {
     const client = DiscoveryClient({
       services: [
         {
-          name: 'opentrons-dev',
+          ...MOCK_SERVICE,
           ip: 'foo',
           port: 1,
         },
@@ -264,17 +186,7 @@ describe('discovery client', () => {
   })
 
   test('if polls come back good, oks should be flagged true from null', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -290,17 +202,7 @@ describe('discovery client', () => {
   })
 
   test('if polls come back good, oks should be flagged true from false', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.services[0].ok = false
     client.services[0].serverOk = false
@@ -317,17 +219,7 @@ describe('discovery client', () => {
   })
 
   test('if API health comes back bad, ok should be flagged false from null', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -339,17 +231,7 @@ describe('discovery client', () => {
   })
 
   test('if API health comes back bad, ok should be flagged false from true', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.services[0].ok = true
     client.start()
@@ -362,17 +244,7 @@ describe('discovery client', () => {
   })
 
   test('if /server health comes back bad, serverOk should be flagged false from null', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -383,17 +255,7 @@ describe('discovery client', () => {
   })
 
   test('if /server health comes back bad, serverOk should be flagged false from true', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.services[0].serverOk = true
     client.start()
@@ -405,17 +267,7 @@ describe('discovery client', () => {
   })
 
   test('if both polls comes back bad, oks should be flagged false from null', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -427,17 +279,7 @@ describe('discovery client', () => {
   })
 
   test('if both polls comes back bad, oks should be flagged false from true', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.services[0].ok = true
     client.services[0].serverOk = true
@@ -451,17 +293,7 @@ describe('discovery client', () => {
   })
 
   test('if names come back conflicting, prefer /server and set ok to false', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -491,19 +323,20 @@ describe('discovery client', () => {
     expect(client.candidates).toEqual([])
     expect(client.services).toEqual([
       {
-        name: 'opentrons-dev',
-        ip: '192.168.1.42',
-        port: 31950,
+        ...MOCK_SERVICE,
         ok: true,
         serverOk: true,
       },
     ])
   })
 
-  test('if health comes back with IP conflict, null out old service', () => {
-    const client = DiscoveryClient({
-      services: [{name: 'bar', ip: 'foo', port: 31950}],
-    })
+  test('if health comes back with IP conflict, null out old services', () => {
+    const client = DiscoveryClient()
+
+    client.services = [
+      {name: 'bar', ip: 'foo', port: 31950},
+      {name: 'baz', ip: 'foo', port: 31950},
+    ]
 
     client.start()
     const onHealth = poller.poll.mock.calls[0][2]
@@ -514,7 +347,6 @@ describe('discovery client', () => {
     )
 
     expect(client.services).toEqual([
-      {name: 'bar', ip: null, port: 31950, ok: null, serverOk: null},
       {
         name: 'opentrons-dev',
         ip: 'foo',
@@ -522,6 +354,8 @@ describe('discovery client', () => {
         ok: true,
         serverOk: true,
       },
+      {name: 'bar', ip: null, port: 31950, ok: null, serverOk: null},
+      {name: 'baz', ip: null, port: 31950, ok: null, serverOk: null},
     ])
   })
 
@@ -548,19 +382,19 @@ describe('discovery client', () => {
       )
     })
 
-    mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+    mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
   })
 
   test('services may be removed and removes candidates', () => {
     const client = DiscoveryClient({
       services: [
         {
-          name: 'opentrons-dev',
+          ...MOCK_SERVICE,
           ip: '192.168.1.42',
           port: 31950,
         },
         {
-          name: 'opentrons-dev',
+          ...MOCK_SERVICE,
           ip: '[fd00:0:cafe:fefe::1]',
           port: 31950,
         },
@@ -575,15 +409,7 @@ describe('discovery client', () => {
   })
 
   test('candidate removal restarts poll', () => {
-    const client = DiscoveryClient({
-      services: [
-        {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-        },
-      ],
-    })
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     poller.poll.mockReturnValueOnce({id: 1234})
     client.start()
@@ -601,19 +427,11 @@ describe('discovery client', () => {
     'candidate removal emits removal events',
     done => {
       let services = [
+        MOCK_SERVICE,
         {
-          name: 'opentrons-dev',
-          ip: '192.168.1.42',
-          port: 31950,
-          ok: null,
-          serverOk: null,
-        },
-        {
-          name: 'opentrons-dev',
+          ...MOCK_SERVICE,
           ip: '[fd00:0:cafe:fefe::1]',
           port: 31950,
-          ok: null,
-          serverOk: null,
         },
       ]
 
@@ -649,13 +467,15 @@ describe('discovery client', () => {
     const client = DiscoveryClient({nameFilter: ['OPENTRONS']})
 
     client.start()
-    mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+    mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
+      addresses: ['192.168.1.1'],
       fullname: 'Opentrons-2._http._tcp.local',
     })
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
+      addresses: ['192.168.1.2'],
       fullname: 'apentrons._http._tcp.local',
     })
 
@@ -670,11 +490,11 @@ describe('discovery client', () => {
 
     client.start()
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
       addresses: ['169.254.1.2'],
     })
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
       addresses: ['192.168.3.4'],
     })
 
@@ -685,15 +505,17 @@ describe('discovery client', () => {
     const client = DiscoveryClient({portFilter: [31950, 31951]})
 
     client.start()
-    mdns.__mockBrowser.emit('update', BROWSER_SERVICE)
+    mdns.__mockBrowser.emit('update', MOCK_BROWSER_SERVICE)
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
       fullname: '2._http._tcp.local',
+      addresses: ['192.168.1.1'],
       port: 31951,
     })
     mdns.__mockBrowser.emit('update', {
-      ...BROWSER_SERVICE,
+      ...MOCK_BROWSER_SERVICE,
       fullname: '3._http._tcp.local',
+      addresses: ['192.168.1.2'],
       port: 22,
     })
 

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -177,7 +177,7 @@ describe('discovery client', () => {
   })
 
   test('client.stop should stop polling', () => {
-    const client = DiscoveryClient()
+    const client = DiscoveryClient({services: [MOCK_SERVICE]})
 
     poller.poll.mockReturnValueOnce({id: 'foobar'})
     client.start()
@@ -360,13 +360,15 @@ describe('discovery client', () => {
   })
 
   test('if new service is added, poller is restarted', () => {
-    const client = DiscoveryClient()
+    const client = DiscoveryClient({
+      candidates: [{ip: '192.168.1.1', port: 31950}],
+    })
 
     poller.poll.mockReturnValueOnce({id: 1234})
 
     client.start()
     expect(poller.poll).toHaveBeenLastCalledWith(
-      [],
+      [{ip: '192.168.1.1', port: 31950}],
       expect.anything(),
       expect.anything(),
       client._logger
@@ -375,7 +377,7 @@ describe('discovery client', () => {
     client.once('service', robot => {
       expect(poller.stop).toHaveBeenLastCalledWith({id: 1234}, client._logger)
       expect(poller.poll).toHaveBeenLastCalledWith(
-        [{ip: '192.168.1.42', port: 31950}],
+        [{ip: '192.168.1.42', port: 31950}, {ip: '192.168.1.1', port: 31950}],
         expect.anything(),
         expect.anything(),
         client._logger

--- a/discovery-client/src/__tests__/poller.test.js
+++ b/discovery-client/src/__tests__/poller.test.js
@@ -39,6 +39,12 @@ describe('discovery poller', () => {
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 2000)
   })
 
+  test('will not set a subinterval smaller than 100ms', () => {
+    poll([{ip: 'foo', port: 31950}, {ip: 'bar', port: 31950}], 42, jest.fn())
+
+    expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 100)
+  })
+
   test('returns interval ID in request object', () => {
     const intervalId = 1234
     setInterval.mockReturnValueOnce(intervalId)

--- a/discovery-client/src/__tests__/poller.test.js
+++ b/discovery-client/src/__tests__/poller.test.js
@@ -1,12 +1,12 @@
 import fetch from 'node-fetch'
-import { poll, stop } from '../poller'
+import {poll, stop} from '../poller'
 
 jest.mock('node-fetch')
 
 describe('discovery poller', () => {
   beforeEach(() => {
     jest.useFakeTimers()
-    fetch.__setMockResponse({ ok: false })
+    fetch.__setMockResponse({ok: false})
   })
 
   afterEach(() => {
@@ -21,20 +21,16 @@ describe('discovery poller', () => {
   })
 
   test('sets an interval to poll candidates evenly', () => {
-    poll(
-      [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
-      6000,
-      jest.fn()
-    )
+    poll([{ip: 'foo', port: 31950}, {ip: 'bar', port: 31950}], 6000, jest.fn())
 
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 3000)
     setInterval.mockClear()
 
     poll(
       [
-        { ip: 'foo', port: 31950 },
-        { ip: 'bar', port: 31950 },
-        { ip: 'baz', port: 31950 },
+        {ip: 'foo', port: 31950},
+        {ip: 'bar', port: 31950},
+        {ip: 'baz', port: 31950},
       ],
       6000,
       jest.fn()
@@ -48,7 +44,7 @@ describe('discovery poller', () => {
     setInterval.mockReturnValueOnce(intervalId)
 
     const request = poll(
-      [{ ip: 'foo', port: 31950 }, { ip: 'bar', port: 31950 }],
+      [{ip: 'foo', port: 31950}, {ip: 'bar', port: 31950}],
       6000,
       jest.fn()
     )
@@ -57,7 +53,7 @@ describe('discovery poller', () => {
   })
 
   test('can stop polling', () => {
-    const request = { id: 1234 }
+    const request = {id: 1234}
 
     stop(request)
     expect(clearInterval).toHaveBeenCalledWith(1234)
@@ -66,9 +62,9 @@ describe('discovery poller', () => {
   test('calls fetch health for all candidates in an interval', () => {
     poll(
       [
-        { ip: 'foo', port: 31950 },
-        { ip: 'bar', port: 31950 },
-        { ip: 'baz', port: 31950 },
+        {ip: 'foo', port: 31950},
+        {ip: 'bar', port: 31950},
+        {ip: 'baz', port: 31950},
       ],
       6000,
       jest.fn()
@@ -76,12 +72,27 @@ describe('discovery poller', () => {
 
     jest.runTimersToTime(6000)
     expect(fetch).toHaveBeenCalledTimes(6)
-    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/server/update/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/server/update/health`)
-    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/server/update/health`)
+    expect(fetch).toHaveBeenCalledWith(`http://foo:31950/health`, {
+      timeout: 6000,
+    })
+    expect(fetch).toHaveBeenCalledWith(`http://bar:31950/health`, {
+      timeout: 6000,
+    })
+    expect(fetch).toHaveBeenCalledWith(`http://baz:31950/health`, {
+      timeout: 6000,
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      `http://foo:31950/server/update/health`,
+      {timeout: 6000}
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      `http://bar:31950/server/update/health`,
+      {timeout: 6000}
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      `http://baz:31950/server/update/health`,
+      {timeout: 6000}
+    )
   })
 
   test(
@@ -89,19 +100,15 @@ describe('discovery poller', () => {
     done => {
       fetch.__setMockResponse({
         ok: true,
-        json: () => Promise.resolve({ name: 'foo' }),
+        json: () => Promise.resolve({name: 'foo'}),
       })
 
-      poll(
-        [{ ip: 'foo', port: 31950 }],
-        1000,
-        (candidate, apiRes, serverRes) => {
-          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
-          expect(apiRes).toEqual({ name: 'foo' })
-          expect(serverRes).toEqual({ name: 'foo' })
-          done()
-        }
-      )
+      poll([{ip: 'foo', port: 31950}], 1000, (candidate, apiRes, serverRes) => {
+        expect(candidate).toEqual({ip: 'foo', port: 31950})
+        expect(apiRes).toEqual({name: 'foo'})
+        expect(serverRes).toEqual({name: 'foo'})
+        done()
+      })
 
       jest.runTimersToTime(1000)
     },
@@ -113,19 +120,15 @@ describe('discovery poller', () => {
     done => {
       fetch.__setMockResponse({
         ok: false,
-        json: () => Promise.resolve({ message: 'oh no!' }),
+        json: () => Promise.resolve({message: 'oh no!'}),
       })
 
-      poll(
-        [{ ip: 'foo', port: 31950 }],
-        1000,
-        (candidate, apiRes, serverRes) => {
-          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
-          expect(apiRes).toEqual(null)
-          expect(serverRes).toEqual(null)
-          done()
-        }
-      )
+      poll([{ip: 'foo', port: 31950}], 1000, (candidate, apiRes, serverRes) => {
+        expect(candidate).toEqual({ip: 'foo', port: 31950})
+        expect(apiRes).toEqual(null)
+        expect(serverRes).toEqual(null)
+        done()
+      })
 
       jest.runTimersToTime(1000)
     },
@@ -137,16 +140,12 @@ describe('discovery poller', () => {
     done => {
       fetch.__setMockError(new Error('failed to fetch'))
 
-      poll(
-        [{ ip: 'foo', port: 31950 }],
-        1000,
-        (candidate, apiRes, serverRes) => {
-          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
-          expect(apiRes).toEqual(null)
-          expect(serverRes).toEqual(null)
-          done()
-        }
-      )
+      poll([{ip: 'foo', port: 31950}], 1000, (candidate, apiRes, serverRes) => {
+        expect(candidate).toEqual({ip: 'foo', port: 31950})
+        expect(apiRes).toEqual(null)
+        expect(serverRes).toEqual(null)
+        done()
+      })
 
       jest.runTimersToTime(1000)
     },
@@ -161,16 +160,12 @@ describe('discovery poller', () => {
         json: () => Promise.reject(new Error('oh no!')),
       })
 
-      poll(
-        [{ ip: 'foo', port: 31950 }],
-        1000,
-        (candidate, apiRes, serverRes) => {
-          expect(candidate).toEqual({ ip: 'foo', port: 31950 })
-          expect(apiRes).toEqual(null)
-          expect(serverRes).toEqual(null)
-          done()
-        }
-      )
+      poll([{ip: 'foo', port: 31950}], 1000, (candidate, apiRes, serverRes) => {
+        expect(candidate).toEqual({ip: 'foo', port: 31950})
+        expect(apiRes).toEqual(null)
+        expect(serverRes).toEqual(null)
+        done()
+      })
 
       jest.runTimersToTime(1000)
     },

--- a/discovery-client/src/__tests__/service-list.test.js
+++ b/discovery-client/src/__tests__/service-list.test.js
@@ -1,0 +1,96 @@
+import * as serviceList from '../service-list'
+import MOCK_SERVICE from '../__fixtures__/service'
+
+describe('serviceList', () => {
+  describe('createServiceList', () => {
+    const SPECS = [
+      {
+        name: 'returns empty array by default',
+        input: [],
+        expected: [],
+      },
+      {
+        name: 'cleans up input list',
+        input: [
+          {...MOCK_SERVICE, name: 'foo', ok: true, serverOk: false},
+          {...MOCK_SERVICE, name: 'bar', ok: false, serverOk: true},
+          {...MOCK_SERVICE, name: 'baz', ok: true, serverOk: true},
+        ],
+        expected: [
+          {...MOCK_SERVICE, name: 'foo'},
+          {...MOCK_SERVICE, name: 'bar', ip: null},
+          {...MOCK_SERVICE, name: 'baz', ip: null},
+        ],
+      },
+      {
+        name: 'removes unknown IP entries if known IP entry exists',
+        input: [MOCK_SERVICE, {...MOCK_SERVICE, ip: null}],
+        expected: [MOCK_SERVICE],
+      },
+      {
+        name: 'collapses multiple IP unknown duplicates into one',
+        input: [
+          {...MOCK_SERVICE, ip: null},
+          MOCK_SERVICE,
+          {...MOCK_SERVICE, name: 'bar', ip: null},
+          {...MOCK_SERVICE, name: 'bar', ip: null},
+        ],
+        expected: [MOCK_SERVICE, {...MOCK_SERVICE, name: 'bar', ip: null}],
+      },
+    ]
+
+    SPECS.forEach(spec => {
+      const {name, input, expected} = spec
+      const result = serviceList.createServiceList.call(null, input)
+      test(name, () => expect(result).toEqual(expected))
+    })
+  })
+
+  describe('upsertServiceList', () => {
+    const SPECS = [
+      {
+        name: 'adds service if new',
+        list: [],
+        upsert: MOCK_SERVICE,
+        expected: [MOCK_SERVICE],
+      },
+      {
+        name: 'does not add existing service',
+        list: [MOCK_SERVICE],
+        upsert: MOCK_SERVICE,
+        expected: [MOCK_SERVICE],
+      },
+      {
+        name: 'updates existing service',
+        list: [MOCK_SERVICE],
+        upsert: {...MOCK_SERVICE, ok: true, serverOk: false},
+        expected: [{...MOCK_SERVICE, ok: true, serverOk: false}],
+      },
+      {
+        name: 'does not null out ok flags of existing service',
+        list: [{...MOCK_SERVICE, ok: true, serverOk: false}],
+        upsert: MOCK_SERVICE,
+        expected: [{...MOCK_SERVICE, ok: true, serverOk: false}],
+      },
+      {
+        name: 'nulls out IP duplicates',
+        list: [
+          {...MOCK_SERVICE, name: 'bar', ok: false, serverOk: true},
+          {...MOCK_SERVICE, name: 'baz', ok: false, serverOk: true},
+        ],
+        upsert: MOCK_SERVICE,
+        expected: [
+          MOCK_SERVICE,
+          {...MOCK_SERVICE, name: 'bar', ip: null, ok: null, serverOk: null},
+          {...MOCK_SERVICE, name: 'baz', ip: null, ok: null, serverOk: null},
+        ],
+      },
+    ]
+
+    SPECS.forEach(spec => {
+      const {name, list, upsert, expected} = spec
+      const result = serviceList.upsertServiceList.call(null, list, upsert)
+      test(name, () => expect(result).toEqual(expected))
+    })
+  })
+})

--- a/discovery-client/src/__tests__/service.test.js
+++ b/discovery-client/src/__tests__/service.test.js
@@ -1,0 +1,87 @@
+// tests for service and candidate creation utils
+import cloneDeep from 'lodash/cloneDeep'
+
+import * as service from '../service'
+import MOCK_BROWSER_SERVICE from '../__fixtures__/mdns-browser-service'
+
+describe('service utils', () => {
+  describe('makeService', () => {
+    test('all info specified', () => {
+      expect(service.makeService('name', 'ip', 1234, false, false)).toEqual({
+        name: 'name',
+        ip: 'ip',
+        port: 1234,
+        ok: false,
+        serverOk: false,
+      })
+    })
+
+    test('defaults', () => {
+      expect(service.makeService('name')).toEqual(
+        expect.objectContaining({
+          ip: null,
+          port: 31950,
+          ok: null,
+          serverOk: null,
+        })
+      )
+    })
+  })
+
+  describe('makeCandidate', () => {
+    test('all info specified', () => {
+      expect(service.makeCandidate('ip', 1234)).toEqual({ip: 'ip', port: 1234})
+    })
+
+    test('defaults', () => {
+      expect(service.makeCandidate('ip')).toEqual({ip: 'ip', port: 31950})
+    })
+  })
+
+  describe('fromMdnsBrowser', () => {
+    let mdnsService
+
+    beforeEach(() => {
+      mdnsService = cloneDeep(MOCK_BROWSER_SERVICE)
+    })
+
+    test('gets name from fqdn', () => {
+      expect(service.fromMdnsBrowser(mdnsService)).toEqual(
+        service.makeService(
+          'opentrons-dev',
+          expect.anything(),
+          expect.anything()
+        )
+      )
+    })
+
+    test('with IPv4 service', () => {
+      mdnsService.addresses = [
+        'fe80::caf4:6db4:4652:e975',
+        ...mdnsService.addresses,
+      ]
+
+      expect(service.fromMdnsBrowser(mdnsService)).toEqual(
+        service.makeService('opentrons-dev', '192.168.1.42', 31950)
+      )
+    })
+
+    test('with IPv6 service', () => {
+      mdnsService.addresses = ['fe80::caf4:6db4:4652:e975']
+
+      expect(service.fromMdnsBrowser(mdnsService)).toEqual(
+        service.makeService(
+          'opentrons-dev',
+          '[fe80::caf4:6db4:4652:e975]',
+          31950
+        )
+      )
+    })
+
+    test('return null if no IP found', () => {
+      mdnsService.addresses = []
+
+      expect(service.fromMdnsBrowser(mdnsService)).toEqual(null)
+    })
+  })
+})

--- a/discovery-client/src/poller.js
+++ b/discovery-client/src/poller.js
@@ -15,6 +15,9 @@ export type PollRequest = {
   id: ?IntervalID,
 }
 
+const MIN_SUBINTERVAL_MS = 100
+const MAX_TIMEOUT_MS = 10000
+
 export function poll (
   candidates: Array<Candidate>,
   interval: number,
@@ -25,7 +28,9 @@ export function poll (
 
   log && log.debug('poller start', { interval, candidates: candidates.length })
 
-  const subInterval = interval / candidates.length
+  const subInterval = Math.max(interval / candidates.length, MIN_SUBINTERVAL_MS)
+  const timeout = Math.min(subInterval * candidates.length, MAX_TIMEOUT_MS)
+
   const id = setInterval(pollIp, subInterval)
   const request = { id }
   let current = -1
@@ -35,7 +40,7 @@ export function poll (
   function pollIp () {
     const next = getNextCandidate()
 
-    fetchHealth(next, interval, log).then(([apiRes, serverRes]) =>
+    fetchHealth(next, timeout, log).then(([apiRes, serverRes]) =>
       onHealth(next, apiRes, serverRes)
     )
   }

--- a/discovery-client/src/service-list.js
+++ b/discovery-client/src/service-list.js
@@ -1,0 +1,88 @@
+// @flow
+import {
+  makeService,
+  updateService,
+  clearServiceIfConflict,
+  matchService,
+} from './service'
+
+import type {Service, ServiceList, ServiceUpdate} from './types'
+
+export function createServiceList (list: ServiceList = []): ServiceList {
+  // strip health flags from input list
+  const nextList = list.map(s => makeService(s.name, s.ip, s.port))
+
+  return dedupeServices(nextList)
+}
+
+export function upsertServiceList (
+  list: ServiceList,
+  upsert: Service
+): ServiceList {
+  const previous: ?Service = list.find(matchService(upsert))
+  let nextList = list
+  if (!previous) nextList = nextList.concat(upsert)
+
+  nextList = nextList.map(service => {
+    // don't do anything if this is the added entry
+    if (service === upsert) return service
+    // else update previous entry if it exists
+    if (service === previous) return updateService(service, upsert)
+    // else return the service, clearing flags if it conflicts with the update
+    return clearServiceIfConflict(service, upsert)
+  })
+
+  return dedupeServices(nextList)
+}
+
+export function updateServiceListByIp (
+  list: ServiceList,
+  ip: string,
+  update: ServiceUpdate
+): ServiceList {
+  const nextList = list.map(
+    service => (service.ip === ip ? updateService(service, update) : service)
+  )
+
+  return dedupeServices(nextList)
+}
+
+export function diffServiceLists (
+  prev: ServiceList,
+  next: ServiceList
+): ServiceList {
+  // TODO(mc, 2018-10-02): this could be _way_ more optimized but these lists
+  // will never really get bigger than order of magnitude 10
+  return next.filter(service => !prev.includes(service))
+}
+
+// ensure there aren't multiple entries with the same IP and there aren't
+// multiple entries with the same name and ip: null
+function dedupeServices (list: ServiceList) {
+  const dedupeResult = list
+    .slice()
+    .sort(compareByIpExists)
+    .reduce(
+      (result, service) => {
+        const {unique, seenIps, seenNames} = result
+        const {name} = service
+        const ip = service.ip && seenIps[service.ip] ? null : service.ip
+        const cleanedService = service.ip === ip ? service : {...service, ip}
+
+        if (ip || !seenNames[name]) unique.push(cleanedService)
+        if (ip && !seenIps[ip]) seenIps[ip] = true
+        if (!seenNames[name]) seenNames[name] = true
+
+        return {unique, seenIps, seenNames}
+      },
+      {unique: [], seenIps: {}, seenNames: {}}
+    )
+
+  return dedupeResult.unique
+}
+
+function compareByIpExists (a: Service, b: Service) {
+  if (a.ip && !b.ip) return -1
+  if (!a.ip && b.ip) return 1
+  return 0
+}

--- a/discovery-client/src/service-list.js
+++ b/discovery-client/src/service-list.js
@@ -47,15 +47,6 @@ export function updateServiceListByIp (
   return dedupeServices(nextList)
 }
 
-export function diffServiceLists (
-  prev: ServiceList,
-  next: ServiceList
-): ServiceList {
-  // TODO(mc, 2018-10-02): this could be _way_ more optimized but these lists
-  // will never really get bigger than order of magnitude 10
-  return next.filter(service => !prev.includes(service))
-}
-
 // ensure there aren't multiple entries with the same IP and there aren't
 // multiple entries with the same name and ip: null
 function dedupeServices (list: ServiceList) {

--- a/discovery-client/src/service.js
+++ b/discovery-client/src/service.js
@@ -1,14 +1,13 @@
 // @flow
 // create Services from different sources
 import net from 'net'
-import type {BrowserService, ServiceType} from 'mdns-js'
+import defaultTo from 'lodash/defaultTo'
 
+import type {BrowserService, ServiceType} from 'mdns-js'
 import type {Service, ServiceUpdate, Candidate, HealthResponse} from './types'
 
 const nameExtractor = (st: ServiceType) =>
   new RegExp(`^(.+)\\._${st.name}\\._${st.protocol}`)
-
-const getOrElse = (value, orElse) => (value != null ? value : orElse)
 
 export const DEFAULT_PORT = 31950
 
@@ -38,7 +37,7 @@ export function updateService (
 
   return Object.keys(update).reduce((result, key) => {
     const prevVal = result[key]
-    const nextVal = getOrElse(next[key], prevVal)
+    const nextVal = defaultTo(next[key], prevVal)
     // $FlowFixMe: flow can't type [key]: nextVal but we know this is correct
     return nextVal !== prevVal ? {...result, [key]: nextVal} : result
   }, service)

--- a/discovery-client/src/service.js
+++ b/discovery-client/src/service.js
@@ -1,12 +1,14 @@
 // @flow
 // create Services from different sources
 import net from 'net'
-import type { BrowserService, ServiceType } from 'mdns-js'
+import type {BrowserService, ServiceType} from 'mdns-js'
 
-import type { Service, Candidate, HealthResponse } from './types'
+import type {Service, ServiceUpdate, Candidate, HealthResponse} from './types'
 
 const nameExtractor = (st: ServiceType) =>
   new RegExp(`^(.+)\\._${st.name}\\._${st.protocol}`)
+
+const getOrElse = (value, orElse) => (value != null ? value : orElse)
 
 export const DEFAULT_PORT = 31950
 
@@ -26,19 +28,46 @@ export function makeService (
   }
 }
 
+// apply known value updates (not null or undefined) to a service, returning
+// original service reference if nothing to update
+export function updateService (
+  service: Service,
+  update: ServiceUpdate
+): Service {
+  const next: Service | ServiceUpdate = update
+
+  return Object.keys(update).reduce((result, key) => {
+    const prevVal = result[key]
+    const nextVal = getOrElse(next[key], prevVal)
+    // $FlowFixMe: flow can't type [key]: nextVal but we know this is correct
+    return nextVal !== prevVal ? {...result, [key]: nextVal} : result
+  }, service)
+}
+
+// null out conflicting fields
+export function clearServiceIfConflict (
+  service: Service,
+  update: ?Service
+): Service {
+  return update && service.ip === update.ip
+    ? {...service, ip: null, ok: null, serverOk: null}
+    : service
+}
+
 export function makeCandidate (ip: string, port: ?number): Candidate {
-  return { ip, port: port || DEFAULT_PORT }
+  return {ip, port: port || DEFAULT_PORT}
 }
 
 export function fromMdnsBrowser (browserService: BrowserService): ?Service {
-  const { addresses, type, port, fullname } = browserService
+  const {addresses, type, port, fullname} = browserService
 
   if (!type || !fullname) return null
 
   let ip = addresses.find(address => net.isIPv4(address))
   if (!ip) ip = addresses.find(address => net.isIP(address))
-  if (!ip) ip = browserService.host
-  if (ip && net.isIPv6(ip)) ip = `[${ip}]`
+  if (!ip) return null
+
+  if (net.isIPv6(ip)) ip = `[${ip}]`
 
   const nameMatch = type[0] && fullname.match(nameExtractor(type[0]))
   const name = (nameMatch && nameMatch[1]) || fullname
@@ -81,15 +110,3 @@ export function toCandidate (service: Service): ?Candidate {
 
 export const matchService = (source: Service) => (target: Service) =>
   source.name === target.name && source.ip === target.ip
-
-export const matchUnassigned = (source: Service) => (target: Service) =>
-  source.name === target.name && target.ip === null
-
-export const matchConflict = (source: Service) => (target: Service) =>
-  source.ok && source.name !== target.name && source.ip === target.ip
-
-export const matchCandidate = (source: Service) => (target: Candidate) =>
-  source.ok && source.ip === target.ip
-
-export const rejectCandidate = (source: Service) => (target: Candidate) =>
-  !source.ok || source.ip !== target.ip

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -15,6 +15,10 @@ export type Service = {
   serverOk: ?boolean,
 }
 
+export type ServiceUpdate = $Shape<Service>
+
+export type ServiceList = Array<Service>
+
 // TODO(mc, 2018-07-26): grab common logger type from app and app-shell
 export type LogLevel =
   | 'error'


### PR DESCRIPTION
## overview

Bug report + fix

Internal users reported strange discovery-client bugs where the standalone CLI discovery-client was able to find robots but the app was unable. We were able to track this down to a problem with the app's cached discovery lists.

This PR updates the DC to sanitize its input list of known services (where the app's cache is passed in) and do continue to dedupe the list whenever it is updated. As a result, we have an actual guarantee that `client.services` will only ever:

- Have a single entry per IP
- Have a single entry where `ip: null` for a given `name`

## changelog

- fix(discovery-client): Ensure IPs are actually de-duped 

## review requests

Make sure the discovery list behaves in both the CLI and the app. Things that have tripped us up in the past:

- Discovery health state latching when it shouldn't
- Duplicate IPs showing up in app's cache (`$APP_DATA/Opentrons/discovery.json`)
    - Especially for USB robots