### PR TITLE
fix(api): Filter out missing SSIDs from network list

### DIFF
--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -246,7 +246,7 @@ def _add_security_type_to_scan(scan_out: Dict[str, Any]) -> Dict[str, Any]:
     sec = scan_out['security']
     if '802.1X' in sec:
         scan_out['securityType'] = 'wpa-eap'
-    elif 'WPA2'in sec:
+    elif 'WPA2' in sec:
         scan_out['securityType'] = 'wpa-psk'
     elif '' is sec:
         scan_out['securityType'] = 'none'
@@ -274,8 +274,10 @@ async def available_ssids() -> List[Dict[str, Any]]:
     output = _dict_from_terse_tabular(
         fields, out,
         transformers={'signal': lambda s: int(s) if s.isdigit() else None,
-                      'active': lambda s: s.lower() == 'yes'})
-    return [_add_security_type_to_scan(ssid) for ssid in output]
+                      'active': lambda a: a.lower() == 'yes',
+                      'ssid': lambda s: s if s != '--' else None})
+
+    return [_add_security_type_to_scan(nw) for nw in output if nw['ssid']]
 
 
 async def is_connected() -> str:

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -1,4 +1,4 @@
-import pytest # noqa
+import pytest  # noqa
 
 from opentrons.system import nmcli
 
@@ -25,7 +25,7 @@ def test_sanitize_args():
 def test_output_transformations():
     fields = ['name', 'type', 'autorun', 'active', 'iface', 'state']
     should_have = [['static-eth0',
-                   '802-3-ethernet',
+                    '802-3-ethernet',
                     'yes', 'yes', 'eth0', 'activated'],
                    ['wifi-wlan0',
                     '802-11-wireless',
@@ -51,3 +51,37 @@ wifi-wlan0:802-11-wireless:yes:no:wlan0:--
     assert split[1]['name'] == should_have[1][0].upper()
     assert split[0]['active'] is True
     assert split[1]['active'] is False
+
+
+async def test_available_ssids(monkeypatch):
+    mock_nmcli_output = '''mock_wpa2:90:no:WPA2
+mock_no_security:80:no:
+mock_enterprise:70:no:WPA1 WPA2 802.1X
+mock_connected:60:yes:WPA2
+mock_bad_security:50:no:foobar
+--:40:no:'''
+
+    expected_cmd = ['--terse', '--fields',
+                    'ssid,signal,active,security', 'device', 'wifi', 'list']
+
+    expected = [
+        {'ssid': 'mock_wpa2', 'signal': 90, 'active': False,
+            'security': 'WPA2', 'securityType': 'wpa-psk'},
+        {'ssid': 'mock_no_security', 'signal': 80, 'active': False,
+            'security': '', 'securityType': 'none'},
+        {'ssid': 'mock_enterprise', 'signal': 70, 'active': False,
+            'security': 'WPA1 WPA2 802.1X', 'securityType': 'wpa-eap'},
+        {'ssid': 'mock_connected', 'signal': 60, 'active': True,
+            'security': 'WPA2', 'securityType': 'wpa-psk'},
+        {'ssid': 'mock_bad_security', 'signal': 50, 'active': False,
+            'security': 'foobar', 'securityType': 'unsupported'}
+        # note entry for 'ssid': '--' is expected to be filterd out
+    ]
+
+    async def mock_call(cmd):
+        assert cmd == expected_cmd
+        return mock_nmcli_output, ''
+
+    monkeypatch.setattr(nmcli, '_call', mock_call)
+    result = await nmcli.available_ssids()
+    assert result == expected


### PR DESCRIPTION
## overview

Closes #2489. See ticket for bug details and what this fix does.

## changelog

- fix(api): Filter out missing SSIDs from network list 

## review requests

- [ ] Code changes and test additions look sane
- [ ] Hitting `GET /wifi/list` in the office (where at least one hidden network is present) does not return a network with `'ssid': '--'`
