### PR TITLE
build(webpack): Add cache-busting to default bundle.js output filename

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -14,7 +14,6 @@ const {description, author} = require('./package.json')
 const JS_ENTRY = path.join(__dirname, 'src/index.js')
 const HTML_ENTRY = path.join(__dirname, 'src/index.hbs')
 const OUTPUT_PATH = path.join(__dirname, 'dist')
-const JS_OUTPUT_NAME = 'bundle.js'
 
 const PORT = process.env.PORT || 8080
 const CONTENT_BASE = path.join(__dirname, './src')
@@ -26,7 +25,6 @@ module.exports = webpackMerge(baseConfig, {
   output: Object.assign(
     {
       path: OUTPUT_PATH,
-      filename: JS_OUTPUT_NAME,
       publicPath: PUBLIC_PATH,
     },
     // workaround for worker-loader HMR

--- a/labware-designer/webpack.config.js
+++ b/labware-designer/webpack.config.js
@@ -11,14 +11,12 @@ const {productName: title, description, author} = require('./package.json')
 const JS_ENTRY = path.join(__dirname, 'src/index.js')
 const HTML_ENTRY = path.join(__dirname, 'src/index.hbs')
 const OUTPUT_PATH = path.join(__dirname, 'dist')
-const JS_OUTPUT_NAME = 'bundle.js'
 
 module.exports = webpackMerge(baseConfig, {
   entry: [JS_ENTRY],
 
   output: {
     path: OUTPUT_PATH,
-    filename: JS_OUTPUT_NAME,
   },
 
   plugins: [

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -38,7 +38,6 @@ module.exports = webpackMerge(baseConfig, {
   entry: [JS_ENTRY],
 
   output: {
-    filename: 'bundle.js',
     path: path.join(__dirname, 'dist'),
     publicPath: DEV_MODE ? '' : './',
   },

--- a/protocol-library-kludge/webpack.config.js
+++ b/protocol-library-kludge/webpack.config.js
@@ -11,13 +11,11 @@ const {productName: title, description, author} = require('./package.json')
 const JS_BUNDLE_ENTRY = path.join(__dirname, 'src/index.js')
 const HTML_ENTRY = path.join(__dirname, 'src/index.hbs')
 const OUTPUT_PATH = path.join(__dirname, 'dist')
-const JS_OUTPUT_NAME = 'bundle.js'
 
 module.exports = webpackMerge(baseConfig, {
   entry: [JS_BUNDLE_ENTRY],
 
   output: {
-    filename: JS_OUTPUT_NAME,
     path: OUTPUT_PATH,
     publicPath: DEV_MODE ? '' : './',
   },

--- a/webpack-config/lib/base-config.js
+++ b/webpack-config/lib/base-config.js
@@ -18,6 +18,10 @@ module.exports = {
 
   entry: DEV_MODE ? ['react-hot-loader/patch'] : [],
 
+  output: {
+    filename: DEV_MODE ? 'bundle.js' : 'bundle.[contenthash].js',
+  },
+
   mode: DEV_MODE ? 'development' : 'production',
 
   devtool: DEV_MODE ? 'eval-source-map' : 'source-map',
@@ -36,8 +40,8 @@ module.exports = {
 
   plugins: [
     new MiniCssExtractPlugin({
-      filename: DEV_MODE ? '[name].css' : '[name].[hash].css',
-      chunkFilename: DEV_MODE ? '[id].css' : '[id].[hash].css',
+      filename: DEV_MODE ? '[name].css' : '[name].[contenthash].css',
+      chunkFilename: DEV_MODE ? '[id].css' : '[id].[contenthash].css',
     }),
     ANALYZER,
   ].filter(Boolean),


### PR DESCRIPTION
## overview

As discussed in RL, this change adds a cache-busting hash to the default webpack bundle filename.

## changelog

- build(webpack): Add cache-busting to default bundle.js output filename

## review requests

Ensure dev and prod builds for FE projects affected still work:

- [ ] app
- [ ] labware-designer
- [ ] protocol-designer
- [ ] protocol-library-kludge
