### PR TITLE
fix(api): Fix docs build failure after move to legacy_api

### DIFF
--- a/api/docs/source/api.rst
+++ b/api/docs/source/api.rst
@@ -13,13 +13,13 @@ Robot
 
 All protocols are set up, simulated and executed using a Robot class.
 
-.. autoclass:: Robot
+.. autoclass:: opentrons.legacy_api.robot.Robot
    :members: connect, home, reset, run, simulate, commands, move_to, disconnect, head_speed, pause, resume, stop, get_warnings, add_instrument, get_motor
 
 Pipette
 -----------------
 
-.. module:: opentrons.instruments
+.. module:: opentrons.legacy_api.instruments
 
-.. autoclass:: Pipette
+.. autoclass:: opentrons.legacy_api.instruments.Pipette
    :members: aspirate, dispense, mix, delay, drop_tip, blow_out, touch_tip, pick_up_tip, return_tip, move_to, home, set_flow_rate

--- a/api/opentrons/legacy_api/instruments/pipette.py
+++ b/api/opentrons/legacy_api/instruments/pipette.py
@@ -49,7 +49,7 @@ class Pipette:
     DIRECT USE OF THIS CLASS IS DEPRECATED -- this class should not be used
     directly. Its parameters, defaults, methods, and behaviors are subject to
     change without a major version release. Use the model-specific constructors
-    available through `from opentrons import instruments`.
+    available through ``from opentrons import instruments``.
 
     All model-specific instrument constructors are inheritors of this class.
     With any of those instances you can can:

--- a/api/opentrons/legacy_api/robot/robot.py
+++ b/api/opentrons/legacy_api/robot/robot.py
@@ -65,6 +65,9 @@ class Robot(object):
     """
     This class is the main interface to the robot.
 
+    It should never be instantiated directly; instead, the global instance may
+    be accessed at :py:attr:``opentrons.robot``.
+
     Through this class you can can:
         * define your :class:`opentrons.Deck`
         * :meth:`connect` to Opentrons physical robot


### PR DESCRIPTION
Closes #2468
