### PR TITLE
refactor(shared-data): rename slot width/height constants

### DIFF
--- a/components/src/deck/ContainerNameOverlay.js
+++ b/components/src/deck/ContainerNameOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {SLOT_HEIGHT_MM} from './constants'
+import {SLOT_RENDER_HEIGHT} from './constants'
 import styles from './LabwareContainer.css'
 
 type Props = {
@@ -22,7 +22,7 @@ export function ContainerNameOverlay (props: Props) {
 
   return (
     <g className={styles.name_overlay}>
-      <g transform={`translate(0 ${SLOT_HEIGHT_MM - boxHeight})`}>
+      <g transform={`translate(0 ${SLOT_RENDER_HEIGHT - boxHeight})`}>
         <rect x='0' y='0' height={boxHeight} width='100%' />
         <text
           x={paddingLeft}

--- a/components/src/deck/ContainerNameOverlay.js
+++ b/components/src/deck/ContainerNameOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {SLOT_RENDER_HEIGHT} from './constants'
+import {SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
 import styles from './LabwareContainer.css'
 
 type Props = {

--- a/components/src/deck/Deck.js
+++ b/components/src/deck/Deck.js
@@ -3,11 +3,12 @@ import * as React from 'react'
 import cx from 'classnames'
 import flatMap from 'lodash/flatMap'
 import type {DeckSlot} from '../robot-types'
-
 import {
-  SLOTNAME_MATRIX,
   SLOT_RENDER_WIDTH,
   SLOT_RENDER_HEIGHT,
+} from '@opentrons/shared-data'
+import {
+  SLOTNAME_MATRIX,
   SLOT_SPACING_MM,
   SLOT_OFFSET_MM,
   TRASH_SLOTNAME,

--- a/components/src/deck/Deck.js
+++ b/components/src/deck/Deck.js
@@ -6,8 +6,8 @@ import type {DeckSlot} from '../robot-types'
 
 import {
   SLOTNAME_MATRIX,
-  SLOT_WIDTH_MM,
-  SLOT_HEIGHT_MM,
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
   SLOT_SPACING_MM,
   SLOT_OFFSET_MM,
   TRASH_SLOTNAME,
@@ -50,10 +50,10 @@ function renderLabware (LabwareComponent): React.Node[] {
       return columns.map((slot: DeckSlot, col: number) => {
         if (slot === TRASH_SLOTNAME) return null
 
-        const props = {slot, width: SLOT_WIDTH_MM, height: SLOT_HEIGHT_MM}
+        const props = {slot, width: SLOT_RENDER_WIDTH, height: SLOT_RENDER_HEIGHT}
         const transform = `translate(${[
-          SLOT_WIDTH_MM * col + SLOT_SPACING_MM * (col + 1),
-          SLOT_HEIGHT_MM * row + SLOT_SPACING_MM * (row + 1),
+          SLOT_RENDER_WIDTH * col + SLOT_SPACING_MM * (col + 1),
+          SLOT_RENDER_HEIGHT * row + SLOT_SPACING_MM * (row + 1),
         ].join(',')})`
 
         return (

--- a/components/src/deck/LabwareContainer.js
+++ b/components/src/deck/LabwareContainer.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {SLOT_HEIGHT_MM, SLOT_WIDTH_MM} from '@opentrons/shared-data'
+import {SLOT_RENDER_HEIGHT, SLOT_RENDER_WIDTH} from '@opentrons/shared-data'
 import styles from './LabwareContainer.css'
 
 const defs = {roundSlotClipPath: 'roundSlotClipPath'} // TODO: import these defs instead of hard-coding in applications? Or should they be passed to children?
@@ -16,8 +16,8 @@ type Props = {
 
 export default function LabwareContainer (props: Props) {
   const {x, y, highlighted, children} = props
-  const height = props.height || SLOT_HEIGHT_MM
-  const width = props.width || SLOT_WIDTH_MM
+  const height = props.height || SLOT_RENDER_HEIGHT
+  const width = props.width || SLOT_RENDER_WIDTH
 
   return (
     <g>

--- a/components/src/deck/LabwareOutline.js
+++ b/components/src/deck/LabwareOutline.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {SLOT_WIDTH_MM, SLOT_HEIGHT_MM} from './constants.js'
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from './constants.js'
 import styles from './Labware.css'
 
 type Props = {className?: ?string}
@@ -13,7 +13,7 @@ export default function LabwareOutline (props: Props) {
   return <rect {...rectStyle}
     x='0' y='0'
     className={cx(styles.plate_outline, props.className)}
-    width={SLOT_WIDTH_MM}
-    height={SLOT_HEIGHT_MM}
+    width={SLOT_RENDER_WIDTH}
+    height={SLOT_RENDER_HEIGHT}
   />
 }

--- a/components/src/deck/LabwareOutline.js
+++ b/components/src/deck/LabwareOutline.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from './constants.js'
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
 import styles from './Labware.css'
 
 type Props = {className?: ?string}

--- a/components/src/deck/constants.js
+++ b/components/src/deck/constants.js
@@ -1,7 +1,5 @@
 // @flow
 // ========= OT2 DECK ===============
-import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
-
 export const SLOTNAME_MATRIX = [ // used for deckmap
   ['10', '11', '12'],
   ['7', '8', '9'],
@@ -16,7 +14,3 @@ export const TRASH_SLOTNAME = '12'
 // Slot dims in mm
 export const SLOT_SPACING_MM = 5
 export const SLOT_OFFSET_MM = 10
-export {
-  SLOT_RENDER_WIDTH,
-  SLOT_RENDER_HEIGHT,
-}

--- a/components/src/deck/constants.js
+++ b/components/src/deck/constants.js
@@ -1,6 +1,6 @@
 // @flow
 // ========= OT2 DECK ===============
-import {SLOT_WIDTH_MM, SLOT_HEIGHT_MM} from '@opentrons/shared-data'
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
 
 export const SLOTNAME_MATRIX = [ // used for deckmap
   ['10', '11', '12'],
@@ -17,6 +17,6 @@ export const TRASH_SLOTNAME = '12'
 export const SLOT_SPACING_MM = 5
 export const SLOT_OFFSET_MM = 10
 export {
-  SLOT_WIDTH_MM,
-  SLOT_HEIGHT_MM,
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
 }

--- a/protocol-designer/src/components/SingleLabware.js
+++ b/protocol-designer/src/components/SingleLabware.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {SLOT_WIDTH_MM, SLOT_HEIGHT_MM} from '../constants.js'
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '../constants.js'
 import styles from './SingleLabware.css'
 
 type Props = {
@@ -16,8 +16,8 @@ export default function SingleLabware (props: Props) {
   const {children, className, showLabels = false} = props
   const minX = showLabels ? -LABEL_OFFSET : 0
   const minY = showLabels ? -LABEL_OFFSET : 0
-  const width = showLabels ? SLOT_WIDTH_MM + LABEL_OFFSET : SLOT_WIDTH_MM
-  const height = showLabels ? SLOT_HEIGHT_MM + LABEL_OFFSET : SLOT_HEIGHT_MM
+  const width = showLabels ? SLOT_RENDER_WIDTH + LABEL_OFFSET : SLOT_RENDER_WIDTH
+  const height = showLabels ? SLOT_RENDER_HEIGHT + LABEL_OFFSET : SLOT_RENDER_HEIGHT
   return (
     <div className={cx(styles.single_labware, className)}>
       <svg viewBox={`${minX} ${minY} ${width} ${height}`}>

--- a/protocol-designer/src/components/SingleLabware.js
+++ b/protocol-designer/src/components/SingleLabware.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '../constants.js'
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
 import styles from './SingleLabware.css'
 
 type Props = {

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -5,8 +5,8 @@ import {
   LabwareContainer,
   ContainerNameOverlay,
   EmptyDeckSlot,
-  SLOT_WIDTH_MM,
-  SLOT_HEIGHT_MM,
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
   humanizeLabwareType,
   type DeckSlot,
 } from '@opentrons/components'
@@ -68,7 +68,7 @@ function SlotWithLabware (props: SlotWithLabwareProps) {
       {labwareImages[containerType]
         ? <image
           href={labwareImages[containerType]}
-          width={SLOT_WIDTH_MM} height={SLOT_HEIGHT_MM}
+          width={SLOT_RENDER_WIDTH} height={SLOT_RENDER_HEIGHT}
         />
         : <HighlightableLabware containerId={containerId} />
       }

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -5,11 +5,13 @@ import {
   LabwareContainer,
   ContainerNameOverlay,
   EmptyDeckSlot,
-  SLOT_RENDER_WIDTH,
-  SLOT_RENDER_HEIGHT,
   humanizeLabwareType,
   type DeckSlot,
 } from '@opentrons/components'
+import {
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
+} from '@opentrons/shared-data'
 import styles from './labware.css'
 
 import ClickableText from './ClickableText'

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -8,8 +8,8 @@ export const {
   SLOTNAME_MATRIX,
   sortedSlotnames,
   TRASH_SLOTNAME,
-  SLOT_WIDTH_MM,
-  SLOT_HEIGHT_MM,
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
   SLOT_SPACING_MM,
   // STYLE CONSTANTS
   swatchColors,

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -3,13 +3,12 @@ import reduce from 'lodash/reduce'
 import * as componentLib from '@opentrons/components'
 import {getLabware} from '@opentrons/shared-data'
 import type {JsonWellData, WellVolumes} from './types'
+// TODO Ian 2018-11-27: import these from components lib, not from this contants file
 export const {
   // OT2 DECK CONSTANTS
   SLOTNAME_MATRIX,
   sortedSlotnames,
   TRASH_SLOTNAME,
-  SLOT_RENDER_WIDTH,
-  SLOT_RENDER_HEIGHT,
   SLOT_SPACING_MM,
   // STYLE CONSTANTS
   swatchColors,

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -1,5 +1,9 @@
 // @flow
 
-// in millimeters
-export const SLOT_WIDTH_MM = 127.76
-export const SLOT_HEIGHT_MM = 85.48
+// constants for dealing with robot coordinate system (eg in labwareTools)
+export const SLOT_LENGTH_MM = 127.76 // along X axis in robot coordinate system
+export const SLOT_WIDTH_MM = 85.48 // along Y axis in robot coordinate system
+
+// constants for SVG renders of the deck
+export const SLOT_RENDER_WIDTH = SLOT_LENGTH_MM // along X axis in SVG coords
+export const SLOT_RENDER_HEIGHT = SLOT_WIDTH_MM // along Y axis in SVG coords

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -1,7 +1,7 @@
 // @flow
 import mapValues from 'lodash/mapValues'
 import definitions from '../build/labware.json'
-import {SLOT_HEIGHT_MM} from './constants'
+import {SLOT_RENDER_HEIGHT} from './constants'
 import type {LabwareDefinition, WellDefinition} from './types'
 
 export default function getLabware (labwareName: string): ?LabwareDefinition {
@@ -34,6 +34,6 @@ export function getWellDefsForSVG (labwareName: string) {
     ...wellDef,
     x: wellDef.x + xCorrection,
     // flip y axis to match SVG y axis direction
-    y: SLOT_HEIGHT_MM - wellDef.y + yCorrection,
+    y: SLOT_RENDER_HEIGHT - wellDef.y + yCorrection,
   }))
 }

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -6,8 +6,8 @@ import assignId from './assignId'
 import {toWellName, sortWells, splitWellsOnColumn} from '../helpers/index'
 import labwareSchema from '../../labware-json-schema/labware-schema.json'
 import {
-  SLOT_WIDTH_MM as SLOT_LENGTH_MM,
-  SLOT_HEIGHT_MM as SLOT_WIDTH_MM,
+  SLOT_WIDTH_MM,
+  SLOT_LENGTH_MM,
 } from '../constants'
 
 type Metadata = {


### PR DESCRIPTION
## overview

Closes #2535

As per the slack poll @btmorr conducted two weeks ago, here's my attempt at clearing up "length" vs "width" in different contexts of robot coordinate system (which is used in JS world for JSON labware definition creation) versus SVG coordinate system (used to render deck map + labware).

```js
// constants for dealing with robot coordinate system (eg in labwareTools)
export const SLOT_LENGTH_MM = 127.76 // along X axis in robot coordinate system
export const SLOT_WIDTH_MM = 85.48 // along Y axis in robot coordinate system

// constants for SVG renders of the deck
export const SLOT_RENDER_WIDTH = SLOT_LENGTH_MM // along X axis in SVG coords
export const SLOT_RENDER_HEIGHT = SLOT_WIDTH_MM // along Y axis in SVG coords
```

## changelog

* use separate constants when dealing with robot coordinate system (eg in labwareTools) versus when
rendering deck/labware in SVG coordinates
* remove weird import-then-export redirect in `protocol-designer/src/constants.js` and in `components/src/deck/constants.js` -- and make components import the constants directly from shared-data

## review requests

- [ ] Do the names of these constants seem good to everyone?
- [ ] Deck/labware in App and PD still look right
- [ ] Labware tools still work the same