### PR TITLE
feat(api): Add error checking on generated labware def

### DIFF
--- a/shared-data/js/labwareTools/__tests__/createLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.js
@@ -101,4 +101,17 @@ describe('createLabware', () => {
       })
     })
   })
+  test('invalid schema throws error', () => {
+    const spacing = {row: 11.8, column: 12.1}
+    const grid = {row: 8, column: 12}
+    const input = {
+      metadata: exampleLabware2.metadata,
+      parameters: exampleLabware2.parameters,
+      dimensions: exampleLabware2.dimensions,
+      grid,
+      spacing,
+      well: well2,
+    }
+    expect(() => { createRegularLabware(input) }).toThrow('1 or more required arguments missing from input.')
+  })
 })

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -1,8 +1,10 @@
 // @flow
+import Ajv from 'ajv'
 import range from 'lodash/range'
 
 import assignId from './assignId'
 import {toWellName} from '../helpers/index'
+import labwareSchema from '../../labware-json-schema/labware-schema.json'
 
 type Metadata = {
   displayName: string,
@@ -75,6 +77,12 @@ export type Schema = {
   wells: {[wellName: string]: Well},
 }
 
+const ajv = new Ajv({
+  allErrors: true,
+  jsonPointers: true,
+})
+const validate = ajv.compile(labwareSchema)
+
 function round (value, decimals) {
   return Number(Math.round(Number(value + 'e' + decimals)) + 'e-' + decimals)
 }
@@ -140,5 +148,10 @@ export function createRegularLabware (props: RegularLabwareProps): Schema {
     props.metadata.displayCategory}_${props.well.totalLiquidVolume}_${
       props.metadata.displayVolumeUnits}`
 
+  const valid = validate(definition)
+
+  if (valid !== true) {
+    throw new Error('1 or more required arguments missing from input.')
+  }
   return definition
 }


### PR DESCRIPTION
## overview

It was brought to my attention by @sfoster1 that the `cornerOffsetFromSlot` key was missing from both generated labware defs. This PR is meant to add a check on the labware schema to make sure that no required keys are forgotten.

## changelog
- Raise error if generator function does not create a valid schema definition.

## review requests
