### PR TITLE
feat(protocol-designer): disconnect well selection from hover step state

### DIFF
--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
@@ -119,7 +119,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const labware = labwareId && allLabware && allLabware[labwareId]
   const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
 
-  const stepId = steplistSelectors.getActiveItem(state).id
+  const stepId = steplistSelectors.getSelectedStepId(state)
   // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
   const orderedSteps = steplistSelectors.orderedSteps(state)
   const timelineIdx = orderedSteps.findIndex(id => id === stepId)


### PR DESCRIPTION
Well selection modal well contents are now only correlated with the currently selected step (the one
being edited)

Closes #2558