### PR TITLE
fix(api): Correct well ordering for custom labware

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -105,8 +105,8 @@ def create(name, grid, spacing, diameter, depth, volume=0):
         'total-liquid-volume': volume
     }
 
-    for r in range(rows):
-        for c in range(columns):
+    for c in range(columns):
+        for r in range(rows):
             well = Well(properties=properties)
             well_name = chr(r + ord('A')) + str(1 + c)
             coordinates = (c * col_spacing, (rows - r - 1) * row_spacing, 0)

--- a/api/tests/opentrons/database/test_labware_definitions.py
+++ b/api/tests/opentrons/database/test_labware_definitions.py
@@ -145,6 +145,8 @@ def test_labware_create(dummy_db):
     assert lw.well("C3").coordinates() == (
         2 * col_space, 0, 0)
 
+    assert lw.well(2).get_name() == 'C1'
+
 
 def test_new_labware_create(split_labware_def):
     from opentrons import labware


### PR DESCRIPTION
## overview

Correct well ordering for custom labware (definitions created using `labware.create`) to iterate over columns instead of rows. Fixes #2631 

## changelog

- fix(api): correct well ordering for custom labware

## review requests

Just take a look at the tests and fix. Pretty self-explanatory.