### PR TITLE
fix(protocol-designer): close liquid placement form when clear wells is clicked

### DIFF
--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -42,6 +42,7 @@ const selectedWells = handleActions({
   CLOSE_WELL_SELECTION_MODAL: () => selectedWellsInitialState,
   DESELECT_ALL_WELLS: () => selectedWellsInitialState,
   OPEN_RENAME_LABWARE_FORM: () => selectedWellsInitialState,
+  REMOVE_WELLS_CONTENTS: () => selectedWellsInitialState,
   SET_WELL_CONTENTS: () => selectedWellsInitialState,
 }, selectedWellsInitialState)
 


### PR DESCRIPTION
## overview

Related to #2528

## changelog


## review requests

- [ ] In Liquid Placement Form, clicking "Clear Wells" button should clear the well selection and hide the form.