### PR TITLE
feat(app): Track restart status in discovery state for better alerts

### DIFF
--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -22,6 +22,7 @@ const log = createLogger(__filename)
 const FAST_POLL_INTERVAL_MS = 3000
 const SLOW_POLL_INTERVAL_MS = 15000
 const UPDATE_THROTTLE_MS = 500
+const RESTART_DISCOVERY_TIMEOUT_MS = 60000
 
 let config
 let store
@@ -52,10 +53,34 @@ export function registerDiscovery (dispatch: Action => void) {
     switch (action.type) {
       case 'discovery:START':
         handleServices()
-        return client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
+        fastPollClient()
+        break
+
       case 'discovery:FINISH':
-        return client.setPollInterval(SLOW_POLL_INTERVAL_MS)
+        slowPollClient()
+        break
+
+      // TODO(mc, 2018-11-06): switch to api:SUCCESS when server.js switches
+      case 'api:SERVER_SUCCESS':
+        // on robot restart, go into fast polling to get the robot back asap
+        if (action.payload.path === 'restart') {
+          dispatch({type: 'discovery:START'})
+          fastPollClient()
+          setTimeout(() => {
+            slowPollClient()
+            dispatch({type: 'discovery:FINISH'})
+          }, RESTART_DISCOVERY_TIMEOUT_MS)
+        }
+        break
     }
+  }
+
+  function fastPollClient () {
+    client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
+  }
+
+  function slowPollClient () {
+    client.setPollInterval(SLOW_POLL_INTERVAL_MS)
   }
 
   function handleServices () {

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -53,7 +53,6 @@ export function registerDiscovery (dispatch: Action => void) {
       case 'discovery:START':
         handleServices()
         return client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
-
       case 'discovery:FINISH':
         return client.setPollInterval(SLOW_POLL_INTERVAL_MS)
     }

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -52,12 +52,10 @@ export function registerDiscovery (dispatch: Action => void) {
     switch (action.type) {
       case 'discovery:START':
         handleServices()
-        client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
-        break
+        return client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
 
       case 'discovery:FINISH':
-        client.setPollInterval(SLOW_POLL_INTERVAL_MS)
-        break
+        return client.setPollInterval(SLOW_POLL_INTERVAL_MS)
     }
   }
 

--- a/app/src/components/RobotSettings/ConnectBanner.js
+++ b/app/src/components/RobotSettings/ConnectBanner.js
@@ -13,16 +13,15 @@ export default class ConnectBanner extends React.Component<Robot, State> {
   }
 
   render () {
-    const {name, connected} = this.props
+    const {displayName, connected} = this.props
     const isVisible = connected && !this.state.dismissed
-    const TITLE = `${name} successfully connected`
-
     if (!isVisible) return null
+
     return (
       <AlertItem
         type="success"
         onCloseClick={() => this.setState({dismissed: true})}
-        title={TITLE}
+        title={`${displayName} successfully connected`}
       />
     )
   }

--- a/app/src/components/RobotSettings/ReachableRobotBanner.js
+++ b/app/src/components/RobotSettings/ReachableRobotBanner.js
@@ -7,7 +7,21 @@ import type {ReachableRobot} from '../../discovery'
 
 type State = {dismissed: boolean}
 
-const TITLE = 'Unable to establish connection with robot'
+const UNRESPONSIVE_TITLE = 'Unable to establish connection with robot'
+const RESTARTING_TITLE = 'Robot restarting'
+
+const LAST_RESORT = (
+  <p>
+    If your robot remains unresponsive, please reach out to our Support team.
+  </p>
+)
+
+const RESTARTING_MESSAGE = (
+  <div className={styles.banner}>
+    <p>Your robot is restarting, and should be back online shortly.</p>
+    {LAST_RESORT}
+  </div>
+)
 
 const NO_SERVER_MESSAGE = (
   <div className={styles.banner}>
@@ -16,9 +30,7 @@ const NO_SERVER_MESSAGE = (
       requests.
     </p>
     <p>We recommend power-cycling your robot.</p>
-    <p>
-      If your robot remains unresponsive, please reach out to our Support team.
-    </p>
+    {LAST_RESORT}
   </div>
 )
 
@@ -40,9 +52,7 @@ const SERVER_MESSAGE = (
         </p>
       </li>
     </ol>
-    <p>
-      If your robot remains unresponsive, please reach out to our Support team.
-    </p>
+    {LAST_RESORT}
   </div>
 )
 
@@ -56,9 +66,17 @@ export default class ReachableRobotBanner extends React.Component<
   }
 
   render () {
-    const {serverOk} = this.props
+    const {serverOk, restartStatus} = this.props
     const isVisible = !this.state.dismissed
-    const message = serverOk ? SERVER_MESSAGE : NO_SERVER_MESSAGE
+    let title = ''
+    let message = ''
+    if (restartStatus) {
+      title = RESTARTING_TITLE
+      message = RESTARTING_MESSAGE
+    } else {
+      title = UNRESPONSIVE_TITLE
+      message = serverOk ? SERVER_MESSAGE : NO_SERVER_MESSAGE
+    }
 
     if (!isVisible) return null
 
@@ -66,7 +84,7 @@ export default class ReachableRobotBanner extends React.Component<
       <AlertItem
         type="warning"
         onCloseClick={() => this.setState({dismissed: true})}
-        title={TITLE}
+        title={title}
       >
         {message}
       </AlertItem>

--- a/app/src/discovery/__tests__/actions.test.js
+++ b/app/src/discovery/__tests__/actions.test.js
@@ -30,4 +30,15 @@ describe('discovery actions', () => {
     jest.runTimersToTime(expectedTimeout)
     expect(store.getActions()).toEqual([expectedStart, expectedFinish])
   })
+
+  test('startDiscovery with timeout', () => {
+    const expectedTimeout = 60000
+    const expectedStart = {type: 'discovery:START', meta: {shell: true}}
+    const expectedFinish = {type: 'discovery:FINISH', meta: {shell: true}}
+
+    store.dispatch(startDiscovery(60000))
+    expect(store.getActions()).toEqual([expectedStart])
+    jest.runTimersToTime(expectedTimeout)
+    expect(store.getActions()).toEqual([expectedStart, expectedFinish])
+  })
 })

--- a/app/src/discovery/__tests__/reducer.test.js
+++ b/app/src/discovery/__tests__/reducer.test.js
@@ -2,10 +2,10 @@
 import {discoveryReducer} from '..'
 
 jest.mock('../../shell', () => ({
-  getShellRobots: () => ([
+  getShellRobots: () => [
     {name: 'foo', ip: '192.168.1.1', port: 31950},
     {name: 'bar', ip: '192.168.1.2', port: 31950},
-  ]),
+  ],
 }))
 
 describe('discoveryReducer', () => {
@@ -20,6 +20,7 @@ describe('discoveryReducer', () => {
       initialState: undefined,
       expectedState: {
         scanning: false,
+        restartsByName: {},
         robotsByName: {
           foo: [{name: 'foo', ip: '192.168.1.1', port: 31950}],
           bar: [{name: 'bar', ip: '192.168.1.2', port: 31950}],
@@ -49,12 +50,54 @@ describe('discoveryReducer', () => {
           ],
         },
       },
-      initialState: {robotsByName: {}},
+      initialState: {robotsByName: {}, restartsByName: {}},
       expectedState: {
         robotsByName: {
           foo: [{name: 'foo', ip: '192.168.1.1', port: 31950}],
           bar: [{name: 'bar', ip: '192.168.1.2', port: 31950}],
         },
+        restartsByName: {},
+      },
+    },
+    {
+      name: 'api:SERVER_SUCCESS sets restart pending',
+      action: {
+        type: 'api:SERVER_SUCCESS',
+        payload: {path: 'restart', robot: {name: 'name'}},
+      },
+      initialState: {restartsByName: {}},
+      expectedState: {restartsByName: {name: 'pending'}},
+    },
+    {
+      name: 'discovery:UPDATE_LIST sets restart down if pending robot not ok',
+      action: {
+        type: 'discovery:UPDATE_LIST',
+        payload: {
+          robots: [{name: 'name', ip: '192.168.1.1', port: 31950, ok: false}],
+        },
+      },
+      initialState: {restartsByName: {name: 'pending'}},
+      expectedState: {
+        robotsByName: {
+          name: [{name: 'name', ip: '192.168.1.1', port: 31950, ok: false}],
+        },
+        restartsByName: {name: 'down'},
+      },
+    },
+    {
+      name: 'discovery:UPDATE_LIST clears restart if down robot ok',
+      action: {
+        type: 'discovery:UPDATE_LIST',
+        payload: {
+          robots: [{name: 'name', ip: '192.168.1.1', port: 31950, ok: true}],
+        },
+      },
+      initialState: {restartsByName: {name: 'down'}},
+      expectedState: {
+        robotsByName: {
+          name: [{name: 'name', ip: '192.168.1.1', port: 31950, ok: true}],
+        },
+        restartsByName: {name: null},
       },
     },
   ]

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -24,12 +24,12 @@ type DiscoveryState = {
 
 type StartAction = {|
   type: 'discovery:START',
-  meta?: {|shell: true|},
+  meta: {|shell: true|},
 |}
 
 type FinishAction = {|
   type: 'discovery:FINISH',
-  meta?: {|shell: true|},
+  meta: {|shell: true|},
 |}
 
 type UpdateListAction = {|

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -1,29 +1,35 @@
 // @flow
 // robot discovery state
 import groupBy from 'lodash/groupBy'
+import mapValues from 'lodash/mapValues'
+import some from 'lodash/some'
 import {getShellRobots} from '../shell'
 
 import type {Service} from '@opentrons/discovery-client'
 import type {Action, ThunkAction} from '../types'
+import type {RestartStatus} from './types'
 
 export * from './types'
 export * from './selectors'
 
 type RobotsMap = {[name: string]: Array<Service>}
 
+type RestartsMap = {[name: string]: ?RestartStatus}
+
 type DiscoveryState = {
   scanning: boolean,
   robotsByName: RobotsMap,
+  restartsByName: RestartsMap,
 }
 
 type StartAction = {|
   type: 'discovery:START',
-  meta: {|shell: true|},
+  meta?: {|shell: true|},
 |}
 
 type FinishAction = {|
   type: 'discovery:FINISH',
-  meta: {|shell: true|},
+  meta?: {|shell: true|},
 |}
 
 type UpdateListAction = {|
@@ -34,6 +40,9 @@ type UpdateListAction = {|
 export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
 
 const DISCOVERY_TIMEOUT = 20000
+
+export const RESTART_PENDING: RestartStatus = 'pending'
+export const RESTART_DOWN: RestartStatus = 'down'
 
 export function startDiscovery (): ThunkAction {
   const start: StartAction = {type: 'discovery:START', meta: {shell: true}}
@@ -57,6 +66,7 @@ export function startDiscovery (): ThunkAction {
 const initialState: DiscoveryState = {
   scanning: false,
   robotsByName: normalizeRobots(getShellRobots()),
+  restartsByName: {},
 }
 
 export function discoveryReducer (
@@ -70,11 +80,34 @@ export function discoveryReducer (
     case 'discovery:FINISH':
       return {...state, scanning: false}
 
-    case 'discovery:UPDATE_LIST':
+    case 'discovery:UPDATE_LIST': {
+      const robotsByName = normalizeRobots(action.payload.robots)
+      const restartsByName = mapValues(state.restartsByName, (status, name) => {
+        // TODO(mc, 2018-11-07): once POST /restart sets the status to PENDING,
+        // we need the robot to be health checked by the discovery client at
+        // some point while it's down. This is _probably_ going to happen
+        // because we flip into fast polling when a POST /restart 200s, but
+        // there's a potential gap here that could lead to a latched PENDING
+        const up = some(robotsByName[name], 'ok')
+        if (status === RESTART_PENDING && !up) return RESTART_DOWN
+        if (status === RESTART_DOWN && up) return null
+        return status
+      })
+
+      return {...state, robotsByName, restartsByName}
+    }
+
+    case 'api:SERVER_SUCCESS': {
+      const {path, robot} = action.payload
+      if (path !== 'restart') return state
       return {
         ...state,
-        robotsByName: normalizeRobots(action.payload.robots),
+        restartsByName: {
+          ...state.restartsByName,
+          [robot.name]: RESTART_PENDING,
+        },
       }
+    }
   }
 
   return state

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -6,14 +6,17 @@ export type ConnectableStatus = 'connectable'
 export type ReachableStatus = 'reachable'
 export type UnreachableStatus = 'unreachable'
 
+export type RestartStatus = 'pending' | 'down'
+
 // service with a known IP address
 export type ResolvedRobot = {
   ...$Exact<Service>,
-  displayName: string,
   ip: $NonMaybeType<$PropertyType<Service, 'ip'>>,
   local: $NonMaybeType<$PropertyType<Service, 'local'>>,
   ok: $NonMaybeType<$PropertyType<Service, 'ok'>>,
   serverOk: $NonMaybeType<$PropertyType<Service, 'serverOk'>>,
+  displayName: string,
+  restartStatus: ?RestartStatus,
 }
 
 // fully connectable robot

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -167,6 +167,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'restart'},
+          meta: {robot: true, shell: true},
         },
       ]
 
@@ -217,6 +218,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'update/ignore'},
+          meta: {robot: true, shell: true},
         },
       ]
 
@@ -269,6 +271,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'update/ignore'},
+          meta: {robot: true, shell: true},
         },
       ]
 

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -167,7 +167,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'restart'},
-          meta: {robot: true, shell: true},
+          meta: {robot: true},
         },
       ]
 
@@ -218,7 +218,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'update/ignore'},
-          meta: {robot: true, shell: true},
+          meta: {robot: true},
         },
       ]
 
@@ -271,7 +271,7 @@ describe('server API client', () => {
         {
           type: 'api:SERVER_SUCCESS',
           payload: {robot, response, path: 'update/ignore'},
-          meta: {robot: true, shell: true},
+          meta: {robot: true},
         },
       ]
 

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -54,7 +54,7 @@ export type ServerSuccessAction = {|
     path: RequestPath,
     response: ServerResponse,
   |},
-  meta: {|robot: true, shell: true|},
+  meta: {|robot: true|},
 |}
 
 export type ServerFailureAction = {|
@@ -350,7 +350,7 @@ function serverSuccess (
   return {
     type: 'api:SERVER_SUCCESS',
     payload: {robot, path, response},
-    meta: {robot: true, shell: true},
+    meta: {robot: true},
   }
 }
 

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -54,6 +54,7 @@ export type ServerSuccessAction = {|
     path: RequestPath,
     response: ServerResponse,
   |},
+  meta: {|robot: true, shell: true|},
 |}
 
 export type ServerFailureAction = {|
@@ -349,6 +350,7 @@ function serverSuccess (
   return {
     type: 'api:SERVER_SUCCESS',
     payload: {robot, path, response},
+    meta: {robot: true, shell: true},
   }
 }
 

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -14,7 +14,7 @@ import {checkShellUpdate, shellMiddleware} from './shell'
 import {apiClientMiddleware as robotApiMiddleware} from './robot'
 import {initializeAnalytics, analyticsMiddleware} from './analytics'
 import {initializeSupport, supportMiddleware} from './support'
-import {startDiscovery} from './discovery'
+import {startDiscovery, discoveryMiddleware} from './discovery'
 
 import reducer from './reducer'
 
@@ -31,6 +31,7 @@ const middleware = applyMiddleware(
   shellMiddleware,
   analyticsMiddleware,
   supportMiddleware,
+  discoveryMiddleware,
   routerMiddleware(history)
 )
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -68,6 +68,15 @@ export default function client (dispatch) {
         return cancel(state, action)
       case 'robot:REFRESH_SESSION':
         return refreshSession(state, action)
+
+      // disconnect RPC prior to robot restart
+      // TODO(mc, 2018-11-06): switch to api:RESPONSE when server.js switches
+      case 'api:SERVER_SUCCESS': {
+        const connectedName = selectors.getConnectedRobotName(state)
+        const {path, robot} = action.payload
+        if (path === 'restart' && connectedName === robot.name) disconnect()
+        break
+      }
     }
   }
 


### PR DESCRIPTION
## overview

This PR:

- Adds restart tracking to the discovery substate based on list updates from health checks and successful HTTP responses to POST /server/restart
- Disconnects RPC automatically if a POST /server/restart request is successfully made

Which allows us to:
- Remove bogus lost connection alerts for purposeful restarts
- Tweak the unreachable robot banner to note that the robot is currently restarting

Closes #2516

![2018-11-07 15 15 40](https://user-images.githubusercontent.com/2963448/48162064-22257d00-e2aa-11e8-90b8-50e7a898348e.gif)

## changelog

- feat(app): Track restart status in discovery state for better alerts

## review requests

Do various the things that restart the robot with RPC (connection toggle) both connected and disconnected:

1. Deck calibration
2. Factory data reset

- [ ] The "robot is restarting" message doesn't get stuck
- [ ] The lost connection alert never pops up