### PR TITLE
refactor(protocol-designer): unite delete labware and handleFormChange logic

### DIFF
--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -11,7 +11,7 @@ import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {BaseState, GetState} from '../../types'
 import type {FormData} from '../../form-types'
-
+import type {StepFieldName} from '../fieldLevel'
 import type {ChangeFormPayload} from './types'
 
 function _getAllWells (
@@ -59,7 +59,7 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
   // pass thru, unchanged
   if (unsavedForm == null) { return payload }
 
-  let updateOverrides = reconcileFormLabware(payload.update)
+  let updateOverrides = getChangeLabwareEffects(payload.update)
 
   if (unsavedForm.pipette && payload.update.pipette) {
     if (typeof payload.update.pipette !== 'string') {
@@ -82,7 +82,7 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
   }
 }
 
-export const reconcileFormLabware = (updateFormData: ?mixed, nextChannels: ?number) => {
+export const getChangeLabwareEffects = (updateFormData: {[StepFieldName]: ?mixed}) => {
   let updateOverrides = {}
   // Changing labware clears wells selection: source labware
   if ('aspirate_labware' in updateFormData) {

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -54,42 +54,12 @@ const getChannels = (pipetteId: string, state: BaseState): PipetteChannels => {
 function handleFormChange (payload: ChangeFormPayload, getState: GetState): ChangeFormPayload {
   // Use state to handle form changes
   const baseState = getState()
-  const unsavedForm = selectors.formData(baseState)
-  let updateOverrides = {}
+  const unsavedForm = selectors.getUnsavedForm(baseState)
 
-  if (unsavedForm == null) {
-    // pass thru, unchanged
-    return payload
-  }
+  // pass thru, unchanged
+  if (unsavedForm == null) { return payload }
 
-  // Changing labware clears wells selection: source labware
-  if ('aspirate_labware' in payload.update) {
-    updateOverrides = {
-      ...updateOverrides,
-      'aspirate_wells': null,
-      'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
-    }
-  }
-
-  // Changing labware clears wells selection: dest labware
-  if ('dispense_labware' in payload.update) {
-    updateOverrides = {
-      ...updateOverrides,
-      'dispense_wells': null,
-      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
-    }
-  }
-
-  // Changing labware clears wells selection: labware (eg, mix)
-  if ('labware' in payload.update) {
-    updateOverrides = {
-      ...updateOverrides,
-      'wells': null,
-      // TODO: Ian 2018-09-03 should we have both asp/disp for Mix?
-      // if not, is dispense the right choice vs aspirate?
-      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
-    }
-  }
+  let updateOverrides = reconcileFormLabware(payload.update)
 
   if (unsavedForm.pipette && payload.update.pipette) {
     if (typeof payload.update.pipette !== 'string') {
@@ -110,6 +80,37 @@ function handleFormChange (payload: ChangeFormPayload, getState: GetState): Chan
       ...updateOverrides,
     },
   }
+}
+
+export const reconcileFormLabware = (updateFormData: ?mixed, nextChannels: ?number) => {
+  let updateOverrides = {}
+  // Changing labware clears wells selection: source labware
+  if ('aspirate_labware' in updateFormData) {
+    updateOverrides = {
+      ...updateOverrides,
+      'aspirate_wells': null,
+      'aspirate_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+    }
+  }
+  // Changing labware clears wells selection: dest labware
+  if ('dispense_labware' in updateFormData) {
+    updateOverrides = {
+      ...updateOverrides,
+      'dispense_wells': null,
+      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+    }
+  }
+  // Changing labware clears wells selection: labware (eg, mix)
+  if ('labware' in updateFormData) {
+    updateOverrides = {
+      ...updateOverrides,
+      'wells': null,
+      // TODO: Ian 2018-09-03 should we have both asp/disp for Mix?
+      // if not, is dispense the right choice vs aspirate?
+      'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+    }
+  }
+  return updateOverrides
 }
 
 export const reconcileFormPipette = (formData: FormData, baseState: BaseState, nextPipetteId: ?mixed, nextChannels: ?number) => {

--- a/protocol-designer/src/steplist/actions/types.js
+++ b/protocol-designer/src/steplist/actions/types.js
@@ -1,4 +1,5 @@
 // @flow
+import type {StepFieldName} from '../fieldLevel'
 
 // Update Form input (onChange on inputs)
 export type ChangeFormPayload = {
@@ -6,13 +7,13 @@ export type ChangeFormPayload = {
   // Accessor strings and values depend on StepType
   stepType?: string,
   update: {
-    [accessor: string]: ?mixed, // string | boolean | Array<string> | null,
+    [StepFieldName]: ?mixed, // string | boolean | Array<string> | null,
   },
 }
 
 export type ChangeSavedFormPayload = {
   stepId?: number,
   update: {
-    [accessor: string]: ?mixed, // string | boolean | Array<string> | null,
+    [StepFieldName]: ?mixed, // string | boolean | Array<string> | null,
   },
 }

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -4,7 +4,7 @@ import {handleActions} from 'redux-actions'
 import type {ActionType, Reducer} from 'redux-actions'
 import omit from 'lodash/omit'
 import mapValues from 'lodash/mapValues'
-import each from 'lodash/each'
+import reduce from 'lodash/reduce'
 
 import {getPDMetadata} from '../file-types'
 
@@ -133,13 +133,6 @@ type SavedStepFormState = {
   [StepIdType]: FormData,
 }
 
-const LABWARE_FIELD_NAMES = [
-  'aspirate_labware',
-  'dispense_blowout_labware',
-  'dispense_labware',
-  'labware',
-]
-
 const savedStepForms: Reducer<SavedStepFormState, *> = handleActions({
   SAVE_STEP_FORM: (state, action: SaveStepFormAction) => ({
     ...state,
@@ -155,17 +148,18 @@ const savedStepForms: Reducer<SavedStepFormState, *> = handleActions({
   },
   DELETE_CONTAINER: (state: SavedStepFormState, action: DeleteContainerAction): SavedStepFormState => (
     mapValues(state, savedForm => {
-      let deleteLabwareUpdate = {}
-      each(savedForm, (value, fieldName) => {
-        if (LABWARE_FIELD_NAMES.includes(fieldName) && value === action.payload.containerId) {
+      const deleteLabwareUpdate = reduce(savedForm, (acc, value, fieldName) => {
+        if (value === action.payload.containerId) {
           const formLabwareFieldUpdate = {[fieldName]: null}
-          deleteLabwareUpdate = {
-            ...deleteLabwareUpdate,
+          return {
+            ...acc,
             ...formLabwareFieldUpdate,
             ...getChangeLabwareEffects(formLabwareFieldUpdate),
           }
+        } else {
+          return acc
         }
-      })
+      }, {})
       return {
         ...savedForm,
         ...deleteLabwareUpdate,

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -4,6 +4,7 @@ import {handleActions} from 'redux-actions'
 import type {ActionType, Reducer} from 'redux-actions'
 import omit from 'lodash/omit'
 import mapValues from 'lodash/mapValues'
+import each from 'lodash/each'
 
 import {getPDMetadata} from '../file-types'
 
@@ -45,6 +46,7 @@ import {
   toggleStepCollapsed,
   type ChangeSavedStepFormAction,
 } from './actions'
+import {getChangeLabwareEffects} from './actions/handleFormChange'
 
 type FormState = FormData | null
 
@@ -151,39 +153,25 @@ const savedStepForms: Reducer<SavedStepFormState, *> = handleActions({
       ...stepForm,
     }))
   },
-  DELETE_CONTAINER: (state: SavedStepFormState, action: DeleteContainerAction): SavedStepFormState => {
-    const {payload} = action
-    return mapValues(state, savedForm => {
-      let dependentFields = []
-      const withoutDeletedLabware = mapValues(savedForm, (value, fieldName) => {
-        const isLabware = LABWARE_FIELD_NAMES.includes(fieldName)
-        if (isLabware && value === payload.containerId) {
-          switch (fieldName) {
-            case 'aspirate_labware': {
-              dependentFields = [...dependentFields, 'aspirate_wells']
-              break
-            }
-            case 'dispense_labware': {
-              dependentFields = [...dependentFields, 'dispense_wells']
-              break
-            }
-            case 'labware': {
-              dependentFields = [...dependentFields, 'wells']
-              break
-            }
+  DELETE_CONTAINER: (state: SavedStepFormState, action: DeleteContainerAction): SavedStepFormState => (
+    mapValues(state, savedForm => {
+      let deleteLabwareUpdate = {}
+      each(savedForm, (value, fieldName) => {
+        if (LABWARE_FIELD_NAMES.includes(fieldName) && value === action.payload.containerId) {
+          const formLabwareFieldUpdate = {[fieldName]: null}
+          deleteLabwareUpdate = {
+            ...deleteLabwareUpdate,
+            ...formLabwareFieldUpdate,
+            ...getChangeLabwareEffects(formLabwareFieldUpdate),
           }
-          return null
-        } else {
-          return value
         }
       })
-      const withoutDependentFields = mapValues(withoutDeletedLabware, (value, fieldName) => {
-        if (dependentFields.includes(fieldName)) return null
-        return value
-      })
-      return withoutDependentFields
+      return {
+        ...savedForm,
+        ...deleteLabwareUpdate,
+      }
     })
-  },
+  ),
   CHANGE_SAVED_STEP_FORM: (state: SavedStepFormState, action: ChangeSavedStepFormAction): SavedStepFormState => ({
     ...state,
     [action.payload.stepId]: {


### PR DESCRIPTION
There was some unecessary duplication of concerns between handling unsaved form changes and handling
deletion of labware in all saved forms. This addition creates a function that can be used by both
cases, to unite the logic into one source of truth.

Closes #2657