### PR TITLE
chore(api): Add README on using generator function

### DIFF
--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -1,0 +1,164 @@
+# Overview
+
+This is a simple browser tool which can be used to generate labware definitions for _regular_ labware.
+In the coming months, we will be adding more features to the GUI as well as the ability to generate definitions
+for _irregular_ labware.
+
+### What is a 'regular' labware?
+
+* A labware in which the grid shape is uniform
+..* No uneven number of rows or columns
+* Spacing between columns and rows remains consistent throughout the labware
+* The overall height remains consistent throughout the labware
+
+## Launching the Tool
+First you should make sure that you run `make install` within the `/opentrons` top level folder.
+If you are up-to-date on all other directories you can simply run `yarn` instead.
+Next you have two options:
+1. From the top level folder type: `make -C labware-designer dev`
+2. Open your browser and type in: `localhost:8080`
+OR
+1. Type `make build` within the `opentrons/labware-designer` folder
+2. Open `labware-designer/dist/index.html` in your browser
+
+Once you have the browser page open, you should be able to go to the browser console.
+* Right Click to find the `inspector` or use whichever shortcut you may have associated with this
+
+When you are in the console, you can use the global variable `sharedData` and use any public functions
+which are exported in that project.
+
+## What function do I need to use?
+The generator function is called `createRegularLabware()`. You can use it in the browser
+by typing `sharedData.createRegularLabware(input)`
+
+### What data is needed?
+It takes in an `input` object of the following shape:
+input = {
+  metadata,
+  parameters,
+  offset,
+  dimensions,
+  grid,
+  spacing,
+  well,
+  vendor,
+}
+
+The above inputs are all required except for `vendor`. Each individual input has the following shape(s).
+Variables in bold signify that they are required, those in italics are optional.
+
+metadata = {
+  **name**: string,
+  **displayCategory**: string,
+  _displayVolumeUnits_: string,
+  _displayLengthUnits_: string,
+}
+* Name is what you choose to refer to the container as (i.e.) `96-flat`
+* displayCategory is what category the container type falls into. There are currently five options:
+..* wellPlate
+..* tuberack
+..* tiprack
+..* trough
+..* trash
+
+parameters = {
+  **format**: string,
+  **isTiprack**: boolean,
+  _tipLength_: number,
+}
+* Format is used to determine how a multichannel pipette may (or may not) interact with this labware.
+There are currently four categories
+..* irregular (any type of container a multichannel cannot access -- most tuberacks, irregular labware etc)
+..* 96Standard (any container in a 96 format: well plate or tiprack)
+..* 384Standard (any container in a 96 format: well plate or tiprack)
+..* trough
+
+well = {
+  **depth**: number,
+  **shape**: string,
+  _diameter_: number,
+  _length_: number,
+  _width_: number,
+  _totalLiquidVolume_: number,
+}
+* depth is how deep a given well is
+* shape is what type of well you are dealing with. Currently there are two options:
+..* circular (if of this shape, diameter is required)
+..* rectangular (if of this shape, width and length is required)
+
+grid = {
+  **row**: number,
+  **column**: number,
+}
+* Grid is the number of rows and columns in a given labware
+
+spacing = {
+  **row**: number,
+  **column**: number,
+}
+* Spacing is the center to center distance of wells between rows and columns
+
+offset = {
+  **x**: number,
+  **y**: number,
+  **z**: number,
+}
+* Offset is taken from the top left corner of a container to well `A1`.
+
+## Output
+The output of your data should look something to the affect of this JSON below:
+```
+{
+  "otId": "mock-id",
+  "deprecated": false,
+  "metadata": {
+    "name": "fake labware",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "uL",
+    "displayLengthUnits": "mm"
+  },
+  "vendor": {
+    "sku": "t40u9sernisofsea",
+    "vendor": "opentrons"
+  },
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": false
+  },
+  "cornerOffsetFromSlot": {
+    "x": 10,
+    "y": 10,
+    "z": 5
+  },
+  "dimensions": {
+    "overallLength": 50,
+    "overallWidth": 50,
+    "overallHeight": 50
+  },
+  "ordering": [["A1"], ["A2"]],
+  "wells": {
+    "A1": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    },
+    "A2": {
+      "depth": 40,
+      "totalLiquidVolume": 100,
+      "diameter": 30,
+      "x": 10,
+      "y": 0,
+      "z": 0,
+      "shape": "circular"
+    }
+  }
+}
+```
+
+
+To make the data easier to copy from the browser, simply use the `stringify` function.
+It would look something to the effect of: `JSON.stringify(output)`

--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -17,7 +17,9 @@ If you are up-to-date on all other directories you can simply run `yarn` instead
 Next you have two options:
 1. From the top level folder type: `make -C labware-designer dev`
 2. Open your browser and type in: `localhost:8080`
+
 OR
+
 1. Type `make build` within the `opentrons/labware-designer` folder
 2. Open `labware-designer/dist/index.html` in your browser
 

--- a/shared-data/js/labwareTools/assignId.js
+++ b/shared-data/js/labwareTools/assignId.js
@@ -1,7 +1,7 @@
 // @flow
 import uuidv1 from 'uuid/v1'
 
-function assignId () {
+function assignId (): string {
   return uuidv1()
 }
 

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -28,7 +28,6 @@ type Params = {
   format: string,
   isTiprack: boolean,
   tipLength?: number,
-  wellShape?: string,
 }
 
 type Well = {
@@ -62,7 +61,7 @@ export type RegularLabwareProps = {
   vendor?: Vendor,
 }
 
-type Schema = {
+export type Schema = {
   otId: string,
   deprecated: boolean,
   metadata: Metadata,
@@ -90,21 +89,18 @@ function calculateCoordinates (
   well: Well,
   ordering: Array<Array<string>>,
   spacing: Cell): {[wellName: string]: Well} {
-  let wells = {}
-
   // Note, reverse() on its own mutates ordering. Use slice() as a workaround
   // to prevent mutation
-  ordering.forEach(function (subarray, cIndex) {
-    subarray.slice().reverse().forEach(function (element, rIndex) {
+  return ordering.reduce((wells, column, cIndex) => {
+    column.slice().reverse().forEach((element, rIndex) => {
       wells[element] = {
         ...well,
         x: round(cIndex * spacing.column, 2),
         y: round(rIndex * spacing.row, 2),
         z: 0}
     })
-  })
-
-  return wells
+    return wells
+  }, {})
 }
 
 // Generator function for labware definitions within a regular grid format

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -12,20 +12,25 @@
   "required": ["otId","deprecated","metadata","parameters","cornerOffsetFromSlot","ordering","dimensions","wells"],
   "properties": {
     "otId": {
+      "description": "Unique internal ID generated using UUID",
       "type": "string"
     },
     "deprecated": {
+      "description": "Flag specifying whether a labware is deprecated or not",
       "type": "boolean"
     },
     "metadata": {
       "type": "object",
+      "description": "Properties used for searchability",
       "additionalProperties": false,
       "required": ["name", "displayCategory"],
       "properties": {
         "name": {
+          "description": "Easy to remember name of labware",
           "type": "string"
         },
         "displayCategory": {
+          "description": "Label used in UI to categorize labware",
           "type": "string"
         },
         "displayLengthUnits": {
@@ -38,6 +43,7 @@
     },
     "vendor": {
       "type": "object",
+      "description": "Also for searchability, so that users know exactly which labware this was modeled off",
       "additionalProperties": false,
       "properties": {
         "sku": {
@@ -51,16 +57,20 @@
     },
     "parameters": {
       "type": "object",
+      "description": "Internal describers used to determine pipette movement to labware",
       "additionalProperties": false,
       "required": ["format", "isTiprack"],
       "properties": {
         "format": {
+          "description": "Property to determine compatibility with multichannel pipette",
           "type": "string"
         },
         "isTiprack": {
+          "description": "Flag marking whether a container is a tiprack or not",
           "type": "boolean"
         },
         "tipLength": {
+          "description": "Required if container is tiprack",
           "$ref": "#/definitions/positiveNumber"
         }
       }
@@ -68,7 +78,7 @@
     },
     "ordering": {
       "type": "array",
-      "description": "",
+      "description": "Generated array that keeps track of how wells should be ordered in a container",
       "items": {
         "type": "array",
         "items": {
@@ -79,6 +89,7 @@
     "cornerOffsetFromSlot": {
       "type": "object",
       "additionalProperties": false,
+      "description": "XYZ values from top left corner of container to well A1",
       "required": ["x", "y", "z"],
       "properties": {
         "x": {"type": "number"},
@@ -90,6 +101,7 @@
     "dimensions": {
       "type": "object",
       "additionalProperties": false,
+      "description": "Outer dimensions of a container",
       "required": ["overallWidth", "overallHeight", "overallLength"],
       "properties": {
         "overallWidth": {
@@ -106,6 +118,7 @@
     },
     "wells": {
       "type": "object",
+      "description": "Unordered object of well objects with calculated XYZ",
       "patternProperties": {
         "['A' - 'Z'][*]": {
           "type": "object",

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -21,7 +21,7 @@
     },
     "metadata": {
       "type": "object",
-      "description": "Properties used for searchability",
+      "description": "Properties used for search and display",
       "additionalProperties": false,
       "required": ["name", "displayCategory"],
       "properties": {
@@ -63,14 +63,15 @@
       "properties": {
         "format": {
           "description": "Property to determine compatibility with multichannel pipette",
-          "type": "string"
+          "type": "string",
+          "enum": ["96Standard", "384Standard", "trough", "irregular"]
         },
         "isTiprack": {
-          "description": "Flag marking whether a container is a tiprack or not",
+          "description": "Flag marking whether a labware is a tiprack or not",
           "type": "boolean"
         },
         "tipLength": {
-          "description": "Required if container is tiprack",
+          "description": "Required if labware is tiprack",
           "$ref": "#/definitions/positiveNumber"
         }
       }
@@ -78,7 +79,7 @@
     },
     "ordering": {
       "type": "array",
-      "description": "Generated array that keeps track of how wells should be ordered in a container",
+      "description": "Generated array that keeps track of how wells should be ordered in a labware",
       "items": {
         "type": "array",
         "items": {
@@ -89,7 +90,7 @@
     "cornerOffsetFromSlot": {
       "type": "object",
       "additionalProperties": false,
-      "description": "XYZ values from top left corner of container to well A1",
+      "description": "XYZ values from top left corner of slot to well A1",
       "required": ["x", "y", "z"],
       "properties": {
         "x": {"type": "number"},
@@ -101,7 +102,7 @@
     "dimensions": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Outer dimensions of a container",
+      "description": "Outer dimensions of a labware",
       "required": ["overallWidth", "overallHeight", "overallLength"],
       "properties": {
         "overallWidth": {
@@ -118,7 +119,7 @@
     },
     "wells": {
       "type": "object",
-      "description": "Unordered object of well objects with calculated XYZ",
+      "description": "Unordered object of well objects with position and dimensional information",
       "patternProperties": {
         "['A' - 'Z'][*]": {
           "type": "object",
@@ -133,6 +134,7 @@
                     {"required": ["diameter", "length"]}
           ]},
           "properties": {
+            "description": "XYZ calculated from bottom-left corner of slot to top-center of the well",
             "depth": {"$ref": "#/definitions/positiveNumber"},
             "x": {"$ref": "#/definitions/positiveNumber"},
             "y": {"$ref": "#/definitions/positiveNumber"},
@@ -142,6 +144,7 @@
             "length": {"$ref": "#/definitions/positiveNumber"},
             "diameter": {"$ref": "#/definitions/positiveNumber"},
             "shape": {
+              "description": "If rectangular, use length and width; otherwise use diameter",
               "type": "string",
               "enum": ["rectangular", "circular"]
             }

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -134,9 +134,10 @@
                     {"required": ["diameter", "length"]}
           ]},
           "properties": {
-            "description": "XYZ calculated from bottom-left corner of slot to top-center of the well",
             "depth": {"$ref": "#/definitions/positiveNumber"},
-            "x": {"$ref": "#/definitions/positiveNumber"},
+            "x": {
+              "description": "XYZ calculated from bottom-left corner of slot to top-center of the well",
+              "$ref": "#/definitions/positiveNumber"},
             "y": {"$ref": "#/definitions/positiveNumber"},
             "z": {"$ref": "#/definitions/positiveNumber"},
             "totalLiquidVolume": {"$ref": "#/definitions/positiveNumber"},


### PR DESCRIPTION
## overview
Closes #2382. This PR is meant to add more detail on how to use the generator, and what each term in the schema actually represents.

## changelog
- Adds descriptive README in `labware-designer` on how to use the generator function in the browser
- Addresses changes previously requested by @mcous 
- Adds descriptors to keys in the labware schema

## review requests
Let me know if anything looks confusing!