### PR TITLE
chore(release): 3.6.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Bug Fixes
+
+* **api:** Correct well ordering for custom labware ([#2633](https://github.com/Opentrons/opentrons/issues/2633)) ([8e7530c](https://github.com/Opentrons/opentrons/commit/8e7530c)), closes [#2631](https://github.com/Opentrons/opentrons/issues/2631)
+* **api:** Fix bug where drop-tip current is not used while actually dropping tip ([#2572](https://github.com/Opentrons/opentrons/issues/2572)) ([d7c7f60](https://github.com/Opentrons/opentrons/commit/d7c7f60))
+* **protocol-designer:** add vertical spacing back to form fields ([#2644](https://github.com/Opentrons/opentrons/issues/2644)) ([c7173da](https://github.com/Opentrons/opentrons/commit/c7173da)), closes [#2580](https://github.com/Opentrons/opentrons/issues/2580) [#2597](https://github.com/Opentrons/opentrons/issues/2597)
+* **protocol-designer:** fix sidebar for liquid placement modal ([#2649](https://github.com/Opentrons/opentrons/issues/2649)) ([8da2f7d](https://github.com/Opentrons/opentrons/commit/8da2f7d))
+
+
+### Features
+
+* **api:** Pipette id included in GET /pipettes ([#2564](https://github.com/Opentrons/opentrons/issues/2564)) ([0a171fe](https://github.com/Opentrons/opentrons/commit/0a171fe)), closes [#2148](https://github.com/Opentrons/opentrons/issues/2148)
+* **api:** support offset in json protocol touch-tip command ([#2566](https://github.com/Opentrons/opentrons/issues/2566)) ([d54ee84](https://github.com/Opentrons/opentrons/commit/d54ee84))
+* **app:** Home pipette after tip probe confirmed ([#2586](https://github.com/Opentrons/opentrons/issues/2586)) ([3119379](https://github.com/Opentrons/opentrons/commit/3119379)), closes [#2544](https://github.com/Opentrons/opentrons/issues/2544)
+* **app:** Implement new connectivity card ([#2608](https://github.com/Opentrons/opentrons/issues/2608)) ([a4b26a2](https://github.com/Opentrons/opentrons/commit/a4b26a2)), closes [#2555](https://github.com/Opentrons/opentrons/issues/2555)
+* **app:** Track restart status in discovery state for better alerts ([#2639](https://github.com/Opentrons/opentrons/issues/2639)) ([b4ba600](https://github.com/Opentrons/opentrons/commit/b4ba600)), closes [#2516](https://github.com/Opentrons/opentrons/issues/2516)
+* **docs:** Add opentrons container defs and images ([#2531](https://github.com/Opentrons/opentrons/issues/2531)) ([0619fb3](https://github.com/Opentrons/opentrons/commit/0619fb3))
+* **protocol-designer:** add labware details card ([#2490](https://github.com/Opentrons/opentrons/issues/2490)) ([fb96472](https://github.com/Opentrons/opentrons/commit/fb96472)), closes [#2428](https://github.com/Opentrons/opentrons/issues/2428)
+* **protocol-designer:** add more labware options to PD ([#2634](https://github.com/Opentrons/opentrons/issues/2634)) ([7db10ce](https://github.com/Opentrons/opentrons/commit/7db10ce)), closes [#2583](https://github.com/Opentrons/opentrons/issues/2583)
+* **protocol-designer:** add well tooltip to liquid placement modal ([#2550](https://github.com/Opentrons/opentrons/issues/2550)) ([7c13891](https://github.com/Opentrons/opentrons/commit/7c13891)), closes [#2486](https://github.com/Opentrons/opentrons/issues/2486)
+* **protocol-designer:** allow user to change pipette selection ([#2548](https://github.com/Opentrons/opentrons/issues/2548)) ([bb08aa4](https://github.com/Opentrons/opentrons/commit/bb08aa4)), closes [#2474](https://github.com/Opentrons/opentrons/issues/2474) [#2475](https://github.com/Opentrons/opentrons/issues/2475) [#2477](https://github.com/Opentrons/opentrons/issues/2477) [#2632](https://github.com/Opentrons/opentrons/issues/2632)
+* **protocol-designer:** clean up navigation and modal hierarchy ([#2638](https://github.com/Opentrons/opentrons/issues/2638)) ([134558f](https://github.com/Opentrons/opentrons/commit/134558f)), closes [#2198](https://github.com/Opentrons/opentrons/issues/2198)
+* **protocol-designer:** collapse all step items on newly loaded file ([#2549](https://github.com/Opentrons/opentrons/issues/2549)) ([46066a2](https://github.com/Opentrons/opentrons/commit/46066a2)), closes [#2541](https://github.com/Opentrons/opentrons/issues/2541)
+* **protocol-designer:** edit saved step forms when labware is deleted ([#2653](https://github.com/Opentrons/opentrons/issues/2653)) ([78b99c3](https://github.com/Opentrons/opentrons/commit/78b99c3)), closes [#2361](https://github.com/Opentrons/opentrons/issues/2361)
+* **shared-data:** Add generator function for irregular labware ([#2610](https://github.com/Opentrons/opentrons/issues/2610)) ([ad568c1](https://github.com/Opentrons/opentrons/commit/ad568c1)), closes [#2275](https://github.com/Opentrons/opentrons/issues/2275)
+* **shared-data:** support unversioned pipettes in JSON protocols ([#2605](https://github.com/Opentrons/opentrons/issues/2605)) ([9e84ff6](https://github.com/Opentrons/opentrons/commit/9e84ff6))
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/api/src/opentrons/CHANGELOG.md
+++ b/api/src/opentrons/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Bug Fixes
+
+* **api:** Correct well ordering for custom labware ([#2633](https://github.com/Opentrons/opentrons/issues/2633)) ([8e7530c](https://github.com/Opentrons/opentrons/commit/8e7530c)), closes [#2631](https://github.com/Opentrons/opentrons/issues/2631)
+* **api:** Fix bug where drop-tip current is not used while actually dropping tip ([#2572](https://github.com/Opentrons/opentrons/issues/2572)) ([d7c7f60](https://github.com/Opentrons/opentrons/commit/d7c7f60))
+
+
+### Features
+
+* **api:** Pipette id included in GET /pipettes ([#2564](https://github.com/Opentrons/opentrons/issues/2564)) ([0a171fe](https://github.com/Opentrons/opentrons/commit/0a171fe)), closes [#2148](https://github.com/Opentrons/opentrons/issues/2148)
+* **api:** support offset in json protocol touch-tip command ([#2566](https://github.com/Opentrons/opentrons/issues/2566)) ([d54ee84](https://github.com/Opentrons/opentrons/commit/d54ee84))
+* **shared-data:** support unversioned pipettes in JSON protocols ([#2605](https://github.com/Opentrons/opentrons/issues/2605)) ([9e84ff6](https://github.com/Opentrons/opentrons/commit/9e84ff6))
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0-beta.1...v3.5.1) (2018-10-26)
 

--- a/api/src/opentrons/package.json
+++ b/api/src/opentrons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/api-server",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Opentrons API server application",
   "repository": {
     "type": "git",

--- a/app-shell/CHANGELOG.md
+++ b/app-shell/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package @opentrons/app-shell
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -1,4 +1,4 @@
-# Changes since 3.4.0
+# Changes from 3.5.1 to 3.6.0
 
 For more details, please see the full [technical change log][changelog]
 
@@ -9,36 +9,30 @@ For more details, please see the full [technical change log][changelog]
 
 ### Known issues
 
-- Downgrading back to "3.4.0" from later releases _may_ cause the app to crash unless you delete the configuration folder (which will reset your app's configuration):
-    - macOS: "~/Library/Application Support/Opentrons"
-    - Linux: "~/.config/Opentrons"
-    - Windows: "%APPDATA%\Opentrons"
 - The app's run log is still having problems displaying the current run step, especially if pauses and resumes are involved ([#2047][2047])
+- The app should prevent you from starting a pipette swap while a protocol is
+executing, but it does not ([#2020][2020])
+- If a protocol run encounters an error, the app will suppress the error message instead of displaying it ([#1828][1828])
 
 [2047]: https://github.com/Opentrons/opentrons/issues/2047
+[2020]: https://github.com/Opentrons/opentrons/issues/2020
+[1828]: https://github.com/Opentrons/opentrons/issues/1828
 
 ### Bug fixes
 
-- Fixed a bug that was causing the analytics opt-in modal to fail to pop up on first app launch
-- Switched the labware table of the protocol info page to organize by type instead of nickname
-- Patched up some problems with robot discovery that could cause robots to fail to appear in environments with many robots present
-- Fixed an app crash if a robot reported an invalid server version
-- When calibrating labware, the app will now show all labware of the same type as calibrated once you've calibrated one of them
-    - This is _not_ a change in how the robot saves calibration; the API software has always saved calibration data by labware type
+- Lost connection alert messages will no longer trigger when your robot is restarting for normal reasons (e.g. software update or deck calibration). Sorry for the confusion this caused!
 
 ### New features
 
-- We put a lot of work into the discovered robots list for this release:
-    - The app now displays robots you've connected to in the past as well as robots that it can hear from but are not responding properly to requests
-    - We've stripped off that annoying "opentrons-" that would appear in front of every robot's name
-    - The "Pipettes and Modules" submenu will now only appear for the robot you've currently selected, so the robot list should be a little less noisy
-- We improved the copy of the robot update popup to (hopefully) make it more clear whether you're upgrading, downgrading, or re-installing your robot's software
-- We've upgraded our underlying [Electron framework][electron] to version 3, which closes up a few potential security holes and should result in a faster, smoother app experience for you!
-
-[electron]: https://electronjs.org/
+- We've put a lot of work into improving the Wi-Fi setup experience of your robot:
+    - Most 802.1X enterprise networks (e.g. eduroam) are now supported!
+    - Hidden SSID networks are also supported
+    - Generally, it should be easier to tell what Wi-Fi network your robot is currently connected to, along with signal strength and whether or not the network is secured
+    - The robot settings page now displays the IP and MAC addresses of the Wi-Fi and Ethernet-to-USB interfaces
+    - Please see our support documentation for more details
+- After tip-probe is completed, the app will now move the pipette out of the way so you have better access to the deck
 
 <!-- end:@opentrons/app -->
-
 
 <!-- start:@opentrons/api -->
 ## OT2 and Protocol API
@@ -54,14 +48,11 @@ For more details, please see the full [technical change log][changelog]
 
 ### Bug fixes
 
-- We fixed a launch configuration problem with the Jupyter Notebook server that could result in a boot failure
-- The "Not Now" button for a robot update will now be remembered by the robot, so other users of your robot won't get an update pop-up if you choose to keep your robot at an older software version
-- The temperature module now correctly rounds its input to the nearest degree Celsius to reflect what it is physically capable of
-- The API will no longer show hidden networks as "--" in its available Wi-Fi networks list
-- The height of the P1000 tiprack was incorrect and has been corrected
+- Fixed the iteration order of labware created with `labware.create` to match documentation
+- Fixed a misconfiguration with the motor current settings for drop-tip
 
 ### New features
 
-This release doesn't have any new user facing features, but rest assured that our API team is hard at work laying groundwork for lots of exciting new stuff!
+There aren't any new user facing features in this release, but the API team is hard at work putting exciting new stuff in place behind the scenes!
 
 <!-- end:@opentrons/api -->

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentrons/app-shell",
   "productName": "Opentrons",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Opentrons desktop application",
   "main": "lib/main.js",
   "scripts": {
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "devDependencies": {
-    "@opentrons/app": "3.5.1"
+    "@opentrons/app": "3.6.0-beta.0"
   },
   "dependencies": {
-    "@opentrons/discovery-client": "3.5.1",
+    "@opentrons/discovery-client": "3.6.0-beta.0",
     "@thi.ng/paths": "^1.3.8",
     "dateformat": "^3.0.3",
     "electron-debug": "^2.0.0",

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Features
+
+* **app:** Home pipette after tip probe confirmed ([#2586](https://github.com/Opentrons/opentrons/issues/2586)) ([3119379](https://github.com/Opentrons/opentrons/commit/3119379)), closes [#2544](https://github.com/Opentrons/opentrons/issues/2544)
+* **app:** Implement new connectivity card ([#2608](https://github.com/Opentrons/opentrons/issues/2608)) ([a4b26a2](https://github.com/Opentrons/opentrons/commit/a4b26a2)), closes [#2555](https://github.com/Opentrons/opentrons/issues/2555)
+* **app:** Track restart status in discovery state for better alerts ([#2639](https://github.com/Opentrons/opentrons/issues/2639)) ([b4ba600](https://github.com/Opentrons/opentrons/commit/b4ba600)), closes [#2516](https://github.com/Opentrons/opentrons/issues/2516)
+* **shared-data:** support unversioned pipettes in JSON protocols ([#2605](https://github.com/Opentrons/opentrons/issues/2605)) ([9e84ff6](https://github.com/Opentrons/opentrons/commit/9e84ff6))
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/app",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Opentrons desktop application UI",
   "main": "src/index.js",
   "repository": {
@@ -21,8 +21,8 @@
     "flow-typed": "^2.5.1"
   },
   "dependencies": {
-    "@opentrons/components": "3.5.1",
-    "@opentrons/shared-data": "3.5.1",
+    "@opentrons/components": "3.6.0-beta.0",
+    "@opentrons/shared-data": "3.6.0-beta.0",
     "@thi.ng/paths": "^1.3.8",
     "classnames": "^2.2.5",
     "events": "^3.0.0",

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Features
+
+* **protocol-designer:** add labware details card ([#2490](https://github.com/Opentrons/opentrons/issues/2490)) ([fb96472](https://github.com/Opentrons/opentrons/commit/fb96472)), closes [#2428](https://github.com/Opentrons/opentrons/issues/2428)
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/components",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "React components library for Opentrons' projects",
   "main": "src/index.js",
   "style": "src/index.css",

--- a/discovery-client/CHANGELOG.md
+++ b/discovery-client/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package @opentrons/discovery-client
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/discovery-client",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Node.js client for discovering Opentrons robots on the network",
   "main": "lib/index.js",
   "bin": {

--- a/labware-designer/CHANGELOG.md
+++ b/labware-designer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package labware-designer
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -10,7 +10,7 @@
   "name": "labware-designer",
   "productName": "Opentrons Labware Designer",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Labware Designer",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/shared-data": "3.5.1"
+    "@opentrons/shared-data": "3.6.0-beta.0"
   },
   "devDependencies": {
     "flow-bin": "^0.82.0",

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.5.1"
+  "version": "3.6.0-beta.0"
 }

--- a/protocol-designer/CHANGELOG.md
+++ b/protocol-designer/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Bug Fixes
+
+* **protocol-designer:** add vertical spacing back to form fields ([#2644](https://github.com/Opentrons/opentrons/issues/2644)) ([c7173da](https://github.com/Opentrons/opentrons/commit/c7173da)), closes [#2580](https://github.com/Opentrons/opentrons/issues/2580) [#2597](https://github.com/Opentrons/opentrons/issues/2597)
+* **protocol-designer:** fix sidebar for liquid placement modal ([#2649](https://github.com/Opentrons/opentrons/issues/2649)) ([8da2f7d](https://github.com/Opentrons/opentrons/commit/8da2f7d))
+
+
+### Features
+
+* **api:** support offset in json protocol touch-tip command ([#2566](https://github.com/Opentrons/opentrons/issues/2566)) ([d54ee84](https://github.com/Opentrons/opentrons/commit/d54ee84))
+* **protocol-designer:** add labware details card ([#2490](https://github.com/Opentrons/opentrons/issues/2490)) ([fb96472](https://github.com/Opentrons/opentrons/commit/fb96472)), closes [#2428](https://github.com/Opentrons/opentrons/issues/2428)
+* **protocol-designer:** add more labware options to PD ([#2634](https://github.com/Opentrons/opentrons/issues/2634)) ([7db10ce](https://github.com/Opentrons/opentrons/commit/7db10ce)), closes [#2583](https://github.com/Opentrons/opentrons/issues/2583)
+* **protocol-designer:** add well tooltip to liquid placement modal ([#2550](https://github.com/Opentrons/opentrons/issues/2550)) ([7c13891](https://github.com/Opentrons/opentrons/commit/7c13891)), closes [#2486](https://github.com/Opentrons/opentrons/issues/2486)
+* **protocol-designer:** allow user to change pipette selection ([#2548](https://github.com/Opentrons/opentrons/issues/2548)) ([bb08aa4](https://github.com/Opentrons/opentrons/commit/bb08aa4)), closes [#2474](https://github.com/Opentrons/opentrons/issues/2474) [#2475](https://github.com/Opentrons/opentrons/issues/2475) [#2477](https://github.com/Opentrons/opentrons/issues/2477) [#2632](https://github.com/Opentrons/opentrons/issues/2632)
+* **protocol-designer:** clean up navigation and modal hierarchy ([#2638](https://github.com/Opentrons/opentrons/issues/2638)) ([134558f](https://github.com/Opentrons/opentrons/commit/134558f)), closes [#2198](https://github.com/Opentrons/opentrons/issues/2198)
+* **protocol-designer:** collapse all step items on newly loaded file ([#2549](https://github.com/Opentrons/opentrons/issues/2549)) ([46066a2](https://github.com/Opentrons/opentrons/commit/46066a2)), closes [#2541](https://github.com/Opentrons/opentrons/issues/2541)
+* **protocol-designer:** edit saved step forms when labware is deleted ([#2653](https://github.com/Opentrons/opentrons/issues/2653)) ([78b99c3](https://github.com/Opentrons/opentrons/commit/78b99c3)), closes [#2361](https://github.com/Opentrons/opentrons/issues/2361)
+* **shared-data:** Add generator function for irregular labware ([#2610](https://github.com/Opentrons/opentrons/issues/2610)) ([ad568c1](https://github.com/Opentrons/opentrons/commit/ad568c1)), closes [#2275](https://github.com/Opentrons/opentrons/issues/2275)
+* **shared-data:** support unversioned pipettes in JSON protocols ([#2605](https://github.com/Opentrons/opentrons/issues/2605)) ([9e84ff6](https://github.com/Opentrons/opentrons/commit/9e84ff6))
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -10,7 +10,7 @@
   "name": "protocol-designer",
   "productName": "Opentrons Protocol Designer Prototype",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Protocol designer app",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.5.1",
+    "@opentrons/components": "3.6.0-beta.0",
     "classnames": "^2.2.5",
     "formik": "^1.3.1",
     "i18next": "^11.5.0",

--- a/protocol-library-kludge/CHANGELOG.md
+++ b/protocol-library-kludge/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package protocol-library-kludge
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -9,7 +9,7 @@
   },
   "name": "protocol-library-kludge",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "productName": "Opentrons Protocol Library",
   "description": "Protocol library stuff (WIP)",
   "main": "src/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.5.1",
+    "@opentrons/components": "3.6.0-beta.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "react": "^16.2.0",

--- a/shared-data/CHANGELOG.md
+++ b/shared-data/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+
+### Features
+
+* **api:** support offset in json protocol touch-tip command ([#2566](https://github.com/Opentrons/opentrons/issues/2566)) ([d54ee84](https://github.com/Opentrons/opentrons/commit/d54ee84))
+* **shared-data:** Add generator function for irregular labware ([#2610](https://github.com/Opentrons/opentrons/issues/2610)) ([ad568c1](https://github.com/Opentrons/opentrons/commit/ad568c1)), closes [#2275](https://github.com/Opentrons/opentrons/issues/2275)
+* **shared-data:** support unversioned pipettes in JSON protocols ([#2605](https://github.com/Opentrons/opentrons/issues/2605)) ([9e84ff6](https://github.com/Opentrons/opentrons/commit/9e84ff6))
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/shared-data",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Default labware definitions for Opentrons robots",
   "repository": {
     "type": "git",

--- a/update-server/otupdate/CHANGELOG.md
+++ b/update-server/otupdate/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package @opentrons/update-server
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/update-server/otupdate/package.json
+++ b/update-server/otupdate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/update-server",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Update server for Opentrons robots",
   "repository": {
     "type": "git",

--- a/webpack-config/CHANGELOG.md
+++ b/webpack-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.0-beta.0"></a>
+# [3.6.0-beta.0](https://github.com/Opentrons/opentrons/compare/v3.5.1...v3.6.0-beta.0) (2018-11-13)
+
+**Note:** Version bump only for package @opentrons/webpack-config
+
+
+
+
+
 <a name="3.5.1"></a>
 # [3.5.1](https://github.com/Opentrons/opentrons/compare/v3.5.0...v3.5.1) (2018-10-26)
 

--- a/webpack-config/package.json
+++ b/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/webpack-config",
-  "version": "3.5.1",
+  "version": "3.6.0-beta.0",
   "description": "Shareable pieces of webpack configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## overview

Release PR for `3.6.0-beta.0`

## changelog

https://github.com/Opentrons/opentrons/compare/v3.5.1...edge

## review requests

Give the changelog and [release notes](https://github.com/Opentrons/opentrons/blob/release_3.6.0-beta.0/app-shell/build/release-notes.md) a gander! This is a relatively low surface-area release

### release candidates

- Linux: https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.0-beta.0-linux-b12725-release_3.6.0-beta.0.AppImage
- Mac: https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.0-beta.0-mac-b12725-release_3.6.0-beta.0.zip
- Windows: https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.0-beta.0-win-b8779-release_3.6.0-beta.0.exe