### PR TITLE
refactor(components): Update error and caption styles

### DIFF
--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -108,10 +108,9 @@
 }
 
 .input_caption {
-  padding-top: 0.25rem;
   font-size: var(--fs-caption);
   font-weight: var(--fw-semibold);
-  min-height: var(--fs-caption);
+  line-height: 1.2;
   color: var(--c-med-gray);
 
   & .right {


### PR DESCRIPTION
## overview
This PR is also a ticket for a refactor. 

### Previous Behavior:
An empty div with padding top and a min-height always rendered below all `InputFields` and `DropdownFields`. This was attempting to avoid jumpiness when errors were rendered. Due to border box box-sizing, padding was included in the min-height = jumpiness still existed on error, and the 10px high div wound up being the default vertical spacing for input elements.

### Desired Behavior
- [ ] Remove min-height and padding for input caption/error wrapper div and implement text spacing via line-height.
- [ ] Jumpiness is OK for errors, bottom left/right captions should be considered. 
   - Lower captions are not present in the app currently, and are only present in FlowRate input field. *Not an issue yet with vertical spacing in forms, but captions will affect applied row spacing*

## changelog

- refactor(components): Update error and caption styles

## review requests

-  PD forms spacing (form row) was taking this 10px into account. Follow up PR will be needed to fix some form row spacing.
- App forms spacing will now be zeroed out, but all affected components are still hidden behind a feature flag. And can be styled explicitly in upcoming PR.

Please take a look at forms in App and PD (whichever you are more familiar with) and take note of spacing affects. A follow up conversation with Design may be neccessary to determine a standard vertical spacing for inputs or form rows with/without errors/captions.