### PR TITLE
refactor(protocol-designer): change StepType from number to string

### DIFF
--- a/protocol-designer/src/components/alerts/TimelineAlerts.js
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.js
@@ -8,6 +8,7 @@ import {
 import {selectors as steplistSelectors} from '../../steplist'
 import {selectors as fileDataSelectors} from '../../file-data'
 import type {BaseState} from '../../types'
+import type {StepIdType} from '../../form-types'
 import type {
   CommandCreatorError,
   CommandCreatorWarning,
@@ -18,7 +19,7 @@ import type {AlertLevel} from './types'
 type SP = {
   errors: Array<CommandCreatorError>,
   warnings: Array<CommandCreatorWarning>,
-  _stepId: ?number,
+  _stepId: ?StepIdType,
 }
 
 type MP = {

--- a/protocol-designer/src/dismiss/actions.js
+++ b/protocol-designer/src/dismiss/actions.js
@@ -1,12 +1,13 @@
 // @flow
 import type {CommandCreatorWarning} from '../step-generation'
 import type {FormWarning} from '../steplist'
+import type {StepType} from '../form-types'
 
 export type DismissAction<ActionType, WarningType> = {
   type: ActionType,
   payload: {
     warning: WarningType,
-    stepId: ?number,
+    stepId: ?StepType,
   },
 }
 

--- a/protocol-designer/src/dismiss/actions.js
+++ b/protocol-designer/src/dismiss/actions.js
@@ -1,13 +1,13 @@
 // @flow
 import type {CommandCreatorWarning} from '../step-generation'
 import type {FormWarning} from '../steplist'
-import type {StepType} from '../form-types'
+import type {StepIdType} from '../form-types'
 
 export type DismissAction<ActionType, WarningType> = {
   type: ActionType,
   payload: {
     warning: WarningType,
-    stepId: ?StepType,
+    stepId: ?StepIdType,
   },
 }
 

--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -12,8 +12,9 @@ import type {LoadFileAction} from '../load-file'
 import type {CommandCreatorWarning} from '../step-generation'
 import type {FormWarning} from '../steplist'
 import type {DeleteStepAction} from '../steplist/actions'
+import type {StepIdType} from '../form-types'
 
-export type DismissedWarningsAllSteps<WarningType> = {[stepId: number]: ?Array<WarningType>}
+export type DismissedWarningsAllSteps<WarningType> = {[stepId: StepIdType]: ?Array<WarningType>}
 export type DismissedWarningState = {
   form: DismissedWarningsAllSteps<FormWarning>,
   timeline: DismissedWarningsAllSteps<CommandCreatorWarning>,
@@ -62,7 +63,7 @@ const dismissedWarnings = handleActions({
   },
   DELETE_STEP: (state: DismissedWarningState, action: DeleteStepAction): DismissedWarningState => {
     // remove key for deleted step
-    const stepId = action.payload.toString(10)
+    const stepId = action.payload
     return {
       form: omit(state.form, stepId),
       timeline: omit(state.timeline, stepId),

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -57,13 +57,14 @@ export const getTimelineWarningsForSelectedStep: Selector<Array<CommandCreatorWa
   getTimelineWarningsPerStep,
   steplistSelectors.getSelectedStepId,
   (warningsPerStep, stepId) =>
-    (typeof stepId === 'number' && warningsPerStep[stepId]) || []
+    (stepId && warningsPerStep[stepId]) || []
 )
 
 export const getDismissedFormWarningsForSelectedStep: Selector<Array<FormWarning>> = createSelector(
   getDismissedFormWarnings,
   steplistSelectors.getSelectedStepId,
-  (dismissedWarnings, stepId) => (typeof stepId === 'number' && dismissedWarnings[stepId]) || []
+  (dismissedWarnings, stepId) =>
+    (stepId && dismissedWarnings[stepId]) || []
 )
 
 /** Non-dismissed form-level warnings for selected step */

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -13,6 +13,7 @@ import {selectors as steplistSelectors} from '../../steplist'
 import {selectors as pipetteSelectors} from '../../pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import type {Labware} from '../../labware-ingred/types'
+import type {StepIdType} from '../../form-types'
 
 const all96Tips = reduce(
   StepGeneration.tiprackWellNamesFlat,
@@ -210,7 +211,7 @@ export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector
   }, {})
 )
 
-export const getErrorStepId: Selector<?number> = createSelector(
+export const getErrorStepId: Selector<?StepIdType> = createSelector(
   steplistSelectors.orderedSteps,
   robotStateTimeline,
   (orderedSteps, timeline) => {

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -3,7 +3,7 @@ import type {IconName} from '@opentrons/components'
 import type {ChangeTipOptions} from './step-generation'
 import type {StepFieldName} from './steplist/fieldLevel'
 
-export type StepIdType = number // TODO Ian 2018-05-10 change to string
+export type StepIdType = string
 
 // TODO Ian 2018-01-16 factor out to some constants.js ?
 export const stepIconsByType: {[string]: IconName} = {

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -1,6 +1,6 @@
 // @flow
 import {selectors} from '../index'
-
+import {uuid} from '../../utils'
 import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
 import * as pipetteSelectors from '../../pipettes/selectors'
 import {actions as tutorialActions} from '../../tutorial'
@@ -69,7 +69,7 @@ export const selectStep = (stepId: StepIdType, newStepType?: StepType): ThunkAct
 export const addStep = (payload: {stepType: StepType}) =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
     const state = getState()
-    const stepId = selectors.nextStepId(state)
+    const stepId = uuid()
     const {stepType} = payload
     dispatch({
       type: 'ADD_STEP',

--- a/protocol-designer/src/steplist/actions/types.js
+++ b/protocol-designer/src/steplist/actions/types.js
@@ -11,7 +11,7 @@ export type ChangeFormPayload = {
 }
 
 export type ChangeSavedFormPayload = {
-  stepId?: number,
+  stepId?: string,
   update: {
     [accessor: string]: ?mixed, // string | boolean | Array<string> | null,
   },

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -25,6 +25,7 @@ import {
   mix,
 } from '../step-generation'
 
+import type {StepIdType} from '../form-types'
 import type {RobotState} from '../step-generation'
 
 import type {
@@ -46,7 +47,7 @@ function transferLikeSubsteps (args: {
   allPipetteData: AllPipetteData,
   getLabwareType: GetLabwareType,
   robotState: RobotState,
-  stepId: number,
+  stepId: StepIdType,
 }): ?SourceDestSubstepItem {
   const {
     stepArgs,
@@ -222,7 +223,7 @@ export function generateSubsteps (
   allPipetteData: AllPipetteData,
   getLabwareType: GetLabwareType,
   robotState: ?RobotState,
-  stepId: number // stepId is used only for substeps to reference parent step
+  stepId: string
 ): ?SubstepItemData {
   if (!robotState) {
     console.info(`No robot state, could not generate substeps for step ${stepId}.` +

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -222,8 +222,7 @@ const orderedSteps: Reducer<OrderedStepsState, *> = handleActions({
   ADD_STEP: (state: OrderedStepsState, action: AddStepAction) =>
     [...state, action.payload.id],
   DELETE_STEP: (state: OrderedStepsState, action: DeleteStepAction) =>
-    // TODO Ian 2018-05-10 standardize StepIdType to string, number is implicitly cast to string somewhere
-    state.filter(stepId => !(stepId === action.payload || `${stepId}` === action.payload)),
+    state.filter(stepId => stepId !== action.payload),
   LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
     getPDMetadata(action.payload).orderedSteps,
   REORDER_SELECTED_STEP: (state: OrderedStepsState, action: ReorderSelectedStepAction): OrderedStepsState => {
@@ -252,7 +251,7 @@ export type SelectableItem = {
 
 type SelectedItemState = ?SelectableItem
 
-function stepIdHelper (id: StepIdType): SelectedItemState {
+function stepIdHelper (id: ?StepIdType): SelectedItemState {
   if (id == null) return null
   return {
     isStep: true,
@@ -260,7 +259,7 @@ function stepIdHelper (id: StepIdType): SelectedItemState {
   }
 }
 
-function terminalItemIdHelper (id: TerminalItemId): SelectedItemState {
+function terminalItemIdHelper (id: ?TerminalItemId): SelectedItemState {
   if (id == null) return null
   return {
     isStep: false,

--- a/protocol-designer/src/steplist/selectors.js
+++ b/protocol-designer/src/steplist/selectors.js
@@ -3,7 +3,6 @@ import {createSelector} from 'reselect'
 import last from 'lodash/last'
 import reduce from 'lodash/reduce'
 import mapValues from 'lodash/mapValues'
-import max from 'lodash/max'
 import isEmpty from 'lodash/isEmpty'
 import each from 'lodash/each'
 import some from 'lodash/some'
@@ -254,7 +253,7 @@ const hoveredStepLabware: Selector<Array<string>> = createSelector(
   getHoveredStepId,
   (allStepArgsAndErrors, hoveredStep) => {
     const blank = []
-    if (typeof hoveredStep !== 'number' || !allStepArgsAndErrors[hoveredStep]) {
+    if (!hoveredStep || !allStepArgsAndErrors[hoveredStep]) {
       return blank
     }
 
@@ -294,16 +293,6 @@ const hoveredStepLabware: Selector<Array<string>> = createSelector(
 const stepCreationButtonExpandedSelector: Selector<boolean> = createSelector(
   rootSelector,
   (state: RootState) => state.stepCreationButtonExpanded
-)
-
-const nextStepId: Selector<number> = createSelector( // generates the next step ID to use
-  getSteps,
-  (steps): number => {
-    const allStepIds = Object.keys(steps).map(stepId => parseInt(stepId))
-    return allStepIds.length === 0
-      ? 0
-      : max(allStepIds) + 1
-  }
 )
 
 const formLevelWarnings: Selector<Array<FormWarning>> = createSelector(
@@ -414,7 +403,6 @@ export default {
   getHydratedUnsavedForm,
   formData, // TODO: remove after sunset
   formModalData,
-  nextStepId,
   getArgsAndErrorsByStepId,
   isNewStepForm,
   formLevelWarnings,

--- a/protocol-designer/src/steplist/test/reducers.test.js
+++ b/protocol-designer/src/steplist/test/reducers.test.js
@@ -14,12 +14,12 @@ describe('steps reducer', () => {
     const state = {}
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 123, stepType: 'transfer'},
+      payload: {id: '123', stepType: 'transfer'},
     }
 
     expect(steps(state, action)).toEqual({
       '123': {
-        id: 123,
+        id: '123',
         stepType: 'transfer',
         title: 'transfer', // title gets added
       },
@@ -29,24 +29,24 @@ describe('steps reducer', () => {
   test('second add step', () => {
     const state = {
       '333': {
-        id: 333,
+        id: '333',
         stepType: 'mix',
         title: 'mix',
       },
     }
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 123, stepType: 'transfer'},
+      payload: {id: '123', stepType: 'transfer'},
     }
 
     expect(steps(state, action)).toEqual({
       '333': {
-        id: 333,
+        id: '333',
         stepType: 'mix',
         title: 'mix',
       },
       '123': {
-        id: 123,
+        id: '123',
         stepType: 'transfer',
         title: 'transfer',
       },
@@ -59,7 +59,7 @@ describe('collapsedSteps reducer', () => {
     const state = {}
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 1, stepType: 'transfer'},
+      payload: {id: '1', stepType: 'transfer'},
     }
     expect(collapsedSteps(state, action)).toEqual({
       '1': false, // default is false: not collapsed
@@ -75,7 +75,7 @@ describe('collapsedSteps reducer', () => {
     }
     const action = {
       type: 'TOGGLE_STEP_COLLAPSED',
-      payload: 3,
+      payload: '3',
     }
     expect(collapsedSteps(state, action)).toEqual({
       '1': true,
@@ -94,7 +94,7 @@ describe('collapsedSteps reducer', () => {
     }
     const action = {
       type: 'TOGGLE_STEP_COLLAPSED',
-      payload: 2,
+      payload: '2',
     }
     expect(collapsedSteps(state, action)).toEqual({
       '1': true,
@@ -110,18 +110,18 @@ describe('orderedSteps reducer', () => {
     const state = []
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 123, stepType: 'transfer'},
+      payload: {id: '123', stepType: 'transfer'},
     }
-    expect(orderedSteps(state, action)).toEqual([123])
+    expect(orderedSteps(state, action)).toEqual(['123'])
   })
 
   test('second add step', () => {
-    const state = [123]
+    const state = ['123']
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 22, stepType: 'transfer'},
+      payload: {id: '22', stepType: 'transfer'},
     }
-    expect(orderedSteps(state, action)).toEqual([123, 22])
+    expect(orderedSteps(state, action)).toEqual(['123', '22'])
   })
 
   describe('reorder steps', () => {
@@ -209,7 +209,7 @@ describe('orderedSteps reducer', () => {
 
 describe('selectedItem reducer', () => {
   test('select step', () => {
-    const stepId = 123
+    const stepId = '123'
     const action = {
       type: 'SELECT_STEP',
       payload: stepId,
@@ -237,7 +237,7 @@ describe('stepCreationButtonExpanded reducer', () => {
   test('close (or stay closed) on newly added step', () => {
     const action = {
       type: 'ADD_STEP',
-      payload: {id: 123, stepType: 'transfer'},
+      payload: {id: '123', stepType: 'transfer'},
     }
     expect(stepCreationButtonExpanded(true, action)).toEqual(false)
     expect(stepCreationButtonExpanded(false, action)).toEqual(false)


### PR DESCRIPTION
## overview

Closes #2588

## changelog

* uses UUID for steps
* update step reducer tests to use string IDs not numbers

## review requests

- Try deleting, moving, creating, hovering steps -- shouldn't break!