### PR TITLE
refactor(app): Match wifi dropdown styles to design

### DIFF
--- a/app/src/components/RobotSettings/connection.js
+++ b/app/src/components/RobotSettings/connection.js
@@ -1,7 +1,7 @@
 // @flow
 // UI components for displaying connection info
 import * as React from 'react'
-import Select from 'react-select'
+import Select, {components} from 'react-select'
 import find from 'lodash/find'
 import {Icon} from '@opentrons/components'
 import {CardContentHalf} from '../layout'
@@ -88,6 +88,55 @@ export function NetworkDropdown (props: NetworkDropdownProps) {
   const options = list.map(NetworkOption)
   const selectedOption = find(options, {value})
 
+  const selectStyles = {
+    option: (base, state) => ({
+      ...base,
+      padding: '0.25rem 0',
+    }),
+    input: () => ({
+      marginTop: '-0.25rem',
+      marginLeft: 0,
+    }),
+    container: base => ({
+      ...base,
+      backgroundColor: 'transparent',
+      height: '2rem',
+      overflow: 'visible',
+    }),
+    control: () => ({
+      backgroundColor: '#e5e2e2',
+      border: 'none',
+      padding: '0.25rem 0rem',
+      outline: 'none',
+      borderRadius: '3px',
+      height: '1.75rem',
+      boxShadow: 'none',
+    }),
+    indicatorSeparator: () => ({
+      display: 'none',
+    }),
+  }
+  // Custom dropdown indicator icon component needed to match comp lib
+  const DropdownIndicator = props => {
+    return (
+      components.DropdownIndicator && (
+        <components.DropdownIndicator {...props}>
+          <div className={styles.dropdown_icon}>
+            <Icon name="menu-down" width="100%" />
+          </div>
+        </components.DropdownIndicator>
+      )
+    )
+  }
+  // custom Menu (options dropwdown) component
+  const Menu = props => {
+    return (
+      <components.Menu {...props}>
+        <div className={styles.options_menu}>{props.children}</div>
+      </components.Menu>
+    )
+  }
+
   return (
     <Select
       className={styles.wifi_dropdown}
@@ -95,6 +144,8 @@ export function NetworkDropdown (props: NetworkDropdownProps) {
       value={selectedOption}
       onChange={onChange}
       options={options}
+      styles={selectStyles}
+      components={{DropdownIndicator, Menu}}
     />
   )
 }

--- a/app/src/components/RobotSettings/connection.js
+++ b/app/src/components/RobotSettings/connection.js
@@ -89,7 +89,7 @@ export function NetworkDropdown (props: NetworkDropdownProps) {
   const selectedOption = find(options, {value})
 
   const selectStyles = {
-    option: (base, state) => ({
+    option: base => ({
       ...base,
       padding: '0.25rem 0',
     }),
@@ -128,7 +128,7 @@ export function NetworkDropdown (props: NetworkDropdownProps) {
       )
     )
   }
-  // custom Menu (options dropwdown) component
+  // custom Menu (options dropdown) component
   const Menu = props => {
     return (
       <components.Menu {...props}>
@@ -182,7 +182,7 @@ function NetworkOption (nw: WifiNetwork): SelectNetworkOption {
   const label = (
     <div className={styles.wifi_option}>
       {connectedIcon}
-      {value}
+      <span className={styles.wifi_name}>{value}</span>
       {signalIcon}
       {securedIcon}
     </div>

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -61,10 +61,19 @@
 /* TODO(mc, 2018-10-15): switch wifi select/options to flex ASAP */
 .wifi_dropdown {
   max-width: 75%;
+
+  /* TODO(ka, 2018-10-19): This is needed to address an inaccessible positioning element from react-select */
+  & > div:not(:first-child) {
+    box-shadow: none;
+    background-color: transparent;
+  }
 }
 
 .wifi_option {
   @apply --font-body-1-dark;
+
+  width: 100%;
+  padding: 0.25rem 0.5rem;
 }
 
 .wifi_option_icon,
@@ -83,6 +92,26 @@
 .wifi_option_icon_right {
   float: right;
   padding-left: 0.25rem;
+}
+
+.dropdown_icon {
+  position: absolute;
+  top: 0.2rem;
+  right: 0.25rem;
+  width: 1.25rem;
+  pointer-events: none;
+
+  & svg {
+    color: var(--c-dark-gray);
+  }
+}
+
+.options_menu {
+  background-color: var(--c-light-gray);
+  position: relative;
+  top: -2.5rem;
+  border-radius: 3px;
+  padding: 0.25rem 0 0.5rem;
 }
 
 .connection_label {

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -60,7 +60,7 @@
 
 /* TODO(mc, 2018-10-15): switch wifi select/options to flex ASAP */
 .wifi_dropdown {
-  max-width: 75%;
+  max-width: 14rem;
 
   /* TODO(ka, 2018-10-19): This is needed to address an inaccessible positioning element from react-select */
   & > div:not(:first-child) {
@@ -74,6 +74,14 @@
 
   width: 100%;
   padding: 0.25rem 0.5rem;
+}
+
+.wifi_name {
+  display: inline-block;
+  width: calc(100% - 3rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .wifi_option_icon,

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -60,7 +60,7 @@
 
 /* TODO(mc, 2018-10-15): switch wifi select/options to flex ASAP */
 .wifi_dropdown {
-  max-width: 14rem;
+  max-width: 16.875rem;
 
   /* TODO(ka, 2018-10-19): This is needed to address an inaccessible positioning element from react-select */
   & > div:not(:first-child) {


### PR DESCRIPTION
## overview

This PR overrides default react-select styles to match design screens.

<img width="1024" alt="screen shot 2018-10-19 at 1 19 47 pm" src="https://user-images.githubusercontent.com/3430313/47307898-3016a500-d5fe-11e8-96ec-9e8fec2e384e.png">
<img width="1021" alt="screen shot 2018-10-19 at 1 19 58 pm" src="https://user-images.githubusercontent.com/3430313/47307899-3016a500-d5fe-11e8-8ae0-87eef1bedd1c.png">

## changelog

- refactor(app): Match wifi dropdown styles to design

## review requests
Standard review. I ran into an unstylable DOM element in `react-select`. See my comment in `styles.css`.

To view the new card:
`make -C app dev OT_APP_DEV_INTERNAL__MANAGE_ROBOT_CONNECTION__NEW_CARD=1`

