### PR TITLE
refactor(app): Simplify upgrade/downgrade modal render logic

### DIFF
--- a/app/src/components/RobotSettings/UpdateRobot/ReinstallModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/ReinstallModal.js
@@ -12,7 +12,7 @@ type Props = {
   update: () => mixed,
 }
 
-const HEADING = 'Robot is up to date'
+const HEADING = 'Robot Server is up to date'
 const REINSTALL_MESSAGE =
   "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
 
@@ -27,7 +27,7 @@ export default function ReinstallModal (props: Props) {
       ]}
       alertOverlay
     >
-      <p className={styles.sync_message}>{REINSTALL_MESSAGE}</p>
+      <p className={styles.reinstall_message}>{REINSTALL_MESSAGE}</p>
       <VersionList {...versionProps} ignoreAppUpdate />
     </AlertModal>
   )

--- a/app/src/components/RobotSettings/UpdateRobot/ReinstallModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/ReinstallModal.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+import {AlertModal} from '@opentrons/components'
+import VersionList from './VersionList'
+import type {VersionProps} from './types'
+import styles from './styles.css'
+
+type Props = {
+  versionProps: VersionProps,
+  parentUrl: string,
+  update: () => mixed,
+}
+
+const HEADING = 'Robot is up to date'
+const REINSTALL_MESSAGE =
+  "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
+
+export default function ReinstallModal (props: Props) {
+  const {parentUrl, update, versionProps} = props
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {Component: Link, to: parentUrl, children: 'not now'},
+        {onClick: update, children: 'Reinstall'},
+      ]}
+      alertOverlay
+    >
+      <p className={styles.sync_message}>{REINSTALL_MESSAGE}</p>
+      <VersionList {...versionProps} ignoreAppUpdate />
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateRobot/SkipAppUpdateMessage.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SkipAppUpdateMessage.js
@@ -1,17 +1,15 @@
 // @flow
 import * as React from 'react'
 import styles from './styles.css'
-import type {VersionProps} from './types.js'
+
 type Props = {
-  ...$Exact<VersionProps>,
   onClick: () => mixed,
 }
 
 const SKIP_APP_MESSAGE =
   'If you wish to skip this app update and only sync your robot server with your current app version, please '
+
 export default function SkipAppUpdateMessage (props: Props) {
-  const {appVersion, robotVersion} = props
-  if (appVersion === robotVersion) return null
   return (
     <p className={styles.sync_message}>
       {SKIP_APP_MESSAGE}

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotMessage.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotMessage.js
@@ -4,7 +4,6 @@ import styles from './styles.css'
 import type {RobotUpdateInfo} from '../../../http-api-client'
 type Props = {
   updateInfo: RobotUpdateInfo,
-  appVersion: string,
 }
 
 const notSyncedMessage = (
@@ -15,8 +14,7 @@ const notSyncedMessage = (
 
 export default function SyncRobotMessage (props: Props) {
   const {
-    appVersion,
-    updateInfo: {type},
+    updateInfo: {type, version},
   } = props
 
   if (type === 'upgrade') {
@@ -32,7 +30,7 @@ export default function SyncRobotMessage (props: Props) {
     return (
       <p className={styles.sync_message}>
         {notSyncedMessage}
-        You may wish to downgrade to robot server version {appVersion} to ensure
+        You may wish to downgrade to robot server version {version} to ensure
         compatibility.
       </p>
     )

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotMessage.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotMessage.js
@@ -37,10 +37,3 @@ export default function SyncRobotMessage (props: Props) {
   }
   return null
 }
-
-const REINSTALL_MESSAGE =
-  "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
-
-export function ReinstallMessage () {
-  return <p className={styles.sync_message}>{REINSTALL_MESSAGE}</p>
-}

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -1,0 +1,102 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+import SyncRobotMessage from './SyncRobotMessage'
+import VersionList from './VersionList'
+import {ScrollableAlertModal} from '../../modals'
+import ReleaseNotes from '../../ReleaseNotes'
+
+import {API_RELEASE_NOTES} from '../../../shell'
+
+import type {VersionProps} from './types'
+import type {RobotUpdateInfo} from '../../../http-api-client'
+import type {ButtonProps} from '@opentrons/components'
+type Props = {
+  versionProps: VersionProps,
+  updateInfo: RobotUpdateInfo,
+  parentUrl: string,
+  ignoreUpdate: () => mixed,
+  update: () => mixed,
+}
+
+type SyncRobotState = {
+  showReleaseNotes: boolean,
+}
+
+export default class SyncRobotModal extends React.Component<
+  Props,
+  SyncRobotState
+> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {showReleaseNotes: false}
+  }
+
+  setShowReleaseNotes = () => {
+    this.setState({showReleaseNotes: true})
+  }
+
+  render () {
+    const {
+      updateInfo,
+      versionProps,
+      update,
+      ignoreUpdate,
+      parentUrl,
+    } = this.props
+    const {availableUpdate} = versionProps
+    const {showReleaseNotes} = this.state
+
+    const heading = `Version ${availableUpdate} available`
+    let buttons: Array<?ButtonProps>
+
+    if (showReleaseNotes) {
+      buttons = [
+        {onClick: ignoreUpdate, children: 'not now'},
+        {
+          children: 'Update Robot Server',
+          onClick: update,
+        },
+      ]
+    } else if (updateInfo.type === 'upgrade') {
+      buttons = [
+        {onClick: ignoreUpdate, children: 'not now'},
+        {
+          children: 'View Robot Server Update',
+          onClick: this.setShowReleaseNotes,
+        },
+      ]
+    } else if (updateInfo.type === 'downgrade') {
+      buttons = [
+        {Component: Link, to: parentUrl, children: 'not now'},
+        {
+          children: 'Downgrade Robot',
+          onClick: update,
+        },
+      ]
+    }
+
+    return (
+      <ScrollableAlertModal
+        heading={heading}
+        buttons={buttons}
+        alertOverlay
+        key={String(showReleaseNotes)}
+      >
+        {showReleaseNotes ? (
+          <ReleaseNotes source={API_RELEASE_NOTES} />
+        ) : (
+          <React.Fragment>
+            <SyncRobotMessage
+              updateInfo={updateInfo}
+              // TODO fix this to only be available robot version
+              appVersion={availableUpdate}
+            />
+            <VersionList {...versionProps} ignoreAppUpdate />
+          </React.Fragment>
+        )}
+      </ScrollableAlertModal>
+    )
+  }
+}

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -18,6 +18,7 @@ type Props = {
   versionProps: VersionProps,
   ignoreUpdate: () => mixed,
   update: () => mixed,
+  showReleaseNotes: boolean,
 }
 
 type SyncRobotState = {
@@ -30,7 +31,7 @@ export default class SyncRobotModal extends React.Component<
 > {
   constructor (props: Props) {
     super(props)
-    this.state = {showReleaseNotes: false}
+    this.state = {showReleaseNotes: this.props.showReleaseNotes}
   }
 
   setShowReleaseNotes = () => {

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -45,11 +45,11 @@ export default class SyncRobotModal extends React.Component<
       ignoreUpdate,
       parentUrl,
     } = this.props
-    // should this always be the app version for sync purposes?
+
     const {version} = updateInfo
     const {showReleaseNotes} = this.state
 
-    const heading = `Version ${version} available`
+    const heading = `Robot Server Version ${version} Available`
     let buttons: Array<?ButtonProps>
 
     if (showReleaseNotes) {

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -12,13 +12,13 @@ import {API_RELEASE_NOTES} from '../../../shell'
 import type {RobotUpdateInfo} from '../../../http-api-client'
 import type {VersionProps} from './types'
 import type {ButtonProps} from '@opentrons/components'
+
 type Props = {
   updateInfo: RobotUpdateInfo,
   parentUrl: string,
   versionProps: VersionProps,
   ignoreUpdate: () => mixed,
   update: () => mixed,
-  showReleaseNotes: boolean,
 }
 
 type SyncRobotState = {
@@ -31,7 +31,7 @@ export default class SyncRobotModal extends React.Component<
 > {
   constructor (props: Props) {
     super(props)
-    this.state = {showReleaseNotes: this.props.showReleaseNotes}
+    this.state = {showReleaseNotes: false}
   }
 
   setShowReleaseNotes = () => {

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -19,6 +19,7 @@ type Props = {
   versionProps: VersionProps,
   ignoreUpdate: () => mixed,
   update: () => mixed,
+  showReleaseNotes: boolean,
 }
 
 type SyncRobotState = {
@@ -31,7 +32,7 @@ export default class SyncRobotModal extends React.Component<
 > {
   constructor (props: Props) {
     super(props)
-    this.state = {showReleaseNotes: false}
+    this.state = {showReleaseNotes: this.props.showReleaseNotes}
   }
 
   setShowReleaseNotes = () => {

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -9,13 +9,13 @@ import ReleaseNotes from '../../ReleaseNotes'
 
 import {API_RELEASE_NOTES} from '../../../shell'
 
-import type {VersionProps} from './types'
 import type {RobotUpdateInfo} from '../../../http-api-client'
+import type {VersionProps} from './types'
 import type {ButtonProps} from '@opentrons/components'
 type Props = {
-  versionProps: VersionProps,
   updateInfo: RobotUpdateInfo,
   parentUrl: string,
+  versionProps: VersionProps,
   ignoreUpdate: () => mixed,
   update: () => mixed,
 }
@@ -45,10 +45,11 @@ export default class SyncRobotModal extends React.Component<
       ignoreUpdate,
       parentUrl,
     } = this.props
-    const {availableUpdate} = versionProps
+    // should this always be the app version for sync purposes?
+    const {version} = updateInfo
     const {showReleaseNotes} = this.state
 
-    const heading = `Version ${availableUpdate} available`
+    const heading = `Version ${version} available`
     let buttons: Array<?ButtonProps>
 
     if (showReleaseNotes) {
@@ -88,11 +89,7 @@ export default class SyncRobotModal extends React.Component<
           <ReleaseNotes source={API_RELEASE_NOTES} />
         ) : (
           <React.Fragment>
-            <SyncRobotMessage
-              updateInfo={updateInfo}
-              // TODO fix this to only be available robot version
-              appVersion={availableUpdate}
-            />
+            <SyncRobotMessage updateInfo={updateInfo} />
             <VersionList {...versionProps} ignoreAppUpdate />
           </React.Fragment>
         )}

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
@@ -11,22 +11,23 @@ import type {VersionProps} from './types'
 
 type Props = {
   versionProps: VersionProps,
-  parentUrl: string,
+  ignoreUpdate: () => mixed,
   onClick: () => mixed,
 }
 
 export default function UpdateAppModal (props: Props) {
-  const {parentUrl, versionProps, onClick} = props
+  const {versionProps, onClick, ignoreUpdate} = props
   const HEADING = `Robot Server Version ${
     versionProps.availableUpdate
   } Available`
   return (
     <AlertModal
       heading={HEADING}
+      // Ignore available robot update on robot, set app update to seen in state
+      // TODO: set app update to seen
       buttons={[
         {
-          Component: Link,
-          to: parentUrl,
+          onClick: ignoreUpdate,
           children: 'not now',
         },
         {

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
@@ -1,0 +1,43 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+import {AlertModal} from '@opentrons/components'
+import UpdateAppMessage from './UpdateAppMessage'
+import VersionList from './VersionList'
+import SkipAppUpdateMessage from './SkipAppUpdateMessage'
+
+import type {VersionProps} from './types'
+
+type Props = {
+  versionProps: VersionProps,
+  parentUrl: string,
+  onClick: () => mixed,
+}
+
+export default function UpdateAppModal (props: Props) {
+  const {parentUrl, versionProps, onClick} = props
+  const HEADING = `Version ${versionProps.availableUpdate} available`
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        {
+          Component: Link,
+          to: parentUrl,
+          children: 'not now',
+        },
+        {
+          Component: Link,
+          to: '/menu/app/update',
+          children: 'View App Update',
+        },
+      ]}
+      alertOverlay
+    >
+      <UpdateAppMessage {...versionProps} />
+      <VersionList {...versionProps} />
+      <SkipAppUpdateMessage onClick={onClick} />
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
@@ -7,29 +7,37 @@ import UpdateAppMessage from './UpdateAppMessage'
 import VersionList from './VersionList'
 import SkipAppUpdateMessage from './SkipAppUpdateMessage'
 
+import type {RobotUpdateInfo} from '../../../http-api-client'
 import type {VersionProps} from './types'
 
 type Props = {
+  updateInfo: RobotUpdateInfo,
+  parentUrl: string,
   versionProps: VersionProps,
   ignoreUpdate: () => mixed,
   onClick: () => mixed,
 }
 
 export default function UpdateAppModal (props: Props) {
-  const {versionProps, onClick, ignoreUpdate} = props
+  const {updateInfo, parentUrl, versionProps, onClick, ignoreUpdate} = props
   const HEADING = `Robot Server Version ${
     versionProps.availableUpdate
   } Available`
+  const isUpgrade = updateInfo.type === 'upgrade'
+  let notNowButton
+  if (isUpgrade) {
+    notNowButton = {
+      onClick: ignoreUpdate,
+      children: 'not now',
+    }
+  } else {
+    notNowButton = {Component: Link, to: parentUrl, children: 'not now'}
+  }
   return (
     <AlertModal
       heading={HEADING}
-      // Ignore available robot update on robot, set app update to seen in state
-      // TODO: set app update to seen
       buttons={[
-        {
-          onClick: ignoreUpdate,
-          children: 'not now',
-        },
+        notNowButton,
         {
           Component: Link,
           to: '/menu/app/update',

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateAppModal.js
@@ -17,7 +17,9 @@ type Props = {
 
 export default function UpdateAppModal (props: Props) {
   const {parentUrl, versionProps, onClick} = props
-  const HEADING = `Version ${versionProps.availableUpdate} available`
+  const HEADING = `Robot Server Version ${
+    versionProps.availableUpdate
+  } Available`
   return (
     <AlertModal
       heading={HEADING}

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -81,9 +81,11 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
     } else if (robotUpdateInfo.type) {
       return (
         <SyncRobotModal
-          {...this.props}
-          versionProps={versionProps}
           updateInfo={robotUpdateInfo}
+          parentUrl={parentUrl}
+          versionProps={versionProps}
+          update={this.props.update}
+          ignoreUpdate={this.props.ignoreUpdate}
         />
       )
     } else {

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -74,6 +74,8 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
     if (appUpdateAvailable && !ignoreAppUpdate) {
       return (
         <UpdateAppModal
+          updateInfo={robotUpdateInfo}
+          parentUrl={parentUrl}
           onClick={onClick}
           versionProps={versionProps}
           ignoreUpdate={this.props.ignoreUpdate}

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -69,11 +69,13 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
     const robotUpdateVersion = robotUpdateInfo.version
     const availableUpdate = appUpdateVersion || robotUpdateVersion
     const versionProps = {appVersion, robotVersion, availableUpdate}
+    const isUpgrade = robotUpdateInfo.type === 'upgrade'
+    const onClick = isUpgrade ? this.setIgnoreAppUpdate : this.props.update
 
     if (appUpdateAvailable && !ignoreAppUpdate) {
       return (
         <UpdateAppModal
-          onClick={this.setIgnoreAppUpdate}
+          onClick={onClick}
           versionProps={versionProps}
           parentUrl={parentUrl}
         />
@@ -86,6 +88,7 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
           versionProps={versionProps}
           update={this.props.update}
           ignoreUpdate={this.props.ignoreUpdate}
+          showReleaseNotes={isUpgrade && ignoreAppUpdate}
         />
       )
     } else {

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -12,7 +12,7 @@ import {
 
 import {getRobotApiVersion} from '../../../discovery'
 
-import {CURRENT_VERSION, getShellUpdateState} from '../../../shell'
+import {CURRENT_VERSION} from '../../../shell'
 
 import UpdateAppModal from './UpdateAppModal'
 import SyncRobotModal from './SyncRobotModal'
@@ -23,12 +23,11 @@ import type {ShellUpdateState} from '../../../shell'
 import type {ViewableRobot} from '../../../discovery'
 import type {RobotUpdateInfo} from '../../../http-api-client'
 
-type OP = {robot: ViewableRobot}
+type OP = {robot: ViewableRobot, appUpdate: ShellUpdateState}
 
 type SP = {|
   appVersion: string,
   robotVersion: string,
-  appUpdate: ShellUpdateState,
   robotUpdateInfo: RobotUpdateInfo,
 |}
 
@@ -69,15 +68,13 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
     const robotUpdateVersion = robotUpdateInfo.version
     const availableUpdate = appUpdateVersion || robotUpdateVersion
     const versionProps = {appVersion, robotVersion, availableUpdate}
-    const isUpgrade = robotUpdateInfo.type === 'upgrade'
-    const onClick = isUpgrade ? this.setIgnoreAppUpdate : this.props.update
 
     if (appUpdateAvailable && !ignoreAppUpdate) {
       return (
         <UpdateAppModal
-          onClick={onClick}
+          onClick={this.props.update}
           versionProps={versionProps}
-          parentUrl={parentUrl}
+          ignoreUpdate={this.props.ignoreUpdate}
         />
       )
     } else if (robotUpdateInfo.type) {
@@ -88,7 +85,6 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
           versionProps={versionProps}
           update={this.props.update}
           ignoreUpdate={this.props.ignoreUpdate}
-          showReleaseNotes={isUpgrade && ignoreAppUpdate}
         />
       )
     } else {
@@ -103,7 +99,6 @@ function makeMapStateToProps (): (State, OP) => SP {
   return (state, ownProps) => ({
     appVersion: CURRENT_VERSION,
     robotVersion: getRobotApiVersion(ownProps.robot) || 'Unknown',
-    appUpdate: getShellUpdateState(state),
     robotUpdateInfo: getRobotUpdateInfo(state, ownProps.robot),
   })
 }

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -68,11 +68,13 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
     const robotUpdateVersion = robotUpdateInfo.version
     const availableUpdate = appUpdateVersion || robotUpdateVersion
     const versionProps = {appVersion, robotVersion, availableUpdate}
+    const isUpgrade = robotUpdateInfo.type === 'upgrade'
+    const onClick = isUpgrade ? this.setIgnoreAppUpdate : this.props.update
 
     if (appUpdateAvailable && !ignoreAppUpdate) {
       return (
         <UpdateAppModal
-          onClick={this.props.update}
+          onClick={onClick}
           versionProps={versionProps}
           ignoreUpdate={this.props.ignoreUpdate}
         />
@@ -85,6 +87,7 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
           versionProps={versionProps}
           update={this.props.update}
           ignoreUpdate={this.props.ignoreUpdate}
+          showReleaseNotes={isUpgrade && ignoreAppUpdate}
         />
       )
     } else {

--- a/app/src/components/RobotSettings/UpdateRobot/VersionList.js
+++ b/app/src/components/RobotSettings/UpdateRobot/VersionList.js
@@ -3,12 +3,18 @@ import * as React from 'react'
 import styles from './styles.css'
 import type {VersionProps} from './types.js'
 
-export default function VersionList (props: VersionProps) {
+type Props = {
+  ...$Exact<VersionProps>,
+  ignoreAppUpdate?: boolean,
+}
+export default function VersionList (props: Props) {
   return (
     <ol className={styles.version_list}>
       <li>Your current app version: {props.appVersion}</li>
       <li>Your current robot server version: {props.robotVersion}</li>
-      <li>Available update: {props.availableUpdate}</li>
+      {!props.ignoreAppUpdate && (
+        <li>Available update: {props.availableUpdate}</li>
+      )}
     </ol>
   )
 }

--- a/app/src/components/RobotSettings/UpdateRobot/index.js
+++ b/app/src/components/RobotSettings/UpdateRobot/index.js
@@ -10,9 +10,10 @@ import RestartRobotModal from './RestartRobotModal'
 
 import type {State} from '../../../types'
 import type {ViewableRobot} from '../../../discovery'
+import type {ShellUpdateState} from '../../../shell'
 import type {RobotServerUpdate} from '../../../http-api-client'
 
-type OP = {robot: ViewableRobot}
+type OP = {robot: ViewableRobot, appUpdate: ShellUpdateState}
 
 type SP = {|
   updateRequest: RobotServerUpdate,
@@ -29,7 +30,7 @@ export default connect(
 )(UpdateRobot)
 
 function UpdateRobot (props: Props) {
-  const {updateRequest, robot} = props
+  const {updateRequest, robot, appUpdate} = props
   if (updateRequest.response) {
     return <RestartRobotModal robot={robot} />
   }
@@ -37,7 +38,7 @@ function UpdateRobot (props: Props) {
     // TODO (ka 2018-11-27): Clarify update message with UX
     return <SpinnerModal message="Robot is updating" alertOverlay />
   } else {
-    return <UpdateRobotModal robot={robot} />
+    return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
   }
 }
 
@@ -45,9 +46,8 @@ function makeMapStateToProps (): (State, OP) => Props {
   const getRobotUpdateRequest = makeGetRobotUpdateRequest()
 
   return (state, ownProps) => {
-    const {robot} = ownProps
     return {
-      robot,
+      ...ownProps,
       updateRequest: getRobotUpdateRequest(state, ownProps.robot),
     }
   }

--- a/app/src/components/RobotSettings/UpdateRobot/styles.css
+++ b/app/src/components/RobotSettings/UpdateRobot/styles.css
@@ -14,4 +14,9 @@
 
 .sync_message {
   margin-left: 1rem;
+  padding-bottom: 1rem;
+}
+
+.reinstall_message {
+  margin-left: 1rem;
 }

--- a/app/src/components/RobotSettings/UpdateRobot/styles.css
+++ b/app/src/components/RobotSettings/UpdateRobot/styles.css
@@ -13,5 +13,5 @@
 }
 
 .sync_message {
-  margin-bottom: 1.5rem;
+  margin-left: 1rem;
 }

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -31,9 +31,11 @@ import ResetRobotModal from '../../components/RobotSettings/ResetRobotModal'
 
 import type {State, Dispatch, Error} from '../../types'
 import type {ViewableRobot} from '../../discovery'
+import type {ShellUpdateState} from '../../shell'
 
 type OP = {
   robot: ViewableRobot,
+  appUpdate: ShellUpdateState,
   match: Match,
 }
 
@@ -71,6 +73,7 @@ const RESET_FRAGMENT = 'reset'
 function RobotSettingsPage (props: Props) {
   const {
     robot,
+    appUpdate,
     homeInProgress,
     homeError,
     closeHomeAlert,
@@ -108,7 +111,7 @@ function RobotSettingsPage (props: Props) {
           path={`${path}/${UPDATE_FRAGMENT}`}
           render={() => {
             if (props.__featureEnabled) {
-              return <UpdateRobot robot={robot} />
+              return <UpdateRobot robot={robot} appUpdate={appUpdate} />
             } else {
               return <RobotUpdateModal robot={robot} />
             }

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -13,6 +13,8 @@ import {
   getReachableRobots,
 } from '../../discovery'
 
+import {getShellUpdateState} from '../../shell'
+
 import {Splash} from '@opentrons/components'
 import Page from '../../components/Page'
 import RobotSettings from './RobotSettings'
@@ -20,10 +22,12 @@ import InstrumentSettings from './InstrumentSettings'
 
 import type {State} from '../../types'
 import type {ViewableRobot} from '../../discovery'
+import type {ShellUpdateState} from '../../shell'
 
 type SP = {
   robot: ?ViewableRobot,
   connectedName: ?string,
+  appUpdate: ShellUpdateState,
 }
 
 type OP = {match: Match}
@@ -43,12 +47,18 @@ function Robots (props: Props) {
   const {
     robot,
     connectedName,
+    appUpdate,
     match: {
       path,
       url,
       params: {name},
     },
   } = props
+
+  if (appUpdate.available && !appUpdate.seen) {
+    log.warn('App update available on load, redirecting to app update.')
+    return <Redirect to={'menu/app/update'} />
+  }
 
   if (name && !robot) {
     const redirectUrl = url.replace(`/${name}`, '')
@@ -76,7 +86,10 @@ function Robots (props: Props) {
           render={props => <InstrumentSettings {...props} robot={robot} />}
         />
       )}
-      <Route path={path} render={() => <RobotSettings robot={robot} />} />
+      <Route
+        path={path}
+        render={() => <RobotSettings robot={robot} appUpdate={appUpdate} />}
+      />
     </Switch>
   )
 }
@@ -97,5 +110,6 @@ function mapStateToProps (state: State, ownProps: OP): SP {
   return {
     robot,
     connectedName,
+    appUpdate: getShellUpdateState(state),
   }
 }

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -4,8 +4,11 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {withRouter, Route, Switch, Redirect, type Match} from 'react-router'
 import find from 'lodash/find'
+import {getIn} from '@thi.ng/paths'
 
+import {getConfig} from '../../config'
 import createLogger from '../../logger'
+
 import {
   CONNECTABLE,
   getConnectedRobot,
@@ -28,6 +31,7 @@ type SP = {
   robot: ?ViewableRobot,
   connectedName: ?string,
   appUpdate: ShellUpdateState,
+  __featureEnabled: boolean,
 }
 
 type OP = {match: Match}
@@ -35,6 +39,8 @@ type OP = {match: Match}
 type Props = SP & OP
 
 const log = createLogger(__filename)
+
+const __FEATURE_FLAG = 'devInternal.newUpdateModal'
 
 export default withRouter(
   connect(
@@ -55,7 +61,7 @@ function Robots (props: Props) {
     },
   } = props
 
-  if (appUpdate.available && !appUpdate.seen) {
+  if (appUpdate.available && !appUpdate.seen && props.__featureEnabled) {
     log.warn('App update available on load, redirecting to app update.')
     return <Redirect to={'menu/app/update'} />
   }
@@ -111,5 +117,6 @@ function mapStateToProps (state: State, ownProps: OP): SP {
     robot,
     connectedName,
     appUpdate: getShellUpdateState(state),
+    __featureEnabled: !!getIn(getConfig(state), __FEATURE_FLAG),
   }
 }


### PR DESCRIPTION
## overview

This PR addresses #2401 by implementing finalized upgrade/downgrade/reinstall screens, actions, and user flow.

## changelog

- refactor: break up UpdateRobotModal into AppUpdate, RobotSync, and Reinstall modals
- refactor: streamline modal actions
- feature: redirect to menu/app/update on load if an app update is available

## review requests
`make -C app dev OT_APP_DEV_INTERNAL__NEW_UPDATE_MODAL=1`

### App Update Available
- robot = app, app < latest
- robot > app, app < latest

- [x] redirect to `menu/app/update` on load
- [x] always show `UpdateAppModal` first when there is `appUpdate.available`, regardless of upgrade downgrade/reinstall action
- [x] `VersionList` shows:
  - [x] current app version
  - [x] current robot version
  - [x] available app update version
- [x] [click here] installs current available wheel (spinner modal screen)
  - [x] reinstall
  - [x] downgrade
- [x] [not now] closes modal, does not ignore this api version
- [x] [view app update] links to `menu/app/update`

### App Update Available & Robot Upgrade Available
- robot < app, app < latest

- [x] redirect to `menu/app/update` on load
- [x] always show `UpdateAppModal` first when there is `appUpdate.available`, regardless of upgrade downgrade/reinstall action
- [x] `VersionList` shows:
  - [x] current app version
  - [x] current robot version
  - [x] available app update version
- [x] [click here] shows available upgrade release notes (for robot, not app)
- [x] [not now] closes modal, sets current available wheel version to ignored
- [x] [view app update] links to `menu/app/update`

### Robot Upgrade Available

- robot < app, app = latest)
- [x] `SyncRobotModal` shows upgrade message
- [x] `VersionList` shows:
  - [x] current app version
  - [x] current robot version
- [x] [not now] closes modal, sets current available wheel version to ignored
- [x] [view robot server update] hides message and version list, shows release notes
- [x] [update] installs available robot upgrade

### Robot Downgrade Available
- robot > app, app = latest

- [x] `SyncRobotModal` shows upgrade message
- [x] `VersionList` shows:
  - [x] current app version
  - [x] current robot version
- [x] [not now] closes modal, does not ignore current downgrade version
- [x] [downgrade robot server] installs available robot wheel version (syncs app and robot)

### Robot Reinstall Available
- robot = app, app = latest

- [x] Robot `InformationCard` button reads [Reinstall]
- [x] `ReinstallModal` renders shows reinstall message
- [x] `VersionList` shows:
  - [x] current app version
  - [x] current robot version
- [x] [not now] closes modal, does not ignore current reinstall version
- [x] [reinstall] reinstalls current version

### Install inProgress/Complete
- [x] When install of any kind is `inProgress`, spinner modal renders
- [x] When install of any kind is complete (`response`) restart robot modal renders
  - [x] [not now] closes modal
  - [x] [restart] restarts robot