### PR TITLE
docs(api): Fix whitespace in code block for delete_container docs

### DIFF
--- a/api/docs/source/labware.rst
+++ b/api/docs/source/labware.rst
@@ -357,6 +357,7 @@ If you are creating a custom tiprack, it must be `tiprack`-REST-OF-CONTAINER-NAM
 If you would like to delete a container you have already added to the database, you can do the following:
 
 .. code-block:: python
+
     from opentrons.data_storage import database
     database.delete_container('3x6_plate')
 


### PR DESCRIPTION
## overview

Incorrectly formatted whitespace caused a code block in the labware documents to not show up

## changelog

- docs(api): Fix whitespace in code block for delete_container docs

## review requests

Ensure that the code block for `delete_container` shows up under the labware page of the docs
