### PR TITLE
API: Add motion to protocol API

### DIFF
--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -1,5 +1,10 @@
+.. _protocol-api:
+
 New Protocol API
 ================
+
+
+.. _protocol-api-backcompat:
 
 Backwards Compatibility
 -----------------------
@@ -19,6 +24,8 @@ Backwards Compatibility
    :members:
 
 
+.. _protocol-api-robot:
+
 Robot and Pipette
 -----------------
 .. module:: opentrons.protocol_api.contexts
@@ -29,16 +36,24 @@ Robot and Pipette
 .. autoclass:: opentrons.protocol_api.contexts.InstrumentContext
    :members:
 
+
+.. _protocol-api-labware:
+
 Labware and Wells
 -----------------
 .. automodule:: opentrons.protocol_api.labware
    :members:
+
+
+.. _protocol-api-types:
 
 Useful Types and Definitions
 ----------------------------
 .. automodule:: opentrons.types
    :members:
 
+
+.. _protocol-api-deck-coords:
 
 Deck Coordinates
 ----------------

--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -1,0 +1,32 @@
+New Protocol API
+================
+
+Robot and Pipette
+-----------------
+.. module:: opentrons.protocol_api.contexts
+
+.. autoclass:: opentrons.protocol_api.contexts.ProtocolContext
+   :members:
+
+.. autoclass:: opentrons.protocol_api.contexts.InstrumentContext
+   :members:
+
+Labware and Wells
+-----------------
+.. automodule:: opentrons.protocol_api.labware
+   :members:
+
+Useful Types and Definitions
+----------------------------
+.. automodule:: opentrons.types
+   :members:
+
+
+Deck Coordinates
+----------------
+
+The OT2’s base coordinate system is known as deck coordinates. This coordinate system is referenced frequently through the API. It is a right-handed coordinate system always specified in mm, with `(0, 0, 0)` at the front left of the robot. `+x` is to the right, `+y` is to the back, and `+z` is up.
+
+Note that there are technically two `z` axes, one for each pipette mount. In these terms, `z` is the axis of the left pipette mount and `a` is the axis of the right pipette mount. These are obscured by the API’s habit of defining motion commands on a per-pipette basis; the pipettes internally select the correct `z` axis to move. This is also true of the pipette plunger axes, `b` (left) and `c` (right).
+
+When locations are specified to functions like :py:meth:`opentrons.protocol_api.contexts.InstrumentContext.move_to`, in addition to being an instance of :py:class:`opentrons.protocol_api.labware.Well` they may define coordinates in this deck coordinate space. These coordinates can be specified either as a standard python :py:class:`tuple` of three floats, or as an instance of the :py:class:`collections.namedtuple` :py:class:`opentrons.types.Point`, which can be created in the same way.

--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -1,6 +1,24 @@
 New Protocol API
 ================
 
+Backwards Compatibility
+-----------------------
+
+.. automodule:: opentrons.protocol_api.back_compat
+
+.. autoclass:: opentrons.protocol_api.back_compat.BCRobot
+   :members:
+
+.. autoclass:: opentrons.protocol_api.back_compat.BCInstruments
+   :members:
+
+.. autoclass:: opentrons.protocol_api.back_compat.BCLabware
+   :members:
+
+.. autoclass:: opentrons.protocol_api.back_compat.BCModules
+   :members:
+
+
 Robot and Pipette
 -----------------
 .. module:: opentrons.protocol_api.contexts

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -23,18 +23,26 @@ if not ff.split_labware_definitions():
     database_migration.check_version_and_perform_necessary_migrations()
 
 if ff.use_protocol_api_v2():
-    import protocol_api
-    from protocol_api.back_compat\
-        import robot, reset as bcreset, instruments, containers, labware,\
-        modules
+    import opentrons.hardware_control as hardware_control
+    try:
+        hardware = hardware_control.API.build_hardware_controller()
+        """ The global singleton of :py:class:`.hardware_control.API`.
 
-    def reset():
-        ctx = protocol_api.ProtocolContext()
-        bcreset(ctx)
-
-else:
-    from .legacy_api.api\
+        If this is running on a real robot (and no other Python process
+        is running on the robot) it will be connected to the actual
+        hardware. Otherwise, it will be a simulator.
+        """
+    except RuntimeError:
+        hardware = hardware_control.API.build_hardware_simulator()
+    from opentrons.protocol_api.back_compat\
         import robot, reset, instruments, containers, labware, modules
+else:
+    from .legacy_api.api import (robot,  # type: ignore
+                                 reset,  # type: ignore
+                                 instruments,  # type: ignore
+                                 containers,  # type: ignore
+                                 labware,  # type: ignore
+                                 modules)  # type: ignore
 
 
 __all__ = ['containers', 'instruments', 'labware', 'robot', 'reset',

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -28,9 +28,9 @@ if ff.use_protocol_api_v2():
         hardware = hardware_control.API.build_hardware_controller()
         """ The global singleton of :py:class:`.hardware_control.API`.
 
-        If this is running on a real robot (and no other Python process
-        is running on the robot) it will be connected to the actual
-        hardware. Otherwise, it will be a simulator.
+        If this is running on a real robot (and no other Opentrons API server
+        is running and connected to the robot's hardware) it will be connected
+        to the actual hardware. Otherwise, it will be a simulator.
         """
     except RuntimeError:
         hardware = hardware_control.API.build_hardware_simulator()

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,27 +1,36 @@
 from functools import lru_cache
+import os
 from opentrons.config import advanced_settings as advs
 
 
+def get_setting_with_env_overload(setting_name):
+    env_name = 'OT_FF_' + setting_name
+    if env_name in os.environ:
+        return os.environ[env_name].lower() in ('1', 'true', 'on')
+    else:
+        return advs.get_adv_setting(setting_name)
+
+
 def short_fixed_trash():
-    return advs.get_adv_setting('shortFixedTrash')
+    return get_setting_with_env_overload('shortFixedTrash')
 
 
 @lru_cache()
 def split_labware_definitions():
-    return advs.get_adv_setting('splitLabwareDefinitions')
+    return get_setting_with_env_overload('splitLabwareDefinitions')
 
 
 def calibrate_to_bottom():
-    return advs.get_adv_setting('calibrateToBottom')
+    return get_setting_with_env_overload('calibrateToBottom')
 
 
 def dots_deck_type():
-    return advs.get_adv_setting('deckCalibrationDots')
+    return get_setting_with_env_overload('deckCalibrationDots')
 
 
 def disable_home_on_boot():
-    return advs.get_adv_setting('disableHomeOnBoot')
+    return get_setting_with_env_overload('disableHomeOnBoot')
 
 
 def use_protocol_api_v2():
-    return advs.get_adv_setting('useProtocolApi2')
+    return get_setting_with_env_overload('useProtocolApi2')

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -215,8 +215,7 @@ class CLITool:
         log.debug("save_mount_offset mxyz: {}".format((mx, my, mz)))
         offset = (mx - dx, my - dy, mz - dz)
         log.debug("save_mount_offset mount offset: {}".format(offset))
-        robot.config = robot.config._replace(
-            mount_offset=offset)
+        robot.update_config(mount_offset=offset)
         msg = 'saved mount-offset: {}'.format(
             robot.config.mount_offset)
         return msg
@@ -244,8 +243,7 @@ class CLITool:
         log.debug("save_transform calibration_matrix: {}".format(
             gantry_calibration))
 
-        robot.config = robot.config._replace(
-            gantry_calibration=gantry_calibration)
+        robot.update_config(gantry_calibration=gantry_calibration)
         res = str(robot.config)
 
         return '{}\n{}'.format(res, save_config())
@@ -341,14 +339,14 @@ class CLITool:
 def probe(tip_length: float) -> str:
     robot.reset()
 
-    pipette = instruments.Pipette(
-        mount='right', channels=1, max_volume=1000, ul_per_mm=1000)
+    # TODO seth, 10/29/2018: Change this to not use a deprecated ctor
+    pipette = instruments.Pipette(  # type: ignore
+        mount='right', channels=1,
+        max_volume=1000, ul_per_mm=1000)
     probe_center = tuple(probe_instrument(
         pipette, robot, tip_length=tip_length))
     log.debug("Setting probe center to {}".format(probe_center))
-    robot.config = robot.config._replace(
-        probe_center=probe_center
-    )
+    robot.update_config(probe_center=probe_center)
     return 'Tip probe'
 
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -481,7 +481,8 @@ class API:
         """ Update values of the robot's configuration.
 
         `kwargs` should contain keys of the robot's configuration. For instace,
-        `update_config(name='Grace Hopper')` would change the name of the robot
+        `update_config(log_level='debug)` would change the API server log level
+        to :py:attr:`logging.DEBUG`.
 
         Documentation on keys can be found in the documentation for
         :py:class:`.robot_config`.

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -98,6 +98,7 @@ class API:
     @classmethod
     def build_hardware_controller(
             cls, config: robot_configs.robot_config = None,
+            port: str = None,
             loop: asyncio.AbstractEventLoop = None) -> 'API':
         """ Build a hardware controller that will actually talk to hardware.
 
@@ -109,7 +110,7 @@ class API:
             raise RuntimeError(
                 'The hardware controller may only be instantiated on a robot')
         backend = Controller(config, loop)
-        backend._connect()
+        backend.connect(port)
         return cls(backend, config=config, loop=loop)
 
     @classmethod
@@ -192,7 +193,7 @@ class API:
     def attached_instruments(self):
         configs = ['name', 'min_volume', 'max_volume',
                    'aspirate_flow_rate', 'dispense_flow_rate',
-                   'pipette_id']
+                   'pipette_id', 'current_volume', 'display_name']
         instruments = {top_types.Mount.LEFT: {},
                        top_types.Mount.RIGHT: {}}
         for mount in top_types.Mount:
@@ -470,7 +471,22 @@ class API:
     # Gantry/frame (i.e. not pipette) config API
     @property
     def config(self) -> robot_configs.robot_config:
+        """ Get the robot's configuration object.
+
+        :returns .robot_config: The object.
+        """
         return self._config
+
+    def update_config(self, **kwargs):
+        """ Update values of the robot's configuration.
+
+        `kwargs` should contain keys of the robot's configuration. For instace,
+        `update_config(name='Grace Hopper')` would change the name of the robot
+
+        Documentation on keys can be found in the documentation for
+        :py:class:`.robot_config`.
+        """
+        self._config = self._config._replace(**kwargs)
 
     async def update_deck_calibration(self, new_transform):
         pass

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -1,0 +1,57 @@
+""" Adapters for the :py:class:`.hardware_control.API` instances.
+"""
+import asyncio
+import functools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import hardware_control  # noqa(F401): Avoid circular dependency
+
+
+def sync_call(loop, to_call, *args, **kwargs):
+    loop.run_until_complete(to_call(*args, **kwargs))
+
+
+class SynchronousAdapter:
+    """ A wrapper to make every call into :py:class:`.hardware_control.API`
+    synchronous.
+
+    Example
+    -------
+    .. code-block::
+    >>> import opentrons.hardware_control as hc
+    >>> import opentrons.hardware_control.adapters as adapts
+    >>> api = hc.API.build_hardware_simulator()
+    >>> synch = adapts.SynchronousAdapter(api)
+    >>> synch.home()
+    """
+
+    def __init__(self, api: 'hardware_control.API') -> None:
+        """ Build the SynchronousAdapter.
+
+        :param api: The API instance to wrap
+        """
+        self._api = api
+        self._loop = self._api._loop
+
+    def __getattribute__(self, attr_name):
+        """ Retrieve attributes from our API and wrap coroutines """
+        # Almost every attribute retrieved from us will be fore people actually
+        # looking for an attribute of the hardware API, so check there first.
+        api = object.__getattribute__(self, '_api')
+        try:
+            attr = getattr(api, attr_name)
+        except AttributeError:
+            # Maybe this actually was for us? Let’s find it
+            return object.__getattribute__(self, attr_name)
+
+        try:
+            check = attr.__wrapped__
+        except AttributeError:
+            check = attr
+        if asyncio.iscoroutinefunction(check):
+            loop = object.__getattribute__(self, '_loop')
+            # Return a synchronized version of the coroutine
+            return functools.partial(sync_call, loop, attr)
+
+        return attr

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -157,8 +157,8 @@ class Controller:
         return await modules.update_firmware(
             module, firmware_file, loop)
 
-    def _connect(self):
-        self._smoothie_driver.connect()
+    def connect(self, port: str = None):
+        self._smoothie_driver.connect(port)
 
     @contextmanager
     def _set_temp_speed(self, speed):

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -1,15 +1,16 @@
-from . import robot, instruments as inst, containers as cnt, modules
+from . import (robot as _robot_module,
+               instruments as inst,
+               containers as cnt,
+               modules)
 from opentrons.config import pipette_config
 
 # Ignore the type here because well, this is exactly why this is the legacy_api
-robot = robot.Robot()  # type: ignore
+robot = _robot_module.Robot()  # type: ignore
 modules.provide_singleton(robot)
 
 
 def reset():
-    global robot
-    robot = robot.Robot()
-    modules.provide_singleton(robot)
+    robot.reset()
     return robot
 
 

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -65,7 +65,7 @@ class Robot(object):
     This class is the main interface to the robot.
 
     It should never be instantiated directly; instead, the global instance may
-    be accessed at :py:attr:``opentrons.robot``.
+    be accessed at :py:attr:`opentrons.robot`.
 
     Through this class you can can:
         * define your :class:`opentrons.Deck`
@@ -958,3 +958,12 @@ class Robot(object):
         )
         placeable_tallest_point = pose_tracker.max_z(self.poses, placeable)
         return placeable_coordinate[2] + placeable_tallest_point
+
+    def update_config(self, **kwargs):
+        """ Replace configuration values.
+
+        kwargs should contain configuration keys. For instance:
+        `robot.update_config(name='Grace Hopper')` will update the `name` key
+        of the configuration.
+        """
+        self.config._replace(**kwargs)

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,15 +4,12 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from collections import UserDict
-import enum
 import logging
 import os
-from typing import List, Dict
 
-from opentrons.protocol_api.labware import Well, Labware, load
-from opentrons import types
 from . import back_compat
+from .contexts import ProtocolContext, InstrumentContext
+
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -20,357 +17,32 @@ MODULE_LOG = logging.getLogger(__name__)
 def run(protocol_bytes: bytes = None,
         protocol_json: str = None,
         simulate: bool = False,
-        context: 'ProtocolContext' = None):
-        """ Create a ProtocolRunner instance from one of a variety of protocol
-        sources.
+        context: ProtocolContext = None):
+    """ Create a ProtocolRunner instance from one of a variety of protocol
+    sources.
 
-        :param protocol_bytes: If the protocol is a Python protocol, pass the
-        file contents here.
-        :param protocol_json: If the protocol is a json file, pass the contents
-        here.
-        :param simulate: True to simulate; False to execute. If thsi is not an
-        OT2, ``simulate`` will be forced ``True``.
-        :param context: The context to use. If ``None``, create a new
-        ProtocolContext.
-        """
-        if not os.environ.get('RUNNING_ON_PI'):
-            simulate = True # noqa - will be used later
-        if None is context and simulate:
-            true_context = ProtocolContext()
-        elif context:
-            true_context = context
-        else:
-            raise RuntimeError(
-                'Will not automatically generate hardware controller')
-        if protocol_bytes:
-            back_compat.run(protocol_bytes, true_context)
-        elif protocol_json:
-            pass
-
-
-class ProtocolContext:
-    """ The Context class is a container for the state of a protocol.
-
-    It encapsulates many of the methods formerly found in the Robot class,
-    including labware, instrument, and module loading; core functions like
-    pause and resume.
+    :param protocol_bytes: If the protocol is a Python protocol, pass the
+    file contents here.
+    :param protocol_json: If the protocol is a json file, pass the contents
+    here.
+    :param simulate: True to simulate; False to execute. If thsi is not an
+    OT2, ``simulate`` will be forced ``True``.
+    :param context: The context to use. If ``None``, create a new
+    ProtocolContext.
     """
-
-    def __init__(self):
-        self._deck_layout = Deck()
-
-    def load_labware(
-            self, labware_obj: Labware, location: types.DeckLocation,
-            label: str = None, share: bool = False) -> Labware:
-        """ Specify the presence of a piece of labware on the OT2 deck.
-
-        This function loads the labware specified by ``labware``
-        (previously loaded from a configuration file) to the location
-        specified by ``location``.
-        """
-        self._deck_layout[location] = labware_obj
-        return labware_obj
-
-    def load_labware_by_name(
-            self, labware_name: str, location: types.DeckLocation) -> Labware:
-        """ A convenience function to specify a piece of labware by name.
-
-        For labware already defined by Opentrons, this is a convient way
-        to collapse the two stages of labware initialization (creating
-        the labware and adding it to the protocol) into one.
-
-        This function returns the created and initialized labware for use
-        later in the protocol.
-        """
-        labware = load(labware_name,
-                       self._deck_layout.position_for(location), str(location))
-        return self.load_labware(labware, location)
-
-    @property
-    def loaded_labwares(self) -> Dict[int, Labware]:
-        """ Get the labwares that have been loaded into the protocol context.
-
-        The return value is a dict mapping locations to labware, sorted
-        in order of the locations.
-        """
-        return dict(self._deck_layout)
-
-    def load_instrument(
-            self, instrument_name: str, mount: str) \
-            -> 'InstrumentContext':
-        """ Specify a specific instrument required by the protocol.
-
-        This value will actually be checked when the protocol runs, to
-        ensure that the correct instrument is attached in the specified
-        location.
-        """
-        pass
-
-    @property
-    def loaded_instruments(self) -> Dict[str, 'InstrumentContext']:
-        """ Get the instruments that have been loaded into the protocol context
-
-        The return value is a dict mapping locations to instruments, sorted
-        in order of mounts (so 'left' (if any), then 'right' (if any))
-        """
-        pass
-
-    def pause(self):
-        """ Pause execution of the protocol until resume is called.
-
-        Note: This function call will not return until the protocol
-        is resumed (presumably by a user in the run app).
-        """
-        pass
-
-    def resume(self):
-        """ Resume a previously-paused protocol. """
-        pass
-
-    def comment(self, msg):
-        """ Add a user-readable comment string that will be echoed to the
-        Opentrons app. """
+    if not os.environ.get('RUNNING_ON_PI'):
+        simulate = True # noqa - will be used later
+    if None is context and simulate:
+        true_context = ProtocolContext()
+    elif context:
+        true_context = context
+    else:
+        raise RuntimeError(
+            'Will not automatically generate hardware controller')
+    if protocol_bytes:
+        back_compat.run(protocol_bytes, true_context)
+    elif protocol_json:
         pass
 
 
-class InstrumentContext:
-    """ A context for a specific pipette or instrument.
-
-    This can be used to call methods related to pipettes - moves or
-    aspirates or dispenses, or higher-level methods.
-
-    Instances of this class bundle up state and config changes to a
-    pipette - for instance, changes to flow rates or trash containers.
-    Action methods (like :py:meth:``aspirate`` or :py:meth:``distribute``) are
-    defined here for convenience.
-
-    In general, this class should not be instantiated directly; rather,
-    instances are returned from :py:meth:``ProtcolContext.load_instrument``.
-    """
-
-    class MODE(enum.Enum):
-        """ Definition for the modes in which a pipette can operate.
-        """
-        ASPIRATE = 'aspirate'
-        DISPENSE = 'dispense'
-
-    class TYPE(enum.Enum):
-        """ Definition for the types of pipettte.
-        """
-        SINGLE = 'single'
-        MULTI = 'multi'
-
-    def __init__(self, ctx, tip_racks,
-                 **config_kwargs):
-        pass
-
-    def aspirate(self,
-                 volume: float = None,
-                 location: Well = None,
-                 rate: float = 1.0):
-        pass
-
-    def dispense(self,
-                 volume: float = None,
-                 location: Well = None,
-                 rate: float = 1.0):
-        pass
-
-    def mix(self,
-            repetitions: int = 1,
-            volume: float = None,
-            location: Well = None,
-            rate: float = 1.0):
-        pass
-
-    def blow_out(self, location: Well = None):
-        pass
-
-    def touch_tip(self,
-                  location: Well = None,
-                  radius: float = 1.0,
-                  v_offset: float = -1.0,
-                  speed: float = 60.0):
-        pass
-
-    def air_gap(self,
-                volume: float = None,
-                height: float = None):
-        pass
-
-    def return_tip(self, home_after: bool = True):
-        pass
-
-    def pick_up_tip(self, location: Well = None,
-                    presses: int = 3,
-                    increment: int = 1):
-        pass
-
-    def drop_tip(self, location: Well = None,
-                 home_after: bool = True):
-        pass
-
-    def home(self):
-        pass
-
-    def distribute(self,
-                   volume: float,
-                   source: Well,
-                   dest: Well,
-                   *args, **kwargs):
-        pass
-
-    def consolidate(self,
-                    volume: float,
-                    source: Well,
-                    dest: Well,
-                    *args, **kwargs):
-        pass
-
-    def transfer(self,
-                 volume: float,
-                 source: Well,
-                 dest: Well,
-                 **kwargs):
-        pass
-
-    @property
-    def speeds(self) -> Dict[MODE, float]:
-        """ The speeds (in mm/s) configured for the pipette, as a dict.
-
-        The keys will be 'aspirate' and 'dispense' (e.g. the keys of
-        :py:class:`MODE`)
-
-        :note: This property is equivalent to :py:attr:`speeds`; the only
-        difference is the units in which this property is specified.
-        """
-        pass
-
-    @speeds.setter
-    def speeds(self, new_speeds: Dict[MODE, float]) -> None:
-        """ Update the speeds (in mm/s) set for the pipette.
-
-        :param new_speeds: A dict containing at least one of 'aspirate'
-        and 'dispense',  mapping to new speeds in mm/s.
-        """
-        pass
-
-    @property
-    def flow_rate(self) -> Dict[MODE, float]:
-        """ The speeds (in uL/s) configured for the pipette, as a dict.
-
-        The  keys will be 'aspirate' and 'dispense'.
-
-        :note: This property is equivalent to :py:attr:`speeds`; the only
-        difference is the units in which this property is specified.
-        """
-        pass
-
-    @flow_rate.setter
-    def flow_rate(self, new_flow_rate: Dict[MODE, float]) -> None:
-        """ Update the speeds (in uL/s) for the pipette.
-
-        :param new_flow_rates: A dict containing at least one of 'aspirate
-        and 'dispense', mapping to new speeds in uL/s.
-        """
-        pass
-
-    @property
-    def pick_up_current(self) -> float:
-        """
-        The current (amperes) the pipette mount's motor will use
-        while picking up a tip. Specified in amps.
-        """
-        pass
-
-    @pick_up_current.setter
-    def pick_up_current(self, amps: float):
-        """ Set the current used when picking up a tip.
-
-        :param amps: The current, in amperes. Acceptable values: (0.0, 2.0)
-        """
-        pass
-
-    @property
-    def type(self) -> TYPE:
-        """ One of :py:class:`TYPE`.
-        """
-        pass
-
-    @property
-    def tip_racks(self) -> List[Labware]:
-        """ Query which tipracks have been linked to this PipetteContext"""
-        pass
-
-    @tip_racks.setter
-    def tip_racks(self, racks: List[Labware]):
-        pass
-
-    @property
-    def trash_container(self) -> Labware:
-        """ The location the pipette will dispense trash to.
-        """
-        pass
-
-    @trash_container.setter
-    def trash_container(self, trash: Labware):
-        pass
-
-
-class Deck(UserDict):
-    def __init__(self):
-        super().__init__()
-        row_offset = 90.5
-        col_offset = 132.5
-        for idx in range(1, 13):
-            self.data[idx] = None
-        self._positions = {idx+1: types.Point((idx % 3) * col_offset,
-                                              idx//3 * row_offset,
-                                              0)
-                           for idx in range(12)}
-
-    @staticmethod
-    def _assure_int(key: object) -> int:
-        if isinstance(key, str):
-            return int(key)
-        elif isinstance(key, int):
-            return key
-        else:
-            raise TypeError(type(key))
-
-    def _check_name(self, key: object) -> int:
-        should_raise = False
-        try:
-            key_int = Deck._assure_int(key)
-        except Exception:
-            MODULE_LOG.exception("Bad slot name: {}".format(key))
-            should_raise = True
-        should_raise = should_raise or key_int not in self.data
-        if should_raise:
-            raise ValueError("Unknown slot: {}".format(key))
-        else:
-            return key_int
-
-    def __getitem__(self, key: types.DeckLocation) -> Labware:
-        return self.data[self._check_name(key)]
-
-    def __delitem__(self, key: types.DeckLocation) -> None:
-        self.data[self._check_name(key)] = None
-
-    def __setitem__(self, key: types.DeckLocation, val: Labware) -> None:
-        key_int = self._check_name(key)
-        if self.data.get(key_int) is not None:
-            raise ValueError('Deck location {} already has an item: {}'
-                             .format(key, self.data[key_int]))
-        self.data[key_int] = val
-
-    def __contains__(self, key: object) -> bool:
-        try:
-            key_int = self._check_name(key)
-        except ValueError:
-            return False
-        return key_int in self.data
-
-    def position_for(self, key: types.DeckLocation) -> types.Point:
-        key_int = self._check_name(key)
-        return self._positions[key_int]
+__all__ = ['run', 'ProtocolContext', 'InstrumentContext', 'back_compat']

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -25,7 +25,7 @@ def run(protocol_bytes: bytes = None,
     file contents here.
     :param protocol_json: If the protocol is a json file, pass the contents
     here.
-    :param simulate: True to simulate; False to execute. If thsi is not an
+    :param simulate: True to simulate; False to execute. If this is not an
     OT2, ``simulate`` will be forced ``True``.
     :param context: The context to use. If ``None``, create a new
     ProtocolContext.

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -3,69 +3,228 @@
 """
 
 import importlib.util
+from typing import Union, Any, List
 
-from typing import TYPE_CHECKING
+import opentrons.hardware_control as hc
+from opentrons.config.pipette_config import configs
+from opentrons.types import Mount
+from .labware import Labware
+from .contexts import ProtocolContext, InstrumentContext
 
-import opentrons
 
-if TYPE_CHECKING:
-    import opentrons.protocol_api as papi # noqa(F401) - used in func sigs
-
-
-def run(protocol_bytes: bytes, context: 'papi.ProtocolContext'):
-    reset(context)
+def run(protocol_bytes: bytes, context: ProtocolContext):
+    reset()
     source = importlib.util.decode_source(protocol_bytes)
     exec(source)
 
 
 class BCRobot:
-    def __init__(self, protocol_ctx: 'papi.ProtocolContext') -> None:
+    """ A backwards-compatibility shim for the `New Protocol API`_.
+
+    This class is for providing a global instance of a
+    :py:class:`.ProtocolContext` in an object called :py:attr:`.robot`. It
+    should not be instantiated by user code, and use of its methods should
+    be replaced with methods of :py:class:`.ProtocolContext`. For more
+    information on how to replace its methods, see the method documentation.
+
+    Attribute accesses to attributes not defined here will fall back to the
+    global :py:class:`.ProtocolContext`; for instance, calling `robot.reset()`
+    will fall back to calling :py:meth:`.ProtocolContext.reset`.
+
+    For more information see :py:class:`.ProtocolContext`.
+    """
+    def __init__(self, protocol_ctx: ProtocolContext) -> None:
         self._ctx = protocol_ctx
 
+    def connect(self, port: Union[str, hc.API] = None,
+                options: Any = None):
+        """ Connect to the robot hardware.
 
-class BCInstruments:
-    def __init__(self, ctx: 'papi.ProtocolContext') -> None:
-        pass
+        This function is provided for backwards compatibility. In most cases
+        it need not be called.
+
+        Calls to this method should be replaced with calls to
+        :py:meth:`.ProtocolContext.connect` (notice the difference in
+        arguments) if necessary; however, since the context of protocols
+        executed by an OT2 is automatically connected to either the hardware or
+        a simulator (depending on whether the protocol is being simulated or
+        run) this should be unnecessary.
+
+        :param port: The port to connect to the smoothie board; the magic
+                     string ``"Virtual Smoothie"``, which will initialize and
+                     connect to a simulator; or an initialized hardware control
+                     API.
+        :param options: Ignored.
+        """
+        if isinstance(port, str) and port == 'Virtual Smoothie':
+            self._ctx.connect(hc.API.build_hardware_simulator())
+        elif isinstance(port, hc.API):
+            self._ctx.connect(port)
+        else:
+            try:
+                self._ctx.connect(hc.API.build_hardware_controller(port=port))
+            except RuntimeError:
+                self._ctx.connect(hc.API.build_hardware_simulator())
+
+    def __getattr__(self, name):
+        """ Provide transparent access to the protocol context """
+        return getattr(self._ctx, name)
+
+
+class AddInstrumentCtors(type):
+
+    @staticmethod
+    def _build_initializer(model, proper_name):
+        """ Build an initializer function for a given pipette.
+
+        This is a separate function so that the `proper_name` is correctly
+        caught in the closure that it returns.
+        """
+        def initializer(
+                self,
+                mount: str,
+                trash_container: Labware = None,
+                tip_racks: List[Labware] = None,
+                aspirate_flow_rate: float = None,
+                dispense_flow_rate: float = None,
+                min_volume: float = None,
+                max_volume: float = None) -> InstrumentContext:
+            return AddInstrumentCtors._load_instr(self._ctx,
+                                                  model,
+                                                  mount)
+        initializer.__name__ = proper_name
+        initializer.__qualname__ = '.'.join([AddInstrumentCtors.__qualname__,
+                                             proper_name])
+        initializer.__doc__ = \
+            """Build a {} in a backwards-compatible way.
+
+            :param mount: The mount to load the instrument. One of
+                          `'left'` or `'right'`.
+            :param trash_container: If specified, a :py:class:`.Labware` to
+                                    use for trash.
+            :param tip_racks: If specified, a list of :py:class:`.Labware`
+                              containing tips.
+            :param aspirate_flow_rate: If specified, a flow rate (in uL/s)
+                                       to use when aspirating. By default,
+                                       the value from the pipette's
+                                       configuration.
+            :param dispense_flow_rate: If specified, a flow rate (in uL/s)
+                                       to use when dispensing. By default,
+                                       the value from the pipette's
+                                       configuration.
+            :param min_volume: The minimum volume that can be aspirated at
+                               once. By default, the pipette's minimum
+                               volume.
+            :param max_volume: The maximum volume that can be aspirated at
+                               once. By default, the pipette's maximum
+                               volume.
+
+            :returns: An :py:class:`.InstrumentContext`, which represents
+                      the newly-loaded pipette.
+            """.format(' '.join(proper_name.split('_')))
+        return initializer
+
+    @staticmethod
+    def _load_instr(ctx,
+                    name: str,
+                    mount: str,
+                    *args, **kwargs) -> InstrumentContext:
+        """ Build an instrument in a backwards-compatible way.
+
+        You should almost certainly not be calling this function from a
+        protocol; if you want to create a pipette on a lower level, use
+        :py:meth:`.ProtocolContext.load_instrument` directly, and if you
+        want to create an instrument easily use one of the partials below.
+        """
+        return ctx.load_instrument(name, Mount[mount.upper()])
+
+    def __new__(cls, name, bases, namespace, **kwds):
+        """ Add the pipette initializer functions to the class. """
+        res = type.__new__(cls, name, bases, namespace)
+        for config in configs:
+            # Split the long name with the version
+            comps = config.split('_')
+            # To get the name without the version
+            generic_model = '_'.join(comps[:2])
+            number = comps[0].upper()
+            ptype_0 = comps[1][0].upper()
+            # And a nicely formatted version to name the function
+            ptype = ptype_0 + comps[1][1:]
+            proper_name = number + '_' + ptype
+            if hasattr(res, proper_name):
+                # Only build one initializer function for each versionless
+                # model (i.e. don’t make a P10_Single for both p10_single_v1
+                # and p10_single_v1.3)
+                continue
+
+            initializer = cls._build_initializer(generic_model, proper_name)
+            setattr(res, proper_name, initializer)
+
+        return res
+
+
+class BCInstruments(metaclass=AddInstrumentCtors):
+    """ A backwards-compatibility shim for the `New Protocol API`_.
+
+    This class is provides a replacement for the `opentrons.instrument`
+    global instance. Like that global instance, it shims object creation
+    functions for ease of use. It should not be instantiated by user code, and
+    use of its methods should be replaced with use of the corresponding methods
+    of :py:class:`.ProtocolContext`. For information on how to replace calls to
+    methods of this class, see the method documentation.
+    """
+    def __init__(self, ctx: ProtocolContext) -> None:
+        self._ctx = ctx
 
 
 class BCLabware:
-    def __init__(self, ctx: 'papi.ProtocolContext') -> None:
+    """ A backwards-compatibility shim for the `New Protocol API`_.
+
+    This class provides a replacement for the `opentrons.labware` and
+    `opentrons.containers` global instances. Like those global instances,
+    this class shims labware load functions for ease of use. This class should
+    not be instantiated by user code, and use of its methods should be
+    replaced with use of the corresponding functions of
+    :py:class:`.ProtocolContext`. For information on how to replace calls to
+    methods of this class, see the method documentation.
+    """
+    def __init__(self, ctx: ProtocolContext) -> None:
         self._ctx = ctx
 
     def load(self, *args, **kwargs):
+        """ Load a piece of labware by specifying its name and position.
+
+        This method calls :py:meth:`.ProtocolContext.load_labware_by_name`;
+        see that documentation for more information on arguments and return
+        values. Calls to this function should be replaced with calls to
+        :py:meth:`.Protocolcontext.load_labware_by_name`.
+        """
         return self._ctx.load_labware_by_name(*args, **kwargs)
 
     def create(self,  *args, **kwargs):
-        pass
+        raise NotImplementedError
 
     def list(self, *args, **kwargs):
-        pass
+        raise NotImplementedError
 
 
 class BCModules:
-    def __init__(self, ctx: 'papi.ProtocolContext') -> None:
+    def __init__(self, ctx: ProtocolContext) -> None:
         self._ctx = ctx
 
     def load(self, *args, **wargs):
         pass
 
 
-def reset(api: 'papi.ProtocolContext'):
-    global robot
-    global labware
-    global containers
-    global instruments
-    robot = BCRobot(api)
-    labware = BCLabware(api)
-    containers = labware
-    instruments = BCInstruments(api)
+robot = BCRobot(ProtocolContext())
+labware = BCLabware(robot._ctx)
+containers = labware
+instruments = BCInstruments(robot._ctx)
+modules = BCModules(robot._ctx)
+
+
+def reset():
     return robot
 
 
-__version__ = opentrons.__version__
-robot = None
-labware = None
-containers = None
-instruments = None
-
-__all__ = ['containers', 'instruments', 'labware', 'robot', 'reset']
+__all__ = ['containers', 'instruments', 'labware', 'robot', 'reset', 'modules']

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,0 +1,290 @@
+import enum
+import logging
+from typing import List, Dict
+
+from opentrons.protocol_api.labware import Well, Labware, load
+from opentrons import types
+from . import geometry
+
+
+MODULE_LOG = logging.getLogger(__name__)
+
+
+class ProtocolContext:
+    """ The Context class is a container for the state of a protocol.
+
+    It encapsulates many of the methods formerly found in the Robot class,
+    including labware, instrument, and module loading; core functions like
+    pause and resume.
+    """
+
+    def __init__(self) -> None:
+        self._deck_layout = geometry.Deck()
+
+    def load_labware(
+            self, labware_obj: Labware, location: types.DeckLocation,
+            label: str = None, share: bool = False) -> Labware:
+        """ Specify the presence of a piece of labware on the OT2 deck.
+
+        This function loads the labware specified by ``labware``
+        (previously loaded from a configuration file) to the location
+        specified by ``location``.
+        """
+        self._deck_layout[location] = labware_obj
+        return labware_obj
+
+    def load_labware_by_name(
+            self, labware_name: str, location: types.DeckLocation) -> Labware:
+        """ A convenience function to specify a piece of labware by name.
+
+        For labware already defined by Opentrons, this is a convient way
+        to collapse the two stages of labware initialization (creating
+        the labware and adding it to the protocol) into one.
+
+        This function returns the created and initialized labware for use
+        later in the protocol.
+        """
+        labware = load(labware_name,
+                       self._deck_layout.position_for(location),
+                       str(location))
+        return self.load_labware(labware, location)
+
+    @property
+    def loaded_labwares(self) -> Dict[int, Labware]:
+        """ Get the labwares that have been loaded into the protocol context.
+
+        The return value is a dict mapping locations to labware, sorted
+        in order of the locations.
+        """
+        return dict(self._deck_layout)
+
+    def load_instrument(
+                    self, instrument_name: str, mount: types.Mount) \
+            -> 'InstrumentContext':
+        """ Specify a specific instrument required by the protocol.
+
+        This value will actually be checked when the protocol runs, to
+        ensure that the correct instrument is attached in the specified
+        location.
+        """
+        pass
+
+    @property
+    def loaded_instruments(self) -> Dict[str, 'InstrumentContext']:
+        """ Get the instruments that have been loaded into the protocol context
+
+        The return value is a dict mapping locations to instruments, sorted
+        in order of mounts (so 'left' (if any), then 'right' (if any))
+        """
+        pass
+
+    def pause(self):
+        """ Pause execution of the protocol until resume is called.
+
+        Note: This function call will not return until the protocol
+        is resumed (presumably by a user in the run app).
+        """
+        pass
+
+    def resume(self):
+        """ Resume a previously-paused protocol. """
+        pass
+
+    def comment(self, msg):
+        """ Add a user-readable comment string that will be echoed to the
+        Opentrons app. """
+        pass
+
+    def move_to(self, mount: types.Mount,
+                location: geometry.Location,
+                strategy: types.MotionStrategy = None):
+        pass
+
+
+class InstrumentContext:
+    """ A context for a specific pipette or instrument.
+
+    This can be used to call methods related to pipettes - moves or
+    aspirates or dispenses, or higher-level methods.
+
+    Instances of this class bundle up state and config changes to a
+    pipette - for instance, changes to flow rates or trash containers.
+    Action methods (like :py:meth:``aspirate`` or :py:meth:``distribute``) are
+    defined here for convenience.
+
+    In general, this class should not be instantiated directly; rather,
+    instances are returned from :py:meth:``ProtcolContext.load_instrument``.
+    """
+
+    class MODE(enum.Enum):
+        """ Definition for the modes in which a pipette can operate.
+        """
+        ASPIRATE = 'aspirate'
+        DISPENSE = 'dispense'
+
+    class TYPE(enum.Enum):
+        """ Definition for the types of pipettte.
+        """
+        SINGLE = 'single'
+        MULTI = 'multi'
+
+    def __init__(self, ctx, mount: types.Mount, tip_racks,
+                 **config_kwargs) -> None:
+        pass
+
+    def aspirate(self,
+                 volume: float = None,
+                 location: Well = None,
+                 rate: float = 1.0):
+        pass
+
+    def dispense(self,
+                 volume: float = None,
+                 location: Well = None,
+                 rate: float = 1.0):
+        pass
+
+    def mix(self,
+            repetitions: int = 1,
+            volume: float = None,
+            location: Well = None,
+            rate: float = 1.0):
+        pass
+
+    def blow_out(self, location: Well = None):
+        pass
+
+    def touch_tip(self,
+                  location: Well = None,
+                  radius: float = 1.0,
+                  v_offset: float = -1.0,
+                  speed: float = 60.0):
+        pass
+
+    def air_gap(self,
+                volume: float = None,
+                height: float = None):
+        pass
+
+    def return_tip(self, home_after: bool = True):
+        pass
+
+    def pick_up_tip(self, location: Well = None,
+                    presses: int = 3,
+                    increment: int = 1):
+        pass
+
+    def drop_tip(self, location: Well = None,
+                 home_after: bool = True):
+        pass
+
+    def home(self):
+        pass
+
+    def distribute(self,
+                   volume: float,
+                   source: Well,
+                   dest: Well,
+                   *args, **kwargs):
+        pass
+
+    def consolidate(self,
+                    volume: float,
+                    source: Well,
+                    dest: Well,
+                    *args, **kwargs):
+        pass
+
+    def transfer(self,
+                 volume: float,
+                 source: Well,
+                 dest: Well,
+                 **kwargs):
+        pass
+
+    def move_to(self,
+                location: geometry.Location,
+                strategy: types.MotionStrategy = None):
+        pass
+
+    @property
+    def speeds(self) -> Dict[MODE, float]:
+        """ The speeds (in mm/s) configured for the pipette, as a dict.
+
+        The keys will be 'aspirate' and 'dispense' (e.g. the keys of
+        :py:class:`MODE`)
+
+        :note: This property is equivalent to :py:attr:`speeds`; the only
+        difference is the units in which this property is specified.
+        """
+        pass
+
+    @speeds.setter
+    def speeds(self, new_speeds: Dict[MODE, float]) -> None:
+        """ Update the speeds (in mm/s) set for the pipette.
+
+        :param new_speeds: A dict containing at least one of 'aspirate'
+        and 'dispense',  mapping to new speeds in mm/s.
+        """
+        pass
+
+    @property
+    def flow_rate(self) -> Dict[MODE, float]:
+        """ The speeds (in uL/s) configured for the pipette, as a dict.
+
+        The  keys will be 'aspirate' and 'dispense'.
+
+        :note: This property is equivalent to :py:attr:`speeds`; the only
+        difference is the units in which this property is specified.
+        """
+        pass
+
+    @flow_rate.setter
+    def flow_rate(self, new_flow_rate: Dict[MODE, float]) -> None:
+        """ Update the speeds (in uL/s) for the pipette.
+
+        :param new_flow_rates: A dict containing at least one of 'aspirate
+        and 'dispense', mapping to new speeds in uL/s.
+        """
+        pass
+
+    @property
+    def pick_up_current(self) -> float:
+        """
+        The current (amperes) the pipette mount's motor will use
+        while picking up a tip. Specified in amps.
+        """
+        pass
+
+    @pick_up_current.setter
+    def pick_up_current(self, amps: float):
+        """ Set the current used when picking up a tip.
+
+        :param amps: The current, in amperes. Acceptable values: (0.0, 2.0)
+        """
+        pass
+
+    @property
+    def type(self) -> TYPE:
+        """ One of :py:class:`TYPE`.
+        """
+        pass
+
+    @property
+    def tip_racks(self) -> List[Labware]:
+        """ Query which tipracks have been linked to this PipetteContext"""
+        pass
+
+    @tip_racks.setter
+    def tip_racks(self, racks: List[Labware]):
+        pass
+
+    @property
+    def trash_container(self) -> Labware:
+        """ The location the pipette will dispense trash to.
+        """
+        pass
+
+    @trash_container.setter
+    def trash_container(self, trash: Labware):
+        pass

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,9 +1,10 @@
+import asyncio
 import enum
 import logging
 from typing import List, Dict
 
 from opentrons.protocol_api.labware import Well, Labware, load
-from opentrons import types
+from opentrons import types, hardware_control as hc
 from . import geometry
 
 
@@ -18,8 +19,30 @@ class ProtocolContext:
     pause and resume.
     """
 
-    def __init__(self) -> None:
+    def __init__(self,
+                 hardware: hc.API = None,
+                 loop: asyncio.AbstractEventLoop = None) -> None:
+        self._loop = loop or asyncio.get_event_loop()
+        if hardware:
+            self._hardware = hardware
+        else:
+            self._hardware = hc.API.build_hardware_simulator(loop=self._loop)
         self._deck_layout = geometry.Deck()
+        self._instruments = {mount: None for mount in types.Mount}
+
+    def connect(self, hardware: hc.API):
+        """ Connect to a running hardware API.
+
+        This can be either a simulator or a full hardware controller.
+        """
+        self._hardware = hardware
+        self._loop.run_until_complete(
+            self._hardware.cache_instruments())
+
+    def disconnect(self):
+        """ Disconnect from currently-connected hardware and simulate instead
+        """
+        self.connect(hc.API.build_hardware_simulator())
 
     def load_labware(
             self, labware_obj: Labware, location: types.DeckLocation,
@@ -59,7 +82,7 @@ class ProtocolContext:
         return dict(self._deck_layout)
 
     def load_instrument(
-                    self, instrument_name: str, mount: types.Mount) \
+            self, instrument_name: str, mount: types.Mount) \
             -> 'InstrumentContext':
         """ Specify a specific instrument required by the protocol.
 
@@ -67,16 +90,16 @@ class ProtocolContext:
         ensure that the correct instrument is attached in the specified
         location.
         """
-        pass
-
-    @property
-    def loaded_instruments(self) -> Dict[str, 'InstrumentContext']:
-        """ Get the instruments that have been loaded into the protocol context
-
-        The return value is a dict mapping locations to instruments, sorted
-        in order of mounts (so 'left' (if any), then 'right' (if any))
-        """
-        pass
+        attached = {att_mount: instr.get('name', None)
+                    for att_mount, instr
+                    in self._hardware.attached_instruments.items()}
+        attached[mount] = instrument_name
+        self._loop.run_until_complete(
+            self._hardware.cache_instruments(attached))
+        # If the cache call didn’t raise, the instrument is attached
+        return InstrumentContext(self, mount,
+                                 [],
+                                 self._hardware.attached_instruments[mount])
 
     def pause(self):
         """ Pause execution of the protocol until resume is called.
@@ -98,7 +121,13 @@ class ProtocolContext:
     def move_to(self, mount: types.Mount,
                 location: geometry.Location,
                 strategy: types.MotionStrategy = None):
-        pass
+        where = geometry.point_from_location(location)
+        self._loop.run_until_complete(self._hardware.move_to(mount, where))
+
+    def home(self):
+        """ Homes the robot.
+        """
+        self._loop.run_until_complete(self._hardware.home())
 
 
 class InstrumentContext:
@@ -129,8 +158,11 @@ class InstrumentContext:
         MULTI = 'multi'
 
     def __init__(self, ctx, mount: types.Mount, tip_racks,
+                 info,
                  **config_kwargs) -> None:
-        pass
+        self._ctx = ctx
+        self._info = info
+        self._mount = mount
 
     def aspirate(self,
                  volume: float = None,
@@ -179,7 +211,12 @@ class InstrumentContext:
         pass
 
     def home(self):
-        pass
+        """ Home the robot.
+
+        :returns: This instance.
+        """
+        self._ctx.home()
+        return self
 
     def distribute(self,
                    volume: float,
@@ -205,7 +242,12 @@ class InstrumentContext:
     def move_to(self,
                 location: geometry.Location,
                 strategy: types.MotionStrategy = None):
-        pass
+        self._ctx.move_to(self._mount, location, strategy)
+        return self
+
+    @property
+    def mount(self) -> str:
+        return self._mount.name.lower()
 
     @property
     def speeds(self) -> Dict[MODE, float]:
@@ -288,3 +330,7 @@ class InstrumentContext:
     @trash_container.setter
     def trash_container(self, trash: Labware):
         pass
+
+    @property
+    def name(self):
+        return self._info['name']

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -287,7 +287,7 @@ class InstrumentContext:
                          unspecified, the current position. For advanced usage,
                          an (x, y, z) tuple or instance of
                          :py:class:`types.Point` may be passed. This is a
-                         location in `Deck Coordinates`_.
+                         location in :ref:`protocol-api-deck-coords`.
         :type location: Well or tuple[float, float, float] or types.Point
         :param rate: The relative plunger speed for this aspirate. During
                      this aspirate, the speed of the plunger will be
@@ -348,7 +348,7 @@ class InstrumentContext:
                          unspecified, the bottom of the current well. For
                          advanced usage, an `(x, y, z)` tuple or instance of
                          :py:class:`types.Point` may be passed containing a
-                         location in `Deck Coordinates`_.
+                         location in :ref:`protocol-api-deck-coords`.
         :type location: .Well or tuple[float, float, float] or types.Point
         :param rate: The relative plunger speed for this aspirate. During
                      this aspirate, the speed of the plunger will be
@@ -458,7 +458,8 @@ class InstrumentContext:
                          well; or a position, whether specified by the result
                          of a call to something like :py:class:`.Well.top` or
                          directly specified as a `tuple` or
-                         :py:attr:`types.Point` in `Deck Coordinates`_.
+                         :py:attr:`types.Point` in
+                         :ref:`protocol-api-deck-coords`.
         :type location: Well or tuple[float, float, float] or types.Point
         :param strategy: How to move. This can be a member of
                          :py:class:`types.MotionStrategy` or one of the strings

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,10 +1,11 @@
 import asyncio
-import enum
 import logging
-from typing import List, Dict
+from typing import Any, Dict, List, Optional, Union
 
-from opentrons.protocol_api.labware import Well, Labware, load
+from .labware import Well, Labware, load
 from opentrons import types, hardware_control as hc
+import opentrons.config.robot_configs as rc
+from opentrons.hardware_control import adapters
 from . import geometry
 
 
@@ -15,43 +16,56 @@ class ProtocolContext:
     """ The Context class is a container for the state of a protocol.
 
     It encapsulates many of the methods formerly found in the Robot class,
-    including labware, instrument, and module loading; core functions like
-    pause and resume.
+    including labware, instrument, and module loading, as well as core
+    functions like pause and resume.
+
+    Unlike the old robot class, it is designed to be ephemeral. The lifetime
+    of a particular instance should be about the same as the lifetime of a
+    protocol. The only exception is the one stored in
+    :py:attr:`.back_compat.robot`, which is provided only for back
+    compatibility and should be used less and less as time goes by.
     """
 
     def __init__(self,
-                 hardware: hc.API = None,
                  loop: asyncio.AbstractEventLoop = None) -> None:
+        """ Build a :py:class:`.ProtocolContext`.
+
+        :param loop: An event loop to use. If not specified, this ctor will
+                     (eventually) call :py:meth:`asyncio.get_event_loop`.
+        """
         self._loop = loop or asyncio.get_event_loop()
-        if hardware:
-            self._hardware = hardware
-        else:
-            self._hardware = hc.API.build_hardware_simulator(loop=self._loop)
         self._deck_layout = geometry.Deck()
-        self._instruments = {mount: None for mount in types.Mount}
+        self._instruments: Dict[types.Mount, Optional[InstrumentContext]]\
+            = {mount: None for mount in types.Mount}
+        self._last_moved_instrument: Optional[types.Mount] = None
+        self._hardware = self._build_hardware_adapter(self._loop)
+        self._log = MODULE_LOG.getChild(self.__class__.__name__)
 
     def connect(self, hardware: hc.API):
         """ Connect to a running hardware API.
 
         This can be either a simulator or a full hardware controller.
+
+        Note that there is no true disconnected state for a
+        :py:class:`.ProtocolContext`; :py:meth:`disconnect` simply creates
+        a new simulator and replaces the current hardware with it.
         """
-        self._hardware = hardware
-        self._loop.run_until_complete(
-            self._hardware.cache_instruments())
+        self._hardware = self._build_hardware_adapter(self._loop, hardware)
+        self._hardware.cache_instruments()
 
     def disconnect(self):
         """ Disconnect from currently-connected hardware and simulate instead
         """
-        self.connect(hc.API.build_hardware_simulator())
+        self._hardware = self._build_hardware_adapter(self._loop)
 
     def load_labware(
             self, labware_obj: Labware, location: types.DeckLocation,
             label: str = None, share: bool = False) -> Labware:
         """ Specify the presence of a piece of labware on the OT2 deck.
 
-        This function loads the labware specified by ``labware``
+        This function loads the labware specified by `labware`
         (previously loaded from a configuration file) to the location
-        specified by ``location``.
+        specified by `location`.
         """
         self._deck_layout[location] = labware_obj
         return labware_obj
@@ -82,24 +96,69 @@ class ProtocolContext:
         return dict(self._deck_layout)
 
     def load_instrument(
-            self, instrument_name: str, mount: types.Mount) \
-            -> 'InstrumentContext':
-        """ Specify a specific instrument required by the protocol.
+            self,
+            instrument_name: str,
+            mount: types.Mount,
+            replace: bool = False) -> 'InstrumentContext':
+        """ Load a specific instrument required by the protocol.
 
         This value will actually be checked when the protocol runs, to
         ensure that the correct instrument is attached in the specified
         location.
+
+        :param str instrument_name: The name of the instrument model, or a
+                                    prefix. For instance, 'p10_single' may be
+                                    used to request a P10 single regardless of
+                                    the version.
+        :param types.Mount mount: The mount in which this instrument should be
+                                  attached.
+        :param bool replace: Indicate that the currently-loaded instrument in
+                             `mount` (if such an instrument exists) should be
+                             replaced by `instrument_name`.
         """
+        self._log.info("Trying to load {} on {} mount"
+                       .format(instrument_name, mount.name.lower()))
+        instr = self._instruments[mount]
+        if instr and not replace:
+            raise RuntimeError("Instrument already present in {} mount: {}"
+                               .format(mount.name.lower(),
+                                       instr.name))
         attached = {att_mount: instr.get('name', None)
                     for att_mount, instr
                     in self._hardware.attached_instruments.items()}
         attached[mount] = instrument_name
-        self._loop.run_until_complete(
-            self._hardware.cache_instruments(attached))
+        self._log.debug("cache instruments expectation: {}"
+                        .format(attached))
+        self._hardware.cache_instruments(attached)
         # If the cache call didn’t raise, the instrument is attached
-        return InstrumentContext(self, mount,
-                                 [],
-                                 self._hardware.attached_instruments[mount])
+        new_instr = InstrumentContext(
+            self, self._hardware, mount, [], self._log)
+        self._instruments[mount] = new_instr
+        self._log.info("Instrument {} loaded".format(new_instr))
+        return new_instr
+
+    @property
+    def loaded_instruments(self) -> Dict[str, Optional['InstrumentContext']]:
+        """ Get the instruments that have been loaded into the protocol.
+
+        :returns: A dict mapping mount names in lowercase to the instrument
+                  in that mount, or `None` if no instrument is present.
+        """
+        return {mount.name.lower(): instr for mount, instr
+                in self._instruments.items()}
+
+    def reset(self):
+        """ Reset the state of the context and the hardware.
+
+        For instance, this call will
+        - reset all cached knowledge about attached tips
+        - unload all labware
+        - unload all instruments
+        - clear all location and instrument caches
+
+        The only state that will be kept is the position of the robot.
+        """
+        raise NotImplementedError
 
     def pause(self):
         """ Pause execution of the protocol until resume is called.
@@ -107,27 +166,69 @@ class ProtocolContext:
         Note: This function call will not return until the protocol
         is resumed (presumably by a user in the run app).
         """
-        pass
+        raise NotImplementedError
 
     def resume(self):
         """ Resume a previously-paused protocol. """
-        pass
+        raise NotImplementedError
 
     def comment(self, msg):
         """ Add a user-readable comment string that will be echoed to the
         Opentrons app. """
-        pass
+        raise NotImplementedError
+
+    @property
+    def config(self) -> rc.robot_config:
+        """ Get the robot's configuration object.
+
+        :returns .robot_config: The loaded configuration.
+        """
+        return self._hardware.config
+
+    def update_config(self, **kwargs):
+        """ Update values of the robot's configuration.
+
+        `kwargs` should contain keys of the robot's configuration. For instace,
+        `update_config(name='Grace Hopper')` would change the name of the robot
+
+        Documentation on keys can be found in the documentation for
+        :py:class:`.robot_config`.
+        """
+        self._hardware.update_config(**kwargs)
 
     def move_to(self, mount: types.Mount,
                 location: geometry.Location,
-                strategy: types.MotionStrategy = None):
+                strategy: types.MotionStrategy):
         where = geometry.point_from_location(location)
-        self._loop.run_until_complete(self._hardware.move_to(mount, where))
+        if self._last_moved_instrument\
+           and self._last_moved_instrument != mount:
+            # TODO: Is 10 the right number here? This is what’s used in
+            # robot since it’s a default to an argument that is never
+            # changed
+            self._log.debug("retract {}".format(self._last_moved_instrument))
+            self._hardware.retract(self._last_moved_instrument, 10)
+        if strategy == types.MotionStrategy.DIRECT:
+            self._hardware.move_to(mount, where)
+            self._log.debug("move {} direct {}".format(mount.name, where))
+        else:
+            self._log.debug("move {} arc {}".format(mount.name, where))
+            self._log.warn(
+                "Arc moves are not implemented, following back to direct")
+            self._hardware.move_to(mount, where)
 
     def home(self):
         """ Homes the robot.
         """
-        self._loop.run_until_complete(self._hardware.home())
+        self._log.debug("home")
+        self._hardware.home()
+
+    @staticmethod
+    def _build_hardware_adapter(
+            loop: asyncio.AbstractEventLoop,
+            hardware: hc.API = None) -> adapters.SynchronousAdapter:
+        if not hardware:
+            hardware = hc.API.build_hardware_simulator(loop=loop)
+        return adapters.SynchronousAdapter(hardware)
 
 
 class InstrumentContext:
@@ -138,77 +239,183 @@ class InstrumentContext:
 
     Instances of this class bundle up state and config changes to a
     pipette - for instance, changes to flow rates or trash containers.
-    Action methods (like :py:meth:``aspirate`` or :py:meth:``distribute``) are
+    Action methods (like :py:meth:`aspirate` or :py:meth:`distribute`) are
     defined here for convenience.
 
     In general, this class should not be instantiated directly; rather,
-    instances are returned from :py:meth:``ProtcolContext.load_instrument``.
+    instances are returned from :py:meth:`ProtcolContext.load_instrument`.
     """
 
-    class MODE(enum.Enum):
-        """ Definition for the modes in which a pipette can operate.
-        """
-        ASPIRATE = 'aspirate'
-        DISPENSE = 'dispense'
-
-    class TYPE(enum.Enum):
-        """ Definition for the types of pipettte.
-        """
-        SINGLE = 'single'
-        MULTI = 'multi'
-
-    def __init__(self, ctx, mount: types.Mount, tip_racks,
-                 info,
+    def __init__(self,
+                 ctx: ProtocolContext,
+                 hardware: adapters.SynchronousAdapter,
+                 mount: types.Mount, tip_racks,
+                 log_parent: logging.Logger,
                  **config_kwargs) -> None:
+        self._hardware = hardware
         self._ctx = ctx
-        self._info = info
         self._mount = mount
+        self._last_location: Union[Labware, Well, None] = None
+        self._log = log_parent.getChild(repr(self))
+        self._log.info("attached")
 
     def aspirate(self,
                  volume: float = None,
-                 location: Well = None,
+                 location: geometry.Location = None,
                  rate: float = 1.0):
-        pass
+        """
+        Aspirate a volume of liquid (in microliters/uL) using this pipette
+        from the specified location
+
+        If only a volume is passed, the pipette will aspirate
+        from its current position. If only a location is passed,
+        :py:meth:`aspirate` will default to its :py:attr:`max_volume`.
+
+        The location may be a :py:class:`.Well`, or a specific position in
+        relation to a :py:class:`.Well`, such as the return value of
+        :py:meth:`.Well.top`. If a :py:class:`.Well` is specified without
+        calling a position method (such as :py:meth:`.Well.top` or
+        :py:meth:`.Well.bottom`), this method will aspirate from the bottom
+        of the well.
+
+        :param volume: The volume to aspirate, in microliters. If not
+                       specified, :py:attr:`max_volume`.
+        :type volume: int or float
+        :param location: Where to aspirate from. A :py:class:`.Well` or
+                         position (e.g. the return value from
+                         :py:meth:`.Well.top` or :py:meth:`.Well.bottom`). If
+                         unspecified, the current position. For advanced usage,
+                         an (x, y, z) tuple or instance of
+                         :py:class:`types.Point` may be passed. This is a
+                         location in `Deck Coordinates`_.
+        :type location: Well or tuple[float, float, float] or types.Point
+        :param rate: The relative plunger speed for this aspirate. During
+                     this aspirate, the speed of the plunger will be
+                     `rate` * :py:attr:`aspirate_speed`. If not specified,
+                     defaults to 1.0 (speed will not be modified).
+        :type rate: float
+        :returns: This instance.
+
+        Examples
+        --------
+        ..
+        >>> from opentrons import instruments, labware, robot # doctest: +SKIP
+        >>> robot.reset() # doctest: +SKIP
+        >>> plate = labware.load('96-flat', '2') # doctest: +SKIP
+        >>> p300 = instruments.P300_Single(mount='right') # doctest: +SKIP
+        >>> p300.pick_up_tip() # doctest: +SKIP
+        # aspirate 50uL from a Well
+        >>> p300.aspirate(50, plate[0]) # doctest: +SKIP
+        # aspirate 50uL from the center of a well
+        >>> p300.aspirate(50, plate[1].bottom()) # doctest: +SKIP
+        >>> # aspirate 20uL in place, twice as fast
+        >>> p300.aspirate(20, rate=2.0) # doctest: +SKIP
+        >>> # aspirate the pipette's remaining volume (80uL) from a Well
+        >>> p300.aspirate(plate[2]) # doctest: +SKIP
+        """
+        where = self._get_point_and_cache(location, 'bottom')
+        self._log.debug("aspirate {} from {} at {}"
+                        .format(volume, where, rate))
+        self._ctx.move_to(self._mount, where, types.MotionStrategy.ARC)
+        self._hardware.aspirate(self._mount, volume, rate)
+        return self
 
     def dispense(self,
                  volume: float = None,
-                 location: Well = None,
+                 location: geometry.Location = None,
                  rate: float = 1.0):
-        pass
+        """
+        Dispense a volume of liquid (in microliters/uL) using this pipette
+        into the specified location.
+
+        If only a volume is passed, the pipette will dispense from its current
+        position. If only a location is passed, all of the liquid aspirated
+        into the pipette will be dispensed (this volume is accessible through
+        :py:attr:`current_volume`).
+
+        The location may be a :py:class:`.Well`, or a specific position in
+        relation to a :py:class:`.Well`, such as :py:meth:`.Well.top`. If a
+        :py:class:`.Well` is specified without calling a position method
+        (such as :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the liquid
+        will be dispensed at the bottom of the well.
+
+        :param volume: The volume of liquid to dispense, in microliters. If not
+                       specified, defaults to :py:attr:`current_volume`.
+        :type volume: int or float
+        :param location: Where to dispense into. A :py:class:`.Well` or
+                         position (e.g. the return value from
+                         :py:meth:`.Well.top` or :py:meth:`.Well.bottom`). If
+                         unspecified, the bottom of the current well. For
+                         advanced usage, an `(x, y, z)` tuple or instance of
+                         :py:class:`types.Point` may be passed containing a
+                         location in `Deck Coordinates`_.
+        :type location: .Well or tuple[float, float, float] or types.Point
+        :param rate: The relative plunger speed for this aspirate. During
+                     this aspirate, the speed of the plunger will be
+                     `rate` * :py:attr:`aspirate_speed`. If not specified,
+                     defaults to 1.0 (speed will not be modified).
+        :type rate: float
+        :returns: This instance.
+
+        Examples
+        --------
+        ..
+        >>> from opentrons import instruments, labware, robot # doctest: +SKIP
+        >>> robot.reset() # doctest: +SKIP
+        >>> plate = labware.load('96-flat', '3') # doctest: +SKIP
+        >>> p300 = instruments.P300_Single(mount='left') # doctest: +SKIP
+        # fill the pipette with liquid (200uL)
+        >>> p300.aspirate(plate[0]) # doctest: +SKIP
+        # dispense 50uL to a Well
+        >>> p300.dispense(50, plate[0]) # doctest: +SKIP
+        # dispense 50uL to the center of a well
+        >>> relative_vector = plate[1].center() # doctest: +SKIP
+        >>> p300.dispense(50, (plate[1], relative_vector)) # doctest: +SKIP
+        # dispense 20uL in place, at half the speed
+        >>> p300.dispense(20, rate=0.5) # doctest: +SKIP
+        # dispense the pipette's remaining volume (80uL) to a Well
+        >>> p300.dispense(plate[2]) # doctest: +SKIP
+        """
+        where = self._get_point_and_cache(location, 'bottom')
+        self._log.debug("dispense {} from {} at {}"
+                        .format(volume, where, rate))
+        self._ctx.move_to(self._mount, where, types.MotionStrategy.ARC)
+        self._hardware.dispense(self._mount, volume, rate)
+        return self
 
     def mix(self,
             repetitions: int = 1,
             volume: float = None,
             location: Well = None,
             rate: float = 1.0):
-        pass
+        raise NotImplementedError
 
     def blow_out(self, location: Well = None):
-        pass
+        raise NotImplementedError
 
     def touch_tip(self,
                   location: Well = None,
                   radius: float = 1.0,
                   v_offset: float = -1.0,
                   speed: float = 60.0):
-        pass
+        raise NotImplementedError
 
     def air_gap(self,
                 volume: float = None,
                 height: float = None):
-        pass
+        raise NotImplementedError
 
     def return_tip(self, home_after: bool = True):
-        pass
+        raise NotImplementedError
 
     def pick_up_tip(self, location: Well = None,
                     presses: int = 3,
                     increment: int = 1):
-        pass
+        raise NotImplementedError
 
     def drop_tip(self, location: Well = None,
                  home_after: bool = True):
-        pass
+        raise NotImplementedError
 
     def home(self):
         """ Home the robot.
@@ -223,26 +430,70 @@ class InstrumentContext:
                    source: Well,
                    dest: Well,
                    *args, **kwargs):
-        pass
+        raise NotImplementedError
 
     def consolidate(self,
                     volume: float,
                     source: Well,
                     dest: Well,
                     *args, **kwargs):
-        pass
+        raise NotImplementedError
 
     def transfer(self,
                  volume: float,
                  source: Well,
                  dest: Well,
                  **kwargs):
-        pass
+        raise NotImplementedError
 
     def move_to(self,
                 location: geometry.Location,
-                strategy: types.MotionStrategy = None):
-        self._ctx.move_to(self._mount, location, strategy)
+                strategy: Union[types.MotionStrategy, str] = None):
+        """ Move this pipette to a specific location on the deck.
+
+        :param location: Where to move to. This can be a :py:class:`.Well`, in
+                         which case the pipette will move to its
+                         :py:meth:`.Well.top`; a :py:class:`Labware`, in which
+                         case the pipette will move to the top of its first
+                         well; or a position, whether specified by the result
+                         of a call to something like :py:class:`.Well.top` or
+                         directly specified as a `tuple` or
+                         :py:attr:`types.Point` in `Deck Coordinates`_.
+        :type location: Well or tuple[float, float, float] or types.Point
+        :param strategy: How to move. This can be a member of
+                         :py:class:`types.MotionStrategy` or one of the strings
+                         `'arc'` and `'direct'` (with any capitalization).
+                         The `'arc'` strategy (default) will pick the head up
+                         on Z axis, then move over to the XY destination, then
+                         finally down to the Z destination. This avoids any
+                         obstacles, like labware, and is suitable for moving
+                         around between different areas on the deck. The
+                         `'direct'` strategy will simply move in a straight
+                         line from the current position to the destination,
+                         and is suitable for smaller motions, for instance
+                         plate streaking or custom touch tip implementations.
+        :raises ValueError: if an argument is incorrect.
+        """
+        if None is strategy:
+            strategy = types.MotionStrategy.DIRECT
+        if strategy not in types.MotionStrategy:
+            # ignore the type here because mypy isn’t quite good enough
+            # to catch that if strategy is not in types.MotionStrategy
+            # it definitely isn’t an instance of types.MotionStrategy
+            name = strategy.upper()  # type: ignore
+            try:
+                checked_strategy = types.MotionStrategy[name]
+            except KeyError:
+                raise ValueError(
+                    "invalid motion strategy {}. Please use 'arc', 'direct'"
+                    "opentrons.types.MotionStrategy.ARC or "
+                    "opentrons.types.MotionStrategy.DIRECT"
+                    .format(strategy))
+        else:
+            # Same reason for the type: ignore as above
+            checked_strategy = strategy  # type: ignore
+        where = self._get_point_and_cache(location, 'top')
+        self._ctx.move_to(self._mount, where, checked_strategy)
         return self
 
     @property
@@ -250,7 +501,7 @@ class InstrumentContext:
         return self._mount.name.lower()
 
     @property
-    def speeds(self) -> Dict[MODE, float]:
+    def speeds(self) -> Dict[str, float]:
         """ The speeds (in mm/s) configured for the pipette, as a dict.
 
         The keys will be 'aspirate' and 'dispense' (e.g. the keys of
@@ -259,19 +510,19 @@ class InstrumentContext:
         :note: This property is equivalent to :py:attr:`speeds`; the only
         difference is the units in which this property is specified.
         """
-        pass
+        raise NotImplementedError
 
     @speeds.setter
-    def speeds(self, new_speeds: Dict[MODE, float]) -> None:
+    def speeds(self, new_speeds: Dict[str, float]) -> None:
         """ Update the speeds (in mm/s) set for the pipette.
 
         :param new_speeds: A dict containing at least one of 'aspirate'
         and 'dispense',  mapping to new speeds in mm/s.
         """
-        pass
+        raise NotImplementedError
 
     @property
-    def flow_rate(self) -> Dict[MODE, float]:
+    def flow_rate(self) -> Dict[str, float]:
         """ The speeds (in uL/s) configured for the pipette, as a dict.
 
         The  keys will be 'aspirate' and 'dispense'.
@@ -279,16 +530,16 @@ class InstrumentContext:
         :note: This property is equivalent to :py:attr:`speeds`; the only
         difference is the units in which this property is specified.
         """
-        pass
+        raise NotImplementedError
 
     @flow_rate.setter
-    def flow_rate(self, new_flow_rate: Dict[MODE, float]) -> None:
+    def flow_rate(self, new_flow_rate: Dict[str, float]) -> None:
         """ Update the speeds (in uL/s) for the pipette.
 
         :param new_flow_rates: A dict containing at least one of 'aspirate
         and 'dispense', mapping to new speeds in uL/s.
         """
-        pass
+        raise NotImplementedError
 
     @property
     def pick_up_current(self) -> float:
@@ -296,7 +547,7 @@ class InstrumentContext:
         The current (amperes) the pipette mount's motor will use
         while picking up a tip. Specified in amps.
         """
-        pass
+        raise NotImplementedError
 
     @pick_up_current.setter
     def pick_up_current(self, amps: float):
@@ -304,33 +555,124 @@ class InstrumentContext:
 
         :param amps: The current, in amperes. Acceptable values: (0.0, 2.0)
         """
-        pass
+        raise NotImplementedError
 
     @property
-    def type(self) -> TYPE:
-        """ One of :py:class:`TYPE`.
+    def type(self) -> str:
+        """ One of `'single'` or `'multi'`.
         """
-        pass
+        model = self.name
+        if 'single' in model:
+            return 'single'
+        elif 'multi' in model:
+            return 'multi'
+        else:
+            raise RuntimeError("Bad pipette model name: {}".format(model))
 
     @property
     def tip_racks(self) -> List[Labware]:
         """ Query which tipracks have been linked to this PipetteContext"""
-        pass
+        raise NotImplementedError
 
     @tip_racks.setter
     def tip_racks(self, racks: List[Labware]):
-        pass
+        raise NotImplementedError
 
     @property
     def trash_container(self) -> Labware:
         """ The location the pipette will dispense trash to.
         """
-        pass
+        raise NotImplementedError
 
     @trash_container.setter
     def trash_container(self, trash: Labware):
-        pass
+        raise NotImplementedError
 
     @property
     def name(self):
-        return self._info['name']
+        return self.hw_pipette['name']
+
+    @property
+    def max_volume(self):
+        """
+        The maximum volume, in microliters, this pipette can hold.
+        """
+        return self.hw_pipette['max_volume']
+
+    @property
+    def current_volume(self):
+        """
+        The current amount of liquid, in microliters, held in the pipette.
+        """
+        return self.hw_pipette['current_volume']
+
+    @property
+    def hw_pipette(self) -> Optional[Dict[str, Any]]:
+        """ View the information returned by the hardware API directly.
+        """
+        return self._hardware.attached_instruments[self._mount]
+
+    def _get_point_and_cache(self,
+                             location: Optional[geometry.Location],
+                             accessor: str) -> types.Point:
+        """ Take a location and turn it into a point, caching the labware.
+
+        This method resolves a :py:class:`.Point` in absolute coordinates.
+        If given a :py:class:`.Point` (or a 3-tuple of coordinates) it will
+        use the input directly; otherwise it will attempt to resolve a
+        :py:class:`.Well` (by taking the first well of a passed
+        :py:class:`.Labware` if necessary) and use the specified `accessor`
+        on it.
+
+        If `location` is `None` and there is a cached location, the cache
+        will be used.
+
+        If a :py:class:`.Well` could be resolved (i.e. `location` was a
+        :py:class:`.Labware` or :py:class:`.Well` or it was `None` and there
+        was a cached location) the resolved :py:class:`.Well` will be cached.
+        If `location` did not resolve to a :py:class:`.Well` the location
+        cache will be invalidated.
+
+        If `location` is `None` and nothing is cached, raises.
+
+        :param location: The location to resolve (see above).
+        :param accessor: The name of the position accessor on
+                         :py:class:`.Well` (e.g. 'top' or 'bottom') to use
+                         on the eventually-resolved :py:class:`.Well`.
+        :raises RuntimeError: If `location` was `None` and no location is
+                              cached.
+        """
+        if None is location:
+            if self._last_location:
+                location = self._last_location
+            else:
+                raise RuntimeError(
+                    'Locationless move specified but no location cached')
+        if isinstance(location, Labware):
+            well: Optional[Well] = location.wells()[0]
+            point: types.Point = getattr(well, accessor)()
+        elif isinstance(location, Well):
+            well = location
+            point = getattr(well, accessor)()
+        elif isinstance(location, types.Point):
+            point = location
+            well = None
+        elif isinstance(location, tuple):
+            point = types.Point(location[0], location[1], location[2])
+            well = None
+        else:
+            raise TypeError(
+                'Bad location {}, must be None, Labware, Well, Point or tuple'
+                .format(location))
+
+        self._last_location = well
+        return point
+
+    def __repr__(self):
+        return '<{}: {} in {}>'.format(self.__class__.__name__,
+                                       self.hw_pipette['name'],
+                                       self._mount.name)
+
+    def __str__(self):
+        return '{} on {} mount'.format(self.hw_pipette['display_name'],
+                                       self._mount.name.lower())

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -1,0 +1,89 @@
+from collections import UserDict
+import logging
+from typing import Union, Tuple
+
+from opentrons.protocol_api.labware import Labware, Well
+from opentrons import types
+
+MODULE_LOG = logging.getLogger(__name__)
+
+Location = Union[Labware, Well, types.Point, Tuple[float, float, float]]
+
+
+def point_from_location(location: Location) -> types.Point:
+    """ Build a deck-abs point from anything the user passes in """
+
+    # Defined with an inner function like this to make logging the result
+    # a bit less tedious and reasonably mypy-compliant
+    def _point(loc: Location) -> types.Point:
+        if isinstance(location, Well):
+            return location.top()
+        elif isinstance(location, Labware):
+            return location.wells()[0].top()
+        elif isinstance(location, tuple):
+            return types.Point(*location[:3])
+        else:
+            return location
+
+    point = _point(location)
+    MODULE_LOG.debug("Location {} -> {}".format(location, point))
+    return point
+
+
+class Deck(UserDict):
+    def __init__(self):
+        super().__init__()
+        row_offset = 90.5
+        col_offset = 132.5
+        for idx in range(1, 13):
+            self.data[idx] = None
+        self._positions = {idx+1: types.Point((idx % 3) * col_offset,
+                                              idx//3 * row_offset,
+                                              0)
+                           for idx in range(12)}
+
+    @staticmethod
+    def _assure_int(key: object) -> int:
+        if isinstance(key, str):
+            return int(key)
+        elif isinstance(key, int):
+            return key
+        else:
+            raise TypeError(type(key))
+
+    def _check_name(self, key: object) -> int:
+        should_raise = False
+        try:
+            key_int = Deck._assure_int(key)
+        except Exception:
+            MODULE_LOG.exception("Bad slot name: {}".format(key))
+            should_raise = True
+        should_raise = should_raise or key_int not in self.data
+        if should_raise:
+            raise ValueError("Unknown slot: {}".format(key))
+        else:
+            return key_int
+
+    def __getitem__(self, key: types.DeckLocation) -> Labware:
+        return self.data[self._check_name(key)]
+
+    def __delitem__(self, key: types.DeckLocation) -> None:
+        self.data[self._check_name(key)] = None
+
+    def __setitem__(self, key: types.DeckLocation, val: Labware) -> None:
+        key_int = self._check_name(key)
+        if self.data.get(key_int) is not None:
+            raise ValueError('Deck location {} already has an item: {}'
+                             .format(key, self.data[key_int]))
+        self.data[key_int] = val
+
+    def __contains__(self, key: object) -> bool:
+        try:
+            key_int = self._check_name(key)
+        except ValueError:
+            return False
+        return key_int in self.data
+
+    def position_for(self, key: types.DeckLocation) -> types.Point:
+        key_int = self._check_name(key)
+        return self._positions[key_int]

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -396,9 +396,9 @@ def running_on_pi():
                            '(probably windows)')
 @pytest.fixture
 def cntrlr_mock_connect(monkeypatch):
-    def mock_connect(s):
+    def mock_connect(obj, port=None):
         return
-    monkeypatch.setattr(hc.Controller, '_connect', mock_connect)
+    monkeypatch.setattr(hc.Controller, 'connect', mock_connect)
 
 
 setup_testing_env()

--- a/api/tests/opentrons/hardware_control/test_adapters.py
+++ b/api/tests/opentrons/hardware_control/test_adapters.py
@@ -1,0 +1,10 @@
+from opentrons.types import Mount
+from opentrons.hardware_control import adapters, API
+
+
+def test_synch_adapter(loop):
+    api = API.build_hardware_simulator(loop=loop)
+    synch = adapters.SynchronousAdapter(api)
+    synch.cache_instruments({Mount.LEFT: 'p10_single'})
+    assert synch.attached_instruments[Mount.LEFT]['name']\
+                .startswith('p10_single')

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -27,7 +27,7 @@ def dummy_instruments():
 async def test_cache_instruments(dummy_instruments, loop):
     expected_keys = [
         'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
-        'dispense_flow_rate', 'pipette_id']
+        'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     hw_api = hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments,
@@ -45,7 +45,7 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
                                     running_on_pi, cntrlr_mock_connect, loop):
     expected_keys = [
         'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
-        'dispense_flow_rate', 'pipette_id']
+        'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     hw_api_cntrlr = hc.API.build_hardware_controller(loop=loop)
 
@@ -83,7 +83,7 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
 async def test_cache_instruments_sim(loop, dummy_instruments):
     expected_keys = [
         'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
-        'dispense_flow_rate', 'pipette_id']
+        'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     sim = hc.API.build_hardware_simulator(loop=loop)
     # With nothing specified at init or expected, we should have nothing

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -1,6 +1,11 @@
 """ Test the functions and classes in the protocol context """
 
+import opentrons.protocol_api as papi
 from opentrons.protocol_api.geometry import Deck
+from opentrons.types import Mount
+from opentrons.hardware_control import API
+from opentrons.hardware_control.types import Axis
+from opentrons.config.pipette_config import configs
 
 import pytest
 
@@ -22,3 +27,25 @@ def test_slot_names():
     assert 'hasasdaia' not in d
     with pytest.raises(ValueError):
         d['ahgoasia'] = 'nope'
+
+
+def test_load_instrument(loop):
+    ctx = papi.ProtocolContext(loop=loop)
+    for config in configs:
+        loaded = ctx.load_instrument(config, Mount.LEFT)
+        assert loaded.name == config
+        prefix = config.split('_v')[0]
+        loaded = ctx.load_instrument(prefix, Mount.RIGHT)
+        assert loaded.name.startswith(prefix)
+
+
+def test_motion(loop):
+    hardware = API.build_hardware_simulator(loop=loop)
+    ctx = papi.ProtocolContext(hardware, loop)
+    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+    instr.home()
+    instr.move_to((0, 0, 0))
+    assert hardware.current_position(instr._mount) == {Axis.X: 0,
+                                                       Axis.Y: 0,
+                                                       Axis.A: 0,
+                                                       Axis.C: 19}

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -1,6 +1,6 @@
 """ Test the functions and classes in the protocol context """
 
-from opentrons import protocol_api as papi
+from opentrons.protocol_api.geometry import Deck
 
 import pytest
 
@@ -9,7 +9,7 @@ def test_slot_names():
     slots_by_int = list(range(1, 13))
     slots_by_str = [str(idx) for idx in slots_by_int]
     for method in (slots_by_int, slots_by_str):
-        d = papi.Deck()
+        d = Deck()
         for idx, slot in enumerate(method):
             assert slot in d
             d[slot] = 'its real'

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -1,8 +1,12 @@
 """ Test the functions and classes in the protocol context """
 
+import json
+import pkgutil
+
 import opentrons.protocol_api as papi
 from opentrons.protocol_api.geometry import Deck
-from opentrons.types import Mount
+from opentrons.protocol_api.labware import load
+from opentrons.types import MotionStrategy, Mount, Point
 from opentrons.hardware_control import API
 from opentrons.hardware_control.types import Axis
 from opentrons.config.pipette_config import configs
@@ -10,14 +14,28 @@ from opentrons.config.pipette_config import configs
 import pytest
 
 
-def test_slot_names():
+labware_name = 'generic_96_wellPlate_380_uL'
+labware_def = json.loads(
+    pkgutil.get_data('opentrons',
+                     'shared_data/definitions2/{}.json'.format(labware_name)))
+
+
+@pytest.fixture
+def load_my_labware(monkeypatch):
+    def dummy_load(labware):
+        return labware_def
+    monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
+
+
+def test_slot_names(load_my_labware):
     slots_by_int = list(range(1, 13))
     slots_by_str = [str(idx) for idx in slots_by_int]
     for method in (slots_by_int, slots_by_str):
         d = Deck()
         for idx, slot in enumerate(method):
+            lw = load(labware_name, d.position_for(slot), str(slot))
             assert slot in d
-            d[slot] = 'its real'
+            d[slot] = lw
             with pytest.raises(ValueError):
                 d[slot] = 'not this time boyo'
             del d[slot]
@@ -29,23 +47,123 @@ def test_slot_names():
         d['ahgoasia'] = 'nope'
 
 
+def test_highest_z(load_my_labware):
+    deck = Deck()
+    assert deck.highest_z == 0
+    lw = load(labware_name, deck.position_for(1), '1')
+    deck[1] = lw
+    assert deck.highest_z == lw.wells()[0].top().z
+    del deck[1]
+    assert deck.highest_z == 0
+
+
 def test_load_instrument(loop):
     ctx = papi.ProtocolContext(loop=loop)
     for config in configs:
-        loaded = ctx.load_instrument(config, Mount.LEFT)
+        loaded = ctx.load_instrument(config, Mount.LEFT, replace=True)
         assert loaded.name == config
         prefix = config.split('_v')[0]
-        loaded = ctx.load_instrument(prefix, Mount.RIGHT)
+        loaded = ctx.load_instrument(prefix, Mount.RIGHT, replace=True)
         assert loaded.name.startswith(prefix)
 
 
 def test_motion(loop):
     hardware = API.build_hardware_simulator(loop=loop)
-    ctx = papi.ProtocolContext(hardware, loop)
+    ctx = papi.ProtocolContext(loop)
+    ctx.connect(hardware)
     instr = ctx.load_instrument('p10_single', Mount.RIGHT)
     instr.home()
-    instr.move_to((0, 0, 0))
+    assert instr.move_to((0, 0, 0)) is instr
     assert hardware.current_position(instr._mount) == {Axis.X: 0,
                                                        Axis.Y: 0,
                                                        Axis.A: 0,
                                                        Axis.C: 19}
+
+
+def test_location_parsing(loop, load_my_labware):
+    ctx = papi.ProtocolContext(loop)
+    lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', '1')
+    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+    w0 = lw.wells()[0]
+    assert instr._get_point_and_cache(w0, 'top') == w0.top()
+    assert instr._last_location is w0
+    assert instr._get_point_and_cache(w0, 'bottom') == w0.bottom()
+    assert instr._last_location is w0
+    assert instr._get_point_and_cache(w0, 'center') == w0.center()
+    assert instr._last_location is w0
+    assert instr._get_point_and_cache(w0.bottom(), 'top') == w0.bottom()
+    assert instr._last_location is None
+    assert instr._get_point_and_cache(lw, 'top') == lw.wells()[0].top()
+    assert instr._last_location == lw.wells()[0]
+    assert instr._get_point_and_cache(None, 'top') == w0.top()
+    assert instr._last_location == lw.wells()[0]
+    assert instr._get_point_and_cache((0, 1, 2), 'bottom') == Point(0, 1, 2)
+    with pytest.raises(RuntimeError):
+        instr._get_point_and_cache(None, 'top')
+    with pytest.raises(TypeError):
+        instr._get_point_and_cache(2, 'bottom')
+
+
+def test_pipette_info(loop):
+    ctx = papi.ProtocolContext(loop)
+    right = ctx.load_instrument('p300_multi', Mount.RIGHT)
+    left = ctx.load_instrument('p1000_single', Mount.LEFT)
+    assert right.type == 'multi'
+    assert right.name\
+        == ctx._hardware.attached_instruments[Mount.RIGHT]['name']
+    assert left.type == 'single'
+    assert left.name == ctx._hardware.attached_instruments[Mount.LEFT]['name']
+
+
+def test_aspirate(loop, load_my_labware, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
+    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+
+    asp_called_with = None
+
+    async def fake_hw_aspirate(mount, volume=None, rate=1.0):
+        nonlocal asp_called_with
+        asp_called_with = (mount, volume, rate)
+
+    move_called_with = None
+
+    def fake_move(mount, loc, strat):
+        nonlocal move_called_with
+        move_called_with = (mount, loc, strat)
+
+    monkeypatch.setattr(ctx._hardware._api, 'aspirate', fake_hw_aspirate)
+    monkeypatch.setattr(ctx, 'move_to', fake_move)
+
+    instr.aspirate(2.0, lw)
+
+    assert asp_called_with == (Mount.RIGHT, 2.0, 1.0)
+    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom(),
+                                MotionStrategy.ARC)
+
+
+def test_dispense(loop, load_my_labware, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
+    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+
+    disp_called_with = None
+
+    async def fake_hw_dispense(mount, volume=None, rate=1.0):
+        nonlocal disp_called_with
+        disp_called_with = (mount, volume, rate)
+
+    move_called_with = None
+
+    def fake_move(mount, loc, strat):
+        nonlocal move_called_with
+        move_called_with = (mount, loc, strat)
+
+    monkeypatch.setattr(ctx._hardware._api, 'dispense', fake_hw_dispense)
+    monkeypatch.setattr(ctx, 'move_to', fake_move)
+
+    instr.dispense(2.0, lw)
+
+    assert disp_called_with == (Mount.RIGHT, 2.0, 1.0)
+    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom(),
+                                MotionStrategy.ARC)

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -9,31 +9,31 @@ labware_def = json.loads(
                      'shared_data/definitions2/{}.json'.format(labware_name)))
 
 
-def test_load_to_slot(monkeypatch):
+def test_load_to_slot(monkeypatch, loop):
     def dummy_load(labware):
         return labware_def
     monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext()
+    ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert labware._offset == types.Point(0, 0, 0)
     other = ctx.load_labware_by_name(labware_name, 2)
     assert other._offset == types.Point(132.5, 0, 0)
 
 
-def test_loaded(monkeypatch):
+def test_loaded(monkeypatch, loop):
     def dummy_load(labware):
         return labware_def
     monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext()
+    ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert ctx.loaded_labwares[1] == labware
 
 
-def test_from_backcompat(monkeypatch):
+def test_from_backcompat(monkeypatch, loop):
     def dummy_load(labware):
         return labware_def
     monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext()
+    ctx = papi.ProtocolContext(loop=loop)
     papi.back_compat.reset(ctx)
     lw = papi.back_compat.labware.load(labware_name, 3)
     assert lw == ctx.loaded_labwares[3]

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -33,7 +33,5 @@ def test_from_backcompat(monkeypatch, loop):
     def dummy_load(labware):
         return labware_def
     monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext(loop=loop)
-    papi.back_compat.reset(ctx)
     lw = papi.back_compat.labware.load(labware_name, 3)
-    assert lw == ctx.loaded_labwares[3]
+    assert lw == papi.back_compat.robot.loaded_labwares[3]


### PR DESCRIPTION
This has a lot of backend work to prepare the protocol API for actually interacting with hardware.

We can now load instruments; we can use the backwards-compatibility layer to do it; and we can call move, aspirate, and dispense on them.

In addition, there is now (autogenerated) documentation for the protocol API. It is not included in the doctree but can be accessed at
${docsroot}/new_protocol_api.html once built.

Particular things to check out in this (admittedly probably too large) PR aside from the main event:

- [AddInstrumentCtors](https://github.com/Opentrons/opentrons/blob/4ce1f295948004e1e2cede0ec9addf614cd043a0/api/src/opentrons/protocol_api/back_compat.py#L74-L163) in the back_compat shim. This builds the old pipette constructors (like `instruments.P300_Single` dynamically. Normally I wouldn't do this, but there's a bunch of them, they're all the same, and because this way of doing things actually assigns a docstring, they do in fact get documented just like any other function.
- [Ability to specify robot feature flags in the environment](https://github.com/Opentrons/opentrons/blob/4ce1f295948004e1e2cede0ec9addf614cd043a0/api/src/opentrons/config/feature_flags.py#L6-L11) in feature_flags. This is a really big lifesaver for switching between the old and new apis without having to edit a file; it's hard to mock because it changes behavior that occurs when doing `import opentrons` in python.
- The [hardware API adapter](https://github.com/Opentrons/opentrons/blob/api_protocol-api-motion/api/src/opentrons/hardware_control/adapters.py) is something that wraps the async hardware api in sync calls automatically. 
- [the location cache](https://github.com/Opentrons/opentrons/blob/4ce1f295948004e1e2cede0ec9addf614cd043a0/api/src/opentrons/protocol_api/contexts.py#L615-L669) is the beginnings of the protocol api (mis?)feature of being able to call motion functions repeatedly without location arguments, so doing ```instr.aspirate(lw['a1']).dispense()```, which would dispense back into a1. I'm not sure why we have this and it doesn't fully work yet because we no longer pass locations around with labwares but it's the beginning of that feature.


Closes #2243