### PR TITLE
feat(protocol-designer): add liquids tab and sidebar

### DIFF
--- a/protocol-designer/src/components/IngredientsList.js
+++ b/protocol-designer/src/components/IngredientsList.js
@@ -1,5 +1,6 @@
 // @flow
 // TODO: Ian 2018-06-07 break out these components into their own files (make IngredientsList a directory)
+// TODO: Ian 2018-10-09 figure out what belongs in LiquidsSidebar vs IngredientsList after #2427
 import React from 'react'
 
 import {IconButton, SidePanel, swatchColors} from '@opentrons/components'

--- a/protocol-designer/src/components/LiquidsPage/index.js
+++ b/protocol-designer/src/components/LiquidsPage/index.js
@@ -1,0 +1,6 @@
+// @flow
+import * as React from 'react'
+
+export default function LiquidsPage () {
+  return <div>TODO! This page will be implemented in the next ticket (#2427)</div>
+}

--- a/protocol-designer/src/components/LiquidsSidebar/index.js
+++ b/protocol-designer/src/components/LiquidsSidebar/index.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {SidePanel, swatchColors} from '@opentrons/components'
+import {PDTitledList} from '../lists'
+
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import type {OrderedLiquids} from '../../labware-ingred/types'
+import type {BaseState} from '../../types'
+
+type Props = {
+  liquids: OrderedLiquids,
+  selectedLiquid: ?string,
+  handleClickLiquid: (liquidId: string) => () => mixed,
+}
+
+type SP = {
+  liquids: $PropertyType<Props, 'liquids'>,
+  selectedLiquid: $PropertyType<Props, 'selectedLiquid'>,
+}
+
+type DP = $Diff<Props, SP>
+
+function LiquidsSidebar (props: Props) {
+  const {liquids, selectedLiquid, handleClickLiquid} = props
+  return (
+    <SidePanel title='Liquids'>
+      {liquids.map(({ingredientId, name}) => (
+        <PDTitledList
+          key={ingredientId}
+          selected={selectedLiquid === ingredientId}
+          onClick={handleClickLiquid(ingredientId)}
+          iconName='circle'
+          iconProps={{style: {fill: swatchColors(Number(ingredientId))}}}
+          title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
+        />
+      ))}
+    </SidePanel>
+  )
+}
+
+function mapStateToProps (state: BaseState): SP {
+  return {
+    liquids: labwareIngredSelectors.allIngredientNamesIds(state),
+    selectedLiquid: '0', // TODO: Ian 2018-10-09 implement in #2427
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch<*>): DP {
+  return {
+    handleClickLiquid: (liquidId) => () => console.log('TODO: select liquid', liquidId), // TODO: Ian 2018-10-09 implement in #2427
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(LiquidsSidebar)

--- a/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
@@ -13,18 +13,18 @@ type SP = {currentPage: Page}
 type DP = {makeNavigateToPage: (Page) => () => mixed}
 
 const SettingsSidebar = (props: SP & DP) => (
-  <SidePanel title={i18n.t('nav.settings')}>
+  <SidePanel title={i18n.t('nav.tab_name.settings')}>
     <PDTitledList
       className={styles.sidebar_item}
       selected={props.currentPage === 'settings-privacy'}
       onClick={props.makeNavigateToPage('settings-privacy')}
-      title={i18n.t('nav.privacy')}/>
+      title={i18n.t('nav.settings.privacy')}/>
     {/* <PDTitledList
       disabled
       className={styles.sidebar_item}
       onClick={props.makeNavigateToPage('settings-features')}
       selected={props.currentPage === 'settings-features'}
-      title={i18n.t('nav.feature_flags')}/> */}
+      title={i18n.t('nav.settings.feature_flags')}/> */}
   </SidePanel>
 )
 

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -6,6 +6,7 @@ import {Splash} from '@opentrons/components'
 import ConnectedDeckSetup from '../containers/ConnectedDeckSetup'
 import ConnectedFilePage from '../containers/ConnectedFilePage'
 import SettingsPage from '../components/SettingsPage'
+import LiquidsPage from '../components/LiquidsPage'
 
 import type {BaseState} from '../types'
 import {selectors, type Page} from '../navigation'
@@ -21,6 +22,8 @@ function MainPanel (props: Props) {
       return <Splash />
     case 'file-detail':
       return <ConnectedFilePage />
+    case 'liquids':
+      return <LiquidsPage />
     case 'settings-privacy':
       return <SettingsPage />
     default:

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -20,18 +20,18 @@ function Nav (props: Props) {
         <React.Fragment>
           <NavTab
             iconName='ot-file'
-            title={i18n.t('nav.file')}
+            title={i18n.t('nav.tab_name.file')}
             selected={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
             onClick={props.handleClick('file-detail')} />
           <NavTab
             iconName='water'
-            title={i18n.t('nav.liquids')}
+            title={i18n.t('nav.tab_name.liquids')}
             disabled={props.currentPage === 'file-splash'}
             selected={props.currentPage === 'liquids'}
             onClick={props.handleClick('liquids')} />
           <NavTab
             iconName='ot-design'
-            title={i18n.t('nav.design')}
+            title={i18n.t('nav.tab_name.design')}
             disabled={props.currentPage === 'file-splash'}
             selected={props.currentPage === 'steplist' || props.currentPage === 'ingredient-detail'}
             onClick={props.handleClick('steplist')} />
@@ -41,11 +41,11 @@ function Nav (props: Props) {
         <React.Fragment>
           <OutsideLinkTab
             iconName='help-circle'
-            title={i18n.t('nav.help')}
+            title={i18n.t('nav.tab_name.help')}
             to={KNOWLEDGEBASE_ROOT_URL} />
           <NavTab
             iconName='settings'
-            title={i18n.t('nav.settings')}
+            title={i18n.t('nav.tab_name.settings')}
             selected={props.currentPage === 'settings-privacy'}
             onClick={props.handleClick('settings-privacy')} />
         </React.Fragment>

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -24,6 +24,12 @@ function Nav (props: Props) {
             selected={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
             onClick={props.handleClick('file-detail')} />
           <NavTab
+            iconName='water'
+            title={i18n.t('nav.liquids')}
+            disabled={props.currentPage === 'file-splash'}
+            selected={props.currentPage === 'liquids'}
+            onClick={props.handleClick('liquids')} />
+          <NavTab
             iconName='ot-design'
             title={i18n.t('nav.design')}
             disabled={props.currentPage === 'file-splash'}

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -6,6 +6,7 @@ import {selectors} from '../navigation'
 import ConnectedStepList from './ConnectedStepList'
 import IngredientsList from './IngredientsList'
 import FileSidebar from '../components/FileSidebar'
+import LiquidsSidebar from '../components/LiquidsSidebar'
 import { SettingsSidebar } from '../components/SettingsPage'
 
 import type {BaseState} from '../types'
@@ -17,6 +18,8 @@ type Props = {
 
 function Sidebar (props: Props) {
   switch (props.page) {
+    case 'liquids':
+      return <LiquidsSidebar />
     case 'steplist':
     case 'well-selection-modal':
       return <ConnectedStepList />

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -50,14 +50,17 @@ function mapStateToProps (state: BaseState): SP {
   const labwareNames = labwareIngredSelectors.getLabwareNames(state)
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
 
-  // TODO IMMEDIATELY: use internationalization not strings
   switch (_page) {
     case 'liquids':
-      return {_page, title: fileName, subtitle: 'liquids'}
     case 'file-splash':
-      return { _page, title: 'Opentrons Protocol Designer' }
     case 'file-detail':
-      return {_page, title: fileName, subtitle: 'FILE DETAILS'}
+    case 'settings-features':
+    case 'settings-privacy':
+      return {
+        _page,
+        title: i18n.t([`nav.title.${_page}`, fileName]),
+        subtitle: i18n.t([`nav.subtitle.${_page}`, '']),
+      }
     case 'ingredient-detail': {
       return {
         _page,
@@ -74,13 +77,6 @@ function mapStateToProps (state: BaseState): SP {
           text={selectedStep && selectedStep.title}
         />,
         subtitle: labwareNickname,
-      }
-    case 'settings-features':
-    case 'settings-privacy':
-      return {
-        _page,
-        title: i18n.t('nav.title.settings'),
-        subtitle: i18n.t(`nav.subtitle.${_page}`),
       }
     case 'steplist':
     default: {

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -50,7 +50,10 @@ function mapStateToProps (state: BaseState): SP {
   const labwareNames = labwareIngredSelectors.getLabwareNames(state)
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
 
+  // TODO IMMEDIATELY: use internationalization not strings
   switch (_page) {
+    case 'liquids':
+      return {_page, title: fileName, subtitle: 'liquids'}
     case 'file-splash':
       return { _page, title: 'Opentrons Protocol Designer' }
     case 'file-detail':

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -23,6 +23,7 @@ import type {
   IngredientGroups,
   AllIngredGroupFields,
   IngredientInstance,
+  OrderedLiquids,
   Labware,
   LabwareTypeById,
 } from '../types'
@@ -410,7 +411,7 @@ const allIngredientGroupFields: Selector<AllIngredGroupFields> = createSelector(
     }), {})
 )
 
-const allIngredientNamesIds: BaseState => Array<{ingredientId: string, name: ?string}> = createSelector(
+const allIngredientNamesIds: BaseState => OrderedLiquids = createSelector(
   getIngredientGroups,
   ingreds => Object.keys(ingreds).map(ingredId =>
       ({ingredientId: ingredId, name: ingreds[ingredId].name}))

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -39,6 +39,11 @@ export type WellContentsByLabware = {
 
 // ==== INGREDIENTS ====
 
+export type OrderedLiquids = Array<{
+  ingredientId: string,
+  name: ?string,
+}>
+
 export type IngredInputs = {
   name: string | null,
   volume: number | null,

--- a/protocol-designer/src/localization/en/nav.json
+++ b/protocol-designer/src/localization/en/nav.json
@@ -3,6 +3,7 @@
   "file": "FILE",
   "feature_flags": "Feature Flags",
   "help": "HELP",
+  "liquids": "LIQUIDS",
   "settings": "SETTINGS",
   "privacy": "PRIVACY",
   "title": {

--- a/protocol-designer/src/localization/en/nav.json
+++ b/protocol-designer/src/localization/en/nav.json
@@ -1,19 +1,27 @@
 {
-  "design": "DESIGN",
-  "file": "FILE",
-  "feature_flags": "Feature Flags",
-  "help": "HELP",
-  "liquids": "LIQUIDS",
-  "settings": "SETTINGS",
-  "privacy": "PRIVACY",
-  "title": {
-    "settings": "Opentrons Beta"
+  "settings": {
+    "privacy": "PRIVACY",
+    "feature_flags": "Feature Flags"
+  },
+  "tab_name": {
+    "design": "DESIGN",
+    "file": "FILE",
+    "help": "HELP",
+    "liquids": "LIQUIDS",
+    "settings": "SETTINGS"
   },
   "terminal_item": {
     "__initial_setup__": "Starting Deck State",
     "__end__": "Final Deck State"
   },
+  "title": {
+    "settings-features": "Opentrons Beta",
+    "settings-privacy": "Opentrons Beta",
+    "file-splash": "Opentrons Beta"
+  },
   "subtitle": {
-    "settings-privacy": "Privacy"
+    "file-detail": "File Details",
+    "settings-privacy": "Privacy",
+    "liquids": "Liquids"
   }
 }

--- a/protocol-designer/src/navigation/types.js
+++ b/protocol-designer/src/navigation/types.js
@@ -1,6 +1,8 @@
 // @flow
-export type Page = 'file-splash' |
+export type Page =
+  'file-splash' |
   'file-detail' |
+  'liquids' |
   'steplist' |
   'ingredient-detail' |
   'well-selection-modal' |


### PR DESCRIPTION
## overview

Closes #2426

## changelog

* liquids page stub
* liquids sidebar
* use i18n more for nav/titlebar; clean up nav.json

## review requests

In this sprint we've broken up the changes to creating & editing liquids into several tickets, until they're all done the experience will be incomplete. This just introduces a functional new page with nav tab. 

- [ ] New 'Liquids' tab in primary nav
- [ ] New 'Liquids' view under 'Liquids' tab
  - [ ] 'Liquids' view includes sidebar -- this sidebar should show any liquids you've created (in the original as-yet-unchanged "Add Liquids" modal/form that you get to from deck setup)
- Note this user story does not include instructional content in right panel

This PR also re-organizes the internationalization for tabs + title bar, nothing visual should be changed (except that main title is now consistently "Protocol Designer Beta" to match designs.