### PR TITLE
feat(app): Only display instrument settings for selected robot

### DIFF
--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -1,14 +1,14 @@
 // @flow
 // item in a RobotList
-import { connect } from 'react-redux'
-import { withRouter, type Match } from 'react-router'
+import {connect} from 'react-redux'
+import {withRouter, type Match} from 'react-router'
 
-import type { State, Dispatch } from '../../types'
-import type { Robot } from '../../robot'
-import { actions as robotActions } from '../../robot'
-import { makeGetRobotUpdateInfo } from '../../http-api-client'
+import type {State, Dispatch} from '../../types'
+import type {Robot} from '../../robot'
+import {actions as robotActions} from '../../robot'
+import {makeGetRobotUpdateInfo} from '../../http-api-client'
 
-import { RobotListItem } from './RobotListItem.js'
+import {RobotListItem} from './RobotListItem.js'
 
 type OP = Robot & {
   match: Match,

--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -1,19 +1,22 @@
 // @flow
 // item in a RobotList
-import {connect} from 'react-redux'
-import {withRouter} from 'react-router'
+import { connect } from 'react-redux'
+import { withRouter, type Match } from 'react-router'
 
-import type {State, Dispatch} from '../../types'
-import type {Robot} from '../../robot'
-import {actions as robotActions} from '../../robot'
-import {makeGetRobotUpdateInfo} from '../../http-api-client'
+import type { State, Dispatch } from '../../types'
+import type { Robot } from '../../robot'
+import { actions as robotActions } from '../../robot'
+import { makeGetRobotUpdateInfo } from '../../http-api-client'
 
-import {RobotListItem} from './RobotList.js'
+import { RobotListItem } from './RobotListItem.js'
 
-type OP = Robot
+type OP = Robot & {
+  match: Match,
+}
 
 type SP = {
   upgradable: boolean,
+  selected: boolean,
 }
 
 type DP = {
@@ -22,7 +25,10 @@ type DP = {
 }
 
 export default withRouter(
-  connect(makeMapStateToProps, mapDispatchToProps)(RobotListItem)
+  connect(
+    makeMapStateToProps,
+    mapDispatchToProps
+  )(RobotListItem)
 )
 
 function makeMapStateToProps () {
@@ -30,6 +36,7 @@ function makeMapStateToProps () {
 
   return (state: State, ownProps: OP): SP => ({
     upgradable: getUpdateInfo(state, ownProps).type === 'upgrade',
+    selected: ownProps.match.params.name === ownProps.name,
   })
 }
 

--- a/app/src/components/ConnectPanel/RobotList.js
+++ b/app/src/components/ConnectPanel/RobotList.js
@@ -1,77 +1,12 @@
 // @flow
 // list of robots
 import * as React from 'react'
-
-import {
-  NotificationIcon,
-  Icon,
-} from '@opentrons/components'
-
-import type {Robot} from '../../robot'
-import {ToggleButton} from '../controls'
-import RobotLink from './RobotLink'
 import styles from './connect-panel.css'
 
 type ListProps = {
   children: React.Node,
 }
 
-type ItemProps = Robot & {
-  upgradable: ?string,
-  connect: () => mixed,
-  disconnect: () => mixed,
-}
-
 export default function RobotList (props: ListProps) {
-  return (
-    <ol className={styles.robot_list}>
-      {props.children}
-    </ol>
-  )
-}
-
-export function RobotListItem (props: ItemProps) {
-  const {name, wired, isConnected, upgradable, connect, disconnect} = props
-  const onClick = isConnected
-    ? disconnect
-    : connect
-
-  return (
-    <li className={styles.robot_group}>
-      <RobotLink
-        url={`/robots/${name}`}
-        className={styles.robot_item}
-        exact
-      >
-        <NotificationIcon
-          name={wired ? 'usb' : 'wifi'}
-          className={styles.robot_item_icon}
-          childName={upgradable ? 'circle' : null}
-          childClassName={styles.notification}
-        />
-
-        <p className={styles.link_text}>
-          {name}
-        </p>
-
-        <ToggleButton
-          toggledOn={isConnected}
-          onClick={onClick}
-          className={styles.robot_item_icon}
-        />
-      </RobotLink>
-      <RobotLink
-        url={`/robots/${name}/instruments`}
-        className={styles.instrument_item}
-      >
-        <p className={styles.link_text}>
-          Pipettes & Modules
-        </p>
-        <Icon
-          name='chevron-right'
-          className={styles.robot_item_icon}
-        />
-      </RobotLink>
-    </li>
-  )
+  return <ol className={styles.robot_list}>{props.children}</ol>
 }

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -1,0 +1,59 @@
+// @flow
+// list of robots
+import * as React from 'react'
+import { NotificationIcon, Icon } from '@opentrons/components'
+
+import type { Robot } from '../../robot'
+import { ToggleButton } from '../controls'
+import RobotLink from './RobotLink'
+import styles from './connect-panel.css'
+
+type ItemProps = Robot & {
+  upgradable: ?string,
+  selected: boolean,
+  connect: () => mixed,
+  disconnect: () => mixed,
+}
+
+export function RobotListItem (props: ItemProps) {
+  const {
+    name,
+    wired,
+    selected,
+    isConnected,
+    upgradable,
+    connect,
+    disconnect,
+  } = props
+  const onClick = isConnected ? disconnect : connect
+
+  return (
+    <li className={styles.robot_group}>
+      <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+        <NotificationIcon
+          name={wired ? 'usb' : 'wifi'}
+          className={styles.robot_item_icon}
+          childName={upgradable ? 'circle' : null}
+          childClassName={styles.notification}
+        />
+
+        <p className={styles.link_text}>{name}</p>
+
+        <ToggleButton
+          toggledOn={isConnected}
+          onClick={onClick}
+          className={styles.robot_item_icon}
+        />
+      </RobotLink>
+      {selected && (
+        <RobotLink
+          url={`/robots/${name}/instruments`}
+          className={styles.instrument_item}
+        >
+          <p className={styles.link_text}>Pipettes & Modules</p>
+          <Icon name="chevron-right" className={styles.robot_item_icon} />
+        </RobotLink>
+      )}
+    </li>
+  )
+}

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -1,10 +1,10 @@
 // @flow
 // list of robots
 import * as React from 'react'
-import { NotificationIcon, Icon } from '@opentrons/components'
+import {NotificationIcon, Icon} from '@opentrons/components'
 
-import type { Robot } from '../../robot'
-import { ToggleButton } from '../controls'
+import type {Robot} from '../../robot'
+import {ToggleButton} from '../controls'
 import RobotLink from './RobotLink'
 import styles from './connect-panel.css'
 

--- a/app/src/pages/SidePanel.js
+++ b/app/src/pages/SidePanel.js
@@ -12,7 +12,7 @@ import RunPanel from '../components/RunPanel'
 export default function NavPanel () {
   return (
     <Switch>
-      <Route path='/robots' component={ConnectPanel} />
+      <Route path='/robots/:name?' component={ConnectPanel} />
       <Route path='/menu' component={MenuPanel} />
       <Route path='/upload' component={UploadPanel} />
       <Route path='/calibrate' component={CalibratePanel} />


### PR DESCRIPTION
## overview

This PR closes #2362 by only showing the `Pipettes and Modules` link for selected robots in the `RobotList`.

<img width="1026" alt="screen shot 2018-10-02 at 3 54 22 pm" src="https://user-images.githubusercontent.com/3430313/46373250-7c07a700-c65b-11e8-83f5-5b1e1d6b9db4.png">

*note: The ticket says only show sublink for connectable robots. A follow up PR will put this logic in once we have the concept of advertising but not connectable in DC.*

## changelog

- feat(app): Only display instrument settings for selected robot

## review requests

Standard review. I pulled out `RobotListItem` into its own file for clarity's sake.

Sorry for the style diffs, I installed Prettier atom plugin and it added the spaces to import { ... }

- [ ] Pipettes and Modules 'sublink' only shows up under the currently selected robot
- [ ] Pipettes and Modules link still works when visible + clicked