### PR TITLE
fix(app): Use labware.type for labware table, not labware.name

### DIFF
--- a/app/src/components/FileInfo/ProtocolLabwareCard.js
+++ b/app/src/components/FileInfo/ProtocolLabwareCard.js
@@ -24,7 +24,7 @@ function ProtocolLabwareCard (props: Props) {
 
   if (labware.length === 0) return null
 
-  const labwareCount = countBy(labware, 'name')
+  const labwareCount = countBy(labware, 'type')
   const labwareList = Object.keys(labwareCount).map(type => (
     <tr key={type}>
       <td>{type}</td>


### PR DESCRIPTION
## overview

Closes #2407. See ticket for relevant details and acceptance criteria

## changelog

- fix(app): Use labware.type for labware table, not labware.name

## review requests

See #2407
