### PR TITLE
refactor(protocol-designer): gate timeline generation with form and field validation

### DIFF
--- a/protocol-designer/src/components/SettingsPage/SettingsPage.css
+++ b/protocol-designer/src/components/SettingsPage/SettingsPage.css
@@ -1,5 +1,9 @@
 @import '@opentrons/components';
 
+:root {
+  --mw-labeled-toggle: 25rem;
+}
+
 .sidebar_item {
   background-color: white;
   margin: 0.4rem 0.125rem;

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -5,25 +5,31 @@ import WellSelectionModal from './WellSelectionModal'
 import {Portal} from '../../portals/MainPageModalPortal'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
 import styles from '../StepEditForm.css'
+import { FocusHandlers } from '../index'
 
 type Props = {
   name: StepFieldName,
   primaryWellCount?: number,
   disabled: boolean,
-  onClick?: (e: SyntheticMouseEvent<*>) => mixed,
   errorToShow: ?string,
   isMulti: ?boolean,
   pipetteId: ?string,
   labwareId: ?string,
-}
+} & FocusHandlers
 
 type State = {isModalOpen: boolean}
 
 class WellSelectionInput extends React.Component<Props, State> {
   state = {isModalOpen: false}
 
-  toggleModal = () => {
-    this.setState({isModalOpen: !this.state.isModalOpen})
+  handleOpen = () => {
+    this.props.onFieldFocus(this.props.name)
+    this.setState({isModalOpen: true})
+  }
+
+  handleClose= () => {
+    this.props.onFieldBlur(this.props.name)
+    this.setState({isModalOpen: false})
   }
 
   render () {
@@ -37,7 +43,7 @@ class WellSelectionInput extends React.Component<Props, State> {
           readOnly
           name={this.props.name}
           value={this.props.primaryWellCount ? String(this.props.primaryWellCount) : null}
-          onClick={this.toggleModal}
+          onClick={this.handleOpen}
           error={this.props.errorToShow} />
         <Portal>
           <WellSelectionModal
@@ -45,7 +51,7 @@ class WellSelectionInput extends React.Component<Props, State> {
             pipetteId={this.props.pipetteId}
             labwareId={this.props.labwareId}
             isOpen={this.state.isModalOpen}
-            onCloseClick={this.toggleModal}
+            onCloseClick={this.handleClose}
             name={this.props.name} />
         </Portal>
       </FormGroup>

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -5,7 +5,7 @@ import WellSelectionModal from './WellSelectionModal'
 import {Portal} from '../../portals/MainPageModalPortal'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
 import styles from '../StepEditForm.css'
-import { FocusHandlers } from '../index'
+import type { FocusHandlers } from '../index'
 
 type Props = {
   name: StepFieldName,
@@ -15,7 +15,9 @@ type Props = {
   isMulti: ?boolean,
   pipetteId: ?string,
   labwareId: ?string,
-} & FocusHandlers
+  onFieldBlur: $PropertyType<FocusHandlers, 'onFieldBlur'>,
+  onFieldFocus: $PropertyType<FocusHandlers, 'onFieldFocus'>,
+}
 
 type State = {isModalOpen: boolean}
 

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
@@ -5,7 +5,6 @@ import {connect} from 'react-redux'
 import {selectors as pipetteSelectors} from '../../../pipettes'
 import {selectors as steplistSelectors} from '../../../steplist'
 import {getFieldErrors, type StepFieldName} from '../../../steplist/fieldLevel'
-import {openWellSelectionModal} from '../../../well-selection/actions'
 import type {BaseState, ThunkDispatch} from '../../../types'
 import {showFieldErrors} from '../StepFormField'
 import type {FocusHandlers} from '../index'
@@ -47,26 +46,10 @@ function mergeProps (
   dispatchProps: {dispatch: ThunkDispatch<*>},
   ownProps: OP
 ): Props {
-  // const {dispatch} = dispatchProps
   const {_pipetteId, _selectedLabwareId, _wellFieldErrors} = stateProps
   const disabled = !(_pipetteId && _selectedLabwareId)
   const {name, focusedField, dirtyFields, onFieldBlur, onFieldFocus} = ownProps
   const showErrors = showFieldErrors({name, focusedField, dirtyFields})
-
-  // const onClick = () => {
-  //   if (onFieldBlur) {
-  //     onFieldBlur(name)
-  //   }
-  //   if (_pipetteId && _selectedLabwareId) {
-  //     dispatch(
-  //       openWellSelectionModal({
-  //         pipetteId: _pipetteId,
-  //         labwareId: _selectedLabwareId,
-  //         formFieldAccessor: ownProps.name,
-  //       })
-  //     )
-  //   }
-  // }
 
   return {
     name,

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
@@ -15,7 +15,11 @@ type OP = {
   name: StepFieldName,
   pipetteFieldName: StepFieldName,
   labwareFieldName: StepFieldName,
-} & FocusHandlers
+  onFieldBlur: $PropertyType<FocusHandlers, 'onFieldBlur'>,
+  onFieldFocus: $PropertyType<FocusHandlers, 'onFieldFocus'>,
+  focusedField: $PropertyType<FocusHandlers, 'focusedField'>,
+  dirtyFields: $PropertyType<FocusHandlers, 'dirtyFields'>,
+}
 
 type SP = {
   isMulti: $PropertyType<Props, 'isMulti'>,

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
@@ -47,26 +47,26 @@ function mergeProps (
   dispatchProps: {dispatch: ThunkDispatch<*>},
   ownProps: OP
 ): Props {
-  const {dispatch} = dispatchProps
+  // const {dispatch} = dispatchProps
   const {_pipetteId, _selectedLabwareId, _wellFieldErrors} = stateProps
   const disabled = !(_pipetteId && _selectedLabwareId)
-  const {name, focusedField, dirtyFields} = ownProps
+  const {name, focusedField, dirtyFields, onFieldBlur, onFieldFocus} = ownProps
   const showErrors = showFieldErrors({name, focusedField, dirtyFields})
 
-  const onClick = () => {
-    if (ownProps.onFieldBlur) {
-      ownProps.onFieldBlur(ownProps.name)
-    }
-    if (_pipetteId && _selectedLabwareId) {
-      dispatch(
-        openWellSelectionModal({
-          pipetteId: _pipetteId,
-          labwareId: _selectedLabwareId,
-          formFieldAccessor: ownProps.name,
-        })
-      )
-    }
-  }
+  // const onClick = () => {
+  //   if (onFieldBlur) {
+  //     onFieldBlur(name)
+  //   }
+  //   if (_pipetteId && _selectedLabwareId) {
+  //     dispatch(
+  //       openWellSelectionModal({
+  //         pipetteId: _pipetteId,
+  //         labwareId: _selectedLabwareId,
+  //         formFieldAccessor: ownProps.name,
+  //       })
+  //     )
+  //   }
+  // }
 
   return {
     name,
@@ -76,7 +76,8 @@ function mergeProps (
     isMulti: stateProps.isMulti,
     primaryWellCount: stateProps.primaryWellCount,
     errorToShow: showErrors ? _wellFieldErrors[0] : null,
-    onClick,
+    onFieldBlur,
+    onFieldFocus,
   }
 }
 

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -191,7 +191,7 @@ export const LabwareDropdown = connect(LabwareDropdownSTP)((props: LabwareDropdo
       name={name}
       focusedField={focusedField}
       dirtyFields={dirtyFields}
-      render={({value, updateValue}) => {
+      render={({value, updateValue, errorToShow}) => {
         // blank out the dropdown if labware id does not exist
         const availableLabwareIds = labwareOptions.map(opt => opt.value)
         const fieldValue = availableLabwareIds.includes(value)
@@ -199,6 +199,7 @@ export const LabwareDropdown = connect(LabwareDropdownSTP)((props: LabwareDropdo
           : null
         return (
           <DropdownField
+            error={errorToShow}
             className={className}
             options={labwareOptions}
             onBlur={() => { onFieldBlur(name) }}

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -41,7 +41,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = steplistSelectors.getHoveredStepId(state)
   const selected = steplistSelectors.getSelectedStepId(state) === stepId
   const collapsed = steplistSelectors.getCollapsedSteps(state)[stepId]
-  const formAndFieldErrors = steplistSelectors.allStepsFormAndFieldErrors(state)[stepId]
+  const formAndFieldErrors = steplistSelectors.getFormAndFieldErrorsByStepId(state)[stepId]
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
   const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
     ? dismissSelectors.getTimelineWarningsPerStep(state)[stepId]

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
+import isEmpty from 'lodash/isEmpty'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import type {SubstepIdentifier} from '../steplist/types'
@@ -40,8 +41,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = steplistSelectors.getHoveredStepId(state)
   const selected = steplistSelectors.getSelectedStepId(state) === stepId
   const collapsed = steplistSelectors.getCollapsedSteps(state)[stepId]
-
-  const hasError = fileDataSelectors.getErrorStepId(state) === stepId
+  const formAndFieldErrors = steplistSelectors.allStepsFormAndFieldErrors(state)[stepId]
+  const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
   const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
     ? dismissSelectors.getTimelineWarningsPerStep(state)[stepId]
     : []

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -133,7 +133,7 @@ function compoundCommandCreatorFromStepArgs (stepArgs: StepGeneration.CommandCre
 
 // exposes errors and last valid robotState
 export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelector(
-  steplistSelectors.getAllStepArgsAndErrors,
+  steplistSelectors.getArgsAndErrorsByStepId,
   steplistSelectors.orderedSteps,
   getInitialRobotState,
   (allStepArgsAndErrors, orderedSteps, initialRobotState) => {

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -31,7 +31,7 @@ import type {
 } from '../types'
 import * as actions from '../actions'
 import {getPDMetadata} from '../../file-types'
-import type {BaseState, Selector, Options} from '../../types'
+import type {BaseState, Options} from '../../types'
 import type {LoadFileAction} from '../../load-file'
 import type {
   RemoveWellsContents,
@@ -294,8 +294,10 @@ const rootReducer = combineReducers({
   renameLabwareFormMode,
 })
 
+type RootSlice = {labwareIngred: RootState}
+type Selector<T> = (RootSlice) => T
 // SELECTORS
-const rootSelector = (state: BaseState): RootState => state.labwareIngred
+const rootSelector = (state: RootSlice): RootState => state.labwareIngred
 
 const getLabware: Selector<{[labwareId: string]: ?Labware}> = createSelector(
   rootSelector,
@@ -318,8 +320,8 @@ const getLabwareTypes: Selector<LabwareTypeById> = createSelector(
   )
 )
 
-const getLiquidGroupsById = (state: BaseState) => rootSelector(state).ingredients
-const getIngredientLocations = (state: BaseState) => rootSelector(state).ingredLocations
+const getLiquidGroupsById = (state: RootSlice) => rootSelector(state).ingredients
+const getIngredientLocations = (state: RootSlice) => rootSelector(state).ingredLocations
 
 const getNextLiquidGroupId: Selector<string> = createSelector(
   getLiquidGroupsById,

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -4,15 +4,18 @@ import reduce from 'lodash/reduce'
 import get from 'lodash/get'
 import {getPipetteModels, getPipette, getLabware} from '@opentrons/shared-data'
 
-import type {BaseState, Selector} from '../types'
 import type {DropdownOption} from '@opentrons/components'
 import type {PipetteData} from '../step-generation'
+import type {RootState} from './reducers'
 
 type PipettesById = {[pipetteId: string]: PipetteData}
+type RootSlice = {pipettes: RootState}
 
-export const rootSelector = (state: BaseState) => state.pipettes
+type Selector<T> = (RootSlice) => T
 
-export const pipettesById = createSelector(
+export const rootSelector = (state: {pipettes: RootState}) => state.pipettes
+
+export const pipettesById: Selector<PipettesById> = createSelector(
   rootSelector,
   pipettes => pipettes.byId
 )

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -10,7 +10,7 @@ import type {PipetteData} from '../step-generation'
 
 type PipettesById = {[pipetteId: string]: PipetteData}
 
-const rootSelector = (state: BaseState) => state.pipettes.pipettes
+export const rootSelector = (state: BaseState) => state.pipettes
 
 export const pipettesById = createSelector(
   rootSelector,
@@ -54,7 +54,7 @@ export const equippedPipetteOptions: Selector<Array<DropdownOption>> = createSel
           },
         ]
         : acc,
-      [])
+    [])
   }
 )
 

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -7,11 +7,15 @@ import isArray from 'lodash/isArray'
 
 // TODO: reconcile difference between returning error string and key
 
-export type FieldError = 'REQUIRED' | 'UNDER_WELL_MINIMUM' // TODO: add other possible field errors
+export type FieldError =
+  | 'REQUIRED'
+  | 'UNDER_WELL_MINIMUM'
+  | 'NON_ZERO'
 
 const FIELD_ERRORS: {[FieldError]: string} = {
   REQUIRED: 'This field is required',
   UNDER_WELL_MINIMUM: 'or more wells are required',
+  NON_ZERO: 'Must be greater than zero',
 }
 
 // TODO: test these
@@ -21,6 +25,7 @@ const FIELD_ERRORS: {[FieldError]: string} = {
 type errorChecker = (value: mixed) => ?string
 
 export const requiredField = (value: mixed): ?string => !value ? FIELD_ERRORS.REQUIRED : null
+export const nonZero = (value: mixed) => (value && Number(value) === 0) ? FIELD_ERRORS.NON_ZERO : null
 export const minimumWellCount = (minimum: number): errorChecker => (wells: mixed): ?string => (
   (isArray(wells) && (wells.length < minimum)) ? `${minimum} ${FIELD_ERRORS.UNDER_WELL_MINIMUM}` : null
 )

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -1,4 +1,5 @@
 // @flow
+import assert from 'assert'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import {selectors as pipetteSelectors} from '../../pipettes'
 import {
@@ -16,20 +17,29 @@ import {
   type ValueProcessor,
 } from './processing'
 import type {StepFieldName} from './types'
+import type {StepFormContextualState} from '../types'
 import type {BaseState} from '../../types'
 
 export type {
   StepFieldName,
 }
+type HydrationState = BaseState | StepFormContextualState
 
-// TODO: BC 2018-10-26 type these with StepFormContextualState
-const hydrateLabware = (state, id) => labwareIngredSelectors.getLabware(state)[id]
-const hydratePipette = (state, id) => pipetteSelectors.pipettesById(state)[id]
+const hydrateLabware = (state: HydrationState, id: string) => {
+  assert(state.labwareIngred.containers != null, 'labwareIngred.containers was not found in the state slice passed to the labware hydrator')
+  // $FlowFixMe flow doesn't like these receiving BaseState or StepFormContextualState
+  return labwareIngredSelectors.getLabware(state)[id]
+}
+const hydratePipette = (state: HydrationState, id: string) => {
+  assert(state.pipettes.byId != null, 'pipettes.byId was not found in the state slice passed to the pipette hydrator')
+  // $FlowFixMe flow doesn't like these receiving BaseState or StepFormContextualState
+  return pipetteSelectors.pipettesById(state)[id]
+}
 
 type StepFieldHelpers = {
   getErrors?: (mixed) => Array<string>,
   processValue?: ValueProcessor,
-  hydrate?: (state: BaseState, id: string) => mixed,
+  hydrate?: (state: HydrationState, id: string) => mixed,
 }
 const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   'aspirate_airGap_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
@@ -98,7 +108,7 @@ export const processField = (name: StepFieldName, value: mixed): ?mixed => {
   return fieldProcessor ? fieldProcessor(value) : value
 }
 
-export const hydrateField = (state: BaseState, name: StepFieldName, value: string): ?mixed => {
+export const hydrateField = (state: HydrationState, name: StepFieldName, value: string): ?mixed => {
   const hydrator = stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
   return hydrator ? hydrator(state, value) : value
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -4,6 +4,7 @@ import {selectors as pipetteSelectors} from '../../pipettes'
 import {
   requiredField,
   minimumWellCount,
+  nonZero,
   composeErrors,
 } from './errors'
 import {
@@ -41,6 +42,10 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     hydrate: hydrateLabware,
   },
   'aspirate_mix_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
+  'aspirate_wells': {
+    getErrors: composeErrors(minimumWellCount(1)),
+    processValue: defaultTo([]),
+  },
   'dispense_delayMinutes': {
     processValue: composeProcessors(castToNumber, defaultTo(0)),
   },
@@ -81,7 +86,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     processValue: composeProcessors(castToNumber, onlyPositiveNumbers, onlyIntegers, defaultTo(0)),
   },
   'volume': {
-    getErrors: composeErrors(requiredField),
+    getErrors: composeErrors(requiredField, nonZero),
     processValue: composeProcessors(castToFloat, onlyPositiveNumbers, defaultTo(0)),
   },
   'wells': {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -43,7 +43,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   },
   'aspirate_mix_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
   'aspirate_wells': {
-    getErrors: composeErrors(minimumWellCount(1)),
+    getErrors: composeErrors(requiredField, minimumWellCount(1)),
     processValue: defaultTo([]),
   },
   'dispense_delayMinutes': {
@@ -58,7 +58,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   },
   'dispense_mix_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
   'dispense_wells': {
-    getErrors: composeErrors(minimumWellCount(1)),
+    getErrors: composeErrors(requiredField, minimumWellCount(1)),
     processValue: defaultTo([]),
   },
   'aspirate_disposalVol_volume': {
@@ -90,7 +90,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     processValue: composeProcessors(castToFloat, onlyPositiveNumbers, defaultTo(0)),
   },
   'wells': {
-    getErrors: composeErrors(minimumWellCount(1)),
+    getErrors: composeErrors(requiredField, minimumWellCount(1)),
     processValue: defaultTo([]),
   },
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -1,5 +1,4 @@
 // @flow
-import assert from 'assert'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import {selectors as pipetteSelectors} from '../../pipettes'
 import {
@@ -18,28 +17,22 @@ import {
 } from './processing'
 import type {StepFieldName} from './types'
 import type {StepFormContextualState} from '../types'
-import type {BaseState} from '../../types'
 
 export type {
   StepFieldName,
 }
-type HydrationState = BaseState | StepFormContextualState
 
-const hydrateLabware = (state: HydrationState, id: string) => {
-  assert(state.labwareIngred.containers != null, 'labwareIngred.containers was not found in the state slice passed to the labware hydrator')
-  // $FlowFixMe flow doesn't like these receiving BaseState or StepFormContextualState
-  return labwareIngredSelectors.getLabware(state)[id]
-}
-const hydratePipette = (state: HydrationState, id: string) => {
-  assert(state.pipettes.byId != null, 'pipettes.byId was not found in the state slice passed to the pipette hydrator')
-  // $FlowFixMe flow doesn't like these receiving BaseState or StepFormContextualState
-  return pipetteSelectors.pipettesById(state)[id]
-}
+const hydrateLabware = (state: StepFormContextualState, id: string) => (
+  labwareIngredSelectors.getLabware(state)[id]
+)
+const hydratePipette = (state: StepFormContextualState, id: string) => (
+  pipetteSelectors.pipettesById(state)[id]
+)
 
 type StepFieldHelpers = {
   getErrors?: (mixed) => Array<string>,
   processValue?: ValueProcessor,
-  hydrate?: (state: HydrationState, id: string) => mixed,
+  hydrate?: (state: StepFormContextualState, id: string) => mixed,
 }
 const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   'aspirate_airGap_volume': { processValue: composeProcessors(castToFloat, onlyPositiveNumbers) },
@@ -108,7 +101,7 @@ export const processField = (name: StepFieldName, value: mixed): ?mixed => {
   return fieldProcessor ? fieldProcessor(value) : value
 }
 
-export const hydrateField = (state: HydrationState, name: StepFieldName, value: string): ?mixed => {
+export const hydrateField = (state: StepFormContextualState, name: StepFieldName, value: string): ?mixed => {
   const hydrator = stepFieldHelperMap[name] && stepFieldHelperMap[name].hydrate
   return hydrator ? hydrator(state, value) : value
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -22,7 +22,9 @@ export type {
   StepFieldName,
 }
 
-const hydrateLabware = (state, id) => (labwareIngredSelectors.getLabware(state)[id])
+// TODO: BC 2018-10-26 type these with StepFormContextualState
+const hydrateLabware = (state, id) => labwareIngredSelectors.getLabware(state)[id]
+const hydratePipette = (state, id) => pipetteSelectors.pipettesById(state)[id]
 
 type StepFieldHelpers = {
   getErrors?: (mixed) => Array<string>,
@@ -69,7 +71,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   },
   'pipette': {
     getErrors: composeErrors(requiredField),
-    hydrate: (state, id) => pipetteSelectors.pipettesById(state)[id],
+    hydrate: hydratePipette,
   },
   'times': {
     getErrors: composeErrors(requiredField),

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -41,7 +41,7 @@ const FORM_ERRORS: {[FormErrorKey]: FormError} = {
   },
   TIME_PARAM_REQUIRED: {
     title: 'Must include hours, minutes, or seconds',
-    dependentFields: ['pauseFormAmountOfTime'],
+    dependentFields: ['pauseForAmountOfTime'],
   },
   WELL_RATIO_TRANSFER: {
     title: 'In transfer actions the number of source and destination wells must match',

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -6,12 +6,15 @@ import type {StepFieldName} from '../fieldLevel'
 /*******************
 ** Error Messages **
 ********************/
-export type FormErrorKey = 'INCOMPATIBLE_ASPIRATE_LABWARE'
+export type FormErrorKey =
+  | 'INCOMPATIBLE_ASPIRATE_LABWARE'
   | 'INCOMPATIBLE_DISPENSE_LABWARE'
   | 'INCOMPATIBLE_LABWARE'
   | 'WELL_RATIO_TRANSFER'
   | 'WELL_RATIO_CONSOLIDATE'
   | 'WELL_RATIO_DISTRIBUTE'
+  | 'PAUSE_TYPE_REQUIRED'
+  | 'TIME_PARAM_REQUIRED'
 
 export type FormError = {
   title: string,
@@ -31,6 +34,14 @@ const FORM_ERRORS: {[FormErrorKey]: FormError} = {
   INCOMPATIBLE_LABWARE: {
     title: 'Selected labware may be incompatible with selected pipette',
     dependentFields: ['labware', 'pipette'],
+  },
+  PAUSE_TYPE_REQUIRED: {
+    title: 'Must either pause for amount of time, or until told to resume',
+    dependentFields: ['pauseForAmountOfTime'],
+  },
+  TIME_PARAM_REQUIRED: {
+    title: 'Must include hours, minutes, or seconds',
+    dependentFields: ['pauseFormAmountOfTime'],
   },
   WELL_RATIO_TRANSFER: {
     title: 'In transfer actions the number of source and destination wells must match',
@@ -72,6 +83,24 @@ export const incompatibleAspirateLabware = (fields: HydratedFormData): ?FormErro
   const {aspirate_labware, pipette} = fields
   if (!aspirate_labware || !pipette) return null
   return (!canPipetteUseLabware(pipette.model, aspirate_labware.type)) ? FORM_ERRORS.INCOMPATIBLE_ASPIRATE_LABWARE : null
+}
+
+export const pauseForTimeOrUntilTold = (fields: HydratedFormData): ?FormError => {
+  const {pauseForAmountOfTime, pauseHour, pauseMinute, pauseSecond} = fields
+  if (pauseForAmountOfTime === 'true') {
+    // user selected pause for amount of time
+    const hours = parseFloat(pauseHour) || 0
+    const minutes = parseFloat(pauseMinute) || 0
+    const seconds = parseFloat(pauseSecond) || 0
+    const totalSeconds = hours * 3600 + minutes * 60 + seconds
+    return totalSeconds <= 0 ? FORM_ERRORS.TIME_PARAM_REQUIRED : null
+  } else if (pauseForAmountOfTime === 'false') {
+    // user selected pause until resume
+    return null
+  } else {
+    // user selected neither pause until resume nor pause for amount of time
+    return FORM_ERRORS.PAUSE_TYPE_REQUIRED
+  }
 }
 
 export const wellRatioTransfer = (fields: HydratedFormData): ?FormError => {

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -18,10 +18,12 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        'aspirate_wells': [],
         'dispense_labware': null,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'dispense_wells': [],
         'volume': undefined,
       }
     case 'consolidate':
@@ -31,8 +33,10 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
+        'aspirate_wells': [],
         'dispense_labware': null,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'dispense_wells': [],
         'volume': undefined,
       }
     case 'mix':
@@ -41,6 +45,7 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'labware': null,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
+        'wells': [],
         'mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE, // NOTE: mix uses dispense for both asp + disp, for now
         'volume': undefined,
       }
@@ -51,10 +56,12 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'aspirate_disposalVol_destination': FIXED_TRASH_ID,
         'aspirate_labware': null,
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        'aspirate_wells': [],
         'dispense_labware': null,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'dispense_wells': [],
         'volume': undefined,
       }
     default:

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -14,37 +14,48 @@ export default function getDefaultsForStepType (stepType: StepType) {
     case 'transfer':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
+        'aspirate_labware': null,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        'dispense_labware': null,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'volume': undefined,
       }
     case 'consolidate':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
+        'aspirate_labware': null,
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
+        'dispense_labware': null,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'volume': undefined,
       }
     case 'mix':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
+        'labware': null,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE, // NOTE: mix uses dispense for both asp + disp, for now
+        'volume': undefined,
       }
     case 'distribute':
       return {
         'aspirate_changeTip': DEFAULT_CHANGE_TIP_OPTION,
         'aspirate_disposalVol_checkbox': true,
         'aspirate_disposalVol_destination': FIXED_TRASH_ID,
+        'aspirate_labware': null,
         'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        'dispense_labware': null,
         'dispense_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        'volume': undefined,
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -4,6 +4,7 @@ import {
   incompatibleAspirateLabware,
   incompatibleDispenseLabware,
   incompatibleLabware,
+  pauseForTimeOrUntilTold,
   wellRatioTransfer,
   wellRatioConsolidate,
   wellRatioDistribute,
@@ -26,7 +27,7 @@ export {default as stepFormToArgs} from './stepFormToArgs'
 type FormHelpers = {getErrors?: (mixed) => Array<FormError>, getWarnings?: (mixed) => Array<FormWarning>}
 const stepFormHelperMap: {[StepType]: FormHelpers} = {
   mix: {getErrors: composeErrors(incompatibleLabware)},
-  pause: {getErrors: composeErrors(incompatibleLabware)},
+  pause: {getErrors: composeErrors(pauseForTimeOrUntilTold)},
   transfer: {
     getErrors: composeErrors(incompatibleAspirateLabware, incompatibleDispenseLabware, wellRatioTransfer),
     getWarnings: composeWarnings(maxDispenseWellVolume),

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -1,21 +1,24 @@
 // @flow
 
 import type { FormData } from '../../../form-types'
-import type { CommandCreatorData } from '../../../step-generation'
+import type {
+  ConsolidateFormData,
+  DistributeFormData,
+  TransferFormData,
+  MixFormData,
+  PauseFormData,
+} from '../../../step-generation'
 import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import transferLikeFormToArgs from './transferLikeFormToArgs'
-
-export type ValidFormAndErrors = {
-  errors: {[string]: string},
-  validatedForm: CommandCreatorData | null, // TODO: incompleteData field when this is null?
-}
 
 // NOTE: this acts as an adapter for the PD defined data shape of the step forms
 // to create arguments that the step generation service is expecting
 // in order to generate command creators
 
-const stepFormToArgs = (formData: FormData): StepArgs => { // really returns ValidFormAndErrors
+type StepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | MixFormData | PauseFormData | null
+
+const stepFormToArgs = (formData: FormData): StepArgs => {
   switch (formData.stepType) {
     case 'transfer':
     case 'consolidate':
@@ -26,10 +29,7 @@ const stepFormToArgs = (formData: FormData): StepArgs => { // really returns Val
     case 'mix':
       return mixFormToArgs(formData)
     default:
-      return {
-        errors: {_form: `Unsupported step type: ${formData.stepType}`},
-        validatedForm: null,
-      }
+      return null
   }
 }
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -1,13 +1,7 @@
 // @flow
 
-import type { FormData } from '../../../form-types'
-import type {
-  ConsolidateFormData,
-  DistributeFormData,
-  TransferFormData,
-  MixFormData,
-  PauseFormData,
-} from '../../../step-generation'
+import type {FormData} from '../../../form-types'
+import type {CommandCreatorData} from '../../../step-generation'
 import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import transferLikeFormToArgs from './transferLikeFormToArgs'
@@ -16,7 +10,7 @@ import transferLikeFormToArgs from './transferLikeFormToArgs'
 // to create arguments that the step generation service is expecting
 // in order to generate command creators
 
-type StepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | MixFormData | PauseFormData | null
+type StepArgs = CommandCreatorData | null
 
 const stepFormToArgs = (formData: FormData): StepArgs => {
   switch (formData.stepType) {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -5,7 +5,6 @@ import type { CommandCreatorData } from '../../../step-generation'
 import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import transferLikeFormToArgs from './transferLikeFormToArgs'
-import type { StepFormContext } from './types'
 
 export type ValidFormAndErrors = {
   errors: {[string]: string},
@@ -16,16 +15,16 @@ export type ValidFormAndErrors = {
 // to create arguments that the step generation service is expecting
 // in order to generate command creators
 
-const stepFormToArgs = (formData: FormData, context?: StepFormContext = {}): * => { // really returns ValidFormAndErrors
+const stepFormToArgs = (formData: FormData): StepArgs => { // really returns ValidFormAndErrors
   switch (formData.stepType) {
     case 'transfer':
     case 'consolidate':
     case 'distribute':
-      return transferLikeFormToArgs(formData, context)
+      return transferLikeFormToArgs(formData)
     case 'pause':
       return pauseFormToArgs(formData)
     case 'mix':
-      return mixFormToArgs(formData, context)
+      return mixFormToArgs(formData)
     default:
       return {
         errors: {_form: `Unsupported step type: ${formData.stepType}`},

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -9,6 +9,7 @@ import { orderWells } from '../../utils'
 
 type MixStepArgs = MixFormData
 
+// TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const {labware, pipette} = hydratedFormData
   const touchTip = !!hydratedFormData['touchTip']

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -9,13 +9,13 @@ import { orderWells } from '../../utils'
 
 type MixStepArgs = MixFormData
 
-const mixFormToArgs = (formData: FormData): MixStepArgs => {
-  const {labware, pipette} = formData
-  const touchTip = !!formData['touchTip']
+const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
+  const {labware, pipette} = hydratedFormData
+  const touchTip = !!hydratedFormData['touchTip']
 
-  let wells = formData.wells || []
-  const orderFirst = formData.aspirate_wellOrder_first
-  const orderSecond = formData.aspirate_wellOrder_second
+  let wells = hydratedFormData.wells || []
+  const orderFirst = hydratedFormData.aspirate_wellOrder_first
+  const orderSecond = hydratedFormData.aspirate_wellOrder_second
 
   const labwareDef = labware && getLabware(labware.type)
   if (labwareDef) {
@@ -25,27 +25,27 @@ const mixFormToArgs = (formData: FormData): MixStepArgs => {
     console.warn('the specified labware definition could not be located')
   }
 
-  const volume = Number(formData.volume) || 0
-  const times = Number(formData.times) || 0
+  const volume = Number(hydratedFormData.volume) || 0
+  const times = Number(hydratedFormData.times) || 0
   // NOTE: for mix, there is only one tip offset field,
   // and it applies to both aspirate and dispense
-  const aspirateOffsetFromBottomMm = Number(formData['mmFromBottom'])
-  const dispenseOffsetFromBottomMm = Number(formData['mmFromBottom'])
+  const aspirateOffsetFromBottomMm = Number(hydratedFormData['mmFromBottom'])
+  const dispenseOffsetFromBottomMm = Number(hydratedFormData['mmFromBottom'])
 
   // It's radiobutton, so one should always be selected.
-  const changeTip = formData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
+  const changeTip = hydratedFormData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
 
-  const blowout = formData['dispense_blowout_labware']
+  const blowout = hydratedFormData['dispense_blowout_labware']
 
-  const delay = formData['dispense_delay_checkbox']
-    ? ((Number(formData['dispense_delayMinutes']) || 0) * 60) +
-      (Number(formData['dispense_delaySeconds'] || 0))
+  const delay = hydratedFormData['dispense_delay_checkbox']
+    ? ((Number(hydratedFormData['dispense_delayMinutes']) || 0) * 60) +
+      (Number(hydratedFormData['dispense_delaySeconds'] || 0))
     : null
   // TODO Ian 2018-05-08 delay number parsing errors
 
   return {
     stepType: 'mix',
-    name: `Mix ${formData.id}`, // TODO real name for steps
+    name: `Mix ${hydratedFormData.id}`, // TODO real name for steps
     description: 'description would be here 2018-03-01', // TODO get from form
     labware,
     wells,
@@ -55,7 +55,7 @@ const mixFormToArgs = (formData: FormData): MixStepArgs => {
     delay,
     changeTip,
     blowout,
-    pipette,
+    pipette: pipette.id,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
   }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -47,7 +47,7 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
     stepType: 'mix',
     name: `Mix ${hydratedFormData.id}`, // TODO real name for steps
     description: 'description would be here 2018-03-01', // TODO get from form
-    labware,
+    labware: labware.id,
     wells,
     volume,
     times,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -3,12 +3,9 @@
 import type { FormData } from '../../../form-types'
 import type { PauseFormData } from '../../../step-generation'
 
-type ValidationAndErrors<F> = {
-  errors: {[string]: string},
-  validatedForm: F | null,
-}
+type PauseStepArgs = PauseFormData
 
-const pauseFormToArgs = (formData: FormData): ValidationAndErrors<PauseFormData> => {
+const pauseFormToArgs = (formData: FormData): PauseStepArgs => {
   const hours = parseFloat(formData['pauseHour']) || 0
   const minutes = parseFloat(formData['pauseMinute']) || 0
   const seconds = parseFloat(formData['pauseSecond']) || 0
@@ -16,34 +13,17 @@ const pauseFormToArgs = (formData: FormData): ValidationAndErrors<PauseFormData>
 
   const message = formData['pauseMessage'] || ''
 
-  // TODO: BC 2018-08-21 remove this old validation logic once no longer preventing save
-  let errors = {}
-  if (!formData['pauseForAmountOfTime']) {
-    errors = {...errors, 'pauseForAmountOfTime': 'Pause for amount of time vs pause until user input is required'}
-  }
-  if (formData['pauseForAmountOfTime'] === 'true' && (totalSeconds <= 0)) {
-    errors = {...errors, '_pause-times': 'Must include hours, minutes, or seconds'}
-  }
-  const hasErrors = Object.values(errors).length > 0
-
   return {
-    errors,
-    validatedForm: hasErrors
-      ? null
-      : {
-        stepType: 'pause',
-        name: `Pause ${formData.id}`, // TODO real name for steps
-        description: 'description would be here 2018-03-01', // TODO get from form
-        wait: (formData['pauseForAmountOfTime'] === 'false')
-          ? true
-          : totalSeconds,
-        message,
-        meta: {
-          hours,
-          minutes,
-          seconds,
-        },
-      },
+    stepType: 'pause',
+    name: `Pause ${formData.id}`, // TODO real name for steps
+    description: 'description would be here 2018-03-01', // TODO get from form
+    wait: (formData['pauseForAmountOfTime'] === 'false') ? true : totalSeconds,
+    message,
+    meta: {
+      hours,
+      minutes,
+      seconds,
+    },
   }
 }
 

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -23,7 +23,7 @@ function getMixData (formData, checkboxField, volumeField, timesField) {
     : null
 }
 
-type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData
+type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
 
 const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
   const stepType = formData.stepType
@@ -130,33 +130,6 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
       disposalWell = 'A1'
     }
   }
-
-  // TODO: BC 2018-08-21 remove this old validation logic once no longer preventing save
-  // const requiredFieldErrors = [
-  //   'pipette',
-  //   'aspirate_labware',
-  //   'dispense_labware',
-  // ].reduce((acc, fieldName) => (!formData[fieldName])
-  //   ? {...acc, [fieldName]: 'This field is required'}
-  //   : acc,
-  // {})
-  // let errors = {...requiredFieldErrors}
-  // if (isNaN(volume) || !(volume > 0)) {
-  //   // $FlowFixMe: Cannot assign `'Volume mus...'` to `errors['volume']` because property `volume` is missing in object literal
-  //   errors = {...errors, 'volume': 'Volume must be a positive number'}
-  // }
-  // if (stepType === 'transfer' && (sourceWells.length !== destWells.length || sourceWells.length === 0)) {
-  //   // $FlowFixMe: Cannot assign `'Numbers of...'` to `errors._mismatchedWells` because property `_mismatchedWells` is missing in object literal
-  //   errors = {...errors, '_mismatchedWells': 'Numbers of wells must match'}
-  // }
-  // if (stepType === 'consolidate' && (sourceWells.length <= 1 || destWells.length !== 1)) {
-  //   // $FlowFixMe: Cannot assign `'Multiple s...'` to `errors._mismatchedWells` because property `_mismatchedWells` is missing in object literal
-  //   errors = {...errors, '_mismatchedWells': 'Multiple source wells and exactly one destination well is required.'}
-  // }
-  // if (stepType === 'distribute' && (sourceWells.length !== 1 || destWells.length <= 1)) {
-  //   // $FlowFixMe: Cannot assign `'Single sou...'` to `errors._mismatchedWells` because property `_mismatchedWells` is missing in object literal
-  //   errors = {...errors, '_mismatchedWells': 'Single source well and multiple destination wells is required.'}
-  // }
 
   switch (stepType) {
     case 'transfer': {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -14,7 +14,6 @@ import { orderWells } from '../../utils'
 export const SOURCE_WELL_DISPOSAL_DESTINATION = 'source_well'
 
 function getMixData (hydratedFormData, checkboxField, volumeField, timesField) {
-  // TODO Ian 2018-04-03 is error reporting necessary? Or are only valid inputs allowed in these fields?
   const checkbox = hydratedFormData[checkboxField]
   const volume = parseFloat(hydratedFormData[volumeField])
   const times = parseInt(hydratedFormData[timesField])
@@ -25,6 +24,7 @@ function getMixData (hydratedFormData, checkboxField, volumeField, timesField) {
 
 type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
 
+// TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArgs => {
   const stepType = hydratedFormData.stepType
   const pipette = hydratedFormData['pipette']
@@ -44,7 +44,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
   const mixFirstAspirate = hydratedFormData['aspirate_mix_checkbox']
     ? {
       volume: Number(hydratedFormData['aspirate_mix_volume']),
-      times: parseInt(hydratedFormData['aspirate_mix_times']), // TODO handle unparseable
+      times: parseInt(hydratedFormData['aspirate_mix_times']),
     }
     : null
 
@@ -118,7 +118,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
   let disposalDestination = null
   let disposalLabware = null
   let disposalWell = null
-  if (hydratedFormData['aspirate_disposalVol_checkbox']) { // TODO: BC 09-17-2018 handle unparseable values?
+  if (hydratedFormData['aspirate_disposalVol_checkbox']) {
     disposalVolume = Number(hydratedFormData['aspirate_disposalVol_volume'])
     disposalDestination = hydratedFormData['aspirate_disposalVol_destination']
     if (disposalDestination === SOURCE_WELL_DISPOSAL_DESTINATION) {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -13,11 +13,11 @@ import { orderWells } from '../../utils'
 
 export const SOURCE_WELL_DISPOSAL_DESTINATION = 'source_well'
 
-function getMixData (formData, checkboxField, volumeField, timesField) {
+function getMixData (hydratedFormData, checkboxField, volumeField, timesField) {
   // TODO Ian 2018-04-03 is error reporting necessary? Or are only valid inputs allowed in these fields?
-  const checkbox = formData[checkboxField]
-  const volume = parseFloat(formData[volumeField])
-  const times = parseInt(formData[timesField])
+  const checkbox = hydratedFormData[checkboxField]
+  const volume = parseFloat(hydratedFormData[volumeField])
+  const times = parseInt(hydratedFormData[timesField])
   return (checkbox && volume > 0 && times > 0)
     ? {volume, times}
     : null
@@ -25,44 +25,44 @@ function getMixData (formData, checkboxField, volumeField, timesField) {
 
 type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
 
-const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
-  const stepType = formData.stepType
-  const pipette = formData['pipette']
-  const volume = Number(formData['volume'])
-  const sourceLabware = formData['aspirate_labware']
-  const destLabware = formData['dispense_labware']
-  const blowout = formData['dispense_blowout_checkbox'] ? formData['dispense_blowout_labware'] : null
+const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArgs => {
+  const stepType = hydratedFormData.stepType
+  const pipette = hydratedFormData['pipette']
+  const volume = Number(hydratedFormData['volume'])
+  const sourceLabware = hydratedFormData['aspirate_labware']
+  const destLabware = hydratedFormData['dispense_labware']
+  const blowout = hydratedFormData['dispense_blowout_checkbox'] ? hydratedFormData['dispense_blowout_labware'] : null
 
-  const aspirateOffsetFromBottomMm = Number(formData['aspirate_mmFromBottom'])
-  const dispenseOffsetFromBottomMm = Number(formData['dispense_mmFromBottom'])
+  const aspirateOffsetFromBottomMm = Number(hydratedFormData['aspirate_mmFromBottom'])
+  const dispenseOffsetFromBottomMm = Number(hydratedFormData['dispense_mmFromBottom'])
 
-  const delayAfterDispense = formData['dispense_delay_checkbox']
-    ? ((Number(formData['dispense_delayMinutes']) || 0) * 60) +
-      (Number(formData['dispense_delaySeconds'] || 0))
+  const delayAfterDispense = hydratedFormData['dispense_delay_checkbox']
+    ? ((Number(hydratedFormData['dispense_delayMinutes']) || 0) * 60) +
+      (Number(hydratedFormData['dispense_delaySeconds'] || 0))
     : null
 
-  const mixFirstAspirate = formData['aspirate_mix_checkbox']
+  const mixFirstAspirate = hydratedFormData['aspirate_mix_checkbox']
     ? {
-      volume: Number(formData['aspirate_mix_volume']),
-      times: parseInt(formData['aspirate_mix_times']), // TODO handle unparseable
+      volume: Number(hydratedFormData['aspirate_mix_volume']),
+      times: parseInt(hydratedFormData['aspirate_mix_times']), // TODO handle unparseable
     }
     : null
 
   const mixBeforeAspirate = getMixData(
-    formData,
+    hydratedFormData,
     'aspirate_mix_checkbox',
     'aspirate_mix_volume',
     'aspirate_mix_times'
   )
 
   const mixInDestination = getMixData(
-    formData,
+    hydratedFormData,
     'dispense_mix_checkbox',
     'dispense_mix_volume',
     'dispense_mix_times'
   )
 
-  const changeTip = formData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
+  const changeTip = hydratedFormData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
 
   const commonFields = {
     pipette: pipette.id,
@@ -78,9 +78,9 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
     changeTip,
     delayAfterDispense,
     mixInDestination,
-    preWetTip: formData['aspirate_preWetTip'] || false,
-    touchTipAfterAspirate: formData['aspirate_touchTip'] || false,
-    touchTipAfterDispense: formData['dispense_touchTip'] || false,
+    preWetTip: hydratedFormData['aspirate_preWetTip'] || false,
+    touchTipAfterAspirate: hydratedFormData['aspirate_touchTip'] || false,
+    touchTipAfterDispense: hydratedFormData['dispense_touchTip'] || false,
     description: 'description would be here 2018-03-01', // TODO get from form
   }
 
@@ -91,7 +91,7 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
     aspirate_wellOrder_second,
     dispense_wellOrder_first,
     dispense_wellOrder_second,
-  } = formData
+  } = hydratedFormData
   sourceWells = sourceWells || []
   destWells = destWells || []
 
@@ -118,9 +118,9 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
   let disposalDestination = null
   let disposalLabware = null
   let disposalWell = null
-  if (formData['aspirate_disposalVol_checkbox']) { // TODO: BC 09-17-2018 handle unparseable values?
-    disposalVolume = Number(formData['aspirate_disposalVol_volume'])
-    disposalDestination = formData['aspirate_disposalVol_destination']
+  if (hydratedFormData['aspirate_disposalVol_checkbox']) { // TODO: BC 09-17-2018 handle unparseable values?
+    disposalVolume = Number(hydratedFormData['aspirate_disposalVol_volume'])
+    disposalDestination = hydratedFormData['aspirate_disposalVol_destination']
     if (disposalDestination === SOURCE_WELL_DISPOSAL_DESTINATION) {
       disposalLabware = sourceLabware
       disposalWell = sourceWells[0]
@@ -140,7 +140,7 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
         sourceWells,
         destWells,
         mixBeforeAspirate,
-        name: `Transfer ${formData.id}`, // TODO Ian 2018-04-03 real name for steps
+        name: `Transfer ${hydratedFormData.id}`, // TODO Ian 2018-04-03 real name for steps
       }
       return transferStepArguments
     }
@@ -152,7 +152,7 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
         sourceWells,
         destWell: destWells[0],
         stepType: 'consolidate',
-        name: `Consolidate ${formData.id}`, // TODO Ian 2018-04-03 real name for steps
+        name: `Consolidate ${hydratedFormData.id}`, // TODO Ian 2018-04-03 real name for steps
       }
       return consolidateStepArguments
     }
@@ -166,7 +166,7 @@ const transferLikeFormToArgs = (formData: FormData): TransferLikeStepArgs => {
         sourceWell: sourceWells[0],
         destWells,
         stepType: 'distribute',
-        name: `Distribute ${formData.id}`, // TODO Ian 2018-04-03 real name for steps
+        name: `Distribute ${hydratedFormData.id}`, // TODO Ian 2018-04-03 real name for steps
       }
       return distributeStepArguments
     }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/types.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/types.js
@@ -1,7 +1,0 @@
-// @flow
-
-import type { Labware } from '../../../labware-ingred/types'
-
-export type StepFormContext = {
-  labware?: ?{[labwareId: string]: ?Labware},
-}

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -2,6 +2,7 @@
 import cloneDeep from 'lodash/cloneDeep'
 import range from 'lodash/range'
 import mapValues from 'lodash/mapValues'
+import isEmpty from 'lodash/isEmpty'
 
 import substepTimeline from './substepTimeline'
 import {
@@ -59,10 +60,9 @@ function transferLikeSubsteps (args: {
   // TODO: Ian 2018-07-31 develop more elegant way to bypass tip handling for simulation/test
   const robotState = cloneDeep(args.robotState)
   robotState.tipState.pipettes = mapValues(robotState.tipState.pipettes, () => true)
-  const {pipette} = validatedForm
-  const {id: pipetteId} = pipette
+  const {pipette: pipetteId} = validatedForm
 
-  // const pipette = allPipetteData[pipetteId]
+  const pipette = allPipetteData[pipetteId]
 
   // TODO Ian 2018-04-06 use assert here
   if (!pipette) {
@@ -233,7 +233,8 @@ export function generateSubsteps (
 
   // TODO: BC: 2018-08-21 replace old error check with new logic in field, form, and timeline level
   // Don't try to render with form errors. TODO LATER: presentational error state of substeps?
-  if (!valForm || !valForm.validatedForm || Object.values(valForm.errors).length > 0) {
+  if (!valForm || !valForm.validatedForm || !isEmpty(valForm.errors)) {
+    console.log('caught', stepId)
     return null
   }
 

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -59,11 +59,10 @@ function transferLikeSubsteps (args: {
   // TODO: Ian 2018-07-31 develop more elegant way to bypass tip handling for simulation/test
   const robotState = cloneDeep(args.robotState)
   robotState.tipState.pipettes = mapValues(robotState.tipState.pipettes, () => true)
-  const {
-    pipette: pipetteId,
-  } = validatedForm
+  const {pipette} = validatedForm
+  const {id: pipetteId} = pipette
 
-  const pipette = allPipetteData[pipetteId]
+  // const pipette = allPipetteData[pipetteId]
 
   // TODO Ian 2018-04-06 use assert here
   if (!pipette) {

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -233,7 +233,6 @@ export function generateSubsteps (
   // TODO: BC: 2018-08-21 replace old error check with new logic in field, form, and timeline level
   // Don't try to render with form errors. TODO LATER: presentational error state of substeps?
   if (!stepArgsAndErrors || !stepArgsAndErrors.stepArgs || !isEmpty(stepArgsAndErrors.errors)) {
-    console.log('caught', stepId)
     return null
   }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -98,7 +98,7 @@ export type StepArgsAndErrors = {
   stepArgs: CommandCreatorData | null, // TODO: incompleteData field when this is null?
 }
 
-export type StepFormContextualState = {|
+export type StepFormContextualState = {
   labwareIngred: $PropertyType<BaseState, 'labwareIngred'>,
   pipettes: $PropertyType<BaseState, 'pipettes'>,
-|}
+}

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,6 +1,9 @@
 // @flow
-import type {PauseFormData} from '../step-generation'
+import type {PauseFormData, CommandCreatorData} from '../step-generation'
 import type {FormData, StepIdType, StepType, TransferLikeStepType} from '../form-types'
+import type {BaseState} from '../types'
+import type {FormError} from './formLevel/errors'
+import type {StepFieldName} from './fieldLevel'
 
 // sections of the form that are expandable/collapsible
 export type FormSectionState = {aspirate: boolean, dispense: boolean}
@@ -84,3 +87,18 @@ export type StepItemData = {
 }
 
 export type SubSteps = {[StepIdType]: ?SubstepItemData}
+
+export type StepFormAndFieldErrors = {
+  field?: {[StepFieldName]: Array<string>},
+  form?: Array<FormError>,
+}
+
+export type StepArgsAndErrors = {
+  errors: StepFormAndFieldErrors,
+  stepArgs: CommandCreatorData | null, // TODO: incompleteData field when this is null?
+}
+
+export type StepFormContextualState = {|
+  labwareIngred: $PropertyType<BaseState, 'labwareIngred'>,
+  pipettes: $PropertyType<BaseState, 'pipettes'>,
+|}

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -136,18 +136,18 @@ function _getSelectedWellsForSubstep (
 
 export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = createSelector(
   fileDataSelectors.robotStateTimeline,
-  steplistSelectors.validatedForms,
+  steplistSelectors.getAllStepArgsAndErrors,
   steplistSelectors.getHoveredStepId,
   steplistSelectors.getHoveredSubstep,
   allSubsteps,
   steplistSelectors.orderedSteps,
-  (robotStateTimeline, forms, hoveredStepId, hoveredSubstep, allSubsteps, orderedSteps) => {
+  (robotStateTimeline, allStepArgsAndErrors, hoveredStepId, hoveredSubstep, allSubsteps, orderedSteps) => {
     const timeline = robotStateTimeline.timeline
     const stepId = hoveredStepId
     const timelineIndex = orderedSteps.findIndex(i => i === stepId)
     const frame = timeline[timelineIndex]
     const robotState = frame && frame.robotState
-    const form = stepId != null && forms[stepId] && forms[stepId].validatedForm
+    const form = stepId != null && allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs
 
     if (!robotState || stepId == null || !form) {
       // nothing hovered, or no form for step

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -136,7 +136,7 @@ function _getSelectedWellsForSubstep (
 
 export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = createSelector(
   fileDataSelectors.robotStateTimeline,
-  steplistSelectors.getAllStepArgsAndErrors,
+  steplistSelectors.getArgsAndErrorsByStepId,
   steplistSelectors.getHoveredStepId,
   steplistSelectors.getHoveredSubstep,
   allSubsteps,
@@ -147,10 +147,10 @@ export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = 
     const timelineIndex = orderedSteps.findIndex(i => i === stepId)
     const frame = timeline[timelineIndex]
     const robotState = frame && frame.robotState
-    const form = stepId != null && allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs
+    const stepArgs = stepId != null && allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs
 
-    if (!robotState || stepId == null || !form) {
-      // nothing hovered, or no form for step
+    if (!robotState || stepId == null || !stepArgs) {
+      // nothing hovered, or no stepArgs for step
       return {}
     }
 
@@ -162,14 +162,14 @@ export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = 
         if (hoveredSubstep != null) {
           // wells for hovered substep
           selectedWells = _getSelectedWellsForSubstep(
-            form,
+            stepArgs,
             labwareId,
             allSubsteps[stepId],
             hoveredSubstep.substepIndex
           )
         } else {
           // wells for step overall
-          selectedWells = _getSelectedWellsForStep(form, labwareId, robotState)
+          selectedWells = _getSelectedWellsForStep(stepArgs, labwareId, robotState)
         }
 
         // return selected wells eg {A1: true, B4: true}

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -30,8 +30,7 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
     robotStateTimeline,
     _initialRobotState,
   ) => {
-    return orderedSteps
-    .reduce((acc: AllSubsteps, stepId, timelineIndex) => {
+    return orderedSteps.reduce((acc: AllSubsteps, stepId, timelineIndex) => {
       const timeline = [{robotState: _initialRobotState}, ...robotStateTimeline.timeline]
       const robotState = timeline[timelineIndex] && timeline[timelineIndex].robotState
 

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -16,14 +16,14 @@ import type {SubstepItemData} from '../steplist/types'
 
 type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
-  steplistSelectors.validatedForms,
+  steplistSelectors.getAllStepArgsAndErrors,
   pipetteSelectors.equippedPipettes,
   labwareIngredSelectors.getLabwareTypes,
   steplistSelectors.orderedSteps,
   fileDataSelectors.robotStateTimeline,
   fileDataSelectors.getInitialRobotState,
   (
-    validatedForms,
+    allStepArgsAndErrors,
     allPipetteData,
     allLabwareTypes,
     orderedSteps,
@@ -35,7 +35,7 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
       const robotState = timeline[timelineIndex] && timeline[timelineIndex].robotState
 
       const substeps = generateSubsteps(
-        validatedForms[stepId],
+        allStepArgsAndErrors[stepId],
         allPipetteData,
         (labwareId: string) => allLabwareTypes[labwareId],
         robotState,

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -16,7 +16,7 @@ import type {SubstepItemData} from '../steplist/types'
 
 type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
-  steplistSelectors.getAllStepArgsAndErrors,
+  steplistSelectors.getArgsAndErrorsByStepId,
   pipetteSelectors.equippedPipettes,
   labwareIngredSelectors.getLabwareTypes,
   steplistSelectors.orderedSteps,

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -46,6 +46,7 @@ const selectedWells = handleActions({
   SET_WELL_CONTENTS: () => selectedWellsInitialState,
 }, selectedWellsInitialState)
 
+// TODO: BC 2018-11-01 unused, remove and all references to the actions
 type WellSelectionModalState = OpenWellSelectionModalPayload | null
 const wellSelectionModal = handleActions({
   OPEN_WELL_SELECTION_MODAL: (state, action: {payload: OpenWellSelectionModalPayload}) => action.payload,


### PR DESCRIPTION
## overview

Deprecate old validation logic lingering in stepFormToArgs and protect from invalid arg creation by passing formData through field and form level errors getters.

Remove error block from stepFormToArgs functions. Clean up hydration pathways.

Closes #2485

## changelog

- split out pipette reducer
- hydrate forms before they hit stepFormToArgs, remove context param
- show warning icon on ConnectedStepItem if that step has a form or field level error
- still block save on field and form level errors, but now only use new validation logic (in `fieldLevel` and `formLevel`)

