### PR TITLE
refactor(app): Enable certificate usage with 802.1x

### DIFF
--- a/api/src/opentrons/server/endpoints/networking.py
+++ b/api/src/opentrons/server/endpoints/networking.py
@@ -435,6 +435,7 @@ async def list_keys(request: web.Request) -> web.Response:
     """
     keys_dir = environment.get_path('WIFI_KEYS_DIR')
     keys: List[Dict[str, str]] = []
+    # TODO(mc, 2018-10-24): add last modified info to keys for sort purposes
     for path in os.listdir(keys_dir):
         full_path = os.path.join(keys_dir, path)
         if os.path.isdir(full_path):

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
@@ -2,9 +2,10 @@
 import * as React from 'react'
 import {Formik} from 'formik'
 import get from 'lodash/get'
-import find from 'lodash/find'
-import set from 'lodash/set'
 import isEmpty from 'lodash/isEmpty'
+import find from 'lodash/find'
+import map from 'lodash/map'
+import set from 'lodash/set'
 
 import {WPA_PSK_SECURITY, WPA_EAP_SECURITY} from '../../../http-api-client'
 
@@ -15,7 +16,8 @@ import FormTable, {FormTableRow} from './FormTable'
 
 import type {
   WifiSecurityType,
-  WifiEapOption,
+  WifiEapOptionsList,
+  WifiKeysList,
   WifiAuthField,
   WifiConfigureRequest,
 } from '../../../http-api-client'
@@ -24,8 +26,10 @@ type Props = {
   // TODO(mc, 2018-10-22): optional SSID
   ssid: string,
   securityType: WifiSecurityType,
-  eapOptions: ?Array<WifiEapOption>,
+  eapOptions: ?WifiEapOptionsList,
+  keys: ?WifiKeysList,
   configure: WifiConfigureRequest => mixed,
+  addKey: File => mixed,
   close: () => mixed,
 }
 
@@ -33,9 +37,27 @@ type State = {|
   showPassword: {[name: string]: boolean},
 |}
 
-const WIFI_PSK_FIELDS = [
-  {name: 'psk', displayName: 'Password', type: 'password', required: true},
+type FormValues = {[string]: ?(string | {[string]: string})}
+
+const PSK_FIELD_NAME = 'psk'
+const PSK_MIN_LENGTH = 8
+
+const WPA_PSK_FIELDS = [
+  {
+    name: PSK_FIELD_NAME,
+    displayName: 'Password',
+    type: 'password',
+    required: true,
+  },
 ]
+
+// all eap options go in a sub-object `eapConfig`
+// eap method is stored under eapConfig.eapType
+const EAP_FIELD_PREFIX = 'eapConfig.'
+const EAP_METHOD_DISPLAY_NAME = 'Authentication'
+const EAP_METHOD_FIELD = `${EAP_FIELD_PREFIX}eapType`
+const EAP_METHOD_FIELD_ID = `${CONNECT_FIELD_ID_PREFIX}${EAP_METHOD_FIELD}`
+const getEapMethod = (v: FormValues): ?string => get(v, EAP_METHOD_FIELD)
 
 export default class ConnectForm extends React.Component<Props, State> {
   constructor (props: Props) {
@@ -63,41 +85,57 @@ export default class ConnectForm extends React.Component<Props, State> {
     })
   }
 
-  getEapFields = (eapMethod: ?WifiEapOption): Array<WifiAuthField> => {
-    return get(eapMethod, 'options', []).map(field => ({
-      ...field,
-      name: `eapConfig.${field.name}`,
-    }))
+  getValidationSchema = (values: FormValues) => {
+    const errors = this.getFields(values).reduce((errors, field) => {
+      const {name, displayName, required} = field
+      const value = get(values, name, '')
+
+      if (required && !value) {
+        set(errors, name, `${displayName} is required`)
+      } else if (name === PSK_FIELD_NAME && value.length < PSK_MIN_LENGTH) {
+        set(errors, name, `${displayName} must be at least 8 characters`)
+      }
+
+      return errors
+    }, {})
+
+    if (this.getSecurityType(values) === WPA_EAP_SECURITY) {
+      if (!getEapMethod(values)) {
+        set(errors, EAP_METHOD_FIELD, `${EAP_METHOD_DISPLAY_NAME} is required`)
+      }
+    }
+
+    return errors
   }
 
-  getValidationSchema = (values: any) => {
-    let fields = []
-    const errors = {}
-    if (this.props.securityType === WPA_PSK_SECURITY) {
-      fields = WIFI_PSK_FIELDS
-    } else {
-      const selectedEapMethod = find(this.props.eapOptions, {
-        name: values.eapConfig.eapType,
-      })
-      fields = this.getEapFields(selectedEapMethod)
+  // TODO(mc, 2018-10-26): allow security type to be pulled from values
+  // if not in props
+  getSecurityType (values: FormValues): WifiSecurityType {
+    return this.props.securityType
+  }
+
+  getFields (values: FormValues): Array<WifiAuthField> {
+    const securityType = this.getSecurityType(values)
+
+    if (securityType === WPA_PSK_SECURITY) return WPA_PSK_FIELDS
+    if (securityType === WPA_EAP_SECURITY) {
+      const method = find(this.props.eapOptions, {name: getEapMethod(values)})
+      return get(method, 'options', []).map(field => ({
+        ...field,
+        name: `${EAP_FIELD_PREFIX}${field.name}`,
+      }))
     }
-    fields.forEach(f => {
-      if (f.required && !get(values, f.name)) {
-        set(errors, f.name, `${f.displayName} is required`)
-      } else if (f.name === 'psk' && get(values, f.name).length < 8) {
-        set(errors, f.name, 'Password must be at least 8 characters')
-      }
-    })
-    return errors
+
+    return []
   }
 
   render () {
     const {showPassword} = this.state
-    const {securityType, eapOptions, close} = this.props
-    const eapMethodField = eapOptions ? 'eapConfig.eapType' : ''
-    const eapMethodId = eapOptions
-      ? `${CONNECT_FIELD_ID_PREFIX}${eapMethodField}`
-      : ''
+    const {securityType, keys, addKey, close} = this.props
+    const eapOptions = map(this.props.eapOptions, o => ({
+      name: o.displayName || o.name,
+      value: o.name,
+    }))
 
     return (
       <Formik
@@ -105,62 +143,61 @@ export default class ConnectForm extends React.Component<Props, State> {
         validate={this.getValidationSchema}
         render={formProps => {
           const {
-            handleChange,
-            handleSubmit,
             values,
-            setValues,
+            handleChange,
             handleBlur,
+            handleSubmit,
+            setFieldValue,
+            setFieldTouched,
+            resetForm,
             errors,
             touched,
           } = formProps
 
           // disable submit if form is pristine or errors present
           const disabled = isEmpty(touched) || !isEmpty(errors)
+          const fields = this.getFields(values)
 
-          const eapMethod = get(values, eapMethodField)
-          let fields: Array<WifiAuthField> = []
-
-          if (securityType === WPA_PSK_SECURITY) {
-            fields = WIFI_PSK_FIELDS
-          } else if (securityType === WPA_EAP_SECURITY) {
-            const selectedEapMethod = find(eapOptions, {name: eapMethod})
-            fields = this.getEapFields(selectedEapMethod)
-          }
           return (
             <form onSubmit={handleSubmit}>
               <FormTable>
-                {securityType === WPA_EAP_SECURITY &&
-                  eapOptions && (
-                    <FormTableRow
-                      label="* Authentication:"
-                      labelFor={eapMethodId}
-                    >
-                      <DropdownField
-                        id={eapMethodId}
-                        name={eapMethodField}
-                        value={eapMethod}
-                        options={eapOptions.map(o => ({
-                          name: o.displayName || o.name,
-                          value: o.name,
-                        }))}
-                        onChange={e => {
-                          // reset all other fields on EAP type change
-                          setValues(set({}, eapMethodField, e.target.value))
-                        }}
-                      />
-                    </FormTableRow>
-                  )}
+                {securityType === WPA_EAP_SECURITY && (
+                  <FormTableRow
+                    label={`* ${EAP_METHOD_DISPLAY_NAME}:`}
+                    labelFor={EAP_METHOD_FIELD_ID}
+                  >
+                    <DropdownField
+                      id={EAP_METHOD_FIELD_ID}
+                      name={EAP_METHOD_FIELD}
+                      value={getEapMethod(values)}
+                      options={eapOptions}
+                      onChange={e => {
+                        // reset all other fields on EAP type change
+                        resetForm(set({}, EAP_METHOD_FIELD, e.target.value))
+                      }}
+                      onBlur={handleBlur}
+                      error={
+                        get(touched, EAP_METHOD_FIELD) &&
+                        get(errors, EAP_METHOD_FIELD)
+                      }
+                    />
+                  </FormTableRow>
+                )}
                 {fields.map(field => (
                   <ConnectFormField
                     key={field.name}
                     field={field}
                     value={get(values, field.name, '')}
+                    keys={keys}
                     showPassword={!!showPassword[field.name]}
                     onChange={handleChange}
-                    toggleShowPassword={this.toggleShowPassword}
+                    onValueChange={setFieldValue}
                     onBlur={handleBlur}
-                    errors={errors}
-                    touched={touched}
+                    onLoseFocus={setFieldTouched}
+                    addKey={addKey}
+                    toggleShowPassword={this.toggleShowPassword}
+                    error={get(errors, field.name)}
+                    touched={get(touched, field.name)}
                   />
                 ))}
               </FormTable>

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectForm.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {Formik} from 'formik'
 import get from 'lodash/get'
-import isEmpty from 'lodash/isEmpty'
 import find from 'lodash/find'
 import map from 'lodash/map'
 import set from 'lodash/set'
@@ -144,19 +143,16 @@ export default class ConnectForm extends React.Component<Props, State> {
         render={formProps => {
           const {
             values,
-            handleChange,
-            handleBlur,
-            handleSubmit,
-            setFieldValue,
-            setFieldTouched,
-            resetForm,
             errors,
             touched,
+            isValid,
+            handleChange,
+            setFieldValue,
+            handleBlur,
+            setFieldTouched,
+            resetForm,
+            handleSubmit,
           } = formProps
-
-          // disable submit if form is pristine or errors present
-          const disabled = isEmpty(touched) || !isEmpty(errors)
-          const fields = this.getFields(values)
 
           return (
             <form onSubmit={handleSubmit}>
@@ -183,7 +179,7 @@ export default class ConnectForm extends React.Component<Props, State> {
                     />
                   </FormTableRow>
                 )}
-                {fields.map(field => (
+                {this.getFields(values).map(field => (
                   <ConnectFormField
                     key={field.name}
                     field={field}
@@ -204,7 +200,7 @@ export default class ConnectForm extends React.Component<Props, State> {
               <BottomButtonBar
                 buttons={[
                   {children: 'Cancel', onClick: close},
-                  {children: 'Join', type: 'submit', disabled},
+                  {children: 'Join', type: 'submit', disabled: !isValid},
                 ]}
               />
             </form>

--- a/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
+++ b/app/src/components/RobotSettings/SelectNetwork/ConnectFormField.js
@@ -1,24 +1,24 @@
 // @flow
 import * as React from 'react'
-import get from 'lodash/get'
-import {InputField, CheckboxField, DropdownField} from '@opentrons/components'
+import {InputField, CheckboxField} from '@opentrons/components'
+import SelectKey from './SelectKey'
 import {FormTableRow} from './FormTable'
 
-import type {WifiAuthField} from '../../../http-api-client'
+import type {WifiAuthField, WifiKeysList} from '../../../http-api-client'
 
 type Props = {
   field: WifiAuthField,
   value: string,
-  showPassword: boolean,
+  touched: ?boolean,
+  error: ?string,
   onChange: (*) => mixed,
-  toggleShowPassword: (name: string) => mixed,
-  errors: {
-    [string]: string,
-  },
-  touched: {
-    [string]: boolean,
-  },
   onBlur: (SyntheticFocusEvent<*>) => mixed,
+  onValueChange: (name: string, value: *) => mixed,
+  onLoseFocus: (name: string) => mixed,
+  showPassword: boolean,
+  toggleShowPassword: (name: string) => mixed,
+  keys: ?WifiKeysList,
+  addKey: File => mixed,
 }
 
 export const CONNECT_FIELD_ID_PREFIX = '__ConnectForm__'
@@ -26,14 +26,17 @@ export const CONNECT_FIELD_ID_PREFIX = '__ConnectForm__'
 export default function ConnectFormField (props: Props) {
   const {
     value,
-    showPassword,
     onChange,
-    toggleShowPassword,
+    onValueChange,
     onBlur,
-    touched,
-    errors,
+    onLoseFocus,
+    showPassword,
+    toggleShowPassword,
+    keys,
+    addKey,
   } = props
   const {name, displayName, type, required} = props.field
+  const error = props.touched ? props.error : null
   const id = `${CONNECT_FIELD_ID_PREFIX}${name}`
   const label = required ? `* ${displayName}:` : `${displayName}:`
   let input = null
@@ -47,18 +50,21 @@ export default function ConnectFormField (props: Props) {
         type={inputType}
         value={value}
         onChange={onChange}
-        error={get(touched, name) && get(errors, name)}
+        error={error}
         onBlur={onBlur}
       />
     )
   } else if (type === 'file') {
     input = (
-      <DropdownField
-        disabled
+      <SelectKey
         id={id}
         name={name}
-        onChange={onChange}
-        options={[{name: 'Certificates not yet supported', value: ''}]}
+        value={value}
+        error={error}
+        keys={keys}
+        addKey={addKey}
+        onValueChange={onValueChange}
+        onLoseFocus={onLoseFocus}
       />
     )
   }
@@ -76,6 +82,7 @@ export default function ConnectFormField (props: Props) {
         {inputRow}
         <FormTableRow>
           <CheckboxField
+            name="Show password"
             label="Show password"
             value={showPassword}
             onChange={() => toggleShowPassword(name)}

--- a/app/src/components/RobotSettings/SelectNetwork/SelectKey.js
+++ b/app/src/components/RobotSettings/SelectNetwork/SelectKey.js
@@ -1,0 +1,111 @@
+// @flow
+import * as React from 'react'
+import find from 'lodash/find'
+import map from 'lodash/map'
+
+import SelectField from '../../SelectField'
+import styles from './styles.css'
+
+import type {WifiKeysList} from '../../../http-api-client'
+
+type Props = {
+  id: string,
+  name: string,
+  value: string,
+  error: ?string,
+  keys: ?WifiKeysList,
+  addKey: File => mixed,
+  onValueChange: (name: string, value: *) => mixed,
+  onLoseFocus: (name: string) => mixed,
+}
+
+type State = {
+  nextKeyName: ?string,
+}
+
+const UPLOAD_KEY_VALUE = '__uploadWifiKey__'
+const UPLOAD_KEY_LABEL = 'Add new...'
+
+export default class SelectKey extends React.Component<Props, State> {
+  fileInput: ?HTMLInputElement
+
+  constructor (props: Props) {
+    super(props)
+    this.fileInput = null
+    this.state = {nextKeyName: null}
+  }
+
+  setFileInputRef = ($el: ?HTMLInputElement) => (this.fileInput = $el)
+
+  handleInputLabelClick = () => this.fileInput && this.fileInput.click()
+
+  upload = (event: SyntheticInputEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length) {
+      const file: File = event.target.files[0]
+      event.target.value = ''
+      this.props.addKey(file)
+      this.props.onValueChange(this.props.name, null)
+      this.setState({nextKeyName: file.name})
+    }
+  }
+
+  handleValueChange = (name: string, value: string) => {
+    if (value !== UPLOAD_KEY_VALUE) {
+      this.props.onValueChange(name, value)
+    }
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    const {name, keys, value} = this.props
+    const {nextKeyName} = this.state
+
+    if (!value && nextKeyName && keys !== prevProps.keys) {
+      // TODO(mc, 2018-10-24): this will select an arbitrary key file if the
+      // user uploads multiple keys with the same filename; see TODO in
+      // api/src/opentrons/server/endpoints/networking.py::list_keys
+      const nextKey = find(keys, {name: nextKeyName})
+      if (nextKey) {
+        this.handleValueChange(name, nextKey.id)
+        this.setState({nextKeyName: null})
+      }
+    }
+  }
+
+  render () {
+    const {id, name, value, error, keys, onLoseFocus} = this.props
+    const keyOptions = map(keys, k => ({value: k.id, label: k.name}))
+    const addNewGroup = {
+      options: [
+        {
+          value: UPLOAD_KEY_VALUE,
+          label: (
+            <div onClick={this.handleInputLabelClick} aria-hidden>
+              {UPLOAD_KEY_LABEL}
+            </div>
+          ),
+        },
+      ],
+    }
+
+    return (
+      <div className={styles.wifi_key_select}>
+        <SelectField
+          id={id}
+          name={name}
+          value={value}
+          error={error}
+          onValueChange={this.handleValueChange}
+          onLoseFocus={onLoseFocus}
+          options={keyOptions.concat(addNewGroup)}
+        />
+        <input
+          type="file"
+          ref={this.setFileInputRef}
+          onChange={this.upload}
+          className={styles.wifi_add_key_input}
+          aria-label={UPLOAD_KEY_LABEL}
+        />
+      </div>
+    )
+  }
+}

--- a/app/src/components/RobotSettings/SelectNetwork/SelectSsid.js
+++ b/app/src/components/RobotSettings/SelectNetwork/SelectSsid.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import find from 'lodash/find'
 import map from 'lodash/map'
 
 import {Icon} from '@opentrons/components'
@@ -12,13 +13,14 @@ import type {OptionType} from '../../SelectField'
 
 type Props = {
   list: ?WifiNetworkList,
-  value: ?string,
   disabled?: boolean,
   onValueChange: (name: string, ssid: string) => mixed,
 }
 
 export default function SelectSsid (props: Props) {
-  const {value, list, disabled, onValueChange} = props
+  const {list, disabled, onValueChange} = props
+  const connected = find(list, 'active')
+  const value = connected && connected.ssid
 
   return (
     <SelectField

--- a/app/src/components/RobotSettings/SelectNetwork/index.js
+++ b/app/src/components/RobotSettings/SelectNetwork/index.js
@@ -115,7 +115,6 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
     return (
       <IntervalWrapper refresh={fetchList} interval={LIST_REFRESH_MS}>
         <SelectSsid
-          value={ssid}
           list={list}
           disabled={connectingTo != null}
           onValueChange={this.setCurrentSsid}

--- a/app/src/components/RobotSettings/SelectNetwork/index.js
+++ b/app/src/components/RobotSettings/SelectNetwork/index.js
@@ -8,9 +8,12 @@ import {
   WPA_EAP_SECURITY,
   fetchWifiList,
   fetchWifiEapOptions,
+  fetchWifiKeys,
+  addWifiKey,
   configureWifi,
   makeGetRobotWifiList,
   makeGetRobotWifiEapOptions,
+  makeGetRobotWifiKeys,
   makeGetRobotWifiConfigure,
 } from '../../../http-api-client'
 
@@ -25,7 +28,8 @@ import type {ViewableRobot} from '../../../discovery'
 import type {
   WifiNetworkList,
   WifiSecurityType,
-  WifiEapOption,
+  WifiEapOptionsList,
+  WifiKeysList,
   WifiConfigureRequest,
 } from '../../../http-api-client'
 
@@ -34,12 +38,15 @@ type OP = {robot: ViewableRobot}
 type SP = {|
   list: ?WifiNetworkList,
   connectingTo: ?string,
-  eapOptions: ?Array<WifiEapOption>,
+  eapOptions: ?WifiEapOptionsList,
+  keys: ?WifiKeysList,
 |}
 
 type DP = {|
   fetchList: () => mixed,
   fetchEapOptions: () => mixed,
+  fetchKeys: () => mixed,
+  addKey: (file: File) => mixed,
   configure: WifiConfigureRequest => mixed,
 |}
 
@@ -63,15 +70,14 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
     const network = find(this.props.list, {ssid})
 
     if (network) {
-      const nextState: $Shape<SelectNetworkState> = {
-        ssid,
-        securityType: network.securityType,
-      }
+      const securityType = network.securityType
+      const nextState: $Shape<SelectNetworkState> = {ssid, securityType}
 
-      if (network.securityType === NO_SECURITY) {
+      if (securityType === NO_SECURITY) {
         this.props.configure({ssid})
-      } else if (network.securityType === WPA_EAP_SECURITY) {
+      } else if (securityType === WPA_EAP_SECURITY) {
         this.props.fetchEapOptions()
+        this.props.fetchKeys()
       }
       // TODO(mc, 2018-10-18): handle hidden network
 
@@ -95,7 +101,15 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
   }
 
   render () {
-    const {list, connectingTo, eapOptions, fetchList, configure} = this.props
+    const {
+      list,
+      connectingTo,
+      eapOptions,
+      keys,
+      fetchList,
+      configure,
+      addKey,
+    } = this.props
     const {ssid, securityType} = this.state
 
     return (
@@ -123,10 +137,12 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
               >
                 <ConnectForm
                   ssid={ssid}
+                  securityType={securityType}
+                  eapOptions={eapOptions}
+                  keys={keys}
                   configure={configure}
                   close={this.closeConnectForm}
-                  eapOptions={eapOptions}
-                  securityType={securityType}
+                  addKey={addKey}
                 />
               </ConnectModal>
             )}
@@ -139,12 +155,14 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
 function makeMapStateToProps (): (State, OP) => SP {
   const getListCall = makeGetRobotWifiList()
   const getEapCall = makeGetRobotWifiEapOptions()
+  const getKeysCall = makeGetRobotWifiKeys()
   const getConfigureCall = makeGetRobotWifiConfigure()
 
   return (state, ownProps) => {
     const {robot} = ownProps
     const {response: listResponse} = getListCall(state, robot)
     const {response: eapResponse} = getEapCall(state, robot)
+    const {response: keysResponse} = getKeysCall(state, robot)
     const {
       request: cfgRequest,
       inProgress: cfgInProgress,
@@ -154,6 +172,7 @@ function makeMapStateToProps (): (State, OP) => SP {
     return {
       list: listResponse && listResponse.list,
       eapOptions: eapResponse && eapResponse.options,
+      keys: keysResponse && keysResponse.keys,
       connectingTo:
         !cfgError && cfgInProgress && cfgRequest ? cfgRequest.ssid : null,
     }
@@ -166,6 +185,8 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   return {
     fetchList: () => dispatch(fetchWifiList(robot)),
     fetchEapOptions: () => dispatch(fetchWifiEapOptions(robot)),
+    fetchKeys: () => dispatch(fetchWifiKeys(robot)),
+    addKey: file => dispatch(addWifiKey(robot, file)),
     configure: params => dispatch(configureWifi(robot, params)),
   }
 }

--- a/app/src/components/RobotSettings/SelectNetwork/styles.css
+++ b/app/src/components/RobotSettings/SelectNetwork/styles.css
@@ -68,3 +68,23 @@
   font-weight: var(--fw-semibold);
   text-align: right;
 }
+
+/**
+ * TODO(mc, 2018-10-23): move this padding to form_table_row once CL text
+ * fields stop having empty caption divs that take up height
+ */
+.wifi_key_select {
+  /* padding-bottom: 0.5rem; */
+}
+
+.wifi_add_key_input {
+  /* copied from components/src/forms/forms.css > .accessibly_hidden */
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+}

--- a/app/src/components/SelectField/index.js
+++ b/app/src/components/SelectField/index.js
@@ -1,6 +1,7 @@
 // @flow
 // TODO(mc, 2018-10-23): eventually move to components library
 import * as React from 'react'
+import cx from 'classnames'
 import find from 'lodash/find'
 import flatMap from 'lodash/flatMap'
 
@@ -25,22 +26,29 @@ type SelectProps = {
   value: ?string,
   /** change handler called with (name, value) */
   onValueChange: (name: string, value: string) => mixed,
+  /** blur handler called with (name) */
+  onLoseFocus?: (name: string) => mixed,
   /** disable the select */
   disabled?: boolean,
   /** optional placeholder  */
   placeholder?: string,
   /** optional className */
   className?: string,
+  /** optional caption. hidden when `error` is given */
+  caption?: string,
+  /** if included, use error style and display error instead of caption */
+  error?: ?string,
 }
 
 const SELECT_STYLES = {
-  control: () => ({
-    height: '1.75rem',
-  }),
-  input: () => ({
-    padding: 0,
+  input: () => ({padding: 0}),
+  groupHeading: () => ({
+    margin: 0,
+    borderBottom: '1px solid #9b9b9b',
   }),
 }
+
+const clearStyles = () => null
 
 const getOpts = (og: OptionType | GroupType): OptionList => og.options || [og]
 
@@ -50,42 +58,76 @@ export default class SelectField extends React.Component<SelectProps> {
     onValueChange(name, option.value)
   }
 
+  handleBlur = () => {
+    const {name, onLoseFocus} = this.props
+    if (onLoseFocus) onLoseFocus(name)
+  }
+
   render () {
-    const {id, name, options, disabled, placeholder, className} = this.props
+    const {
+      id,
+      name,
+      options,
+      disabled,
+      placeholder,
+      className,
+      error,
+    } = this.props
     const allOptions = flatMap(options, getOpts)
     const value = find(allOptions, {value: this.props.value}) || null
+    const caption = error || this.props.caption
+    const captionCx = cx(styles.select_caption, {[styles.error_color]: error})
 
     return (
-      <Select
-        id={id}
-        name={name}
-        options={options}
-        value={value}
-        onChange={this.handleChange}
-        isDisabled={disabled}
-        placeholder={placeholder}
-        styles={SELECT_STYLES}
-        className={className}
-        components={{
-          Control,
-          DropdownIndicator,
-          Menu,
-          IndicatorSeparator: null,
-        }}
-      />
+      <div className={styles.select_wrapper}>
+        <Select
+          id={id}
+          name={name}
+          options={options}
+          value={value}
+          error={error}
+          onChange={this.handleChange}
+          onBlur={this.handleBlur}
+          isDisabled={disabled}
+          placeholder={placeholder}
+          styles={SELECT_STYLES}
+          components={{
+            Control,
+            DropdownIndicator,
+            Menu,
+            Group,
+            IndicatorSeparator: null,
+          }}
+          className={className}
+        />
+        {caption && <p className={captionCx}>{caption}</p>}
+      </div>
     )
   }
 }
 
 function Control (props) {
-  return <components.Control {...props} className={styles.select_control} />
+  return (
+    <components.Control
+      {...props}
+      getStyles={clearStyles}
+      className={cx(styles.select_control, {
+        [styles.error_bg]: props.selectProps.error,
+        [styles.focus]: props.isFocused,
+      })}
+    />
+  )
 }
 
 function DropdownIndicator (props) {
+  const iconWrapperCx = cx(styles.dropdown_icon_wrapper, {
+    [styles.flipped]: props.selectProps.menuIsOpen,
+  })
+
   return (
     components.DropdownIndicator && (
       <components.DropdownIndicator {...props}>
-        <div className={styles.dropdown_icon}>
+        <div className={iconWrapperCx}>
           <Icon name="menu-down" width="100%" />
         </div>
       </components.DropdownIndicator>
@@ -98,5 +140,16 @@ function Menu (props) {
     <components.Menu {...props}>
       <div className={styles.select_menu}>{props.children}</div>
     </components.Menu>
+  )
+}
+
+// custom option group wrapper component
+function Group (props) {
+  return (
+    <components.Group
+      {...props}
+      className={styles.select_group}
+      getStyles={clearStyles}
+    />
   )
 }

--- a/app/src/components/SelectField/styles.css
+++ b/app/src/components/SelectField/styles.css
@@ -1,15 +1,27 @@
 @import '@opentrons/components';
 
-.dropdown_icon {
+.dropdown_icon_wrapper {
   position: absolute;
-  top: 0.2rem;
+  top: 0.25rem;
   right: 0.25rem;
   width: 1.25rem;
   pointer-events: none;
 
-  & svg {
+  & > svg {
     color: var(--c-dark-gray);
   }
+
+  &.flipped > svg {
+    transform: rotate(180deg);
+  }
+}
+
+.select_wrapper {
+  /* TODO(mc, 2018-10-29): this value comes from existing fields in components
+   * library that always render a caption div with a height, even when empty.
+   * Figure out what we should be doing here moving forward
+   */
+  padding-bottom: 0.625rem;
 }
 
 .select_control {
@@ -20,19 +32,38 @@
   padding: 0.25rem 0;
   outline: none;
   border-radius: 3px;
-  max-height: 1.75rem;
+  height: 1.75rem;
   box-shadow: none;
+
+  &.focus {
+    background-color: var(--c-white);
+    box-shadow: var(--shadow-lvl-1);
+  }
 }
 
 .select_menu {
   @apply --font-body-1-dark;
 
-  background-color: var(--c-light-gray);
-  border-radius: 3px;
-  padding: 0.25rem 0;
+  background-color: var(--c-white);
+  border-radius: 2px;
+  padding: 2px 0 0 0;
 }
 
-.error div,
-.error span {
+.select_group {
+  &:not(:first-child) {
+    border-top: 1px solid var(--c-med-gray);
+  }
+}
+
+.select_caption {
+  font-size: var(--fs-caption);
+}
+
+.error_bg {
+  background-color: var(--c-warning-light);
+}
+
+.error_color {
   color: var(--c-warning-dark);
+  font-weight: var(--fw-semibold);
 }

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -191,7 +191,8 @@
     color: var(--c-light-gray);
   }
 
-  & input { /* stylelint-disable no-descending-specificity */
+  /* stylelint-disable no-descending-specificity */
+  & input {
     color: var(--c-med-gray);
   }
 }


### PR DESCRIPTION
## overview

This PR closes #2415. See ticket for acceptance criteria. `refactor` because behind feature flag.

## changelog

- refactor(app): Enable certificate usage with 802.1x

## review requests

We have an EAP network in the office, which we're working on getting set up with certificate auth. Will ping Slack when it's ready, but until then please check out the code + UI.

### known issues

Still trying to figure out how caption and padding should interact:

- Current component library form fields have a div for caption that is always rendered, regardless of whether or not there's a caption to render
- That div has a height (via padding), which ends up kind of being an intrinsic padding for all CL form fields, only it cannot be overridden
- Until then, the padding + caption of the `SelectField` component (which is currently app-only) looks different than the other fields
