### PR TITLE
fix(protocol-designer): close step form when edit pipettes

### DIFF
--- a/protocol-designer/src/pipettes/thunks.js
+++ b/protocol-designer/src/pipettes/thunks.js
@@ -37,6 +37,9 @@ export const editPipettes = (payload: EditPipettesFields) =>
       {}
     )
 
+    // NOTE: this clears out currently selected step form so that we're only updating savedForms
+    dispatch(steplistActions.cancelStepForm())
+
     each(nextPipettesByMount, (nextPipette, mount) => {
       const prevPipette = prevPipettesByMount[mount]
       if ((prevPipette && prevPipette.id) !== (nextPipette && nextPipette.id)) {


### PR DESCRIPTION
Because saved step forms may be changed by editing pipettes, close the active unsaved step form to
avoid adverse symptoms after pipette change.