### PR TITLE
refactor(api): Add a back-compat shim for ways of accessing wells

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -2,7 +2,24 @@ import enum
 from typing import Union
 from collections import namedtuple
 
-Point = namedtuple('Point', ['x', 'y', 'z'])
+_PointTuple = namedtuple('Point', ['x', 'y', 'z'])
+
+
+class Point(_PointTuple):
+    def __eq__(self, other: 'Point') -> bool:
+        if not isinstance(other, Point):
+            return False
+        return self.x == other.x and self.y == other.y and self.z == other.z
+
+    def __add__(self, other: 'Point') -> 'Point':
+        if not isinstance(other, Point):
+            return NotImplemented
+        return Point(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other: 'Point') -> 'Point':
+        if not isinstance(other, Point):
+            return NotImplemented
+        return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
 
 class Mount(enum.Enum):


### PR DESCRIPTION
## overview

Add a back-compat shim for ways of accessing wells in a labware. Closes #2265

## changelog

- refactor(api): Add a back-compat shim for ways of accessing wells in a labware

## review requests

- look over tests and code