### PR TITLE
fix(discovery-client): Monkeypatch uncatchable throw in mdns-js

### DIFF
--- a/discovery-client/__mocks__/mdns-js.js
+++ b/discovery-client/__mocks__/mdns-js.js
@@ -20,4 +20,6 @@ const __mockReset = () => {
   createBrowser.mockReturnValue(__mockBrowser)
 }
 
-module.exports = {tcp, createBrowser, __mockBrowser, __mockReset}
+const ServiceType = function () {}
+
+module.exports = {tcp, createBrowser, ServiceType, __mockBrowser, __mockReset}

--- a/discovery-client/src/index.js
+++ b/discovery-client/src/index.js
@@ -4,11 +4,11 @@
 
 import EventEmitter from 'events'
 import escape from 'escape-string-regexp'
-import mdns from 'mdns-js'
 import toRegex from 'to-regex'
 import differenceBy from 'lodash/differenceBy'
 import xorBy from 'lodash/xorBy'
 
+import MdnsBrowser from './mdns-browser'
 import {poll, stop, type PollRequest} from './poller'
 import {
   createServiceList,
@@ -178,8 +178,7 @@ export class DiscoveryClient extends EventEmitter {
   _startBrowser (): void {
     this._stopBrowser()
 
-    const browser = mdns
-      .createBrowser(mdns.tcp('http'))
+    const browser = MdnsBrowser()
       .once('ready', () => browser.discover())
       .on('update', service => this._handleUp(service))
       .on('error', error => this.emit('error', error))

--- a/discovery-client/src/mdns-browser.js
+++ b/discovery-client/src/mdns-browser.js
@@ -1,0 +1,23 @@
+// @flow
+// mdns browser wrapper
+import mdns, {ServiceType} from 'mdns-js'
+import type {Browser} from 'mdns-js'
+
+monkeyPatchThrowers()
+
+export default function MdnsBrowser (): Browser {
+  return mdns.createBrowser(mdns.tcp('http'))
+}
+
+function monkeyPatchThrowers () {
+  // this method can throw (without emitting), so we need to patch this up
+  const originalServiceTypeFromString = ServiceType.prototype.fromString
+
+  ServiceType.prototype.fromString = function (...args) {
+    try {
+      originalServiceTypeFromString.apply(this, args)
+    } catch (error) {
+      console.warn(error)
+    }
+  }
+}

--- a/flow-typed/npm/mdns-js_v1.0.x.js
+++ b/flow-typed/npm/mdns-js_v1.0.x.js
@@ -17,18 +17,19 @@ declare module 'mdns-js' {
   }
 
   declare module.exports: {
-    createBrowser: (serviceType: ServiceType) => Browser,
-    tcp: (type: string) => ServiceType
+    createBrowser: (serviceType: MdnsServiceType) => Browser,
+    tcp: (type: string) => MdnsServiceType,
+    ServiceType: any
   }
 
   declare type Browser = mdns$Browser
 
-  declare type ServiceType = mdns$ServiceType
+  declare type MdnsServiceType = mdns$ServiceType
 
   declare type BrowserService = {
     addresses: Array<string>,
     query: Array<string>,
-    type?: Array<ServiceType>,
+    type?: Array<MdnsServiceType>,
     txt?: Array<string>,
     port?: number,
     fullname?: string,


### PR DESCRIPTION
## overview

Bug report + fix.

We use the [`mdns-js`](https://github.com/mdns-js/node-mdns-js) library as out underlying mDNS client for robot discovery. It turns out, this module asyncronously (i.e. uncatchably) throws instead of emitting an error when it encounters a TLD in an advertisement name it doesn't expect (mdns-js/node-mdns-js#78). `mdns-js` only expects a TLD of `.local`.

From user reports, there are definitely devices out in the wild (not our robots) that advertise with TLDs that are not `.local`, and because of the throw, if one of those devices is on the network, the `discovery` client CLI will die on the uncaught throw.

## changelog

- fix(discovery-client): Monkeypatch async throw in mdns-js

## review requests

- [ ] Nothing weird and crazy starts happening with discovery
- [x] Error is successfully caught (setup for this test is annoying, so if you're curious I can show you on my machine)