### PR TITLE
fix(api): Fix bug where drop-tip current is not used during drop-tip

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1040,12 +1040,12 @@ class Pipette:
             pos_bottom = self._get_plunger_position('bottom')
             pos_drop_tip = self._get_plunger_position('drop_tip')
 
-            self.instrument_actuator.set_active_current(self._drop_tip_current)
+            self.instrument_actuator.set_active_current(self._plunger_current)
             self.robot.poses = self.instrument_actuator.move(
                 self.robot.poses,
                 x=pos_bottom
             )
-            self.instrument_actuator.set_active_current(self._plunger_current)
+            self.instrument_actuator.set_active_current(self._drop_tip_current)
             self.robot.poses = self.instrument_actuator.move(
                 self.robot.poses,
                 x=pos_drop_tip

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -414,9 +414,9 @@ def test_drop_tip_current(model):
     # Instrument in `model` is configured to right mount, which is the A axis
     # on the Smoothie (see `Robot._actuators`)
     expected = [
-        {'C': 0.456},   # make to 'drop_tip' position
-        {'C': 0.05},    # dwell
         {'C': 0.123},   # move to 'bottom' position
+        {'C': 0.05},    # dwell
+        {'C': 0.456},   # move to 'drop_tip' position
         {'C': 0.05},    # dwell
         {'C': 0.123},   # fast-home move upwards
         {'C': 0.05},    # dwell


### PR DESCRIPTION
## overview

Fix bug where the pipette-specific drop-tip current values form the config are not used while actually dropping-tip.