### PR TITLE
feat(protocol-designer): remove option of tiprack-1000ul-chem from pd

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -28,7 +28,6 @@ const hardcodedLabware = {
     ['tiprack-200ul', '200uL Tip Rack', 'Tiprack-200ul'],
     ['opentrons-tiprack-300ul', '300µL Tip Rack', 'Tiprack-200ul'],
     ['tiprack-1000ul', '1000µL Tip Rack', 'Tiprack-200ul'],
-    ['tiprack-1000ul-chem', '10x10 1000µL Chem-Tip Rack', 'Tiprack-1000ul-chem'],
   ],
   'Aluminum Block': [
     ['opentrons-aluminum-block-2ml-eppendorf', 'Aluminum Block - 2mL Eppendorf Tubes'],

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -57,7 +57,6 @@ const tiprackOptions = [
   {name: '200 μL', value: 'tiprack-200ul'},
   {name: '300 μL', value: 'opentrons-tiprack-300ul'},
   {name: '1000 μL', value: 'tiprack-1000ul'},
-  {name: '1000 μL Chem', value: 'tiprack-1000ul-chem'},
 ]
 
 const DEFAULT_SELECTION = {pipetteModel: '', tiprackModel: null}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -51,7 +51,6 @@ const tiprackOptions = [
   {name: '200 μL', value: 'tiprack-200ul'},
   {name: '300 μL', value: 'opentrons-tiprack-300ul'},
   {name: '1000 μL', value: 'tiprack-1000ul'},
-  {name: '1000 μL Chem', value: 'tiprack-1000ul-chem'},
 ]
 
 const initialState = {

--- a/protocol-designer/src/images/labware/index.js
+++ b/protocol-designer/src/images/labware/index.js
@@ -9,7 +9,6 @@ const _fileMap = {
   'Tiprack-10ul': require('./Tiprack-10ul.png'),
   'Tiprack-200ul': require('./Tiprack-200ul.png'),
   'Tiprack-1000': require('./Tiprack-1000.png'),
-  'Tiprack-1000ul-chem': require('./Tiprack-1000ul-chem.png'),
   'Trough-12row': require('./Trough-12row.png'),
   'Tuberack-2ml': require('./Tuberack-2ml.png'),
   'Tuberack-15-50ml': require('./Tuberack-15-50ml.png'),


### PR DESCRIPTION
## overview

With #2614 we are planning to remove the `tiprack-1000ul-chem` definition (this is the non-grid, staggered layout tiprack). This PR serves as its own ticket, it removes the 1000-chem tiprack from PD to prepare for the removal of this labware.

As of now, this is the only labware that #2614 will remove which will affect PD. The other labware to be removed aren't in PD.

## changelog

* remove ability to add `tiprack-1000ul-chem` to the deck or select it for a pipette

## review requests

Is it OK to remove this now? I haven't heard of anyone ever using this tiprack since I've been working here so IMO it should be safe.