### PR TITLE
feat(app): Show in progress modal during wifi connect request

### DIFF
--- a/app/src/components/Page/styles.css
+++ b/app/src/components/Page/styles.css
@@ -21,5 +21,5 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 3;
 }

--- a/app/src/components/RobotSettings/ConnectionCard.js
+++ b/app/src/components/RobotSettings/ConnectionCard.js
@@ -34,7 +34,6 @@ type SP = {|
   internetStatus: ?InternetStatus,
   wifiNetwork: ?NetworkInterface,
   ethernetNetwork: ?NetworkInterface,
-  configInProgress: boolean,
   connectingTo: ?string,
 |}
 
@@ -58,13 +57,9 @@ function ConnectionCard (props: Props) {
     internetStatus,
     wifiNetwork,
     ethernetNetwork,
-    configInProgress,
     connectingTo,
   } = props
 
-  const connectMessage = connectingTo
-    ? `Attempting to connect to network ${connectingTo}`
-    : ''
   return (
     <RefreshCard title={TITLE} refresh={() => console.log('placeholder')}>
       <ConnectionStatusMessage
@@ -75,7 +70,11 @@ function ConnectionCard (props: Props) {
         <AvailableNetworks list={wifiList} />
       </ConnectionInfo>
       <ConnectionInfo connection={ethernetNetwork} title="USB" wired />
-      {configInProgress && <SpinnerModal message={connectMessage} />}
+      {connectingTo && (
+        <SpinnerModal
+          message={`Attempting to connect to network ${connectingTo}`}
+        />
+      )}
     </RefreshCard>
   )
 }
@@ -102,7 +101,6 @@ function makeMapStateToProps (): (State, OP) => SP {
       wifiNetwork: find(interfaces, {type: 'wifi'}),
       ethernetNetwork: find(interfaces, {type: 'ethernet'}),
       __featureEnabled: !!getIn(getConfig(state), __FEATURE_FLAG),
-      configInProgress: configureCall.inProgress,
       connectingTo,
     }
   }

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -87,7 +87,7 @@
   flex-direction: column;
   font-style: italic;
   text-align: center;
-  z-index: 4;
+  z-index: 3;
 }
 
 .spinner_modal_icon {

--- a/components/src/modals/modals.css
+++ b/components/src/modals/modals.css
@@ -87,7 +87,7 @@
   flex-direction: column;
   font-style: italic;
   text-align: center;
-  z-index: 3;
+  z-index: 2;
 }
 
 .spinner_modal_icon {


### PR DESCRIPTION
## overview
closes #2383: 

<img width="1024" alt="screen shot 2018-10-16 at 2 06 20 pm" src="https://user-images.githubusercontent.com/3430313/47037761-d02b8480-d14d-11e8-826d-7cd35dc3612c.png">

## changelog

- feat(app): Show in progress modal during wifi connect request

## review requests

The new card is still behind a feature flag. To view new card:
`make -C app dev OT_APP_DEV_INTERNAL__MANAGE_ROBOT_CONNECTION__NEW_CARD=1`

New connection card functionality is coming soon, to test this PR attempt a connect/reconnect to a wifi network using the still visible older `ConnectivityCard`

- [ ] Robot Connection card is inactive while robot is actively trying to connect to a network
- [ ] Spinner modal displays over new `ConnectionCard` with the message:
'Attempting to connect to network [network name]' 