### PR TITLE
chore(api): Update pipenv and use pipenv sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install: install-py install-js
 
 .PHONY: install-py
 install-py:
-	$(OT_PYTHON) -m pip install pipenv==11.6.8
+	$(OT_PYTHON) -m pip install pipenv==2018.10.9
 	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -14,14 +14,14 @@ python := pipenv run python
 pip := pipenv run pip
 pytest := pipenv run py.test
 pipenv_opts := --dev
-pipenv_opts += $(and $(CI),--ignore-pipfile)
+pipenv_opts += $(and $(CI),--keep-outdated)
 
 tests ?= tests
 test_opts ?=
 
 .PHONY: install
 install:
-	pipenv install $(pipenv_opts)
+	pipenv sync $(pipenv_opts)
 
 .PHONY: all
 all: lint test

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -5,7 +5,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 
 python := pipenv run python
 pipenv_opts := --dev
-pipenv_opts += $(and $(CI),--ignore-pipfile)
+pipenv_opts += $(and $(CI),--keep-outdated)
 port ?= 34000
 
 # make bootstrap wheel file (= rather than := to expand at every use)
@@ -13,7 +13,7 @@ wheel = $(wildcard dist/*.whl)
 
 .PHONY: install
 install:
-	pipenv install $(pipenv_opts)
+	pipenv sync $(pipenv_opts)
 
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true


### PR DESCRIPTION
Pipenv sync was added here: https://github.com/pypa/pipenv/issues/1463 and had a
subsequent bug in it where it would sometimes update pipfile.lock, but that’s
fixed now.

There’s now a solid three part workflow to pipenv, as there should be:

- If you want to change the dependencies of a project, you use pipenv
  install/uninstall or edit Pipfile
- When you want to crystallize those dependencies and check in, you use pipenv
  lock to generate the lockfile
- When you want to install the dependencies, as in when you checkout from scm,
  you use pipenv sync

Please checkout and run `make install` (top level `make install`) and then `make -C api test`.