### PR TITLE
feat(protocol-designer): continue to liquids not design page

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -8,6 +8,7 @@ import {
   OutlineButton,
   PrimaryButton,
 } from '@opentrons/components'
+import i18n from '../localization'
 import type {FormConnector} from '../utils'
 import styles from './FilePage.css'
 import formStyles from '../components/forms.css'
@@ -16,12 +17,12 @@ export type FilePageProps = {
   formConnector: FormConnector<any>,
   isFormAltered: boolean,
   instruments: React.ElementProps<typeof InstrumentGroup>,
-  goToDesignPage: () => mixed,
+  goToNextPage: () => mixed,
   saveFileMetadata: () => mixed,
   swapPipettes: () => mixed,
 }
 
-const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, goToDesignPage, swapPipettes}: FilePageProps) => {
+const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, goToNextPage, swapPipettes}: FilePageProps) => {
   const handleSubmit = (e: SyntheticEvent<*>) => {
     // blur focused field on submit
     if (document && document.activeElement) document.activeElement.blur()
@@ -68,11 +69,11 @@ const FilePage = ({formConnector, isFormAltered, instruments, saveFileMetadata, 
 
       <div className={styles.button_row}>
         <PrimaryButton
-          onClick={goToDesignPage}
+          onClick={goToNextPage}
           className={styles.continue_button}
           iconName="arrow-right"
         >
-          Continue to Design
+          {i18n.t('button.continue_to_liquids')}
         </PrimaryButton>
       </div>
     </div>

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -18,7 +18,7 @@ type SP = {
 type DP = {
   _updateFileMetadataFields: typeof actions.updateFileMetadataFields,
   _saveFileMetadata: ({[accessor: FileMetadataFieldAccessors]: mixed}) => mixed,
-  goToDesignPage: $PropertyType<FilePageProps, 'goToDesignPage'>,
+  goToNextPage: $PropertyType<FilePageProps, 'goToNextPage'>,
   swapPipettes: $PropertyType<FilePageProps, 'swapPipettes'>,
 }
 
@@ -37,13 +37,13 @@ const mapStateToProps = (state: BaseState): SP => {
 const mapDispatchToProps: DP = {
   _updateFileMetadataFields: actions.updateFileMetadataFields,
   _saveFileMetadata: actions.saveFileMetadata,
-  goToDesignPage: () => navActions.navigateToPage('steplist'),
+  goToNextPage: () => navActions.navigateToPage('liquids'),
   swapPipettes: pipetteActions.swapPipettes,
 }
 
 const mergeProps = (
   {instruments, isFormAltered, _values}: SP,
-  {_updateFileMetadataFields, _saveFileMetadata, goToDesignPage, swapPipettes}: DP
+  {_updateFileMetadataFields, _saveFileMetadata, goToNextPage, swapPipettes}: DP
 ): FilePageProps => {
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
     if (accessor === 'protocol-name' || accessor === 'description' || accessor === 'author') {
@@ -59,7 +59,7 @@ const mergeProps = (
     formConnector,
     isFormAltered,
     instruments,
-    goToDesignPage,
+    goToNextPage,
     saveFileMetadata: () => _saveFileMetadata(_values),
     swapPipettes,
   }

--- a/protocol-designer/src/localization/en/button.json
+++ b/protocol-designer/src/localization/en/button.json
@@ -2,6 +2,7 @@
   "add_step": "+ Add Step",
   "cancel": "cancel",
   "clear_wells": "Clear Wells",
+  "continue_to_liquids": "Continue to Liquids",
   "delete": "delete",
   "done": "done",
   "new_liquid": "New Liquid",


### PR DESCRIPTION
## overview

Closes #2534

## changelog

- Change "Continue to Design" button at the bottom of the file page to "Continue to Liquids"
- Change button destination to liquids tab

## review requests

- [ ] "Continue to Liquids" works