### PR TITLE
feat(protocol-designer): make settings tab always active

### DIFF
--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -7,13 +7,16 @@ import {KNOWLEDGEBASE_ROOT_URL} from '../components/KnowledgeBaseLink'
 import {NavTab, TabbedNavBar, OutsideLinkTab} from '@opentrons/components'
 import i18n from '../localization'
 import {type Page, actions, selectors} from '../navigation'
+import {selectors as fileSelectors} from '../file-data'
 
 type Props = {
   currentPage: Page,
+  currentProtocolExists: boolean,
   handleClick: Page => (e: ?SyntheticEvent<>) => void,
 }
 
 function Nav (props: Props) {
+  const noCurrentProtocol = !props.currentProtocolExists
   return (
     <TabbedNavBar
       topChildren={
@@ -26,13 +29,13 @@ function Nav (props: Props) {
           <NavTab
             iconName='water'
             title={i18n.t('nav.tab_name.liquids')}
-            disabled={props.currentPage === 'file-splash'}
+            disabled={noCurrentProtocol}
             selected={props.currentPage === 'liquids'}
             onClick={props.handleClick('liquids')} />
           <NavTab
             iconName='ot-design'
             title={i18n.t('nav.tab_name.design')}
-            disabled={props.currentPage === 'file-splash'}
+            disabled={noCurrentProtocol}
             selected={props.currentPage === 'steplist'}
             onClick={props.handleClick('steplist')} />
         </React.Fragment>
@@ -46,7 +49,6 @@ function Nav (props: Props) {
           <NavTab
             iconName='settings'
             title={i18n.t('nav.tab_name.settings')}
-            disabled={props.currentPage === 'file-splash'}
             selected={props.currentPage === 'settings-privacy'}
             onClick={props.handleClick('settings-privacy')} />
         </React.Fragment>
@@ -58,6 +60,7 @@ function Nav (props: Props) {
 function mapStateToProps (state: BaseState) {
   return {
     currentPage: selectors.currentPage(state),
+    currentProtocolExists: fileSelectors.getCurrentProtocolExists(state),
   }
 }
 

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -23,6 +23,12 @@ const updateMetadataFields = (
   return metadata
 }
 
+// track if a protocol has been created or loaded
+const currentProtocolExists = handleActions({
+  LOAD_FILE: () => true,
+  CREATE_NEW_PROTOCOL: () => true,
+}, false)
+
 function newProtocolMetadata (
   state: FileMetadataFields,
   action: {payload: NewProtocolFields}
@@ -61,11 +67,13 @@ const fileMetadata = handleActions({
 }, defaultFields)
 
 export type RootState = {
+  currentProtocolExists: boolean,
   unsavedMetadataForm: FileMetadataFields,
   fileMetadata: FileMetadataFields,
 }
 
 const _allReducers = {
+  currentProtocolExists,
   unsavedMetadataForm,
   fileMetadata,
 }

--- a/protocol-designer/src/file-data/selectors/fileFields.js
+++ b/protocol-designer/src/file-data/selectors/fileFields.js
@@ -6,6 +6,11 @@ import type {RootState} from '../reducers'
 
 export const rootSelector = (state: BaseState): RootState => state.fileData
 
+export const getCurrentProtocolExists = createSelector(
+  rootSelector,
+  (rootState) => rootState.currentProtocolExists
+)
+
 export const fileFormValues = createSelector(
   rootSelector,
   state => state.unsavedMetadataForm


### PR DESCRIPTION
## overview

Closes #2697 - settings tab is always active, but the "Liquids" and "Design" tabs are only activated when a protocol has been created or loaded.

## changelog

## review requests

Are there any bugs I missed where tabs don't work correctly?