### PR TITLE
fix(api): Fix the flaky tempdeck test

### DIFF
--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -55,6 +55,7 @@ def test_fail_get_temp_deck_temperature():
     temp_deck.simulating = False
 
     done = False
+
     def _mock_send_command1(self, command, timeout=None):
         nonlocal done
         done = True

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -8,6 +8,8 @@
 # If you send a commmand to the serial comm module and it never sees the
 # expected ACK, then it'll eventually time out and return an error
 
+import time
+
 
 def test_get_temp_deck_temperature():
     # Get the curent and target temperatures
@@ -52,21 +54,32 @@ def test_fail_get_temp_deck_temperature():
     temp_deck = TempDeck()
     temp_deck.simulating = False
 
+    done = False
     def _mock_send_command1(self, command, timeout=None):
+        nonlocal done
+        done = True
         return 'T:none C:90'
 
     temp_deck._send_command = types.MethodType(_mock_send_command1, temp_deck)
 
     temp_deck.update_temperature()
+    time.sleep(0.25)
+    while not done:
+        time.sleep(0.25)
 
     assert temp_deck._temperature == {'current': 90, 'target': None}
 
     def _mock_send_command2(self, command, timeout=None):
+        nonlocal done
+        done = True
         return 'Tx:none C:1'    # Failure premise
 
     temp_deck._send_command = types.MethodType(_mock_send_command2, temp_deck)
-
+    done = False
     temp_deck.update_temperature()
+    time.sleep(0.25)
+    while not done:
+        time.sleep(0.25)
     assert temp_deck._temperature == {'current': 90, 'target': None}
 
 


### PR DESCRIPTION
The tempdeck driver, when it fails, will sleep and try again. When we’re testing
that, we need to wait a bit - since it’s in a thread - before checking the output.

This is super hacky.
