### PR TITLE
feat(protocol-designer): add tooltip to advanced settings icon

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -3,8 +3,9 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import startCase from 'lodash/startCase'
 import cx from 'classnames'
-import {IconButton} from '@opentrons/components'
+import {IconButton, HoverTooltip} from '@opentrons/components'
 
+import i18n from '../../localization'
 import {selectors as steplistSelectors} from '../../steplist'
 import {collapseFormSection} from '../../steplist/actions'
 import type {BaseState, ThunkDispatch} from '../../types'
@@ -34,12 +35,19 @@ const FormSection = (props: FormSectionProps) => {
       </div>
 
       {props.collapsed !== undefined && // if doesn't exist in redux
-        <div onClick={props.onCollapseToggle} className={styles.carat}>
-          <IconButton
-            name='settings'
-            hover={!props.collapsed}
-          />
-        </div>
+        <HoverTooltip tooltipComponent={i18n.t('tooltip.advanced_settings')}>
+          {(hoverTooltipHandlers) => (
+            <div {...hoverTooltipHandlers}
+              onClick={props.onCollapseToggle}
+              className={styles.carat}
+            >
+              <IconButton
+                name='settings'
+                hover={!props.collapsed}
+              />
+            </div>
+          )}
+        </HoverTooltip>
       }
     </div>
   )

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -1,5 +1,6 @@
 {
   "not_in_beta": "ⓘ Coming Soon",
+  "advanced_settings": "Advanced Settings",
 
   "step_description": {
     "transfer": "Move liquid from wells to an equal number of wells",


### PR DESCRIPTION
## overview

Simple one - just add a tooltip that says "Advanced Settings" to the cog icon.

Closes #2706

## changelog

## review requests

Should work for all forms that have the cog icon (transfer/consolidate/distribute)