### PR TITLE
feat(protocol-designer): implement rounding properly

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
+++ b/protocol-designer/src/components/StepEditForm/FlowRateField/FlowRateField.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import round from 'lodash/round'
 import {
   AlertModal,
   FormGroup,
@@ -121,7 +122,7 @@ export default class FlowRateField extends React.Component<Props, State> {
       minFlowRate > modalFlowRateNum ||
       modalFlowRateNum > maxFlowRate
     )
-    const correctDecimals = Number(modalFlowRateNum.toFixed(DECIMALS_ALLOWED)) === modalFlowRateNum
+    const correctDecimals = round(modalFlowRateNum, DECIMALS_ALLOWED) === modalFlowRateNum
     const allowSave = modalUseDefault || (!outOfBounds && correctDecimals)
 
     let errorMessage = null

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -39,11 +39,13 @@ type OP = {
 }
 
 type Props = OP & DP
-type State = { value: string }
+type State = { value: number }
 
-const formatValue = (value: number): string => (
-  String(round(value, DECIMALS_ALLOWED))
-)
+const formatValue = (value: number | string): number => {
+  let val = value || 0
+  if (typeof val === 'string') val = Number(val)
+  return round(val, DECIMALS_ALLOWED)
+}
 
 class TipPositionModal extends React.Component<Props, State> {
   constructor (props: Props) {
@@ -56,7 +58,7 @@ class TipPositionModal extends React.Component<Props, State> {
     }
   }
   applyChanges = () => {
-    this.props.updateValue(formatValue(Number(this.state.value) || 0))
+    this.props.updateValue(String(formatValue(this.state.value)))
   }
   handleReset = () => {
     // NOTE: when `prefix` isn't set (eg in the Mix form), we'll use
@@ -76,34 +78,32 @@ class TipPositionModal extends React.Component<Props, State> {
     this.props.closeModal()
   }
   handleChange = (e: SyntheticEvent<HTMLSelectElement>) => {
-    const {value} = e.currentTarget
-    const valueFloat = Number(formatValue(Number(value)))
+    const rawValue = e.currentTarget.value
+    const value = formatValue(rawValue)
     const maximumHeightMM = (this.props.wellHeightMM * 2)
 
-    if (!value) {
-      this.setState({value})
-    } else if (valueFloat > maximumHeightMM) {
+    if (value > maximumHeightMM) {
       this.setState({value: formatValue(maximumHeightMM)})
-    } else if (valueFloat >= 0) {
-      const numericValue = value.replace(/[^.0-9]/, '')
-      this.setState({value: numericValue.replace(/(\d*[.]{1}\d{1})(\d*)/, (match, group1) => group1)})
+    } else if (value >= 0) {
+      this.setState({value})
     } else {
       this.setState({value: formatValue(0)})
     }
   }
   makeHandleIncrement = (step: number) => () => {
     const {value} = this.state
-    const incrementedValue = parseFloat(value || 0) + step
+    const incrementedValue = (value || 0) + step
     const maximumHeightMM = (this.props.wellHeightMM * 2)
     this.setState({value: formatValue(Math.min(incrementedValue, maximumHeightMM))})
   }
   makeHandleDecrement = (step: number) => () => {
-    const nextValueFloat = parseFloat(this.state.value || 0) - step
+    const nextValueFloat = (this.state.value || 0) - step
     this.setState({value: formatValue(nextValueFloat < 0 ? 0 : nextValueFloat)})
   }
   render () {
     if (!this.props.isOpen) return null
     const {value} = this.state
+    const valueString = String(value)
     const {wellHeightMM} = this.props
 
     return (
@@ -131,24 +131,24 @@ class TipPositionModal extends React.Component<Props, State> {
                     className={styles.position_from_bottom_input}
                     onChange={this.handleChange}
                     units="mm"
-                    value={value } />
+                    value={valueString} />
                 </FormGroup>
                 <div className={styles.viz_group}>
                   <div className={styles.adjustment_buttons}>
                     <OutlineButton
                       className={styles.adjustment_button}
-                      disabled={parseFloat(value) >= (wellHeightMM * 2)}
+                      disabled={value >= (wellHeightMM * 2)}
                       onClick={this.makeHandleIncrement(SMALL_STEP_MM)}>
                       <Icon name="plus" />
                     </OutlineButton>
                     <OutlineButton
                       className={styles.adjustment_button}
-                      disabled={parseFloat(value) <= 0}
+                      disabled={value <= 0}
                       onClick={this.makeHandleDecrement(SMALL_STEP_MM)}>
                       <Icon name="minus" />
                     </OutlineButton>
                   </div>
-                  <TipPositionZAxisViz mmFromBottom={value} wellHeightMM={wellHeightMM} />
+                  <TipPositionZAxisViz mmFromBottom={valueString} wellHeightMM={wellHeightMM} />
                 </div>
               </div>
               <div className={styles.rightHalf}>{/* TODO: xy tip positioning */}</div>

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -41,8 +41,8 @@ type OP = {
 type Props = OP & DP
 type State = { value: string }
 
-const formatValue = (value: number): string => (
-  String(round(value, DECIMALS_ALLOWED))
+const formatValue = (value: number | string): string => (
+  String(round(Number(value), DECIMALS_ALLOWED))
 )
 
 class TipPositionModal extends React.Component<Props, State> {
@@ -56,7 +56,7 @@ class TipPositionModal extends React.Component<Props, State> {
     }
   }
   applyChanges = () => {
-    this.props.updateValue(formatValue(Number(this.state.value) || 0))
+    this.props.updateValue(formatValue(this.state.value || 0))
   }
   handleReset = () => {
     // NOTE: when `prefix` isn't set (eg in the Mix form), we'll use
@@ -77,7 +77,7 @@ class TipPositionModal extends React.Component<Props, State> {
   }
   handleChange = (e: SyntheticEvent<HTMLSelectElement>) => {
     const {value} = e.currentTarget
-    const valueFloat = Number(formatValue(Number(value)))
+    const valueFloat = Number(formatValue(value))
     const maximumHeightMM = (this.props.wellHeightMM * 2)
 
     if (!value) {

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import cx from 'classnames'
 import {connect} from 'react-redux'
+import round from 'lodash/round'
 import {
   Modal,
   OutlineButton,
@@ -25,6 +26,7 @@ import styles from './TipPositionInput.css'
 
 const SMALL_STEP_MM = 1
 const LARGE_STEP_MM = 10
+const DECIMALS_ALLOWED = 1
 
 type DP = { updateValue: (string) => mixed }
 
@@ -37,10 +39,10 @@ type OP = {
 }
 
 type Props = OP & DP
-type State = { value: string}
+type State = { value: string }
 
-const formatValue = (value: mixed) => (
-  parseFloat(value).toFixed(1)
+const formatValue = (value: number): string => (
+  String(round(value, DECIMALS_ALLOWED))
 )
 
 class TipPositionModal extends React.Component<Props, State> {
@@ -54,7 +56,7 @@ class TipPositionModal extends React.Component<Props, State> {
     }
   }
   applyChanges = () => {
-    this.props.updateValue(formatValue(this.state.value || 0))
+    this.props.updateValue(formatValue(Number(this.state.value) || 0))
   }
   handleReset = () => {
     // NOTE: when `prefix` isn't set (eg in the Mix form), we'll use
@@ -75,14 +77,14 @@ class TipPositionModal extends React.Component<Props, State> {
   }
   handleChange = (e: SyntheticEvent<HTMLSelectElement>) => {
     const {value} = e.currentTarget
-    const valueFloat = formatValue(value)
+    const valueFloat = Number(formatValue(Number(value)))
     const maximumHeightMM = (this.props.wellHeightMM * 2)
 
     if (!value) {
       this.setState({value})
-    } else if (Number(valueFloat) > maximumHeightMM) {
+    } else if (valueFloat > maximumHeightMM) {
       this.setState({value: formatValue(maximumHeightMM)})
-    } else if (Number(valueFloat) >= 0) {
+    } else if (valueFloat >= 0) {
       const numericValue = value.replace(/[^.0-9]/, '')
       this.setState({value: numericValue.replace(/(\d*[.]{1}\d{1})(\d*)/, (match, group1) => group1)})
     } else {

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionZAxisViz.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionZAxisViz.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import round from 'lodash/round'
 
 import PIPETTE_TIP_IMAGE from '../../../images/pipette_tip.svg'
 import WELL_CROSS_SECTION_IMAGE from '../../../images/well_cross_section.svg'
@@ -7,6 +8,7 @@ import WELL_CROSS_SECTION_IMAGE from '../../../images/well_cross_section.svg'
 import styles from './TipPositionInput.css'
 
 const WELL_HEIGHT_PIXELS = 48
+const PIXEL_DECIMALS = 2
 type Props = {
   mmFromBottom: string,
   wellHeightMM: number,
@@ -15,7 +17,7 @@ type Props = {
 const TipPositionZAxisViz = (props: Props) => {
   const fractionOfWellHeight = Number(props.mmFromBottom) / props.wellHeightMM
   const pixelsFromBottom = (Number(fractionOfWellHeight) * WELL_HEIGHT_PIXELS) - WELL_HEIGHT_PIXELS
-  const roundedPixelsFromBottom = String(pixelsFromBottom.toFixed(2))
+  const roundedPixelsFromBottom = String(round(pixelsFromBottom, PIXEL_DECIMALS))
   const bottomPx = props.wellHeightMM ? roundedPixelsFromBottom : (parseFloat(props.mmFromBottom) - WELL_HEIGHT_PIXELS)
   return (
     <div className={styles.viz_wrapper}>

--- a/protocol-designer/src/components/steplist/utils.js
+++ b/protocol-designer/src/components/steplist/utils.js
@@ -13,5 +13,5 @@ export function formatVolume (inputVolume: ?string | ?number, sigDigits?: number
 }
 
 export const formatPercentage = (part: number, total: number): string => {
-  return `${Number((part / total) * 100).toFixed(1)}%`
+  return `${round(Number((part / total) * 100), 1)}%`
 }

--- a/protocol-designer/src/components/steplist/utils.js
+++ b/protocol-designer/src/components/steplist/utils.js
@@ -12,6 +12,7 @@ export function formatVolume (inputVolume: ?string | ?number, sigDigits?: number
   return inputVolume || ''
 }
 
+const PERCENTAGE_DECIMALS_ALLOWED = 1
 export const formatPercentage = (part: number, total: number): string => {
-  return `${round(Number((part / total) * 100), 1)}%`
+  return `${round((part / total) * 100, PERCENTAGE_DECIMALS_ALLOWED)}%`
 }


### PR DESCRIPTION
## overview

Closes #2405 chore

We've been rounding all wrong! `.toFixed` [isn't reliable](https://bugs.chromium.org/p/chromium/issues/detail?id=778669&can=1&q=tofixed&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified) for rounding to fixed precision, so this PR replaces it with lodash's `round` which [uses](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L5434) exponent notation to avoid the floating-point conversion issues.

This is more of a housekeeping best practice chore than fixing actual bugs -- I think to get a bug, you'd have to load a JSON protocol that has its step fields (not even commands, but step fields) edited to add more decimals than allowed. This might be a practical case if we ever increase then decrease allowed decimals for a field in PD that bug could appear and mess protocols up in a subtle hard-to-catch way.

## changelog

* use lodash/round instead of Number.toFixed

## review requests

These should all be formatted with the correct number of decimals (all of these allow max of 1 decimal) and everything should work the same:

- Flow rate
- Tip position
- Percentages (in liquid tracking tooltip when there are multiple liquids in a well)