### PR TITLE
refactor(api): Use modules in protocol api

### DIFF
--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -10,7 +10,7 @@ from .types import Axis, HardwareAPILike
 
 
 def sync_call(loop, to_call, *args, **kwargs):
-    loop.run_until_complete(to_call(*args, **kwargs))
+    return loop.run_until_complete(to_call(*args, **kwargs))
 
 
 class SynchronousAdapter(HardwareAPILike):

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -192,7 +192,7 @@ class Controller:
     @property
     def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos) for ax, pos
+        return {ax: (0, pos+.05) for ax, pos
                 in self._smoothie_driver.homed_position.items()
                 if ax not in 'BC'}
 

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -12,6 +12,7 @@ class MissingDevicePortError(Exception):
 class SimulatingDriver:
     def __init__(self):
         self._port = None
+        self._height = 0
 
     def probe_plate(self):
         pass
@@ -20,7 +21,7 @@ class SimulatingDriver:
         pass
 
     def move(self, location):
-        pass
+        self._height = location
 
     def get_device_info(self):
         return {'serial': 'dummySerial',
@@ -35,6 +36,10 @@ class SimulatingDriver:
 
     def enter_programming_mode(self):
         pass
+
+    @property
+    def plate_height(self):
+        return self._height
 
 
 class MagDeck(mod_abc.AbstractModule):

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -42,7 +42,7 @@ class SimulatingDriver:
 
     @property
     def target(self):
-        return self._target_temp
+        return self._target_temp if self._active else None
 
     @property
     def status(self):

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -150,7 +150,7 @@ class Simulator:
     @property
     def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos) for ax, pos in _HOME_POSITION.items()
+        return {ax: (0, pos+0.5) for ax, pos in _HOME_POSITION.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -8,7 +8,10 @@ import logging
 import os
 
 from . import back_compat, labware
-from .contexts import ProtocolContext, InstrumentContext
+from .contexts import (ProtocolContext,
+                       InstrumentContext,
+                       TemperatureModuleContext,
+                       MagneticModuleContext)
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -48,5 +51,7 @@ def run(protocol_bytes: bytes = None,
 __all__ = ['run',
            'ProtocolContext',
            'InstrumentContext',
+           'TemperatureModuleContext',
+           'MagneticModuleContext',
            'back_compat',
            'labware']

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -4,7 +4,9 @@ from typing import Any, NamedTuple, TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from typing import (Optional,       # noqa(F401) Used for typechecking
                         Tuple)
-    from .labware import Labware, Well  # noqa(F401) Used for typechecking
+    from .labware import (Labware,      # noqa(F401) Used for typechecking
+                          Well,
+                          ModuleGeometry)
 
 
 class PipetteNotAttachedError(KeyError):
@@ -60,7 +62,7 @@ class Location(NamedTuple):
        of each item.
     """
     point: Point
-    labware: 'Union[Labware, Well, None]'
+    labware: 'Union[Labware, Well, str, ModuleGeometry, None]'
 
 
 class Mount(enum.Enum):

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -11,7 +11,7 @@ def test_sim_initialization():
 def test_sim_state():
     temp = modules.build('', 'tempdeck', True)
     assert temp.temperature == 0
-    assert temp.target == 0
+    assert temp.target is None
     assert temp.status == 'idle'
     assert temp.live_data['status'] == temp.status
     assert temp.live_data['data']['currentTemp'] == temp.temperature
@@ -31,7 +31,7 @@ async def test_sim_update():
     await asyncio.wait_for(temp.wait_for_temp(), timeout=0.2)
     temp.disengage()
     assert temp.temperature == 0
-    assert temp.target == 0
+    assert temp.target is None
     assert temp.status == 'idle'
 
 

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -1,5 +1,5 @@
 from opentrons.protocol_api import labware
-from opentrons.types import Point
+from opentrons.types import Point, Location
 
 minimalLabwareDef = {
     "metadata": {
@@ -121,8 +121,8 @@ minimalLabwareDef2 = {
 
 
 def test_labware_init():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     ordering = [well for col in minimalLabwareDef['ordering'] for well in col]
     assert fake_labware._ordering == ordering
     assert fake_labware._well_definition == minimalLabwareDef['wells']
@@ -130,16 +130,16 @@ def test_labware_init():
 
 
 def test_well_pattern():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     assert fake_labware._pattern.match('A1')
     assert fake_labware._pattern.match('A10')
     assert not fake_labware._pattern.match('A0')
 
 
 def test_wells_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
     depth2 = minimalLabwareDef['wells']['A2']['depth']
     x = minimalLabwareDef['wells']['A2']['x']
@@ -152,8 +152,8 @@ def test_wells_accessor():
 
 
 def test_wells_index_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
     depth2 = minimalLabwareDef['wells']['A2']['depth']
     x = minimalLabwareDef['wells']['A2']['x']
@@ -166,8 +166,8 @@ def test_wells_index_accessor():
 
 
 def test_rows_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef2, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef2, deck)
     depth1 = minimalLabwareDef2['wells']['A1']['depth']
     x1 = minimalLabwareDef2['wells']['A1']['x']
     y1 = minimalLabwareDef2['wells']['A1']['y']
@@ -182,8 +182,8 @@ def test_rows_accessor():
 
 
 def test_row_index_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef2, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef2, deck)
     depth1 = minimalLabwareDef2['wells']['A1']['depth']
     x1 = minimalLabwareDef2['wells']['A1']['x']
     y1 = minimalLabwareDef2['wells']['A1']['y']
@@ -198,8 +198,8 @@ def test_row_index_accessor():
 
 
 def test_cols_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
     depth2 = minimalLabwareDef['wells']['A2']['depth']
     x = minimalLabwareDef['wells']['A2']['x']
@@ -212,8 +212,8 @@ def test_cols_accessor():
 
 
 def test_col_index_accessor():
-    deck = Point(0, 0, 0)
-    fake_labware = labware.Labware(minimalLabwareDef, deck, 'deck')
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
     depth2 = minimalLabwareDef['wells']['A2']['depth']
     x = minimalLabwareDef['wells']['A2']['x']

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -247,3 +247,95 @@ def test_dispense(loop, load_my_labware, monkeypatch):
     move_called_with = None
     instr.dispense(2.0)
     assert move_called_with is None
+
+
+def test_load_module(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hardware._backend._attached_modules = [('mod0', 'tempdeck')]
+    ctx.home()
+    mod = ctx.load_module('tempdeck', 1)
+    assert isinstance(mod, papi.TemperatureModuleContext)
+
+
+def test_tempdeck(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hardware._backend._attached_modules = [('mod0', 'tempdeck')]
+    mod = ctx.load_module('tempdeck', 1)
+    assert ctx.deck[1] == mod._geometry
+    assert mod.target is None
+    mod.set_temperature(20)
+    assert mod.target == 20
+    mod.wait_for_temp()
+    assert mod.temperature == 20
+    mod.deactivate()
+    assert mod.target is None
+    mod.set_temperature(0)
+    assert mod.target == 0
+
+
+def test_magdeck(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hardware._backend._attached_modules = [('mod0', 'magdeck')]
+    mod = ctx.load_module('magdeck', 1)
+    assert ctx.deck[1] == mod._geometry
+    assert mod.status == 'disengaged'
+    with pytest.raises(ValueError):
+        mod.engage()
+    mod.engage(2)
+    assert mod.status == 'engaged'
+    mod.disengage()
+    assert mod.status == 'disengaged'
+    mod.calibrate()
+
+
+def test_module_load_labware(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    labware_name = 'generic_96_wellPlate_380_uL'
+    labware_def = json.loads(
+        pkgutil.get_data('opentrons',
+                         'shared_data/definitions2/{}.json'.format(
+                             labware_name)))
+    ctx._hardware._backend._attached_modules = [('mod0', 'tempdeck')]
+    mod = ctx.load_module('tempdeck', 1)
+    assert mod.labware is None
+    lw = mod.load_labware_by_name(labware_name)
+    lw_offset = Point(labware_def['cornerOffsetFromSlot']['x'],
+                      labware_def['cornerOffsetFromSlot']['y'],
+                      labware_def['cornerOffsetFromSlot']['z'])
+    assert lw._offset == lw_offset + mod._geometry.location.point
+    assert lw.name == labware_name
+    mod2 = ctx.load_module('tempdeck', 2)
+    lw2 = mod2.load_labware_by_name(labware_name)
+    assert lw2._offset == lw_offset + mod2._geometry.location.point
+    assert lw2.name == labware_name
+
+
+def test_magdeck_labware_props(loop):
+    ctx = papi.ProtocolContext(loop)
+    labware_name = 'biorad_96_wellPlate_pcr_200_uL'
+    labware_def = json.loads(
+        pkgutil.get_data('opentrons',
+                         'shared_data/definitions2/{}.json'.format(
+                             labware_name)))
+    ctx._hardware._backend._attached_modules = [('mod0', 'magdeck')]
+    mod = ctx.load_module('magdeck', 1)
+    assert mod.labware is None
+    mod.load_labware_by_name(labware_name)
+    mod.engage()
+    lw_offset = labware_def['parameters']['magneticModuleEngageHeight']
+    assert mod._module._driver.plate_height == lw_offset
+    mod.disengage()
+    mod.engage(offset=2)
+    assert mod._module._driver.plate_height == lw_offset + 2
+    mod.disengage()
+    mod.engage(height=3)
+    assert mod._module._driver.plate_height == 3
+    mod._geometry.reset_labware()
+    labware_name = 'generic_96_wellPlate_380_uL'
+    mod.load_labware_by_name(labware_name)
+    with pytest.raises(ValueError):
+        mod.engage()
+    with pytest.raises(ValueError):
+        mod.engage(offset=1)
+    mod.engage(height=2)
+    assert mod._module._driver.plate_height == 2

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -4,7 +4,7 @@ import os
 import json
 import time
 from opentrons.protocol_api import labware
-from opentrons.types import Point
+from opentrons.types import Point, Location
 import pytest
 
 minimalLabwareDef = {
@@ -80,7 +80,8 @@ def test_save_calibration(monkeypatch, clear_calibration):
         labware.Labware,
         'set_calibration', mock_set_calibration)
 
-    test_labware = labware.Labware(minimalLabwareDef, Point(0, 0, 0), 'deck')
+    test_labware = labware.Labware(minimalLabwareDef,
+                                   Location(Point(0, 0, 0), 'deck'))
 
     labware.save_calibration(test_labware, Point(1, 1, 1))
     assert os.path.exists(path)
@@ -90,7 +91,8 @@ def test_save_calibration(monkeypatch, clear_calibration):
 def test_save_tip_length(monkeypatch, clear_calibration):
     assert not os.path.exists(path)
 
-    test_labware = labware.Labware(minimalLabwareDef, Point(0, 0, 0), 'deck')
+    test_labware = labware.Labware(minimalLabwareDef,
+                                   Location(Point(0, 0, 0), 'deck'))
     calibrated_length = 22.0
     labware.save_tip_length(test_labware, calibrated_length)
     assert os.path.exists(path)
@@ -104,7 +106,8 @@ def test_schema_shape(monkeypatch, clear_calibration):
         return 1
     monkeypatch.setattr(time, 'time', fake_time)
 
-    test_labware = labware.Labware(minimalLabwareDef, Point(0, 0, 0), 'deck')
+    test_labware = labware.Labware(minimalLabwareDef,
+                                   Location(Point(0, 0, 0), 'deck'))
 
     labware.save_calibration(test_labware, Point(1, 1, 1))
     expected = {"default": {"offset": [1, 1, 1], "lastModified": 1}}
@@ -125,7 +128,8 @@ def test_load_calibration(monkeypatch, clear_calibration):
         labware.Labware,
         'set_calibration', mock_set_calibration)
 
-    test_labware = labware.Labware(minimalLabwareDef, Point(0, 0, 0), 'deck')
+    test_labware = labware.Labware(minimalLabwareDef,
+                                   Location(Point(0, 0, 0), 'deck'))
 
     test_offset = Point(1, 1, 1)
     test_tip_length = 34.5
@@ -144,7 +148,8 @@ def test_load_calibration(monkeypatch, clear_calibration):
 
 
 def test_wells_rebuilt_with_offset():
-    test_labware = labware.Labware(minimalLabwareDef, Point(0, 0, 0), 'deck')
+    test_labware = labware.Labware(minimalLabwareDef,
+                                   Location(Point(0, 0, 0), 'deck'))
     old_wells = test_labware._wells
     assert test_labware._offset == Point(10, 10, 5)
     assert test_labware._calibrated_offset == Point(10, 10, 5)

--- a/shared-data/definitions2/Opentrons_24_tuberack_1.5_mL_Eppendorf.json
+++ b/shared-data/definitions2/Opentrons_24_tuberack_1.5_mL_Eppendorf.json
@@ -57,7 +57,8 @@
     "parameters": {
         "format": "irregular",
         "isTiprack": false,
-        "loadName": "Opentrons_24_tuberack_1.5_mL_Eppendorf"
+        "loadName": "Opentrons_24_tuberack_1.5_mL_Eppendorf",
+        "isMagneticModuleCompatible": false
     },
     "wells": {
         "D1": {

--- a/shared-data/definitions2/Opentrons_6x15_mL_4x50_mL_tuberack.json
+++ b/shared-data/definitions2/Opentrons_6x15_mL_4x50_mL_tuberack.json
@@ -48,7 +48,8 @@
     "parameters": {
         "isTiprack": false,
         "format": "irregular",
-        "loadName": "Opentrons_6x15_mL_4x50_mL_tuberack"
+        "loadName": "Opentrons_6x15_mL_4x50_mL_tuberack",
+        "isMagneticModuleCompatible": false
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/Opentrons_96_tiprack_300_uL.json
+++ b/shared-data/definitions2/Opentrons_96_tiprack_300_uL.json
@@ -149,7 +149,8 @@
         "format": "96Standard",
         "isTiprack": true,
         "tipLength": 59.17,
-        "loadName": "Opentrons_96_tiprack_300_uL"
+        "loadName": "Opentrons_96_tiprack_300_uL",
+        "isMagneticModuleCompatible": false
     },
     "wells": {
         "H1": {

--- a/shared-data/definitions2/biorad_96_wellPlate_pcr_200_uL.json
+++ b/shared-data/definitions2/biorad_96_wellPlate_pcr_200_uL.json
@@ -1,0 +1,1039 @@
+{
+  "ordering": [
+    [
+      "A1",
+      "B1",
+      "C1",
+      "D1",
+      "E1",
+      "F1",
+      "G1",
+      "H1"
+    ],
+    [
+      "A2",
+      "B2",
+      "C2",
+      "D2",
+      "E2",
+      "F2",
+      "G2",
+      "H2"
+    ],
+    [
+      "A3",
+      "B3",
+      "C3",
+      "D3",
+      "E3",
+      "F3",
+      "G3",
+      "H3"
+    ],
+    [
+      "A4",
+      "B4",
+      "C4",
+      "D4",
+      "E4",
+      "F4",
+      "G4",
+      "H4"
+    ],
+    [
+      "A5",
+      "B5",
+      "C5",
+      "D5",
+      "E5",
+      "F5",
+      "G5",
+      "H5"
+    ],
+    [
+      "A6",
+      "B6",
+      "C6",
+      "D6",
+      "E6",
+      "F6",
+      "G6",
+      "H6"
+    ],
+    [
+      "A7",
+      "B7",
+      "C7",
+      "D7",
+      "E7",
+      "F7",
+      "G7",
+      "H7"
+    ],
+    [
+      "A8",
+      "B8",
+      "C8",
+      "D8",
+      "E8",
+      "F8",
+      "G8",
+      "H8"
+    ],
+    [
+      "A9",
+      "B9",
+      "C9",
+      "D9",
+      "E9",
+      "F9",
+      "G9",
+      "H9"
+    ],
+    [
+      "A10",
+      "B10",
+      "C10",
+      "D10",
+      "E10",
+      "F10",
+      "G10",
+      "H10"
+    ],
+    [
+      "A11",
+      "B11",
+      "C11",
+      "D11",
+      "E11",
+      "F11",
+      "G11",
+      "H11"
+    ],
+    [
+      "A12",
+      "B12",
+      "C12",
+      "D12",
+      "E12",
+      "F12",
+      "G12",
+      "H12"
+    ]
+  ],
+  "otId": "a07a3f50-ec38-11e8-a3cc-d7bd32b6c4b1",
+  "deprecated": false,
+  "metadata": {
+    "displayName": "Bio-Rad HardShell 96-Well PCR Plate",
+    "displayCategory": "wellPlate",
+    "displayVolumeUnits": "uL",
+    "displayLengthUnits": "mm",
+    "tags": [
+      "flat",
+      "plate",
+      "pcr",
+      "magdeck",
+      "biorad",
+      "low_profile",
+      "hardshell",
+      "thin_wall",
+      "96_well"
+    ]
+  },
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "dimensions": {
+    "overallWidth": 85.48,
+    "overallLength": 127.76,
+    "overallHeight": 16.06
+  },
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": false,
+    "loadName": "biorad_96_wellPlate_pcr_200_uL",
+    "isMagneticModuleCompatible": true,
+    "magneticModuleEngageHeight": 18
+  },
+  "wells": {
+    "H1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A1": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A2": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A3": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A4": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A5": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A6": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A7": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A8": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A9": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A10": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A11": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 74.24,
+      "z": 1.25
+    },
+    "H12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 11.24,
+      "z": 1.25
+    },
+    "G12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 20.24,
+      "z": 1.25
+    },
+    "F12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 29.24,
+      "z": 1.25
+    },
+    "E12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 38.24,
+      "z": 1.25
+    },
+    "D12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 47.24,
+      "z": 1.25
+    },
+    "C12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 56.24,
+      "z": 1.25
+    },
+    "B12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 65.24,
+      "z": 1.25
+    },
+    "A12": {
+      "depth": 14.81,
+      "shape": "circular",
+      "diameter": 5.46,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 74.24,
+      "z": 1.25
+    }
+  },
+  "brand": {
+    "brand": "Bio-Rad",
+    "brandId": [
+      "hsp9601",
+      "hsp9601b",
+      "hsp9611",
+      "hsp9621",
+      "hsp9631",
+      "hsp9641",
+      "hsp9661",
+      "hsp9xxx"
+    ]
+  }
+}

--- a/shared-data/definitions2/generic_96_wellPlate_380_uL.json
+++ b/shared-data/definitions2/generic_96_wellPlate_380_uL.json
@@ -149,7 +149,8 @@
     "parameters": {
         "format": "96Standard",
         "isTiprack": false,
-        "loadName": "generic_96_wellPlate_380_uL"
+        "loadName": "generic_96_wellPlate_380_uL",
+        "isMagneticModuleCompatible": false
     },
     "wells": {
         "H1": {

--- a/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
+++ b/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
@@ -101,7 +101,8 @@
     "parameters": {
         "isTiprack": false,
         "format": "irregular",
-        "loadName": "generic_50x3_mL_5x10_mL_irregular"
+        "loadName": "generic_50x3_mL_5x10_mL_irregular",
+        "isMagneticModuleCompatible": false
     },
     "wells": {
         "A1": {

--- a/shared-data/js/__tests__/fixtures/labwareExample.json
+++ b/shared-data/js/__tests__/fixtures/labwareExample.json
@@ -14,7 +14,8 @@
   "parameters": {
     "loadName": "opentrons_2_wellPlate_100_uL",
     "format": "96Standard",
-    "isTiprack": false
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false
   },
   "cornerOffsetFromSlot": {
     "x": 0,

--- a/shared-data/js/__tests__/fixtures/labwareExample2.json
+++ b/shared-data/js/__tests__/fixtures/labwareExample2.json
@@ -10,7 +10,8 @@
   "parameters": {
     "format": "irregular",
     "isTiprack": false,
-    "loadName": "6_wellPlate_100_uL"
+    "loadName": "6_wellPlate_100_uL",
+    "isMagneticModuleCompatible": false
   },
   "cornerOffsetFromSlot": {
     "x": -77.76,

--- a/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
@@ -74,6 +74,7 @@ describe('test createIrregularLabware function', () => {
       parameters: {
         format: 'irregular',
         isTiprack: false,
+        isMagneticModuleCompatible: false,
       },
       dimensions: {
         overallLength: 127.76,

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -36,6 +36,8 @@ type Params = {
   isTiprack: boolean,
   tipLength?: number,
   loadName?: string,
+  isMagneticModuleCompatible: boolean,
+  magneticModuleEngageHeight?: number,
 }
 
 type Well = {

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -70,7 +70,7 @@
       "type": "object",
       "description": "Internal describers used to determine pipette movement to labware",
       "additionalProperties": false,
-      "required": ["format", "isTiprack", "loadName"],
+      "required": ["format", "isTiprack", "loadName", "isMagneticModuleCompatible"],
       "properties": {
         "format": {
           "description": "Property to determine compatibility with multichannel pipette",
@@ -88,6 +88,14 @@
         "loadName": {
           "description": "Generated unique name of container",
           "type": "string"
+        },
+        "isMagneticModuleCompatible": {
+          "description": "Flag marking whether a labware is compatible by default with the Magnetic Module",
+          "type": "boolean"
+        },
+        "magneticModuleEngageHeight": {
+          "description": "Distance to move magnetic module magnets to engage",
+          "$ref": "#/definitions/positiveNumber"
         }
       }
 
@@ -130,8 +138,8 @@
           "$ref": "#/definitions/positiveNumber"
         }
       }
-
     },
+
     "wells": {
       "type": "object",
       "description": "Unordered object of well objects with position and dimensional information",

--- a/shared-data/robot-data/moduleSpecs.json
+++ b/shared-data/robot-data/moduleSpecs.json
@@ -1,0 +1,38 @@
+{
+    "magdeck": {
+        "labwareOffset": {
+            "x": 0.125,
+            "y": -0.125,
+            "z": 82.25
+        },
+        "dimensions": {
+            "bareOverallHeight": 110.152,
+            "overLabwareHeight": 4.052
+        },
+        "calibrationPoints": {
+            "x": 124.875,
+            "y": 2.75
+        },
+        "displayName": "Magnetic Module",
+        "loadName": "magdeck",
+        "quirks": []
+    },
+    "tempdeck": {
+        "labwareOffset": {
+            "x": -0.15,
+            "y": -0.15,
+            "z": 80.09
+        },
+        "dimensions": {
+            "bareOverallHeight": 84,
+            "overLabwareHeight": 0
+        },
+        "calibrationPoint": {
+            "x": 12.0,
+            "y":8.75
+        },
+        "displayName": "Temperature Module",
+        "loadName": "tempdeck",
+        "quirks": []
+    }
+}


### PR DESCRIPTION
## Overview

There are now ModuleContexts in protocol_api/contexts.py that expose the module
API. The protocol API also has a new workflow for adding labware to modules:

- create a module with ProtocolContext.load_module()
- call module.load_labware[_by_name]() to load the labware

This avoids the shared=True functionality that was only used for modules but was
designed to be super generic.

Modules also now have their own specs file that defines their geometry,
including the offsets from the deck to their labware and their overall shape.

In addition, fix some minor bugs:
- axis maxima bumped by +0.05mm for all axes to avoid floating point precision
problems when positions are run through deck transform
- hardware_control SynchronousAdapter needs to actually return the results of
coroutines it executes
- Reset the protocol context location cache after homing

feature(api): Add magnetic module compatiblity to labware schema

Labware now has an extra couple of parameters. isMagneticModuleCompatible is a
bool indicating whether the labware can be easily used by a magdeck;
magneticModuleEngageHeight is the height to raise the magnets for that piece of
labware. If a labware that is not compatible is loaded onto a magdeck, you get a
warning and must explicitly specify the magnet height.

## Review Requests

```
kill server
build ctx
from opentrons import protocol_api, hardware_control, types
import asyncio
ctx = protocol_api.ProtocolContext()
l = asyncio.get_event_loop()
api = l.run_until_complete(hardware_control.API.build_hardware_controller(force=True))
ad = hardware_control.adapters.SynchronousAdapter(api)
ctx.connect(ad)
ctx.home()
td = ctx.load_module(’tempdeck’, 3)
md = ctx.load_module(’magdeck’, 6)
td.set_temperature(30)
td.wait_for_temp()
td.deactivate()
md.engage(height=10) # without a labware
md.disengage()
md.load_labware_by_name(’biorad_96_wellPlate_pcr_200_uL’)
md.engage()
md.disengage()
td.load_labware_by_name(’generic_96_wellPlate_380_uL’)
pip = ctx.load_instrument(’p300_single’, types.Mount.LEFT)
pip.move_to(td.labware.wells()[0].top())
pip.move_to(md.labware.wells()[0].top())
```

Closes #2244, #2273 
