### PR TITLE
refactor(app): Add validation to network auth forms

### DIFF
--- a/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
@@ -4,6 +4,7 @@ import {Formik} from 'formik'
 import get from 'lodash/get'
 import find from 'lodash/find'
 import set from 'lodash/set'
+import isEmpty from 'lodash/isEmpty'
 
 import {WPA_PSK_SECURITY, WPA_EAP_SECURITY} from '../../../http-api-client'
 
@@ -84,7 +85,7 @@ export default class ConnectForm extends React.Component<Props, State> {
       if (f.required && !get(values, f.name)) {
         set(errors, f.name, `${f.displayName} is required`)
       } else if (f.name === 'psk' && get(values, f.name).length < 8) {
-        set(errors, `${f.name}`, 'Password must be at least 8 characters')
+        set(errors, f.name, 'Password must be at least 8 characters')
       }
     })
     return errors
@@ -175,12 +176,4 @@ export default class ConnectForm extends React.Component<Props, State> {
       />
     )
   }
-}
-
-// Helper function to check for empty objects
-function isEmpty (obj) {
-  for (var key in obj) {
-    if (obj.hasOwnProperty(key)) return false
-  }
-  return true
 }

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
@@ -76,7 +76,6 @@ export default function ConnectFormField (props: Props) {
         {inputRow}
         <FormTableRow>
           <CheckboxField
-            name="Show password"
             label="Show password"
             value={showPassword}
             onChange={() => toggleShowPassword(name)}

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-
+import get from 'lodash/get'
 import {InputField, CheckboxField, DropdownField} from '@opentrons/components'
 import {FormTableRow} from './FormTable'
 
@@ -12,12 +12,27 @@ type Props = {
   showPassword: boolean,
   onChange: (*) => mixed,
   toggleShowPassword: (name: string) => mixed,
+  errors: {
+    [string]: string,
+  },
+  touched: {
+    [string]: boolean,
+  },
+  onBlur: (SyntheticFocusEvent<*>) => mixed,
 }
 
 export const CONNECT_FIELD_ID_PREFIX = '__ConnectForm__'
 
 export default function ConnectFormField (props: Props) {
-  const {value, showPassword, onChange, toggleShowPassword} = props
+  const {
+    value,
+    showPassword,
+    onChange,
+    toggleShowPassword,
+    onBlur,
+    touched,
+    errors,
+  } = props
   const {name, displayName, type, required} = props.field
   const id = `${CONNECT_FIELD_ID_PREFIX}${name}`
   const label = required ? `* ${displayName}:` : `${displayName}:`
@@ -25,7 +40,6 @@ export default function ConnectFormField (props: Props) {
 
   if (type === 'string' || type === 'password') {
     const inputType = type === 'string' || showPassword ? 'text' : 'password'
-
     input = (
       <InputField
         id={id}
@@ -33,6 +47,8 @@ export default function ConnectFormField (props: Props) {
         type={inputType}
         value={value}
         onChange={onChange}
+        error={get(touched, name) && get(errors, name)}
+        onBlur={onBlur}
       />
     )
   } else if (type === 'file') {
@@ -60,6 +76,7 @@ export default function ConnectFormField (props: Props) {
         {inputRow}
         <FormTableRow>
           <CheckboxField
+            name="Show password"
             label="Show password"
             value={showPassword}
             onChange={() => toggleShowPassword(name)}


### PR DESCRIPTION
## overview

This PR adds validation to Wifi Auth forms. closes #2416 

Tagged as refactor, behind feature flag.

Form is pristine, submit disabled
<img width="535" alt="screen shot 2018-10-25 at 11 47 11 am" src="https://user-images.githubusercontent.com/3430313/47513620-a4468800-d84c-11e8-834b-edfef59e964e.png">


Required form field `touched` but empty
<img width="536" alt="screen shot 2018-10-25 at 11 47 25 am" src="https://user-images.githubusercontent.com/3430313/47513622-a4468800-d84c-11e8-8eaa-51f68b8e4e4a.png">


Min char of 8 for WPA2 passwords
<img width="537" alt="screen shot 2018-10-25 at 11 47 36 am" src="https://user-images.githubusercontent.com/3430313/47513623-a4468800-d84c-11e8-8a8e-29d252cc1cec.png">


Form validated submit enabled
<img width="537" alt="screen shot 2018-10-25 at 11 47 52 am" src="https://user-images.githubusercontent.com/3430313/47513624-a4468800-d84c-11e8-882a-1362c8b4cf2e.png">


## changelog
- refactor(app): Add validation to network auth forms

## review requests

To enable new connectivity card:
`make -C app dev OT_APP_DEV_INTERNAL__MANAGE_ROBOT_CONNECTION__NEW_CARD=1`

Please double check EAP/PEAP on network in office!

- [ ] All required * fields render error on `touched` but empty
- [ ] Character min error only displays for WPA2 password field
- [ ] Submit is disabled until form is valid
- [ ] Submit/Connect still works

