### PR TITLE
feat(protocol-designer): implement "clear wells" button

### DIFF
--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
@@ -29,7 +29,7 @@ type Props = {
   showForm: boolean,
 
   cancelForm: () => mixed,
-  clearWells: () => mixed,
+  clearWells: ?() => mixed,
   saveForm: (ValidFormValues) => mixed,
 }
 
@@ -66,7 +66,7 @@ export default class LiquidPlacementForm extends React.Component <Props> {
   }
 
   handleClearWells = () => {
-    this.props.clearWells()
+    this.props.clearWells && this.props.clearWells()
   }
 
   handleChangeVolume = (setFieldValue: *) => (e: SyntheticInputEvent<*>) => {
@@ -123,7 +123,9 @@ export default class LiquidPlacementForm extends React.Component <Props> {
             </div>
 
             <div className={styles.button_row}>
-              <OutlineButton onClick={this.handleClearWells}>
+              <OutlineButton
+                disabled={!this.props.clearWells}
+                onClick={this.handleClearWells}>
                 {i18n.t('button.clear_wells')}
               </OutlineButton>
               <OutlineButton onClick={this.handleCancelForm}>

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -115,7 +115,6 @@ export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware
 export type RemoveWellsContents = {
   type: 'REMOVE_WELLS_CONTENTS',
   payload: {
-    liquidGroupId: string,
     labwareId: string,
     wells: Array<string>,
   },


### PR DESCRIPTION
## overview

Closes #2430 - now the button does something

## changelog

* implement "clear wells" button

## review requests

- [ ] New 'Empty Wells' button in the liquids placement editor 
  - [ ] Button is inactive if there are no liquids selected
- [ ] User sees a warning dialogue when they click 'Empty Wells'
