### PR TITLE
feat(app): Move deck calibration to robot controls

### DIFF
--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -7,7 +7,6 @@ import StatusCard from './StatusCard'
 import InformationCard from './InformationCard'
 import ControlsCard from './ControlsCard'
 import ConnectivityCard from './ConnectivityCard'
-import CalibrationCard from './CalibrationCard'
 import AdvancedSettingsCard from './AdvancedSettingsCard'
 import ConnectAlertModal from './ConnectAlertModal'
 import RobotUpdateModal from './RobotUpdateModal'
@@ -33,14 +32,11 @@ export default function RobotSettings (props: Props) {
         <InformationCard robot={robot} updateUrl={updateUrl} />
       </CardRow>
       <CardRow>
-        <ControlsCard robot={robot} />
+        <ControlsCard robot={robot} calibrateDeckUrl={calibrateDeckUrl} />
       </CardRow>
       <CardRow>
         <CardColumn>
           <ConnectivityCard robot={robot} />
-        </CardColumn>
-        <CardColumn>
-          <CalibrationCard robot={robot} calibrateDeckUrl={calibrateDeckUrl} />
         </CardColumn>
       </CardRow>
       <CardRow>


### PR DESCRIPTION
## overview

closes #2377

<img width="1025" alt="screen shot 2018-10-12 at 10 25 01 am" src="https://user-images.githubusercontent.com/3430313/46875492-d2b67300-ce09-11e8-8da2-086c42424f94.png">

## changelog

- feat(app): Move deck calibration to robot controls

## review requests

Please check that deck calibration works on a robot.