### PR TITLE
chore(release): 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+
+### Bug Fixes
+
+* **api:** Fix bad P10S config causing under-aspirations ([#2774](https://github.com/Opentrons/opentrons/issues/2774)) ([9c5e0a2](https://github.com/Opentrons/opentrons/commit/9c5e0a2))
+* **protocol-designer:** fix missing disposal volume in new distribute forms ([#2733](https://github.com/Opentrons/opentrons/issues/2733)) ([5657164](https://github.com/Opentrons/opentrons/commit/5657164)), closes [#2705](https://github.com/Opentrons/opentrons/issues/2705)
+
+
+### Features
+
+* **protocol-designer:** allow user to re-enable dismissed hints ([#2726](https://github.com/Opentrons/opentrons/issues/2726)) ([af52d1e](https://github.com/Opentrons/opentrons/commit/af52d1e)), closes [#2652](https://github.com/Opentrons/opentrons/issues/2652)
+* **protocol-designer:** drag and drop step reordering ([#2714](https://github.com/Opentrons/opentrons/issues/2714)) ([13d6fe3](https://github.com/Opentrons/opentrons/commit/13d6fe3)), closes [#2654](https://github.com/Opentrons/opentrons/issues/2654)
+* **protocol-designer:** highlight tips per substep ([#2716](https://github.com/Opentrons/opentrons/issues/2716)) ([eb2c2ce](https://github.com/Opentrons/opentrons/commit/eb2c2ce)), closes [#2537](https://github.com/Opentrons/opentrons/issues/2537)
+* **protocol-designer:** new protocol modal defaults and visual updates ([#2739](https://github.com/Opentrons/opentrons/issues/2739)) ([333ad5a](https://github.com/Opentrons/opentrons/commit/333ad5a)), closes [#2721](https://github.com/Opentrons/opentrons/issues/2721)
+* **protocol-designer:** place tipracks on protocol creation ([#2750](https://github.com/Opentrons/opentrons/issues/2750)) ([a110a8d](https://github.com/Opentrons/opentrons/commit/a110a8d)), closes [#1327](https://github.com/Opentrons/opentrons/issues/1327)
+* **protocol-designer:** remove delay from advanced settings of all step types ([#2731](https://github.com/Opentrons/opentrons/issues/2731)) ([b26abdd](https://github.com/Opentrons/opentrons/commit/b26abdd)), closes [#2579](https://github.com/Opentrons/opentrons/issues/2579)
+* **protocol-designer:** remove option of tiprack-1000ul-chem from pd ([#2745](https://github.com/Opentrons/opentrons/issues/2745)) ([3d5f276](https://github.com/Opentrons/opentrons/commit/3d5f276))
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/api/src/opentrons/CHANGELOG.md
+++ b/api/src/opentrons/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+### Bug Fixes
+
+* **api:** Fix bad P10S config causing under-aspirations ([#2774](https://github.com/Opentrons/opentrons/issues/2774)) ([9c5e0a2](https://github.com/Opentrons/opentrons/commit/9c5e0a2))
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/api/src/opentrons/package.json
+++ b/api/src/opentrons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/api-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Opentrons API server application",
   "repository": {
     "type": "git",

--- a/app-shell/CHANGELOG.md
+++ b/app-shell/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/app-shell
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -37,11 +37,17 @@ executing, but it does not ([#2020][2020])
 <!-- start:@opentrons/api -->
 ## OT2 and Protocol API
 
-**Important**: This release changes the aspirate function of the P10 single pipette. This change was made because the old function was found to be inaccurate. The new function is based on extensive testing by our hardware team.
+**Important**: This release updates the calibration of the P10 single pipette.
+
+This update includes a refinement to the aspiration function of the P10 single-channel pipette based on an expanded data set.
+
+Please note this is a small but material change to the P10's pipetting performance, in particular decreasing the low-volume µl-to-mm conversion factor to address under-aspiration users have reported.
+
+As always, please reach out to our team with any questions.
 
 ### Bug fixes
 
-- **Fixed the aspirate configuration of the P10 single pipette to avoid under-aspirating**
+- **Updated the configuration of the P10 single based on an expanded dataset**
 - Fixed the iteration order of labware created with `labware.create` to match documentation
 - Fixed various misconfigurations with pipette motor current/position settings
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -1,4 +1,4 @@
-# Changes from 3.5.1 to 3.6.0
+# Changes from 3.5.1 to 3.6.1
 
 For more details, please see the full [technical change log][changelog]
 
@@ -37,8 +37,11 @@ executing, but it does not ([#2020][2020])
 <!-- start:@opentrons/api -->
 ## OT2 and Protocol API
 
+**Important**: This release changes the aspirate function of the P10 single pipette. This change was made because the old function was found to be inaccurate. The new function is based on extensive testing by our hardware team.
+
 ### Bug fixes
 
+- **Fixed the aspirate configuration of the P10 single pipette to avoid under-aspirating**
 - Fixed the iteration order of labware created with `labware.create` to match documentation
 - Fixed various misconfigurations with pipette motor current/position settings
 

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentrons/app-shell",
   "productName": "Opentrons",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Opentrons desktop application",
   "main": "lib/main.js",
   "scripts": {
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "devDependencies": {
-    "@opentrons/app": "3.6.0"
+    "@opentrons/app": "3.6.1"
   },
   "dependencies": {
-    "@opentrons/discovery-client": "3.6.0",
+    "@opentrons/discovery-client": "3.6.1",
     "@thi.ng/paths": "^1.3.8",
     "dateformat": "^3.0.3",
     "electron-debug": "^2.0.0",

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/app
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/app",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Opentrons desktop application UI",
   "main": "src/index.js",
   "repository": {
@@ -21,8 +21,8 @@
     "flow-typed": "^2.5.1"
   },
   "dependencies": {
-    "@opentrons/components": "3.6.0",
-    "@opentrons/shared-data": "3.6.0",
+    "@opentrons/components": "3.6.1",
+    "@opentrons/shared-data": "3.6.1",
     "@thi.ng/paths": "^1.3.8",
     "classnames": "^2.2.5",
     "events": "^3.0.0",

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/components
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/components",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "React components library for Opentrons' projects",
   "main": "src/index.js",
   "style": "src/index.css",

--- a/discovery-client/CHANGELOG.md
+++ b/discovery-client/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/discovery-client
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/discovery-client",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Node.js client for discovering Opentrons robots on the network",
   "main": "lib/index.js",
   "bin": {

--- a/labware-designer/CHANGELOG.md
+++ b/labware-designer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package labware-designer
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -10,7 +10,7 @@
   "name": "labware-designer",
   "productName": "Opentrons Labware Designer",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Labware Designer",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/shared-data": "3.6.0"
+    "@opentrons/shared-data": "3.6.1"
   },
   "devDependencies": {
     "flow-bin": "^0.82.0",

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.6.0"
+  "version": "3.6.1"
 }

--- a/protocol-designer/CHANGELOG.md
+++ b/protocol-designer/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+
+### Bug Fixes
+
+* **protocol-designer:** fix missing disposal volume in new distribute forms ([#2733](https://github.com/Opentrons/opentrons/issues/2733)) ([5657164](https://github.com/Opentrons/opentrons/commit/5657164)), closes [#2705](https://github.com/Opentrons/opentrons/issues/2705)
+
+
+### Features
+
+* **protocol-designer:** allow user to re-enable dismissed hints ([#2726](https://github.com/Opentrons/opentrons/issues/2726)) ([af52d1e](https://github.com/Opentrons/opentrons/commit/af52d1e)), closes [#2652](https://github.com/Opentrons/opentrons/issues/2652)
+* **protocol-designer:** drag and drop step reordering ([#2714](https://github.com/Opentrons/opentrons/issues/2714)) ([13d6fe3](https://github.com/Opentrons/opentrons/commit/13d6fe3)), closes [#2654](https://github.com/Opentrons/opentrons/issues/2654)
+* **protocol-designer:** highlight tips per substep ([#2716](https://github.com/Opentrons/opentrons/issues/2716)) ([eb2c2ce](https://github.com/Opentrons/opentrons/commit/eb2c2ce)), closes [#2537](https://github.com/Opentrons/opentrons/issues/2537)
+* **protocol-designer:** new protocol modal defaults and visual updates ([#2739](https://github.com/Opentrons/opentrons/issues/2739)) ([333ad5a](https://github.com/Opentrons/opentrons/commit/333ad5a)), closes [#2721](https://github.com/Opentrons/opentrons/issues/2721)
+* **protocol-designer:** place tipracks on protocol creation ([#2750](https://github.com/Opentrons/opentrons/issues/2750)) ([a110a8d](https://github.com/Opentrons/opentrons/commit/a110a8d)), closes [#1327](https://github.com/Opentrons/opentrons/issues/1327)
+* **protocol-designer:** remove delay from advanced settings of all step types ([#2731](https://github.com/Opentrons/opentrons/issues/2731)) ([b26abdd](https://github.com/Opentrons/opentrons/commit/b26abdd)), closes [#2579](https://github.com/Opentrons/opentrons/issues/2579)
+* **protocol-designer:** remove option of tiprack-1000ul-chem from pd ([#2745](https://github.com/Opentrons/opentrons/issues/2745)) ([3d5f276](https://github.com/Opentrons/opentrons/commit/3d5f276))
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -10,7 +10,7 @@
   "name": "protocol-designer",
   "productName": "Opentrons Protocol Designer Prototype",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Protocol designer app",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.6.0",
+    "@opentrons/components": "3.6.1",
     "classnames": "^2.2.5",
     "formik": "^1.3.1",
     "i18next": "^11.5.0",

--- a/protocol-library-kludge/CHANGELOG.md
+++ b/protocol-library-kludge/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package protocol-library-kludge
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -9,7 +9,7 @@
   },
   "name": "protocol-library-kludge",
   "private": true,
-  "version": "3.6.0",
+  "version": "3.6.1",
   "productName": "Opentrons Protocol Library",
   "description": "Protocol library stuff (WIP)",
   "main": "src/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.6.0",
+    "@opentrons/components": "3.6.1",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "react": "^16.6.3",

--- a/shared-data/CHANGELOG.md
+++ b/shared-data/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/shared-data
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/shared-data",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Default labware definitions for Opentrons robots",
   "repository": {
     "type": "git",

--- a/update-server/otupdate/CHANGELOG.md
+++ b/update-server/otupdate/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/update-server
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/update-server/otupdate/package.json
+++ b/update-server/otupdate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/update-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Update server for Opentrons robots",
   "repository": {
     "type": "git",

--- a/webpack-config/CHANGELOG.md
+++ b/webpack-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.1"></a>
+## [3.6.1](https://github.com/Opentrons/opentrons/compare/v3.6.0...v3.6.1) (2018-12-05)
+
+**Note:** Version bump only for package @opentrons/webpack-config
+
+
+
+
+
 <a name="3.6.0"></a>
 # [3.6.0](https://github.com/Opentrons/opentrons/compare/v3.6.0-beta.1...v3.6.0) (2018-11-29)
 

--- a/webpack-config/package.json
+++ b/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/webpack-config",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Shareable pieces of webpack configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## overview

Updates the changelogs and version numbers for the 3.6.1 release of the app/API. This release updates the aspirate configuration for the P10 single pipette.

## changelog

https://github.com/Opentrons/opentrons/compare/v3.6.0...edge

## review requests

Please ensure the changelogs and release notes look good
