### PR TITLE
API: hardware_control/protocol api integration

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -55,7 +55,7 @@ Z_OFFSET_P1000 = 20  # shortest single-channel pipette
 
 
 with open(config_file) as cfg_file:
-    configs = json.load(cfg_file).keys()
+    configs = list(json.load(cfg_file).keys())
 
 
 def load(pipette_model: str) -> pipette_config:

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -8,7 +8,6 @@ from opentrons.drivers.smoothie_drivers import driver_3_0
 from opentrons.config import robot_configs
 from opentrons.types import Mount
 from . import modules
-from .types import Axis
 
 
 _lock = threading.Lock()
@@ -76,12 +75,15 @@ class Controller:
         self._smoothie_driver.move(
             target_position, home_flagged_axes=home_flagged_axes)
 
-    def home(self, axes: List[Axis] = None) -> Dict[str, float]:
+    def home(self, axes: List[str] = None) -> Dict[str, float]:
         if axes:
-            args: Tuple[Any, ...] = (''.join([ax.name for ax in axes]),)
+            args: Tuple[Any, ...] = (''.join(axes),)
         else:
             args = tuple()
         return self._smoothie_driver.home(*args)
+
+    def fast_home(self, axis: str, margin: float) -> Dict[str, float]:
+        return self._smoothie_driver.fast_home(axis, margin)
 
     def get_attached_instruments(
             self, expected: Dict[Mount, str]) -> Dict[Mount, Optional[str]]:

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -2,8 +2,18 @@ import asyncio
 from typing import Dict, Optional, List, Tuple
 
 from opentrons import types
+from opentrons.config.pipette_config import configs
 from . import modules
 from .types import Axis
+
+
+def find_config(prefix: str) -> str:
+    """ Find the most recent config matching `prefix` or None """
+    matches = [conf for conf in configs if conf.startswith(prefix)]
+    if prefix in matches:
+        return prefix
+    else:
+        return sorted(matches)[0]
 
 
 class Simulator:
@@ -29,8 +39,45 @@ class Simulator:
         # driver_3_0-> HOMED_POSITION
         return {'X': 418, 'Y': 353, 'Z': 218, 'A': 218, 'B': 19, 'C': 19}
 
-    def get_attached_instrument(self, mount) -> Optional[str]:
-        return self._attached_instruments.get(mount, None)
+    def get_attached_instruments(
+            self, expected: Dict[types.Mount, str])\
+            -> Dict[types.Mount, Optional[str]]:
+        """ Update the internal cache of attached instruments.
+
+        This method allows after-init-time specification of attached simulated
+        instruments. The method will return
+        - the instruments specified at init-time, or if those do not exists,
+        - the instruments specified in expected, or if that is not passed,
+        - nothing
+
+        :param expected: A mapping of mount to instrument model prefixes. When
+                         loading instruments from a prefix, we return the
+                         lexically-first model that matches the prefix. If the
+                         models specified in expected do not match the models
+                         specified in the `attached_instruments` argument of
+                         :py:meth:`__init__`, :py:attr:`RuntimeError` is
+                         raised.
+        :raises RuntimeError: If an instrument is expected but not found.
+        :returns: A dict of mount to either instrument model names or `None`.
+        """
+        to_return: Dict[types.Mount, Optional[str]] = {}
+        for mount in types.Mount:
+            expected_instr = expected.get(mount, None)
+            init_instr = self._attached_instruments.get(mount, None)
+            if expected_instr and init_instr\
+               and not init_instr.startswith(expected_instr):
+                raise RuntimeError(
+                    'mount {}: expected instrument {} but got {}'
+                    .format(mount.name, expected_instr, init_instr))
+            elif init_instr and expected_instr:
+                to_return[mount] = init_instr
+            elif init_instr:
+                to_return[mount] = init_instr
+            elif expected_instr:
+                to_return[mount] = find_config(expected_instr)
+            else:
+                to_return[mount] = None
+        return to_return
 
     def set_active_current(self, axis, amp):
         pass

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -29,3 +29,8 @@ class Mount(enum.Enum):
 
 
 DeckLocation = Union[int, str]
+
+
+class MotionStrategy(enum.Enum):
+    DIRECT = enum.auto()
+    ARC = enum.auto()

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -55,6 +55,40 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
     await hw_api_cntrlr.cache_instruments()
     assert hw_api_cntrlr.attached_instruments == attached_instruments(
         dummy_instruments)
+    # If we pass a conflicting expectation we should get an error
+    with pytest.raises(RuntimeError):
+        await hw_api_cntrlr.cache_instruments({types.Mount.LEFT: 'p300_multi'})
+    # If we pass a matching expects it should work
+    await hw_api_cntrlr.cache_instruments({types.Mount.LEFT: 'p10_single'})
+    assert hw_api_cntrlr.attached_instruments\
+        == attached_instruments(dummy_instruments)
+
+
+async def test_cache_instruments_sim(loop, dummy_instruments):
+    sim = hc.API.build_hardware_simulator(loop=loop)
+    # With nothing specified at init or expected, we should have nothing
+    await sim.cache_instruments()
+    assert sim.attached_instruments == {types.Mount.LEFT: {},
+                                        types.Mount.RIGHT: {}}
+    # When we expect instruments, we should get what we expect since nothing
+    # was specified at init time
+    await sim.cache_instruments({types.Mount.LEFT: 'p10_single_v1.3'})
+    assert sim.attached_instruments[types.Mount.LEFT]['name']\
+        == 'p10_single_v1.3'
+    # If we use prefixes, that should work too
+    await sim.cache_instruments({types.Mount.RIGHT: 'p300_single'})
+    assert sim.attached_instruments[types.Mount.RIGHT]['name']\
+        == 'p300_single_v1'
+    # If we specify instruments at init time, we should get them without
+    # passing an expectation
+    sim = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments)
+    await sim.cache_instruments()
+    assert sim.attached_instruments == attached_instruments(dummy_instruments)
+    # If we specify conflicting expectations and init arguments we should
+    # get a RuntimeError
+    with pytest.raises(RuntimeError):
+        await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
 
 
 async def test_aspirate(dummy_instruments, loop):


### PR DESCRIPTION
Some key changes to instrument handling and homing in hardware_control

These became increasingly necessary as I was doing other things and should be split into their own PR.

## overview

There must be a way for callers to specify instruments they expect to be attached when they are simulating. This could previously only be done when initializing a simulator; now, this can be expressed in the call to `hardware_control.API.cache_instruments()` (which also saves a second step of verifying that the result of `cache_instruments()` fits requirements):

```python
>>> api = opentrons.hardware_control.API.build_hardware_simulator()
>>> api.cache_instruments({opentrons.types.Mount.LEFT: 'p10_single'}) # always results in loading a p10 single
>>> api.cache_instruments({opentrons.types.Mount.LEFT: 'p300_single'}) # raises because something is already there
```

Also, add the `retract` method required for retracting an instrument out of the way; change the `home` methods to be able to home individual axes; and start tracking positions in the simulator.
