### PR TITLE
refactor(protocol-designer): rename selectors to start with "get"

### DIFF
--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -24,7 +24,7 @@ export default connect(mapStateToProps, null, mergeProps)(FileSidebar)
 function mapStateToProps (state: BaseState): SP & MP {
   const protocolName = fileDataSelectors.getFileMetadata(state)['protocol-name'] || 'untitled'
   const fileData = fileDataSelectors.createFile(state)
-  const canDownload = selectors.currentPage(state) !== 'file-splash'
+  const canDownload = selectors.getCurrentPage(state) !== 'file-splash'
 
   return {
     downloadData: (canDownload)
@@ -34,8 +34,8 @@ function mapStateToProps (state: BaseState): SP & MP {
       }
       : null,
     // Ignore clicking 'CREATE NEW' button in these cases
-    _canCreateNew: !selectors.newProtocolModal(state),
-    _hasUnsavedChanges: loadFileSelectors.hasUnsavedChanges(state),
+    _canCreateNew: !selectors.getNewProtocolModal(state),
+    _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
   }
 }
 

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -17,7 +17,7 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const labwareData = labwareIngredSelectors.getSelectedContainer(state)
+  const labwareData = labwareIngredSelectors.getSelectedLabware(state)
   assert(labwareData, 'Expected labware data to exist in connected labware details card')
 
   const props = (labwareData)

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -18,7 +18,7 @@ type SP = {
 function mapStateToProps (state: BaseState): SP {
   return {
     slot: labwareIngredSelectors.selectedAddLabwareSlot(state) || null,
-    permittedTipracks: pipetteSelectors.permittedTipracks(state),
+    permittedTipracks: pipetteSelectors.getPermittedTipracks(state),
   }
 }
 

--- a/protocol-designer/src/components/LiquidPlacementForm/index.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/index.js
@@ -32,8 +32,8 @@ type SP = $Diff<Props, DP> & {
 function mapStateToProps (state: BaseState): SP {
   const selectedWells = Object.keys(wellSelectionSelectors.getSelectedWells(state))
 
-  const _labwareId = labwareIngredSelectors.getSelectedContainerId(state)
-  const liquidLocations = labwareIngredSelectors.getIngredientLocations(state)
+  const _labwareId = labwareIngredSelectors.getSelectedLabwareId(state)
+  const liquidLocations = labwareIngredSelectors.getLiquidsByLabwareId(state)
   const _selectionHasLiquids = Boolean(
     _labwareId &&
     liquidLocations[_labwareId] &&
@@ -45,7 +45,7 @@ function mapStateToProps (state: BaseState): SP {
     commonSelectedVolume: wellContentsSelectors.getSelectedWellsCommonVolume(state),
     liquidSelectionOptions: labwareIngredSelectors.getLiquidSelectionOptions(state),
     showForm: selectedWells.length > 0,
-    selectedWellsMaxVolume: wellContentsSelectors.selectedWellsMaxVolume(state),
+    selectedWellsMaxVolume: wellContentsSelectors.getSelectedWellsMaxVolume(state),
 
     _labwareId,
     _selectedWells: selectedWells,

--- a/protocol-designer/src/components/LiquidPlacementModal.js
+++ b/protocol-designer/src/components/LiquidPlacementModal.js
@@ -71,7 +71,7 @@ class LiquidPlacementModal extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: BaseState): SP => {
-  const containerId = selectors.getSelectedContainerId(state)
+  const containerId = selectors.getSelectedLabwareId(state)
   const selectedWells = wellSelectionSelectors.getSelectedWells(state)
   if (containerId === null) {
     console.error('LiquidPlacementModal: No labware is selected, and no labwareId was given to LiquidPlacementModal')
@@ -83,11 +83,11 @@ const mapStateToProps = (state: BaseState): SP => {
     }
   }
 
-  const labware = selectors.getLabware(state)[containerId]
+  const labware = selectors.getLabwareById(state)[containerId]
   let wellContents: ContentsByWell = {}
 
   // selection for deck setup: shows initial state of liquids
-  wellContents = wellContentsSelectors.wellContentsAllLabware(state)[containerId]
+  wellContents = wellContentsSelectors.getWellContentsAllLabware(state)[containerId]
 
   return {
     selectedWells,

--- a/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
@@ -29,7 +29,7 @@ const SettingsSidebar = (props: SP & DP) => (
 )
 
 const STP = (state: BaseState): SP => ({
-  currentPage: selectors.currentPage(state),
+  currentPage: selectors.getCurrentPage(state),
 })
 
 const DTP = (dispatch: ThunkDispatch<*>): DP => ({

--- a/protocol-designer/src/components/SettingsPage/index.js
+++ b/protocol-designer/src/components/SettingsPage/index.js
@@ -23,7 +23,7 @@ const SettingsPage = (props: SP) => {
 }
 
 const STP = (state: BaseState): SP => ({
-  currentPage: selectors.currentPage(state),
+  currentPage: selectors.getCurrentPage(state),
 })
 
 export default connect(STP)(SettingsPage)

--- a/protocol-designer/src/components/StepEditForm/ButtonRow.js
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow.js
@@ -29,7 +29,9 @@ const ButtonRow = (props: Props) => {
   )
 }
 
-const STP = (state: BaseState): SP => ({ canSave: selectors.currentFormCanBeSaved(state) })
+const STP = (state: BaseState): SP => ({
+  canSave: selectors.getCurrentFormCanBeSaved(state),
+})
 
 const DTP = (dispatch: ThunkDispatch<*>): DP => ({
   onCancel: () => dispatch(actions.cancelStepForm()),

--- a/protocol-designer/src/components/StepEditForm/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/FlowRateField/index.js
@@ -40,7 +40,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const formData = steplistSelectors.getUnsavedForm(state)
 
   const pipetteId = formData ? formData[pipetteFieldName] : null
-  const pipette = pipetteId && pipetteSelectors.pipettesById(state)[pipetteId]
+  const pipette = pipetteId && pipetteSelectors.getPipettesById(state)[pipetteId]
   const pipetteConfig = pipette && getPipetteNameSpecs(pipette.model)
   const pipetteDisplayName = pipetteConfig ? pipetteConfig.displayName : 'pipette'
 

--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -69,7 +69,7 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
     alerts: dismissSelectors.getFormWarningsForSelectedStep(state),
   })
 
-  const errors = steplistSelectors.formLevelErrors(state)
+  const errors = steplistSelectors.getFormLevelErrors(state)
   const filteredErrors = getVisibleAlerts({
     focusedField,
     dirtyFields,

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -46,7 +46,7 @@ const FormSection = (props: FormSectionProps) => {
 }
 
 const FormSectionSTP = (state: BaseState, ownProps: OP) => ({
-  collapsed: steplistSelectors.formSectionCollapse(state)[ownProps.sectionName],
+  collapsed: steplistSelectors.getFormSectionCollapsed(state)[ownProps.sectionName],
 })
 const FormSectionDTP = (dispatch: ThunkDispatch<*>, ownProps: OP) => ({
   onCollapseToggle: () => dispatch(collapseFormSection(ownProps.sectionName)),

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
@@ -99,7 +99,7 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
 
   let wellHeightMM = null
   if (formData && formData[labwareFieldName]) {
-    const labwareById = labwareIngredsSelectors.getLabware(state)
+    const labwareById = labwareIngredsSelectors.getLabwareById(state)
     const labware = labwareById[formData[labwareFieldName]]
     const labwareDef = labware && labware.type && getLabware(labware.type)
     if (labwareDef) {

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
@@ -115,13 +115,13 @@ class WellSelectionModal extends React.Component<Props, State> {
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {pipetteId, labwareId} = ownProps
 
-  const allLabware = selectors.getLabware(state)
+  const allLabware = selectors.getLabwareById(state)
   const labware = labwareId && allLabware && allLabware[labwareId]
-  const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
+  const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
 
   const stepId = steplistSelectors.getSelectedStepId(state)
   // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
-  const orderedSteps = steplistSelectors.orderedSteps(state)
+  const orderedSteps = steplistSelectors.getOrderedSteps(state)
   const timelineIdx = orderedSteps.findIndex(id => id === stepId)
   const allWellContentsForStep = allWellContentsForSteps[timelineIdx]
   const formData = steplistSelectors.getUnsavedForm(state)
@@ -129,7 +129,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
   return {
     initialSelectedWells: formData ? formData[ownProps.name] : [],
-    pipette: pipetteId ? pipetteSelectors.equippedPipettes(state)[pipetteId] : null,
+    pipette: pipetteId ? pipetteSelectors.getEquippedPipettes(state)[pipetteId] : null,
     wellContents: labware && allWellContentsForStep ? allWellContentsForStep[labware.id] : {},
     containerType: labware ? labware.type : 'missing labware',
     ingredNames,

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/index.js
@@ -34,7 +34,7 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
   const formData = steplistSelectors.getUnsavedForm(state)
   const pipetteId = formData && formData[ownProps.pipetteFieldName]
   const selectedWells = formData ? formData[ownProps.name] : []
-  const pipetteData = pipetteId && pipetteSelectors.pipettesById(state)[pipetteId]
+  const pipetteData = pipetteId && pipetteSelectors.getPipettesById(state)[pipetteId]
   const isMulti = pipetteData && (pipetteData.channels > 1)
 
   return {

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -121,7 +121,7 @@ type PipetteFieldSP = {pipetteOptions: Options, getHydratedPipette: (string) => 
 type PipetteFieldDP = {updateDisposalVolume: (?mixed) => void}
 type PipetteFieldProps = PipetteFieldOP & PipetteFieldSP & PipetteFieldDP
 const PipetteFieldSTP = (state: BaseState, ownProps: PipetteFieldOP): PipetteFieldSP => ({
-  pipetteOptions: pipetteSelectors.equippedPipetteOptions(state),
+  pipetteOptions: pipetteSelectors.getEquippedPipetteOptions(state),
   getHydratedPipette: (value) => hydrateField(state, ownProps.name, value),
 })
 const PipetteFieldDTP = (dispatch: ThunkDispatch<*>): PipetteFieldDP => ({

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -123,7 +123,7 @@ class StepEditForm extends React.Component<Props, StepEditFormState> {
 
 const mapStateToProps = (state: BaseState): SP => ({
   formData: selectors.formData(state),
-  isNewStep: selectors.isNewStepForm(state),
+  isNewStep: selectors.getIsNewStepForm(state),
 })
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -122,7 +122,7 @@ class StepEditForm extends React.Component<Props, StepEditFormState> {
 }
 
 const mapStateToProps = (state: BaseState): SP => ({
-  formData: selectors.formData(state),
+  formData: selectors.getUnsavedForm(state),
   isNewStep: selectors.getIsNewStepForm(state),
 })
 

--- a/protocol-designer/src/components/alerts/TimelineAlerts.js
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.js
@@ -39,7 +39,7 @@ type MP = {
   */
 
 function mapStateToProps (state: BaseState): SP {
-  const timeline = fileDataSelectors.robotStateTimeline(state)
+  const timeline = fileDataSelectors.getRobotStateTimeline(state)
   const errors = timeline.errors || []
   const warnings = dismissSelectors.getTimelineWarningsForSelectedStep(state)
   const _stepId = steplistSelectors.getSelectedStepId(state)

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.js
@@ -91,9 +91,9 @@ class BrowseLabwareModal extends React.Component<Props> {
 
 function mapStateToProps (state: BaseState): SP {
   const labwareId = selectors.getDrillDownLabwareId(state)
-  const allLabware = selectors.getLabware(state)
+  const allLabware = selectors.getLabwareById(state)
   const labware = labwareId && allLabware ? allLabware[labwareId] : null
-  const allWellContents = wellContentsSelectors.lastValidWellContents(state)
+  const allWellContents = wellContentsSelectors.getLastValidWellContents(state)
   const wellContents = labwareId && allWellContents ? allWellContents[labwareId] : {}
   const ingredNames = selectors.getLiquidNamesById(state)
   return {

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -203,7 +203,7 @@ class EditPipettesModal extends React.Component<Props, State> {
 }
 
 const mapSTP = (state: BaseState): SP => {
-  const pipetteData = pipetteSelectors.pipettesForEditPipettes(state)
+  const pipetteData = pipetteSelectors.getPipettesForEditPipettes(state)
   return {
     initialLeft: pipetteData.find(i => i.mount === 'left'),
     initialRight: pipetteData.find(i => i.mount === 'right'),

--- a/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
+++ b/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
@@ -29,7 +29,7 @@ function StartingDeckStateTerminalItem (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   // since default-trash counts as 1, labwareCount <= 1 means "user did not add labware"
-  const noLabware = Object.keys(labwareIngredsSelectors.getLabware(state)).length <= 1
+  const noLabware = Object.keys(labwareIngredsSelectors.getLabwareById(state)).length <= 1
   return {showHint: noLabware}
 }
 

--- a/protocol-designer/src/containers/Alerts.js
+++ b/protocol-designer/src/containers/Alerts.js
@@ -64,7 +64,7 @@ function Alerts (props: Props) {
 }
 
 function mapStateToProps (state: BaseState): SP {
-  const timeline = fileDataSelectors.robotStateTimeline(state)
+  const timeline = fileDataSelectors.getRobotStateTimeline(state)
   const errors = timeline.errors || []
   const warnings = dismissSelectors.getTimelineWarningsForSelectedStep(state)
   const _stepId = steplistSelectors.getSelectedStepId(state)

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -40,9 +40,9 @@ type Props = {
 
 const mapStateToProps = (state: BaseState): StateProps => ({
   selectedTerminalItemId: steplistSelectors.getSelectedTerminalItemId(state),
-  ingredSelectionMode: Boolean(selectors.getSelectedContainer(state)),
+  ingredSelectionMode: Boolean(selectors.getSelectedLabware(state)),
   drilledDown: !!selectors.getDrillDownLabwareId(state),
-  _moveLabwareMode: !!selectors.slotToMoveFrom(state),
+  _moveLabwareMode: !!selectors.getSlotToMoveFrom(state),
 })
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DispatchProps => ({

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -23,7 +23,7 @@ type DP = {
 }
 
 const mapStateToProps = (state: BaseState): SP => {
-  const pipetteData = pipetteSelectors.pipettesForInstrumentGroup(state)
+  const pipetteData = pipetteSelectors.getPipettesForInstrumentGroup(state)
   return {
     _values: fileSelectors.fileFormValues(state),
     isFormAltered: fileSelectors.isUnsavedMetadatFormAltered(state),

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -33,6 +33,6 @@ function MainPanel (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   return {
-    page: selectors.currentPage(state),
+    page: selectors.getCurrentPage(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
+++ b/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
@@ -14,7 +14,7 @@ import {
 import type {BaseState, ThunkDispatch} from '../types'
 
 function mapStateToProps (state: BaseState) {
-  const formModalData = selectors.formModalData(state)
+  const formModalData = selectors.getFormModalData(state)
   return {
     hideModal: formModalData === null,
     formData: formModalData,

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -59,7 +59,7 @@ function Nav (props: Props) {
 
 function mapStateToProps (state: BaseState) {
   return {
-    currentPage: selectors.currentPage(state),
+    currentPage: selectors.getCurrentPage(state),
     currentProtocolExists: fileSelectors.getCurrentProtocolExists(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -25,8 +25,8 @@ type DP = {
 
 function mapStateToProps (state: BaseState): SP {
   return {
-    hideModal: !selectors.newProtocolModal(state),
-    _hasUnsavedChanges: loadFileSelectors.hasUnsavedChanges(state),
+    hideModal: !selectors.getNewProtocolModal(state),
+    _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -35,8 +35,8 @@ function Sidebar (props: Props) {
 }
 
 function mapStateToProps (state: BaseState): Props {
-  const page = selectors.currentPage(state)
-  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedContainer(state)
+  const page = selectors.getCurrentPage(state)
+  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedLabware(state)
 
   return {
     page,

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -35,7 +35,7 @@ type DP = $Diff<$Diff<Props, SP>, OP>
 
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {stepId} = ownProps
-  const allSteps = steplistSelectors.allSteps(state)
+  const allSteps = steplistSelectors.getAllSteps(state)
 
   const hoveredSubstep = steplistSelectors.getHoveredSubstep(state)
   const hoveredStep = steplistSelectors.getHoveredStepId(state)
@@ -62,7 +62,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // user is not hovering on substep.
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
-    getLabware: (labwareId: ?string) => labwareId ? labwareIngredSelectors.getLabware(state)[labwareId] : null,
+    getLabware: (labwareId: ?string) => labwareId ? labwareIngredSelectors.getLabwareById(state)[labwareId] : null,
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -19,7 +19,7 @@ type DP = $Diff<Props, SP>
 
 function mapStateToProps (state: BaseState): SP {
   return {
-    orderedSteps: steplistSelectors.orderedSteps(state),
+    orderedSteps: steplistSelectors.getOrderedSteps(state),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -46,15 +46,15 @@ function TitleWithIcon (props: TitleWithIconProps) {
 }
 
 function mapStateToProps (state: BaseState): SP {
-  const _page = selectors.currentPage(state)
+  const _page = selectors.getCurrentPage(state)
   const fileName = fileDataSelectors.protocolName(state)
   const selectedStep = steplistSelectors.getSelectedStep(state)
   const selectedTerminalId = steplistSelectors.getSelectedTerminalItemId(state)
-  const labware = labwareIngredSelectors.getSelectedContainer(state)
+  const labware = labwareIngredSelectors.getSelectedLabware(state)
   const labwareNames = labwareIngredSelectors.getLabwareNames(state)
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
-  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedContainer(state)
+  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedLabware(state)
   const wellSelectionLabwareKey = steplistSelectors.getWellSelectionLabwareKey(state)
 
   switch (_page) {
@@ -90,7 +90,7 @@ function mapStateToProps (state: BaseState): SP {
         subtitle = END_TERMINAL_TITLE
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
-          const drilledDownLabware = labwareIngredSelectors.getLabware(state)[drilledDownLabwareId]
+          const drilledDownLabware = labwareIngredSelectors.getLabwareById(state)[drilledDownLabwareId]
           title = drilledDownLabware && drilledDownLabware.name
           subtitle = drilledDownLabware && humanizeLabwareType(drilledDownLabware.type)
         }

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -29,7 +29,7 @@ type OP = {
 type SP = $Diff<Props, OP>
 
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
-  const selectedContainerId = selectors.getSelectedContainerId(state)
+  const selectedContainerId = selectors.getSelectedLabwareId(state)
   const containerId = ownProps.containerId || selectedContainerId
 
   if (containerId === null) {
@@ -41,8 +41,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     }
   }
 
-  const labware = selectors.getLabware(state)[containerId]
-  const allWellContentsForSteps = wellContentsSelectors.allWellContentsForSteps(state)
+  const labware = selectors.getLabwareById(state)[containerId]
+  const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
   const wellSelectionModeForLabware = selectedContainerId === containerId
   let wellContents: ContentsByWell = {}
 
@@ -51,18 +51,18 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     !activeItem.isStep && activeItem.id === START_TERMINAL_ITEM_ID
   ) {
     // selection for deck setup: shows initial state of liquids
-    wellContents = wellContentsSelectors.wellContentsAllLabware(state)[containerId]
+    wellContents = wellContentsSelectors.getWellContentsAllLabware(state)[containerId]
   } else if (
     !activeItem.isStep && activeItem.id === END_TERMINAL_ITEM_ID
   ) {
     // "end" terminal
-    wellContents = wellContentsSelectors.lastValidWellContents(state)[containerId]
+    wellContents = wellContentsSelectors.getLastValidWellContents(state)[containerId]
   } else if (!activeItem.isStep) {
     console.warn(`HighlightableLabware got unhandled terminal id: "${activeItem.id}"`)
   } else {
     const stepId = activeItem.id
     // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
-    const orderedSteps = steplistSelectors.orderedSteps(state)
+    const orderedSteps = steplistSelectors.getOrderedSteps(state)
     const timelineIdx = orderedSteps.includes(stepId)
       ? orderedSteps.findIndex(id => id === stepId)
       : null
@@ -77,7 +77,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
         // Valid non-end step
         ? allWellContentsForSteps[timelineIdx][containerId]
         // Erroring step: show last valid well contents in timeline
-        : wellContentsSelectors.lastValidWellContents(state)[containerId]
+        : wellContentsSelectors.getLastValidWellContents(state)[containerId]
     }
 
     if (wellSelectionModeForLabware) {

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -18,12 +18,12 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const container = selectors.getSelectedContainer(state)
+  const container = selectors.getSelectedLabware(state)
   const _labwareId = container && container.id
 
   return {
     liquidGroupsById: selectors.getLiquidGroupsById(state),
-    labwareWellContents: (container && selectors.getIngredientLocations(state)[container.id]) || {},
+    labwareWellContents: (container && selectors.getLiquidsByLabwareId(state)[container.id]) || {},
     selectedIngredientGroupId: wellSelectionSelectors.getSelectedWellsCommonIngredId(state),
     selected: false,
     _labwareId,

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -58,7 +58,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const containerId = container && container.id
   const containerName = containerId && labwareNames[containerId]
 
-  const selectedContainer = selectors.getSelectedContainer(state)
+  const selectedContainer = selectors.getSelectedLabware(state)
   const isSelectedSlot = !!(selectedContainer && selectedContainer.slot === slot)
 
   const selectedTerminalItem = steplistSelectors.getSelectedTerminalItemId(state)
@@ -66,7 +66,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const isTiprack = getIsTiprack(containerType)
   const showNameOverlay = container && !isTiprack && !labwareHasName
 
-  const slotToMoveFrom = selectors.slotToMoveFrom(state)
+  const slotToMoveFrom = selectors.getSlotToMoveFrom(state)
 
   const slotHasLabware = !!containerType
   const addLabwareMode = selectors.getLabwareSelectionMode(state)
@@ -101,7 +101,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // or when targeted by an open "Add Labware" modal
       ? (isSelectedSlot || selectors.selectedAddLabwareSlot(state) === slot)
     // outside of deckSetupMode, labware is highlighted when step/substep is hovered
-      : steplistSelectors.hoveredStepLabware(state).includes(containerId),
+      : steplistSelectors.getHoveredStepLabware(state).includes(containerId),
     selectedTerminalItem,
 
     slot,

--- a/protocol-designer/src/containers/StepCreationButton.js
+++ b/protocol-designer/src/containers/StepCreationButton.js
@@ -18,7 +18,7 @@ type DispatchProps = $Diff<Props, StateProps>
 
 function mapStateToProps (state: BaseState): StateProps {
   return ({
-    expanded: selectors.stepCreationButtonExpanded(state),
+    expanded: selectors.getStepCreationButtonExpanded(state),
   })
 }
 

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -30,7 +30,7 @@ export const getDismissedTimelineWarnings: Selector<DismissedWarningsAllSteps<Co
 export const getTimelineWarningsPerStep: Selector<DismissedWarningsAllSteps<CommandCreatorWarning>> = createSelector(
   getDismissedTimelineWarnings,
   timelineWarningsPerStep,
-  steplistSelectors.orderedSteps,
+  steplistSelectors.getOrderedSteps,
   (dismissedWarnings, warningsPerStep, orderedSteps) => {
     return orderedSteps.reduce(
       (stepAcc: DismissedWarningsAllSteps<CommandCreatorWarning>, stepId) => {
@@ -69,7 +69,7 @@ export const getDismissedFormWarningsForSelectedStep: Selector<Array<FormWarning
 
 /** Non-dismissed form-level warnings for selected step */
 export const getFormWarningsForSelectedStep: Selector<Array<FormWarning>> = createSelector(
-  steplistSelectors.formLevelWarnings,
+  steplistSelectors.getFormLevelWarnings,
   getDismissedFormWarningsForSelectedStep,
   (warnings, dismissedWarnings) => {
     const dismissedTypesForStep = dismissedWarnings.map(dw => dw.type)

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -23,8 +23,8 @@ const all96Tips = reduce(
 
 // NOTE this just adds missing well keys to the labware-ingred 'deck setup' liquid state
 export const getLabwareLiquidState: Selector<StepGeneration.LabwareLiquidState> = createSelector(
-  labwareIngredSelectors.getIngredientLocations,
-  labwareIngredSelectors.getLabware,
+  labwareIngredSelectors.getLiquidsByLabwareId,
+  labwareIngredSelectors.getLabwareById,
   (ingredLocations, allLabware) => {
     const allLabwareIds: Array<string> = Object.keys(allLabware)
     return allLabwareIds.reduce((
@@ -59,8 +59,8 @@ function labwareConverter (labwareAppState: {[labwareId: string]: ?Labware}): {[
 }
 
 export const getInitialRobotState: BaseState => StepGeneration.RobotState = createSelector(
-  pipetteSelectors.equippedPipettes,
-  labwareIngredSelectors.getLabware,
+  pipetteSelectors.getEquippedPipettes,
+  labwareIngredSelectors.getLabwareById,
   getLabwareLiquidState,
   (pipettes, labwareAppState, labwareLiquidState) => {
     type TipState = $PropertyType<StepGeneration.RobotState, 'tipState'>
@@ -133,9 +133,9 @@ function compoundCommandCreatorFromStepArgs (stepArgs: StepGeneration.CommandCre
 }
 
 // exposes errors and last valid robotState
-export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelector(
+export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSelector(
   steplistSelectors.getArgsAndErrorsByStepId,
-  steplistSelectors.orderedSteps,
+  steplistSelectors.getOrderedSteps,
   getInitialRobotState,
   (allStepArgsAndErrors, orderedSteps, initialRobotState) => {
     const allStepArgs: Array<StepGeneration.CommandCreatorData | null> = orderedSteps.map(stepId => {
@@ -198,8 +198,8 @@ export const robotStateTimeline: Selector<StepGeneration.Timeline> = createSelec
 
 type WarningsPerStep = {[stepId: number | string]: ?Array<StepGeneration.CommandCreatorWarning>}
 export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector(
-  steplistSelectors.orderedSteps,
-  robotStateTimeline,
+  steplistSelectors.getOrderedSteps,
+  getRobotStateTimeline,
   (orderedSteps, timeline) => timeline.timeline.reduce((acc: WarningsPerStep, frame, timelineIndex) => {
     const stepId = orderedSteps[timelineIndex]
 
@@ -212,8 +212,8 @@ export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector
 )
 
 export const getErrorStepId: Selector<?StepIdType> = createSelector(
-  steplistSelectors.orderedSteps,
-  robotStateTimeline,
+  steplistSelectors.getOrderedSteps,
+  getRobotStateTimeline,
   (orderedSteps, timeline) => {
     const hasErrors = timeline.errors && timeline.errors.length > 0
     if (hasErrors) {
@@ -227,7 +227,7 @@ export const getErrorStepId: Selector<?StepIdType> = createSelector(
 )
 
 export const lastValidRobotState: Selector<StepGeneration.RobotState> = createSelector(
-  robotStateTimeline,
+  getRobotStateTimeline,
   getInitialRobotState,
   (timeline, initialRobotState) => {
     const lastTimelineFrame = last(timeline.timeline)

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -3,7 +3,7 @@ import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
 import {getPropertyAllPipettes} from '@opentrons/shared-data'
 import {getFileMetadata} from './fileFields'
-import {getInitialRobotState, robotStateTimeline} from './commands'
+import {getInitialRobotState, getRobotStateTimeline} from './commands'
 import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/reducers'
 import {selectors as steplistSelectors} from '../../steplist'
@@ -36,16 +36,16 @@ const executionDefaults = {
 export const createFile: BaseState => ProtocolFile = createSelector(
   getFileMetadata,
   getInitialRobotState,
-  robotStateTimeline,
+  getRobotStateTimeline,
   dismissSelectors.getAllDismissedWarnings,
   ingredSelectors.getLiquidGroupsById,
-  ingredSelectors.getIngredientLocations,
+  ingredSelectors.getLiquidsByLabwareId,
   steplistSelectors.getSavedForms,
-  steplistSelectors.orderedSteps,
+  steplistSelectors.getOrderedSteps,
   (
     fileMetadata,
     initialRobotState,
-    _robotStateTimeline,
+    robotStateTimeline,
     dismissedWarnings,
     ingredients,
     ingredLocations,
@@ -124,7 +124,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
       pipettes: instruments,
       labware,
 
-      procedure: _robotStateTimeline.timeline.map((timelineItem, i) => ({
+      procedure: robotStateTimeline.timeline.map((timelineItem, i) => ({
         annotation: {
           name: `TODO Name ${i}`,
           description: 'todo description',

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -101,7 +101,7 @@ export type MoveLabware = {
 
 export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
   const state = getState()
-  const fromSlot = selectors.slotToMoveFrom(state)
+  const fromSlot = selectors.getSlotToMoveFrom(state)
   if (fromSlot) {
     return dispatch({
       type: 'MOVE_LABWARE',

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -298,33 +298,33 @@ type Selector<T> = (RootSlice) => T
 // SELECTORS
 const rootSelector = (state: RootSlice): RootState => state.labwareIngred
 
-const getLabware: Selector<{[labwareId: string]: ?Labware}> = createSelector(
+const getLabwareById: Selector<{[labwareId: string]: ?Labware}> = createSelector(
   rootSelector,
   rootState => rootState.containers
 )
 
 const getLabwareNames: Selector<{[labwareId: string]: string}> = createSelector(
-  getLabware,
-  (_labware) => mapValues(
-    _labware,
+  getLabwareById,
+  (labwareById) => mapValues(
+    labwareById,
     labwareToDisplayName,
   )
 )
 
 const getLabwareTypes: Selector<LabwareTypeById> = createSelector(
-  getLabware,
-  (_labware) => mapValues(
-    _labware,
-    (l: Labware) => l.type
+  getLabwareById,
+  (labwareById) => mapValues(
+    labwareById,
+    (labware: Labware) => labware.type
   )
 )
 
 const getLiquidGroupsById = (state: RootSlice) => rootSelector(state).ingredients
-const getIngredientLocations = (state: RootSlice) => rootSelector(state).ingredLocations
+const getLiquidsByLabwareId = (state: RootSlice) => rootSelector(state).ingredLocations
 
 const getNextLiquidGroupId: Selector<string> = createSelector(
   getLiquidGroupsById,
-  (_ingredGroups) => ((max(Object.keys(_ingredGroups).map(id => parseInt(id))) + 1) || 0).toString()
+  (ingredGroups) => ((max(Object.keys(ingredGroups).map(id => parseInt(id))) + 1) || 0).toString()
 )
 
 const getLiquidNamesById: Selector<{[ingredId: string]: string}> = createSelector(
@@ -352,15 +352,15 @@ const _loadedContainersBySlot = (containers: ContainersState) =>
     , {})
 
 const loadedContainersBySlot = createSelector(
-  getLabware,
+  getLabwareById,
   containers => _loadedContainersBySlot(containers)
 )
 
 /** Returns options for dropdowns, excluding tiprack labware */
 const labwareOptions: Selector<Options> = createSelector(
-  getLabware,
+  getLabwareById,
   getLabwareNames,
-  (_labware, names) => reduce(_labware, (acc: Options, labware: Labware, labwareId): Options => {
+  (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
     const isTiprack = getIsTiprack(labware.type)
     if (!labware.type || isTiprack) {
       return acc
@@ -378,9 +378,9 @@ const labwareOptions: Selector<Options> = createSelector(
 const DISPOSAL_LABWARE_TYPES = ['trash-box', 'fixed-trash']
 /** Returns options for disposal (e.g. fixed trash and trash box) */
 const disposalLabwareOptions: Selector<Options> = createSelector(
-  getLabware,
+  getLabwareById,
   getLabwareNames,
-  (_labware, names) => reduce(_labware, (acc: Options, labware: Labware, labwareId): Options => {
+  (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
     if (!labware.type || !DISPOSAL_LABWARE_TYPES.includes(labware.type)) {
       return acc
     }
@@ -399,7 +399,7 @@ const selectedAddLabwareSlot = (state: BaseState) => rootSelector(state).modeLab
 
 const getSavedLabware = (state: BaseState) => rootSelector(state).savedLabware
 
-const getSelectedContainerId: Selector<SelectedContainerId> = createSelector(
+const getSelectedLabwareId: Selector<SelectedContainerId> = createSelector(
   rootSelector,
   rootState => rootState.selectedContainerId
 )
@@ -409,10 +409,11 @@ const getSelectedLiquidGroupState: Selector<SelectedLiquidGroupState> = createSe
   rootState => rootState.selectedLiquidGroup
 )
 
-const getSelectedContainer: Selector<?Labware> = createSelector(
-  getSelectedContainerId,
-  getLabware,
-  (_selectedId, _labware) => (_selectedId && _labware[_selectedId]) || null
+const getSelectedLabware: Selector<?Labware> = createSelector(
+  getSelectedLabwareId,
+  getLabwareById,
+  (selectedLabwareId, labware) =>
+    (selectedLabwareId && labware[selectedLabwareId]) || null
 )
 
 const getDrillDownLabwareId: Selector<DrillDownLabwareId> = createSelector(
@@ -423,7 +424,7 @@ const getDrillDownLabwareId: Selector<DrillDownLabwareId> = createSelector(
 type ContainersBySlot = { [DeckSlot]: {...Labware, containerId: string} }
 
 const containersBySlot: Selector<ContainersBySlot> = createSelector(
-  getLabware,
+  getLabwareById,
   containers => reduce(
     containers,
     (acc: ContainersBySlot, containerObj: Labware, containerId: string) => ({
@@ -464,12 +465,12 @@ const getLabwareSelectionMode: Selector<boolean> = createSelector(
   }
 )
 
-const slotToMoveFrom = (state: BaseState) => rootSelector(state).moveLabwareMode
+const getSlotToMoveFrom = (state: BaseState) => rootSelector(state).moveLabwareMode
 
-const hasLiquid = (state: BaseState) => !isEmpty(getLiquidGroupsById(state))
+const getDeckHasLiquid = (state: BaseState) => !isEmpty(getLiquidGroupsById(state))
 
 const getLiquidGroupsOnDeck: Selector<Array<string>> = createSelector(
-  getIngredientLocations,
+  getLiquidsByLabwareId,
   (ingredLocationsByLabware) => {
     let liquidGroups: Set<string> = new Set()
     forEach(ingredLocationsByLabware, (byWell: $Values<typeof ingredLocationsByLabware>) =>
@@ -490,9 +491,9 @@ export const selectors = {
   rootSelector,
 
   getLiquidGroupsById,
-  getIngredientLocations,
+  getLiquidsByLabwareId,
   getLiquidNamesById,
-  getLabware,
+  getLabwareById,
   getLabwareNames,
   getLabwareSelectionMode,
   getLabwareTypes,
@@ -500,12 +501,12 @@ export const selectors = {
   getLiquidGroupsOnDeck,
   getNextLiquidGroupId,
   getSavedLabware,
-  getSelectedContainer,
-  getSelectedContainerId,
+  getSelectedLabware,
+  getSelectedLabwareId,
   getSelectedLiquidGroupState,
   getDrillDownLabwareId,
 
-  slotToMoveFrom,
+  getSlotToMoveFrom,
 
   allIngredientGroupFields,
   allIngredientNamesIds,
@@ -514,7 +515,7 @@ export const selectors = {
   selectedAddLabwareSlot,
   disposalLabwareOptions,
   labwareOptions,
-  hasLiquid,
+  getDeckHasLiquid,
 }
 
 export default rootReducer

--- a/protocol-designer/src/load-file/selectors.js
+++ b/protocol-designer/src/load-file/selectors.js
@@ -10,7 +10,7 @@ export const getFileLoadErrors: Selector<$PropertyType<RootState, 'fileErrors'>>
   s => s.fileErrors
 )
 
-export const hasUnsavedChanges: Selector<$PropertyType<RootState, 'unsavedChanges'>> = createSelector(
+export const getHasUnsavedChanges: Selector<$PropertyType<RootState, 'unsavedChanges'>> = createSelector(
   rootSelector,
   s => s.unsavedChanges
 )

--- a/protocol-designer/src/navigation/selectors.js
+++ b/protocol-designer/src/navigation/selectors.js
@@ -4,10 +4,10 @@ import {rootSelector as navigationRootSelector} from './reducers'
 
 import type {Page} from './types'
 
-export const newProtocolModal = (state: BaseState) =>
+export const getNewProtocolModal = (state: BaseState) =>
   navigationRootSelector(state).newProtocolModal
 
-export const currentPage: Selector<Page> = (state: BaseState) => {
+export const getCurrentPage: Selector<Page> = (state: BaseState) => {
   let page = navigationRootSelector(state).page
 
   return page

--- a/protocol-designer/src/pipettes/selectors.js
+++ b/protocol-designer/src/pipettes/selectors.js
@@ -19,17 +19,17 @@ type Selector<T> = (RootSlice) => T
 
 export const rootSelector = (state: {pipettes: RootState}) => state.pipettes
 
-export const pipettesById: Selector<PipettesById> = createSelector(
+export const getPipettesById: Selector<PipettesById> = createSelector(
   rootSelector,
   pipettes => pipettes.byId
 )
 
-export const pipetteIdsByMount: Selector<*> = createSelector(
+export const getPipetteIdsByMount: Selector<*> = createSelector(
   rootSelector,
   pipettes => pipettes.byMount
 )
 
-export const pipettesByMount: Selector<*> = createSelector(
+export const getPipettesByMount: Selector<*> = createSelector(
   rootSelector,
   pipettes => mapValues(pipettes.byMount, id => pipettes.byId[id])
 )
@@ -51,7 +51,7 @@ function _getPipetteName (pipetteData): string {
 }
 
 // Shows equipped (left & right) pipettes by ID, not mount
-export const equippedPipettes: Selector<PipettesById> = createSelector(
+export const getEquippedPipettes: Selector<PipettesById> = createSelector(
   rootSelector,
   pipettes => reduce(pipettes.byMount, (acc: PipettesById, pipetteId: string): PipettesById => {
     const pipetteData = pipettes.byId[pipetteId]
@@ -63,8 +63,8 @@ export const equippedPipettes: Selector<PipettesById> = createSelector(
   }, {})
 )
 
-export const equippedPipetteOptions: Selector<Array<DropdownOption>> = createSelector(
-  equippedPipettes,
+export const getEquippedPipetteOptions: Selector<Array<DropdownOption>> = createSelector(
+  getEquippedPipettes,
   (pipettesById: PipettesById) => {
     const pipetteIds = Object.keys(pipettesById)
     const pipetteNamesById = pipetteIds.reduce((acc: {[string]: string}, pipetteId: string) => {
@@ -99,7 +99,7 @@ export const equippedPipetteOptions: Selector<Array<DropdownOption>> = createSel
 )
 
 // Formats pipette data specifically for edit pipette
-export const pipettesForInstrumentGroup: Selector<*> = createSelector(
+export const getPipettesForInstrumentGroup: Selector<*> = createSelector(
   rootSelector,
   pipettes => [pipettes.byMount.left, pipettes.byMount.right].reduce((acc, pipetteId) => {
     if (!pipetteId) return acc
@@ -123,7 +123,7 @@ export const pipettesForInstrumentGroup: Selector<*> = createSelector(
 )
 
 // Formats pipette data specifically for edit pipette
-export const pipettesForEditPipettes: Selector<Array<FormattedPipette>> = createSelector(
+export const getPipettesForEditPipettes: Selector<Array<FormattedPipette>> = createSelector(
   rootSelector,
   pipettes => [pipettes.byMount.left, pipettes.byMount.right].reduce((acc, pipetteId) => {
     if (!pipetteId) return acc
@@ -146,10 +146,10 @@ export const pipettesForEditPipettes: Selector<Array<FormattedPipette>> = create
   }, [])
 )
 
-export const permittedTipracks: Selector<Array<string>> = createSelector(
-  equippedPipettes,
-  (_equippedPipettes) =>
-    reduce(_equippedPipettes, (acc: Array<string>, pipette: PipetteData) => {
+export const getPermittedTipracks: Selector<Array<string>> = createSelector(
+  getEquippedPipettes,
+  (equippedPipettes) =>
+    reduce(equippedPipettes, (acc: Array<string>, pipette: PipetteData) => {
       return (pipette.tiprackModel)
         ? [...acc, pipette.tiprackModel]
         : acc

--- a/protocol-designer/src/pipettes/thunks.js
+++ b/protocol-designer/src/pipettes/thunks.js
@@ -23,7 +23,7 @@ import {createPipette} from './utils'
 export const editPipettes = (payload: EditPipettesFields) =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
     const state = getState()
-    const prevPipettesByMount = pipetteSelectors.pipettesByMount(state)
+    const prevPipettesByMount = pipetteSelectors.getPipettesByMount(state)
     const savedForms = steplistSelectors.getSavedForms(state)
 
     const nextPipettesByMount: PipettesByMount = Object.keys(payload).reduce(

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -123,7 +123,7 @@ export const saveStepForm = () =>
   (dispatch: Dispatch<*>, getState: GetState) => {
     const state = getState()
 
-    if (selectors.currentFormCanBeSaved(state)) {
+    if (selectors.getCurrentFormCanBeSaved(state)) {
       dispatch({
         type: 'SAVE_STEP_FORM',
         payload: selectors.formData(state),
@@ -184,7 +184,7 @@ export type SaveMoreOptionsModal = {
 export const saveMoreOptionsModal = () => (dispatch: Dispatch<*>, getState: GetState) => {
   dispatch({
     type: 'SAVE_MORE_OPTIONS_MODAL',
-    payload: selectors.formModalData(getState()),
+    payload: selectors.getFormModalData(getState()),
   })
 }
 

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -126,7 +126,7 @@ export const saveStepForm = () =>
     if (selectors.getCurrentFormCanBeSaved(state)) {
       dispatch({
         type: 'SAVE_STEP_FORM',
-        payload: selectors.formData(state),
+        payload: selectors.getUnsavedForm(state),
       })
     }
   }
@@ -157,7 +157,7 @@ export type OpenMoreOptionsModal = {
 export const openMoreOptionsModal = () => (dispatch: Dispatch<*>, getState: GetState) => {
   dispatch({
     type: 'OPEN_MORE_OPTIONS_MODAL',
-    payload: selectors.formData(getState()), // TODO only pull in relevant fields?
+    payload: selectors.getUnsavedForm(getState()), // TODO only pull in relevant fields?
   })
 }
 

--- a/protocol-designer/src/steplist/actions/handleFormChange.js
+++ b/protocol-designer/src/steplist/actions/handleFormChange.js
@@ -34,7 +34,7 @@ function _getAllWells (
 // maybe remove channels from pipette state and use shared-data?
 // or if not, make this its own selector in pipettes/ atom
 const getChannels = (pipetteId: string, state: BaseState): PipetteChannels => {
-  const pipettes = pipetteSelectors.pipettesById(state)
+  const pipettes = pipetteSelectors.getPipettesById(state)
   const pipette = pipettes[pipetteId]
   if (!pipette) {
     console.error(`${pipetteId} not found in pipettes, cannot handleFormChange properly`)
@@ -154,7 +154,7 @@ export const reconcileFormPipette = (formData: FormData, baseState: BaseState, n
     } else if (multiToSingle) {
       // multi-channel to single-channel: convert primary wells to all wells
       const labwareId = formData.labware
-      const labware = labwareId && labwareIngredSelectors.getLabware(baseState)[labwareId]
+      const labware = labwareId && labwareIngredSelectors.getLabwareById(baseState)[labwareId]
       const labwareType = labware && labware.type
 
       updateOverrides = {
@@ -171,9 +171,9 @@ export const reconcileFormPipette = (formData: FormData, baseState: BaseState, n
       const sourceLabwareId = formData['aspirate_labware']
       const destLabwareId = formData['dispense_labware']
 
-      const sourceLabware = sourceLabwareId && labwareIngredSelectors.getLabware(baseState)[sourceLabwareId]
+      const sourceLabware = sourceLabwareId && labwareIngredSelectors.getLabwareById(baseState)[sourceLabwareId]
       const sourceLabwareType = sourceLabware && sourceLabware.type
-      const destLabware = destLabwareId && labwareIngredSelectors.getLabware(baseState)[destLabwareId]
+      const destLabware = destLabwareId && labwareIngredSelectors.getLabwareById(baseState)[destLabwareId]
       const destLabwareType = destLabware && destLabware.type
 
       updateOverrides = {

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -24,8 +24,8 @@ function getStepFormData (state: BaseState, stepId: StepIdType, newStepType?: St
 
   const defaultNextPipette = getNextDefaultPipetteId(
     selectors.getSavedForms(state),
-    selectors.orderedSteps(state),
-    pipetteSelectors.pipetteIdsByMount(state)
+    selectors.getOrderedSteps(state),
+    pipetteSelectors.getPipetteIdsByMount(state)
   )
 
   // TODO: Ian 2018-09-19 sunset 'steps' reducer. Right now, it's needed here to get stepType
@@ -78,7 +78,7 @@ export const addStep = (payload: {stepType: StepType}) =>
         id: stepId,
       },
     })
-    const deckHasLiquid = labwareIngredsSelectors.hasLiquid(state)
+    const deckHasLiquid = labwareIngredsSelectors.getDeckHasLiquid(state)
     const stepNeedsLiquid = ['transfer', 'distribute', 'consolidate', 'mix'].includes(payload.stepType)
     if (stepNeedsLiquid && !deckHasLiquid) {
       dispatch(tutorialActions.addHint('add_liquids_and_labware'))

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -24,10 +24,10 @@ export type {
 }
 
 const hydrateLabware = (state: StepFormContextualState, id: string) => (
-  labwareIngredSelectors.getLabware(state)[id]
+  labwareIngredSelectors.getLabwareById(state)[id]
 )
 const hydratePipette = (state: StepFormContextualState, id: string) => (
-  pipetteSelectors.pipettesById(state)[id]
+  pipetteSelectors.getPipettesById(state)[id]
 )
 
 type StepFieldHelpers = {

--- a/protocol-designer/src/steplist/selectors.js
+++ b/protocol-designer/src/steplist/selectors.js
@@ -69,10 +69,6 @@ const getHydratedUnsavedForm: Selector<?FormData> = createSelector(
   )
 )
 
-// TODO Ian 2018-02-08 rename formData to something like getUnsavedForm or unsavedFormFields
-// NOTE: DEPRECATED use getUnsavedForm instead
-const formData = getUnsavedForm
-
 const getFormModalData = createSelector(
   rootSelector,
   (state: RootState) => state.unsavedFormModal
@@ -401,7 +397,6 @@ export default {
   getHoveredSubstep,
   getUnsavedForm,
   getHydratedUnsavedForm,
-  formData, // TODO: remove after sunset
   getFormModalData,
   getArgsAndErrorsByStepId,
   getIsNewStepForm,

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -135,12 +135,12 @@ function _getSelectedWellsForSubstep (
 }
 
 export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = createSelector(
-  fileDataSelectors.robotStateTimeline,
+  fileDataSelectors.getRobotStateTimeline,
   steplistSelectors.getArgsAndErrorsByStepId,
   steplistSelectors.getHoveredStepId,
   steplistSelectors.getHoveredSubstep,
   allSubsteps,
-  steplistSelectors.orderedSteps,
+  steplistSelectors.getOrderedSteps,
   (robotStateTimeline, allStepArgsAndErrors, hoveredStepId, hoveredSubstep, allSubsteps, orderedSteps) => {
     const timeline = robotStateTimeline.timeline
     const stepId = hoveredStepId

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -17,10 +17,10 @@ import type {SubstepItemData} from '../steplist/types'
 type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
   steplistSelectors.getArgsAndErrorsByStepId,
-  pipetteSelectors.equippedPipettes,
+  pipetteSelectors.getEquippedPipettes,
   labwareIngredSelectors.getLabwareTypes,
-  steplistSelectors.orderedSteps,
-  fileDataSelectors.robotStateTimeline,
+  steplistSelectors.getOrderedSteps,
+  fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.getInitialRobotState,
   (
     allStepArgsAndErrors,

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -86,8 +86,8 @@ const getLastValidTips: GetTipSelector = createSelector(
 )
 
 export const getTipsForCurrentStep: GetTipSelector = createSelector(
-  steplistSelectors.orderedSteps,
-  fileDataSelectors.robotStateTimeline,
+  steplistSelectors.getOrderedSteps,
+  fileDataSelectors.getRobotStateTimeline,
   steplistSelectors.getHoveredStepId,
   steplistSelectors.getActiveItem,
   getInitialTips,

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
@@ -1,4 +1,4 @@
-import wellContentsAllLabware from '../wellContentsAllLabware'
+import getWellContentsAllLabware from '../getWellContentsAllLabware'
 
 // FIXTURES
 const baseIngredFields = {
@@ -53,8 +53,8 @@ const defaultWellContents = {
 
 const container1MaxVolume = 400
 
-describe('wellContentsAllLabware', () => {
-  const singleIngredResult = wellContentsAllLabware.resultFunc(
+describe('getWellContentsAllLabware', () => {
+  const singleIngredResult = getWellContentsAllLabware.resultFunc(
     containerState, // all labware
     ingredsByLabwareXXSingleIngred,
     {id: 'container1Id'}, // selected labware
@@ -63,7 +63,7 @@ describe('wellContentsAllLabware', () => {
   )
 
   // TODO: 2nd test case
-  // const twoIngredResult = selectors.wellContentsAllLabware.resultFunc(
+  // const twoIngredResult = selectors.getWellContentsAllLabware.resultFunc(
   //   containerState, // all labware
   //   ingredsByLabwareXXTwoIngred,
   //   containerState.container2Id, // selected labware

--- a/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
@@ -54,32 +54,32 @@ const _getWellContents = (
   }, {})
 }
 
-const wellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
-  labwareIngredSelectors.getLabware,
-  labwareIngredSelectors.getIngredientLocations,
-  labwareIngredSelectors.getSelectedContainer,
+const getWellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
+  labwareIngredSelectors.getLabwareById,
+  labwareIngredSelectors.getLiquidsByLabwareId,
+  labwareIngredSelectors.getSelectedLabware,
   wellSelectionSelectors.getSelectedWells,
   wellSelectionSelectors.getHighlightedWells,
-  (_labware, _ingredsByLabware, _selectedLabware, _selectedWells, _highlightedWells) => {
-    const allLabwareIds: Array<string> = Object.keys(_labware) // TODO Ian 2018-05-29 weird flow error w/o annotation
+  (labwareById, liquidsByLabware, selectedLabware, selectedWells, highlightedWells) => {
+    const allLabwareIds: Array<string> = Object.keys(labwareById) // TODO Ian 2018-05-29 weird flow error w/o annotation
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: ContentsByWell | null}, labwareId: string) => {
-      const ingredsForLabware = _ingredsByLabware[labwareId]
-      const isSelectedLabware = _selectedLabware && (_selectedLabware.id === labwareId)
+      const liquidsForLabware = liquidsByLabware[labwareId]
+      const isSelectedLabware = selectedLabware && (selectedLabware.id === labwareId)
 
-      // Skip labware ids with no ingreds
+      // Skip labware ids with no liquids
       return {
         ...acc,
         [labwareId]: _getWellContents(
-          _labware[labwareId] && _labware[labwareId].type,
-          ingredsForLabware,
+          labwareById[labwareId] && labwareById[labwareId].type,
+          liquidsForLabware,
           // Only give _getWellContents the selection data if it's a selected container
-          isSelectedLabware ? _selectedWells : null,
-          isSelectedLabware ? _highlightedWells : null
+          isSelectedLabware ? selectedWells : null,
+          isSelectedLabware ? highlightedWells : null
         ),
       }
     }, {})
   }
 )
 
-export default wellContentsAllLabware
+export default getWellContentsAllLabware

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -22,8 +22,8 @@ import type {
 
 // TODO Ian 2018-04-19: factor out all these selectors to their own files,
 // and make this index.js just imports and exports.
-import wellContentsAllLabwareExport from './wellContentsAllLabware'
-export const wellContentsAllLabware = wellContentsAllLabwareExport
+import getWellContentsAllLabware from './getWellContentsAllLabware'
+export {getWellContentsAllLabware}
 export type {WellContentsByLabware}
 
 function _wellContentsForWell (
@@ -68,11 +68,11 @@ export function _wellContentsForLabware (
   )
 }
 
-export const allWellContentsForSteps: Selector<Array<WellContentsByLabware>> = createSelector(
+export const getAllWellContentsForSteps: Selector<Array<WellContentsByLabware>> = createSelector(
   fileDataSelectors.getInitialRobotState,
-  fileDataSelectors.robotStateTimeline,
-  (_initialRobotState, _robotStateTimeline) => {
-    const timeline = [{robotState: _initialRobotState}, ..._robotStateTimeline.timeline]
+  fileDataSelectors.getRobotStateTimeline,
+  (initialRobotState, robotStateTimeline) => {
+    const timeline = [{robotState: initialRobotState}, ...robotStateTimeline.timeline]
 
     return timeline.map((timelineStep, timelineIndex) => {
       const liquidState = timelineStep.robotState.liquidState.labware
@@ -93,7 +93,7 @@ export const allWellContentsForSteps: Selector<Array<WellContentsByLabware>> = c
   }
 )
 
-export const lastValidWellContents: Selector<WellContentsByLabware> = createSelector(
+export const getLastValidWellContents: Selector<WellContentsByLabware> = createSelector(
   fileDataSelectors.lastValidRobotState,
   (robotState) => {
     return mapValues(
@@ -109,9 +109,9 @@ export const lastValidWellContents: Selector<WellContentsByLabware> = createSele
   }
 )
 
-export const selectedWellsMaxVolume: Selector<number> = createSelector(
+export const getSelectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
-  labwareIngredSelectors.getSelectedContainer,
+  labwareIngredSelectors.getSelectedLabware,
   (selectedWells, selectedContainer) => {
     const selectedWellNames = Object.keys(selectedWells)
     const selectedContainerType = selectedContainer && selectedContainer.type
@@ -135,8 +135,8 @@ type CommonWellValues = {ingredientId: ?string, volume: ?number}
  * or null if there is not a single common ingredient group */
 export const getSelectedWellsCommonValues: Selector<CommonWellValues> = createSelector(
   wellSelectionSelectors.getSelectedWells,
-  labwareIngredSelectors.getSelectedContainerId,
-  labwareIngredSelectors.getIngredientLocations,
+  labwareIngredSelectors.getSelectedLabwareId,
+  labwareIngredSelectors.getLiquidsByLabwareId,
   (selectedWellsObj, labwareId, allIngreds) => {
     if (!labwareId) return {ingredientId: null, volume: null}
     const ingredsInLabware = allIngreds[labwareId]

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -67,8 +67,8 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
     // initially selected wells in form get selected in state before modal opens
     dispatch(selectWells(wells))
 
-    const pipettes = pipetteSelectors.equippedPipettes(state)
-    const labware = labwareIngredSelectors.getLabware(state)
+    const pipettes = pipetteSelectors.getEquippedPipettes(state)
+    const labware = labwareIngredSelectors.getLabwareById(state)
     // TODO type this action, make an underline fn action creator
 
     dispatch({
@@ -89,13 +89,13 @@ export const closeWellSelectionModal = (): * => ({
 export const saveWellSelectionModal = () =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
     const state = getState()
-    const wellSelectionModalData = selectors.wellSelectionModalData(state)
+    const wellSelectionModalData = selectors.getWellSelectionModalData(state)
 
     // this if-else is mostly for Flow
     if (wellSelectionModalData) {
       dispatch(changeFormInput({
         update: {
-          [wellSelectionModalData.formFieldAccessor]: selectors.selectedWellNames(state),
+          [wellSelectionModalData.formFieldAccessor]: selectors.getSelectedWellNames(state),
         },
       }))
     } else {

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -59,7 +59,7 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
     const state = getState()
     const accessor = payload.formFieldAccessor
-    const formData = steplistSelectors.formData(state)
+    const formData = steplistSelectors.getUnsavedForm(state)
 
     const wells: Wells = (accessor && formData && formData[accessor] &&
       _wellArrayToObj(formData[accessor])) || {}

--- a/protocol-designer/src/well-selection/selectors.js
+++ b/protocol-designer/src/well-selection/selectors.js
@@ -9,7 +9,7 @@ import type {OpenWellSelectionModalPayload} from './actions'
 
 const rootSelector = (state: BaseState) => state.wellSelection
 
-const wellSelectionModalData: Selector<?OpenWellSelectionModalPayload> = createSelector(
+const getWellSelectionModalData: Selector<?OpenWellSelectionModalPayload> = createSelector(
   rootSelector,
   s => s.wellSelectionModal
 )
@@ -47,24 +47,24 @@ function _primaryToAllWells (
 
 const getSelectedWells: Selector<Wells> = createSelector(
   getSelectedPrimaryWells,
-  wellSelectionModalData,
+  getWellSelectionModalData,
   _primaryToAllWells
 )
 
 const getHighlightedWells: Selector<Wells> = createSelector(
   getHighlightedPrimaryWells,
-  wellSelectionModalData,
+  getWellSelectionModalData,
   _primaryToAllWells
 )
 
-const selectedWellNames: Selector<Array<string>> = createSelector(
+const getSelectedWellNames: Selector<Array<string>> = createSelector(
   (state: BaseState) => rootSelector(state).selectedWells.selected,
   selectedWells => Object.keys(selectedWells).sort(sortWells)
 )
 
 export default {
-  selectedWellNames,
+  getSelectedWellNames,
   getSelectedWells,
   getHighlightedWells,
-  wellSelectionModalData,
+  getWellSelectionModalData,
 }


### PR DESCRIPTION
Closes #2591

Added `get` to the start of selector names

Changed the names of:
* `getLabware -> getLabwareById`
* `formSectionCollapse -> getFormSectionCollapsed`
* `getIngredientLocations -> getLiquidsByLabwareId`
* `getSelectedContainer -> getSelectedLabware`

Renamed all the underscored selector fn args like `_labware` so they don't have the underscore

Rename file for the selector `wellContentsAllLabware.js` to `getWellContentsAllLabware.js`, and its corresponding test file

Use `getUnsavedForm` instead of `formData` (`formData` was just an alias for that selector)

Should be no other changes. Everything in PD should work exactly the same.

## Review requests

Are there any selectors I missed? Trying to be comprehensive.
