### PR TITLE
feat(protocol-designer): edit saved step forms when labware is deleted

### DIFF
--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -70,7 +70,7 @@ class WellSelectionInput extends React.Component<Props> {
             key={modalKey}
             pipetteId={this.props.pipetteId}
             labwareId={this.props.labwareId}
-            isOpen={this.props.wellSelectionLabwareKey && this.props.wellSelectionLabwareKey === modalKey}
+            isOpen={Boolean(this.props.wellSelectionLabwareKey && this.props.wellSelectionLabwareKey === modalKey)}
             onCloseClick={this.handleClose}
             name={this.props.name} />
         </Portal>

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -70,7 +70,7 @@ class WellSelectionInput extends React.Component<Props> {
             key={modalKey}
             pipetteId={this.props.pipetteId}
             labwareId={this.props.labwareId}
-            isOpen={Boolean(this.props.wellSelectionLabwareKey && this.props.wellSelectionLabwareKey === modalKey)}
+            isOpen={this.props.wellSelectionLabwareKey === modalKey}
             onCloseClick={this.handleClose}
             name={this.props.name} />
         </Portal>

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -13,7 +13,7 @@ import type {BaseState} from '../../../types'
 import type { FocusHandlers } from '../index'
 
 type SP = {
-  wellSelectionLabwareId: ?string,
+  wellSelectionLabwareKey: ?string,
 }
 type DP = {
   onOpen: (string) => mixed,
@@ -36,10 +36,10 @@ type Props = OP & SP & DP
 
 class WellSelectionInput extends React.Component<Props> {
   handleOpen = () => {
-    const {labwareId, name} = this.props
+    const {labwareId, pipetteId, name} = this.props
     this.props.onFieldFocus(name)
-    if (labwareId) {
-      this.props.onOpen(labwareId)
+    if (labwareId && pipetteId) {
+      this.props.onOpen(this.getModalKey())
     }
   }
 
@@ -48,11 +48,12 @@ class WellSelectionInput extends React.Component<Props> {
     this.props.onClose()
   }
 
+  getModalKey = () => {
+    const {name, pipetteId, labwareId} = this.props
+    return `${name}${pipetteId || 'noPipette'}${labwareId || 'noLabware'}`
+  }
   render () {
-    const modalKey = `${this.props.name}${
-      this.props.pipetteId ||
-      'noPipette'}${this.props.labwareId ||
-      'noLabware'}${String(this.props.wellSelectionLabwareId)}`
+    const modalKey = this.getModalKey()
     return (
       <FormGroup
         label={this.props.isMulti ? 'Columns:' : 'Wells:'}
@@ -69,7 +70,7 @@ class WellSelectionInput extends React.Component<Props> {
             key={modalKey}
             pipetteId={this.props.pipetteId}
             labwareId={this.props.labwareId}
-            isOpen={this.props.wellSelectionLabwareId === this.props.labwareId}
+            isOpen={this.props.wellSelectionLabwareKey && this.props.wellSelectionLabwareKey === modalKey}
             onCloseClick={this.handleClose}
             name={this.props.name} />
         </Portal>
@@ -79,11 +80,11 @@ class WellSelectionInput extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: BaseState): SP => ({
-  wellSelectionLabwareId: steplistSelectors.getWellSelectionLabwareId(state),
+  wellSelectionLabwareKey: steplistSelectors.getWellSelectionLabwareKey(state),
 })
 const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
-  onOpen: id => dispatch(steplistActions.setWellSelectionLabwareId(id)),
-  onClose: () => dispatch(steplistActions.clearWellSelectionLabwareId()),
+  onOpen: key => dispatch(steplistActions.setWellSelectionLabwareKey(key)),
+  onClose: () => dispatch(steplistActions.clearWellSelectionLabwareKey()),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(WellSelectionInput)

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -55,7 +55,7 @@ function mapStateToProps (state: BaseState): SP {
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
   const liquidPlacementMode = !!labwareIngredSelectors.getSelectedContainer(state)
-  const wellSelectionLabwareId = steplistSelectors.getWellSelectionLabwareId(state)
+  const wellSelectionLabwareKey = steplistSelectors.getWellSelectionLabwareKey(state)
 
   switch (_page) {
     case 'liquids':
@@ -95,7 +95,7 @@ function mapStateToProps (state: BaseState): SP {
           subtitle = drilledDownLabware && humanizeLabwareType(drilledDownLabware.type)
         }
       } else if (selectedStep) {
-        if (wellSelectionLabwareId) { // well selection modal
+        if (wellSelectionLabwareKey) { // well selection modal
           return {
             _page,
             _wellSelectionMode: true,
@@ -103,7 +103,7 @@ function mapStateToProps (state: BaseState): SP {
               iconName={selectedStep && stepIconsByType[selectedStep.stepType]}
               text={selectedStep && selectedStep.title}
             />,
-            subtitle: labwareNames[wellSelectionLabwareId],
+            subtitle: labwareNames[wellSelectionLabwareKey],
             backButtonLabel: 'Back',
           }
         } else {
@@ -125,7 +125,7 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
     if (_liquidPlacementMode) {
       onBackClick = () => dispatch(closeIngredientSelector())
     } else if (_wellSelectionMode) {
-      onBackClick = () => dispatch(steplistActions.clearWellSelectionLabwareId())
+      onBackClick = () => dispatch(steplistActions.clearWellSelectionLabwareKey())
     } else if (props.backButtonLabel) {
       onBackClick = () => {}
     }

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -61,6 +61,14 @@ export const createContainer = createAction(
   |}) => args
 )
 
+export type DeleteContainerAction = {
+  type: 'DELETE_CONTAINER',
+  payload: {
+    containerId: string,
+    slot: DeckSlot,
+    containerType: string,
+  },
+}
 export const deleteContainer = createAction(
   'DELETE_CONTAINER',
   (args: {|

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -71,11 +71,7 @@ export type DeleteContainerAction = {
 }
 export const deleteContainer = createAction(
   'DELETE_CONTAINER',
-  (args: {|
-    containerId: string,
-    slot: DeckSlot,
-    containerType: string,
-  |}) => args
+  (args: $PropertyType<DeleteContainerAction, 'payload'>) => args
 )
 
 export type RenameLabwareAction = {

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -20,6 +20,7 @@ const unsavedChanges = (state: boolean = false, action: {type: string}): boolean
     case 'DISMISS_TIMELINE_WARNING':
     case 'CREATE_CONTAINER':
     case 'DELETE_CONTAINER':
+    case 'CHANGE_SAVED_STEP_FORM':
     case 'MOVE_LABWARE':
     case 'RENAME_LABWARE':
     case 'DELETE_LIQUID_GROUP':

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -188,12 +188,12 @@ export const saveMoreOptionsModal = () => (dispatch: Dispatch<*>, getState: GetS
   })
 }
 
-export const setWellSelectionLabwareId = (labwareName: ?string): * => ({
-  type: 'SET_WELL_SELECTION_LABWARE_ID',
+export const setWellSelectionLabwareKey = (labwareName: ?string): * => ({
+  type: 'SET_WELL_SELECTION_LABWARE_KEY',
   payload: labwareName,
 })
 
-export const clearWellSelectionLabwareId = (): * => ({
-  type: 'CLEAR_WELL_SELECTION_LABWARE_ID',
+export const clearWellSelectionLabwareKey = (): * => ({
+  type: 'CLEAR_WELL_SELECTION_LABWARE_KEY',
   payload: null,
 })

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -15,6 +15,7 @@ import type {
   TerminalItemId,
 } from './types'
 import type {LoadFileAction} from '../load-file'
+import type {DeleteContainerAction} from '../labware-ingred/actions'
 import type {FormData, StepIdType, FormModalFields} from '../form-types'
 import {getDefaultsForStepType} from './formLevel'
 

--- a/protocol-designer/src/steplist/selectors.js
+++ b/protocol-designer/src/steplist/selectors.js
@@ -389,9 +389,9 @@ export const currentFormCanBeSaved: Selector<boolean | null> = createSelector(
   }
 )
 
-export const getWellSelectionLabwareId: Selector<?string> = createSelector(
+export const getWellSelectionLabwareKey: Selector<?string> = createSelector(
   rootSelector,
-  (state: RootState) => state.wellSelectionLabwareId
+  (state: RootState) => state.wellSelectionLabwareKey
 )
 
 export default {
@@ -421,7 +421,7 @@ export default {
   formLevelErrors,
   formSectionCollapse: formSectionCollapseSelector,
   hoveredStepLabware,
-  getWellSelectionLabwareId,
+  getWellSelectionLabwareKey,
 
   // NOTE: these are exposed only for substeps/selectors.js
   getSteps,


### PR DESCRIPTION
Improve the user experience when deleting labware that is being used across the protocol. Also
includes some fixes to intermittent bugs associated with the well selection modal given aspiration
and dispense in the same labware.

Closes #2361