### PR TITLE
feat(protocol-designer): place tipracks on protocol creation

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -32,7 +32,7 @@ import type {
 import * as actions from '../actions'
 import {getPDMetadata} from '../../file-types'
 import type {BaseState, Options} from '../../types'
-import type {LoadFileAction} from '../../load-file'
+import type {LoadFileAction, NewProtocolFields} from '../../load-file'
 import type {
   RemoveWellsContents,
   DeleteLiquidGroup,
@@ -194,6 +194,30 @@ export const containers = handleActions({
         },
       }
     }, {})
+  },
+  CREATE_NEW_PROTOCOL: (
+    state: ContainersState,
+    action: {payload: NewProtocolFields}
+  ): ContainersState => {
+    const initialTipracks = [action.payload.left, action.payload.right].reduce((acc, mount) => {
+      if (mount.tiprackModel) {
+        const id = `${uuid()}:${String(mount.tiprackModel)}`
+        return {
+          ...acc,
+          [id]: {
+            slot: nextEmptySlot(_loadedContainersBySlot({...state, ...acc})),
+            type: mount.tiprackModel,
+            disambiguationNumber: getNextDisambiguationNumber({...state, ...acc}, String(mount.tiprackModel)),
+            id,
+            name: null, // create with null name, so we force explicit naming.
+          },
+        }
+      }
+    }, {})
+    return {
+      ...state,
+      ...initialTipracks,
+    }
   },
 }, initialLabwareState)
 

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -205,19 +205,16 @@ export const containers = handleActions({
         return {
           ...acc,
           [id]: {
-            slot: nextEmptySlot(_loadedContainersBySlot({...state, ...acc})),
+            slot: nextEmptySlot(_loadedContainersBySlot(acc || {})),
             type: mount.tiprackModel,
-            disambiguationNumber: getNextDisambiguationNumber({...state, ...acc}, String(mount.tiprackModel)),
+            disambiguationNumber: getNextDisambiguationNumber(acc || {}, String(mount.tiprackModel)),
             id,
             name: null, // create with null name, so we force explicit naming.
           },
         }
       }
-    }, {})
-    return {
-      ...state,
-      ...initialTipracks,
-    }
+    }, state)
+    return initialTipracks || {}
   },
 }, initialLabwareState)
 


### PR DESCRIPTION
By default, when a user creates a protocol, one tip rack for each given mount should be placed on
the deck.

Closes #1327

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
