### PR TITLE
feat(protocol-designer): use tip max vol, not pipette max vol

### DIFF
--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -54,10 +54,10 @@ const pipetteOptionsWithNone = [
 // and also auto-select tiprack if there's only one compatible tiprack for a pipette
 const tiprackOptions = [
   {name: '10 μL', value: 'tiprack-10ul'},
+  {name: '200 μL', value: 'tiprack-200ul'},
   {name: '300 μL', value: 'opentrons-tiprack-300ul'},
   {name: '1000 μL', value: 'tiprack-1000ul'},
   {name: '1000 μL Chem', value: 'tiprack-1000ul-chem'},
-  // {name: '300 μL', value: 'GEB-tiprack-300ul'} // NOTE this is not supported by Python API yet
 ]
 
 const DEFAULT_SELECTION = {pipetteModel: '', tiprackModel: null}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -48,10 +48,10 @@ const pipetteOptionsWithInvalid = [
 // and also auto-select tiprack if there's only one compatible tiprack for a pipette
 const tiprackOptions = [
   {name: '10 μL', value: 'tiprack-10ul'},
+  {name: '200 μL', value: 'tiprack-200ul'},
   {name: '300 μL', value: 'opentrons-tiprack-300ul'},
   {name: '1000 μL', value: 'tiprack-1000ul'},
   {name: '1000 μL Chem', value: 'tiprack-1000ul-chem'},
-  // {name: '300 μL', value: 'GEB-tiprack-300ul'} // NOTE this is not supported by Python API yet
 ]
 
 const initialState = {

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -82,7 +82,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
       },
       {})
 
-    type PipetteTipState = {[pipetteId: string]: boolean}
+    type PipetteTipState = {[pipetteId: string]: StepGeneration.PipetteTip}
     const pipetteTipState: PipetteTipState = reduce(
       pipettes,
       (acc: PipetteTipState, pipetteData: StepGeneration.PipetteData) =>

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -82,7 +82,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
       },
       {})
 
-    type PipetteTipState = {[pipetteId: string]: StepGeneration.PipetteTip}
+    type PipetteTipState = {[pipetteId: string]: boolean}
     const pipetteTipState: PipetteTipState = reduce(
       pipettes,
       (acc: PipetteTipState, pipetteData: StepGeneration.PipetteData) =>

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -21,7 +21,6 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, volume, labware, well}))
   }
 
-  // TODO IMMEDIATELY write/check test
   const tipMaxVolume = getMaxTipVolumeForPipette(pipette, prevRobotState)
   if (tipMaxVolume < volume && errors.length === 0) {
     errors.push(errorCreators.tipVolumeExceeded({actionName, volume, maxVolume: tipMaxVolume}))

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -1,6 +1,7 @@
 // @flow
 import updateLiquidState from './aspirateUpdateLiquidState'
 import * as errorCreators from './errorCreators'
+import {getMaxTipVolumeForPipette} from './robotStateSelectors'
 import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseArgs} from './'
 
 /** Aspirate with given args. Requires tip. */
@@ -20,8 +21,10 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, volume, labware, well}))
   }
 
-  if (pipetteData && pipetteData.maxVolume < volume) {
-    errors.push(errorCreators.pipetteVolumeExceeded({actionName, volume, maxVolume: pipetteData.maxVolume}))
+  // TODO IMMEDIATELY write/check test
+  const tipMaxVolume = getMaxTipVolumeForPipette(pipette, prevRobotState)
+  if (tipMaxVolume < volume && errors.length === 0) {
+    errors.push(errorCreators.tipVolumeExceeded({actionName, volume, maxVolume: tipMaxVolume}))
   }
 
   if (!labware || !prevRobotState.labware[labware]) {

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -1,7 +1,7 @@
 // @flow
 import updateLiquidState from './aspirateUpdateLiquidState'
 import * as errorCreators from './errorCreators'
-import {getMaxTipVolumeForPipette} from './robotStateSelectors'
+import {getPipetteWithTipMaxVol} from './robotStateSelectors'
 import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseArgs} from './'
 
 /** Aspirate with given args. Requires tip. */
@@ -17,16 +17,15 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.pipetteDoesNotExist({actionName, pipette}))
   }
 
-  if (prevRobotState.tipState.pipettes[pipette] === false) {
+  if (!prevRobotState.tipState.pipettes[pipette]) {
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, volume, labware, well}))
   }
 
-  // TODO IMMEDIATELY update tests for both
   if (pipetteData && pipetteData.maxVolume < volume && errors.length === 0) {
     errors.push(errorCreators.pipetteVolumeExceeded({actionName, volume, maxVolume: pipetteData.maxVolume}))
   }
 
-  const tipMaxVolume = getMaxTipVolumeForPipette(pipette, prevRobotState)
+  const tipMaxVolume = getPipetteWithTipMaxVol(pipette, prevRobotState)
   if (tipMaxVolume < volume && errors.length === 0) {
     errors.push(errorCreators.tipVolumeExceeded({actionName, volume, maxVolume: tipMaxVolume}))
   }

--- a/protocol-designer/src/step-generation/aspirate.js
+++ b/protocol-designer/src/step-generation/aspirate.js
@@ -21,6 +21,11 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, volume, labware, well}))
   }
 
+  // TODO IMMEDIATELY update tests for both
+  if (pipetteData && pipetteData.maxVolume < volume && errors.length === 0) {
+    errors.push(errorCreators.pipetteVolumeExceeded({actionName, volume, maxVolume: pipetteData.maxVolume}))
+  }
+
   const tipMaxVolume = getMaxTipVolumeForPipette(pipette, prevRobotState)
   if (tipMaxVolume < volume && errors.length === 0) {
     errors.push(errorCreators.tipVolumeExceeded({actionName, volume, maxVolume: tipMaxVolume}))

--- a/protocol-designer/src/step-generation/blowout.js
+++ b/protocol-designer/src/step-generation/blowout.js
@@ -20,7 +20,7 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
     errors.push(errorCreators.pipetteDoesNotExist({actionName, pipette}))
   }
 
-  if (prevRobotState.tipState.pipettes[pipette] === false) {
+  if (!prevRobotState.tipState.pipettes[pipette]) {
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
   }
 

--- a/protocol-designer/src/step-generation/consolidate.js
+++ b/protocol-designer/src/step-generation/consolidate.js
@@ -5,6 +5,7 @@ import {FIXED_TRASH_ID} from '../constants'
 import {aspirate, dispense, blowout, replaceTip, touchTip} from './'
 import {mixUtil} from './mix'
 import * as errorCreators from './errorCreators'
+import {getPipetteWithTipMaxVol} from './robotStateSelectors'
 import type {ConsolidateFormData, RobotState, CommandCreator, CompoundCommandCreator} from './'
 
 const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prevRobotState: RobotState) => {
@@ -45,7 +46,7 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
     : 0
 
   const maxWellsPerChunk = Math.floor(
-    (pipetteData.maxVolume - disposalVolume) / data.volume
+    (getPipetteWithTipMaxVol(data.pipette, prevRobotState) - disposalVolume) / data.volume
   )
 
   const commandCreators = flatMap(

--- a/protocol-designer/src/step-generation/dispense.js
+++ b/protocol-designer/src/step-generation/dispense.js
@@ -10,7 +10,7 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
   const actionName = 'dispense'
   let errors: Array<CommandCreatorError> = []
 
-  if (prevRobotState.tipState.pipettes[pipette] === false) {
+  if (!prevRobotState.tipState.pipettes[pipette]) {
     errors.push(errorCreators.noTipOnPipette({actionName, pipette, labware, well}))
   }
 

--- a/protocol-designer/src/step-generation/distribute.js
+++ b/protocol-designer/src/step-generation/distribute.js
@@ -8,6 +8,7 @@ import {aspirate, dispense, blowout, replaceTip, touchTip} from './'
 import transfer from './transfer'
 import {mixUtil} from './mix'
 import * as errorCreators from './errorCreators'
+import {getPipetteWithTipMaxVol} from './robotStateSelectors'
 import type {DistributeFormData, RobotState, CommandCreator, CompoundCommandCreator, TransferLikeFormDataFields, TransferFormData} from './'
 
 const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRobotState: RobotState) => {
@@ -49,7 +50,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
     : 0
 
   const maxWellsPerChunk = Math.floor(
-    (pipetteData.maxVolume - disposalVolume) / data.volume
+    (getPipetteWithTipMaxVol(data.pipette, prevRobotState) - disposalVolume) / data.volume
   )
 
   const {pipette} = data

--- a/protocol-designer/src/step-generation/dropTip.js
+++ b/protocol-designer/src/step-generation/dropTip.js
@@ -6,7 +6,7 @@ import updateLiquidState from './dispenseUpdateLiquidState'
 
 const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotState) => {
   // No-op if there is no tip
-  if (prevRobotState.tipState.pipettes[pipetteId] === false) {
+  if (!prevRobotState.tipState.pipettes[pipetteId]) {
     return {
       robotState: prevRobotState,
       commands: [],

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -50,3 +50,15 @@ export function tipVolumeExceeded (args: {
     type: 'TIP_VOLUME_EXCEEDED',
   }
 }
+
+export function pipetteVolumeExceeded (args: {
+  actionName: string,
+  volume: string | number,
+  maxVolume: string | number,
+}): CommandCreatorError {
+  const {actionName, volume, maxVolume} = args
+  return {
+    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
+    type: 'PIPETTE_VOLUME_EXCEEDED',
+  }
+}

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -39,14 +39,14 @@ export function labwareDoesNotExist (args: {actionName: string, labware: string}
   }
 }
 
-export function pipetteVolumeExceeded (args: {
+export function tipVolumeExceeded (args: {
   actionName: string,
   volume: string | number,
   maxVolume: string | number,
 }): CommandCreatorError {
   const {actionName, volume, maxVolume} = args
   return {
-    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
-    type: 'PIPETTE_VOLUME_EXCEEDED',
+    message: `Attempted to ${actionName} volume greater than tip max volume (${volume} > ${maxVolume})`,
+    type: 'TIP_VOLUME_EXCEEDED',
   }
 }

--- a/protocol-designer/src/step-generation/replaceTip.js
+++ b/protocol-designer/src/step-generation/replaceTip.js
@@ -1,6 +1,5 @@
 // @flow
 import cloneDeep from 'lodash/cloneDeep'
-import {getTiprackVolumeByLabwareId} from './robotStateSelectors'
 import {dropTip, getNextTiprack, tiprackWellNamesByCol} from './'
 import {insufficientTips} from './errorCreators'
 import type {RobotState, CommandCreator} from './types'
@@ -45,9 +44,8 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
     },
   ]
 
-  // pipette now has tip. Remember tip max volume in tipState.pipettes.
-  const tipMaxVolume = getTiprackVolumeByLabwareId(nextTiprack.tiprackId, robotState) || 0
-  robotState.tipState.pipettes[pipetteId] = {tipMaxVolume}
+  // pipette now has tip
+  robotState.tipState.pipettes[pipetteId] = true
 
   // update tiprack-to-pipette assignment
   robotState.tiprackAssignment = {

--- a/protocol-designer/src/step-generation/replaceTip.js
+++ b/protocol-designer/src/step-generation/replaceTip.js
@@ -45,7 +45,7 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
     },
   ]
 
-  // pipette now has tip
+  // pipette now has tip. Remember tip max volume in tipState.pipettes.
   const tipMaxVolume = getTiprackVolumeByLabwareId(nextTiprack.tiprackId, robotState) || 0
   robotState.tipState.pipettes[pipetteId] = {tipMaxVolume}
 

--- a/protocol-designer/src/step-generation/replaceTip.js
+++ b/protocol-designer/src/step-generation/replaceTip.js
@@ -1,7 +1,6 @@
 // @flow
-import assert from 'assert'
 import cloneDeep from 'lodash/cloneDeep'
-import {getLabware} from '@opentrons/shared-data'
+import {getTiprackVolumeByLabwareId} from './robotStateSelectors'
 import {dropTip, getNextTiprack, tiprackWellNamesByCol} from './'
 import {insufficientTips} from './errorCreators'
 import type {RobotState, CommandCreator} from './types'
@@ -47,12 +46,7 @@ const replaceTip = (pipetteId: string): CommandCreator => (prevRobotState: Robot
   ]
 
   // pipette now has tip
-  // TODO IMMEDIATELY: make this into selector in shared-data / robotStateSelector
-  const tiprackType = robotState.labware[nextTiprack.tiprackId].type
-  const tiprackData = getLabware(tiprackType)
-  assert(tiprackData, `could not get labware data for tiprack: id=${nextTiprack.tiprackId}, type=${tiprackType}. ${JSON.stringify(tiprackData)}`)
-  const tipMaxVolume = (tiprackData && tiprackData.metadata.tipVolume) || 0 // TODO IMMEDIATELY better bug reporting than 'max vol is 0 I guess'
-  assert(tipMaxVolume > 0, `expected tipMaxVolume > 0, got ${tipMaxVolume}. tiprack id: ${nextTiprack.tiprackId}`)
+  const tipMaxVolume = getTiprackVolumeByLabwareId(nextTiprack.tiprackId, robotState) || 0
   robotState.tipState.pipettes[pipetteId] = {tipMaxVolume}
 
   // update tiprack-to-pipette assignment

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -1,4 +1,5 @@
 // @flow
+import assert from 'assert'
 import {tiprackWellNamesByCol, tiprackWellNamesFlat} from './'
 import type {Channels} from '@opentrons/components'
 import type {RobotState, PipetteData, LabwareData} from './'
@@ -16,8 +17,7 @@ export function getPipetteChannels (pipetteId: string, robotState: RobotState): 
   const pipette = robotState.instruments[pipetteId]
 
   if (!pipette) {
-    // TODO Ian 2018-06-04 use assert
-    console.warn(`no pipette id: "${pipetteId}"`)
+    assert(pipette, `no pipette with ID {pipetteId} found in robot state`)
     return null
   }
 
@@ -113,4 +113,9 @@ export function getNextTiprack (pipette: PipetteData, robotState: RobotState): N
   }
   // No available tipracks (for given pipette channels)
   return null
+}
+
+export function getMaxTipVolumeForPipette (pipetteId: string, robotState: RobotState): number {
+  const pipetteTipstate = robotState.tipState.pipettes[pipetteId]
+  return (pipetteTipstate && pipetteTipstate.tipMaxVolume) || 0
 }

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -19,27 +19,12 @@ export function getPipetteChannels (pipetteId: string, robotState: RobotState): 
   const pipette = robotState.instruments[pipetteId]
 
   if (!pipette) {
-    assert(pipette, `no pipette with ID {pipetteId} found in robot state`)
+    assert(false, `no pipette with ID {pipetteId} found in robot state`)
     return null
   }
 
   const pipetteChannels = pipette.channels
   return pipetteChannels
-}
-
-export function getTiprackVolumeByLabwareId (labwareId: string, robotState: RobotState): ?number {
-  const tiprackType = robotState.labware[labwareId].type
-  const tiprackData = getLabware(tiprackType)
-  assert(
-    tiprackData,
-    `could not get labware data for tiprack: id=${labwareId}, type=${tiprackType}.`)
-
-  const tipMaxVolume = (tiprackData && tiprackData.metadata.tipVolume) || null
-
-  assert(
-    tipMaxVolume && tipMaxVolume > 0,
-    `expected tipMaxVolume > 0, got ${String(tipMaxVolume)}. tiprack id: ${labwareId}`)
-  return tipMaxVolume
 }
 
 export function getLabwareType (labwareId: string, robotState: RobotState): ?string {
@@ -139,7 +124,7 @@ export function getPipetteWithTipMaxVol (pipetteId: string, robotState: RobotSta
   const tiprackTipVol = tiprackData && tiprackData.metadata.tipVolume
 
   if (!pipetteMaxVol || !tiprackTipVol) {
-    console.error('getPipetteEffectiveMaxVol expected tiprackMaxVol and pipette maxVolume to be > 0, got', {pipetteMaxVol, tiprackTipVol})
+    console.warn('getPipetteEffectiveMaxVol expected tiprackMaxVol and pipette maxVolume to be > 0, got', {pipetteMaxVol, tiprackTipVol})
     return NaN
   }
   return min([tiprackTipVol, pipetteMaxVol])

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -2,6 +2,7 @@
 import assert from 'assert'
 import {tiprackWellNamesByCol, tiprackWellNamesFlat} from './'
 import type {Channels} from '@opentrons/components'
+import {getLabware} from '@opentrons/shared-data'
 import type {RobotState, PipetteData, LabwareData} from './'
 import sortBy from 'lodash/sortBy'
 
@@ -23,6 +24,21 @@ export function getPipetteChannels (pipetteId: string, robotState: RobotState): 
 
   const pipetteChannels = pipette.channels
   return pipetteChannels
+}
+
+export function getTiprackVolumeByLabwareId (labwareId: string, robotState: RobotState): ?number {
+  const tiprackType = robotState.labware[labwareId].type
+  const tiprackData = getLabware(tiprackType)
+  assert(
+    tiprackData,
+    `could not get labware data for tiprack: id=${labwareId}, type=${tiprackType}.`)
+
+  const tipMaxVolume = (tiprackData && tiprackData.metadata.tipVolume) || null
+
+  assert(
+    tipMaxVolume && tipMaxVolume > 0,
+    `expected tipMaxVolume > 0, got ${String(tipMaxVolume)}. tiprack id: ${labwareId}`)
+  return tipMaxVolume
 }
 
 export function getLabwareType (labwareId: string, robotState: RobotState): ?string {

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -41,6 +41,17 @@ export function getTiprackVolumeByLabwareId (labwareId: string, robotState: Robo
   return tipMaxVolume
 }
 
+export function getPipetteWithTipMaxVol (pipetteId: string, robotState: RobotState): number {
+  const pipetteTipstate = robotState.tipState.pipettes[pipetteId]
+  assert(pipetteTipstate, `expected pipette ${pipetteId} to be in tipState.pipettes`)
+
+  const tipMaxVolume = (pipetteTipstate && pipetteTipstate.tipMaxVolume) || 0
+  assert(tipMaxVolume > 0, `expected tipMaxVolume of pipette ${pipetteId} to be > 0`)
+
+  const pipetteData = robotState.instruments[pipetteId]
+  return Math.min(tipMaxVolume, pipetteData.maxVolume)
+}
+
 export function getLabwareType (labwareId: string, robotState: RobotState): ?string {
   const labware = robotState.labware[labwareId]
 

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -34,14 +34,14 @@ describe('aspirate', () => {
       destPlateType: '96-flat',
       fillPipetteTips: false,
       fillTiprackTips: true,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
     robotStateWithTip = createRobotState({
       sourcePlateType: 'trough-12row',
       destPlateType: '96-flat',
-      fillPipetteTips: true,
+      fillPipetteTips: 300,
       fillTiprackTips: true,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
   })
 
@@ -49,9 +49,9 @@ describe('aspirate', () => {
   const robotStateWithTipNoLiquidState = createRobotStateFixture({
     sourcePlateType: 'trough-12row',
     destPlateType: '96-flat',
-    fillPipetteTips: true,
-    fillTiprackTips: true,
-    tipracks: [200, 200],
+    fillPipetteTips: 300,
+    fillTiprackTips: 300,
+    tipracks: [300, 300],
   })
 
   test('aspirate with tip', () => {
@@ -75,17 +75,17 @@ describe('aspirate', () => {
     expect(result.robotState).toMatchObject(robotStateWithTipNoLiquidState)
   })
 
-  test('aspirate with volume > pipette max vol should throw error', () => {
+  test('aspirate with volume > pipette tip vol should throw error', () => {
     const result = aspirateWithErrors({
       pipette: 'p300SingleId',
-      volume: 10000,
+      volume: 301,
       labware: 'sourcePlateId',
       well: 'A1',
     })(robotStateWithTip)
 
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]).toMatchObject({
-      type: 'PIPETTE_VOLUME_EXCEEDED',
+      type: 'TIP_VOLUME_EXCEEDED',
     })
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -75,7 +75,23 @@ describe('aspirate', () => {
     expect(result.robotState).toMatchObject(robotStateWithTipNoLiquidState)
   })
 
-  test('aspirate with volume > pipette tip vol should throw error', () => {
+  test('aspirate with volume > tip max volume should throw error', () => {
+    robotStateWithTip.tipState.pipettes['p300SingleId'].tipMaxVolume = 200
+    const result = aspirateWithErrors({
+      pipette: 'p300SingleId',
+      volume: 201,
+      labware: 'sourcePlateId',
+      well: 'A1',
+    })(robotStateWithTip)
+
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toMatchObject({
+      type: 'TIP_VOLUME_EXCEEDED',
+    })
+  })
+
+  test('aspirate with volume > pipette max volume should throw error', () => {
+    robotStateWithTip.tipState.pipettes['p300SingleId'].tipMaxVolume = 9999
     const result = aspirateWithErrors({
       pipette: 'p300SingleId',
       volume: 301,
@@ -85,7 +101,7 @@ describe('aspirate', () => {
 
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]).toMatchObject({
-      type: 'TIP_VOLUME_EXCEEDED',
+      type: 'PIPETTE_VOLUME_EXCEEDED',
     })
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {expectTimelineError} from './testMatchers'
 import _blowout from '../blowout'
 import {createRobotState, commandCreatorNoErrors, commandCreatorHasErrors} from './fixtures'
 
@@ -19,7 +20,7 @@ describe('blowout', () => {
       destPlateType: '96-flat',
       fillTiprackTips: true,
       fillPipetteTips: false,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
 
     robotStateWithTip = {
@@ -65,10 +66,7 @@ describe('blowout', () => {
       well: 'A1',
     })(robotStateWithTip)
 
-    expect(result.errors).toHaveLength(1)
-    expect(result.errors[0]).toMatchObject({
-      type: 'PIPETTE_DOES_NOT_EXIST',
-    })
+    expectTimelineError(result.errors, 'PIPETTE_DOES_NOT_EXIST')
   })
 
   test('blowout with invalid labware ID should throw error', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -30,8 +30,6 @@ function tripleMix (well: string, volume: number, labware: string) {
   ]
 }
 
-const pipetteTip300uL = {tipMaxVolume: 300}
-
 const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
   destPlateType: '96-flat',
@@ -55,7 +53,7 @@ const robotStatePickedUpOneTipNoLiquidState = merge(
         tiprack1Id: {A1: false},
       },
       pipettes: {
-        p300SingleId: pipetteTip300uL,
+        p300SingleId: true,
       },
     },
   }
@@ -70,7 +68,7 @@ const robotStatePickedUpMultiTipsNoLiquidState = merge(
         tiprack1Id: getTipColumn(1, false),
       },
       pipettes: {
-        p300MultiId: pipetteTip300uL,
+        p300MultiId: true,
       },
     },
   }
@@ -180,7 +178,7 @@ describe('consolidate single-channel', () => {
         },
         pipettes: {
           ...robotInitialState.tipState.pipettes,
-          p300SingleId: pipetteTip300uL,
+          p300SingleId: true,
         },
       },
     })

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -30,12 +30,14 @@ function tripleMix (well: string, volume: number, labware: string) {
   ]
 }
 
+const pipetteTip300uL = {tipMaxVolume: 300}
+
 const robotInitialStateNoLiquidState = createRobotStateFixture({
   sourcePlateType: 'trough-12row',
   destPlateType: '96-flat',
   fillTiprackTips: true,
   fillPipetteTips: false,
-  tipracks: [200, 200],
+  tipracks: [300, 300],
 })
 
 const emptyLiquidState = createEmptyLiquidState({
@@ -53,7 +55,7 @@ const robotStatePickedUpOneTipNoLiquidState = merge(
         tiprack1Id: {A1: false},
       },
       pipettes: {
-        p300SingleId: true,
+        p300SingleId: pipetteTip300uL,
       },
     },
   }
@@ -68,7 +70,7 @@ const robotStatePickedUpMultiTipsNoLiquidState = merge(
         tiprack1Id: getTipColumn(1, false),
       },
       pipettes: {
-        p300MultiId: true,
+        p300MultiId: pipetteTip300uL,
       },
     },
   }
@@ -178,7 +180,7 @@ describe('consolidate single-channel', () => {
         },
         pipettes: {
           ...robotInitialState.tipState.pipettes,
-          p300SingleId: true,
+          p300SingleId: pipetteTip300uL,
         },
       },
     })

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -22,7 +22,7 @@ describe('dispense', () => {
       destPlateType: '96-flat',
       fillTiprackTips: true,
       fillPipetteTips: false,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
 
     robotStateWithTip = {

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -46,7 +46,7 @@ beforeEach(() => {
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
     tipracks: [300],
-    fillPipetteTips: 300,
+    fillPipetteTips: true,
     fillTiprackTips: true,
   })
 
@@ -54,7 +54,7 @@ beforeEach(() => {
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
     tipracks: [300],
-    fillPipetteTips: 300,
+    fillPipetteTips: true,
     fillTiprackTips: false,
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -45,16 +45,16 @@ beforeEach(() => {
   robotInitialState = createRobotState({
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
-    tipracks: [200],
-    fillPipetteTips: true,
+    tipracks: [300],
+    fillPipetteTips: 300,
     fillTiprackTips: true,
   })
 
   robotInitialStatePipettesLackTips = createRobotState({
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
-    tipracks: [200],
-    fillPipetteTips: true,
+    tipracks: [300],
+    fillPipetteTips: 300,
     fillTiprackTips: false,
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
@@ -16,7 +16,7 @@ beforeEach(() => {
     destPlateType: '96-flat',
     fillTiprackTips: true,
     fillPipetteTips: false,
-    tipracks: [200, 200],
+    tipracks: [300, 300],
   })
 })
 

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -19,7 +19,7 @@ describe('dropTip', () => {
       destPlateType: '96-flat',
       fillTiprackTips: true,
       fillPipetteTips: false,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
 
     robotStateWithTip = {
@@ -45,7 +45,7 @@ describe('dropTip', () => {
       createRobotState({
         sourcePlateType: 'trough-12row',
         destPlateType: '96-flat',
-        tipracks: [200, 200],
+        tipracks: [300, 300],
         fillPipetteTips: false,
         fillTiprackTips: true,
       }),

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -68,7 +68,7 @@ describe('createRobotState fixture generator', () => {
         const result = createRobotState({
           sourcePlateType: 'trough-12row',
           destPlateType: '96-flat',
-          fillPipetteTips: fillPipetteTips,
+          fillPipetteTips,
           fillTiprackTips: true,
           tipracks: [300, 300],
         })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -49,7 +49,7 @@ describe('createRobotState fixture generator', () => {
           destPlateType: '96-flat',
           fillPipetteTips: false,
           fillTiprackTips,
-          tipracks: [200, 200],
+          tipracks: [300, 300],
         })
 
         const tiprackIds = ['tiprack1Id', 'tiprack2Id']
@@ -65,20 +65,18 @@ describe('createRobotState fixture generator', () => {
 
     tipFillingOptions.forEach(fillPipetteTips => {
       test('tiprack tips ' + (fillPipetteTips ? 'full' : 'empty'), () => {
-        const pipetteTipMaxVol = 200
         const result = createRobotState({
           sourcePlateType: 'trough-12row',
           destPlateType: '96-flat',
-          fillPipetteTips: fillPipetteTips ? pipetteTipMaxVol : false,
+          fillPipetteTips: fillPipetteTips,
           fillTiprackTips: true,
-          tipracks: [200, 200],
+          tipracks: [300, 300],
         })
 
         const pipetteIds = ['p300SingleId', 'p300MultiId']
         pipetteIds.forEach(pipetteId => {
           expect(result).toHaveProperty(`tipState.pipettes.${pipetteId}`)
-          expect(result.tipState.pipettes[pipetteId]).toEqual(
-            fillPipetteTips ? {tipMaxVolume: pipetteTipMaxVol} : false)
+          expect(result.tipState.pipettes[pipetteId]).toEqual(fillPipetteTips)
         })
       })
     })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtureGeneration.test.js
@@ -65,10 +65,11 @@ describe('createRobotState fixture generator', () => {
 
     tipFillingOptions.forEach(fillPipetteTips => {
       test('tiprack tips ' + (fillPipetteTips ? 'full' : 'empty'), () => {
+        const pipetteTipMaxVol = 200
         const result = createRobotState({
           sourcePlateType: 'trough-12row',
           destPlateType: '96-flat',
-          fillPipetteTips,
+          fillPipetteTips: fillPipetteTips ? pipetteTipMaxVol : false,
           fillTiprackTips: true,
           tipracks: [200, 200],
         })
@@ -76,7 +77,8 @@ describe('createRobotState fixture generator', () => {
         const pipetteIds = ['p300SingleId', 'p300MultiId']
         pipetteIds.forEach(pipetteId => {
           expect(result).toHaveProperty(`tipState.pipettes.${pipetteId}`)
-          expect(result.tipState.pipettes[pipetteId]).toEqual(fillPipetteTips)
+          expect(result.tipState.pipettes[pipetteId]).toEqual(
+            fillPipetteTips ? {tipMaxVolume: pipetteTipMaxVol} : false)
         })
       })
     })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -8,14 +8,14 @@ export const replaceTipCommands = (tip: number | string): Array<Command> => [
 ]
 
 export const dropTip = (
-  tip: number | string, // TODO IMMEDIATELY should this be well?: string & default to A1?
+  well: string,
   params?: {| pipette?: string, labware?: string |}
 ): Command => ({
   command: 'drop-tip',
   params: {
     pipette: 'p300SingleId',
     labware: 'trashId',
-    well: (typeof tip === 'string') ? tip : tiprackWellNamesFlat[tip],
+    well: (typeof well === 'string') ? well : tiprackWellNamesFlat[well],
     ...params,
   },
 })

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/fixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/fixtures.js
@@ -1,5 +1,4 @@
 // @flow
-import assert from 'assert'
 import {getLabware} from '@opentrons/shared-data'
 import map from 'lodash/map'
 import mapValues from 'lodash/mapValues'
@@ -84,6 +83,7 @@ export const p300Single = {
   id: 'p300SingleId',
   mount: 'right',
   model: 'p300_single_v1',
+  tiprackModel: 'opentrons-tiprack-300ul',
   maxVolume: 300,
   channels: 1,
 }
@@ -92,6 +92,7 @@ export const p300Multi = {
   id: 'p300MultiId',
   mount: 'left',
   model: 'p300_multi_v1',
+  tiprackModel: 'opentrons-tiprack-300ul',
   maxVolume: 300,
   channels: 8,
 }
@@ -146,7 +147,7 @@ type CreateRobotArgs = {
   sourcePlateType: string,
   destPlateType?: string,
   tipracks: Array<10 | 200 | 300 | 1000>,
-  fillPipetteTips?: number,
+  fillPipetteTips: boolean,
   fillTiprackTips?: boolean,
 }
 /** RobotState with empty liquid state */
@@ -180,8 +181,6 @@ function getTiprackType (volume: number): string {
 
 /** RobotState without liquidState key, for use with jest's `toMatchObject` */
 export function createRobotStateFixture (args: CreateRobotArgs): RobotStateNoLiquidState {
-  assert(args.fillPipetteTips === false || typeof args.fillPipetteTips === 'number',
-    `fillPipetteTips should be false, or a number. Got ${String(args.fillTiprackTips)}`)
   function _getTiprackSlot (tiprackIndex: number, occupiedSlots: Array<string>): string {
     const slot = (tiprackIndex + 1).toString()
     if (occupiedSlots.includes(slot)) {
@@ -246,12 +245,8 @@ export function createRobotStateFixture (args: CreateRobotArgs): RobotStateNoLiq
         [tiprackId]: getTiprackTipstate(args.fillTiprackTips),
       }), {}),
       pipettes: {
-        p300SingleId: args.fillPipetteTips
-          ? {tipMaxVolume: args.fillPipetteTips}
-          : false,
-        p300MultiId: args.fillPipetteTips
-          ? {tipMaxVolume: args.fillPipetteTips}
-          : false,
+        p300SingleId: args.fillPipetteTips,
+        p300MultiId: args.fillPipetteTips,
       },
     },
   }

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
     tipracks: [200],
-    fillPipetteTips: true,
+    fillPipetteTips: 200,
     fillTiprackTips: true,
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -17,8 +17,8 @@ beforeEach(() => {
   robotInitialState = createRobotState({
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
-    tipracks: [200],
-    fillPipetteTips: 200,
+    tipracks: [300],
+    fillPipetteTips: true,
     fillTiprackTips: true,
   })
 

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -23,7 +23,9 @@ const p300MultiId = 'p300MultiId'
 describe('replaceTip', () => {
   let labwareTypes1
   let robotInitialState
+  let tip200uL
   beforeEach(() => {
+    tip200uL = {tipMaxVolume: 200}
     labwareTypes1 = {
       sourcePlateType: 'trough-12row',
       destPlateType: '96-flat',
@@ -61,7 +63,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: true,
+              p300SingleId: tip200uL,
             },
           },
         }
@@ -102,7 +104,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: true,
+              p300SingleId: tip200uL,
             },
           },
         }
@@ -142,7 +144,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: true,
+              p300SingleId: tip200uL,
             },
           },
         }
@@ -161,7 +163,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: true,
+              p300SingleId: tip200uL,
             },
           },
         }
@@ -222,7 +224,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: true,
+              p300SingleId: tip200uL,
             },
           },
         }
@@ -247,7 +249,7 @@ describe('replaceTip', () => {
               [tiprack1Id]: getTipColumn(1, false),
             },
             pipettes: {
-              p300MultiId: true,
+              p300MultiId: tip200uL,
             },
           },
         }
@@ -292,7 +294,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300MultiId: true,
+              p300MultiId: tip200uL,
             },
           },
         }
@@ -305,7 +307,7 @@ describe('replaceTip', () => {
         tipState: {
           ...robotInitialState.tipState,
           pipettes: {
-            p300MultiId: true,
+            p300MultiId: tip200uL,
           },
         },
       }
@@ -328,7 +330,7 @@ describe('replaceTip', () => {
               [tiprack2Id]: getTiprackTipstate(true),
             },
             pipettes: {
-              p300MultiId: true,
+              p300MultiId: tip200uL,
             },
           },
         }

--- a/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/replaceTip.test.js
@@ -23,9 +23,7 @@ const p300MultiId = 'p300MultiId'
 describe('replaceTip', () => {
   let labwareTypes1
   let robotInitialState
-  let tip200uL
   beforeEach(() => {
-    tip200uL = {tipMaxVolume: 200}
     labwareTypes1 = {
       sourcePlateType: 'trough-12row',
       destPlateType: '96-flat',
@@ -35,7 +33,7 @@ describe('replaceTip', () => {
       ...labwareTypes1,
       fillTiprackTips: true,
       fillPipetteTips: false,
-      tipracks: [200, 200],
+      tipracks: [300, 300],
     })
 
     // $FlowFixMe: mock methods
@@ -63,7 +61,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: tip200uL,
+              p300SingleId: true,
             },
           },
         }
@@ -104,7 +102,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: tip200uL,
+              p300SingleId: true,
             },
           },
         }
@@ -144,7 +142,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: tip200uL,
+              p300SingleId: true,
             },
           },
         }
@@ -163,7 +161,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: tip200uL,
+              p300SingleId: true,
             },
           },
         }
@@ -224,7 +222,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300SingleId: tip200uL,
+              p300SingleId: true,
             },
           },
         }
@@ -249,7 +247,7 @@ describe('replaceTip', () => {
               [tiprack1Id]: getTipColumn(1, false),
             },
             pipettes: {
-              p300MultiId: tip200uL,
+              p300MultiId: true,
             },
           },
         }
@@ -294,7 +292,7 @@ describe('replaceTip', () => {
               },
             },
             pipettes: {
-              p300MultiId: tip200uL,
+              p300MultiId: true,
             },
           },
         }
@@ -307,7 +305,7 @@ describe('replaceTip', () => {
         tipState: {
           ...robotInitialState.tipState,
           pipettes: {
-            p300MultiId: tip200uL,
+            p300MultiId: true,
           },
         },
       }
@@ -330,7 +328,7 @@ describe('replaceTip', () => {
               [tiprack2Id]: getTiprackTipstate(true),
             },
             pipettes: {
-              p300MultiId: tip200uL,
+              p300MultiId: true,
             },
           },
         }

--- a/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
@@ -8,8 +8,6 @@ const basicLiquidState = {
   labware: {},
 }
 
-const pipetteTip300uL = {tipMaxVolume: 300}
-
 describe('sortLabwareBySlot', () => {
   test('sorts all labware by slot', () => {
     // TODO use a fixture, standardize
@@ -28,12 +26,12 @@ describe('sortLabwareBySlot', () => {
         },
         one: {
           slot: '1',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack',
         },
         eleven: {
           slot: '11',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack',
         },
         two: {
@@ -44,7 +42,7 @@ describe('sortLabwareBySlot', () => {
       },
       tipState: {
         tipracks: {
-          tiprack1Id: getTiprackTipstate(pipetteTip300uL),
+          tiprack1Id: getTiprackTipstate(true),
         },
         pipettes: {
           p300SingleId: false,
@@ -67,7 +65,7 @@ describe('sortLabwareBySlot', () => {
       labware: {},
       tipState: {
         tipracks: {
-          tiprack1Id: getTiprackTipstate(pipetteTip300uL),
+          tiprack1Id: getTiprackTipstate(true),
         },
         pipettes: {
           p300SingleId: false,
@@ -86,23 +84,23 @@ describe('sortLabwareBySlot', () => {
 
 describe('_getNextTip', () => {
   test('full tiprack should start at A1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL)})
+    const result = _getNextTip(1, {...getTiprackTipstate(true)})
     expect(result).toEqual('A1')
   })
 
   test('missing A1, go to B1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL), A1: false})
+    const result = _getNextTip(1, {...getTiprackTipstate(true), A1: false})
     expect(result).toEqual('B1')
   })
 
   test('missing A1 and B1, go to C1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL), A1: false, B1: false})
+    const result = _getNextTip(1, {...getTiprackTipstate(true), A1: false, B1: false})
     expect(result).toEqual('C1')
   })
 
   test('missing first column, go to A2', () => {
     const result = _getNextTip(1, {
-      ...getTiprackTipstate(pipetteTip300uL),
+      ...getTiprackTipstate(true),
       ...getTipColumn(1, false),
     })
     expect(result).toEqual('A2')
@@ -110,7 +108,7 @@ describe('_getNextTip', () => {
 
   test('missing a few random tips, go to lowest col, then lowest row', () => {
     const result = _getNextTip(1, {
-      ...getTiprackTipstate(pipetteTip300uL),
+      ...getTiprackTipstate(true),
       ...getTipColumn(1, false),
       ...getTipColumn(2, false),
       D2: true,
@@ -129,7 +127,7 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -151,7 +149,7 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
           },
         },
@@ -214,12 +212,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -241,10 +239,10 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
           },
           tiprack11Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
           },
         },
         pipettes: {
@@ -269,12 +267,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -296,11 +294,11 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
           },
           tiprack11Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
           },
         },
@@ -326,12 +324,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -382,7 +380,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -403,7 +401,7 @@ describe('getNextTiprack - 8-channel', () => {
       },
       tipState: {
         tipracks: {
-          tiprack2Id: {...getTiprackTipstate(pipetteTip300uL)},
+          tiprack2Id: {...getTiprackTipstate(true)},
         },
         pipettes: {
           p300SingleId: false,
@@ -427,7 +425,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -449,7 +447,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
             A2: false,
             A5: false,
@@ -513,7 +511,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -535,7 +533,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             F1: false,
             B2: false,
             C3: false,
@@ -571,17 +569,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -603,13 +601,13 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
           },
           tiprack3Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
           },
           tiprack10Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
           },
         },
         pipettes: {
@@ -634,17 +632,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -666,7 +664,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             // empty diagonal, 8-channel cannot use
             F1: false,
             B2: false,
@@ -682,7 +680,7 @@ describe('getNextTiprack - 8-channel', () => {
             F12: false,
           },
           tiprack3Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             // empty row, 8-channel cannot use
             A1: false,
             A2: false,
@@ -698,7 +696,7 @@ describe('getNextTiprack - 8-channel', () => {
             A12: false,
           },
           tiprack10Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
           },
         },
@@ -724,17 +722,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'opentrons-tiprack-300uL',
+          type: 'opentrons-tiprack-300ul',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -756,7 +754,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             F1: false,
             B2: false,
             C3: false,
@@ -771,7 +769,7 @@ describe('getNextTiprack - 8-channel', () => {
             F12: false,
           },
           tiprack3Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
             A2: false,
             A3: false,
@@ -786,7 +784,7 @@ describe('getNextTiprack - 8-channel', () => {
             A12: false,
           },
           tiprack10Id: {
-            ...getTiprackTipstate(pipetteTip300uL),
+            ...getTiprackTipstate(true),
             A1: false,
             A2: false,
             A3: false,
@@ -817,7 +815,7 @@ describe('getNextTiprack - 8-channel', () => {
 describe('tiprackIsAvailableToPipette', () => {
   let pipette
   let tiprack
-  const tiprackModel = 'opentrons-tiprack-300uL'
+  const tiprackModel = 'opentrons-tiprack-300ul'
   const pipetteId = 'pipetteId'
 
   beforeEach(() => {

--- a/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
@@ -8,6 +8,8 @@ const basicLiquidState = {
   labware: {},
 }
 
+const pipetteTip300uL = {tipMaxVolume: 300}
+
 describe('sortLabwareBySlot', () => {
   test('sorts all labware by slot', () => {
     // TODO use a fixture, standardize
@@ -26,12 +28,12 @@ describe('sortLabwareBySlot', () => {
         },
         one: {
           slot: '1',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack',
         },
         eleven: {
           slot: '11',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack',
         },
         two: {
@@ -42,7 +44,7 @@ describe('sortLabwareBySlot', () => {
       },
       tipState: {
         tipracks: {
-          tiprack1Id: getTiprackTipstate(true),
+          tiprack1Id: getTiprackTipstate(pipetteTip300uL),
         },
         pipettes: {
           p300SingleId: false,
@@ -65,7 +67,7 @@ describe('sortLabwareBySlot', () => {
       labware: {},
       tipState: {
         tipracks: {
-          tiprack1Id: getTiprackTipstate(true),
+          tiprack1Id: getTiprackTipstate(pipetteTip300uL),
         },
         pipettes: {
           p300SingleId: false,
@@ -84,23 +86,23 @@ describe('sortLabwareBySlot', () => {
 
 describe('_getNextTip', () => {
   test('full tiprack should start at A1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(true)})
+    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL)})
     expect(result).toEqual('A1')
   })
 
   test('missing A1, go to B1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(true), A1: false})
+    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL), A1: false})
     expect(result).toEqual('B1')
   })
 
   test('missing A1 and B1, go to C1', () => {
-    const result = _getNextTip(1, {...getTiprackTipstate(true), A1: false, B1: false})
+    const result = _getNextTip(1, {...getTiprackTipstate(pipetteTip300uL), A1: false, B1: false})
     expect(result).toEqual('C1')
   })
 
   test('missing first column, go to A2', () => {
     const result = _getNextTip(1, {
-      ...getTiprackTipstate(true),
+      ...getTiprackTipstate(pipetteTip300uL),
       ...getTipColumn(1, false),
     })
     expect(result).toEqual('A2')
@@ -108,7 +110,7 @@ describe('_getNextTip', () => {
 
   test('missing a few random tips, go to lowest col, then lowest row', () => {
     const result = _getNextTip(1, {
-      ...getTiprackTipstate(true),
+      ...getTiprackTipstate(pipetteTip300uL),
       ...getTipColumn(1, false),
       ...getTipColumn(2, false),
       D2: true,
@@ -127,7 +129,7 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -149,7 +151,7 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
           },
         },
@@ -212,12 +214,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -239,10 +241,10 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
           },
           tiprack11Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
           },
         },
         pipettes: {
@@ -267,12 +269,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -294,11 +296,11 @@ describe('getNextTiprack - single-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
           },
           tiprack11Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
           },
         },
@@ -324,12 +326,12 @@ describe('getNextTiprack - single-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 11',
         },
         sourcePlateId: {
@@ -380,7 +382,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -401,7 +403,7 @@ describe('getNextTiprack - 8-channel', () => {
       },
       tipState: {
         tipracks: {
-          tiprack2Id: {...getTiprackTipstate(true)},
+          tiprack2Id: {...getTiprackTipstate(pipetteTip300uL)},
         },
         pipettes: {
           p300SingleId: false,
@@ -425,7 +427,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -447,7 +449,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
             A2: false,
             A5: false,
@@ -511,7 +513,7 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         sourcePlateId: {
@@ -533,7 +535,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             F1: false,
             B2: false,
             C3: false,
@@ -569,17 +571,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -601,13 +603,13 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
           },
           tiprack3Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
           },
           tiprack10Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
           },
         },
         pipettes: {
@@ -632,17 +634,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -664,8 +666,8 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
-            // empty diagona, 8-channel cannot use
+            ...getTiprackTipstate(pipetteTip300uL),
+            // empty diagonal, 8-channel cannot use
             F1: false,
             B2: false,
             C3: false,
@@ -680,7 +682,7 @@ describe('getNextTiprack - 8-channel', () => {
             F12: false,
           },
           tiprack3Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             // empty row, 8-channel cannot use
             A1: false,
             A2: false,
@@ -696,7 +698,7 @@ describe('getNextTiprack - 8-channel', () => {
             A12: false,
           },
           tiprack10Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
           },
         },
@@ -722,17 +724,17 @@ describe('getNextTiprack - 8-channel', () => {
       labware: {
         tiprack2Id: {
           slot: '2',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
-          type: 'tiprack-200uL',
+          type: 'opentrons-tiprack-300uL',
           name: 'Tip rack 10',
         },
         sourcePlateId: {
@@ -754,7 +756,7 @@ describe('getNextTiprack - 8-channel', () => {
       tipState: {
         tipracks: {
           tiprack2Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             F1: false,
             B2: false,
             C3: false,
@@ -769,7 +771,7 @@ describe('getNextTiprack - 8-channel', () => {
             F12: false,
           },
           tiprack3Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
             A2: false,
             A3: false,
@@ -784,7 +786,7 @@ describe('getNextTiprack - 8-channel', () => {
             A12: false,
           },
           tiprack10Id: {
-            ...getTiprackTipstate(true),
+            ...getTiprackTipstate(pipetteTip300uL),
             A1: false,
             A2: false,
             A3: false,
@@ -815,7 +817,7 @@ describe('getNextTiprack - 8-channel', () => {
 describe('tiprackIsAvailableToPipette', () => {
   let pipette
   let tiprack
-  const tiprackModel = 'tiprack-200uL'
+  const tiprackModel = 'opentrons-tiprack-300uL'
   const pipetteId = 'pipetteId'
 
   beforeEach(() => {

--- a/protocol-designer/src/step-generation/test-with-flow/testMatchers.js
+++ b/protocol-designer/src/step-generation/test-with-flow/testMatchers.js
@@ -1,0 +1,10 @@
+// error of type exists somewhere in timeline errors
+export function expectTimelineError (errors, errorType) {
+  expect(errors).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: errorType,
+      }),
+    ])
+  )
+}

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -19,7 +19,7 @@ describe('touchTip', () => {
     tipracks: [300, 300],
   }
   const initialRobotState = createRobotState(_robotFixtureArgs)
-  const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: 200})
+  const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: true})
 
   test('touchTip with tip', () => {
     const result = touchTip({

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {expectTimelineError} from './testMatchers'
 import _touchTip from '../touchTip'
 import {
   createRobotState,
@@ -15,7 +16,7 @@ describe('touchTip', () => {
     destPlateType: '96-flat',
     fillTiprackTips: true,
     fillPipetteTips: false,
-    tipracks: [200, 200],
+    tipracks: [300, 300],
   }
   const initialRobotState = createRobotState(_robotFixtureArgs)
   const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: 200})
@@ -67,10 +68,7 @@ describe('touchTip', () => {
       well: 'A1',
     })(robotStateWithTip)
 
-    expect(result.errors).toEqual([{
-      message: 'Attempted to touchTip with pipette id "badPipette", this pipette was not found under "instruments"',
-      type: 'PIPETTE_DOES_NOT_EXIST',
-    }])
+    expectTimelineError(result.errors, 'PIPETTE_DOES_NOT_EXIST')
   })
 
   test('touchTip with no tip should throw error', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/touchTip.test.js
@@ -18,7 +18,7 @@ describe('touchTip', () => {
     tipracks: [200, 200],
   }
   const initialRobotState = createRobotState(_robotFixtureArgs)
-  const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: true})
+  const robotStateWithTip = createRobotState({..._robotFixtureArgs, fillPipetteTips: 200})
 
   test('touchTip with tip', () => {
     const result = touchTip({

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -277,7 +277,7 @@ describe('single transfer exceeding pipette max', () => {
       changeTip: 'never',
     }
     // begin with tip on pipette
-    robotInitialState.tipState.pipettes.p300SingleId = {tipMaxVolume: 300}
+    robotInitialState.tipState.pipettes.p300SingleId = true
 
     const result = transfer(transferArgs)(robotInitialState)
     expect(result.commands).toEqual([

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -38,8 +38,8 @@ beforeEach(() => {
   robotInitialState = createRobotState({
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
-    tipracks: [200],
-    fillPipetteTips: true,
+    tipracks: [300],
+    fillPipetteTips: 300,
     fillTiprackTips: true,
   })
 })
@@ -277,7 +277,7 @@ describe('single transfer exceeding pipette max', () => {
       changeTip: 'never',
     }
     // begin with tip on pipette
-    robotInitialState.tipState.pipettes.p300SingleId = true
+    robotInitialState.tipState.pipettes.p300SingleId = {tipMaxVolume: 300}
 
     const result = transfer(transferArgs)(robotInitialState)
     expect(result.commands).toEqual([

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -39,7 +39,7 @@ beforeEach(() => {
     sourcePlateType: '96-flat',
     destPlateType: '96-flat',
     tipracks: [300],
-    fillPipetteTips: 300,
+    fillPipetteTips: true,
     fillTiprackTips: true,
   })
 })

--- a/protocol-designer/src/step-generation/touchTip.js
+++ b/protocol-designer/src/step-generation/touchTip.js
@@ -16,7 +16,7 @@ const touchTip = (args: TouchTipArgs): CommandCreator => (prevRobotState: RobotS
     errors.push(pipetteDoesNotExist({actionName, pipette}))
   }
 
-  if (prevRobotState.tipState.pipettes[pipette] === false) {
+  if (!prevRobotState.tipState.pipettes[pipette]) {
     errors.push(noTipOnPipette({actionName, pipette, labware, well}))
   }
 

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -46,12 +46,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
     dispenseOffsetFromBottomMm,
   } = data
 
-  // TODO error on negative data.disposalVolume?
-  const disposalVolume = (data.disposalVolume && data.disposalVolume > 0)
-    ? data.disposalVolume
-    : 0
-
-  const effectiveTransferVol = getPipetteWithTipMaxVol(data.pipette, prevRobotState) - disposalVolume
+  const effectiveTransferVol = getPipetteWithTipMaxVol(data.pipette, prevRobotState)
 
   const chunksPerSubTransfer = Math.ceil(
     data.volume / effectiveTransferVol
@@ -72,7 +67,6 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
       return flatMap(
         subTransferVolumes,
         (subTransferVol: number, chunkIdx: number): Array<CommandCreator> => {
-          // TODO IMMEDIATELY disposal vol ^^^
           const tipCommands: Array<CommandCreator> = (
             (data.changeTip === 'once' && pairIdx === 0 && chunkIdx === 0) ||
             data.changeTip === 'always')

--- a/protocol-designer/src/step-generation/transfer.js
+++ b/protocol-designer/src/step-generation/transfer.js
@@ -7,6 +7,7 @@ import {mixUtil} from './mix'
 import replaceTip from './replaceTip'
 import touchTip from './touchTip'
 import * as errorCreators from './errorCreators'
+import {getPipetteWithTipMaxVol} from './robotStateSelectors'
 import type {TransferFormData, RobotState, CommandCreator, CompoundCommandCreator} from './'
 
 const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotState: RobotState) => {
@@ -50,7 +51,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
     ? data.disposalVolume
     : 0
 
-  const effectiveTransferVol = pipetteData.maxVolume - disposalVolume
+  const effectiveTransferVol = getPipetteWithTipMaxVol(data.pipette, prevRobotState) - disposalVolume
 
   const chunksPerSubTransfer = Math.ceil(
     data.volume / effectiveTransferVol

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -140,7 +140,7 @@ export type PipetteData = {| // TODO refactor all 'pipette fields', split Pipett
   model: string, // TODO Ian 2018-11-05 rename 'model' to 'name' when breaking change is made in JSON protocols
   maxVolume: number,
   channels: Channels,
-  tiprackModel?: string, // NOTE: this will go away when tiprack sharing is implemented
+  tiprackModel: string, // NOTE: this will go away when tiprack choice-per-step and/or tiprack sharing is implemented
 |}
 
 export type LabwareData = {|
@@ -161,8 +161,6 @@ export type SingleLabwareLiquidState = {[well: string]: LocationLiquidState}
 export type LabwareLiquidState = {[labwareId: string]: SingleLabwareLiquidState}
 
 export type SourceAndDest = {|source: LocationLiquidState, dest: LocationLiquidState|}
-
-export type PipetteTip = {tipMaxVolume: number} | false // false if no tip in rack
 
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
@@ -185,7 +183,7 @@ export type RobotState = {|
       },
     },
     pipettes: {
-      [pipetteId: string]: PipetteTip,
+      [pipetteId: string]: boolean, // true if pipette has tip(s)
     },
   },
   liquidState: {

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -162,6 +162,8 @@ export type LabwareLiquidState = {[labwareId: string]: SingleLabwareLiquidState}
 
 export type SourceAndDest = {|source: LocationLiquidState, dest: LocationLiquidState|}
 
+export type PipetteTip = {tipMaxVolume: number} | false // false if no tip in rack
+
 // TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
 export type RobotState = {|
   instruments: { // TODO Ian 2018-05-23 rename this 'pipettes' to match tipState (& to disambiguate from future 'modules')
@@ -183,7 +185,7 @@ export type RobotState = {|
       },
     },
     pipettes: {
-      [pipetteId: string]: boolean, // true if tip is on pipette
+      [pipetteId: string]: PipetteTip,
     },
   },
   liquidState: {
@@ -252,7 +254,7 @@ export type ErrorType =
   | 'LABWARE_DOES_NOT_EXIST'
   | 'PIPETTE_DOES_NOT_EXIST'
   | 'NO_TIP_ON_PIPETTE'
-  | 'PIPETTE_VOLUME_EXCEEDED'
+  | 'TIP_VOLUME_EXCEEDED'
 
 export type CommandCreatorError = {|
   message: string,

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -254,6 +254,7 @@ export type ErrorType =
   | 'LABWARE_DOES_NOT_EXIST'
   | 'PIPETTE_DOES_NOT_EXIST'
   | 'NO_TIP_ON_PIPETTE'
+  | 'PIPETTE_VOLUME_EXCEEDED'
   | 'TIP_VOLUME_EXCEEDED'
 
 export type CommandCreatorError = {|

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -109,12 +109,13 @@ export function getLocationTotalVolume (loc: LocationLiquidState): number {
 export function splitLiquid (volume: number, sourceLiquidState: LocationLiquidState): SourceAndDest {
   const totalSourceVolume = getLocationTotalVolume(sourceLiquidState)
 
-  if (AIR in sourceLiquidState) {
-    console.warn('Splitting liquid with air present', sourceLiquidState)
-  }
+  // TODO IMMEDIATELY: re-enable console.warn's under feature flag???
+  // if (AIR in sourceLiquidState) {
+  //   console.warn('Splitting liquid with air present', sourceLiquidState)
+  // }
 
   if (totalSourceVolume === 0) {
-    console.warn('splitting with zero source volume')
+    // console.warn('splitting with zero source volume')
     // Splitting from empty source
     return {
       source: sourceLiquidState,
@@ -123,7 +124,7 @@ export function splitLiquid (volume: number, sourceLiquidState: LocationLiquidSt
   }
 
   if (volume > totalSourceVolume) {
-    console.warn('volume to split exceeds total source volume, adding air', sourceLiquidState, volume, totalSourceVolume)
+    // console.warn('volume to split exceeds total source volume, adding air', sourceLiquidState, volume, totalSourceVolume)
     // Take all of source, plus air
     return {
       source: mapValues(sourceLiquidState, () => ({volume: 0})),

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -118,7 +118,6 @@ export function splitLiquid (volume: number, sourceLiquidState: LocationLiquidSt
   }
 
   if (volume > totalSourceVolume) {
-    // console.warn('volume to split exceeds total source volume, adding air', sourceLiquidState, volume, totalSourceVolume)
     // Take all of source, plus air
     return {
       source: mapValues(sourceLiquidState, () => ({volume: 0})),

--- a/protocol-designer/src/step-generation/utils.js
+++ b/protocol-designer/src/step-generation/utils.js
@@ -109,13 +109,7 @@ export function getLocationTotalVolume (loc: LocationLiquidState): number {
 export function splitLiquid (volume: number, sourceLiquidState: LocationLiquidState): SourceAndDest {
   const totalSourceVolume = getLocationTotalVolume(sourceLiquidState)
 
-  // TODO IMMEDIATELY: re-enable console.warn's under feature flag???
-  // if (AIR in sourceLiquidState) {
-  //   console.warn('Splitting liquid with air present', sourceLiquidState)
-  // }
-
   if (totalSourceVolume === 0) {
-    // console.warn('splitting with zero source volume')
     // Splitting from empty source
     return {
       source: sourceLiquidState,

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -41,7 +41,7 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
         robotState,
         stepId
       )
-      console.log({substeps, timeline})
+
       return {
         ...acc,
         [stepId]: substeps,

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -41,6 +41,7 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
         robotState,
         stepId
       )
+      console.log({substeps, timeline})
       return {
         ...acc,
         [stepId]: substeps,


### PR DESCRIPTION
## overview

Closes #2160 

Decent amount of churn in the tests because RobotState changed so args to fn to make RobotState fixures needed tweak. Also everything was using 200uL tiprack b/c we didn't have the 300 when the tests were written

## changelog

* aspirate/consolidate/transfer/distribute use smallest of (tip max volume, pipette max volume)
* Added 200uL Tiprack to PD as an option

## review requests

- [ ] Probably the easiest way to test is by making a protocol with 2x P300s, one assigned to 200uL tips and the other to 300uL tips. In a transfer/distribute/~consolidate~ step, set the volume to 200 vs 201 and use the P300-200uL vs the P300-300uL. You should see that the pipette using 200uL will split up substeps to have a max of 200uL aspirates, and switching the step to use the 300uL pipette will make the substeps go up to 300uL on the big aspirates.

- [ ] Also play around with deleting tipracks, editing pipettes, deleting steps. Make sure there's no whitescreens.

Note that the bug with consolidate #1850 is still hanging around, out of scope of this PR.
