### PR TITLE
feature(api): pipette critical points

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -20,7 +20,6 @@ pipette_config = namedtuple(
         'aspirate_flow_rate',
         'dispense_flow_rate',
         'channels',
-        'name',
         'model_offset',
         'plunger_current',
         'drop_tip_current',
@@ -28,7 +27,8 @@ pipette_config = namedtuple(
         'max_volume',
         'ul_per_mm',
         'quirks',
-        'tip_length'  # TODO (andy): remove from pipette, move to tip-rack
+        'tip_length',  # TODO (andy): remove from pipette, move to tip-rack
+        'display_name'
     ]
 )
 
@@ -86,7 +86,6 @@ def load(pipette_model: str) -> pipette_config:
             aspirate_flow_rate=cfg.get('aspirateFlowRate'),
             dispense_flow_rate=cfg.get('dispenseFlowRate'),
             channels=cfg.get('channels'),
-            name=pipette_model,
             model_offset=cfg.get('modelOffset'),
             plunger_current=cfg.get('plungerCurrent'),
             drop_tip_current=cfg.get('dropTipCurrent'),
@@ -94,7 +93,8 @@ def load(pipette_model: str) -> pipette_config:
             max_volume=cfg.get('maxVolume'),
             ul_per_mm=cfg.get('ulPerMm'),
             quirks=cfg.get('quirks'),
-            tip_length=cfg.get('tipLength')
+            tip_length=cfg.get('tipLength'),
+            display_name=cfg.get('displayName')
         )
 
     # Verify that stored values agree with calculations

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -125,12 +125,12 @@ def set_current_mount(attached_pipettes):
     if left['model'] in pipette_config.configs:
         pip_config = pipette_config.load(left['model'])
         left_pipette = instruments._create_pipette_from_config(
-            mount='left', config=pip_config)
+            mount='left', config=pip_config, name=left['model'])
 
     if right['model'] in pipette_config.configs:
         pip_config = pipette_config.load(right['model'])
         right_pipette = instruments._create_pipette_from_config(
-            mount='right', config=pip_config)
+            mount='right', config=pip_config, name=right['model'])
 
     if right_pipette and right_pipette.channels == 1:
         session.current_mount = 'A'

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -1,0 +1,94 @@
+""" Classes and functions for pipette state tracking
+"""
+from typing import Any, Dict, Optional, Union
+
+from opentrons.types import Point
+from opentrons.config import pipette_config
+
+
+class Pipette:
+    """ A class to gather and track pipette state and configs.
+
+    This class should not touch hardware or call back out to the hardware
+    control API. Its only purpose is to gather state.
+    """
+
+    def __init__(self, model: str) -> None:
+        self._config = pipette_config.load(model)
+        self._name = model
+        self._tip_length: Optional[float] = None
+        self._current_volume = 0.0
+
+    @property
+    def config(self) -> pipette_config.pipette_config:
+        return self._config
+
+    def update_config_item(self, elem_name: str, elem_val: Any):
+        self._config = self._config._replace(**{elem_name: elem_val})
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def critical_point(self) -> Point:
+        """ The vector from the pipette's origin to its critical point """
+        pass
+
+    @property
+    def current_volume(self) -> float:
+        """ The amount of liquid currently aspirated """
+        return self._current_volume
+
+    @property
+    def available_volume(self) -> float:
+        """ The amount of liquid possible to aspirate """
+        return self.config.max_volume - self.current_volume
+
+    def set_current_volume(self, new_volume: float):
+        assert new_volume >= 0
+        assert new_volume <= self.config.max_volume
+        self._current_volume = new_volume
+
+    def add_current_volume(self, volume_incr: float):
+        assert self.ok_to_add_volume(volume_incr)
+        self._current_volume += volume_incr
+
+    def remove_current_volume(self, volume_incr: float):
+        assert self._current_volume >= volume_incr
+        self._current_volume -= volume_incr
+
+    def ok_to_add_volume(self, volume_incr: float) -> bool:
+        return self.current_volume + volume_incr <= self.config.max_volume
+
+    def add_tip(self, length: float):
+        self._tip_length = length
+
+    def remove_tip(self):
+        self._tip_length = None
+
+    @property
+    def has_tip(self) -> bool:
+        return self._tip_length is not None
+
+    def ul_per_mm(self, ul: float, action: str) -> float:
+        sequence = self._config.ul_per_mm[action]
+        return pipette_config.piecewise_volume_conversion(ul, sequence)
+
+    def __str__(self) -> str:
+        return '{} current volume {}ul critical point {} at {}'\
+            .format(self._config.display_name,
+                    self.current_volume,
+                    '<unknown>',
+                    0)
+
+    def __repr__(self) -> str:
+        return '<{}: {} {}>'.format(self.__class__.__name__,
+                                    self._config.display_name,
+                                    id(self))
+
+    def as_dict(self) -> Dict[str, Union[str, float]]:
+        config_dict = self.config._asdict()
+        config_dict.update({'current_volume': self.current_volume,
+                            'name': self.name})
+        return config_dict

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Optional, List, Tuple, Any
+from typing import Dict, Optional, List, Tuple
 
 from opentrons import types
 from . import modules
@@ -12,7 +12,7 @@ class Simulator:
     a robot with no smoothie connected.
     """
     def __init__(self,
-                 attached_instruments: Dict[types.Mount, Dict[str, Any]],
+                 attached_instruments: Dict[types.Mount, str],
                  attached_modules: List[str],
                  config, loop) -> None:
         self._config = config
@@ -30,10 +30,7 @@ class Simulator:
         return {'X': 418, 'Y': 353, 'Z': 218, 'A': 218, 'B': 19, 'C': 19}
 
     def get_attached_instrument(self, mount) -> Optional[str]:
-        try:
-            return self._attached_instruments[mount]['name']
-        except KeyError:
-            return None
+        return self._attached_instruments.get(mount, None)
 
     def set_active_current(self, axis, amp):
         pass

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -55,6 +55,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -79,6 +80,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -103,6 +105,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -127,6 +130,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -151,6 +155,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -175,6 +180,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -199,6 +205,7 @@ class InstrumentsWrapper(object):
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
+            name=pipette_model_version,
             trash_container=trash_container,
             tip_racks=tip_racks,
             aspirate_flow_rate=aspirate_flow_rate,
@@ -210,6 +217,7 @@ class InstrumentsWrapper(object):
             self,
             config,
             mount,
+            name,
             trash_container='',
             tip_racks=[],
             aspirate_flow_rate=None,
@@ -230,7 +238,7 @@ class InstrumentsWrapper(object):
         p = self.Pipette(
             model_offset=config.model_offset,
             mount=mount,
-            name=config.name,
+            name=name,
             trash_container=trash_container,
             tip_racks=tip_racks,
             channels=config.channels,

--- a/api/src/opentrons/protocols/__init__.py
+++ b/api/src/opentrons/protocols/__init__.py
@@ -19,7 +19,8 @@ def load_pipettes(protocol_data):
         config = pipette_config.load(model)
         pipettes_by_id[pipette_id] = instruments._create_pipette_from_config(
             config=config,
-            mount=mount)
+            mount=mount,
+            name=model)
 
     return pipettes_by_id
 

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -250,7 +250,8 @@ def _fetch_or_create_pipette(mount, model=None):
             config = pipette_config.load(model)
             pipette = instruments._create_pipette_from_config(
                 config=config,
-                mount=mount)
+                mount=mount,
+                name=model)
     return pipette, should_remove
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -23,34 +23,6 @@ from opentrons.deck_calibration import endpoints
 from opentrons.util import environment
 from opentrons import hardware_control as hc
 
-# Uncomment to enable logging during tests
-
-# logging_config = dict(
-#     version=1,
-#     formatters={
-#         'basic': {
-#             'format':
-#             '[Line %(lineno)s] %(message)s'
-#         }
-#     },
-#     handlers={
-#         'debug': {
-#             'class': 'logging.StreamHandler',
-#             'formatter': 'basic',
-#         }
-#     },
-#     loggers={
-#         '__main__': {
-#             'handlers': ['debug'],
-#             'level': logging.DEBUG
-#         },
-#         'opentrons.server': {
-#             'handlers': ['debug'],
-#             'level': logging.DEBUG
-#         },
-#     }
-# )
-# dictConfig(logging_config)
 
 Session = namedtuple(
     'Session',

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -99,6 +99,48 @@ async def test_mount_offset_applied(hardware_api):
     assert hardware_api._current_position == target_position
 
 
+async def test_critical_point_applied(hardware_api, monkeypatch):
+    await hardware_api.home()
+    hardware_api._backend._attached_instruments\
+        = {types.Mount.LEFT: None,
+           types.Mount.RIGHT: 'p10_single_v1'}
+    await hardware_api.cache_instruments()
+    # Our critical point is now the tip of the nozzle
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    target_no_offset = {Axis.X: 0,
+                        Axis.Y: 0,
+                        Axis.Z: 218,
+                        Axis.A: 13,  # from pipette-config.json model offset
+                        Axis.B: 19,
+                        Axis.C: 19}
+    assert hardware_api._current_position == target_no_offset
+    target = {Axis.X: 0,
+              Axis.Y: 0,
+              Axis.A: 0,
+              Axis.C: 19}
+    assert hardware_api.current_position(types.Mount.RIGHT) == target
+    await hardware_api.pick_up_tip(types.Mount.RIGHT)
+    # Now the current position (with offset applied) should change
+    target[Axis.A] = -33
+    assert hardware_api.current_position(types.Mount.RIGHT) == target
+    # This move should take the new critical point into account
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    target_no_offset[Axis.A] = 46
+    assert hardware_api._current_position == target_no_offset
+    # But the position with offset should be back to the original
+    target[Axis.A] = 0
+    assert hardware_api.current_position(types.Mount.RIGHT) == target
+    # And removing the tip should move us back to the original
+    await hardware_api.drop_tip(types.Mount.RIGHT)
+    target[Axis.A] = 33
+    assert hardware_api.current_position(types.Mount.RIGHT) == target
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    target_no_offset[Axis.A] = 13
+    target[Axis.A] = 0
+    assert hardware_api._current_position == target_no_offset
+    assert hardware_api.current_position(types.Mount.RIGHT) == target
+
+
 async def test_deck_cal_applied(monkeypatch, loop):
     new_gantry_cal = [[1, 0, 0, 10],
                       [0, 1, 0, 20],

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -1,0 +1,56 @@
+import pytest
+from opentrons.types import Point
+from opentrons.hardware_control import pipette
+from opentrons.config import pipette_config
+
+
+def test_tip_tracking():
+    pip = pipette.Pipette('p10_single_v1')
+    with pytest.raises(AssertionError):
+        pip.remove_tip()
+    assert not pip.has_tip
+    pip.add_tip()
+    assert pip.has_tip
+    with pytest.raises(AssertionError):
+        pip.add_tip()
+    pip.remove_tip()
+    assert not pip.has_tip
+    with pytest.raises(AssertionError):
+        pip.remove_tip()
+
+
+def test_critical_points():
+    for config in pipette_config.configs:
+        loaded = pipette_config.load(config)
+        pip = pipette.Pipette(config)
+        mod_offset = Point(*loaded.model_offset)
+        assert pip.critical_point == mod_offset
+        pip.add_tip()
+        new = mod_offset._replace(z=mod_offset.z - loaded.tip_length)
+        assert pip.critical_point == new
+        pip.remove_tip()
+        assert pip.critical_point == mod_offset
+
+
+def test_volume_tracking():
+    for config in pipette_config.configs:
+        loaded = pipette_config.load(config)
+        pip = pipette.Pipette(config)
+        assert pip.current_volume == 0.0
+        assert pip.available_volume == loaded.max_volume
+        assert pip.ok_to_add_volume(loaded.max_volume - 0.1)
+        pip.set_current_volume(0.1)
+        with pytest.raises(AssertionError):
+            pip.set_current_volume(loaded.max_volume + 0.1)
+        with pytest.raises(AssertionError):
+            pip.set_current_volume(-1)
+        assert pip.current_volume == 0.1
+        pip.remove_current_volume(0.1)
+        with pytest.raises(AssertionError):
+            pip.remove_current_volume(0.1)
+        assert pip.current_volume == 0.0
+        pip.set_current_volume(loaded.max_volume)
+        assert not pip.ok_to_add_volume(0.1)
+        with pytest.raises(AssertionError):
+            pip.add_current_volume(0.1)
+        assert pip.current_volume == loaded.max_volume

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -19,12 +19,16 @@ def test_pipette_version_1_0_and_1_3_extended_travel():
 
     for m in models:
         robot.reset()
+        v1 = m + '_v1'
+        v13 = m + '_v1.3'
         left = instruments._create_pipette_from_config(
-            config=pipette_config.load(m + '_v1'),
-            mount='left')
+            config=pipette_config.load(v1),
+            mount='left',
+            name=v1)
         right = instruments._create_pipette_from_config(
-            config=pipette_config.load(m + '_v1.3'),
-            mount='right')
+            config=pipette_config.load(v13),
+            mount='right',
+            name=v13)
 
         # the difference between v1 and v1.3 is that the plunger's travel
         # distance extended, allowing greater ranges for aspirate/dispense
@@ -46,12 +50,16 @@ def test_all_pipette_models_can_transfer():
 
     for m in models:
         robot.reset()
+        v1 = m + '_v1'
+        v13 = m + '_v1.3'
         left = instruments._create_pipette_from_config(
-            config=pipette_config.load(m + '_v1'),
-            mount='left')
+            config=pipette_config.load(v1),
+            mount='left',
+            name=v1)
         right = instruments._create_pipette_from_config(
-            config=pipette_config.load(m + '_v1.3'),
-            mount='right')
+            config=pipette_config.load(v13),
+            mount='right',
+            name=v13)
 
         left.tip_attached = True
         right.tip_attached = True
@@ -66,7 +74,8 @@ def test_pipette_models_reach_max_volume():
         robot.reset()
         pipette = instruments._create_pipette_from_config(
             config=config,
-            mount='right')
+            mount='right',
+            name=model)
 
         pipette.tip_attached = True
         pipette.aspirate(pipette.max_volume)

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -55,13 +55,13 @@ async def test_get_pipettes(
     model = pipette_config.load(test_model)
     expected = {
         'left': {
-            'model': model.name,
+            'model': test_model,
             'tip_length': model.tip_length,
             'mount_axis': 'z',
             'plunger_axis': 'b'
         },
         'right': {
-            'model': model.name,
+            'model': test_model,
             'tip_length': model.tip_length,
             'mount_axis': 'a',
             'plunger_axis': 'c'
@@ -114,13 +114,13 @@ async def test_get_cached_pipettes(
     model = pipette_config.load(test_model)
     expected = {
         'left': {
-            'model': model.name,
+            'model': test_model,
             'tip_length': model.tip_length,
             'mount_axis': 'z',
             'plunger_axis': 'b'
         },
         'right': {
-            'model': model.name,
+            'model': test_model,
             'tip_length': model.tip_length,
             'mount_axis': 'a',
             'plunger_axis': 'c'
@@ -132,10 +132,11 @@ async def test_get_cached_pipettes(
     assert resp.status == 200
     assert json.loads(text) == expected
 
-    model1 = pipette_config.load('p10_single_v1.3')
+    name1 = 'p10_single_v1.3'
+    model1 = pipette_config.load(name1)
 
     def dummy_model(mount):
-        return model1.name
+        return name1
 
     monkeypatch.setattr(robot._driver, 'read_pipette_model', dummy_model)
 
@@ -146,13 +147,13 @@ async def test_get_cached_pipettes(
 
     expected2 = {
         'left': {
-            'model': model1.name,
+            'model': name1,
             'tip_length': model1.tip_length,
             'mount_axis': 'z',
             'plunger_axis': 'b'
         },
         'right': {
-            'model': model1.name,
+            'model': name1,
             'tip_length': model1.tip_length,
             'mount_axis': 'a',
             'plunger_axis': 'c'


### PR DESCRIPTION
## overview

Add critical point tracking to the hardware control API.

This layer keeps track of whether a pipette or tip is attached in a given mount, and makes the `move_to` method do "the right thing".

The `move_to` moves the critical point of the specified mount to a location. We define the critical point as:

- The mount, or a location convenient to the mount (Right now, the bottom of a P300 single for legacy reasons - open to change here) if there is no pipette attached
- The end of the nozzle of a single pipette or the end of the +Y-most nozzle of a multi pipette if a pipette is attached but has no tip
- The end of the tip of a single pipette or the end of the tip of the +y-most nozzle of a multi pipette if a tip is attached

So doing a `move_to` to the same point for the same mount interspersed with adding and removing tips should move the machine around.

One added caveat is this still uses the tip lengths from the pipette config file; when or if we add that data to the tip rack definitions, it should be easy to change this.

## changelog

- Added pipette critical point tracking to hardware_control API
- Refactored various parts of pipette state in hardware_control API to all live in one data object
- Changed pipette model names to live separately from the pipette_config

Closes #2239 

## review requests

Test on a robot. SSH in and kill the API server (find with `ps` and then `kill`) in case it's talking to the smoothie.

Setup:
```python
>>> import opentrons.hardware_control as hc
>>> l=asyncio.get_event_loop()
>>> a = hc.API.build_hardware_controller()
>>> l.run_until_complete(a.cache_instruments())
>>> a.attached_instruments    # please be sure instruments are attached
```

Then, move a pipette around and intersperse attach and drop tips (there's currently no actual motion involved there) checking that the position changes, and further moves move the pipettes:

```
>>> l.run_until_complete(a.home())
>>> l.run_until_complete(a.move_to(Mount.RIGHT, Point(15, 15, 50)))
>>> a.current_position(Mount.RIGHT)
{<Axis.X: 1>: 15.0, <Axis.Y: 2>: 15.0, <Axis.A: 4>: 50.0, <Axis.C: 6>: 18.0}   # Should be the position you specified
>>> l.run_until_complete(a.pick_up_tip(Mount.RIGHT)  # pipette should not move
>>> a.current_position(Mount.RIGHT)
{<Axis.X: 1>: 0.0, <Axis.Y: 2>: 0.0, <Axis.A: 4>: -1.7000000000000028, <Axis.C: 6>: 18.0}   # position has changed because the critical point changed
>>> l.run_until_complete(a.move_to(Mount.RIGHT, Point(15, 15, 50)))  # pipette should move +z by a tip length
>>> a.current_position(Mount.RIGHT)
{<Axis.X: 1>: 15.0, <Axis.Y: 2>: 15.0, <Axis.A: 4>: 50.0, <Axis.C: 6>: 18.0}   # Should be the position you specified
```

Try with multipipettes and different pipette models.