### PR TITLE
API: add out of bounds move checks to hardware_control

### DIFF
--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -171,3 +171,10 @@ class Controller:
                 yield
             finally:
                 self._smoothie_driver.pop_speed()
+
+    @property
+    def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
+        """ The (minimum, maximum) bounds for each axis. """
+        return {ax: (0, pos) for ax, pos
+                in self._smoothie_driver.homed_position.items()
+                if ax not in 'BC'}

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -125,3 +125,9 @@ class Simulator:
             loop: Optional[asyncio.AbstractEventLoop])\
             -> modules.AbstractModule:
         return module
+
+    @property
+    def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
+        """ The (minimum, maximum) bounds for each axis. """
+        return {ax: (0, pos) for ax, pos in _HOME_POSITION.items()
+                if ax not in 'BC'}

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -56,12 +56,12 @@ async def test_controller_musthome(hardware_api):
 
 async def test_home_specific_sim(hardware_api, monkeypatch):
     await hardware_api.home()
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(-10, 10, 20))
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 10, 20))
     # Avoid the autoretract when moving two difference instruments
     hardware_api._last_moved_mount = None
     await hardware_api.move_rel(types.Mount.LEFT, types.Point(0, 0, -20))
     await hardware_api.home([Axis.Z, Axis.C])
-    assert hardware_api._current_position == {Axis.X: -10,
+    assert hardware_api._current_position == {Axis.X: 0,
                                               Axis.Y: 10,
                                               Axis.Z: 218,
                                               Axis.A: 20,
@@ -71,9 +71,9 @@ async def test_home_specific_sim(hardware_api, monkeypatch):
 
 async def test_retract(hardware_api):
     await hardware_api.home()
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(-10, 10, 20))
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 10, 20))
     await hardware_api.retract(types.Mount.RIGHT, 10)
-    assert hardware_api._current_position == {Axis.X: -10,
+    assert hardware_api._current_position == {Axis.X: 0,
                                               Axis.Y: 10,
                                               Axis.Z: 218,
                                               Axis.A: 218,
@@ -97,11 +97,11 @@ async def test_move(hardware_api):
     # This assert implicitly checks that the mount offset is not applied to
     # relative moves; if you change this to move_to, the offset will be
     # applied again
-    rel_position = types.Point(30, 20, 10)
+    rel_position = types.Point(30, 20, -10)
     mount2 = types.Mount.LEFT
     target_position2 = {Axis.X: 60,
                         Axis.Y: 40,
-                        Axis.Z: 228,
+                        Axis.Z: 208,
                         Axis.A: 218,  # The other instrument is retracted
                         Axis.B: 19,
                         Axis.C: 19}
@@ -157,10 +157,15 @@ async def test_critical_point_applied(hardware_api, monkeypatch):
     target[Axis.A] = 0
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     # And removing the tip should move us back to the original
+    await hardware_api.move_rel(types.Mount.RIGHT, types.Point(2.5, 0, 0))
     await hardware_api.drop_tip(types.Mount.RIGHT)
     target[Axis.A] = 33 + hc.DROP_TIP_RELEASE_DISTANCE
+    target_no_offset[Axis.X] = 2.5
+    target[Axis.X] = 2.5
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    target[Axis.X] = 0
+    target_no_offset[Axis.X] = 0
     target_no_offset[Axis.A] = 13
     target[Axis.A] = 0
     assert hardware_api._current_position == target_no_offset
@@ -203,3 +208,59 @@ async def test_other_mount_retracted(hardware_api):
     await hardware_api.move_to(types.Mount.LEFT, types.Point(20, 20, 0))
     assert hardware_api.gantry_position(types.Mount.RIGHT) \
         == types.Point(54, 20, 218)
+
+
+async def catch_oob_moves(hardware_api):
+    await hardware_api.home()
+    # Check axis max checking for move and move rel
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(1, 0, 0))
+    assert hardware_api.gantry_position(types.Mount.RIGHT)\
+        == types.Point(418, 353, 218)
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(0, 1, 0))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(0, 0, 1))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(419, 353, 218))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(418, 354, 218))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(418, 353, 219))
+    assert hardware_api.gantry_position(types.Mount.RIGHT)\
+        == types.Point(418, 353, 218)
+    # Axis min checking for move and move rel
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(-1, 353, 218))
+    assert hardware_api.gantry_position(types.Mount.RIGHT)\
+        == types.Point(418, 353, 218)
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(418, -1, 218))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.RIGHT,
+                                   types.Point(418, 353, -1))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(-419, 0, 0))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(0, -354, 0))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.RIGHT, types.Point(0, 0, -219))
+    assert hardware_api.gantry_position(types.Mount.RIGHT)\
+        == types.Point(418, 353, 218)
+    # Make sure we are checking after mount offset and critical points
+    # are applied
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.LEFT, types.Point(33, 0, 0))
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_to(types.Mount.LEFT, types.Point(385, 0, 0))
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(50, 50, 100))
+    await hardware_api.cache_instruments({types.Mount.LEFT: 'p10_single'})
+    with pytest.raises(RuntimeError):
+        await hardware_api.move_rel(types.Mount.LEFT, types.Point(0, 0, 12))
+    await hardware_api.pick_up_tip(types.Mount.LEFT)
+    await hardware_api.move_rel(types.Mount.LEFT, types.Point(0, 0, 0))


### PR DESCRIPTION
Add out-of-bounds move checks to gantry axes.

This checks for out of bound moves, where the bounds are defined as (0, home_position) in smoothie coordinates, to gantry axis motions. These are checked in smoothie coordinates before the move is sent to the smoothie. If a move is out of bounds, we raise a RuntimeError with a reasonably human readable message.

The positions are checked after all transforms, meaning that different points are reachable depending on
- whether a pipette is attached to a given mount
- what kind of pipette it is
- whether it has tips

For instance, moving to (50, 50, 0) with the right mount when no pipette is attached (or a p300 single without a tip is attached) is out of bounds - that transforms to roughly (50, 50, -25.6) with a proper deck calibration. When a tip is attached, however, that move puts the end of the attached tip on the deck. Similarly, the left mount may or may not be able to move to (0, 0, 0) depending on whether a multichannel pipette is attached.

Try it on a robot:
```python
from opentrons import hardware_control as hc
from opentrons.hardware_control import adapters
from opentrons.types import *
a = hc.api.build_hardware_controller()
sa = adapters.SynchronousAdapter(a)
sa.home()
sa.move_rel(Mount.RIGHT, Point(1, 0, 0)) # RuntimeError: Out of bounds move
sa.move_to(Mount.LEFT, Point(0, 0, 30)) # Works ok
sa.move_to(Mount.LEFT, Point(0, 0, 0)) # RuntimeError
sa.cache_instruments()
sa.move_to(Mount.LEFT, Point(100, 100, 50))
sa.pick_up_tip(Mount.LEFT) # Put a tip on here if you want
sa.move_to(Mount.LEFT, Point(0, 0, 0)) # Works if left mount has a single channel, otherwise use Point(0, 31.5, 0)
```