### PR TITLE
feat(protocol-designer): show file created and modified date

### DIFF
--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -24,6 +24,7 @@
     "formik": "^1.3.1",
     "i18next": "^11.5.0",
     "lodash": "^4.17.4",
+    "moment": "^2.19.1",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-hot-loader": "^3.0.0-beta.7",

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -16,8 +16,10 @@ import {Portal} from './portals/MainPageModalPortal'
 import styles from './FilePage.css'
 import EditPipettesModal from './modals/EditPipettesModal'
 import formStyles from '../components/forms.css'
+import type {FileMetadataFields} from '../file-data'
 
 export type Props = {
+  formValues: FileMetadataFields,
   formConnector: FormConnector<any>,
   isFormAltered: boolean,
   instruments: React.ElementProps<typeof InstrumentGroup>,
@@ -28,11 +30,10 @@ export type Props = {
 
 type State = { isEditPipetteModalOpen: boolean }
 
-// TODO IMMEDIATELY don't use placeholder, really pass in the timestamp
-const todo_placeholder = 92345678
 const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
 const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'
 
+// TODO rewrite as Formik form
 class FilePage extends React.Component<Props, State> {
   state = {isEditPipetteModalOpen: false}
 
@@ -48,6 +49,7 @@ class FilePage extends React.Component<Props, State> {
 
   render () {
     const {formConnector, isFormAltered, instruments, goToNextPage, swapPipettes} = this.props
+    const {created, 'last-modified': lastModified} = this.props.formValues
 
     return (
       <div className={styles.file_page}>
@@ -55,11 +57,11 @@ class FilePage extends React.Component<Props, State> {
           <form onSubmit={this.handleSubmit} className={styles.card_content}>
             <div className={cx(formStyles.row_wrapper, formStyles.stacked_row)}>
               <FormGroup label='Date Created:' className={formStyles.column_1_2}>
-                {moment(todo_placeholder).format(DATE_ONLY_FORMAT)}
+                {created && moment(created).format(DATE_ONLY_FORMAT)}
               </FormGroup>
 
               <FormGroup label='Last Exported:' className={formStyles.column_1_2}>
-                {moment(todo_placeholder).format(DATETIME_FORMAT)}
+                {lastModified && moment(lastModified).format(DATETIME_FORMAT)}
               </FormGroup>
             </div>
 

--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import moment from 'moment'
 import {
   Card,
   FormGroup,
@@ -27,6 +28,11 @@ export type Props = {
 
 type State = { isEditPipetteModalOpen: boolean }
 
+// TODO IMMEDIATELY don't use placeholder, really pass in the timestamp
+const todo_placeholder = 92345678
+const DATE_ONLY_FORMAT = 'MMM DD, YYYY'
+const DATETIME_FORMAT = 'MMM DD, YYYY | h:mm A'
+
 class FilePage extends React.Component<Props, State> {
   state = {isEditPipetteModalOpen: false}
 
@@ -47,6 +53,16 @@ class FilePage extends React.Component<Props, State> {
       <div className={styles.file_page}>
         <Card title='Information'>
           <form onSubmit={this.handleSubmit} className={styles.card_content}>
+            <div className={cx(formStyles.row_wrapper, formStyles.stacked_row)}>
+              <FormGroup label='Date Created:' className={formStyles.column_1_2}>
+                {moment(todo_placeholder).format(DATE_ONLY_FORMAT)}
+              </FormGroup>
+
+              <FormGroup label='Last Exported:' className={formStyles.column_1_2}>
+                {moment(todo_placeholder).format(DATETIME_FORMAT)}
+              </FormGroup>
+            </div>
+
             <div className={cx(formStyles.row_wrapper, formStyles.stacked_row)}>
               <FormGroup label='Protocol Name:' className={formStyles.column_1_2}>
                 <InputField placeholder='Untitled' {...formConnector('protocol-name')} />

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -1,32 +1,26 @@
 // @flow
 import {connect} from 'react-redux'
+import * as React from 'react'
 import type {BaseState} from '../types'
 import FilePage from '../components/FilePage'
-import type {Props as FilePageProps} from '../components/FilePage'
 import {actions, selectors as fileSelectors} from '../file-data'
 import {actions as pipetteActions, selectors as pipetteSelectors} from '../pipettes'
-import type {FileMetadataFields, FileMetadataFieldAccessors} from '../file-data'
+import type {FileMetadataFields} from '../file-data'
 import {actions as navActions} from '../navigation'
-import {formConnectorFactory, type FormConnector} from '../utils'
+
+type Props = React.ElementProps<typeof FilePage>
 
 type SP = {
-  instruments: $PropertyType<FilePageProps, 'instruments'>,
-  isFormAltered: $PropertyType<FilePageProps, 'isFormAltered'>,
-  formValues: {[accessor: FileMetadataFieldAccessors]: any},
+  instruments: $PropertyType<Props, 'instruments'>,
+  formValues: $PropertyType<Props, 'formValues'>,
 }
 
-type DP = {
-  _updateFileMetadataFields: typeof actions.updateFileMetadataFields,
-  _saveFileMetadata: ({[accessor: FileMetadataFieldAccessors]: mixed}) => mixed,
-  goToNextPage: $PropertyType<FilePageProps, 'goToNextPage'>,
-  swapPipettes: $PropertyType<FilePageProps, 'swapPipettes'>,
-}
+type DP = $Diff<Props, SP>
 
 const mapStateToProps = (state: BaseState): SP => {
   const pipetteData = pipetteSelectors.getPipettesForInstrumentGroup(state)
   return {
-    formValues: fileSelectors.fileFormValues(state),
-    isFormAltered: fileSelectors.isUnsavedMetadatFormAltered(state),
+    formValues: fileSelectors.getFileMetadata(state),
     instruments: {
       left: pipetteData.find(i => i.mount === 'left'),
       right: pipetteData.find(i => i.mount === 'right'),
@@ -34,36 +28,11 @@ const mapStateToProps = (state: BaseState): SP => {
   }
 }
 
-const mapDispatchToProps: DP = {
-  _updateFileMetadataFields: actions.updateFileMetadataFields,
-  _saveFileMetadata: actions.saveFileMetadata,
-  goToNextPage: () => navActions.navigateToPage('liquids'),
-  swapPipettes: pipetteActions.swapPipettes,
-}
+const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
+  goToNextPage: () => dispatch(navActions.navigateToPage('liquids')),
+  saveFileMetadata: (nextFormValues: FileMetadataFields) =>
+    dispatch(actions.saveFileMetadata(nextFormValues)),
+  swapPipettes: () => dispatch(pipetteActions.swapPipettes),
+})
 
-const mergeProps = (
-  {instruments, isFormAltered, formValues}: SP,
-  {_updateFileMetadataFields, _saveFileMetadata, goToNextPage, swapPipettes}: DP
-): FilePageProps => {
-  const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
-    if (accessor === 'protocol-name' || accessor === 'description' || accessor === 'author') {
-      _updateFileMetadataFields({[accessor]: e.target.value})
-    } else {
-      console.warn('Invalid accessor in ConnectedFilePage:', accessor)
-    }
-  }
-
-  const formConnector: FormConnector<FileMetadataFields> = formConnectorFactory(onChange, formValues)
-
-  return {
-    formValues,
-    formConnector,
-    isFormAltered,
-    instruments,
-    goToNextPage,
-    saveFileMetadata: () => _saveFileMetadata(formValues),
-    swapPipettes,
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(FilePage)
+export default connect(mapStateToProps, mapDispatchToProps)(FilePage)

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -12,7 +12,7 @@ import {formConnectorFactory, type FormConnector} from '../utils'
 type SP = {
   instruments: $PropertyType<FilePageProps, 'instruments'>,
   isFormAltered: $PropertyType<FilePageProps, 'isFormAltered'>,
-  _values: {[accessor: FileMetadataFieldAccessors]: any},
+  formValues: {[accessor: FileMetadataFieldAccessors]: any},
 }
 
 type DP = {
@@ -25,7 +25,7 @@ type DP = {
 const mapStateToProps = (state: BaseState): SP => {
   const pipetteData = pipetteSelectors.getPipettesForInstrumentGroup(state)
   return {
-    _values: fileSelectors.fileFormValues(state),
+    formValues: fileSelectors.fileFormValues(state),
     isFormAltered: fileSelectors.isUnsavedMetadatFormAltered(state),
     instruments: {
       left: pipetteData.find(i => i.mount === 'left'),
@@ -42,7 +42,7 @@ const mapDispatchToProps: DP = {
 }
 
 const mergeProps = (
-  {instruments, isFormAltered, _values}: SP,
+  {instruments, isFormAltered, formValues}: SP,
   {_updateFileMetadataFields, _saveFileMetadata, goToNextPage, swapPipettes}: DP
 ): FilePageProps => {
   const onChange = (accessor) => (e: SyntheticInputEvent<*>) => {
@@ -53,14 +53,15 @@ const mergeProps = (
     }
   }
 
-  const formConnector: FormConnector<FileMetadataFields> = formConnectorFactory(onChange, _values)
+  const formConnector: FormConnector<FileMetadataFields> = formConnectorFactory(onChange, formValues)
 
   return {
+    formValues,
     formConnector,
     isFormAltered,
     instruments,
     goToNextPage,
-    saveFileMetadata: () => _saveFileMetadata(_values),
+    saveFileMetadata: () => _saveFileMetadata(formValues),
     swapPipettes,
   }
 }

--- a/protocol-designer/src/file-data/actions.js
+++ b/protocol-designer/src/file-data/actions.js
@@ -1,12 +1,7 @@
 // @flow
-import type {FileMetadataFieldAccessors} from './types'
+import type {FileMetadataFields} from './types'
 
-export const updateFileMetadataFields = (payload: {[accessor: FileMetadataFieldAccessors]: mixed}) => ({
-  type: 'UPDATE_FILE_METADATA_FIELDS',
-  payload,
-})
-
-export const saveFileMetadata = (payload: {[accessor: FileMetadataFieldAccessors]: mixed}) => ({
+export const saveFileMetadata = (payload: FileMetadataFields) => ({
   type: 'SAVE_FILE_METADATA',
   payload,
 })

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -2,10 +2,7 @@
 import {combineReducers} from 'redux'
 import {handleActions, type ActionType} from 'redux-actions'
 
-import {
-  saveFileMetadata,
-  updateFileMetadataFields,
-} from '../actions'
+import {saveFileMetadata} from '../actions'
 import type {FileMetadataFields} from '../types'
 import type {LoadFileAction, NewProtocolFields} from '../../load-file'
 
@@ -40,19 +37,6 @@ function newProtocolMetadata (
   }
 }
 
-const unsavedMetadataForm = handleActions({
-  LOAD_FILE: updateMetadataFields,
-  CREATE_NEW_PROTOCOL: newProtocolMetadata,
-  UPDATE_FILE_METADATA_FIELDS: (state: FileMetadataFields, action: ActionType<typeof updateFileMetadataFields>): FileMetadataFields => ({
-    ...state,
-    ...action.payload,
-  }),
-  SAVE_FILE_METADATA: (state: FileMetadataFields, action: ActionType<typeof saveFileMetadata>): FileMetadataFields => ({
-    ...state,
-    ...action.payload,
-  }),
-}, defaultFields)
-
 const fileMetadata = handleActions({
   LOAD_FILE: updateMetadataFields,
   CREATE_NEW_PROTOCOL: newProtocolMetadata,
@@ -68,13 +52,11 @@ const fileMetadata = handleActions({
 
 export type RootState = {
   currentProtocolExists: boolean,
-  unsavedMetadataForm: FileMetadataFields,
   fileMetadata: FileMetadataFields,
 }
 
 const _allReducers = {
   currentProtocolExists,
-  unsavedMetadataForm,
   fileMetadata,
 }
 

--- a/protocol-designer/src/file-data/selectors/fileFields.js
+++ b/protocol-designer/src/file-data/selectors/fileFields.js
@@ -1,5 +1,4 @@
 // @flow
-import isEqual from 'lodash/isEqual'
 import {createSelector} from 'reselect'
 import type {BaseState} from '../../types'
 import type {RootState} from '../reducers'
@@ -9,16 +8,6 @@ export const rootSelector = (state: BaseState): RootState => state.fileData
 export const getCurrentProtocolExists = createSelector(
   rootSelector,
   (rootState) => rootState.currentProtocolExists
-)
-
-export const fileFormValues = createSelector(
-  rootSelector,
-  state => state.unsavedMetadataForm
-)
-
-export const isUnsavedMetadatFormAltered = createSelector(
-  rootSelector,
-  state => !isEqual(state.unsavedMetadataForm, state.fileMetadata)
 )
 
 export const protocolName = createSelector(rootSelector, state => state.fileMetadata['protocol-name'])


### PR DESCRIPTION
## overview

Closes #1623 

## changelog

* Add moment.js to PD (just for datetime string formatting :cry:)
* Add "Date Created" and "Last Exported" fields
* Replace "unsaved file metadata fields" stuff in Redux with a Formik form

## review requests

* File Information card only lets you click "Update" button when changes have been made to the form
* Exporting a file will update the "Last exported" datetime immediately

* Is it OK that changing the fields then exporting the file without clicking "Update" will reset the form? Seems like that's necessary if you need to click the button
* Is it OK that unsaved changes in the form are cleared when you leave the page and come back?