### PR TITLE
refactor(protocol-designer): remove activeModals selector

### DIFF
--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -21,8 +21,6 @@ import {selectors as steplistSelectors, START_TERMINAL_ITEM_ID, type TerminalIte
 
 import type {BaseState, ThunkDispatch} from '../types'
 
-const ingredSelModIsVisible = activeModals => activeModals.ingredientSelection && activeModals.ingredientSelection.slot
-
 type StateProps = {
   selectedTerminalItemId: ?TerminalItemId,
   ingredSelectionMode: boolean,
@@ -42,8 +40,7 @@ type Props = {
 
 const mapStateToProps = (state: BaseState): StateProps => ({
   selectedTerminalItemId: steplistSelectors.getSelectedTerminalItemId(state),
-  // TODO SOON remove all uses of the `activeModals` selector
-  ingredSelectionMode: !!ingredSelModIsVisible(selectors.activeModals(state)),
+  ingredSelectionMode: Boolean(selectors.getSelectedContainer(state)),
   drilledDown: !!selectors.getDrillDownLabwareId(state),
   _moveLabwareMode: !!selectors.slotToMoveFrom(state),
 })

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -67,10 +67,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const showNameOverlay = container && !isTiprack && !labwareHasName
 
   const slotToMoveFrom = selectors.slotToMoveFrom(state)
-  const activeModals = selectors.activeModals(state)
 
   const slotHasLabware = !!containerType
-  const addLabwareMode = activeModals.labwareSelection
+  const addLabwareMode = selectors.getLabwareSelectionMode(state)
   const moveLabwareMode = Boolean(slotToMoveFrom)
 
   const setDefaultLabwareName = () => renameLabware({

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -457,29 +457,10 @@ const allIngredientNamesIds: BaseState => OrderedLiquids = createSelector(
     ({ingredientId: ingredId, name: ingreds[ingredId].name}))
 )
 
-// TODO: just use the individual selectors separately, no need to combine it into 'activeModals'
-// -- so you'd have to refactor the props of the containers that use this selector too
-type ActiveModals = {
-  labwareSelection: boolean,
-  ingredientSelection: ?{
-    slot: ?DeckSlot,
-    containerName: ?string,
-  },
-}
-
-const activeModals: Selector<ActiveModals> = createSelector(
+const getLabwareSelectionMode: Selector<boolean> = createSelector(
   rootSelector,
-  getLabware,
-  getSelectedContainerId,
-  (state, _allLabware, _selectedContainerId) => {
-    const selectedContainer = _selectedContainerId && _allLabware[_selectedContainerId]
-    return ({
-      labwareSelection: state.modeLabwareSelection !== false,
-      ingredientSelection: {
-        slot: selectedContainer ? selectedContainer.slot : null,
-        containerName: selectedContainer && selectedContainer.type,
-      },
-    })
+  (rootState) => {
+    return rootState.modeLabwareSelection !== false
   }
 )
 
@@ -513,6 +494,7 @@ export const selectors = {
   getLiquidNamesById,
   getLabware,
   getLabwareNames,
+  getLabwareSelectionMode,
   getLabwareTypes,
   getLiquidSelectionOptions,
   getLiquidGroupsOnDeck,
@@ -522,8 +504,6 @@ export const selectors = {
   getSelectedContainerId,
   getSelectedLiquidGroupState,
   getDrillDownLabwareId,
-
-  activeModals,
 
   slotToMoveFrom,
 


### PR DESCRIPTION
## overview

Closes #2592

## changelog

* remove `activeModals` selector

## review requests

Should be a quick one, kept the changes tiny since I think #2587 is going to go over this in a more holistic way?

If this breaks anything, it would be in
1. Adding new labware to the deck
2. Liquid placement flow ("Add Liquids" on the Design tab)