### PR TITLE
feat(app): Remove 'opentrons-' prefix in robot displayNames

### DIFF
--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -14,6 +14,7 @@ import type {RobotItemProps} from './RobotItem'
 export function RobotListItem (props: RobotItemProps) {
   const {
     name,
+    displayName,
     local,
     status,
     connected,
@@ -35,7 +36,7 @@ export function RobotListItem (props: RobotItemProps) {
           childClassName={styles.notification}
         />
 
-        <p className={styles.link_text}>{name}</p>
+        <p className={styles.link_text}>{displayName}</p>
 
         {connectable ? (
           <ToggleButton

--- a/app/src/components/ConnectPanel/UnreachableRobotItem.js
+++ b/app/src/components/ConnectPanel/UnreachableRobotItem.js
@@ -7,7 +7,7 @@ import RobotLink from './RobotLink'
 import styles from './styles.css'
 
 export default function UnreachableRobotItem (props: UnreachableRobot) {
-  const {name} = props
+  const {displayName} = props
   return (
     <li className={styles.robot_group}>
       <HoverTooltip
@@ -27,7 +27,7 @@ export default function UnreachableRobotItem (props: UnreachableRobot) {
               className={styles.robot_item_icon}
               disabled
             />
-            <p className={styles.link_text}>{name}</p>
+            <p className={styles.link_text}>{displayName}</p>
           </RobotLink>
         )}
       </HoverTooltip>

--- a/app/src/components/SessionHeader/index.js
+++ b/app/src/components/SessionHeader/index.js
@@ -7,11 +7,7 @@ import {getProtocolFilename} from '../../protocol'
 export default connect(mapStateToProps)(SessionHeader)
 
 function SessionHeader (props) {
-  return (
-    <Link to='/upload'>
-      {props.sessionName}
-    </Link>
-  )
+  return <Link to="/upload">{props.sessionName}</Link>
 }
 
 function mapStateToProps (state) {

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -1,8 +1,15 @@
 // discovery selectors tests
 import * as discovery from '..'
 
-const makeFullyUp = (name, ip, status = null, connected = null) => ({
+const makeFullyUp = (
   name,
+  displayName,
+  ip,
+  status = null,
+  connected = null
+) => ({
+  name,
+  displayName,
   ip,
   local: false,
   ok: true,
@@ -14,8 +21,15 @@ const makeFullyUp = (name, ip, status = null, connected = null) => ({
   connected,
 })
 
-const makeConnectable = (name, ip, status = null, connected = null) => ({
+const makeConnectable = (
   name,
+  displayName,
+  ip,
+  status = null,
+  connected = null
+) => ({
+  name,
+  displayName,
   ip,
   local: false,
   ok: true,
@@ -25,8 +39,9 @@ const makeConnectable = (name, ip, status = null, connected = null) => ({
   connected,
 })
 
-const makeAdvertising = (name, ip, status = null) => ({
+const makeAdvertising = (name, displayName, ip, status = null) => ({
   name,
+  displayName,
   ip,
   local: false,
   ok: false,
@@ -35,8 +50,9 @@ const makeAdvertising = (name, ip, status = null) => ({
   status,
 })
 
-const makeServerUp = (name, ip, advertising, status = null) => ({
+const makeServerUp = (name, displayName, ip, advertising, status = null) => ({
   name,
+  displayName,
   ip,
   advertising,
   local: false,
@@ -46,8 +62,9 @@ const makeServerUp = (name, ip, advertising, status = null) => ({
   status,
 })
 
-const makeUnreachable = (name, ip, status = null) => ({
+const makeUnreachable = (name, displayName, ip, status = null) => ({
   name,
+  displayName,
   ip,
   local: false,
   ok: false,
@@ -76,15 +93,15 @@ describe('discovery selectors', () => {
       state: {
         discovery: {
           robotsByName: {
-            foo: [makeConnectable('foo', '10.0.0.1')],
-            bar: [makeFullyUp('bar', '10.0.0.2')],
+            foo: [makeConnectable('foo', 'foo', '10.0.0.1')],
+            bar: [makeFullyUp('bar', 'bar', '10.0.0.2')],
           },
         },
         robot: {connection: {connectedTo: 'bar'}},
       },
       expected: [
-        makeConnectable('foo', '10.0.0.1', 'connectable', false),
-        makeFullyUp('bar', '10.0.0.2', 'connectable', true),
+        makeConnectable('foo', 'foo', '10.0.0.1', 'connectable', false),
+        makeFullyUp('bar', 'bar', '10.0.0.2', 'connectable', true),
       ],
     },
     {
@@ -94,16 +111,18 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              makeConnectable('foo', '10.0.0.1'),
-              makeConnectable('foo', '10.0.0.2'),
-              makeServerUp('foo', '10.0.0.3', false),
-              makeAdvertising('foo', '10.0.0.4', false),
+              makeConnectable('foo', 'foo', '10.0.0.1'),
+              makeConnectable('foo', 'foo', '10.0.0.2'),
+              makeServerUp('foo', 'foo', '10.0.0.3', false),
+              makeAdvertising('foo', 'foo', '10.0.0.4', false),
             ],
           },
         },
         robot: {connection: {connectedTo: 'foo'}},
       },
-      expected: [makeConnectable('foo', '10.0.0.1', 'connectable', true)],
+      expected: [
+        makeConnectable('foo', 'foo', '10.0.0.1', 'connectable', true),
+      ],
     },
     {
       name: 'getReachableRobots grabs robots with serverUp or advertising',
@@ -111,14 +130,14 @@ describe('discovery selectors', () => {
       state: {
         discovery: {
           robotsByName: {
-            foo: [makeServerUp('foo', '10.0.0.1', false)],
-            bar: [makeAdvertising('bar', '10.0.0.2')],
+            foo: [makeServerUp('foo', 'foo', '10.0.0.1', false)],
+            bar: [makeAdvertising('bar', 'bar', '10.0.0.2')],
           },
         },
       },
       expected: [
-        makeServerUp('foo', '10.0.0.1', false, 'reachable'),
-        makeAdvertising('bar', '10.0.0.2', 'reachable'),
+        makeServerUp('foo', 'foo', '10.0.0.1', false, 'reachable'),
+        makeAdvertising('bar', 'bar', '10.0.0.2', 'reachable'),
       ],
     },
     {
@@ -128,14 +147,14 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              makeServerUp('foo', '10.0.0.1', true),
-              makeServerUp('foo', '10.0.0.1', false),
-              makeAdvertising('foo', '10.0.0.2'),
+              makeServerUp('foo', 'foo', '10.0.0.1', true),
+              makeServerUp('foo', 'foo', '10.0.0.1', false),
+              makeAdvertising('foo', 'foo', '10.0.0.2'),
             ],
           },
         },
       },
-      expected: [makeServerUp('foo', '10.0.0.1', true, 'reachable')],
+      expected: [makeServerUp('foo', 'foo', '10.0.0.1', true, 'reachable')],
     },
     {
       name: 'getReachableRobots does not grab connectable robots',
@@ -144,18 +163,18 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              makeConnectable('foo', '10.0.0.1'),
-              makeServerUp('foo', '10.0.0.2', true),
+              makeConnectable('foo', 'foo', '10.0.0.1'),
+              makeServerUp('foo', 'foo', '10.0.0.2', true),
             ],
             bar: [
-              makeConnectable('bar', '10.0.0.3'),
-              makeServerUp('bar', '10.0.0.4', false),
+              makeConnectable('bar', 'bar', '10.0.0.3'),
+              makeServerUp('bar', 'bar', '10.0.0.4', false),
             ],
             baz: [
-              makeConnectable('baz', '10.0.0.5'),
-              makeAdvertising('baz', '10.0.0.6'),
+              makeConnectable('baz', 'baz', '10.0.0.5'),
+              makeAdvertising('baz', 'baz', '10.0.0.6'),
             ],
-            qux: [makeFullyUp('qux', '10.0.0.7')],
+            qux: [makeFullyUp('qux', 'baz', '10.0.0.7')],
           },
         },
       },
@@ -165,9 +184,13 @@ describe('discovery selectors', () => {
       name: 'getUnreachableRobots grabs robots with no ip',
       selector: discovery.getUnreachableRobots,
       state: {
-        discovery: {robotsByName: {foo: [{name: 'foo', ip: null}]}},
+        discovery: {
+          robotsByName: {foo: [{name: 'foo', displayName: 'foo', ip: null}]},
+        },
       },
-      expected: [{name: 'foo', ip: null, status: 'unreachable'}],
+      expected: [
+        {name: 'foo', displayName: 'foo', ip: null, status: 'unreachable'},
+      ],
     },
     {
       name: 'getUnreachableRobots grabs robots with IP but no responses',
@@ -176,13 +199,13 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              makeUnreachable('foo', '10.0.0.1'),
-              makeUnreachable('foo', '10.0.0.2'),
+              makeUnreachable('foo', 'foo', '10.0.0.1'),
+              makeUnreachable('foo', 'foo', '10.0.0.2'),
             ],
           },
         },
       },
-      expected: [makeUnreachable('foo', '10.0.0.1', 'unreachable')],
+      expected: [makeUnreachable('foo', 'foo', '10.0.0.1', 'unreachable')],
     },
     {
       name: "getUnreachableRobots won't grab connectable/reachable robots",
@@ -191,18 +214,18 @@ describe('discovery selectors', () => {
         discovery: {
           robotsByName: {
             foo: [
-              makeServerUp('foo', '10.0.0.1', true),
-              makeUnreachable('foo', '10.0.0.2'),
+              makeServerUp('foo', 'foo', '10.0.0.1', true),
+              makeUnreachable('foo', 'foo', '10.0.0.2'),
             ],
             bar: [
-              makeServerUp('bar', '10.0.0.3', false),
+              makeServerUp('bar', 'bar', '10.0.0.3', false),
               makeUnreachable('bar', '10.0.0.4'),
             ],
             baz: [
-              makeAdvertising('bar', '10.0.0.5'),
-              makeUnreachable('baz', '10.0.0.6'),
+              makeAdvertising('bar', 'bar', '10.0.0.5'),
+              makeUnreachable('baz', 'baz', '10.0.0.6'),
             ],
-            qux: [makeConnectable('qux', '10.0.0.7')],
+            qux: [makeConnectable('qux', 'qux', '10.0.0.7')],
           },
         },
       },

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -59,16 +59,27 @@ const getGroupedRobotsMap: GetGroupedRobotsMap = createSelector(
     mapValues(robotsMap, services => {
       const servicesWithStatus = services.map(s => {
         const resolved = maybeGetResolved(s)
+        const displayName = makeDisplayName(s)
         if (resolved) {
-          if (isConnectable(resolved)) return {...s, status: CONNECTABLE}
-          if (isReachable(resolved)) return {...s, status: REACHABLE}
+          if (isConnectable(resolved)) {
+            return {...s, status: CONNECTABLE, displayName}
+          }
+          if (isReachable(resolved)) {
+            return {...s, status: REACHABLE, displayName}
+          }
         }
-        return {...s, status: UNREACHABLE}
+        return {...s, status: UNREACHABLE, displayName}
       })
 
       return groupBy(servicesWithStatus, 'status')
     })
 )
+
+function makeDisplayName (robot: Service) {
+  const {name} = robot
+  const displayName = name.replace('opentrons-', '')
+  return displayName
+}
 
 export const getConnectableRobots: GetConnectableRobots = createSelector(
   getGroupedRobotsMap,

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -9,6 +9,7 @@ export type UnreachableStatus = 'unreachable'
 // service with a known IP address
 export type ResolvedRobot = {
   ...$Exact<Service>,
+  displayName: string,
   ip: $NonMaybeType<$PropertyType<Service, 'ip'>>,
   local: $NonMaybeType<$PropertyType<Service, 'local'>>,
   ok: $NonMaybeType<$PropertyType<Service, 'ok'>>,
@@ -34,6 +35,7 @@ export type ReachableRobot = {
 // robot with an unknown IP
 export type UnreachableRobot = {
   ...$Exact<Service>,
+  displayName: string,
   status: UnreachableStatus,
 }
 

--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -19,18 +19,21 @@ export default function InstrumentSettingsPage (props: Props) {
     robot,
     match: {path, url},
   } = props
-  const titleBarProps = {title: robot.name}
+  const titleBarProps = {title: robot.displayName}
 
   return (
     <React.Fragment>
-    <Page titleBarProps={titleBarProps}>
-      <InstrumentSettings {...robot} />
-    </Page>
-    <Switch>
-      <Route path={`${path}/pipettes`} render={(props) => (
-        <ChangePipette {...props} robot={robot} parentUrl={url} />
-      )} />
-    </Switch>
+      <Page titleBarProps={titleBarProps}>
+        <InstrumentSettings {...robot} />
+      </Page>
+      <Switch>
+        <Route
+          path={`${path}/pipettes`}
+          render={props => (
+            <ChangePipette {...props} robot={robot} parentUrl={url} />
+          )}
+        />
+      </Switch>
     </React.Fragment>
   )
 }

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -74,7 +74,7 @@ function RobotSettingsPage (props: Props) {
     match: {path, url},
   } = props
 
-  const titleBarProps = {title: robot.name}
+  const titleBarProps = {title: robot.displayName}
   const updateUrl = `${url}/${UPDATE_FRAGMENT}`
   const calibrateDeckUrl = `${url}/${CALIBRATE_DECK_FRAGMENT}`
   const resetUrl = `${url}/${RESET_FRAGMENT}`


### PR DESCRIPTION
## overview

closes #2357 by creating a `displayName` which strips out 'opentrons-' and preserving `name` as is.

<img width="1024" alt="screen shot 2018-10-10 at 6 04 24 pm" src="https://user-images.githubusercontent.com/3430313/46768793-8e1ac280-ccb7-11e8-8761-f9d881f02cc1.png">

## changelog

- feat(app): Remove 'opentrons-' prefix in robot displayNames

## review requests
- [ ] Robot list renders properly with displayName (old name minus `opentrons-`)
- [ ] 

> TitleBar

 in RobotSettings and InstrumentSettings pages displays displayName
