### PR TITLE
feat(api): Add /networking/status endpoint to get all interface info

### DIFF
--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -1,6 +1,6 @@
 import logging
 from . import endpoints as endp
-from .endpoints import (wifi, control, settings, update)
+from .endpoints import (networking, control, settings, update)
 from opentrons.deck_calibration import endpoints as dc_endp
 
 
@@ -16,16 +16,18 @@ class HTTPServer(object):
         self.app.router.add_get(
             '/health', endp.health)
         self.app.router.add_get(
-            '/wifi/list', wifi.list_networks)
+            '/networking/status', networking.status)
+        # TODO(mc, 2018-10-12): s/wifi/networking
+        self.app.router.add_get(
+            '/wifi/list', networking.list_networks)
         self.app.router.add_post(
-            '/wifi/configure', wifi.configure)
+            '/wifi/configure', networking.configure)
+        self.app.router.add_post('/wifi/keys', networking.add_key)
+        self.app.router.add_get('/wifi/keys', networking.list_keys)
+        self.app.router.add_delete(
+            '/wifi/keys/{key_uuid}', networking.remove_key)
         self.app.router.add_get(
-            '/wifi/status', wifi.status)
-        self.app.router.add_post('/wifi/keys', wifi.add_key)
-        self.app.router.add_get('/wifi/keys', wifi.list_keys)
-        self.app.router.add_delete('/wifi/keys/{key_uuid}', wifi.remove_key)
-        self.app.router.add_get(
-            '/wifi/eap-options', wifi.eap_options)
+            '/wifi/eap-options', networking.eap_options)
         self.app.router.add_post(
             '/identify', control.identify)
         self.app.router.add_get(

--- a/api/tests/opentrons/server/test_networking_endpoints.py
+++ b/api/tests/opentrons/server/test_networking_endpoints.py
@@ -22,17 +22,16 @@ async def test_networking_status(
         if 'connectivity' in cmd:
             res = 'full'
         elif 'wlan0' in cmd:
-            res = '''B8:27:EB:5F:A6:89
---
---
-wifi
-30 (disconnected)'''
+            res = '''GENERAL.HWADDR:B8:27:EB:5F:A6:89
+IP4.ADDRESS[1]:--
+IP4.GATEWAY:--
+GENERAL.TYPE:wifi
+GENERAL.STATE:30 (disconnected)'''
         elif 'eth0' in cmd:
-            res = '''B8:27:EB:39:C0:9A
-169.254.229.173/16
---
-ethernet
-100 (connected)'''
+            res = '''GENERAL.HWADDR:B8:27:EB:39:C0:9A
+IP4.ADDRESS[1]:169.254.229.173/16
+GENERAL.TYPE:ethernet
+GENERAL.STATE:100 (connected)'''
         else:
             res = 'incorrect nmcli call'
 
@@ -44,8 +43,10 @@ ethernet
         'status': 'full',
         'interfaces': {
             'wlan0': {
+                # test "--" gets mapped to None
                 'ipAddress': None,
                 'macAddress': 'B8:27:EB:5F:A6:89',
+                # test "--" gets mapped to None
                 'gatewayAddress': None,
                 'state': 'disconnected',
                 'type': 'wifi'
@@ -53,6 +54,7 @@ ethernet
             'eth0': {
                 'ipAddress': '169.254.229.173/16',
                 'macAddress': 'B8:27:EB:39:C0:9A',
+                # test missing output gets mapped to None
                 'gatewayAddress': None,
                 'state': 'connected',
                 'type': 'ethernet'

--- a/api/tests/opentrons/server/test_networking_endpoints.py
+++ b/api/tests/opentrons/server/test_networking_endpoints.py
@@ -5,14 +5,14 @@ import tempfile
 import pytest
 from opentrons.system import nmcli
 from opentrons.server import init
-from opentrons.server.endpoints import wifi
+from opentrons.server.endpoints import networking
 
 """
 All mocks in this test suite represent actual output from nmcli commands
 """
 
 
-async def test_wifi_status(
+async def test_networking_status(
         virtual_smoothie_env, loop, test_client, monkeypatch):
     app = init(loop)
     cli = await loop.create_task(test_client(app))
@@ -20,21 +20,47 @@ async def test_wifi_status(
     async def mock_call(cmd):
         # Command: `nmcli networking connectivity`
         if 'connectivity' in cmd:
-            return 'full', ''
-        else:
+            res = 'full'
+        elif 'wlan0' in cmd:
             res = '''B8:27:EB:5F:A6:89
-192.168.1.137/24
-192.168.1.1
+--
+--
+wifi
+30 (disconnected)'''
+        elif 'eth0' in cmd:
+            res = '''B8:27:EB:39:C0:9A
+169.254.229.173/16
+--
+ethernet
 100 (connected)'''
-            return res, ''
+        else:
+            res = 'incorrect nmcli call'
+
+        return res, ''
 
     monkeypatch.setattr(nmcli, '_call', mock_call)
 
-    expected = json.dumps({'status': 'full',
-                           'ipAddress': '192.168.1.137/24',
-                           'macAddress': 'B8:27:EB:5F:A6:89',
-                           'gatewayAddress': '192.168.1.1'})
-    resp = await cli.get('/wifi/status')
+    expected = json.dumps({
+        'status': 'full',
+        'interfaces': {
+            'wlan0': {
+                'ipAddress': None,
+                'macAddress': 'B8:27:EB:5F:A6:89',
+                'gatewayAddress': None,
+                'state': 'disconnected',
+                'type': 'wifi'
+            },
+            'eth0': {
+                'ipAddress': '169.254.229.173/16',
+                'macAddress': 'B8:27:EB:39:C0:9A',
+                'gatewayAddress': None,
+                'state': 'connected',
+                'type': 'ethernet'
+            }
+        }
+    })
+
+    resp = await cli.get('/networking/status')
     text = await resp.text()
     assert resp.status == 200
     assert text == expected
@@ -46,7 +72,7 @@ async def test_wifi_status(
             return '', 'this is a dummy error'
 
     monkeypatch.setattr(nmcli, '_call', mock_call)
-    resp = await cli.get('/wifi/status')
+    resp = await cli.get('/networking/status')
     assert resp.status == 500
 
 
@@ -105,15 +131,16 @@ async def test_wifi_configure(
 
 
 def test_deduce_security():
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._deduce_security({'psk': 'hi', 'eapConfig': {'hi': 'nope'}})
-    assert wifi._deduce_security({'psk': 'test-psk'})\
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._deduce_security({'psk': 'hi', 'eapConfig': {'hi': 'nope'}})
+    assert networking._deduce_security({'psk': 'test-psk'})\
         == nmcli.SECURITY_TYPES.WPA_PSK
-    assert wifi._deduce_security({'eapConfig': {'hi': 'this is bad'}})\
+    assert networking._deduce_security({'eapConfig': {'hi': 'this is bad'}})\
         == nmcli.SECURITY_TYPES.WPA_EAP
-    assert wifi._deduce_security({}) == nmcli.SECURITY_TYPES.NONE
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._deduce_security({'securityType': 'this is invalid you fool'})
+    assert networking._deduce_security({}) == nmcli.SECURITY_TYPES.NONE
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._deduce_security(
+            {'securityType': 'this is invalid you fool'})
 
 
 def test_check_eap_config(wifi_keys_tempdir):
@@ -124,24 +151,24 @@ def test_check_eap_config(wifi_keys_tempdir):
                            'test.pem'), 'w') as f:
         f.write('what a terrible key')
     # Bad eap types should fail
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_config({'eapType': 'afaosdasd'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_config({'eapType': 'afaosdasd'})
     # Valid (if short) arguments should work
-    wifi._eap_check_config({'eapType': 'peap/eap-mschapv2',
-                            'identity': 'test@hi.com',
-                            'password': 'passwd'})
+    networking._eap_check_config({'eapType': 'peap/eap-mschapv2',
+                                  'identity': 'test@hi.com',
+                                  'password': 'passwd'})
     # Extra args should fail
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_config({'eapType': 'tls',
-                                'identity': 'test@example.com',
-                                'privateKey': wifi_key_id,
-                                'clientCert': wifi_key_id,
-                                'phase2CaCertf': 'foo'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_config({'eapType': 'tls',
+                                      'identity': 'test@example.com',
+                                      'privateKey': wifi_key_id,
+                                      'clientCert': wifi_key_id,
+                                      'phase2CaCertf': 'foo'})
     # Filenames should be rewritten
-    rewritten = wifi._eap_check_config({'eapType': 'ttls/eap-md5',
-                                        'identity': 'hello@example.com',
-                                        'password': 'hi',
-                                        'caCert': wifi_key_id})
+    rewritten = networking._eap_check_config({'eapType': 'ttls/eap-md5',
+                                              'identity': 'hello@example.com',
+                                              'password': 'hi',
+                                              'caCert': wifi_key_id})
     assert rewritten['caCert'] == os.path.join(wifi_keys_tempdir,
                                                wifi_key_id,
                                                'test.pem')
@@ -150,64 +177,64 @@ def test_check_eap_config(wifi_keys_tempdir):
               'identity': "test@hello.com",
               'phase2ClientCert': wifi_key_id,
               'phase2PrivateKey': wifi_key_id}
-    out = wifi._eap_check_config(config)
+    out = networking._eap_check_config(config)
     for key in config.keys():
         assert key in out
 
 
 def test_eap_check_option():
     # Required arguments that are not specified should raise
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'test-opt', 'required': True,
-                                   'displayName': 'Test Option'},
-                                  {'eapType': 'test'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_option_ok({'name': 'test-opt', 'required': True,
+                                         'displayName': 'Test Option'},
+                                        {'eapType': 'test'})
     # Non-required arguments that are not specified should not raise
-    wifi._eap_check_option_ok({'name': 'test-1',
-                               'required': False,
-                               'type': 'string',
-                               'displayName': 'Test Option'},
-                              {'eapType': 'test'})
+    networking._eap_check_option_ok({'name': 'test-1',
+                                     'required': False,
+                                     'type': 'string',
+                                     'displayName': 'Test Option'},
+                                    {'eapType': 'test'})
 
     # Check type mismatch detection pos and neg
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'identity',
-                                   'displayName': 'Username',
-                                   'required': True,
-                                   'type': 'string'},
-                                  {'identity': 2,
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'identity',
-                               'required': True,
-                               'displayName': 'Username',
-                               'type': 'string'},
-                              {'identity': 'hi',
-                               'eapType': 'test'})
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'password',
-                                   'required': True,
-                                   'displayName': 'Password',
-                                   'type': 'password'},
-                                  {'password': [2, 3],
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'password',
-                               'required': True,
-                               'displayName': 'password',
-                               'type': 'password'},
-                              {'password': 'secret',
-                               'eapType': 'test'})
-    with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'phase2CaCert',
-                                   'displayName': 'some file who cares',
-                                   'required': True,
-                                   'type': 'file'},
-                                  {'phase2CaCert': 2,
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'phase2CaCert',
-                               'required': True,
-                               'displayName': 'hello',
-                               'type': 'file'},
-                              {'phase2CaCert': '82141cceaf',
-                               'eapType': 'test'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_option_ok({'name': 'identity',
+                                         'displayName': 'Username',
+                                         'required': True,
+                                         'type': 'string'},
+                                        {'identity': 2,
+                                         'eapType': 'test'})
+    networking._eap_check_option_ok({'name': 'identity',
+                                     'required': True,
+                                     'displayName': 'Username',
+                                     'type': 'string'},
+                                    {'identity': 'hi',
+                                     'eapType': 'test'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_option_ok({'name': 'password',
+                                         'required': True,
+                                         'displayName': 'Password',
+                                         'type': 'password'},
+                                        {'password': [2, 3],
+                                         'eapType': 'test'})
+    networking._eap_check_option_ok({'name': 'password',
+                                     'required': True,
+                                     'displayName': 'password',
+                                     'type': 'password'},
+                                    {'password': 'secret',
+                                     'eapType': 'test'})
+    with pytest.raises(networking.ConfigureArgsError):
+        networking._eap_check_option_ok({'name': 'phase2CaCert',
+                                         'displayName': 'some file who cares',
+                                         'required': True,
+                                         'type': 'file'},
+                                        {'phase2CaCert': 2,
+                                         'eapType': 'test'})
+    networking._eap_check_option_ok({'name': 'phase2CaCert',
+                                     'required': True,
+                                     'displayName': 'hello',
+                                     'type': 'file'},
+                                    {'phase2CaCert': '82141cceaf',
+                                     'eapType': 'test'})
 
 
 async def test_list_keys(loop, test_client, wifi_keys_tempdir):


### PR DESCRIPTION
## overview

This PR replaces the unused `GET /wifi/status` with `GET /networking/status` which returns:

- Internet connectivity status
- IP/MAC/Gateway addresses, device type, and connection state of all networking interfaces defined in the `nmcli.NETWORK_IFACES` enum (`eth0` and `wlan0`)

## changelog

- feat(api): Add /networking/status endpoint to get all interface info
    - Also renames `wifi.py` to `networking.py`

## review requests

This branch has been pushed to 🌆 so you can test via postman: `GET /networking/status`

Otherwise, please check that the code + unit test changes are sane.
