### PR TITLE
fix(repo): fix gitattr hex bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
-api/opentrons/resources/smoothie*.hex -text
+# These files are binary and line endings should be left untouched
+*.hex binary
+*.bat binary


### PR DESCRIPTION
## overview

For a while, even after changing .gitattributes once or twice, I've been having problems with switching branches when .hex files have been updated. I think our .gitattributes was wrong

This causes a problem on my machine where I have to do a crazy dance in git every time I checkout a branch that has a change in a hex file. Git will convert the line endings, then `git checkout -- .` or `git reset HEAD` or `git stash` don't get rid of the changed file, and the presence of the changed file doesn't let me switch branches.

I find the docs for gitattributes pretty hard to understand, but I think to fix this problem, we need to unset both text and diff `-text -diff` and the [special macro `binary`](https://git-scm.com/docs/gitattributes#_using_macro_attributes) does exactly that while also being more readable IMO. (Before this PR, we were just unsetting text not diff, which is what causes the issue)

## changelog

* fix bug where hex files were treated as text and auto-converted to unix endings
* pre-emptive fix for .bat files as well

## review requests

Seems OK? I just wildcard set all .hex and .bat as binary since there doesn't seem to be a good reason not to.