### PR TITLE
Sneaky key combo for hidden step reordering feature

### DIFF
--- a/protocol-designer/src/components/steplist/StepList.js
+++ b/protocol-designer/src/components/steplist/StepList.js
@@ -12,25 +12,51 @@ import {END_TERMINAL_ITEM_ID} from '../../steplist'
 import type {StepIdType} from '../../form-types'
 import {PortalRoot} from './TooltipPortal'
 
-type StepListProps = {
+type Props = {
   orderedSteps: Array<StepIdType>,
-  handleStepHoverById?: (?StepIdType) => (event?: SyntheticEvent<>) => mixed,
+  reorderSelectedStep: (delta: number) => mixed,
 }
 
-export default function StepList (props: StepListProps) {
-  return (
-    <React.Fragment>
-      <SidePanel
-        title='Protocol Timeline'
-        onMouseLeave={props.handleStepHoverById && props.handleStepHoverById(null)}>
-        <StartingDeckStateTerminalItem />
+export default class StepList extends React.Component<Props> {
+  handleKeyDown = (e: SyntheticKeyboardEvent<*>) => {
+    const {reorderSelectedStep} = this.props
+    const key = e.key
+    const altIsPressed = e.getModifierState('Alt')
 
-        {props.orderedSteps.map((stepId: StepIdType) => <StepItem key={stepId} stepId={stepId} />)}
+    if (altIsPressed) {
+      if (key === 'ArrowUp') {
+        reorderSelectedStep(-1)
+      } else if (key === 'ArrowDown') {
+        reorderSelectedStep(1)
+      }
+    }
+  }
 
-        <StepCreationButton />
-        <TerminalItem id={END_TERMINAL_ITEM_ID} title={END_TERMINAL_TITLE} />
-      </SidePanel>
-      <PortalRoot />
-    </React.Fragment>
-  )
+  componentDidMount () {
+    global.addEventListener('keydown', this.handleKeyDown, false)
+  }
+
+  componentWillUnmount () {
+    global.removeEventListener('keydown', this.handleKeyDown, false)
+  }
+
+  render () {
+    const {orderedSteps} = this.props
+
+    const stepItems = orderedSteps.map((stepId: StepIdType) =>
+      <StepItem key={stepId} stepId={stepId} />)
+
+    return (
+      <React.Fragment>
+        <SidePanel
+          title='Protocol Timeline'>
+          <StartingDeckStateTerminalItem />
+          {stepItems}
+          <StepCreationButton />
+          <TerminalItem id={END_TERMINAL_ITEM_ID} title={END_TERMINAL_TITLE} />
+        </SidePanel>
+        <PortalRoot />
+      </React.Fragment>
+    )
+  }
 }

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -1,17 +1,33 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import type {BaseState} from '../types'
+import type {BaseState, ThunkDispatch} from '../types'
 
-import {selectors} from '../steplist'
+import {
+  actions as steplistActions,
+  selectors as steplistSelectors,
+} from '../steplist'
 import {StepList} from '../components/steplist'
 
 type Props = React.ElementProps<typeof StepList>
 
-function mapStateToProps (state: BaseState): Props {
+type SP = {
+  orderedSteps: $PropertyType<Props, 'orderedSteps'>,
+}
+
+type DP = $Diff<Props, SP>
+
+function mapStateToProps (state: BaseState): SP {
   return {
-    orderedSteps: selectors.orderedSteps(state),
+    orderedSteps: steplistSelectors.orderedSteps(state),
   }
 }
 
-export default connect(mapStateToProps)(StepList)
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
+  return {
+    reorderSelectedStep: (delta: number) =>
+      dispatch(steplistActions.reorderSelectedStep(delta)),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(StepList)

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -23,39 +23,6 @@ if (process.env.NODE_ENV === 'production') {
   }
 }
 
-function handleCheatCodes (e) {
-  const key = e.key
-
-  if (key === 'w') {
-    moveSelectedStep(-1)
-  } else if (key === 's') {
-    moveSelectedStep(1)
-  }
-}
-
-function moveSelectedStep (delta) {
-  const orderedSteps = store.getState().steplist.orderedSteps
-  const selectedItem = store.getState().steplist.selectedItem
-
-  if (selectedItem.isStep) {
-    const stepId = selectedItem.id
-    const selectedIndex = orderedSteps.findIndex(s => s === stepId)
-
-    store.dispatch({
-      type: 'REORDER_STEP_CHEATCODE',
-      payload: {
-        nextIndex: selectedIndex + delta,
-        stepId,
-      },
-    })
-  } else {
-    console.log('cannot do cheat code, no step selected')
-  }
-}
-
-global.document.addEventListener('keydown', handleCheatCodes)
-console.log('CHEAT CODES ENABLED! Use Ctrl + Up or Ctrl + Down with step selected')
-
 const render = (Component) => {
   ReactDOM.render(
     <Provider store={store}>

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -23,6 +23,39 @@ if (process.env.NODE_ENV === 'production') {
   }
 }
 
+function handleCheatCodes (e) {
+  const key = e.key
+
+  if (key === 'w') {
+    moveSelectedStep(-1)
+  } else if (key === 's') {
+    moveSelectedStep(1)
+  }
+}
+
+function moveSelectedStep (delta) {
+  const orderedSteps = store.getState().steplist.orderedSteps
+  const selectedItem = store.getState().steplist.selectedItem
+
+  if (selectedItem.isStep) {
+    const stepId = selectedItem.id
+    const selectedIndex = orderedSteps.findIndex(s => s === stepId)
+
+    store.dispatch({
+      type: 'REORDER_STEP_CHEATCODE',
+      payload: {
+        nextIndex: selectedIndex + delta,
+        stepId,
+      },
+    })
+  } else {
+    console.log('cannot do cheat code, no step selected')
+  }
+}
+
+global.document.addEventListener('keydown', handleCheatCodes)
+console.log('CHEAT CODES ENABLED! Use Ctrl + Up or Ctrl + Down with step selected')
+
 const render = (Component) => {
   ReactDOM.render(
     <Provider store={store}>

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -89,25 +89,20 @@ export const addStep = (payload: {stepType: StepType}) =>
 export type ReorderSelectedStepAction = {
   type: 'REORDER_SELECTED_STEP',
   payload: {
-    nextIndex: number,
+    delta: number,
     stepId: StepIdType,
   },
 }
 
 export const reorderSelectedStep = (delta: number) =>
   (dispatch: ThunkDispatch<ReorderSelectedStepAction>, getState: GetState) => {
-    // TODO IMMEDIATELY: use selectors
-    const orderedSteps = getState().steplist.orderedSteps
-    const selectedItem = getState().steplist.selectedItem
+    const stepId = selectors.getSelectedStepId(getState())
 
-    if (selectedItem && selectedItem.isStep && selectedItem.id) {
-      const stepId = selectedItem.id
-      const selectedIndex = orderedSteps.findIndex(s => s === stepId)
-
+    if (stepId != null) {
       dispatch({
         type: 'REORDER_SELECTED_STEP',
         payload: {
-          nextIndex: selectedIndex + delta,
+          delta,
           stepId,
         },
       })

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -85,3 +85,31 @@ export const addStep = (payload: {stepType: StepType}) =>
     }
     dispatch(selectStep(stepId, stepType))
   }
+
+export type ReorderSelectedStepAction = {
+  type: 'REORDER_SELECTED_STEP',
+  payload: {
+    nextIndex: number,
+    stepId: StepIdType,
+  },
+}
+
+export const reorderSelectedStep = (delta: number) =>
+  (dispatch: ThunkDispatch<ReorderSelectedStepAction>, getState: GetState) => {
+    // TODO IMMEDIATELY: use selectors
+    const orderedSteps = getState().steplist.orderedSteps
+    const selectedItem = getState().steplist.selectedItem
+
+    if (selectedItem && selectedItem.isStep && selectedItem.id) {
+      const stepId = selectedItem.id
+      const selectedIndex = orderedSteps.findIndex(s => s === stepId)
+
+      dispatch({
+        type: 'REORDER_SELECTED_STEP',
+        payload: {
+          nextIndex: selectedIndex + delta,
+          stepId,
+        },
+      })
+    }
+  }

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -177,6 +177,16 @@ const orderedSteps: Reducer<OrderedStepsState, *> = handleActions({
     state.filter(stepId => !(stepId === action.payload || `${stepId}` === action.payload)),
   LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
     getPDMetadata(action.payload).orderedSteps,
+  REORDER_STEP_CHEATCODE: (state: OrderedStepsState, action: {payload: {nextIndex: number, stepId: number}}): any => {
+    const {nextIndex, stepId} = action.payload
+    const filteredStepIds = state.filter(s => s !== stepId)
+
+    return [
+      ...filteredStepIds.slice(0, nextIndex),
+      stepId,
+      ...filteredStepIds.slice(nextIndex),
+    ]
+  },
 }, [])
 
 export type SelectableItem = {

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -178,13 +178,17 @@ const orderedSteps: Reducer<OrderedStepsState, *> = handleActions({
   LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
     getPDMetadata(action.payload).orderedSteps,
   REORDER_SELECTED_STEP: (state: OrderedStepsState, action: ReorderSelectedStepAction): OrderedStepsState => {
-    const {nextIndex, stepId} = action.payload
-    const filteredStepIds = state.filter(s => s !== stepId)
+    const {delta, stepId} = action.payload
+    const stepsWithoutSelectedStep = state.filter(s => s !== stepId)
+    const selectedIndex = state.findIndex(s => s === stepId)
+    const nextIndex = selectedIndex + delta
+
+    if (delta <= 0 && selectedIndex === 0) return state
 
     return [
-      ...filteredStepIds.slice(0, nextIndex),
+      ...stepsWithoutSelectedStep.slice(0, nextIndex),
       stepId,
-      ...filteredStepIds.slice(nextIndex),
+      ...stepsWithoutSelectedStep.slice(nextIndex),
     ]
   },
 }, [])

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -22,10 +22,10 @@ import type {
   AddStepAction,
   ChangeFormInputAction,
   DeleteStepAction,
+  ReorderSelectedStepAction,
   SaveStepFormAction,
   SelectStepAction,
   SelectTerminalItemAction,
-
   PopulateFormAction,
   CollapseFormSectionAction, // <- TODO this isn't a thunk
 
@@ -177,7 +177,7 @@ const orderedSteps: Reducer<OrderedStepsState, *> = handleActions({
     state.filter(stepId => !(stepId === action.payload || `${stepId}` === action.payload)),
   LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
     getPDMetadata(action.payload).orderedSteps,
-  REORDER_STEP_CHEATCODE: (state: OrderedStepsState, action: {payload: {nextIndex: number, stepId: number}}): any => {
+  REORDER_SELECTED_STEP: (state: OrderedStepsState, action: ReorderSelectedStepAction): OrderedStepsState => {
     const {nextIndex, stepId} = action.payload
     const filteredStepIds = state.filter(s => s !== stepId)
 

--- a/protocol-designer/src/steplist/test/reducers.test.js
+++ b/protocol-designer/src/steplist/test/reducers.test.js
@@ -123,6 +123,88 @@ describe('orderedSteps reducer', () => {
     }
     expect(orderedSteps(state, action)).toEqual([123, 22])
   })
+
+  describe('reorder steps', () => {
+    const state = ['1', '2', '3', '4']
+    const testCases = [
+      {
+        label: '+1 to first',
+        payload: {
+          delta: 1,
+          stepId: '1',
+        },
+        expected: ['2', '1', '3', '4'],
+      },
+      {
+        label: '+0 to first: no change',
+        payload: {
+          delta: 0,
+          stepId: '1',
+        },
+        expected: state,
+      },
+      {
+        label: '-1 to first: no change',
+        payload: {
+          delta: -1,
+          stepId: '1',
+        },
+        expected: state,
+      },
+      {
+        label: '-10 to first: no change',
+        payload: {
+          delta: -10,
+          stepId: '1',
+        },
+        expected: state,
+      },
+
+      {
+        label: '-1 to second',
+        payload: {
+          delta: -1,
+          stepId: '2',
+        },
+        expected: ['2', '1', '3', '4'],
+      },
+      {
+        label: '-10 to second',
+        payload: {
+          delta: -10,
+          stepId: '2',
+        },
+        expected: ['2', '1', '3', '4'],
+      },
+
+      {
+        label: '+1 to last: no change',
+        payload: {
+          delta: 1,
+          stepId: '4',
+        },
+        expected: state,
+      },
+      {
+        label: '+10 to last: no change',
+        payload: {
+          delta: 10,
+          stepId: '4',
+        },
+        expected: state,
+      },
+    ]
+
+    testCases.forEach(({label, payload, expected}) => {
+      test(label, () => {
+        const action = {
+          type: 'REORDER_SELECTED_STEP',
+          payload,
+        }
+        expect(orderedSteps(state, action)).toEqual(expected)
+      })
+    })
+  })
 })
 
 describe('selectedItem reducer', () => {


### PR DESCRIPTION
## overview

Serves as its own ticket.

This lets us play around with re-ordering steps. The feature will be hard to discover, in part because we don't want people to use it heavily right now. But we can tell select users that this is available to unblock them.

## changelog

* implement key combo to reorder steps
* unit test for orderedSteps reordering

## requests for reviewers

To try it:

1. Select a step in the step list
2. Use Alt +⬆ to move it UP in the list, use Alt + ⬇ to move it DOWN in the list
3. ??? Profit :man_cook: 