### PR TITLE
API: consolidate motion functions and fix some small design issues

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -293,6 +293,8 @@ class API:
         This returns cached position to avoid hitting the smoothie driver
         unless ``refresh`` is ``True``.
         """
+        if not self._current_position:
+            raise MustHomeError
         if mount == mount.RIGHT:
             offset = top_types.Point(0, 0, 0)
         else:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -344,9 +344,7 @@ class API:
         if not self._current_position:
             raise MustHomeError
 
-        if mount != self._last_moved_mount and self._last_moved_mount:
-            await self.retract(self._last_moved_mount, 10)
-        self._last_moved_mount = mount
+        await self._cache_and_maybe_retract_mount(mount)
 
         z_axis = Axis.by_mount(mount)
         if mount == top_types.Mount.LEFT:
@@ -372,9 +370,7 @@ class API:
         if not self._current_position:
             raise MustHomeError
 
-        if mount != self._last_moved_mount and self._last_moved_mount:
-            await self.retract(self._last_moved_mount, 10)
-        self._last_moved_mount = mount
+        await self._cache_and_maybe_retract_mount(mount)
 
         z_axis = Axis.by_mount(mount)
         try:
@@ -389,6 +385,18 @@ class API:
         except KeyError:
             raise MustHomeError
         await self._move(target_position, speed=speed)
+
+    async def _cache_and_maybe_retract_mount(self, mount: top_types.Mount):
+        """ Retract the 'other' mount if necessary
+
+        If `mount` does not match the value in :py:attr:`_last_moved_mount`
+        (and :py:attr:`_last_moved_mount` exists) then retract the mount
+        in :py:attr:`_last_moved_mount`. Also unconditionally update
+        :py:attr:`_last_moved_mount` to contain `mount`.
+        """
+        if mount != self._last_moved_mount and self._last_moved_mount:
+            await self.retract(self._last_moved_mount, 10)
+        self._last_moved_mount = mount
 
     async def _move_plunger(self, mount: top_types.Mount, dist: float,
                             speed: float = None):

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -94,6 +94,7 @@ class API:
             top_types.Mount.RIGHT: None
         }
         self._attached_modules: Dict[str, Any] = {}
+        self._last_moved_mount: Optional[top_types.Mount] = None
 
     @classmethod
     def build_hardware_controller(
@@ -340,6 +341,11 @@ class API:
         """
         if not self._current_position:
             raise MustHomeError
+
+        if mount != self._last_moved_mount and self._last_moved_mount:
+            await self.retract(self._last_moved_mount, 10)
+        self._last_moved_mount = mount
+
         z_axis = Axis.by_mount(mount)
         if mount == top_types.Mount.LEFT:
             offset = top_types.Point(*self.config.mount_offset)
@@ -363,6 +369,11 @@ class API:
         """
         if not self._current_position:
             raise MustHomeError
+
+        if mount != self._last_moved_mount and self._last_moved_mount:
+            await self.retract(self._last_moved_mount, 10)
+        self._last_moved_mount = mount
+
         z_axis = Axis.by_mount(mount)
         try:
             target_position = OrderedDict(
@@ -379,6 +390,7 @@ class API:
 
     async def _move_plunger(self, mount: top_types.Mount, dist: float,
                             speed: float = None):
+
         z_axis = Axis.by_mount(mount)
         pl_axis = Axis.of_plunger(mount)
         all_axes_pos = OrderedDict(

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -435,9 +435,14 @@ class InstrumentContext:
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck)
         self._log.debug("move {}->{}: {}"
                         .format(from_loc, location, moves))
-        self._ctx.location_cache = location
-        for move in moves:
-            self._hardware.move_to(self._mount, move)
+        try:
+            for move in moves:
+                self._hardware.move_to(self._mount, move)
+        except Exception:
+            self._ctx.location_cache = None
+            raise
+        else:
+            self._ctx.location_cache = location
         return self
 
     @property

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -211,21 +211,12 @@ class ProtocolContext:
         a position attached to it, and its behavior depends on the state of
         that location cache and the passed location.
         """
-        switching_instr = self._last_moved_instrument\
-            and self._last_moved_instrument != mount
-        if switching_instr:
-            # TODO: Is 10 the right number here? This is what’s used in
-            # robot since it’s a default to an argument that is never
-            # changed
-            self._log.debug("retract {}".format(self._last_moved_instrument))
-            self._hardware.retract(self._last_moved_instrument, 10)
-
-        if self._location_cache and not switching_instr:
-            from_loc = self._location_cache
+        if self._location_cache:
+            from_lw = self._location_cache.labware
         else:
-            from_loc = types.Location(
-                point=self._hardware.gantry_position(mount),
-                labware=None)
+            from_lw = None
+        from_loc = types.Location(self._hardware.gantry_position(mount),
+                                  from_lw)
         moves = geometry.plan_moves(from_loc, location, self._deck_layout)
         self._log.debug("planned moves for {}->{}: {}"
                         .format(from_loc, location, moves))

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -195,7 +195,7 @@ async def test_deck_cal_applied(monkeypatch, loop):
     assert called_with['Z'] == 30
 
 
-async def test_other_mount_retracted(hardware_api, monkeypatch):
+async def test_other_mount_retracted(hardware_api):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
     assert hardware_api.gantry_position(types.Mount.RIGHT)\

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -57,6 +57,8 @@ async def test_controller_musthome(hardware_api):
 async def test_home_specific_sim(hardware_api, monkeypatch):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(-10, 10, 20))
+    # Avoid the autoretract when moving two difference instruments
+    hardware_api._last_moved_mount = None
     await hardware_api.move_rel(types.Mount.LEFT, types.Point(0, 0, -20))
     await hardware_api.home([Axis.Z, Axis.C])
     assert hardware_api._current_position == {Axis.X: -10,
@@ -100,7 +102,7 @@ async def test_move(hardware_api):
     target_position2 = {Axis.X: 60,
                         Axis.Y: 40,
                         Axis.Z: 228,
-                        Axis.A: 10,
+                        Axis.A: 218,  # The other instrument is retracted
                         Axis.B: 19,
                         Axis.C: 19}
     await hardware_api.move_rel(mount2, rel_position)
@@ -191,3 +193,13 @@ async def test_deck_cal_applied(monkeypatch, loop):
     assert called_with['X'] == 44
     assert called_with['Y'] == 20
     assert called_with['Z'] == 30
+
+
+async def test_other_mount_retracted(hardware_api, monkeypatch):
+    await hardware_api.home()
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    assert hardware_api.gantry_position(types.Mount.RIGHT)\
+        == types.Point(0, 0, 0)
+    await hardware_api.move_to(types.Mount.LEFT, types.Point(20, 20, 0))
+    assert hardware_api.gantry_position(types.Mount.RIGHT) \
+        == types.Point(54, 20, 218)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -54,7 +54,6 @@ def test_location_cache(loop, monkeypatch, load_my_labware):
     ctx = papi.ProtocolContext(loop)
     ctx.connect(hardware)
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
-    left = ctx.load_instrument('p300_multi', Mount.LEFT)
     lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
     ctx.home()
 
@@ -77,21 +76,16 @@ def test_location_cache(loop, monkeypatch, load_my_labware):
     assert test_args[0].point == Point(418, 353, 205)
     assert test_args[0].labware is None
 
-    # Once we have a location cache, that should be our from_loc
+    # kOnce we have a location cache, that should be our from_loc
     right.move_to(lw.wells()[1].top())
-    assert test_args[0] == lw.wells()[0].top()
-
-    # If we switch instruments, we should ignore the cache
-    here = hardware.gantry_position(Mount.LEFT)
-    left.move_to(lw.wells()[1].top())
-    assert test_args[0].point == here
-    assert test_args[0].labware is None
+    assert test_args[0].labware == lw.wells()[0]
 
 
 def test_move_uses_arc(loop, monkeypatch, load_my_labware):
     hardware = API.build_hardware_simulator(loop=loop)
     ctx = papi.ProtocolContext(loop)
     ctx.connect(hardware)
+    ctx.home()
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
     lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
     ctx.home()
@@ -122,6 +116,7 @@ def test_pipette_info(loop):
 
 def test_aspirate(loop, load_my_labware, monkeypatch):
     ctx = papi.ProtocolContext(loop)
+    ctx.home()
     lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
     instr = ctx.load_instrument('p10_single', Mount.RIGHT)
 
@@ -138,19 +133,18 @@ def test_aspirate(loop, load_my_labware, monkeypatch):
         move_called_with = (mount, loc)
 
     monkeypatch.setattr(ctx._hardware._api, 'aspirate', fake_hw_aspirate)
-    monkeypatch.setattr(ctx, 'move_to', fake_move)
+    monkeypatch.setattr(ctx._hardware._api, 'move_to', fake_move)
 
     instr.aspirate(2.0, lw.wells()[0].bottom())
 
     assert asp_called_with == (Mount.RIGHT, 2.0, 1.0)
-    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom())
+    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom().point)
 
     instr.well_bottom_clearance = 1.0
     instr.aspirate(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
-    assert move_called_with == (Mount.RIGHT,
-                                Location(dest_point, dest_lw))
+    assert move_called_with == (Mount.RIGHT, dest_point)
 
     move_called_with = None
     instr.aspirate(2.0)
@@ -159,6 +153,7 @@ def test_aspirate(loop, load_my_labware, monkeypatch):
 
 def test_dispense(loop, load_my_labware, monkeypatch):
     ctx = papi.ProtocolContext(loop)
+    ctx.home()
     lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 1)
     instr = ctx.load_instrument('p10_single', Mount.RIGHT)
 
@@ -175,19 +170,18 @@ def test_dispense(loop, load_my_labware, monkeypatch):
         move_called_with = (mount, loc)
 
     monkeypatch.setattr(ctx._hardware._api, 'dispense', fake_hw_dispense)
-    monkeypatch.setattr(ctx, 'move_to', fake_move)
+    monkeypatch.setattr(ctx._hardware._api, 'move_to', fake_move)
 
     instr.dispense(2.0, lw.wells()[0].bottom())
 
     assert disp_called_with == (Mount.RIGHT, 2.0, 1.0)
-    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom())
+    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom().point)
 
     instr.well_bottom_clearance = 1.0
     instr.dispense(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
-    assert move_called_with == (Mount.RIGHT,
-                                Location(dest_point, dest_lw))
+    assert move_called_with == (Mount.RIGHT, dest_point)
 
     move_called_with = None
     instr.dispense(2.0)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -145,6 +145,17 @@ def test_aspirate(loop, load_my_labware, monkeypatch):
     assert asp_called_with == (Mount.RIGHT, 2.0, 1.0)
     assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom())
 
+    instr.well_bottom_clearance = 1.0
+    instr.aspirate(2.0, lw.wells()[0])
+    dest_point, dest_lw = lw.wells()[0].bottom()
+    dest_point = dest_point._replace(z=dest_point.z + 1.0)
+    assert move_called_with == (Mount.RIGHT,
+                                Location(dest_point, dest_lw))
+
+    move_called_with = None
+    instr.aspirate(2.0)
+    assert move_called_with is None
+
 
 def test_dispense(loop, load_my_labware, monkeypatch):
     ctx = papi.ProtocolContext(loop)
@@ -170,3 +181,14 @@ def test_dispense(loop, load_my_labware, monkeypatch):
 
     assert disp_called_with == (Mount.RIGHT, 2.0, 1.0)
     assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom())
+
+    instr.well_bottom_clearance = 1.0
+    instr.dispense(2.0, lw.wells()[0])
+    dest_point, dest_lw = lw.wells()[0].bottom()
+    dest_point = dest_point._replace(z=dest_point.z + 1.0)
+    assert move_called_with == (Mount.RIGHT,
+                                Location(dest_point, dest_lw))
+
+    move_called_with = None
+    instr.dispense(2.0)
+    assert move_called_with is None

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -76,7 +76,7 @@ def test_location_cache(loop, monkeypatch, load_my_labware):
     assert test_args[0].point == Point(418, 353, 205)
     assert test_args[0].labware is None
 
-    # kOnce we have a location cache, that should be our from_loc
+    # Once we have a location cache, that should be our from_loc
     right.move_to(lw.wells()[1].top())
     assert test_args[0].labware == lw.wells()[0]
 


### PR DESCRIPTION
There were a couple issues with #2598 that didn't affect functionality and didn't seem worth further delay (since that PR was blocking others). This PR fixes them, specifically

- Re-adding the ability for `aspirate` and `dispense` to take a Well as a location
- Removing `ProtocolContext.move_to` and moving its functionality to `InstrumentContext.move_to`
- Moving the responsibility for retracting a mount when switching between which mount is being moved to `hardware_control`

```python
import asyncio
import opentrons.hardware_control as hc
from opentrons.types import *
a = hc.API.build_hardware_controller()
l = asyncio.get_event_loop()
l.run_until_complete(a.home())
l.run_until_complete(a.move_to(Mount.LEFT, Point(20, 20, 100)))
l.run_until_complete(a.move_to(Mount.RIGHT, Point(40, 20, 100))) # The left mount should retract
l.run_until_complete(a.move_to(Mount.LEFT, Point(20, 20, 100))) # The right mount should retract
```
