### PR TITLE
refactor(components): Add AlertModal heading icon override

### DIFF
--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import cx from 'classnames'
 
 import {OutlineButton, type ButtonProps} from '../buttons'
-import {Icon} from '../icons'
+import {Icon, type IconName} from '../icons'
 import Modal from './Modal'
 import styles from './modals.css'
 
@@ -20,8 +20,10 @@ type Props = {
   className?: string,
   /** optional classes to apply */
   contentsClassName?: string,
-  /** lightens overlay (alert modal over existing modal)**/
+  /** lightens overlay (alert modal over existing modal) */
   alertOverlay?: boolean,
+  /** override default alert icon */
+  iconName?: IconName,
 }
 
 /**
@@ -29,9 +31,14 @@ type Props = {
  */
 export default function AlertModal (props: Props) {
   const {heading, buttons, className, onCloseClick, alertOverlay} = props
-  const wrapperStyle = cx(styles.alert_modal_wrapper, {
-    [styles.no_alert_header]: !heading,
-  }, props.contentsClassName)
+  const iconName = props.iconName || 'alert'
+  const wrapperStyle = cx(
+    styles.alert_modal_wrapper,
+    {
+      [styles.no_alert_header]: !heading,
+    },
+    props.contentsClassName
+  )
 
   return (
     <Modal
@@ -42,18 +49,22 @@ export default function AlertModal (props: Props) {
     >
       {heading && (
         <div className={styles.alert_modal_heading}>
-          <Icon name='alert' className={styles.alert_modal_icon} />
+          <Icon name={iconName} className={styles.alert_modal_icon} />
           {heading}
         </div>
       )}
-      <div className={styles.alert_modal_contents}>
-        {props.children}
-      </div>
+      <div className={styles.alert_modal_contents}>{props.children}</div>
       {buttons && (
         <div className={styles.alert_modal_buttons}>
-          {buttons.filter(Boolean).map((button, index) => (
-            <OutlineButton key={index} {...button} className={cx(styles.alert_button, button.className)}/>
-          ))}
+          {buttons
+            .filter(Boolean)
+            .map((button, index) => (
+              <OutlineButton
+                key={index}
+                {...button}
+                className={cx(styles.alert_button, button.className)}
+              />
+            ))}
         </div>
       )}
     </Modal>

--- a/components/src/modals/AlertModal.md
+++ b/components/src/modals/AlertModal.md
@@ -4,14 +4,13 @@ AlertModal example:
 initialState = {alert: 'foo'}
 
 const alertContents = {
-  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  foo:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar:
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
 }
-
 ;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
-  <FlatButton onClick={() => setState({alert: 'foo'})}>
-    Alert foo
-  </FlatButton>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>Alert foo</FlatButton>
   {state.alert && (
     <AlertModal
       heading={state.alert}
@@ -19,7 +18,37 @@ const alertContents = {
       buttons={[
         {children: 'foo', onClick: () => setState({alert: 'foo'})},
         {children: 'bar', onClick: () => setState({alert: 'bar'})},
-        {children: 'close', onClick: () => setState({alert: ''})}
+        {children: 'close', onClick: () => setState({alert: ''})},
+      ]}
+    >
+      {alertContents[state.alert]}
+    </AlertModal>
+  )}
+</div>
+```
+
+Optional heading icon override:
+
+```js
+initialState = {alert: 'foo'}
+
+const alertContents = {
+  foo:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar:
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+}
+;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>Alert foo</FlatButton>
+  {state.alert && (
+    <AlertModal
+      heading={state.alert}
+      onCloseClick={() => setState({alert: ''})}
+      iconName="wifi"
+      buttons={[
+        {children: 'foo', onClick: () => setState({alert: 'foo'})},
+        {children: 'bar', onClick: () => setState({alert: 'bar'})},
+        {children: 'close', onClick: () => setState({alert: ''})},
       ]}
     >
       {alertContents[state.alert]}
@@ -34,14 +63,13 @@ Optional alertOverlay prop to lighten background
 initialState = {alert: 'foo'}
 
 const alertContents = {
-  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  foo:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar:
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
 }
-
 ;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
-  <FlatButton onClick={() => setState({alert: 'foo'})}>
-    Alert foo
-  </FlatButton>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>Alert foo</FlatButton>
   {state.alert && (
     <AlertModal
       heading={state.alert}
@@ -49,7 +77,7 @@ const alertContents = {
       buttons={[
         {children: 'foo', onClick: () => setState({alert: 'foo'})},
         {children: 'bar', onClick: () => setState({alert: 'bar'})},
-        {children: 'close', onClick: () => setState({alert: ''})}
+        {children: 'close', onClick: () => setState({alert: ''})},
       ]}
       alertOverlay
     >
@@ -65,21 +93,20 @@ Alert modal without heading prop:
 initialState = {alert: 'foo'}
 
 const alertContents = {
-  foo: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-  bar: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  foo:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  bar:
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
 }
-
 ;<div style={{position: 'relative', width: '48em', height: '24rem'}}>
-  <FlatButton onClick={() => setState({alert: 'foo'})}>
-    Alert foo
-  </FlatButton>
+  <FlatButton onClick={() => setState({alert: 'foo'})}>Alert foo</FlatButton>
   {state.alert && (
     <AlertModal
       onCloseClick={() => setState({alert: ''})}
       buttons={[
         {children: 'foo', onClick: () => setState({alert: 'foo'})},
         {children: 'bar', onClick: () => setState({alert: 'bar'})},
-        {children: 'close', onClick: () => setState({alert: ''})}
+        {children: 'close', onClick: () => setState({alert: ''})},
       ]}
     >
       {alertContents[state.alert]}


### PR DESCRIPTION
## overview

This PR addresses #2507 by adding an optional `iconName` prop to override the alert icon in AlertModal headings

## changelog

-refactor(components): Add `AlertModal` heading icon override

## review requests

Standard review
