### PR TITLE
refactor(app): Add app update message and release notes toggle

### DIFF
--- a/app/src/components/AppSettings/UpdateApp/RestartAppModal.js
+++ b/app/src/components/AppSettings/UpdateApp/RestartAppModal.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+
+import {Portal} from '../../portal'
+import {ScrollableAlertModal} from '../../modals'
+import UpdateAppMessage from './UpdateAppMessage'
+
+type Props = {
+  availableVersion: ?string,
+  applyUpdate: () => mixed,
+  closeModal: () => mixed,
+}
+export default function RestartAppModal (props: Props) {
+  const {availableVersion, applyUpdate, closeModal} = props
+  return (
+    <Portal>
+      <ScrollableAlertModal
+        heading={`App Version ${availableVersion || ''} Downloaded`}
+        buttons={[
+          {onClick: closeModal, children: 'not now'},
+          {onClick: applyUpdate, children: 'restart app'},
+        ]}
+      >
+        <UpdateAppMessage downloaded />
+      </ScrollableAlertModal>
+    </Portal>
+  )
+}

--- a/app/src/components/AppSettings/UpdateApp/UpdateAppMessage.js
+++ b/app/src/components/AppSettings/UpdateApp/UpdateAppMessage.js
@@ -1,0 +1,41 @@
+// @flow
+
+import * as React from 'react'
+import styles from './styles.css'
+
+type Props = {
+  downloaded?: boolean,
+}
+
+const UPDATE_MESSAGE = (
+  <p className={styles.update_message}>
+    We recommend that you update to the latest version. <br />
+    Please note the following:
+  </p>
+)
+
+const RESTART_MESSAGE = (
+  <p className={styles.update_message}>
+    Restart your app to complete the update. <br />
+    Please note the following:
+  </p>
+)
+
+export default function UpdateAppMessage (props: Props) {
+  const message = props.downloaded ? RESTART_MESSAGE : UPDATE_MESSAGE
+  return (
+    <React.Fragment>
+      {message}
+
+      <p className={styles.update_message}>
+        1) After updating your app, we recommend you update your robot version
+        to ensure the app and robot versions are in sync.
+      </p>
+
+      <p className={styles.update_message}>
+        2) If you are using more than one computer to operate your robot, please
+        update the app on those computers as well.
+      </p>
+    </React.Fragment>
+  )
+}

--- a/app/src/components/AppSettings/UpdateApp/UpdateAppModal.js
+++ b/app/src/components/AppSettings/UpdateApp/UpdateAppModal.js
@@ -1,0 +1,74 @@
+// @flow
+import * as React from 'react'
+
+import {Portal} from '../../portal'
+import {ScrollableAlertModal} from '../../modals'
+import UpdateAppMessage from './UpdateAppMessage'
+import ReleaseNotes from '../../ReleaseNotes'
+
+import type {ShellUpdateState} from '../../../shell'
+import type {ButtonProps} from '@opentrons/components'
+
+type Props = {
+  update: ShellUpdateState,
+  availableVersion: ?string,
+  downloadUpdate: () => mixed,
+  applyUpdate: () => mixed,
+  closeModal: () => mixed,
+}
+
+type UpdateAppState = {
+  showReleaseNotes: boolean,
+}
+
+export default class UpdateAppModal extends React.Component<
+  Props,
+  UpdateAppState
+> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {showReleaseNotes: false}
+  }
+
+  setShowReleaseNotes = () => {
+    this.setState({showReleaseNotes: true})
+  }
+
+  render () {
+    const {
+      downloadUpdate,
+      closeModal,
+      availableVersion,
+      update: {info},
+    } = this.props
+    const {showReleaseNotes} = this.state
+
+    let children: ?React.Node
+    let button: ?ButtonProps
+
+    if (showReleaseNotes) {
+      button = {
+        children: 'download',
+        onClick: downloadUpdate,
+      }
+      children = <ReleaseNotes source={info && info.releaseNotes} />
+    } else {
+      button = {
+        children: 'View App Update',
+        onClick: this.setShowReleaseNotes,
+      }
+      children = <UpdateAppMessage />
+    }
+
+    return (
+      <Portal>
+        <ScrollableAlertModal
+          heading={`App Version ${availableVersion || ''} Available`}
+          buttons={[{onClick: closeModal, children: 'not now'}, button]}
+        >
+          {children}
+        </ScrollableAlertModal>
+      </Portal>
+    )
+  }
+}

--- a/app/src/components/AppSettings/UpdateApp/index.js
+++ b/app/src/components/AppSettings/UpdateApp/index.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+
+import {SpinnerModal} from '@opentrons/components'
+import UpdateAppModal from './UpdateAppModal'
+import RestartAppModal from './RestartAppModal'
+
+import type {ShellUpdateState} from '../../../shell'
+
+type Props = {
+  update: ShellUpdateState,
+  availableVersion: ?string,
+  checkUpdate: () => mixed,
+  downloadUpdate: () => mixed,
+  applyUpdate: () => mixed,
+  closeModal: () => mixed,
+}
+export default function UpdateApp (props: Props) {
+  const {downloaded, downloading} = props.update
+
+  if (downloaded) {
+    return <RestartAppModal {...props} />
+  } else if (downloading) {
+    return <SpinnerModal message="Download in progress" alertOverlay />
+  } else {
+    return <UpdateAppModal {...props} />
+  }
+}

--- a/app/src/components/AppSettings/UpdateApp/styles.css
+++ b/app/src/components/AppSettings/UpdateApp/styles.css
@@ -1,0 +1,7 @@
+@import '@opentrons/components';
+
+.update_message {
+  @apply --font-body-2-dark;
+
+  margin: 1rem;
+}

--- a/app/src/components/RobotSettings/ReachableRobotBanner.js
+++ b/app/src/components/RobotSettings/ReachableRobotBanner.js
@@ -18,7 +18,7 @@ const LAST_RESORT = (
 
 const RESTARTING_MESSAGE = (
   <div className={styles.banner}>
-    <p>Your robot is restarting, and should be back online shortly.</p>
+    <p>Your robot is restarting and should be back online shortly.</p>
     {LAST_RESORT}
   </div>
 )

--- a/app/src/pages/More/AppSettings.js
+++ b/app/src/pages/More/AppSettings.js
@@ -2,8 +2,11 @@
 // view info about the app and update
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {getIn} from '@thi.ng/paths'
 import {Route, Switch, Redirect, type ContextRouter} from 'react-router'
 import {push} from 'react-router-redux'
+
+import {getConfig} from '../../config'
 
 import {
   getShellUpdateState,
@@ -16,6 +19,7 @@ import {
 
 import Page from '../../components/Page'
 import AppSettings, {AppUpdateModal} from '../../components/AppSettings'
+import UpdateApp from '../../components/AppSettings/UpdateApp'
 import {ErrorModal} from '../../components/modals'
 
 import type {State} from '../../types'
@@ -26,6 +30,7 @@ type OP = ContextRouter
 type SP = {
   update: ShellUpdateState,
   availableVersion: ?string,
+  __featureEnabled: boolean,
 }
 
 type DP = {
@@ -36,6 +41,8 @@ type DP = {
 }
 
 type Props = OP & SP & DP
+
+const __FEATURE_FLAG = 'devInternal.newUpdateModal'
 
 export default connect(
   mapStateToProps,
@@ -49,6 +56,7 @@ function AppSettingsPage (props: Props) {
     closeModal,
     update: {available, seen, error},
     match: {path},
+    __featureEnabled,
   } = props
 
   return (
@@ -64,7 +72,11 @@ function AppSettingsPage (props: Props) {
           path={`${path}/update`}
           render={() =>
             !error ? (
-              <AppUpdateModal {...props} />
+              __featureEnabled ? (
+                <UpdateApp {...props} />
+              ) : (
+                <AppUpdateModal {...props} />
+              )
             ) : (
               <ErrorModal
                 heading="Update Error"
@@ -89,6 +101,7 @@ function mapStateToProps (state: State): SP {
   return {
     update: getShellUpdateState(state),
     availableVersion: getAvailableShellUpdate(state),
+    __featureEnabled: !!getIn(getConfig(state), __FEATURE_FLAG),
   }
 }
 


### PR DESCRIPTION
## overview

This PR addresses #2401 by updating the app update modal to follow a similar flow to robot update
This [screen](https://app.zeplin.io/project/5aa97729db58a2192f10d0d6/screen/5bcff6296bc6d61900626ef9) in particular.

## changelog

- refactor(app): Add app update message and release notes toggle behind feature flag

## review requests

Can be tested on VS

`make -C app dev OT_APP_DEV_INTERNAL__NEW_UPDATE_MODAL=1` to enable new upgrade/downgrade modal feature flag

change `package.json` in `app-shell` to earlier app version so that an app update is available

- [ ] Update App modal auto pop-up when app update available and not ignored/seen
- [ ] Notification dot renders on 'More' tab of main nav
- [ ] Clicking [View Available Update] opens update modal
- [ ] App update modal renders update app message and tips
  - [ ] Heading reads App Version {version} Available
  - [ ] Buttons = [Not Now] and [View App Update]
- [ ] Clicking [View App Update] hides initial message and renders release notes
  - [ ] Buttons = [Not Now] and [Download]
- [ ] Clicking [Download] sends download update request
  - [ ] Spinner modal renders while download in progress
- [ ] On download complete reset app modal renders with message and tips
- [ ] Clicking [Restart App] restarts app

- [ ] Clicking [Not Now] button in any modal closes update modals and sets update seen
- [ ] Original app update modal flow unaffected (feature flag not enabled)

