### PR TITLE
feat(protocol-designer): remove delay from advanced settings of all step types

### DIFF
--- a/protocol-designer/src/components/StepEditForm/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/MixForm.js
@@ -1,13 +1,11 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import i18n from '../../localization'
 import {FormGroup} from '@opentrons/components'
 
 import {
   StepInputField,
   StepCheckboxRow,
-  DispenseDelayFields,
   PipetteField,
   LabwareDropdown,
   ChangeTipField,
@@ -45,11 +43,6 @@ const MixForm = (props: MixFormProps): React.Element<typeof React.Fragment> => {
       <div className={formStyles.row_wrapper}>
         <div className={styles.left_settings_column}>
           <FormGroup label='TECHNIQUE'>
-            <DispenseDelayFields
-              disabled
-              tooltipComponent={i18n.t('tooltip.not_in_beta')}
-              focusHandlers={focusHandlers}
-            />
             <StepCheckboxRow name="dispense_blowout_checkbox" label='Blow out'>
               <LabwareDropdown name="dispense_blowout_labware" className={styles.full_width} {...focusHandlers} />
             </StepCheckboxRow>

--- a/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
+++ b/protocol-designer/src/components/StepEditForm/TransferLikeForm.js
@@ -6,7 +6,6 @@ import i18n from '../../localization'
 import {
   StepInputField,
   StepCheckboxRow,
-  DispenseDelayFields,
   PipetteField,
   DisposalDestinationDropdown,
   LabwareDropdown,
@@ -144,10 +143,6 @@ const TransferLikeForm = (props: TransferLikeFormProps) => {
                 <StepInputField name="dispense_mix_volume" units="μL" {...focusHandlers} />
                 <StepInputField name="dispense_mix_times" units="Times" {...focusHandlers} />
               </StepCheckboxRow>
-              <DispenseDelayFields
-                disabled
-                tooltipComponent={i18n.t('tooltip.not_in_beta')}
-                focusHandlers={focusHandlers} />
               {stepType !== 'distribute' &&
                 <StepCheckboxRow name='dispense_blowout_checkbox' label='Blow out' >
                   <LabwareDropdown name="dispense_blowout_labware" className={styles.full_width} {...focusHandlers} />

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -96,26 +96,6 @@ export const StepRadioGroup = (props: StepRadioGroupProps) => {
   )
 }
 
-type DispenseDelayFieldsProps = {
-  focusHandlers: FocusHandlers,
-  label?: string,
-  disabled?: boolean,
-  tooltipComponent?: React.Node,
-}
-export function DispenseDelayFields (props: DispenseDelayFieldsProps) {
-  const {label = 'Delay', focusHandlers, tooltipComponent, disabled} = props
-  return (
-    <StepCheckboxRow
-      disabled={disabled}
-      tooltipComponent={tooltipComponent}
-      name="dispense_delay_checkbox"
-      label={label}>
-      <StepInputField {...focusHandlers} disabled={disabled} name="dispense_delayMinutes" units='m' />
-      <StepInputField {...focusHandlers} disabled={disabled} name="dispense_delaySeconds" units='s' />
-    </StepCheckboxRow>
-  )
-}
-
 type PipetteFieldOP = {name: StepFieldName, stepType?: StepType} & FocusHandlers
 type PipetteFieldSP = {pipetteOptions: Options, getHydratedPipette: (string) => any} // TODO: real hydrated pipette type
 type PipetteFieldDP = {updateDisposalVolume: (?mixed) => void}

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -26,9 +26,6 @@ export type StepFieldName =
   | 'changeTip'
   | 'dispense_blowout_checkbox'
   | 'dispense_blowout_labware'
-  | 'dispense_delay_checkbox'
-  | 'dispense_delayMinutes'
-  | 'dispense_delaySeconds'
   | 'dispense_flowRate'
   | 'dispense_labware'
   | 'dispense_touchTip'
@@ -74,12 +71,6 @@ export type FormModalFields = {|
   'step-details': string,
 |}
 
-export type DelayFields = {|
-  'dispense_delay_checkbox'?: boolean,
-  'dispense_delayMinutes'?: string,
-  'dispense_delaySeconds'?: string,
-|}
-
 export type BlowoutFields = {|
   'dispense_blowout_checkbox'?: boolean,
   'dispense_blowout_labware'?: string,
@@ -95,7 +86,6 @@ export type TransferLikeForm = {|
   ...FormModalFields,
   ...BlowoutFields,
   ...ChangeTipFields,
-  ...DelayFields,
 
   stepType: TransferLikeStepType,
   id: StepIdType,
@@ -125,7 +115,6 @@ export type MixForm = {|
   ...FormModalFields,
   ...BlowoutFields,
   ...ChangeTipFields,
-  ...DelayFields,
   stepType: 'mix',
   id: StepIdType,
 

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -99,7 +99,6 @@ describe('consolidate single-channel', () => {
 
     touchTipAfterDispense: false,
     mixInDestination: null,
-    delayAfterDispense: null,
     blowout: null,
   }
 
@@ -531,7 +530,6 @@ describe('consolidate single-channel', () => {
     expect(result.errors[0].type).toEqual('PIPETTE_DOES_NOT_EXIST')
   })
 
-  test('delay after dispense') // TODO Ian 2018-04-05 support delay in consolidate
   test('air gap') // TODO Ian 2018-04-05 determine air gap behavior
 })
 
@@ -564,7 +562,6 @@ describe('consolidate multi-channel', () => {
 
     touchTipAfterDispense: false,
     mixInDestination: null,
-    delayAfterDispense: null,
     blowout: null,
   }
 

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -39,7 +39,6 @@ beforeEach(() => {
     mixBeforeAspirate: null,
 
     touchTipAfterDispense: false,
-    delayAfterDispense: null,
   }
 
   robotInitialState = createRobotState({

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -30,7 +30,6 @@ beforeEach(() => {
     pipette: 'p300SingleId',
     labware: 'sourcePlateId',
 
-    delay: null,
     touchTip: false,
   }
 })
@@ -250,8 +249,6 @@ describe('mix: advanced options', () => {
       cmd.touchTip('C1'),
     ])
   })
-
-  test.skip('delay') // TODO Ian 2018-05-08 implement when behavior is decided
 })
 
 describe('mix: errors', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -31,7 +31,6 @@ beforeEach(() => {
 
     touchTipAfterDispense: false,
     mixInDestination: null,
-    delayAfterDispense: null,
     blowout: null,
   }
 
@@ -441,57 +440,6 @@ describe('advanced options', () => {
       ])
     })
 
-    test.skip('delay after dispense', () => { // TODO Ian 2018-04-05 support delay in transfer. REMOVE SKIP
-      transferArgs = {
-        ...transferArgs,
-        volume: 350,
-        delayAfterDispense: 100,
-      }
-
-      const result = transfer(transferArgs)(robotInitialState)
-
-      const delayCommand = {
-        command: 'delay',
-        params: {
-          wait: 100,
-          message: null,
-        },
-      }
-
-      expect(result.commands).toEqual([
-        {
-          command: 'aspirate',
-          labware: 'sourcePlateId',
-          pipette: 'p300SingleId',
-          volume: 300,
-          well: 'A1',
-        },
-        {
-          command: 'dispense',
-          labware: 'destPlateId',
-          pipette: 'p300SingleId',
-          volume: 300,
-          well: 'B1',
-        },
-        delayCommand,
-
-        {
-          command: 'aspirate',
-          labware: 'sourcePlateId',
-          pipette: 'p300SingleId',
-          volume: 50,
-          well: 'A1',
-        },
-        {
-          command: 'dispense',
-          labware: 'destPlateId',
-          pipette: 'p300SingleId',
-          volume: 50,
-          well: 'B1',
-        },
-        delayCommand,
-      ])
-    })
     test('blowout should blowout in specified labware after each dispense') // TODO
   })
 })

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -48,8 +48,6 @@ export type TransferLikeFormDataFields = {
   touchTipAfterDispense: boolean,
   /** Optional offset for touch tip after dispense (if null, use PD default) */
   touchTipAfterDispenseOffsetMmFromBottom?: ?number,
-  /** Number of seconds to delay at the very end of the step (TODO: or after each dispense ?) */
-  delayAfterDispense: ?number,
   /** offset from bottom of well in mm */
   dispenseOffsetFromBottomMm?: ?number,
 }
@@ -109,8 +107,6 @@ export type MixFormData = {
   /** Touch tip after mixing */
   touchTip: boolean,
   touchTipMmFromBottom?: ?number,
-  /** Delay in seconds */
-  delay: ?number,
   /** change tip: see comments in step-generation/mix.js */
   changeTip: ChangeTipOptions,
   /** If given, blow out in the specified labware after mixing each well */

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -46,12 +46,6 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     processValue: defaultTo([]),
   },
-  'dispense_delayMinutes': {
-    processValue: composeProcessors(castToNumber, defaultTo(0)),
-  },
-  'dispense_delaySeconds': {
-    processValue: composeProcessors(castToNumber, defaultTo(0)),
-  },
   'dispense_labware': {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -39,12 +39,6 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
 
   const blowoutLabwareId = hydratedFormData['dispense_blowout_labware']
 
-  const delay = hydratedFormData['dispense_delay_checkbox']
-    ? ((Number(hydratedFormData['dispense_delayMinutes']) || 0) * 60) +
-      (Number(hydratedFormData['dispense_delaySeconds'] || 0))
-    : null
-  // TODO Ian 2018-05-08 delay number parsing errors
-
   return {
     stepType: 'mix',
     name: `Mix ${hydratedFormData.id}`, // TODO real name for steps
@@ -55,7 +49,6 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
     times,
     touchTip,
     touchTipMmFromBottom,
-    delay,
     changeTip,
     blowout: blowoutLabwareId,
     pipette: pipette.id,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -46,11 +46,6 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
     ? hydratedFormData['dispense_touchTipMmFromBottom']
     : null
 
-  const delayAfterDispense = hydratedFormData['dispense_delay_checkbox']
-    ? ((Number(hydratedFormData['dispense_delayMinutes']) || 0) * 60) +
-      (Number(hydratedFormData['dispense_delaySeconds'] || 0))
-    : null
-
   const mixFirstAspirate = hydratedFormData['aspirate_mix_checkbox']
     ? {
       volume: Number(hydratedFormData['aspirate_mix_volume']),
@@ -86,7 +81,6 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
 
     blowout: blowoutLabwareId,
     changeTip,
-    delayAfterDispense,
     mixInDestination,
     preWetTip: hydratedFormData['aspirate_preWetTip'] || false,
     touchTipAfterAspirate,


### PR DESCRIPTION
## overview

Closes #2579

## changelog

* remove all traces of "delay" advanced setting from forms, type defs, unit test placeholders, etc

## review requests

Should be straightforward standard review. I'm pretty sure the removal is thorough because searching across PD for `delay` now only shows things related directly to the delay command creator (which the Pause step uses) and nothing else