### PR TITLE
fix(api): Make the Makefile have more real prerequisites/targets

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 # and also make an explicit version for shx for use in the shell function,
 # where PATH won’t be propagated
-PATH := $(shell cd .. && yarn bin):${PATH}
+PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx
 
 # make push wheel file (= rather than := to expand at every use)
@@ -21,8 +21,8 @@ pipenv_opts += $(and $(CI),--keep-outdated)
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-norm_vers := $(shell ${python} normalized_version.py)
-WHEEL_FILE := dist/opentrons-${norm_vers}-py2.py3-none-any.whl
+wheel_file = dist/opentrons-$(shell $(python) normalized_version.py)-py2.py3-none-any.whl
+wheel_pattern := dist/opentrons-%-py2.py3-none-any.whl
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -33,18 +33,18 @@ test_opts ?=
 
 # Source discovery
 # For the python sources
-OT_PY_SOURCES := $(filter %.py,$(shell ${SHX} find src/opentrons/))
+ot_py_sources := $(filter %.py,$(shell $(SHX) find src/opentrons/))
 # And the out of tree shared data
-OT_SHARED_DATA_SOURCES := $(filter %.json,$(shell ${SHX} find ../shared-data/))
+ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 # And the arbitrary stuff in resources
-OT_RESOURCES := $(filter %,$(shell ${SHX} find src/opentrons/resources))
-OT_SOURCES := ${OT_PY_SOURCES} ${OT_SHARED_DATA_SOURCES} ${OT_RESOURCES}
+ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
+ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
 # And the tests
-OT_TEST_SOURCES := $(filter-out data/configs% configs/%.json,$(shell ${SHX} find tests/))
+ot_test_sources := $(filter-out data/configs% configs/%.json,$(shell $(SHX) find tests/))
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-CLEAN_CMD = shx rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
+clean_cmd = shx rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
 
 .PHONY: install
 install:
@@ -55,25 +55,25 @@ all: lint test
 
 .PHONY: clean
 clean:
-	${CLEAN_CMD}
+	$(clean_cmd)
 
-${WHEEL_FILE}: setup.py ${OT_SOURCES}
-	${CLEAN_CMD}
+$(wheel_pattern): setup.py $(ot_sources)
+	$(clean_cmd)
 	$(python) setup.py bdist_wheel
 	shx rm -rf build
 	shx ls dist
 
 .PHONY: wheel
-wheel: ${WHEEL_FILE}
+wheel: $(wheel_file)
 
 .PHONY: test
-test: local-install ${OT_TEST_SOURCES}
-	${pytest} ${tests} ${test_opts}
+test: local-install $(ot_test_sources)
+	$(pytest) $(tests) $(test_opts)
 
 .PHONY: lint
-lint: ${OT_PY_SOURCES}
+lint: $(ot_py_sources)
 	$(python) -m mypy src/opentrons
-	$(python) -m pylama $? src/opentrons tests
+	$(python) -m pylama src/opentrons tests
 
 .PHONY: docs
 docs:
@@ -92,8 +92,8 @@ dev: local-install
 	$(python) -m opentrons.main -P 31950
 
 .PHONY: local-install
-local-install: ${WHEEL_FILE}
-	$(pip) install --ignore-installed --no-deps ${WHEEL_FILE}
+local-install: wheel
+	$(pip) install --ignore-installed --no-deps $(wildcard dist/opentrons-*.whl)
 
 .PHONY: local-shell
 local-shell: local-install
@@ -103,7 +103,7 @@ local-shell: local-install
 push: wheel
 	curl -X POST \
 		-H "Content-Type: multipart/form-data" \
-		-F "whl=@${WHEEL_FILE}" \
+		-F "whl=@$(wildcard dist/opentrons-*.whl)" \
 		http://$(host):31950/server/update
 
 .PHONY: flash

--- a/api/Makefile
+++ b/api/Makefile
@@ -5,11 +5,8 @@ SHELL := /bin/bash
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 # and also make an explicit version for shx for use in the shell function,
 # where PATH won’t be propagated
-yarn_path := $(shell cd .. && yarn bin)
-PATH := ${yarn_path}:${PATH}
-# Make an explicit version of this for shx so it can be used in the $(shell)
-# function, where the PATH won’t be propagated
-SHX := ${yarn_path}/shx
+PATH := $(shell cd .. && yarn bin):${PATH}
+SHX := npx shx
 
 # make push wheel file (= rather than := to expand at every use)
 firmware = $(wildcard smoothie/*.hex)
@@ -43,7 +40,7 @@ OT_SHARED_DATA_SOURCES := $(filter %.json,$(shell ${SHX} find ../shared-data/))
 OT_RESOURCES := $(filter %,$(shell ${SHX} find src/opentrons/resources))
 OT_SOURCES := ${OT_PY_SOURCES} ${OT_SHARED_DATA_SOURCES} ${OT_RESOURCES}
 # And the tests
-OT_TEST_SOURCES := $(filter-out data/configs% configs/%.json,$(shell %{SHX} find tests/))
+OT_TEST_SOURCES := $(filter-out data/configs% configs/%.json,$(shell ${SHX} find tests/))
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
@@ -95,8 +92,8 @@ dev: local-install
 	$(python) -m opentrons.main -P 31950
 
 .PHONY: local-install
-local-install: wheel
-	$(pip) install --ignore-installed --no-deps dist/opentrons-*.whl
+local-install: ${WHEEL_FILE}
+	$(pip) install --ignore-installed --no-deps ${WHEEL_FILE}
 
 .PHONY: local-shell
 local-shell: local-install
@@ -105,7 +102,7 @@ local-shell: local-install
 .PHONY: push
 push: wheel
 	curl -X POST \
-		-H "Conte<nt-Type: multipart/form-data" \
+		-H "Content-Type: multipart/form-data" \
 		-F "whl=@${WHEEL_FILE}" \
 		http://$(host):31950/server/update
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -39,8 +39,6 @@ ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 # And the arbitrary stuff in resources
 ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
 ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
-# And the tests
-ot_test_sources := $(filter-out data/configs% configs/%.json,$(shell $(SHX) find tests/))
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
@@ -67,7 +65,7 @@ $(wheel_pattern): setup.py $(ot_sources)
 wheel: $(wheel_file)
 
 .PHONY: test
-test: local-install $(ot_test_sources)
+test: local-install
 	$(pytest) $(tests) $(test_opts)
 
 .PHONY: lint

--- a/api/Makefile
+++ b/api/Makefile
@@ -3,10 +3,15 @@
 SHELL := /bin/bash
 
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
-PATH := $(shell cd .. && yarn bin):$(PATH)
+# and also make an explicit version for shx for use in the shell function,
+# where PATH won’t be propagated
+yarn_path := $(shell cd .. && yarn bin)
+PATH := ${yarn_path}:${PATH}
+# Make an explicit version of this for shx so it can be used in the $(shell)
+# function, where the PATH won’t be propagated
+SHX := ${yarn_path}/shx
 
 # make push wheel file (= rather than := to expand at every use)
-wheel = $(wildcard dist/*.whl)
 firmware = $(wildcard smoothie/*.hex)
 
 # python and pipenv config
@@ -16,8 +21,33 @@ pytest := pipenv run py.test
 pipenv_opts := --dev
 pipenv_opts += $(and $(CI),--keep-outdated)
 
+# Find the version of the wheel from package.json using a helper script. We
+# use python here so we can use the same version normalization that will be
+# used to create the wheel.
+norm_vers := $(shell ${python} normalized_version.py)
+WHEEL_FILE := dist/opentrons-${norm_vers}-py2.py3-none-any.whl
+
+# These variables can be overriden when make is invoked to customize the
+# behavior of pytest. For instance,
+# make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
+# specified test
 tests ?= tests
 test_opts ?=
+
+# Source discovery
+# For the python sources
+OT_PY_SOURCES := $(filter %.py,$(shell ${SHX} find src/opentrons/))
+# And the out of tree shared data
+OT_SHARED_DATA_SOURCES := $(filter %.json,$(shell ${SHX} find ../shared-data/))
+# And the arbitrary stuff in resources
+OT_RESOURCES := $(filter %,$(${SHX} find src/opentrons/resources))
+OT_SOURCES := ${OT_PY_SOURCES} ${OT_SHARED_DATA_SOURCES} ${OT_RESOURCES}
+# And the tests
+OT_TEST_SOURCES := $(filter-out data/configs% configs/%.json,$(shell %{SHX} find tests/))
+
+# Defined separately than the clean target so the wheel file doesn’t have to
+# depend on a PHONY target
+CLEAN_CMD = shx rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
 
 .PHONY: install
 install:
@@ -28,23 +58,25 @@ all: lint test
 
 .PHONY: clean
 clean:
-	shx rm -rf \
-		build \
-		dist \
-		.coverage \
-		coverage.xml \
-		'*.egg-info' \
-		'**/__pycache__' \
-		'**/*.pyc'
+	${CLEAN_CMD}
+
+${WHEEL_FILE}: setup.py ${OT_SOURCES}
+	${CLEAN_CMD}
+	$(python) setup.py bdist_wheel
+	shx rm -rf build
+	shx ls dist
+
+.PHONY: wheel
+wheel: ${WHEEL_FILE}
 
 .PHONY: test
-test: local-install
+test: local-install ${OT_TEST_SOURCES}
 	${pytest} ${tests} ${test_opts}
 
 .PHONY: lint
-lint:
+lint: ${OT_PY_SOURCES}
 	$(python) -m mypy src/opentrons
-	$(python) -m pylama src/opentrons tests
+	$(python) -m pylama $? src/opentrons tests
 
 .PHONY: docs
 docs:
@@ -62,12 +94,6 @@ dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev: local-install
 	$(python) -m opentrons.main -P 31950
 
-.PHONY: wheel
-wheel: clean
-	$(python) setup.py bdist_wheel
-	shx rm -rf build
-	shx ls dist
-
 .PHONY: local-install
 local-install: wheel
 	$(pip) install --ignore-installed --no-deps dist/opentrons-*.whl
@@ -79,8 +105,8 @@ local-shell: local-install
 .PHONY: push
 push: wheel
 	curl -X POST \
-		-H "Content-Type: multipart/form-data" \
-		-F "whl=@$(wheel)" \
+		-H "Conte<nt-Type: multipart/form-data" \
+		-F "whl=@${WHEEL_FILE}" \
 		http://$(host):31950/server/update
 
 .PHONY: flash

--- a/api/Makefile
+++ b/api/Makefile
@@ -40,7 +40,7 @@ OT_PY_SOURCES := $(filter %.py,$(shell ${SHX} find src/opentrons/))
 # And the out of tree shared data
 OT_SHARED_DATA_SOURCES := $(filter %.json,$(shell ${SHX} find ../shared-data/))
 # And the arbitrary stuff in resources
-OT_RESOURCES := $(filter %,$(${SHX} find src/opentrons/resources))
+OT_RESOURCES := $(filter %,$(shell ${SHX} find src/opentrons/resources))
 OT_SOURCES := ${OT_PY_SOURCES} ${OT_SHARED_DATA_SOURCES} ${OT_RESOURCES}
 # And the tests
 OT_TEST_SOURCES := $(filter-out data/configs% configs/%.json,$(shell %{SHX} find tests/))

--- a/api/normalized_version.py
+++ b/api/normalized_version.py
@@ -1,6 +1,15 @@
 import json
 import os
-from setuptools.extern import packaging
+# Pipenv requires setuptools >= 36.2.1. Since 36.2.1, setuptools changed
+# the way they vendor dependencies, like the packaging module that
+# provides the way to normalize version numbers for wheel file names. So
+# we try all the possible ways to find it.
+try:
+    # new way
+    from setuptools.extern import packaging
+except ImportError:
+    # old way
+    from pkg_resources.extern import packaging
 
 pkg_json_path = os.path.join('src', 'opentrons', 'package.json')
 old_ver = json.load(open(pkg_json_path))['version']

--- a/api/normalized_version.py
+++ b/api/normalized_version.py
@@ -1,0 +1,9 @@
+import json
+import os
+from setuptools.extern import packaging
+
+pkg_json_path = os.path.join('src', 'opentrons', 'package.json')
+old_ver = json.load(open(pkg_json_path))['version']
+vers_obj = packaging.version.Version(old_ver)
+
+print(str(vers_obj))


### PR DESCRIPTION
Instead of using all phony targets, the makefile now pulls the version out of
package.json so it can find the name of the wheel that will be built and can use
it as a normal Makefile target. Then, we can use that as the prereq for wheel
instead of having wheel contain the commands directly, which means that all the
stuff that now depends on wheel won’t rerun it every single time it’s called.

## Review requests

Let's see what CI does, and please test the following on osx, windows, and linux:

- [x] run `make install`
- [x] run `make local-shell` twice and see that the wheel is only built once (though it will be installed both times)
- [x] change a python file in `src/opentrons` or `setup.py` and see that the wheel is rebuilt
- [x] change a json file in `shared-data` and see that the wheel is rebuilt
- [x] change a file with a weird name in `src/opentrons/resources` and see that the wheel is rebuilt
- [x] run `make clean` and see that the wheel is rebuilt
