### PR TITLE
refactor(api): Add ability to load a labware by definition name

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import time
+import pkgutil
 from typing import List, Dict
 
 from opentrons.types import Point, Location
@@ -458,7 +459,13 @@ def _load_definition_by_name(name: str) -> dict:
         saved to disc. The definition file must have been saved in a known
         location with the filename '${name}.json'
     """
-    raise NotImplementedError
+    labware_def: dict = {}
+    def_path = 'shared_data/definitions2/{}.json'.format(name)
+    try:
+        labware_def = json.loads(pkgutil.get_data('opentrons', def_path))  # type: ignore # NOQA
+    except FileNotFoundError:
+        print("{} definition not found".format(name))
+    return labware_def
 
 
 def load(name: str, parent: Point, parent_name: str) -> Labware:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -590,12 +590,8 @@ def _load_definition_by_name(name: str) -> dict:
         saved to disc. The definition file must have been saved in a known
         location with the filename '${name}.json'
     """
-    labware_def: dict = {}
     def_path = 'shared_data/definitions2/{}.json'.format(name)
-    try:
-        labware_def = json.loads(pkgutil.get_data('opentrons', def_path))  # type: ignore # NOQA
-    except FileNotFoundError:
-        print("{} definition not found".format(name))
+    labware_def = json.loads(pkgutil.get_data('opentrons', def_path))  # type: ignore # NOQA
     return labware_def
 
 

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -113,10 +113,7 @@ def test_from_center_cartesian():
 
 def test_backcompat():
     labware_name = 'generic_96_wellPlate_380_uL'
-    labware_def = json.loads(
-        pkgutil.get_data('opentrons',
-                         'shared_data/definitions2/{}.json'.format(
-                             labware_name)))
+    labware_def = labware._load_definition_by_name(labware_name)
     lw = labware.Labware(labware_def, Point(0, 0, 0), 'Test Slot')
 
     # Note that this test uses the display name of wells to test for equality,
@@ -176,10 +173,7 @@ def test_backcompat():
 
 def test_well_parent():
     labware_name = 'generic_96_wellPlate_380_uL'
-    labware_def = json.loads(
-        pkgutil.get_data('opentrons',
-                         'shared_data/definitions2/{}.json'.format(
-                             labware_name)))
+    labware_def = labware._load_definition_by_name(labware_name)
     lw = labware.Labware(labware_def, Point(0, 0, 0), 'Test Slot')
     parent = Location(Point(7, 8, 9), lw)
     well_name = 'circular_well_json'
@@ -199,10 +193,7 @@ def test_well_parent():
 
 def test_tip_tracking_init():
     labware_name = 'Opentrons_96_tiprack_300_uL'
-    labware_def = json.loads(
-        pkgutil.get_data('opentrons',
-                         'shared_data/definitions2/{}.json'.format(
-                             labware_name)))
+    labware_def = labware._load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def, Point(0, 0, 0), 'Test Slot')
     assert tiprack.is_tiprack
     for well in tiprack.wells():
@@ -221,10 +212,7 @@ def test_tip_tracking_init():
 
 def test_use_tips():
     labware_name = 'Opentrons_96_tiprack_300_uL'
-    labware_def = json.loads(
-        pkgutil.get_data('opentrons',
-                         'shared_data/definitions2/{}.json'.format(
-                             labware_name)))
+    labware_def = labware._load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def, Point(0, 0, 0), 'Test Slot')
     well_list = tiprack.wells()
 
@@ -262,10 +250,7 @@ def test_use_tips():
 
 def test_select_next_tip():
     labware_name = 'Opentrons_96_tiprack_300_uL'
-    labware_def = json.loads(
-        pkgutil.get_data('opentrons',
-                         'shared_data/definitions2/{}.json'.format(
-                             labware_name)))
+    labware_def = labware._load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def, Point(0, 0, 0), 'Test Slot')
     well_list = tiprack.wells()
 

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -1,37 +1,30 @@
-import json
-import pkgutil
 from opentrons import protocol_api as papi, types
 
-# TODO: Remove this when labware load is actually wired up
+
 labware_name = 'generic_96_wellPlate_380_uL'
-labware_def = json.loads(
-    pkgutil.get_data('opentrons',
-                     'shared_data/definitions2/{}.json'.format(labware_name)))
 
 
-def test_load_to_slot(monkeypatch, loop):
-    def dummy_load(labware):
-        return labware_def
-    monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext(loop=loop)
+def test_load_to_slot():
+    ctx = papi.ProtocolContext()
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert labware._offset == types.Point(0, 0, 0)
     other = ctx.load_labware_by_name(labware_name, 2)
     assert other._offset == types.Point(132.5, 0, 0)
 
 
-def test_loaded(monkeypatch, loop):
-    def dummy_load(labware):
-        return labware_def
-    monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
-    ctx = papi.ProtocolContext(loop=loop)
+def test_loaded():
+    ctx = papi.ProtocolContext()
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert ctx.loaded_labwares[1] == labware
 
 
-def test_from_backcompat(monkeypatch, loop):
-    def dummy_load(labware):
-        return labware_def
-    monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
+def test_from_backcompat():
+    ctx = papi.ProtocolContext()
+    papi.back_compat.reset(ctx)
     lw = papi.back_compat.labware.load(labware_name, 3)
-    assert lw == papi.back_compat.robot.loaded_labwares[3]
+    assert lw == ctx.loaded_labwares[3]
+
+
+def test_load_incorrect_definition_by_name():
+    definition = papi.labware._load_definition_by_name('fake_labware')
+    assert definition == {}

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -1,3 +1,4 @@
+import pytest
 from opentrons import protocol_api as papi, types
 
 
@@ -18,13 +19,6 @@ def test_loaded(loop):
     assert ctx.loaded_labwares[1] == labware
 
 
-def test_from_backcompat(loop):
-    ctx = papi.ProtocolContext(loop=loop)
-    papi.back_compat.reset()
-    lw = papi.back_compat.labware.load(labware_name, 3)
-    assert lw == ctx.loaded_labwares[3]
-
-
 def test_load_incorrect_definition_by_name():
-    definition = papi.labware._load_definition_by_name('fake_labware')
-    assert definition == {}
+    with pytest.raises(FileNotFoundError):
+        papi.labware._load_definition_by_name('fake_labware')

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -4,23 +4,23 @@ from opentrons import protocol_api as papi, types
 labware_name = 'generic_96_wellPlate_380_uL'
 
 
-def test_load_to_slot():
-    ctx = papi.ProtocolContext()
+def test_load_to_slot(loop):
+    ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert labware._offset == types.Point(0, 0, 0)
     other = ctx.load_labware_by_name(labware_name, 2)
     assert other._offset == types.Point(132.5, 0, 0)
 
 
-def test_loaded():
-    ctx = papi.ProtocolContext()
+def test_loaded(loop):
+    ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware_by_name(labware_name, '1')
     assert ctx.loaded_labwares[1] == labware
 
 
-def test_from_backcompat():
-    ctx = papi.ProtocolContext()
-    papi.back_compat.reset(ctx)
+def test_from_backcompat(loop):
+    ctx = papi.ProtocolContext(loop=loop)
+    papi.back_compat.reset()
     lw = papi.back_compat.labware.load(labware_name, 3)
     assert lw == ctx.loaded_labwares[3]
 


### PR DESCRIPTION
## overview
Closes #2613. 

## changelog
- Add ability to load labware def by name

## review requests

Test on a robot!
- Set feature flag to use `useProtocolApi2`
```
from opentrons import protocol_api
ctx = protocol_api.ProtocolContext()
labware = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', '1')
```
