### PR TITLE
feat(app): Show all labware of same type as confirmed

### DIFF
--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -1,6 +1,7 @@
 // @flow
 // robot selectors
 import padStart from 'lodash/padStart'
+import some from 'lodash/some'
 import {createSelector} from 'reselect'
 
 import {
@@ -306,7 +307,16 @@ export const getLabware = createSelector(
       .filter(isSlot)
       .map((slot) => {
         const labware = lwBySlot[slot]
-        const confirmed = confirmedBySlot[slot] || false
+        const {type, isTiprack} = labware
+
+        // labware is confirmed if:
+        //   - tiprack: labware in slot is confirmed
+        //   - non-tiprack: labware in slot or any of same type is confirmed
+        const confirmed = some(confirmedBySlot, (value, key) => (
+          value === true &&
+          (key === slot || (!isTiprack && type === lwBySlot[key].type))
+        ))
+
         let calibration: LabwareCalibrationStatus = 'unconfirmed'
         let isMoving = false
 

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -532,6 +532,7 @@ describe('robot selectors', () => {
               calibratorMount: 'left',
             },
             5: {slot: '5', type: 'a', isTiprack: false},
+            7: {slot: '7', type: 'a', isTiprack: false},
             9: {slot: '9', type: 'b', isTiprack: false},
           },
           pipettesByMount: {
@@ -589,6 +590,16 @@ describe('robot selectors', () => {
           isTiprack: false,
           isMoving: false,
           calibration: 'unconfirmed',
+          confirmed: true,
+        },
+        // then other labware by slot
+        {
+          slot: '7',
+          type: 'a',
+          isTiprack: false,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          // note: labware a in slot 7 is confirmed because confirmed in slot 5
           confirmed: true,
         },
         {


### PR DESCRIPTION
## overview

Closes #2523. See ticket for background.

## changelog

- feat(app): Show all labware of same type as confirmed

## review requests

- [ ] Calibrating one tiprack should **not** show all tipracks of that type calibrated
- [ ] Calibrating one labware **should** show all labware of that type calibrated

I used this protocol for testing: https://drive.google.com/file/d/19N5Zajll26FT6FIqRx2iv5H7IyWNOxFt/view?usp=sharing


