### PR TITLE
refactor(api): tiplength from tiprack

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -45,10 +45,6 @@ class MustHomeError(RuntimeError):
     pass
 
 
-class PipetteNotAttachedError(KeyError):
-    pass
-
-
 _Backend = Union[Controller, Simulator]
 Instruments = Dict[top_types.Mount, Optional[Pipette]]
 SHAKE_OFF_TIPS_SPEED = 50
@@ -240,7 +236,7 @@ class API:
         position.
 
         :param mount: the mount associated with the target plunger
-        :type mount: :py:class`.top_types.Mount`
+        :type mount: :py:class:`.top_types.Mount`
         """
         # incase plunger motor stalled while dropping a tip, add a
         # safety margin of the distance between `bottom` and `drop_tip`
@@ -588,8 +584,8 @@ class API:
         """
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
-            raise PipetteNotAttachedError("No pipette attached to {} mount"
-                                          .format(mount.name))
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount.name))
         if volume is None:
             asp_vol = this_pipette.available_volume
             mod_log.debug(
@@ -634,8 +630,8 @@ class API:
         """
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
-            raise PipetteNotAttachedError("No pipette attached to {} mount"
-                                          .format(mount.name))
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount.name))
         if volume is None:
             disp_vol = this_pipette.current_volume
             mod_log.debug("No dispense volume specified. Dispensing all "
@@ -679,8 +675,8 @@ class API:
         """
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
-            raise PipetteNotAttachedError("No pipette attached to {} mount"
-                                          .format(mount.name))
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount.name))
 
         self._backend.set_active_current(Axis.of_plunger(mount),
                                          this_pipette.config.plunger_current)
@@ -797,8 +793,8 @@ class API:
         """
         instr = self._attached_instruments[mount]
         if not instr:
-            raise PipetteNotAttachedError("No pipette attached to {} mount"
-                                          .format(mount.name))
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount.name))
 
         pos_dict: Dict = instr.config.plunger_positions
         if top is not None:
@@ -815,8 +811,8 @@ class API:
     def set_flow_rate(self, mount, aspirate=None, dispense=None):
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
-            raise PipetteNotAttachedError("No pipette attached to {} mount"
-                                          .format(mount))
+            raise top_types.PipetteNotAttachedError(
+                "No pipette attached to {} mount".format(mount))
         if aspirate:
             this_pipette.update_config_item('aspirate_flow_rate', aspirate)
         if dispense:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -192,7 +192,7 @@ class API:
 
     @property
     def attached_instruments(self):
-        configs = ['name', 'min_volume', 'max_volume',
+        configs = ['name', 'min_volume', 'max_volume', 'channels',
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name']
         instruments = {top_types.Mount.LEFT: {},

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -671,7 +671,11 @@ class API:
             this_pipette.set_current_volume(0)
 
     @_log_call
-    async def pick_up_tip(self, mount, presses: int = 3, increment: float = 1):
+    async def pick_up_tip(self,
+                          mount,
+                          tip_length: float,
+                          presses: int = 3,
+                          increment: float = 1):
         """
         Pick up tip from current location
         """
@@ -700,7 +704,7 @@ class API:
             # move nozzle back up
             backup_pos = top_types.Point(0, 0, -dist)
             await self.move_rel(mount, backup_pos)
-        instr.add_tip()
+        instr.add_tip(tip_length=tip_length)
         instr.set_current_volume(0)
 
         # neighboring tips tend to get stuck in the space between

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -678,26 +678,6 @@ class InstrumentContext:
         assert clearance >= 0
         self._well_bottom_clearance = clearance
 
-    # def _find_next_tip(self) -> Well:
-    #     """
-    #     Recursively iterate through the associated tipracks and get the next
-    #     Well that has a tip in it. If no tips are available in any associated
-    #     tipracks, raise an `OutOfTipsError`
-    #     :return: a `Well` that has a tip available
-    #     """
-    #     def _find_tip_all_racks(tiprack_list: List[Labware]) -> Well:
-    #         try:
-    #             tr = tiprack_list.pop(0)
-    #         except IndexError:
-    #             raise OutOfTipsError
-    #         tip_from_tiprack: Optional[Well] = tr.next_tip()
-    #         if tip_from_tiprack:
-    #             return tip_from_tiprack
-    #         else:
-    #             return _find_tip_all_racks(tiprack_list)
-    #
-    #     return _find_tip_all_racks(self.tip_racks)
-
     def __repr__(self):
         return '<{}: {} in {}>'.format(self.__class__.__name__,
                                        self.hw_pipette['name'],

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -418,7 +418,7 @@ class Labware:
 
         :param num_tips: target number of sequential tips in the same column
         :type num_tips: int
-        :return: the :py:class`.Well` meeting the target criteria, or None
+        :return: the :py:class:`.Well` meeting the target criteria, or None
         """
         assert num_tips > 0
 
@@ -451,12 +451,12 @@ class Labware:
         based on the start well, the number of channels, and the geometry of
         the tiprack.
 
-        :param start_well: The :py:class`.Well` from which to pick up a tip.
+        :param start_well: The :py:class:`.Well` from which to pick up a tip.
                            For a single-channel pipette, this is the well to
                            send the pipette to. For a multi-channel pipette,
                            this is the well to send the back-most nozzle of the
                            pipette to.
-        :type start_well: :py:class`.Well`
+        :type start_well: :py:class:`.Well`
         :param num_channels: The number of channels for the current pipette
         :type num_channels: int
         """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -3,14 +3,14 @@ import json
 import os
 import re
 import time
+from collections import defaultdict
+from enum import Enum, auto
 from itertools import takewhile, dropwhile
 from typing import List, Dict, Optional
 
 from opentrons.types import Location
-from enum import Enum, auto
 from opentrons.types import Point
 from opentrons.util import environment as env
-from collections import defaultdict
 
 
 class WellShape(Enum):
@@ -410,13 +410,15 @@ class Labware:
 
     def next_tip(self, num_tips: int = 1) -> Optional[Well]:
         """
+        Find the next valid well for pick-up.
+
         Determines the next valid start tip from which to retrieve the
         specified number of tips. There must be at least `num_tips` sequential
-        wells for which all wells have tips, in the same column
+        wells for which all wells have tips, in the same column.
 
-        :param num_tips: the number of sequential tips in the same column
+        :param num_tips: target number of sequential tips in the same column
         :type num_tips: int
-        :return:
+        :return: the :py:class`.Well` meeting the target criteria, or None
         """
         assert num_tips > 0
 
@@ -440,20 +442,21 @@ class Labware:
 
     def use_tips(self, start_well: Well, num_channels: int = 1):
         """
-        Removes tips from the tip tracker. This method should be called when a
-        tip is picked up. Generally, it will be called with `num_wells=1` or
-        `num_wells=8` for single- and multi-channel respectively. If picking up
-        with more than one channel, this method will automatically determine
-        which tips are used based on the start well, the number of channels,
-        and the geometry of the tiprack.
+        Removes tips from the tip tracker.
 
-        For example, targeting the
+        This method should be called when a tip is picked up. Generally, it
+        will be called with `num_channels=1` or `num_channels=8` for single-
+        and multi-channel respectively. If picking up with more than one
+        channel, this method will automatically determine which tips are used
+        based on the start well, the number of channels, and the geometry of
+        the tiprack.
 
-        :param start_well: The Well from which to pick up a tip. For a single-
-            channel pipette, this is the well to send the pipette to. For a
-            multi-channel pipette, this is the well to send the back-most
-            nozzle of the pipette to.
-        :type start_well: Well
+        :param start_well: The :py:class`.Well` from which to pick up a tip.
+                           For a single-channel pipette, this is the well to
+                           send the pipette to. For a multi-channel pipette,
+                           this is the well to send the back-most nozzle of the
+                           pipette to.
+        :type start_well: :py:class`.Well`
         :param num_channels: The number of channels for the current pipette
         :type num_channels: int
         """
@@ -474,7 +477,6 @@ class Labware:
         assert all([well.has_tip for well in target_wells])
 
         for well in target_wells:
-            print("Using tip in {}".format(well))
             well.has_tip = False
 
     def __repr__(self):

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -7,6 +7,11 @@ if TYPE_CHECKING:
     from .labware import Labware, Well  # noqa(F401) Used for typechecking
 
 
+class PipetteNotAttachedError(KeyError):
+    """ An error raised if a pipette is accessed that is not attached """
+    pass
+
+
 class Point(NamedTuple):
     x: float
     y: float

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -170,7 +170,12 @@ async def test_pick_up_tip(dummy_instruments, loop):
                        Axis.B: 2,
                        Axis.C: 19}
     await hw_api.move_to(mount, tip_position)
-    await hw_api.pick_up_tip(mount)
+
+    # Note: pick_up_tip without a tip_length argument requires the pipette on
+    # the associated mount to have an associated tip rack from which to infer
+    # the tip length. That behavior is not tested here.
+    tip_length = 25.0
+    await hw_api.pick_up_tip(mount, tip_length)
     assert hw_api._attached_instruments[mount].has_tip
     assert hw_api._attached_instruments[mount].current_volume == 0
     assert hw_api._current_position == target_position

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -26,7 +26,7 @@ def dummy_instruments():
 
 async def test_cache_instruments(dummy_instruments, loop):
     expected_keys = [
-        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
+        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
         'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     hw_api = hc.API.build_hardware_simulator(
@@ -44,7 +44,7 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
                                     hardware_controller_lockfile,
                                     running_on_pi, cntrlr_mock_connect, loop):
     expected_keys = [
-        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
+        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
         'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     hw_api_cntrlr = hc.API.build_hardware_controller(loop=loop)
@@ -82,7 +82,7 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
 
 async def test_cache_instruments_sim(loop, dummy_instruments):
     expected_keys = [
-        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate',
+        'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
         'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name']
 
     sim = hc.API.build_hardware_simulator(loop=loop)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -151,7 +151,7 @@ async def test_no_pipette(dummy_instruments, loop):
     await hw_api.cache_instruments()
     aspirate_ul = 3.0
     aspirate_rate = 2
-    with pytest.raises(hc.PipetteNotAttachedError):
+    with pytest.raises(types.PipetteNotAttachedError):
         await hw_api.aspirate(types.Mount.RIGHT, aspirate_ul, aspirate_rate)
         assert not hw_api._current_volume[types.Mount.RIGHT]
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -143,10 +143,11 @@ async def test_critical_point_applied(hardware_api, monkeypatch):
               Axis.A: 0,
               Axis.C: 19}
     assert hardware_api.current_position(types.Mount.RIGHT) == target
-    await hardware_api.pick_up_tip(types.Mount.RIGHT)
+    p10_tip_length = 33
+    await hardware_api.pick_up_tip(types.Mount.RIGHT, p10_tip_length)
     # Now the current position (with offset applied) should change
     # pos_after_pickup + model_offset + critical point
-    target[Axis.A] = 218 + (-13) + (-33)
+    target[Axis.A] = 218 + (-13) + (-1 * p10_tip_length)
     target_no_offset[Axis.C] = target[Axis.C] = 2
     assert hardware_api.current_position(types.Mount.RIGHT) == target
     # This move should take the new critical point into account

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -160,6 +160,7 @@ async def test_critical_point_applied(hardware_api, monkeypatch):
     # And removing the tip should move us back to the original
     await hardware_api.move_rel(types.Mount.RIGHT, types.Point(2.5, 0, 0))
     await hardware_api.drop_tip(types.Mount.RIGHT)
+    await hardware_api.home_plunger(types.Mount.RIGHT)
     target[Axis.A] = 33 + hc.DROP_TIP_RELEASE_DISTANCE
     target_no_offset[Axis.X] = 2.5
     target[Axis.X] = 2.5

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -9,10 +9,11 @@ def test_tip_tracking():
     with pytest.raises(AssertionError):
         pip.remove_tip()
     assert not pip.has_tip
-    pip.add_tip()
+    tip_length = 25.0
+    pip.add_tip(tip_length)
     assert pip.has_tip
     with pytest.raises(AssertionError):
-        pip.add_tip()
+        pip.add_tip(tip_length)
     pip.remove_tip()
     assert not pip.has_tip
     with pytest.raises(AssertionError):
@@ -25,8 +26,9 @@ def test_critical_points():
         pip = pipette.Pipette(config, 'testID')
         mod_offset = Point(*loaded.model_offset)
         assert pip.critical_point == mod_offset
-        pip.add_tip()
-        new = mod_offset._replace(z=mod_offset.z - loaded.tip_length)
+        tip_length = 25.0
+        pip.add_tip(tip_length)
+        new = mod_offset._replace(z=mod_offset.z - tip_length)
         assert pip.critical_point == new
         pip.remove_tip()
         assert pip.critical_point == mod_offset

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -124,25 +124,32 @@ def test_pick_up_and_drop_tip(loop, load_my_labware):
     pipette: Pipette = ctx._hardware._attached_instruments[mount]
     model_offset = Point(*pipette.config.model_offset)
     assert pipette.critical_point == model_offset
+    target_location = tiprack.wells_by_index()['A1'].top()
 
-    instr.pick_up_tip(tiprack.wells_by_index()['A1'])
+    instr.pick_up_tip(target_location)
 
     new_offset = model_offset - Point(0, 0, tip_lenth)
     assert pipette.critical_point == new_offset
 
-    # TODO: uncomment and verify once trash container is added
-    # instr.drop_tip()
-    # assert pipette.critical_point == model_offset
+    instr.drop_tip(target_location)
+    assert pipette.critical_point == model_offset
 
 
 def test_pick_up_tip_no_location(loop, load_my_labware):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    tiprack = ctx.load_labware_by_name('Opentrons_96_tiprack_300_uL', 1)
-    tip_lenth = tiprack.tip_length
+
+    tiprack1 = ctx.load_labware_by_name('Opentrons_96_tiprack_300_uL', 1)
+    tip_lenth1 = tiprack1.tip_length
+
+    tiprack2 = ctx.load_labware_by_name('Opentrons_96_tiprack_300_uL', 2)
+    tip_length2 = tip_lenth1 + 1.0
+    tiprack2.tip_length = tip_length2
+
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
+    instr = ctx.load_instrument(
+        'p300_single', mount, tip_racks=[tiprack1, tiprack2])
 
     pipette: Pipette = ctx._hardware._attached_instruments[mount]
     model_offset = Point(*pipette.config.model_offset)
@@ -150,12 +157,22 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
 
     instr.pick_up_tip()
 
-    new_offset = model_offset - Point(0, 0, tip_lenth)
+    new_offset = model_offset - Point(0, 0, tip_lenth1)
     assert pipette.critical_point == new_offset
 
-    # TODO: uncomment and verify once trash container is added
-    # instr.drop_tip()
-    # assert pipette.critical_point == model_offset
+    # TODO: remove argument and verify once trash container is added
+    instr.drop_tip(tiprack1.wells()[0].top())
+    assert pipette.critical_point == model_offset
+
+    for well in tiprack1.wells():
+        if well.has_tip:
+            tiprack1.use_tips(well)
+
+    assert tiprack1.next_tip() is None
+
+    assert tiprack2.wells()[0].has_tip
+    instr.pick_up_tip()
+    assert not tiprack2.wells()[0].has_tip
 
 
 def test_aspirate(loop, load_my_labware, monkeypatch):


### PR DESCRIPTION
## overview

This PR causes the protcol_api and hardware_control to use the tip length from tip racks instead of from the pipette config. It also causes Well object to have a boolean flag indicating whether or not there is a tip present, and adds methods on `protocol_api.labware.Labware` and protocol_api.contexts.InstrumentContext` to select the next available tip for `pick_up_tip`, taking into account the number of tips the user is attempting to pick up and the number of channels of the pipette. Closes #2271 

## changelog

- Use tip length from tip rack throughout `protocol_api`
- Add tip tracking to `protocol_api.labware` classes
- Add tip selection logic to `protocol_api.labware.Labware` and `protocol_api.contexts.InstrumentContext`
- Track tip length in `hardware_control.pipette.Pipette` instead of just a boolean
- Add calibration method for setting/loading tip length

## review requests

The tests should be explanatory