### PR TITLE
fix(protocol-designer): fix missing disposal volume in new distribute forms

### DIFF
--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/TipPositionModal.js
@@ -60,7 +60,6 @@ class TipPositionModal extends React.Component<Props, State> {
   }
   applyChanges = () => {
     const {value} = this.state
-    console.log('applying changes', value)
     this.props.updateValue(value == null ? null : roundValue(value))
     this.props.closeModal()
   }

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -12,13 +12,11 @@ import {
 import i18n from '../../localization'
 import {selectors as pipetteSelectors} from '../../pipettes'
 import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
-import {actions} from '../../steplist'
 import {hydrateField} from '../../steplist/fieldLevel'
 import type {StepFieldName} from '../../steplist/fieldLevel'
-import {DISPOSAL_PERCENTAGE} from '../../steplist/formLevel/warnings'
 import {SOURCE_WELL_DISPOSAL_DESTINATION} from '../../steplist/formLevel/stepFormToArgs/transferLikeFormToArgs'
 import type {ChangeTipOptions} from '../../step-generation/types'
-import type {BaseState, ThunkDispatch} from '../../types'
+import type {BaseState} from '../../types'
 import type {StepType} from '../../form-types'
 import styles from './StepEditForm.css'
 import StepField from './StepFormField'
@@ -118,18 +116,12 @@ export function DispenseDelayFields (props: DispenseDelayFieldsProps) {
 
 type PipetteFieldOP = {name: StepFieldName, stepType?: StepType} & FocusHandlers
 type PipetteFieldSP = {pipetteOptions: Options, getHydratedPipette: (string) => any} // TODO: real hydrated pipette type
-type PipetteFieldDP = {updateDisposalVolume: (?mixed) => void}
-type PipetteFieldProps = PipetteFieldOP & PipetteFieldSP & PipetteFieldDP
+type PipetteFieldProps = PipetteFieldOP & PipetteFieldSP
 const PipetteFieldSTP = (state: BaseState, ownProps: PipetteFieldOP): PipetteFieldSP => ({
   pipetteOptions: pipetteSelectors.getEquippedPipetteOptions(state),
   getHydratedPipette: (value) => hydrateField(state, ownProps.name, value),
 })
-const PipetteFieldDTP = (dispatch: ThunkDispatch<*>): PipetteFieldDP => ({
-  updateDisposalVolume: (disposalVolume: ?mixed) => {
-    dispatch(actions.changeFormInput({update: {aspirate_disposalVol_volume: disposalVolume}}))
-  },
-})
-export const PipetteField = connect(PipetteFieldSTP, PipetteFieldDTP)((props: PipetteFieldProps) => (
+export const PipetteField = connect(PipetteFieldSTP)((props: PipetteFieldProps) => (
   <StepField
     name={props.name}
     focusedField={props.focusedField}
@@ -143,12 +135,6 @@ export const PipetteField = connect(PipetteFieldSTP, PipetteFieldDTP)((props: Pi
           onFocus={() => { props.onFieldFocus(props.name) }}
           onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
             updateValue(e.currentTarget.value)
-            if (props.stepType === 'distribute') {
-              const hydratedPipette = props.getHydratedPipette(e.currentTarget.value)
-              if (hydratedPipette) {
-                props.updateDisposalVolume(hydratedPipette.maxVolume * DISPOSAL_PERCENTAGE)
-              }
-            }
           }} />
       </FormGroup>
     )} />

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -58,4 +58,6 @@ export const DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP = -1
 export const DEFAULT_WELL_ORDER_FIRST_OPTION: 't2b' = 't2b'
 export const DEFAULT_WELL_ORDER_SECOND_OPTION: 'l2r' = 'l2r'
 
+export const DISPOSAL_VOLUME_PERCENTAGE = 0.2 // 20% percent of pipette capacity
+
 export const WELL_LABEL_OFFSET: number = 8

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -25,9 +25,10 @@ export type ChangeFormInputAction = {
 
 export const changeFormInput = (payload: ChangeFormPayload) =>
   (dispatch: ThunkDispatch<ChangeFormInputAction>, getState: GetState) => {
+    const unsavedForm = selectors.getUnsavedForm(getState())
     dispatch({
       type: 'CHANGE_FORM_INPUT',
-      payload: handleFormChange(payload, getState),
+      payload: handleFormChange(payload, unsavedForm, getState),
     })
   }
 

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -1,8 +1,9 @@
 // @flow
-import {selectors} from '../index'
+import handleFormChange from './handleFormChange'
 import {uuid} from '../../utils'
 import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
 import * as pipetteSelectors from '../../pipettes/selectors'
+import {selectors as steplistSelectors} from '../../steplist'
 import {actions as tutorialActions} from '../../tutorial'
 import {getNextDefaultPipetteId, generateNewForm} from '../formLevel'
 
@@ -14,25 +15,28 @@ export type SelectStepAction = {
   payload: StepIdType,
 }
 
+function isStepWithPipette (stepType: StepType) {
+  const pipetteStepTypes: Array<StepType> = [
+    'consolidate',
+    'distribute',
+    'transfer',
+  ]
+  return pipetteStepTypes.includes(stepType)
+}
+
 // get new or existing step for given stepId
 function getStepFormData (state: BaseState, stepId: StepIdType, newStepType?: StepType): ?FormData {
-  const existingStep = selectors.getSavedForms(state)[stepId]
+  const existingStep = steplistSelectors.getSavedForms(state)[stepId]
 
   if (existingStep) {
     return existingStep
   }
 
-  const defaultNextPipette = getNextDefaultPipetteId(
-    selectors.getSavedForms(state),
-    selectors.getOrderedSteps(state),
-    pipetteSelectors.getPipetteIdsByMount(state)
-  )
-
   // TODO: Ian 2018-09-19 sunset 'steps' reducer. Right now, it's needed here to get stepType
   // for any step that was created but never saved (never clicked Save button).
   // Instead, new steps should have their stepType immediately added
   // to 'savedStepForms' upon creation.
-  const steps = selectors.getSteps(state)
+  const steps = steplistSelectors.getSteps(state)
   const stepTypeFromStepReducer = steps[stepId] && steps[stepId].stepType
   const stepType = newStepType || stepTypeFromStepReducer
 
@@ -44,7 +48,6 @@ function getStepFormData (state: BaseState, stepId: StepIdType, newStepType?: St
   return generateNewForm({
     stepId,
     stepType: stepType,
-    defaultNextPipette,
   })
 }
 
@@ -58,7 +61,31 @@ export const selectStep = (stepId: StepIdType, newStepType?: StepType): ThunkAct
 
     dispatch(selectStepAction)
 
-    const formData = getStepFormData(getState(), stepId, newStepType)
+    const state = getState()
+    let formData = getStepFormData(getState(), stepId, newStepType)
+
+    const defaultPipetteId = getNextDefaultPipetteId(
+      steplistSelectors.getSavedForms(state),
+      steplistSelectors.getOrderedSteps(state),
+      pipetteSelectors.getEquippedPipettes(state),
+    )
+
+    // Set `pipette` field of new steps to the next default pipette id.
+    // In order to trigger dependent field changes (eg default disposal volume)
+    // update the form thru handleFormChange.
+    if (newStepType && isStepWithPipette(newStepType) && defaultPipetteId) {
+      const updatePayload = {update: {pipette: defaultPipetteId}}
+      const updatedFields = handleFormChange(
+        updatePayload,
+        formData,
+        getState).update
+
+      formData = {
+        ...formData,
+        ...updatedFields,
+      }
+    }
+
     dispatch({
       type: 'POPULATE_FORM',
       payload: formData,
@@ -96,7 +123,7 @@ export type ReorderSelectedStepAction = {
 
 export const reorderSelectedStep = (delta: number) =>
   (dispatch: ThunkDispatch<ReorderSelectedStepAction>, getState: GetState) => {
-    const stepId = selectors.getSelectedStepId(getState())
+    const stepId = steplistSelectors.getSelectedStepId(getState())
 
     if (stepId != null) {
       dispatch({

--- a/protocol-designer/src/steplist/formLevel/generateNewForm.js
+++ b/protocol-designer/src/steplist/formLevel/generateNewForm.js
@@ -8,17 +8,14 @@ import type {
   FormData,
 } from '../../form-types'
 
-const FORMS_WITH_PIPETTE = ['transfer', 'mix', 'distribute', 'consolidate']
-
 type NewFormArgs = {
   stepId: StepIdType,
   stepType: StepType,
-  defaultNextPipette: string,
 }
 
 // Add default values to a new step form
 export default function generateNewForm (args: NewFormArgs): FormData {
-  const {stepId, stepType, defaultNextPipette} = args
+  const {stepId, stepType} = args
   const baseForm: BlankForm = {
     id: stepId,
     stepType: stepType,
@@ -27,10 +24,6 @@ export default function generateNewForm (args: NewFormArgs): FormData {
   }
 
   let additionalFields = {}
-
-  if (FORMS_WITH_PIPETTE.includes(stepType)) {
-    additionalFields.pipette = defaultNextPipette
-  }
 
   return {
     ...baseForm,

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -24,6 +24,7 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
         'dispense_wells': [],
+        'pipette': null,
         'volume': undefined,
       }
     case 'consolidate':
@@ -37,6 +38,7 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'dispense_labware': null,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
         'dispense_wells': [],
+        'pipette': null,
         'volume': undefined,
       }
     case 'mix':
@@ -45,9 +47,10 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'labware': null,
         'aspirate_wellOrder_first': DEFAULT_WELL_ORDER_FIRST_OPTION,
         'aspirate_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
-        'wells': [],
         'mix_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE, // NOTE: mix uses dispense for both asp + disp, for now
+        'pipette': null,
         'volume': undefined,
+        'wells': [],
       }
     case 'distribute':
       return {
@@ -62,6 +65,7 @@ export default function getDefaultsForStepType (stepType: StepType) {
         'dispense_wellOrder_second': DEFAULT_WELL_ORDER_SECOND_OPTION,
         'dispense_mmFromBottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
         'dispense_wells': [],
+        'pipette': null,
         'volume': undefined,
       }
     default:

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/index.js
@@ -1,5 +1,7 @@
 // @flow
+import findKey from 'lodash/findKey'
 import last from 'lodash/last'
+import type {PipetteData} from '../../../step-generation'
 import type {StepIdType, FormData} from '../../../form-types'
 
 // TODO: Ian 2018-09-18 once we support switching pipettes mid-protocol,
@@ -11,7 +13,7 @@ import type {StepIdType, FormData} from '../../../form-types'
 export default function getNextDefaultPipetteId (
   savedForms: {[StepIdType]: FormData},
   orderedSteps: Array<StepIdType>,
-  pipetteIdsByMount: {left?: ?string, right?: ?string}
+  equippedPipettesById: {[string]: PipetteData}
 ): string {
   const prevPipetteSteps = orderedSteps
     .map(stepId => savedForms[stepId])
@@ -19,10 +21,11 @@ export default function getNextDefaultPipetteId (
 
   const lastPipetteStep = last(prevPipetteSteps)
 
-  const nextDefaultPipette = (
+  // NOTE: order of findKey not guaranteed, expecting at most one pipette on each mount
+  const nextDefaultPipette: ?string = (
     (lastPipetteStep && lastPipetteStep.pipette) ||
-    pipetteIdsByMount['left'] ||
-    pipetteIdsByMount['right']
+    findKey(equippedPipettesById, p => p.mount === 'left') ||
+    findKey(equippedPipettesById, p => p.mount === 'right')
   )
 
   if (!nextDefaultPipette) {

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
@@ -6,17 +6,20 @@ describe('getNextDefaultPipetteId', () => {
     const testCases = [
       {
         testMsg: 'both pipettes present: use left pipette',
-        equippedPipettes: {'left': 'leftId', 'right': 'rightId'},
+        equippedPipettesById: {
+          'leftId': {id: 'leftId', mount: 'left'},
+          'rightId': {id: 'rightId', mount: 'right'},
+        },
         expected: 'leftId',
       },
       {
         testMsg: 'right only: use right',
-        equippedPipettes: {'right': 'rightId'},
+        equippedPipettesById: {'rightId': {id: 'rightId', mount: 'right'}},
         expected: 'rightId',
       },
     ]
 
-    testCases.forEach(({testMsg, equippedPipettes, expected}) => {
+    testCases.forEach(({testMsg, equippedPipettesById, expected}) => {
       test(testMsg, () => {
         const savedForms = {}
         const orderedSteps = []
@@ -24,7 +27,7 @@ describe('getNextDefaultPipetteId', () => {
         const result = getNextDefaultPipetteId(
           savedForms,
           orderedSteps,
-          equippedPipettes)
+          equippedPipettesById)
 
         expect(result).toBe(expected)
       })
@@ -41,7 +44,7 @@ describe('getNextDefaultPipetteId', () => {
       {
         testMsg: 'no previous forms use pipettes',
         orderedSteps: ['x', 'x', 'x'],
-        expected: 'default',
+        expected: 'defaultId',
       },
       {
         testMsg: 'mix of steps with and without pipettes',
@@ -56,7 +59,7 @@ describe('getNextDefaultPipetteId', () => {
       {
         testMsg: 'only missing steps',
         orderedSteps: ['missingStep', 'missingStep'],
-        expected: 'default',
+        expected: 'defaultId',
       },
     ]
 
@@ -68,12 +71,12 @@ describe('getNextDefaultPipetteId', () => {
           x: {}, // no 'pipette' key, eg a Pause step
         }
 
-        const equippedPipettes = {left: 'default'}
+        const equippedPipettesById = {'defaultId': {id: 'defaultId', mount: 'left'}}
 
         const result = getNextDefaultPipetteId(
           savedForms,
           orderedSteps,
-          equippedPipettes)
+          equippedPipettesById)
 
         expect(result).toBe(expected)
       })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -26,7 +26,6 @@ type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferF
 
 // TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArgs => {
-  console.log([hydratedFormData])
   const stepType = hydratedFormData.stepType
   const pipette = hydratedFormData['pipette']
   const volume = Number(hydratedFormData['volume'])

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
 import {getWellTotalVolume} from '@opentrons/shared-data'
+import {DISPOSAL_VOLUME_PERCENTAGE} from '../../constants'
 import type {StepFieldName} from '../../form-types'
 import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 
-export const DISPOSAL_PERCENTAGE = 0.2 // 20% percent of pipette capacity
 /*******************
 ** Warning Messages **
 ********************/
@@ -62,7 +62,7 @@ export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   if (!pipette) return null
   const isUnselected = !aspirate_disposalVol_checkbox || !aspirate_disposalVol_volume
   if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
-  const isBelowMin = aspirate_disposalVol_volume < (DISPOSAL_PERCENTAGE * pipette.maxVolume)
+  const isBelowMin = aspirate_disposalVol_volume < (DISPOSAL_VOLUME_PERCENTAGE * pipette.maxVolume)
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
 }
 


### PR DESCRIPTION
## overview

Closes #2705. This is a bug fix and a refactor to move towards making `handleChangeForm` the single central place to handle form field value updates to trigger changes in other field values.

## changelog

* rewrite handleChangeForm to be given a base form (instead of always using unsavedForm)

## review requests

- Bug is fixed? Creating a new distribute should auto-fill the disposal volume field with 20% of the default pipette that has automatically been selected. Leaving the pristine step and going back to it, you should see the same thing.

- No new bugs? Eg if you look at the POPULATE_FORM action payload which sets the values of `unsavedForm`, you shouldn't see `pipette` field in any pause steps, and you shouldn't see `aspirate_disposalVol_volume` etc in non-distribute steps, and so on.

- Code changes OK?