### PR TITLE
fix(repo): increase flow merge timeout

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -18,5 +18,6 @@ update-server/.*
 [options]
 module.name_mapper='^default\-containers\.json$' -> '@opentrons/components/interfaces/default-containers.json.js'
 module.name_mapper.extension='css' -> '@opentrons/components/interfaces/CSSModule.js'
+merge_timeout=300
 
 [strict]


### PR DESCRIPTION
## overview

Our Travis builds keep failing due to Flow merge timeout, let's see if this helps.

## changelog

* attempt to fix timeout in Travis by increasing flow merge timeout from 100s to 300s

## review requests

Build should pass, but just because it passes doesn't mean 300s is enough since it's variable :/