### PR TITLE
refactor(api): refactor aspirate/dispense

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -217,6 +217,7 @@ def _clear_file(filename):
         os.remove(filename)
 
 
+# TODO: move to util (write a default load, save JSON function)
 def _load_json(filename) -> dict:
     try:
         with open(filename, 'r') as file:

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -1,6 +1,6 @@
 from aiohttp import web
 from uuid import uuid1
-from opentrons.legacy_api.instruments import pipette_config
+from opentrons.config import pipette_config
 from opentrons import instruments, robot
 from opentrons.config import robot_configs
 from . import jog, position, dots_set, z_pos

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -82,8 +82,14 @@ class Controller:
             args = tuple()
         return self._smoothie_driver.home(*args)
 
-    def get_attached_instruments(self, mount) -> Optional[str]:
+    def get_attached_instrument(self, mount) -> Optional[str]:
         return self._smoothie_driver.read_pipette_model(mount.name.lower())
+
+    def set_active_current(self, axis, amp):
+        self._smoothie_driver.set_active_current({axis.name: amp})
+
+    def set_pipette_speed(self, val: float):
+        self._smoothie_driver.set_speed(val)
 
     def get_attached_modules(self) -> List[Tuple[str, str]]:
         return modules.discover()
@@ -99,3 +105,6 @@ class Controller:
             -> modules.AbstractModule:
         return await modules.update_firmware(
             module, firmware_file, loop)
+
+    def _connect(self):
+        self._smoothie_driver.connect()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Optional, List, Tuple
+from typing import Dict, Optional, List, Tuple, Any
 
 from opentrons import types
 from . import modules
@@ -12,7 +12,7 @@ class Simulator:
     a robot with no smoothie connected.
     """
     def __init__(self,
-                 attached_instruments: Dict[types.Mount, Optional[str]],
+                 attached_instruments: Dict[types.Mount, Dict[str, Any]],
                  attached_modules: List[str],
                  config, loop) -> None:
         self._config = config
@@ -29,8 +29,17 @@ class Simulator:
         # driver_3_0-> HOMED_POSITION
         return {'X': 418, 'Y': 353, 'Z': 218, 'A': 218, 'B': 19, 'C': 19}
 
-    def get_attached_instruments(self, mount) -> Optional[str]:
-        return self._attached_instruments[mount]
+    def get_attached_instrument(self, mount) -> Optional[str]:
+        try:
+            return self._attached_instruments[mount]['name']
+        except KeyError:
+            return None
+
+    def set_active_current(self, axis, amp):
+        pass
+
+    def set_pipette_speed(self, speed):
+        pass
 
     def get_attached_modules(self) -> List[Tuple[str, str]]:
         return self._attached_modules

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -24,3 +24,9 @@ class Axis(enum.Enum):
         calibration transform
         """
         return (cls.X, cls.Y, cls.Z, cls.A)
+
+    @classmethod
+    def of_plunger(cls, mount: opentrons.types.Mount):
+        pm = {opentrons.types.Mount.LEFT: cls.B,
+              opentrons.types.Mount.RIGHT: cls.C}
+        return pm[mount]

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -1,5 +1,5 @@
 from . import robot, instruments as inst, containers as cnt, modules
-from .instruments import pipette_config
+from opentrons.config import pipette_config
 
 # Ignore the type here because well, this is exactly why this is the legacy_api
 robot = robot.Robot()  # type: ignore

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -16,8 +16,8 @@ from opentrons.config import feature_flags as fflags
 from opentrons.config.robot_configs import load
 from opentrons.legacy_api import containers
 from opentrons.legacy_api.containers import Container
-from opentrons.legacy_api.instruments import pipette_config
 from .mover import Mover
+from opentrons.config import pipette_config
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/protocols/__init__.py
+++ b/api/src/opentrons/protocols/__init__.py
@@ -1,7 +1,7 @@
 import time
 from itertools import chain
 from opentrons import instruments, labware, robot
-from opentrons.legacy_api.instruments import pipette_config
+from opentrons.config import pipette_config
 
 
 def _sleep(seconds):

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -5,7 +5,7 @@ import logging
 from aiohttp import web
 from threading import Thread
 from opentrons import robot, instruments, modules
-from opentrons.legacy_api.instruments import pipette_config
+from opentrons.config import pipette_config
 from opentrons.trackers import pose_tracker
 
 log = logging.getLogger(__name__)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -21,6 +21,7 @@ from opentrons.config import advanced_settings as advs
 from opentrons.server import init
 from opentrons.deck_calibration import endpoints
 from opentrons.util import environment
+from opentrons import hardware_control as hc
 
 # Uncomment to enable logging during tests
 
@@ -416,6 +417,16 @@ def running_on_pi():
         os.environ.pop('RUNNING_ON_PI')
     else:
         os.environ['RUNNING_ON_PI'] = oldpi
+
+
+@pytest.mark.skipif(not hc.Controller,
+                    reason='hardware controller not available '
+                           '(probably windows)')
+@pytest.fixture
+def cntrlr_mock_connect(monkeypatch):
+    def mock_connect(s):
+        return
+    monkeypatch.setattr(hc.Controller, '_connect', mock_connect)
 
 
 setup_testing_env()

--- a/api/tests/opentrons/hardware_control/test_instantiation.py
+++ b/api/tests/opentrons/hardware_control/test_instantiation.py
@@ -1,6 +1,5 @@
 import subprocess
 import threading
-
 import pytest
 from opentrons import hardware_control as hc
 
@@ -14,14 +13,15 @@ def test_controller_runs_only_on_pi():
         c = hc.API.build_hardware_controller() # noqa
 
 
-def test_controller_instantiates(
-        hardware_controller_lockfile, running_on_pi, loop):
+def test_controller_instantiates(hardware_controller_lockfile, running_on_pi,
+                                 cntrlr_mock_connect, loop):
     c = hc.API.build_hardware_controller(loop=loop)
     assert None is not c
 
 
-def test_controller_unique_per_thread(
-        hardware_controller_lockfile, running_on_pi, loop):
+def test_controller_unique_per_thread(hardware_controller_lockfile,
+                                      running_on_pi,
+                                      cntrlr_mock_connect, loop):
     c = hc.API.build_hardware_controller(loop=loop) # noqa
     with pytest.raises(RuntimeError):
         _ = hc.API.build_hardware_controller(loop=loop) # noqa
@@ -42,8 +42,8 @@ def test_controller_unique_per_thread(
         loop.run_until_complete(fut)
 
 
-def test_controller_unique_per_proc(
-        hardware_controller_lockfile, running_on_pi, loop):
+def test_controller_unique_per_proc(hardware_controller_lockfile,
+                                    running_on_pi, cntrlr_mock_connect, loop):
     c = hc.API.build_hardware_controller(loop=loop) # noqa
 
     script = '''import os

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -1,30 +1,101 @@
 import pytest
 from opentrons import types
 from opentrons import hardware_control as hc
+from opentrons.config import pipette_config
+from opentrons.hardware_control.types import Axis
 
 
-async def test_cache_instruments(loop):
-    dummy_instruments_attached = {types.Mount.LEFT: 'model_abc',
-                                  types.Mount.RIGHT: None}
+@pytest.fixture
+def dummy_instruments():
+    configs = pipette_config.load('p10_single_v1')
+    dummy_instruments_attached = {types.Mount.LEFT: {},
+                                  types.Mount.RIGHT: {}}
+    for config, default_value in configs._asdict().items():
+        dummy_instruments_attached[types.Mount.LEFT][config] = default_value
+    return dummy_instruments_attached
+
+
+def attached_instruments(inst):
+    """
+    Format inst dict like the public 'attached_instruments' property
+    """
+    configs = ['name', 'min_volume', 'max_volume',
+               'aspirate_flow_rate', 'dispense_flow_rate']
+    instruments = {types.Mount.LEFT: {},
+                   types.Mount.RIGHT: {}}
+    for mount in types.Mount:
+        if not inst[mount].get('name'):
+            continue
+        for key in configs:
+            instruments[mount][key] = inst[mount][key]
+    return instruments
+
+
+async def test_cache_instruments(dummy_instruments, loop):
     hw_api = hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments_attached, loop=loop)
-    await hw_api.cache_instrument_models()
-    assert hw_api._attached_instruments == dummy_instruments_attached
+        attached_instruments=dummy_instruments, loop=loop)
+    await hw_api.cache_instruments()
+    assert hw_api.attached_instruments == attached_instruments(
+        dummy_instruments)
 
 
 @pytest.mark.skipif(not hc.Controller,
                     reason='hardware controller not available '
                            '(probably windows)')
-async def test_cache_instruments_hc(monkeypatch, hardware_controller_lockfile,
-                                    running_on_pi, loop):
-    dummy_instruments_attached = {types.Mount.LEFT: 'model_abc',
-                                  types.Mount.RIGHT: None}
+async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
+                                    hardware_controller_lockfile,
+                                    running_on_pi, cntrlr_mock_connect, loop):
+
     hw_api_cntrlr = hc.API.build_hardware_controller(loop=loop)
 
     def mock_driver_method(mount):
-        attached_pipette = {'left': 'model_abc', 'right': None}
+        attached_pipette = {'left': 'p10_single_v1', 'right': None}
         return attached_pipette[mount]
     monkeypatch.setattr(hw_api_cntrlr._backend._smoothie_driver,
                         'read_pipette_model', mock_driver_method)
-    await hw_api_cntrlr.cache_instrument_models()
-    assert hw_api_cntrlr._attached_instruments == dummy_instruments_attached
+    await hw_api_cntrlr.cache_instruments()
+    assert hw_api_cntrlr.attached_instruments == attached_instruments(
+        dummy_instruments)
+
+
+async def test_aspirate(dummy_instruments, loop):
+    hw_api = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments, loop=loop)
+    await hw_api.home()
+    await hw_api.cache_instruments()
+    aspirate_ul = 3.0
+    aspirate_rate = 2
+    await hw_api.aspirate(types.Mount.LEFT, aspirate_ul, aspirate_rate)
+    new_plunger_pos = 5.660769
+    assert hw_api.current_position(types.Mount.LEFT)[Axis.B] == new_plunger_pos
+
+
+async def test_dispense(dummy_instruments, loop):
+    hw_api = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments, loop=loop)
+    await hw_api.home()
+
+    await hw_api.cache_instruments()
+    aspirate_ul = 10.0
+    aspirate_rate = 2
+    await hw_api.aspirate(types.Mount.LEFT, aspirate_ul, aspirate_rate)
+
+    dispense_1 = 3.0
+    await hw_api.dispense(types.Mount.LEFT, dispense_1)
+    plunger_pos_1 = 10.810573
+    assert hw_api.current_position(types.Mount.LEFT)[Axis.B] == plunger_pos_1
+
+    await hw_api.dispense(types.Mount.LEFT, rate=2)
+    plunger_pos_2 = 2
+    assert hw_api.current_position(types.Mount.LEFT)[Axis.B] == plunger_pos_2
+
+
+async def test_no_pipette(dummy_instruments, loop):
+    hw_api = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments, loop=loop)
+    await hw_api.cache_instruments()
+    aspirate_ul = 3.0
+    aspirate_rate = 2
+    with pytest.raises(hc.PipetteNotAttachedError):
+        await hw_api.aspirate(types.Mount.RIGHT, aspirate_ul, aspirate_rate)
+        assert not hw_api._current_volume[types.Mount.RIGHT]

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -57,7 +57,8 @@ async def test_module_update_logic(monkeypatch):
 
 @pytest.mark.skipif(not hardware_control.Controller,
                     reason='hardware controller not available')
-async def test_module_update_integration(monkeypatch, loop, running_on_pi):
+async def test_module_update_integration(monkeypatch, loop,
+                                         cntrlr_mock_connect, running_on_pi):
     api = hardware_control.API.build_hardware_controller(loop=loop)
 
     def mock_get_modules():

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -42,10 +42,12 @@ async def test_controller_home(loop):
     # Check that we subsequently apply mount offset
     assert c.current_position(types.Mount.RIGHT) == {Axis.X: 408,
                                                      Axis.Y: 333,
-                                                     Axis.A: 188}
+                                                     Axis.A: 188,
+                                                     Axis.C: 19}
     assert c.current_position(types.Mount.LEFT) == {Axis.X: 408,
                                                     Axis.Y: 333,
-                                                    Axis.Z: 198}
+                                                    Axis.Z: 198,
+                                                    Axis.B: 19}
 
 
 async def test_controller_musthome(hardware_api):

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -3,14 +3,14 @@
 
 from opentrons import instruments, robot
 from opentrons.legacy_api.containers import load as containers_load
-from opentrons.legacy_api.instruments import pipette_config
+from opentrons.config import pipette_config
 from opentrons.trackers import pose_tracker
 from numpy import isclose
 import pytest
 
 
 def test_pipette_version_1_0_and_1_3_extended_travel():
-    from opentrons.legacy_api.instruments import pipette_config
+    from opentrons.config import pipette_config
 
     models = [
         'p10_single', 'p10_multi', 'p50_single', 'p50_multi',
@@ -37,7 +37,7 @@ def test_pipette_version_1_0_and_1_3_extended_travel():
 
 
 def test_all_pipette_models_can_transfer():
-    from opentrons.legacy_api.instruments import pipette_config
+    from opentrons.config import pipette_config
 
     models = [
         'p10_single', 'p10_multi', 'p50_single', 'p50_multi',

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -3,7 +3,7 @@ from opentrons import robot
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
 from opentrons.trackers.pose_tracker import absolute
-from opentrons.legacy_api.instruments.pipette_config import Y_OFFSET_MULTI
+from opentrons.config.pipette_config import Y_OFFSET_MULTI
 
 
 # Note that several values in this file have target/expected values that do not

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -4,7 +4,7 @@ from opentrons import robot, modules
 from opentrons.server import init
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons import instruments
-from opentrons.legacy_api.instruments import pipette_config
+from opentrons.config import pipette_config
 
 
 async def test_get_pipettes_uncommissioned(


### PR DESCRIPTION
Closes #2235

## overview
This PR adds aspirate and dispense functions to `hardware_control`

## changelog
Changed instruments cache from being a cache of pipette model to being a cache of all pipette config values
Added:
- `aspirate(mount: types.Mount, volume: float = None, rate: float = 1.0)`
- `dispense(mount: types.Mount, volume: float = None, rate: float = 1.0)`
- Method to retrieve pipette properties: `attached_instruments`
- backend methods: `set_active_current()`, `set_pipette_speed()`, `Controller._connect()`
