### PR TITLE
ci(travis): Move flow typechecking to separate job in test stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,8 @@ jobs:
       install:
         - make install-js
       script:
-        - make -j 2 test-js check-js lint-js lint-css
+        - make test-js
+        - make lint-js lint-css
         - make -C components
         - make -C protocol-designer
       after_success:
@@ -97,6 +98,15 @@ jobs:
           local-dir: components/dist
           bucket: opentrons-components
           upload-dir: $TRAVIS_BRANCH
+
+    # typecheck JavaScript projects
+    - stage: test
+      name: 'JS type checks'
+      language: node_js
+      install:
+        - make install-js
+      script:
+        - make check-js
 
     - # build the Opentrons App for POSIX (dev branch builds)
       <<: *app_stage_build


### PR DESCRIPTION
## overview

Follow-up to #2668: I implemented the JS test stage to run Jest and Flow in parallel as part of the same job, where 1 job === 1 VM (technically container, but whatever).

With that arrangement, it seems flow was hitting merge timeouts more often than not. Rather than increase the flow timeout again (see #2514), I moved `flow check` to its own job (VM).

- It seems to bring down our total run time, because turns out Python tests, JS tests, and Flow check all take about the same amount of time (~6 minutes)
- If flow craps out, we can just restart flow instead of the entire JS suite

Caveats:

- Flow is no longer a gating condition to pushing PD and CL to the `branch-name` folder in S3
- This increases our job usage, which counts against our total

## changelog

- ci(travis): Move flow typechecking to separate job in test stage

## review requests

Example build: <https://travis-ci.org/Opentrons/opentrons/builds/455517331>
