### PR TITLE
build(app-shell): Add publisherName to electron-builder config

### DIFF
--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -25,7 +25,8 @@
     "category": "public.app-category.productivity"
   },
   "win": {
-    "target": ["nsis"]
+    "target": ["nsis"],
+    "publisherName": "Opentrons Labworks Inc."
   },
   "linux": {
     "target": ["AppImage"],


### PR DESCRIPTION
## overview

This PR is an attempted workaround to fix [flaky AppVeyor builds](https://ci.appveyor.com/project/Opentrons/opentrons/builds/20299796#L4379)

## changelog

- build(app-shell): Add publisherName to config

## review requests

🤷‍♂️ 
