### PR TITLE
fix(protocol-designer): do not add __air__ on blowout

### DIFF
--- a/protocol-designer/src/step-generation/blowout.js
+++ b/protocol-designer/src/step-generation/blowout.js
@@ -50,7 +50,7 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
         pipetteData,
         labwareId: labware,
         labwareType: prevRobotState.labware[labware].type,
-        volume: pipetteData.maxVolume, // update liquid state as if it was a dispense, but with max volume of pipette
+        useFullVolume: true,
         well,
       }, prevRobotState.liquidState),
     },

--- a/protocol-designer/src/step-generation/dropTip.js
+++ b/protocol-designer/src/step-generation/dropTip.js
@@ -37,7 +37,7 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
         pipetteData: prevRobotState.instruments[pipetteId],
         labwareId: FIXED_TRASH_ID,
         labwareType: 'fixed-trash',
-        volume: prevRobotState.instruments[pipetteId].maxVolume, // update liquid state as if it was a dispense, but with max volume of pipette
+        useFullVolume: true,
         well: 'A1',
       }, prevRobotState.liquidState),
     },

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -114,7 +114,7 @@ describe('blowout', () => {
       expect(updateLiquidState).toHaveBeenCalledWith({
         pipetteId: 'p300SingleId',
         labwareId: 'sourcePlateId',
-        volume: 300, // pipette's max vol
+        useFullVolume: true,
         well: 'A1',
         labwareType: 'trough-12row',
         pipetteData: robotStateWithTip.instruments.p300SingleId,

--- a/protocol-designer/src/step-generation/test-with-flow/dispenseUpdateLiquidState.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispenseUpdateLiquidState.test.js
@@ -1,5 +1,6 @@
 // @flow
 import merge from 'lodash/merge'
+import omit from 'lodash/omit'
 import {
   createEmptyLiquidState,
   createTipLiquidState,
@@ -35,7 +36,7 @@ beforeEach(() => {
 })
 
 describe('...single-channel pipette', () => {
-  test('fully dispense single ingredient into empty well', () => {
+  test('fully dispense single ingredient into empty well, with explicit volume', () => {
     const initialLiquidState = merge(
       {},
       getBlankLiquidState(),
@@ -52,6 +53,47 @@ describe('...single-channel pipette', () => {
 
     const result = _updateLiquidState(
       dispenseSingleCh150ToA1Args,
+      initialLiquidState
+    )
+
+    expect(result).toMatchObject({
+      pipettes: {
+        p300SingleId: {
+          '0': {
+            ingred1: {volume: 0},
+          },
+        },
+      },
+      labware: {
+        sourcePlateId: {
+          A1: {ingred1: {volume: 150}},
+          A2: {},
+          B1: {},
+        },
+      },
+    })
+  })
+
+  test('fully dispense single ingredient into empty well, with useFullVolume', () => {
+    const initialLiquidState = merge(
+      {},
+      getBlankLiquidState(),
+      {
+        pipettes: {
+          p300SingleId: {
+            '0': {
+              ingred1: {volume: 150},
+            },
+          },
+        },
+      }
+    )
+
+    const result = _updateLiquidState(
+      {
+        ...omit(dispenseSingleCh150ToA1Args, 'volume'),
+        useFullVolume: true,
+      },
       initialLiquidState
     )
 

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -117,7 +117,7 @@ describe('dropTip', () => {
       updateLiquidState.mockReturnValue(mockLiquidReturnValue)
     })
 
-    test('dropTip calls dispenseUpdateLiquidState with the max volume of the pipette', () => {
+    test('dropTip calls dispenseUpdateLiquidState with useFullVolume: true', () => {
       const initialRobotState = makeRobotState({singleHasTips: true, multiHasTips: true})
 
       const result = dropTip('p300MultiId')(initialRobotState)
@@ -126,7 +126,7 @@ describe('dropTip', () => {
         {
           pipetteId: 'p300MultiId',
           labwareId: 'trashId',
-          volume: 300, // pipette's max vol
+          useFullVolume: true,
           well: 'A1',
           labwareType: 'fixed-trash',
           pipetteData: robotStateWithTip.instruments.p300MultiId,

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -7,7 +7,6 @@ import {
   commandFixtures as cmd,
 } from './fixtures'
 import _transfer from '../transfer'
-import {FIXED_TRASH_ID} from '../../constants'
 
 const transfer = compoundCommandCreatorNoErrors(_transfer)
 const transferWithErrors = compoundCommandCreatorHasErrors(_transfer)
@@ -256,9 +255,14 @@ describe('single transfer exceeding pipette max', () => {
       cmd.dispense('B3', 50, {labware: 'destPlateId'}),
     ])
 
-    // ignore trash contents because of "__air__" from dropped tips
-    // TODO: Ian 2018-09-17 fix "__air__" and remove this line $FlowFixMe
-    expectedFinalLiquidState.labware[FIXED_TRASH_ID] = result.robotState.liquidState.labware[FIXED_TRASH_ID]
+    // unlike the other test cases here, we have a new tip when aspirating from B1.
+    // so there's only ingred 1, and no ingred 0
+    // $FlowFixMe flow doesn't like assigning to these objects
+    expectedFinalLiquidState.pipettes.p300SingleId['0'] = {'1': {volume: 0}}
+
+    // likewise, there's no residue of ingred 0 in B3 from a dirty tip.
+    // $FlowFixMe flow doesn't like assigning to these objects
+    expectedFinalLiquidState.labware.destPlateId.B3 = {'1': {volume: 350}}
 
     expect(result.robotState.liquidState).toEqual(merge(
       {},

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -160,6 +160,8 @@ export type SingleLabwareLiquidState = {[well: string]: LocationLiquidState}
 
 export type LabwareLiquidState = {[labwareId: string]: SingleLabwareLiquidState}
 
+export type SourceAndDest = {|source: LocationLiquidState, dest: LocationLiquidState|}
+
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
   instruments: { // TODO Ian 2018-05-23 rename this 'pipettes' to match tipState (& to disambiguate from future 'modules')


### PR DESCRIPTION
## overview

Closes #2498

Prevents adding `__air__` on blowout and drop tip

Before (edge, with example protocol below, final deck state hovering on well F12):

![image](https://user-images.githubusercontent.com/11590381/47439584-a17b6280-d77a-11e8-90df-ee1aeea4d964.png)

After:

![image](https://user-images.githubusercontent.com/11590381/47439670-cc65b680-d77a-11e8-85a8-14ddce976e1e.png)

### Implementation details

This is all about reusing code that does almost the same thing but not quite. The step-generation function blowout, dropTip, and dispense all update their liquid state via `dispenseUpdateLiquidState`. Both blowout and dropTip effectively want "dispense all the volume within each tip on the pipette" while dispense always uses an explicit volume (it permits over-dispensing but maybe we shouldn't even permit that). Instead of making another `dispenseFullVolumeUpdateLiquidState` fn with similar code, I added new argument `useFullVolume` to `dispenseUpdateLiquidState`, which dropTip and blowout use.

This also fixed an inconsistency in "contamination tracking", where dropping a tip didn't clear out the traces of liquids `{[liquidGroupId]: {volume: 0}} --> {}`, as you can see in the `transfer.test.js` diff.

## changelog

* Do not add `__air__` to destination on blowout or drop tip.

## review requests

- [ ] A protocol using blowout (eg via distribute disposal volume) should not put __air__ in wells and make their hover tooltips show a weird extra liquid. [Example test protocol](https://github.com/Opentrons/opentrons/files/2510986/blowout-tester.json.zip)
