### PR TITLE
feat(app): Home pipette after tip probe confirmed

### DIFF
--- a/app/src/components/TipProbe/RemoveTipPanel.js
+++ b/app/src/components/TipProbe/RemoveTipPanel.js
@@ -9,11 +9,7 @@ import CalibrationInfoContent from '../CalibrationInfoContent'
 import removeSingle from '../../img/remove_tip_single.png'
 import removeMulti from '../../img/remove_tip_multi.png'
 
-import {
-  actions as robotActions,
-  type Channels,
-  type Mount,
-} from '../../robot'
+import {actions as robotActions, type Channels, type Mount} from '../../robot'
 
 type OwnProps = {
   mount: Mount,
@@ -29,28 +25,27 @@ type RemoveTipProps = {
   onConfirmClick: () => void,
 }
 
-export default connect(null, mapDispatchToProps)(RemoveTipPanel)
+export default connect(
+  null,
+  mapDispatchToProps
+)(RemoveTipPanel)
 
 function RemoveTipPanel (props: RemoveTipProps) {
   const {channels, onConfirmClick} = props
 
-  const imgSrc = channels === 1
-    ? removeSingle
-    : removeMulti
+  const imgSrc = channels === 1 ? removeSingle : removeMulti
 
   return (
     <CalibrationInfoContent
-      leftChildren={(
+      leftChildren={
         <div>
           <p>Remove tip from pipette.</p>
           <PrimaryButton onClick={onConfirmClick}>
             Confirm Tip Removed
           </PrimaryButton>
         </div>
-      )}
-      rightChildren={(
-        <img src={imgSrc} alt='remove tip' />
-      )}
+      }
+      rightChildren={<img src={imgSrc} alt="remove tip" />}
     />
   )
 }
@@ -62,6 +57,8 @@ function mapDispatchToProps (
   const {mount} = ownProps
 
   return {
-    onConfirmClick: () => { dispatch(robotActions.confirmProbedAndHome(mount)) },
+    onConfirmClick: () => {
+      dispatch(robotActions.confirmProbed(mount))
+    },
   }
 }

--- a/app/src/components/TipProbe/RemoveTipPanel.js
+++ b/app/src/components/TipProbe/RemoveTipPanel.js
@@ -62,6 +62,6 @@ function mapDispatchToProps (
   const {mount} = ownProps
 
   return {
-    onConfirmClick: () => { dispatch(robotActions.confirmProbed(mount)) },
+    onConfirmClick: () => { dispatch(robotActions.confirmProbedAndHome(mount)) },
   }
 }

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -57,11 +57,6 @@ export type UnexpectedDisconnectAction = {|
 export type ConfirmProbedAction = {|
   type: 'robot:CONFIRM_PROBED',
   payload: Mount,
-|}
-
-export type ConfirmProbedAndHomeAction = {|
-  type: 'robot:CONFIRM_PROBED_AND_HOME',
-  payload: {mount: Mount},
   meta: {|
     robotCommand: true,
   |},
@@ -199,7 +194,6 @@ export type Action =
   | ClearConnectResponseAction
   | UnexpectedDisconnectAction
   | ConfirmProbedAction
-  | ConfirmProbedAndHomeAction
   | PipetteCalibrationAction
   | LabwareCalibrationAction
   | CalibrationResponseAction
@@ -382,15 +376,11 @@ export const actions = {
     return action
   },
 
-  confirmProbed (mount: Mount): ConfirmProbedAction {
-    return {type: 'robot:CONFIRM_PROBED', payload: mount}
-  },
-
   // confirm tip removed + tip probed then home pipette on `mount`
-  confirmProbedAndHome (mount: Mount): ConfirmProbedAndHomeAction {
+  confirmProbed (mount: Mount): ConfirmProbedAction {
     return {
-      type: 'robot:CONFIRM_PROBED_AND_HOME',
-      payload: {mount},
+      type: 'robot:CONFIRM_PROBED',
+      payload: mount,
       meta: {robotCommand: true},
     }
   },

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -1,17 +1,11 @@
 // @flow
 // robot actions and action types
 import {_NAME as NAME} from './constants'
-import type {
-  Mount,
-  Slot,
-  Axis,
-  Direction,
-  SessionUpdate,
-} from './types'
+import type {Mount, Slot, Axis, Direction, SessionUpdate} from './types'
 
 // TODO(mc, 2017-11-22): rename this function to actionType
-const makeRobotActionName = (action) => `${NAME}:${action}`
-const tagForRobotApi = (action) => ({...action, meta: {robotCommand: true}})
+const makeRobotActionName = action => `${NAME}:${action}`
+const tagForRobotApi = action => ({...action, meta: {robotCommand: true}})
 
 type Error = {message: string}
 
@@ -65,10 +59,16 @@ export type ConfirmProbedAction = {|
   payload: Mount,
 |}
 
+export type ConfirmProbedAndHomeAction = {|
+  type: 'robot:CONFIRM_PROBED_AND_HOME',
+  payload: {mount: Mount},
+  meta: {|
+    robotCommand: true,
+  |},
+|}
+
 export type PipetteCalibrationAction = {|
-  type: (
-    | 'robot:JOG'
-  ),
+  type: 'robot:JOG',
   payload: {|
     mount: Mount,
     axis?: Axis,
@@ -86,14 +86,12 @@ export type SetJogDistanceAction = {|
 |}
 
 export type LabwareCalibrationAction = {|
-  type: (
-    | 'robot:MOVE_TO'
+  type: | 'robot:MOVE_TO'
     | 'robot:PICKUP_AND_HOME'
     | 'robot:DROP_TIP_AND_HOME'
     | 'robot:CONFIRM_TIPRACK'
     | 'robot:UPDATE_OFFSET'
-    | 'robot:SET_JOG_DISTANCE'
-  ),
+    | 'robot:SET_JOG_DISTANCE',
   payload: {|
     mount: Mount,
     slot: Slot,
@@ -104,15 +102,13 @@ export type LabwareCalibrationAction = {|
 |}
 
 export type CalibrationSuccessAction = {
-  type: (
-    | 'robot:MOVE_TO_SUCCESS'
+  type: | 'robot:MOVE_TO_SUCCESS'
     | 'robot:JOG_SUCCESS'
     | 'robot:PICKUP_AND_HOME_SUCCESS'
     | 'robot:DROP_TIP_AND_HOME_SUCCESS'
     | 'robot:CONFIRM_TIPRACK_SUCCESS'
     | 'robot:UPDATE_OFFSET_SUCCESS'
-    | 'robot:RETURN_TIP_SUCCESS'
-  ),
+    | 'robot:RETURN_TIP_SUCCESS',
   payload: {
     isTiprack?: boolean,
     tipOn?: boolean,
@@ -120,15 +116,13 @@ export type CalibrationSuccessAction = {
 }
 
 export type CalibrationFailureAction = {|
-  type: (
-    | 'robot:MOVE_TO_FAILURE'
+  type: | 'robot:MOVE_TO_FAILURE'
     | 'robot:JOG_FAILURE'
     | 'robot:PICKUP_AND_HOME_FAILURE'
     | 'robot:DROP_TIP_AND_HOME_FAILURE'
     | 'robot:CONFIRM_TIPRACK_FAILURE'
     | 'robot:UPDATE_OFFSET_FAILURE'
-    | 'robot:RETURN_TIP_FAILURE'
-  ),
+    | 'robot:RETURN_TIP_FAILURE',
   error: true,
   payload: Error,
 |}
@@ -205,6 +199,7 @@ export type Action =
   | ClearConnectResponseAction
   | UnexpectedDisconnectAction
   | ConfirmProbedAction
+  | ConfirmProbedAndHomeAction
   | PipetteCalibrationAction
   | LabwareCalibrationAction
   | CalibrationResponseAction
@@ -389,6 +384,15 @@ export const actions = {
 
   confirmProbed (mount: Mount): ConfirmProbedAction {
     return {type: 'robot:CONFIRM_PROBED', payload: mount}
+  },
+
+  // confirm tip removed + tip probed then home pipette on `mount`
+  confirmProbedAndHome (mount: Mount): ConfirmProbedAndHomeAction {
+    return {
+      type: 'robot:CONFIRM_PROBED_AND_HOME',
+      payload: {mount},
+      meta: {robotCommand: true},
+    }
   },
 
   returnTip (mount: Mount) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -42,8 +42,8 @@ export default function client (dispatch) {
         return pickupAndHome(state, action)
       case 'robot:DROP_TIP_AND_HOME':
         return dropTipAndHome(state, action)
-      case 'robot:CONFIRM_PROBED_AND_HOME':
-        return confirmProbedAndHome(state, action)
+      case 'robot:CONFIRM_PROBED':
+        return homePipette(state, action)
       case 'robot:CONFIRM_TIPRACK':
         return confirmTiprack(state, action)
       case actionTypes.MOVE_TO_FRONT:
@@ -160,14 +160,11 @@ export default function client (dispatch) {
       .then(() => dispatch(actions.moveToFrontResponse()))
       .catch(error => dispatch(actions.moveToFrontResponse(error)))
   }
-  // Confirm tip probed, tip removed, then home
-  function confirmProbedAndHome (state, action) {
-    const {
-      payload: {mount},
-    } = action
+  // Home pipette up
+  function homePipette (state, action) {
+    const {payload: mount} = action
     const pipette = {_id: selectors.getPipettesByMount(state)[mount]._id}
 
-    dispatch(actions.confirmProbed(mount))
     remote.calibration_manager.home(pipette)
   }
 

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -229,19 +229,10 @@ describe('robot actions', () => {
     const expected = {
       type: 'robot:CONFIRM_PROBED',
       payload: 'left',
-    }
-
-    expect(actions.confirmProbed('left')).toEqual(expected)
-  })
-
-  test('CONFIRM_PROBED_AND_HOME action', () => {
-    const action = {
-      type: 'robot:CONFIRM_PROBED_AND_HOME',
-      payload: {mount: 'right'},
       meta: {robotCommand: true},
     }
 
-    expect(actions.confirmProbedAndHome('right')).toEqual(action)
+    expect(actions.confirmProbed('left')).toEqual(expected)
   })
 
   test('MOVE_TO action', () => {

--- a/app/src/robot/test/actions.test.js
+++ b/app/src/robot/test/actions.test.js
@@ -234,6 +234,16 @@ describe('robot actions', () => {
     expect(actions.confirmProbed('left')).toEqual(expected)
   })
 
+  test('CONFIRM_PROBED_AND_HOME action', () => {
+    const action = {
+      type: 'robot:CONFIRM_PROBED_AND_HOME',
+      payload: {mount: 'right'},
+      meta: {robotCommand: true},
+    }
+
+    expect(actions.confirmProbedAndHome('right')).toEqual(action)
+  })
+
   test('MOVE_TO action', () => {
     const expected = {
       type: 'robot:MOVE_TO',


### PR DESCRIPTION
## overview

This PR closes #2544. Long story short, now whenever you click 'confirm tip removed' at the end of the tip probe sequence, the pipette homes up and out of the way.

## changelog

- feat(app): Home pipette after tip probe confirmed

## review requests

Please test on a robot
- [ ] Confirm tip removed button confirms tip probed (check mark next to pipette in side panel)
- [ ] Pipette moves up
- [ ] You can move on to text pipette or labware calibration