### PR TITLE
fix(app): Allow portal to re-check for root element

### DIFF
--- a/app/src/components/controls/styles.css
+++ b/app/src/components/controls/styles.css
@@ -18,7 +18,8 @@
   width: 100%;
   padding: 1rem;
 
-  &:not(:last-child) {
+  /* TODO(mc, 2018-10-08): update to :last-of-type in components lib */
+  &:not(:last-of-type) {
     border-bottom: 1px solid var(--c-light-gray);
   }
 }

--- a/app/src/components/portal/index.js
+++ b/app/src/components/portal/index.js
@@ -6,7 +6,7 @@ type Props = {children: React.Node}
 
 type State = {hasRoot: boolean}
 
-const PORTAL_ROOT_ID = '__main-modal-portal-root'
+const PORTAL_ROOT_ID = '__otAppModalPortalRoot'
 const getPortalRoot = () => global.document.getElementById(PORTAL_ROOT_ID)
 
 export function PortalRoot () {

--- a/app/src/components/portal/index.js
+++ b/app/src/components/portal/index.js
@@ -2,30 +2,38 @@
 import * as React from 'react'
 import ReactDom from 'react-dom'
 
-const PORTAL_ROOT_ID = 'main-modal-portal-root'
+type Props = {children: React.Node}
+
+type State = {hasRoot: boolean}
+
+const PORTAL_ROOT_ID = '__main-modal-portal-root'
+const getPortalRoot = () => global.document.getElementById(PORTAL_ROOT_ID)
 
 export function PortalRoot () {
   return <div id={PORTAL_ROOT_ID} />
 }
 
-export function getPortalElem () {
-  return document.getElementById(PORTAL_ROOT_ID)
-}
+// the children of Portal are rendered into the PortalRoot if it exists in DOM
+export class Portal extends React.Component<Props, State> {
+  $root: ?Element
 
-type Props = {children: React.Node}
-
-/** The children of Portal are rendered into the
-  * PortalRoot, if the PortalRoot exists in the DOM */
-export function Portal (props: Props): React.Node {
-  const modalRootElem = getPortalElem()
-
-  if (!modalRootElem) {
-    console.error('Modal root is not present, could not render modal')
-    return null
+  constructor (props: Props) {
+    super(props)
+    this.$root = getPortalRoot()
+    this.state = {hasRoot: !!this.$root}
   }
 
-  return ReactDom.createPortal(
-    props.children,
-    modalRootElem
-  )
+  // on first launch, $portalRoot isn't in DOM; double check once we're mounted
+  // TODO(mc, 2018-10-08): prerender UI instead
+  componentDidMount () {
+    if (!this.$root) {
+      this.$root = getPortalRoot()
+      this.setState({hasRoot: !!this.$root})
+    }
+  }
+
+  render () {
+    if (!this.$root) return null
+    return ReactDom.createPortal(this.props.children, this.$root)
+  }
 }


### PR DESCRIPTION
## overview

Bug report + fix.

#2067 added a Portal-based modal to the app and moved the initial analytics pop-up to that portal. However, if the portal modal was used during the first render (e.g. for the analytics opt-in modal), the
modal root would not be present in the DOM since the root itself is created by the App component. This would then cause the modal to fail to appear.

This PR refactors the Portal component to be stateful in order to a) cache the root
component instead of getting it from the document on every render and b) retry getting the root
after mounting, when we're sure (read: pretty sure) the root is also actually mounted in the DOM

The proper, long-term solution would be to prerender our markup, so this fix should be considered a stop-gap until we do so.

## changelog

- fix(app): Allow portal to re-check for root element

## review requests

1. Open `config.json` in app preferences directory (see app-shell README for per OS location)
2. Change `analytics.seeOptIn` to `false`
3. Open app

- [ ] Opt-in modal appears
- [ ] Other portal based modals still work
    - Pretty much every modal in the app
