### PR TITLE
refactor(api): add blow_out, pick_up_tip, drop_tip

### DIFF
--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -1,7 +1,7 @@
 import asyncio
 import copy
 from typing import Dict, Optional, List, Tuple
-
+from contextlib import contextmanager
 from opentrons import types
 from opentrons.config.pipette_config import configs
 from . import modules
@@ -40,7 +40,8 @@ class Simulator:
                                   in enumerate(attached_modules)]
         self._position = copy.copy(_HOME_POSITION)
 
-    def move(self, target_position: Dict[str, float]):
+    def move(self, target_position: Dict[str, float],
+             home_flagged_axes: bool = True, speed: float = None):
         self._position.update(target_position)
 
     def home(self, axes: List[str] = None) -> Dict[str, float]:
@@ -108,11 +109,12 @@ class Simulator:
     def set_active_current(self, axis, amp):
         pass
 
-    def set_pipette_speed(self, speed):
-        pass
-
     def get_attached_modules(self) -> List[Tuple[str, str]]:
         return self._attached_modules
+
+    @contextmanager
+    def save_current(self):
+        yield
 
     def build_module(self, port: str, model: str) -> modules.AbstractModule:
         return modules.build(port, model, True)

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -143,7 +143,9 @@ async def test_critical_point_applied(hardware_api, monkeypatch):
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     await hardware_api.pick_up_tip(types.Mount.RIGHT)
     # Now the current position (with offset applied) should change
-    target[Axis.A] = -33
+    # pos_after_pickup + model_offset + critical point
+    target[Axis.A] = 218 + (-13) + (-33)
+    target_no_offset[Axis.C] = target[Axis.C] = 2
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     # This move should take the new critical point into account
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
@@ -154,7 +156,7 @@ async def test_critical_point_applied(hardware_api, monkeypatch):
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     # And removing the tip should move us back to the original
     await hardware_api.drop_tip(types.Mount.RIGHT)
-    target[Axis.A] = 33
+    target[Axis.A] = 33 + hc.DROP_TIP_RELEASE_DISTANCE
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
     target_no_offset[Axis.A] = 13
@@ -170,7 +172,7 @@ async def test_deck_cal_applied(monkeypatch, loop):
                       [0, 0, 0, 1]]
     called_with = None
 
-    def mock_move(position):
+    def mock_move(position, speed=None):
         nonlocal called_with
         called_with = position
 


### PR DESCRIPTION
Closes #2483

## changelog

- added `blow_out(mount)`, `pick_up_tip(mount, presses, increment)`, drop_tip(mount)`
- changed all `move` methods to accept move speed. This enables us to implement `touch_tip` in protocol_api using only hardware_control `move`s
- added pick_up_tip test

## review requests

Test the three functions on a robot. 
Example test:
```
>>> import opentrons.hardware_control as hc
>>> import asyncio
>>> import opentrons.types as t
>>> l=asyncio.get_event_loop()
>>> a=hc.API.build_hardware_controller()
>>> l.run_until_complete(a.home())
>>> l.run_until_complete(a.cache_instruments())
>>> l.run_until_complete(a.move_to(t.Mount.LEFT,t.Point(11.6,75,63)))  # rough loc of first tip of P300 tiprack in slot 1
>>> l.run_until_complete(a.pick_up_tip(t.Mount.LEFT))
>>> l.run_until_complete(a.aspirate(t.Mount.LEFT))
>>> l.run_until_complete(a.dispense(t.Mount.LEFT))
>>> l.run_until_complete(a.blow_out(t.Mount.LEFT))
>>> l.run_until_complete(a.move_to(t.Mount.LEFT,t.Point(11.6,75,50)))  #move close to tiprack
>>> l.run_until_complete(a.drop_tip(t.Mount.LEFT))
```
