### PR TITLE
feat(protocol-designer): make multichannel substeps collapsed by default

### DIFF
--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.js
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.js
@@ -57,11 +57,11 @@ export default class MultiChannelSubstep extends React.Component<MultiChannelSub
           <span className={styles.volume_cell}>{`${formatVolume(rowGroup[0].volume)} μL`}</span>
           <span className={styles.emphasized_cell}>{firstChannelDest ? destWellRange : ''}</span>
           <span className={styles.inner_carat} onClick={this.handleToggleCollapsed}>
-            <Icon name={collapsed ? 'chevron-down' : 'chevron-up'} />
+            <Icon name={collapsed ? 'chevron-up' : 'chevron-down'} />
           </span>
         </PDListItem>
 
-        {collapsed && rowGroup.map((row, rowKey) => {
+        {!collapsed && rowGroup.map((row, rowKey) => {
           // Channel rows (1 for each channel in multi-channel pipette
           return (
             <SubstepRow


### PR DESCRIPTION
## overview

Closes #2678

Multichannel substeps are collapsed by default

Note: in the code, we already had `const DEFAULT_COLLAPSED_STATE = true`, but `collapsed` was being used as if it meant the inverse, "expanded".

## changelog

* make multichannel substeps collapsed by default

## review requests

Expanding a collapsed step that uses a multi-channel pipette should open with the inner multi-channel-substep rows collapsed.