### PR TITLE
fix(api): Correct GET /wifi/keys response to match documentation

### DIFF
--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -434,20 +434,20 @@ async def list_keys(request: web.Request) -> web.Response:
     ```
     """
     keys_dir = environment.get_path('WIFI_KEYS_DIR')
-    response: List[Dict[str, str]] = []
+    keys: List[Dict[str, str]] = []
     for path in os.listdir(keys_dir):
         full_path = os.path.join(keys_dir, path)
         if os.path.isdir(full_path):
             in_path = os.listdir(full_path)
             if len(in_path) > 1:
                 log.warning("Garbage in key dir for key {}".format(path))
-            response.append(
+            keys.append(
                 {'uri': '/wifi/keys/{}'.format(path),
                  'id': path,
                  'name': os.path.basename(in_path[0])})
         else:
             log.warning("Garbage in wifi keys dir: {}".format(full_path))
-    return web.json_response(response, status=200)
+    return web.json_response({'keys': keys}, status=200)
 
 
 async def remove_key(request: web.Request) -> web.Response:

--- a/api/tests/opentrons/server/test_networking_endpoints.py
+++ b/api/tests/opentrons/server/test_networking_endpoints.py
@@ -246,7 +246,7 @@ async def test_list_keys(loop, test_client, wifi_keys_tempdir):
     empty_resp = await cli.get('/wifi/keys')
     assert empty_resp.status == 200
     empty_body = await empty_resp.json()
-    assert empty_body == []
+    assert empty_body == {'keys': []}
 
     for dn in dummy_names:
         os.mkdir(os.path.join(wifi_keys_tempdir, dn))
@@ -255,9 +255,10 @@ async def test_list_keys(loop, test_client, wifi_keys_tempdir):
     resp = await cli.get('/wifi/keys')
     assert resp.status == 200
     body = await resp.json()
-    assert len(body) == 3
+    keys = body['keys']
+    assert len(keys) == 3
     for dn in dummy_names:
-        for keyfile in body:
+        for keyfile in keys:
             if keyfile['id'] == dn:
                 assert keyfile['name'] == 'test.pem'
                 assert keyfile['uri'] == '/wifi/keys/{}'.format(dn)
@@ -273,7 +274,7 @@ async def test_key_lifecycle(loop, test_client, wifi_keys_tempdir):
         empty_resp = await cli.get('/wifi/keys')
         assert empty_resp.status == 200
         empty_body = await empty_resp.json()
-        assert empty_body == []
+        assert empty_body == {'keys': []}
 
         results = {}
         # We should be able to add multiple keys
@@ -305,8 +306,9 @@ async def test_key_lifecycle(loop, test_client, wifi_keys_tempdir):
         list_resp = await cli.get('/wifi/keys')
         assert list_resp.status == 200
         list_body = await list_resp.json()
-        assert len(list_body) == 3
-        for elem in list_body:
+        keys = list_body['keys']
+        assert len(keys) == 3
+        for elem in keys:
             assert elem['id'] in [r['id'] for r in results.values()]
 
         for fn, data in results.items():
@@ -316,7 +318,7 @@ async def test_key_lifecycle(loop, test_client, wifi_keys_tempdir):
             assert 'message' in del_body
             del_list_resp = await cli.get('/wifi/keys')
             del_list_body = await del_list_resp.json()
-            assert data['id'] not in [k['id'] for k in del_list_body]
+            assert data['id'] not in [k['id'] for k in del_list_body['keys']]
 
         dup_del_resp = await cli.delete(results['test1.pem']['uri'])
         assert dup_del_resp.status == 404


### PR DESCRIPTION
## overview

The API response from `GET /wifi/keys` did not match what was in the documentation nor what was in the spec listed on the PR that added the endpoint (#2254). This PR fixes the endpoint to match the expected output.

Due to the fact that this went out in `v3.4.0`, the client is going to need to work around malformed responses for this endpoint to handle EAP with certificates for older robots gracefully.

## changelog

- fix(api): Correct GET /wifi/keys response to match documentation

## review requests

Please check that `GET /wifi/keys` returns a response that looks like `{"keys": [...]}`. This code has been pushed to 🌆 