### PR TITLE
refactor(app): Organize robots by connectable, reachable, unreachable

### DIFF
--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -1,27 +1,35 @@
 // @flow
 // item in a RobotList
 import {connect} from 'react-redux'
-import {withRouter, type Match} from 'react-router'
+import {withRouter, type ContextRouter} from 'react-router'
 
 import type {State, Dispatch} from '../../types'
-import type {Robot} from '../../robot'
-import {actions as robotActions} from '../../robot'
+import type {Robot} from '../../discovery'
+import {actions as robotActions, selectors as robotSelectors} from '../../robot'
 import {makeGetRobotUpdateInfo} from '../../http-api-client'
 
 import {RobotListItem} from './RobotListItem.js'
 
-type OP = Robot & {
-  match: Match,
-}
+type OP = {|
+  ...$Exact<Robot>,
+  ...ContextRouter,
+|}
 
-type SP = {
+type SP = {|
+  connected: boolean,
   upgradable: boolean,
   selected: boolean,
-}
+|}
 
-type DP = {
+type DP = {|
   connect: () => mixed,
   disconnect: () => mixed,
+|}
+
+export type RobotItemProps = {
+  ...OP,
+  ...SP,
+  ...DP,
 }
 
 export default withRouter(
@@ -35,6 +43,7 @@ function makeMapStateToProps () {
   const getUpdateInfo = makeGetRobotUpdateInfo()
 
   return (state: State, ownProps: OP): SP => ({
+    connected: robotSelectors.getConnectedRobotName(state) === ownProps.name,
     upgradable: getUpdateInfo(state, ownProps).type === 'upgrade',
     selected: ownProps.match.params.name === ownProps.name,
   })

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -3,35 +3,31 @@
 import * as React from 'react'
 import {NotificationIcon, Icon} from '@opentrons/components'
 
-import type {Robot} from '../../robot'
 import {ToggleButton} from '../controls'
 import RobotLink from './RobotLink'
 import styles from './connect-panel.css'
 
-type ItemProps = Robot & {
-  upgradable: ?string,
-  selected: boolean,
-  connect: () => mixed,
-  disconnect: () => mixed,
-}
+// circular type dependency, thanks flow
+import type {RobotItemProps} from './RobotItem'
 
-export function RobotListItem (props: ItemProps) {
+export function RobotListItem (props: RobotItemProps) {
   const {
     name,
-    wired,
+    local,
+    connected,
     selected,
-    isConnected,
     upgradable,
     connect,
     disconnect,
   } = props
-  const onClick = isConnected ? disconnect : connect
+  const onClick = connected ? disconnect : connect
+
   return (
     <li className={styles.robot_group}>
       <React.Fragment>
         <RobotLink url={`/robots/${name}`} className={styles.robot_item} exact>
           <NotificationIcon
-            name={wired ? 'usb' : 'wifi'}
+            name={local ? 'usb' : 'wifi'}
             className={styles.robot_item_icon}
             childName={upgradable ? 'circle' : null}
             childClassName={styles.notification}
@@ -40,7 +36,7 @@ export function RobotListItem (props: ItemProps) {
           <p className={styles.link_text}>{name}</p>
 
           <ToggleButton
-            toggledOn={isConnected}
+            toggledOn={connected}
             onClick={onClick}
             className={styles.robot_item_icon}
           />

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -3,12 +3,12 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 
 import type {State, Dispatch} from '../../types'
-import type {Robot} from '../../robot'
 
-import {selectors as robotSelectors} from '../../robot'
 import {
   startDiscovery,
   getScanning,
+  getConnectableRobots,
+  getReachableRobots,
   getUnreachableRobots,
 } from '../../discovery'
 
@@ -18,20 +18,24 @@ import RobotItem from './RobotItem'
 import ScanStatus from './ScanStatus'
 import UnreachableRobotItem from './UnreachableRobotItem'
 
-import type {UnreachableRobot} from '../../discovery'
+import type {Robot, ReachableRobot, UnreachableRobot} from '../../discovery'
 
-type StateProps = {
+type StateProps = {|
   robots: Array<Robot>,
+  reachableRobots: Array<ReachableRobot>,
   unreachableRobots: Array<UnreachableRobot>,
   found: boolean,
   isScanning: boolean,
-}
+|}
 
-type DispatchProps = {
+type DispatchProps = {|
   onScanClick: () => mixed,
-}
+|}
 
-type Props = StateProps & DispatchProps
+type Props = {
+  ...StateProps,
+  ...DispatchProps,
+}
 
 export default connect(
   mapStateToProps,
@@ -44,9 +48,9 @@ function ConnectPanel (props: Props) {
       <ScanStatus {...props} />
       <RobotList>
         {props.robots.map(robot => <RobotItem key={robot.name} {...robot} />)}
-        {props.unreachableRobots.map(robot => (
-          <UnreachableRobotItem key={robot.name} {...robot} />
-        ))}
+        {props.reachableRobots
+          .concat(props.unreachableRobots)
+          .map(robot => <UnreachableRobotItem key={robot.name} {...robot} />)}
         {/*
           {props.connectableRobots.map((robot) => (
             <RobotItem key={robot.name} {...robot} />
@@ -61,9 +65,11 @@ function ConnectPanel (props: Props) {
 }
 
 function mapStateToProps (state: State): StateProps {
-  const robots = robotSelectors.getDiscovered(state)
+  const robots = getConnectableRobots(state)
+
   return {
     robots,
+    reachableRobots: getReachableRobots(state),
     unreachableRobots: getUnreachableRobots(state),
     found: robots.length > 0,
     isScanning: getScanning(state),

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -1,6 +1,54 @@
 // discovery selectors tests
 import * as discovery from '..'
 
+const makeFullyUp = (name, ip) => ({
+  name,
+  ip,
+  local: false,
+  ok: true,
+  serverOk: true,
+  advertising: true,
+  health: {},
+  serverHealth: {},
+})
+
+const makeConnectable = (name, ip) => ({
+  name,
+  ip,
+  local: false,
+  ok: true,
+  serverOk: false,
+  health: {},
+})
+
+const makeAdvertising = (name, ip) => ({
+  name,
+  ip,
+  local: false,
+  ok: false,
+  serverOk: false,
+  advertising: true,
+})
+
+const makeServerUp = (name, ip, advertising) => ({
+  name,
+  ip,
+  advertising,
+  local: false,
+  ok: false,
+  serverOk: true,
+  serverHealth: {},
+})
+
+const makeUnreachable = (name, ip) => ({
+  name,
+  ip,
+  local: false,
+  ok: false,
+  serverOk: false,
+  advertising: false,
+})
+
 describe('discovery selectors', () => {
   const SPECS = [
     {
@@ -16,12 +64,101 @@ describe('discovery selectors', () => {
       expected: false,
     },
     {
+      name: 'getConnectableRobots grabs robots with ok: true and health',
+      selector: discovery.getConnectableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [makeConnectable('foo', '10.0.0.1')],
+            bar: [makeFullyUp('bar', '10.0.0.2')],
+          },
+        },
+      },
+      expected: [
+        makeConnectable('foo', '10.0.0.1'),
+        makeFullyUp('bar', '10.0.0.2'),
+      ],
+    },
+    {
+      name: 'getConnectableRobots grabs correct service',
+      selector: discovery.getConnectableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [
+              makeConnectable('foo', '10.0.0.1'),
+              makeConnectable('foo', '10.0.0.2'),
+              makeServerUp('foo', '10.0.0.3', false),
+              makeAdvertising('foo', '10.0.0.4', false),
+            ],
+          },
+        },
+      },
+      expected: [makeConnectable('foo', '10.0.0.1')],
+    },
+    {
+      name: 'getReachableRobots grabs robots with advertising: true',
+      selector: discovery.getReachableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [makeAdvertising('foo', '10.0.0.1', false)],
+            bar: [makeAdvertising('bar', '10.0.0.2', true)],
+          },
+        },
+      },
+      expected: [
+        makeAdvertising('foo', '10.0.0.1', false),
+        makeAdvertising('bar', '10.0.0.2', true),
+      ],
+    },
+    {
+      name: 'getReachableRobots grabs correct service',
+      selector: discovery.getReachableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [
+              makeServerUp('foo', '10.0.0.1', true),
+              makeServerUp('foo', '10.0.0.1', false),
+              makeAdvertising('foo', '10.0.0.2', false),
+            ],
+          },
+        },
+      },
+      expected: [makeServerUp('foo', '10.0.0.1', true)],
+    },
+    {
+      name: 'getReachableRobots does not grab connectable robots',
+      selector: discovery.getReachableRobots,
+      state: {
+        discovery: {
+          robotsByName: {
+            foo: [
+              makeConnectable('foo', '10.0.0.1'),
+              makeServerUp('foo', '10.0.0.2', true),
+            ],
+            bar: [
+              makeConnectable('bar', '10.0.0.3'),
+              makeServerUp('bar', '10.0.0.4', false),
+            ],
+            baz: [
+              makeConnectable('baz', '10.0.0.5'),
+              makeAdvertising('baz', '10.0.0.6'),
+            ],
+            qux: [makeFullyUp('qux', '10.0.0.7')],
+          },
+        },
+      },
+      expected: [],
+    },
+    {
       name: 'getUnreachableRobots grabs robots with no ip',
       selector: discovery.getUnreachableRobots,
       state: {
         discovery: {robotsByName: {foo: [{name: 'foo', ip: null}]}},
       },
-      expected: [{name: 'foo'}],
+      expected: [{name: 'foo', ip: null}],
     },
     {
       name: 'getUnreachableRobots grabs robots with IP but no responses',
@@ -30,37 +167,33 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              {ip: '10.0.0.1', advertising: false, ok: false, serverOk: false},
-              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+              makeUnreachable('foo', '10.0.0.1'),
+              makeUnreachable('foo', '10.0.0.2'),
             ],
           },
         },
       },
-      expected: [{name: 'foo'}],
+      expected: [makeUnreachable('foo', '10.0.0.1')],
     },
     {
-      name: 'getUnreachableRobots will not grab reachable robots',
+      name: "getUnreachableRobots won't grab connectable/reachable robots",
       selector: discovery.getUnreachableRobots,
       state: {
         discovery: {
           robotsByName: {
-            // TODO(mc, 2018-10-08): check advertising and serverOk flags
-            // foo: [
-            //   {ip: '10.0.0.1', advertising: true, ok: false, serverOk: false},
-            //   {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
-            // ],
+            foo: [
+              makeServerUp('foo', '10.0.0.1', true),
+              makeUnreachable('foo', '10.0.0.2'),
+            ],
             bar: [
-              {ip: '10.0.0.1', advertising: false, ok: true, serverOk: false},
-              {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
+              makeServerUp('bar', '10.0.0.3', false),
+              makeUnreachable('bar', '10.0.0.4'),
             ],
-            // TODO(mc, 2018-10-08): check advertising and serverOk flags
-            // baz: [
-            //   {ip: '10.0.0.1', advertising: false, ok: false, serverOk: true},
-            //   {ip: '10.0.0.2', advertising: false, ok: false, serverOk: false},
-            // ],
-            qux: [
-              {ip: '10.0.0.2', advertising: true, ok: true, serverOk: true},
+            baz: [
+              makeAdvertising('bar', '10.0.0.5'),
+              makeUnreachable('baz', '10.0.0.6'),
             ],
+            qux: [makeConnectable('qux', '10.0.0.7')],
           },
         },
       },

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,13 +1,13 @@
 // @flow
 // robot discovery state
 import groupBy from 'lodash/groupBy'
-import map from 'lodash/map'
-import {createSelector} from 'reselect'
 import {getShellRobots} from '../shell'
 
-import type {OutputSelector} from 'reselect'
 import type {Service} from '@opentrons/discovery-client'
 import type {State, Action, ThunkAction} from '../types'
+
+export * from './types'
+export * from './selectors'
 
 type RobotsMap = {[name: string]: Array<Service>}
 
@@ -30,10 +30,6 @@ type UpdateListAction = {|
   type: 'discovery:UPDATE_LIST',
   payload: {|robots: Array<Service>|},
 |}
-
-export type UnreachableRobot = {
-  name: string,
-}
 
 export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
 
@@ -64,28 +60,6 @@ export function getScanning (state: State) {
 export function getDiscoveredRobotsByName (state: State) {
   return state.discovery.robotsByName
 }
-
-// TODO(mc, 2018-08-10): implement in favor of robotSelectors.getDiscovered
-// export function getRobots (state: State) {
-//
-// }
-
-type UnreachableSelector = OutputSelector<State, void, Array<UnreachableRobot>>
-
-const serviceUnreachable = (service: Service) => !service.ip || !service.ok
-// TODO(mc, 2018-10-08): check advertising and serverOk flags
-// !service.ip || (!service.advertising && !service.ok && !service.serverOk)
-
-const robotUnreachable = (robot: Array<Service>) =>
-  robot.every(serviceUnreachable)
-
-const makeUnreachableRobot = (robot: Array<Service>, name: string) =>
-  robotUnreachable(robot) ? {name} : null
-
-export const getUnreachableRobots: UnreachableSelector = createSelector(
-  state => state.discovery.robotsByName,
-  robotsByName => map(robotsByName, makeUnreachableRobot).filter(Boolean)
-)
 
 // getShellRobots makes a sync RPC call, so use sparingly
 const initialState: DiscoveryState = {

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -1,0 +1,82 @@
+// @flow
+import filter from 'lodash/filter'
+import groupBy from 'lodash/groupBy'
+import head from 'lodash/head'
+import map from 'lodash/map'
+import mapValues from 'lodash/mapValues'
+import pickBy from 'lodash/pickBy'
+import {createSelector} from 'reselect'
+
+import type {OutputSelector as Selector} from 'reselect'
+import type {Service} from '@opentrons/discovery-client'
+import type {State} from '../types'
+import type {
+  ResolvedService,
+  Robot,
+  ReachableRobot,
+  UnreachableRobot,
+} from './types'
+
+type GroupedRobotsMap = {
+  [name: string]: {
+    connectable: Array<Robot>,
+    reachable: Array<ReachableRobot>,
+    unreachable: Array<Service>,
+  },
+}
+
+type GetGroupedRobotsMap = Selector<State, void, GroupedRobotsMap>
+type GetConnectableRobots = Selector<State, void, Array<Robot>>
+type GetReachableRobots = Selector<State, void, Array<ReachableRobot>>
+type GetUnreachableRobots = Selector<State, void, Array<UnreachableRobot>>
+
+const isResolved = (s: Service) =>
+  s.ip != null && s.local != null && s.ok != null && s.serverOk != null
+
+const isConnectable = (s: ResolvedService) => s.ok === true && s.health != null
+
+const isReachable = (s: ResolvedService) =>
+  s.advertising === true || s.serverOk === true
+
+const maybeGetResolved = (service: Service): ?ResolvedService =>
+  isResolved(service) ? (service: any) : null
+
+// group services of each robot into connectable, reachable, and unconnectable
+// sort order will be preserved from state (and therefore discovery-client),
+// so the head of each group will be the most "desirable" option for that group
+const getGroupedRobotsMap: GetGroupedRobotsMap = createSelector(
+  state => state.discovery.robotsByName,
+  robotsMap =>
+    mapValues(robotsMap, services =>
+      groupBy(services, s => {
+        const resolved = maybeGetResolved(s)
+        if (resolved && isConnectable(resolved)) return 'connectable'
+        if (resolved && isReachable(resolved)) return 'reachable'
+        return 'unreachable'
+      })
+    )
+)
+
+export const getConnectableRobots: GetConnectableRobots = createSelector(
+  getGroupedRobotsMap,
+  robotsMap => map(robotsMap, g => head(g.connectable)).filter(Boolean)
+)
+
+export const getReachableRobots: GetReachableRobots = createSelector(
+  getGroupedRobotsMap,
+  robotsMap =>
+    filter(robotsMap, g => !g.connectable)
+      .map(g => head(g.reachable))
+      .filter(Boolean)
+)
+
+export const getUnreachableRobots: GetUnreachableRobots = createSelector(
+  getGroupedRobotsMap,
+  robotsMap => {
+    const unreachableMap = pickBy(
+      robotsMap,
+      g => !g.connectable && !g.reachable
+    )
+    return map(unreachableMap, g => head(g.unreachable)).filter(Boolean)
+  }
+)

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -1,0 +1,27 @@
+// @flow
+
+import type {Service} from '@opentrons/discovery-client'
+
+// service with a known IP address
+export type ResolvedService = {
+  ...$Exact<Service>,
+  ip: $NonMaybeType<$PropertyType<Service, 'ip'>>,
+  local: $NonMaybeType<$PropertyType<Service, 'local'>>,
+  ok: $NonMaybeType<$PropertyType<Service, 'ok'>>,
+  serverOk: $NonMaybeType<$PropertyType<Service, 'serverOk'>>,
+}
+
+// fully connectable robot
+export type Robot = {
+  ...$Exact<ResolvedService>,
+  ok: true,
+  health: $NonMaybeType<$PropertyType<Service, 'health'>>,
+}
+
+// robot with a known IP (i.e. advertising over mDNS) but unconnectable
+export type ReachableRobot =
+  | {...$Exact<ResolvedService>, ok: false, serverOk: true}
+  | {...$Exact<ResolvedService>, ok: false, advertising: true}
+
+// robot with an unknown IP
+export type UnreachableRobot = Service

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -14,7 +14,7 @@ import {
 
 import type {OutputSelector} from 'reselect'
 import type {State, ThunkPromiseAction, Action} from '../types'
-import type {RobotService} from '../robot'
+import type {BaseRobot, RobotService} from '../robot'
 import type {ApiCall, ApiRequestError} from './types'
 
 type RequestPath = 'update' | 'restart' | 'update/ignore'
@@ -248,7 +248,9 @@ export type RobotUpdateType = 'upgrade' | 'downgrade' | null
 export type RobotUpdateInfo = {version: string, type: RobotUpdateType}
 
 export const makeGetRobotUpdateInfo = () => {
-  const selector: OutputSelector<State, RobotService, RobotUpdateInfo> = createSelector(
+  const selector: OutputSelector<State,
+    BaseRobot,
+    RobotUpdateInfo> = createSelector(
     makeGetRobotHealth(),
     getApiUpdateVersion,
     (health, updateVersion) => {
@@ -259,9 +261,7 @@ export const makeGetRobotUpdateInfo = () => {
       if (!current || (!upgrade && !downgrade)) {
         type = null
       } else {
-        type = upgrade
-          ? 'upgrade'
-          : 'downgrade'
+        type = upgrade ? 'upgrade' : 'downgrade'
       }
       return {version: updateVersion, type: type}
     }

--- a/discovery-client/src/__tests__/client.test.js
+++ b/discovery-client/src/__tests__/client.test.js
@@ -426,13 +426,13 @@ describe('discovery client', () => {
     'candidate removal emits removal events',
     done => {
       const services = [
-        MOCK_SERVICE,
         {
           ...MOCK_SERVICE,
           ip: '[fd00:0:cafe:fefe::1]',
           port: 31950,
           local: true,
         },
+        MOCK_SERVICE,
       ]
 
       const client = DiscoveryClient({services})
@@ -553,5 +553,9 @@ describe('discovery client', () => {
       expect.anything(),
       client._logger
     )
+  })
+
+  test.skip('periodically refreshes mDNS discovery', () => {
+    // TODO(mc, 2018-10-08): write this test
   })
 })

--- a/discovery-client/src/cli.js
+++ b/discovery-client/src/cli.js
@@ -86,11 +86,13 @@ function find (argv) {
   )
 
   DiscoveryClient(argv)
-    .on('service', s => {
-      if (!argv.name || s.name === argv.name) {
-        process.stdout.write(`${normalizeIp(s.ip)}\n`)
-        process.exit(0)
-      }
+    .on('service', updatedServices => {
+      updatedServices
+        .filter(s => !argv.name || s.name === argv.name)
+        .forEach(s => {
+          process.stdout.write(`${normalizeIp(s.ip)}\n`)
+          process.exit(0)
+        })
     })
     .once('error', argv.handleError)
     .start()

--- a/discovery-client/src/mdns-browser.js
+++ b/discovery-client/src/mdns-browser.js
@@ -2,11 +2,24 @@
 // mdns browser wrapper
 import mdns, {ServiceType} from 'mdns-js'
 import type {Browser} from 'mdns-js'
+import keys from 'lodash/keys'
+import flatMap from 'lodash/flatMap'
 
 monkeyPatchThrowers()
 
 export default function MdnsBrowser (): Browser {
   return mdns.createBrowser(mdns.tcp('http'))
+}
+
+export function getKnownIps (maybeBrowser: ?Browser): Array<string> {
+  if (!maybeBrowser) return []
+  const browser: Browser = maybeBrowser
+
+  // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/2463
+  return flatMap(browser.networking.connections, connection => {
+    const {addresses} = browser.connections[connection.networkInterface] || {}
+    return keys(addresses)
+  })
 }
 
 function monkeyPatchThrowers () {

--- a/discovery-client/src/service-list.js
+++ b/discovery-client/src/service-list.js
@@ -91,7 +91,12 @@ function dedupeServices (list: ServiceList) {
   return sanitizedWithIp.concat(dedupedWithoutIp).sort(compareServices)
 }
 
-// sort service list by: ip exists, update server healthy, API healthy, advertising
+// sort service list by:
+//   1. ip exists,
+//   2. update server healthy
+//   3. API healthy
+//   4. link-local address
+//   5. advertising
 function compareServices (a: Service, b: Service) {
   if (a.ip && !b.ip) return -1
   if (!a.ip && b.ip) return 1
@@ -99,6 +104,8 @@ function compareServices (a: Service, b: Service) {
   if (!a.serverOk && b.serverOk) return 1
   if (a.ok && !b.ok) return -1
   if (!a.ok && b.ok) return 1
+  if (a.local && !b.local) return -1
+  if (!a.local && b.local) return 1
   if (a.advertising && !b.advertising) return -1
   if (!a.advertising && b.advertising) return 1
   return 0

--- a/flow-typed/npm/mdns-js_v1.0.x.js
+++ b/flow-typed/npm/mdns-js_v1.0.x.js
@@ -7,19 +7,35 @@ declare module 'mdns-js' {
   declare class mdns$Browser extends EventEmitter {
     discover(): void;
     stop(): void;
+    networking: {
+      connections: Array<{interfaceIndex: number, networkInterface: string}>,
+    };
+    connections: {
+      services?: {
+        [typeString: string]: {type: MdnsServiceType, addresses: Array<string>},
+      },
+      addresses?: {
+        [ip: string]: {
+          address: string,
+          port: number,
+          host: string,
+          txt: Array<string>,
+        },
+      },
+    };
   }
 
   declare class mdns$ServiceType {
     name: string;
     protocol: string;
     subtypes: Array<string>;
-    description: string;
+    description?: string;
   }
 
   declare module.exports: {
     createBrowser: (serviceType: MdnsServiceType) => Browser,
     tcp: (type: string) => MdnsServiceType,
-    ServiceType: any
+    ServiceType: any,
   }
 
   declare type Browser = mdns$Browser
@@ -35,6 +51,6 @@ declare module 'mdns-js' {
     fullname?: string,
     host?: string,
     interfaceIndex: number,
-    networkInterface: string
+    networkInterface: string,
   }
 }


### PR DESCRIPTION
## overview

This PR lays the groundwork for #2345 by splitting up the `discovery` selectors into:

- `getConnectableRobots` - Gets all connectable robots
- `getReachableRobots` - Gets all robots that are reachable but not connectable
- `getUnreachableRobots` - Gets all robots that are not reachable

## changelog

- refactor(app): Organize robots by connectable, reachable, unreachable

## review requests

Known issue: this PR will (temporarily) break the robot list ordering

- [x] All connectable robots continue to show up in the list as connectable
- [x] All reachable and unreachable robots continue to show up in the list as unreachable
