### PR TITLE
fix(protocol-designer): fix LiquidPlacementForm onBlur typo

### DIFF
--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
@@ -104,7 +104,7 @@ export default class LiquidPlacementForm extends React.Component <Props> {
                   error={touched.selectedLiquidId && errors.selectedLiquidId}
                   value={values.selectedLiquidId}
                   onChange={handleChange}
-                  onBlue={handleBlur}
+                  onBlur={handleBlur}
                 />
               </FormGroup>
               <FormGroup
@@ -117,7 +117,7 @@ export default class LiquidPlacementForm extends React.Component <Props> {
                   error={touched.volume && errors.volume}
                   value={values.volume}
                   onChange={this.handleChangeVolume(setFieldValue)}
-                  onBlue={handleBlur}
+                  onBlur={handleBlur}
                 />
               </FormGroup>
             </div>


### PR DESCRIPTION
## overview

Oops! I wrote `onBlue` instead of `onBlur` so errors were not being shown in LiquidPlacementForm on blur (when user un-focuses the field) but only when they clicked "save".

BUT - I am not sure which is actually the desired behavior for this form: to mask errors until user clicks "save" (existing behavior on edge due to the `onBlue` typo), or to mask errors only until user focuses and un-focuses a field without waiting for them to click "save" (new behavior, this PR)

Since there are only 2 fields in this form, the behavior difference is very subtle.

![image](https://user-images.githubusercontent.com/11590381/47444271-1dc67380-d784-11e8-8ab6-972f82bbe9ac.png)

## changelog

* fix onBlur typo in LiquidPlacementForm - this makes it so you see errors before clicking "save"

## review requests

- Is this fix desirable? If not I can tweak this PR so that there are no `onBlur`s which will give us the behavior on `edge`