### PR TITLE
feat(app): App display unreachable robots

### DIFF
--- a/app/src/components/ConnectPanel/RobotLink.js
+++ b/app/src/components/ConnectPanel/RobotLink.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import {NavLink} from 'react-router-dom'
 
+import type {HoverTooltipHandlers} from '@opentrons/components'
 import cx from 'classnames'
 import styles from './connect-panel.css'
 
@@ -11,19 +12,25 @@ type LinkProps = {
   url: string,
   className?: string,
   activeClassName?: string,
+  disabled: boolean,
+  hoverTooltipHandlers?: ?HoverTooltipHandlers,
 }
 
 export default function RobotLink (props: LinkProps) {
   const {url} = props
-  const className = cx(styles.robot_link, props.className)
+  const className = cx(styles.robot_link, props.className, {
+    [styles.disabled]: props.isabled,
+  })
   return (
-    <NavLink
-      to={url}
-      className={className}
-      activeClassName={styles.active}
-      exact
-    >
-      {props.children}
-    </NavLink>
+    <div className={styles.robot_link_wrapper} {...props.hoverTooltipHandlers}>
+      <NavLink
+        to={url}
+        className={className}
+        activeClassName={styles.active}
+        exact
+      >
+        {props.children}
+      </NavLink>
+    </div>
   )
 }

--- a/app/src/components/ConnectPanel/RobotLink.js
+++ b/app/src/components/ConnectPanel/RobotLink.js
@@ -12,14 +12,14 @@ type LinkProps = {
   url: string,
   className?: string,
   activeClassName?: string,
-  disabled: boolean,
   hoverTooltipHandlers?: ?HoverTooltipHandlers,
+  disabled?: boolean,
 }
 
 export default function RobotLink (props: LinkProps) {
   const {url} = props
   const className = cx(styles.robot_link, props.className, {
-    [styles.disabled]: props.isabled,
+    [styles.disabled]: props.disabled,
   })
   return (
     <div className={styles.robot_link_wrapper} {...props.hoverTooltipHandlers}>

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -1,7 +1,7 @@
 // @flow
 // list of robots
 import * as React from 'react'
-import {NotificationIcon, Icon} from '@opentrons/components'
+import {NotificationIcon, Icon, HoverTooltip} from '@opentrons/components'
 
 import type {Robot} from '../../robot'
 import {ToggleButton} from '../controls'
@@ -29,22 +29,34 @@ export function RobotListItem (props: ItemProps) {
 
   return (
     <li className={styles.robot_group}>
-      <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
-        <NotificationIcon
-          name={wired ? 'usb' : 'wifi'}
-          className={styles.robot_item_icon}
-          childName={upgradable ? 'circle' : null}
-          childClassName={styles.notification}
-        />
+      <HoverTooltip
+        tooltipComponent={<div>Unable to locate this robot</div>}
+        placement="bottom"
+      >
+        {hoverTooltipHandlers => (
+          <RobotLink
+            url={`/robots/${name}`}
+            className={styles.robot_item}
+            exact
+            hoverTooltipHandlers={hoverTooltipHandlers}
+          >
+            <NotificationIcon
+              name={wired ? 'usb' : 'wifi'}
+              className={styles.robot_item_icon}
+              childName={upgradable ? 'circle' : null}
+              childClassName={styles.notification}
+            />
 
-        <p className={styles.link_text}>{name}</p>
+            <p className={styles.link_text}>{name}</p>
 
-        <ToggleButton
-          toggledOn={isConnected}
-          onClick={onClick}
-          className={styles.robot_item_icon}
-        />
-      </RobotLink>
+            <ToggleButton
+              toggledOn={isConnected}
+              onClick={onClick}
+              className={styles.robot_item_icon}
+            />
+          </RobotLink>
+        )}
+      </HoverTooltip>
       {selected && (
         <RobotLink
           url={`/robots/${name}/instruments`}
@@ -55,5 +67,66 @@ export function RobotListItem (props: ItemProps) {
         </RobotLink>
       )}
     </li>
+  )
+}
+
+export function ConnectableRobot (props: ItemProps) {
+  return (
+    <React.Fragment>
+      <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+        <NotificationIcon
+          name={props.wired ? 'usb' : 'wifi'}
+          className={styles.robot_item_icon}
+          childName={props.upgradable ? 'circle' : null}
+          childClassName={styles.notification}
+        />
+
+        <p className={styles.link_text}>{name}</p>
+
+        <ToggleButton
+          toggledOn={props.isConnected}
+          onClick={props.onClick}
+          className={styles.robot_item_icon}
+        />
+      </RobotLink>
+      {props.selected && (
+        <RobotLink
+          url={`/robots/${name}/instruments`}
+          className={styles.instrument_item}
+        >
+          <p className={styles.link_text}>Pipettes & Modules</p>
+          <Icon name="chevron-right" className={styles.robot_item_icon} />
+        </RobotLink>
+      )}
+    </React.Fragment>
+  )
+}
+
+export function ReachableRobot (props: ItemProps) {
+  return (
+    <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+      <Icon
+        name={props.wired ? 'usb' : 'wifi'}
+        className={styles.robot_item_icon}
+      />
+
+      <p className={styles.link_text}>{name}</p>
+
+      <Icon name="chevron-right" className={styles.robot_item_icon} />
+    </RobotLink>
+  )
+}
+
+export function UnreachableRobot (props: ItemProps) {
+  return (
+    <RobotLink
+      url={`/robots/${name}`}
+      className={styles.robot_item}
+      exact
+      disabled
+    >
+      <Icon name={'alert'} className={styles.robot_item_icon} disabled />
+      <p className={styles.link_text}>{name}</p>
+    </RobotLink>
   )
 }

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -1,7 +1,7 @@
 // @flow
 // list of robots
 import * as React from 'react'
-import {NotificationIcon, Icon, HoverTooltip} from '@opentrons/components'
+import {NotificationIcon, Icon} from '@opentrons/components'
 
 import type {Robot} from '../../robot'
 import {ToggleButton} from '../controls'
@@ -26,107 +26,96 @@ export function RobotListItem (props: ItemProps) {
     disconnect,
   } = props
   const onClick = isConnected ? disconnect : connect
-
   return (
     <li className={styles.robot_group}>
-      <HoverTooltip
-        tooltipComponent={<div>Unable to locate this robot</div>}
-        placement="bottom"
-      >
-        {hoverTooltipHandlers => (
+      <React.Fragment>
+        <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+          <NotificationIcon
+            name={wired ? 'usb' : 'wifi'}
+            className={styles.robot_item_icon}
+            childName={upgradable ? 'circle' : null}
+            childClassName={styles.notification}
+          />
+
+          <p className={styles.link_text}>{name}</p>
+
+          <ToggleButton
+            toggledOn={isConnected}
+            onClick={onClick}
+            className={styles.robot_item_icon}
+          />
+        </RobotLink>
+        {selected && (
           <RobotLink
-            url={`/robots/${name}`}
-            className={styles.robot_item}
-            exact
-            hoverTooltipHandlers={hoverTooltipHandlers}
+            url={`/robots/${name}/instruments`}
+            className={styles.instrument_item}
           >
-            <NotificationIcon
-              name={wired ? 'usb' : 'wifi'}
-              className={styles.robot_item_icon}
-              childName={upgradable ? 'circle' : null}
-              childClassName={styles.notification}
-            />
-
-            <p className={styles.link_text}>{name}</p>
-
-            <ToggleButton
-              toggledOn={isConnected}
-              onClick={onClick}
-              className={styles.robot_item_icon}
-            />
+            <p className={styles.link_text}>Pipettes & Modules</p>
+            <Icon name="chevron-right" className={styles.robot_item_icon} />
           </RobotLink>
         )}
-      </HoverTooltip>
-      {selected && (
-        <RobotLink
-          url={`/robots/${name}/instruments`}
-          className={styles.instrument_item}
-        >
-          <p className={styles.link_text}>Pipettes & Modules</p>
-          <Icon name="chevron-right" className={styles.robot_item_icon} />
-        </RobotLink>
-      )}
+      </React.Fragment>
     </li>
   )
 }
 
-export function ConnectableRobot (props: ItemProps) {
-  return (
-    <React.Fragment>
-      <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
-        <NotificationIcon
-          name={props.wired ? 'usb' : 'wifi'}
-          className={styles.robot_item_icon}
-          childName={props.upgradable ? 'circle' : null}
-          childClassName={styles.notification}
-        />
+// TODO (ka 2018-10-5): Separate Connectable and Reachable Robots
+// export function ConnectableRobot (props: ItemProps) {
+// const {
+//   name,
+//   wired,
+//   selected,
+//   isConnected,
+//   upgradable,
+//   connect,
+//   disconnect,
+// } = props
+// const onClick = isConnected ? disconnect : connect
+//   return (
+//     <React.Fragment>
+//       <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+//         <NotificationIcon
+//           name={wired ? 'usb' : 'wifi'}
+//           className={styles.robot_item_icon}
+//           childName={upgradable ? 'circle' : null}
+//           childClassName={styles.notification}
+//         />
+//
+//         <p className={styles.link_text}>{name}</p>
+//
+//         <ToggleButton
+//           toggledOn={isConnected}
+//           onClick={onClick}
+//           className={styles.robot_item_icon}
+//         />
+//       </RobotLink>
+//       {selected && (
+//         <RobotLink
+//           url={`/robots/${name}/instruments`}
+//           className={styles.instrument_item}
+//         >
+//           <p className={styles.link_text}>Pipettes & Modules</p>
+//           <Icon name="chevron-right" className={styles.robot_item_icon} />
+//         </RobotLink>
+//       )}
+//     </React.Fragment>
+//   )
+// }
 
-        <p className={styles.link_text}>{name}</p>
-
-        <ToggleButton
-          toggledOn={props.isConnected}
-          onClick={props.onClick}
-          className={styles.robot_item_icon}
-        />
-      </RobotLink>
-      {props.selected && (
-        <RobotLink
-          url={`/robots/${name}/instruments`}
-          className={styles.instrument_item}
-        >
-          <p className={styles.link_text}>Pipettes & Modules</p>
-          <Icon name="chevron-right" className={styles.robot_item_icon} />
-        </RobotLink>
-      )}
-    </React.Fragment>
-  )
-}
-
-export function ReachableRobot (props: ItemProps) {
-  return (
-    <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
-      <Icon
-        name={props.wired ? 'usb' : 'wifi'}
-        className={styles.robot_item_icon}
-      />
-
-      <p className={styles.link_text}>{name}</p>
-
-      <Icon name="chevron-right" className={styles.robot_item_icon} />
-    </RobotLink>
-  )
-}
-
-export function UnreachableRobot (props: ItemProps) {
-  return (
-    <RobotLink
-      url={`/robots/${name}`}
-      className={styles.robot_item}
-      exact
-      disabled
-    >
-      <Icon name={'alert'} className={styles.robot_item_icon} disabled />
-      <p className={styles.link_text}>{name}</p>
-    </RobotLink>
-  )
-}
+// export function ReachableRobotItem (props: ReachableProps) {
+//   const {name, wired, upgradable} = props
+//   return (
+//     <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
+//       <NotificationIcon
+//         name={wired ? 'usb' : 'wifi'}
+//         className={styles.robot_item_icon}
+//         childName={upgradable ? 'circle' : null}
+//         childClassName={styles.notification}
+//       />
+//
+//       <p className={styles.link_text}>{name}</p>
+//
+//       <Icon name="chevron-right" className={styles.robot_item_icon} />
+//     </RobotLink>
+//   )
+// }

--- a/app/src/components/ConnectPanel/UnreachableRobotItem.js
+++ b/app/src/components/ConnectPanel/UnreachableRobotItem.js
@@ -1,0 +1,36 @@
+// @flow
+// list of robots
+import * as React from 'react'
+import type {UnreachableRobot} from '../../discovery'
+import {Icon, HoverTooltip} from '@opentrons/components'
+import RobotLink from './RobotLink'
+import styles from './connect-panel.css'
+
+export default function UnreachableRobotItem (props: UnreachableRobot) {
+  const {name} = props
+  return (
+    <li className={styles.robot_group}>
+      <HoverTooltip
+        tooltipComponent={<div>Unable to locate this robot</div>}
+        placement="bottom"
+      >
+        {hoverTooltipHandlers => (
+          <RobotLink
+            url="#"
+            className={styles.robot_item}
+            exact
+            disabled
+            hoverTooltipHandlers={hoverTooltipHandlers}
+          >
+            <Icon
+              name={'alert-circle'}
+              className={styles.robot_item_icon}
+              disabled
+            />
+            <p className={styles.link_text}>{name}</p>
+          </RobotLink>
+        )}
+      </HoverTooltip>
+    </li>
+  )
+}

--- a/app/src/components/ConnectPanel/connect-panel.css
+++ b/app/src/components/ConnectPanel/connect-panel.css
@@ -25,6 +25,11 @@
   height: 3rem;
 }
 
+.disabled {
+  color: var(--c-font-disabled);
+  pointer-events: none;
+}
+
 .instrument_item {
   height: 2.5rem;
 }

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -6,15 +6,23 @@ import type {State, Dispatch} from '../../types'
 import type {Robot} from '../../robot'
 
 import {selectors as robotSelectors} from '../../robot'
-import {startDiscovery, getScanning} from '../../discovery'
+import {
+  startDiscovery,
+  getScanning,
+  getUnreachableRobots,
+} from '../../discovery'
 
 import {SidePanel} from '@opentrons/components'
 import RobotList from './RobotList'
 import RobotItem from './RobotItem'
 import ScanStatus from './ScanStatus'
+import UnreachableRobotItem from './UnreachableRobotItem'
+
+import type {UnreachableRobot} from '../../discovery'
 
 type StateProps = {
   robots: Array<Robot>,
+  unreachableRobots: Array<UnreachableRobot>,
   found: boolean,
   isScanning: boolean,
 }
@@ -25,16 +33,28 @@ type DispatchProps = {
 
 type Props = StateProps & DispatchProps
 
-export default connect(mapStateToProps, mapDispatchToProps)(ConnectPanel)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ConnectPanel)
 
 function ConnectPanel (props: Props) {
   return (
-    <SidePanel title='Robots'>
+    <SidePanel title="Robots">
       <ScanStatus {...props} />
       <RobotList>
-        {props.robots.map((robot) => (
-          <RobotItem key={robot.name} {...robot} />
+        {props.robots.map(robot => <RobotItem key={robot.name} {...robot} />)}
+        {props.unreachableRobots.map(robot => (
+          <UnreachableRobotItem key={robot.name} {...robot} />
         ))}
+        {/*
+          {props.connectableRobots.map((robot) => (
+            <RobotItem key={robot.name} {...robot} />
+          ))}
+          {props.reachableRobots.map((robot) => (
+            <RobotItem key={robot.name} {...robot} />
+          ))}
+        */}
       </RobotList>
     </SidePanel>
   )
@@ -42,9 +62,9 @@ function ConnectPanel (props: Props) {
 
 function mapStateToProps (state: State): StateProps {
   const robots = robotSelectors.getDiscovered(state)
-
   return {
     robots,
+    unreachableRobots: getUnreachableRobots(state),
     found: robots.length > 0,
     isScanning: getScanning(state),
   }

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -15,6 +15,55 @@ describe('discovery selectors', () => {
       state: {discovery: {scanning: false}},
       expected: false,
     },
+    {
+      name: 'getUnreachableRobots grabs robots with no ip',
+      selector: discovery.getUnreachableRobots,
+      state: {
+        discovery: {robotsByName: {foo: [{name: 'foo', ip: null}]}},
+      },
+      expected: [{name: 'foo'}],
+    },
+    {
+      name: 'getUnreachableRobots grabs robots with IP but no responses',
+      selector: discovery.getUnreachableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [
+              {ip: '10.0.0.1', advertising: false, ok: false, serverOk: false},
+              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+            ],
+          },
+        },
+      },
+      expected: [{name: 'foo'}],
+    },
+    {
+      name: 'getUnreachableRobots will not grab reachable robots',
+      selector: discovery.getUnreachableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [
+              {ip: '10.0.0.1', advertising: true, ok: false, serverOk: false},
+              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+            ],
+            bar: [
+              {ip: '10.0.0.1', advertising: false, ok: true, serverOk: false},
+              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+            ],
+            baz: [
+              {ip: '10.0.0.1', advertising: false, ok: false, serverOk: true},
+              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+            ],
+            qux: [
+              {ip: '10.0.0.2', advertising: true, ok: true, serverOk: true},
+            ],
+          },
+        },
+      },
+      expected: [],
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,8 +1,11 @@
 // @flow
 // robot discovery state
 import groupBy from 'lodash/groupBy'
+import map from 'lodash/map'
+import {createSelector} from 'reselect'
 import {getShellRobots} from '../shell'
 
+import type {OutputSelector} from 'reselect'
 import type {Service} from '@opentrons/discovery-client'
 import type {State, Action, ThunkAction} from '../types'
 
@@ -27,6 +30,10 @@ type UpdateListAction = {|
   type: 'discovery:UPDATE_LIST',
   payload: {|robots: Array<Service>|},
 |}
+
+export type UnreachableRobot = {
+  name: string,
+}
 
 export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
 
@@ -62,6 +69,22 @@ export function getDiscoveredRobotsByName (state: State) {
 // export function getRobots (state: State) {
 //
 // }
+
+type UnreachableSelector = OutputSelector<State, void, Array<UnreachableRobot>>
+
+const serviceUnreachable = (service: Service) =>
+  !service.ip || (!service.advertising && !service.ok && !service.serverOk)
+
+const robotUnreachable = (robot: Array<Service>) =>
+  robot.every(serviceUnreachable)
+
+const makeUnreachableRobot = (robot: Array<Service>, name: string) =>
+  robotUnreachable(robot) ? {name} : null
+
+export const getUnreachableRobots: UnreachableSelector = createSelector(
+  state => state.discovery.robotsByName,
+  robotsByName => map(robotsByName, makeUnreachableRobot).filter(Boolean)
+)
 
 // getShellRobots makes a sync RPC call, so use sparingly
 const initialState: DiscoveryState = {


### PR DESCRIPTION
## overview

This PR closes #2344 by displaying unreachable robots with tooltip notification.

<img width="1027" alt="screen shot 2018-10-05 at 4 19 03 pm" src="https://user-images.githubusercontent.com/3430313/46558232-6c39ce00-c8ba-11e8-9e1e-260aaef3d528.png">

## changelog

- feat(app): App display unreachable robots

## review requests

Launch the app

- [ ] Discovered connectable robots render as in the past
- [ ] Previously discovered, but unreachable robots render as unreachable with tooltip on hover

*note: Ticket spec called for tooltip on the right. Defaulting to bottom for now due to popper.js limitations in sidebar*
