### PR TITLE
feat(api): Add ability to save new delta from calibrating labware

### DIFF
--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -7,6 +7,10 @@ minimalLabwareDef = {
         "y": 10,
         "z": 5
     },
+    "otId": "minimalLabwareDef",
+    "parameters": {
+        "isTiprack": False,
+    },
     "ordering": [["A1"], ["A2"]],
     "wells": {
         "A1": {
@@ -35,6 +39,10 @@ minimalLabwareDef2 = {
             "x": 10,
             "y": 10,
             "z": 5
+    },
+    "otId": "minimalLabwareDef2",
+    "parameters": {
+        "isTiprack": False,
     },
     "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
     "wells": {
@@ -101,7 +109,7 @@ def test_labware_init():
     fakeLabware = labware.Labware(minimalLabwareDef, deck)
     ordering = [well for col in minimalLabwareDef['ordering'] for well in col]
     assert fakeLabware._ordering == ordering
-    assert fakeLabware._wells == minimalLabwareDef['wells']
+    assert fakeLabware._well_definition == minimalLabwareDef['wells']
     assert fakeLabware._offset == Point(x=10, y=10, z=5)
 
 

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -1,0 +1,93 @@
+import tempfile
+import pytest
+import os
+import json
+import time
+from opentrons.protocol_api import labware
+from opentrons.types import Point
+
+minimalLabwareDef = {
+    "cornerOffsetFromSlot": {
+        "x": 10,
+        "y": 10,
+        "z": 5
+    },
+    "otId": "minimalLabwareDef",
+    "parameters": {
+        "isTiprack": False,
+    },
+    "ordering": [["A1"], ["A2"]],
+    "wells": {
+        "A1": {
+          "depth": 40,
+          "totalLiquidVolume": 100,
+          "diameter": 30,
+          "x": 0,
+          "y": 0,
+          "z": 0,
+          "shape": "circular"
+        },
+        "A2": {
+          "depth": 40,
+          "totalLiquidVolume": 100,
+          "diameter": 30,
+          "x": 10,
+          "y": 0,
+          "z": 0,
+          "shape": "circular"
+        }
+    }
+}
+
+tmpdir = tempfile.mkdtemp("offsets")
+labware.persistentPath = tmpdir
+testLabware = labware.Labware(minimalLabwareDef, Point(0, 0, 0))
+path = os.path.join(labware.persistentPath, "{}.json".format(testLabware._id))
+global testPoint
+
+
+@pytest.fixture
+def patch_calibration(monkeypatch):
+    def fake_set_calibration(delta: Point):
+        global testPoint
+        testPoint = delta
+    monkeypatch.setattr(testLabware, 'set_calibration', fake_set_calibration)
+
+
+def test_save_calibration(patch_calibration):
+    # Test the save calibration file
+    assert not os.path.exists(path)
+    labware.save_calibration(testLabware, Point(1, 1, 1))
+    assert os.path.exists(path)
+    global testPoint
+    testPoint == Point(1, 1, 1)
+
+
+def test_schema_shape(patch_calibration, monkeypatch):
+    assert os.path.exists(path)
+
+    def fake_time():
+        return 1
+    monkeypatch.setattr(time, 'time', fake_time)
+    labware.save_calibration(testLabware, Point(1, 1, 1))
+    expected = {"default": {"offset": [1, 1, 1], "lastModified": 1}}
+    with open(path) as f:
+        result = json.load(f)
+    assert result == expected
+
+
+def test_load_calibration(patch_calibration):
+    labware.load_calibration(testLabware)
+    global testPoint
+    testPoint == Point(1, 1, 1)
+
+
+def test_wells_rebuilt_with_offset():
+    old_wells = testLabware._wells
+    assert testLabware._offset == Point(10, 10, 5)
+    assert testLabware._calibrated_offset == Point(10, 10, 5)
+    labware.save_calibration(testLabware, Point(2, 2, 2))
+    new_wells = testLabware._wells
+    assert old_wells[0] != new_wells[0]
+    assert testLabware._offset == Point(10, 10, 5)
+    assert testLabware._calibrated_offset == Point(12, 12, 7)

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -1,8 +1,9 @@
+# pylama:ignore=W0612
 import tempfile
-import pytest
 import os
 import json
 import time
+from functools import partial
 from opentrons.protocol_api import labware
 from opentrons.types import Point
 
@@ -40,35 +41,37 @@ minimalLabwareDef = {
 }
 
 tmpdir = tempfile.mkdtemp("offsets")
-labware.persistentPath = tmpdir
+labware.persistent_path = tmpdir
 testLabware = labware.Labware(minimalLabwareDef, Point(0, 0, 0))
-path = os.path.join(labware.persistentPath, "{}.json".format(testLabware._id))
-global testPoint
+path = os.path.join(labware.persistent_path, "{}.json".format(testLabware._id))
 
 
-@pytest.fixture
-def patch_calibration(monkeypatch):
-    def fake_set_calibration(delta: Point):
-        global testPoint
-        testPoint = delta
-    monkeypatch.setattr(testLabware, 'set_calibration', fake_set_calibration)
+def mock_set_calibration(test_point, delta):
+    test_point = delta
 
 
-def test_save_calibration(patch_calibration):
+def test_save_calibration(monkeypatch):
     # Test the save calibration file
     assert not os.path.exists(path)
+    calibration_point = None
+    monkeypatch.setattr(
+        testLabware,
+        'set_calibration', partial(mock_set_calibration, calibration_point))
     labware.save_calibration(testLabware, Point(1, 1, 1))
     assert os.path.exists(path)
-    global testPoint
-    testPoint == Point(1, 1, 1)
+    calibration_point == Point(1, 1, 1)
 
 
-def test_schema_shape(patch_calibration, monkeypatch):
+def test_schema_shape(monkeypatch):
     assert os.path.exists(path)
 
     def fake_time():
         return 1
     monkeypatch.setattr(time, 'time', fake_time)
+    calibration_point = None
+    monkeypatch.setattr(
+        testLabware,
+        'set_calibration', partial(mock_set_calibration, calibration_point))
     labware.save_calibration(testLabware, Point(1, 1, 1))
     expected = {"default": {"offset": [1, 1, 1], "lastModified": 1}}
     with open(path) as f:
@@ -76,18 +79,23 @@ def test_schema_shape(patch_calibration, monkeypatch):
     assert result == expected
 
 
-def test_load_calibration(patch_calibration):
+def test_load_calibration(monkeypatch):
     labware.load_calibration(testLabware)
-    global testPoint
-    testPoint == Point(1, 1, 1)
+    calibration_point = None
+    monkeypatch.setattr(
+        testLabware,
+        'set_calibration', partial(mock_set_calibration, calibration_point))
+    labware.save_calibration(testLabware, Point(1, 1, 1))
+    calibration_point == Point(1, 1, 1)
 
 
 def test_wells_rebuilt_with_offset():
+    testLabware2 = labware.Labware(minimalLabwareDef, Point(0, 0, 0))
     old_wells = testLabware._wells
-    assert testLabware._offset == Point(10, 10, 5)
-    assert testLabware._calibrated_offset == Point(10, 10, 5)
-    labware.save_calibration(testLabware, Point(2, 2, 2))
-    new_wells = testLabware._wells
+    assert testLabware2._offset == Point(10, 10, 5)
+    assert testLabware2._calibrated_offset == Point(10, 10, 5)
+    labware.save_calibration(testLabware2, Point(2, 2, 2))
+    new_wells = testLabware2._wells
     assert old_wells[0] != new_wells[0]
-    assert testLabware._offset == Point(10, 10, 5)
-    assert testLabware._calibrated_offset == Point(12, 12, 7)
+    assert testLabware2._offset == Point(10, 10, 5)
+    assert testLabware2._calibrated_offset == Point(12, 12, 7)


### PR DESCRIPTION
## overview
Closes #2269 and  closes #2270.

## changelog
- Add save calibration function for any new deltas from labware calibration
- Add load calibration function to check for any previously saved deltas.
- Changed accessor functions such that they only use 1 instance of a well object _unless_ a new offset is added.

## review requests
