### PR TITLE
fix(protocol-designer): finish implementing flow rate in PD

### DIFF
--- a/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
@@ -7,6 +7,7 @@ import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseAr
 /** Aspirate with given args. Requires tip. */
 const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
   const {pipette, volume, labware, well, offsetFromBottomMm} = args
+  const flowRateUlSec = args['flow-rate']
 
   const actionName = 'aspirate'
   let errors: Array<CommandCreatorError> = []
@@ -48,6 +49,9 @@ const aspirate = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
       offsetFromBottomMm: offsetFromBottomMm == null
         ? undefined
         : offsetFromBottomMm,
+      'flow-rate': flowRateUlSec == null
+        ? undefined
+        : flowRateUlSec,
     },
   }]
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
@@ -6,6 +6,7 @@ import type {RobotState, CommandCreator, CommandCreatorError, AspirateDispenseAr
 /** Dispense with given args. Requires tip. */
 const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState: RobotState) => {
   const {pipette, volume, labware, well, offsetFromBottomMm} = args
+  const flowRateUlSec = args['flow-rate']
 
   const actionName = 'dispense'
   let errors: Array<CommandCreatorError> = []
@@ -32,6 +33,9 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
       offsetFromBottomMm: offsetFromBottomMm == null
         ? undefined
         : offsetFromBottomMm,
+      'flow-rate': flowRateUlSec == null
+        ? undefined
+        : flowRateUlSec,
     },
   }]
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -36,6 +36,8 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
   }
 
   const {
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
   } = data
@@ -64,6 +66,7 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
             volume: data.volume,
             labware: data.sourceLabware,
             well: sourceWell,
+            'flow-rate': aspirateFlowRateUlSec,
             offsetFromBottomMm: aspirateOffsetFromBottomMm,
           }),
           ...touchTipAfterAspirateCommand,
@@ -96,7 +99,9 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
           data.mixFirstAspirate.volume,
           data.mixFirstAspirate.times,
           aspirateOffsetFromBottomMm,
-          dispenseOffsetFromBottomMm
+          dispenseOffsetFromBottomMm,
+          aspirateFlowRateUlSec,
+          dispenseFlowRateUlSec,
         )
         : []
 
@@ -109,7 +114,9 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
           data.volume,
           1,
           aspirateOffsetFromBottomMm,
-          dispenseOffsetFromBottomMm
+          dispenseOffsetFromBottomMm,
+          aspirateFlowRateUlSec,
+          dispenseFlowRateUlSec,
         )
         : []
 
@@ -144,6 +151,7 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
           volume: data.volume * sourceWellChunk.length,
           labware: data.destLabware,
           well: data.destWell,
+          'flow-rate': dispenseFlowRateUlSec,
           offsetFromBottomMm: dispenseOffsetFromBottomMm,
         }),
         ...touchTipAfterDispenseCommands,

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -92,44 +92,44 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
         : []
 
       const mixBeforeCommands = (data.mixFirstAspirate)
-        ? mixUtil(
-          data.pipette,
-          data.sourceLabware,
-          sourceWellChunk[0],
-          data.mixFirstAspirate.volume,
-          data.mixFirstAspirate.times,
+        ? mixUtil({
+          pipette: data.pipette,
+          labware: data.sourceLabware,
+          well: sourceWellChunk[0],
+          volume: data.mixFirstAspirate.volume,
+          times: data.mixFirstAspirate.times,
           aspirateOffsetFromBottomMm,
           dispenseOffsetFromBottomMm,
           aspirateFlowRateUlSec,
           dispenseFlowRateUlSec,
-        )
+        })
         : []
 
       const preWetTipCommands = (data.preWetTip)
         // Pre-wet tip is equivalent to a single mix, with volume equal to the consolidate volume.
-        ? mixUtil(
-          data.pipette,
-          data.sourceLabware,
-          sourceWellChunk[0],
-          data.volume,
-          1,
+        ? mixUtil({
+          pipette: data.pipette,
+          labware: data.sourceLabware,
+          well: sourceWellChunk[0],
+          volume: data.volume,
+          times: 1,
           aspirateOffsetFromBottomMm,
           dispenseOffsetFromBottomMm,
           aspirateFlowRateUlSec,
           dispenseFlowRateUlSec,
-        )
+        })
         : []
 
       const mixAfterCommands = (data.mixInDestination)
-        ? mixUtil(
-          data.pipette,
-          data.destLabware,
-          data.destWell,
-          data.mixInDestination.volume,
-          data.mixInDestination.times,
+        ? mixUtil({
+          pipette: data.pipette,
+          labware: data.destLabware,
+          well: data.destWell,
+          volume: data.mixInDestination.volume,
+          times: data.mixInDestination.times,
           aspirateOffsetFromBottomMm,
-          dispenseOffsetFromBottomMm
-        )
+          dispenseOffsetFromBottomMm,
+        })
         : []
 
       const blowoutCommand = blowoutUtil(

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -137,17 +137,17 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
         : []
 
       const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
-        ? mixUtil(
-          data.pipette,
-          data.sourceLabware,
-          data.sourceWell,
-          data.mixBeforeAspirate.volume,
-          data.mixBeforeAspirate.times,
+        ? mixUtil({
+          pipette: data.pipette,
+          labware: data.sourceLabware,
+          well: data.sourceWell,
+          volume: data.mixBeforeAspirate.volume,
+          times: data.mixBeforeAspirate.times,
           aspirateOffsetFromBottomMm,
           dispenseOffsetFromBottomMm,
           aspirateFlowRateUlSec,
-          dispenseFlowRateUlSec
-        )
+          dispenseFlowRateUlSec,
+        })
         : []
 
       return [

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -40,6 +40,8 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
   }
 
   const {
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
   } = data
@@ -96,6 +98,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
               volume: data.volume,
               labware: data.destLabware,
               well: destWell,
+              'flow-rate': dispenseFlowRateUlSec,
               offsetFromBottomMm: dispenseOffsetFromBottomMm,
             }),
             ...touchTipAfterDispenseCommand,
@@ -141,7 +144,9 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
           data.mixBeforeAspirate.volume,
           data.mixBeforeAspirate.times,
           aspirateOffsetFromBottomMm,
-          dispenseOffsetFromBottomMm
+          dispenseOffsetFromBottomMm,
+          aspirateFlowRateUlSec,
+          dispenseFlowRateUlSec
         )
         : []
 
@@ -153,6 +158,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
           volume: data.volume * destWellChunk.length + disposalVolume,
           labware: data.sourceLabware,
           well: data.sourceWell,
+          'flow-rate': aspirateFlowRateUlSec,
           offsetFromBottomMm: aspirateOffsetFromBottomMm,
         }),
         ...touchTipAfterAspirateCommand,

--- a/protocol-designer/src/step-generation/commandCreators/compound/mix.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/mix.js
@@ -6,8 +6,7 @@ import type {MixFormData, RobotState, CommandCreator, CompoundCommandCreator} fr
 import {aspirate, dispense, replaceTip, touchTip} from '../atomic'
 
 /** Helper fn to make mix command creators w/ minimal arguments */
-// TODO IMMEDIATELY: use named params not ordered args
-export function mixUtil (
+export function mixUtil (args: {
   pipette: string,
   labware: string,
   well: string,
@@ -17,7 +16,18 @@ export function mixUtil (
   dispenseOffsetFromBottomMm?: ?number,
   aspirateFlowRateUlSec?: ?number,
   dispenseFlowRateUlSec?: ?number,
-): Array<CommandCreator> {
+}): Array<CommandCreator> {
+  const {
+    pipette,
+    labware,
+    well,
+    volume,
+    times,
+    aspirateOffsetFromBottomMm,
+    dispenseOffsetFromBottomMm,
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
+  } = args
   return repeatArray([
     aspirate({pipette, volume, labware, well, offsetFromBottomMm: aspirateOffsetFromBottomMm, 'flow-rate': aspirateFlowRateUlSec}),
     dispense({pipette, volume, labware, well, offsetFromBottomMm: dispenseOffsetFromBottomMm, 'flow-rate': dispenseFlowRateUlSec}),
@@ -97,7 +107,7 @@ const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: Robo
         data.blowoutLocation,
       )
 
-      const mixCommands = mixUtil(
+      const mixCommands = mixUtil({
         pipette,
         labware,
         well,
@@ -106,8 +116,8 @@ const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: Robo
         aspirateOffsetFromBottomMm,
         dispenseOffsetFromBottomMm,
         aspirateFlowRateUlSec,
-        dispenseFlowRateUlSec
-      )
+        dispenseFlowRateUlSec,
+      })
 
       return [
         ...tipCommands,

--- a/protocol-designer/src/step-generation/commandCreators/compound/mix.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/mix.js
@@ -6,6 +6,7 @@ import type {MixFormData, RobotState, CommandCreator, CompoundCommandCreator} fr
 import {aspirate, dispense, replaceTip, touchTip} from '../atomic'
 
 /** Helper fn to make mix command creators w/ minimal arguments */
+// TODO IMMEDIATELY: use named params not ordered args
 export function mixUtil (
   pipette: string,
   labware: string,
@@ -13,11 +14,13 @@ export function mixUtil (
   volume: number,
   times: number,
   aspirateOffsetFromBottomMm?: ?number,
-  dispenseOffsetFromBottomMm?: ?number
+  dispenseOffsetFromBottomMm?: ?number,
+  aspirateFlowRateUlSec?: ?number,
+  dispenseFlowRateUlSec?: ?number,
 ): Array<CommandCreator> {
   return repeatArray([
-    aspirate({pipette, volume, labware, well, offsetFromBottomMm: aspirateOffsetFromBottomMm}),
-    dispense({pipette, volume, labware, well, offsetFromBottomMm: dispenseOffsetFromBottomMm}),
+    aspirate({pipette, volume, labware, well, offsetFromBottomMm: aspirateOffsetFromBottomMm, 'flow-rate': aspirateFlowRateUlSec}),
+    dispense({pipette, volume, labware, well, offsetFromBottomMm: dispenseOffsetFromBottomMm, 'flow-rate': dispenseFlowRateUlSec}),
   ], times)
 }
 
@@ -43,6 +46,8 @@ const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: Robo
     changeTip,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
   } = data
 
   // Errors
@@ -99,7 +104,9 @@ const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: Robo
         volume,
         times,
         aspirateOffsetFromBottomMm,
-        dispenseOffsetFromBottomMm
+        dispenseOffsetFromBottomMm,
+        aspirateFlowRateUlSec,
+        dispenseFlowRateUlSec
       )
 
       return [

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -74,31 +74,31 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
             : []
 
           const preWetTipCommands = (data.preWetTip && chunkIdx === 0)
-            ? mixUtil(
-              data.pipette,
-              data.sourceLabware,
-              sourceWell,
-              Math.max(subTransferVol),
-              1,
+            ? mixUtil({
+              pipette: data.pipette,
+              labware: data.sourceLabware,
+              well: sourceWell,
+              volume: Math.max(subTransferVol),
+              times: 1,
               aspirateOffsetFromBottomMm,
               dispenseOffsetFromBottomMm,
               aspirateFlowRateUlSec,
-              dispenseFlowRateUlSec
-            )
+              dispenseFlowRateUlSec,
+            })
             : []
 
           const mixBeforeAspirateCommands = (data.mixBeforeAspirate)
-            ? mixUtil(
-              data.pipette,
-              data.sourceLabware,
-              sourceWell,
-              data.mixBeforeAspirate.volume,
-              data.mixBeforeAspirate.times,
+            ? mixUtil({
+              pipette: data.pipette,
+              labware: data.sourceLabware,
+              well: sourceWell,
+              volume: data.mixBeforeAspirate.volume,
+              times: data.mixBeforeAspirate.times,
               aspirateOffsetFromBottomMm,
               dispenseOffsetFromBottomMm,
               aspirateFlowRateUlSec,
-              dispenseFlowRateUlSec
-            )
+              dispenseFlowRateUlSec,
+            })
             : []
 
           const touchTipAfterAspirateCommands = (data.touchTipAfterAspirate)
@@ -120,17 +120,17 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
             : []
 
           const mixInDestinationCommands = (data.mixInDestination)
-            ? mixUtil(
-              data.pipette,
-              data.destLabware,
-              destWell,
-              data.mixInDestination.volume,
-              data.mixInDestination.times,
+            ? mixUtil({
+              pipette: data.pipette,
+              labware: data.destLabware,
+              well: destWell,
+              volume: data.mixInDestination.volume,
+              times: data.mixInDestination.times,
               aspirateOffsetFromBottomMm,
               dispenseOffsetFromBottomMm,
               aspirateFlowRateUlSec,
-              dispenseFlowRateUlSec
-            )
+              dispenseFlowRateUlSec,
+            })
             : []
 
           const blowoutCommand = blowoutUtil(

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -40,6 +40,8 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
   }
 
   const {
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
   } = data
@@ -79,7 +81,9 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
               Math.max(subTransferVol),
               1,
               aspirateOffsetFromBottomMm,
-              dispenseOffsetFromBottomMm
+              dispenseOffsetFromBottomMm,
+              aspirateFlowRateUlSec,
+              dispenseFlowRateUlSec
             )
             : []
 
@@ -91,7 +95,9 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
               data.mixBeforeAspirate.volume,
               data.mixBeforeAspirate.times,
               aspirateOffsetFromBottomMm,
-              dispenseOffsetFromBottomMm
+              dispenseOffsetFromBottomMm,
+              aspirateFlowRateUlSec,
+              dispenseFlowRateUlSec
             )
             : []
 
@@ -121,7 +127,9 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
               data.mixInDestination.volume,
               data.mixInDestination.times,
               aspirateOffsetFromBottomMm,
-              dispenseOffsetFromBottomMm
+              dispenseOffsetFromBottomMm,
+              aspirateFlowRateUlSec,
+              dispenseFlowRateUlSec
             )
             : []
 
@@ -143,6 +151,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
               volume: subTransferVol,
               labware: data.sourceLabware,
               well: sourceWell,
+              'flow-rate': aspirateFlowRateUlSec,
               offsetFromBottomMm: aspirateOffsetFromBottomMm,
             }),
             ...touchTipAfterAspirateCommands,
@@ -151,6 +160,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
               volume: subTransferVol,
               labware: data.destLabware,
               well: destWell,
+              'flow-rate': dispenseFlowRateUlSec,
               offsetFromBottomMm: dispenseOffsetFromBottomMm,
             }),
             ...touchTipAfterDispenseCommands,

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -45,6 +45,55 @@ describe('aspirate', () => {
     })
   })
 
+  describe('aspirate normally (with tip)', () => {
+    const optionalArgsCases = [
+      {
+        description: 'no optional args',
+        expectInParams: false,
+        args: {},
+      },
+      {
+        description: 'null optional args',
+        expectInParams: false,
+        args: {
+          offsetFromBottomMm: null,
+          'flow-rate': null,
+        },
+      },
+      {
+        description: 'all optional args',
+        expectInParams: true,
+        args: {
+          offsetFromBottomMm: 5,
+          'flow-rate': 6,
+        },
+      },
+    ]
+
+    optionalArgsCases.forEach(testCase => {
+      test(testCase.description, () => {
+        const result = aspirate({
+          pipette: 'p300SingleId',
+          volume: 50,
+          labware: 'sourcePlateId',
+          well: 'A1',
+          ...testCase.args,
+        })(robotStateWithTip)
+
+        expect(result.commands).toEqual([{
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 50,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            ...(testCase.expectInParams ? testCase.args : {}),
+          },
+        }])
+      })
+    })
+  })
+
   test('aspirate with volume > tip max volume should throw error', () => {
     robotStateWithTip.instruments['p300SingleId'].tiprackModel = 'tiprack-200ul'
     const result = aspirateWithErrors({

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -43,22 +43,69 @@ describe('dispense', () => {
   })
 
   describe('tip tracking & commands:', () => {
-    test('dispense with tip', () => {
-      const result = dispense({
+    describe('dispense normally (with tip)', () => {
+      const optionalArgsCases = [
+        {
+          description: 'no optional args',
+          expectInParams: false,
+          args: {},
+        },
+        {
+          description: 'null optional args',
+          expectInParams: false,
+          args: {
+            offsetFromBottomMm: null,
+            'flow-rate': null,
+          },
+        },
+        {
+          description: 'all optional args',
+          expectInParams: true,
+          args: {
+            offsetFromBottomMm: 5,
+            'flow-rate': 6,
+          },
+        },
+      ]
+      optionalArgsCases.forEach(testCase => {
+        test(testCase.description, () => {
+          const result = dispense({
+            pipette: 'p300SingleId',
+            volume: 50,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            ...testCase.args,
+          })(robotStateWithTip)
+
+          expect(result.commands).toEqual([{
+            command: 'dispense',
+            params: {
+              pipette: 'p300SingleId',
+              volume: 50,
+              labware: 'sourcePlateId',
+              well: 'A1',
+              ...(testCase.expectInParams ? testCase.args : {}),
+            },
+          }])
+        })
+      })
+    })
+
+    test('dispense normally (with tip) and optional args', () => {
+      const args = {
         pipette: 'p300SingleId',
         volume: 50,
         labware: 'sourcePlateId',
         well: 'A1',
-      })(robotStateWithTip)
+        offsetFromBottomMm: 5,
+        'flow-rate': 6,
+      }
+
+      const result = dispense(args)(robotStateWithTip)
 
       expect(result.commands).toEqual([{
         command: 'dispense',
-        params: {
-          pipette: 'p300SingleId',
-          volume: 50,
-          labware: 'sourcePlateId',
-          well: 'A1',
-        },
+        params: args,
       }])
     })
 

--- a/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
+++ b/protocol-designer/src/step-generation/test-with-flow/fixtures/commandFixtures.js
@@ -1,6 +1,6 @@
 // @flow
 import {tiprackWellNamesFlat} from '../../data'
-import type {Command} from '../../types'
+import type {AspirateDispenseArgs, Command} from '../../types'
 
 export const replaceTipCommands = (tip: number | string): Array<Command> => [
   dropTip('A1'),
@@ -49,10 +49,7 @@ export const touchTip = (
 export const aspirate = (
   well: string,
   volume: number,
-  params?: {|
-    pipette?: string,
-    labware?: string,
-  |}
+  params?: $Shape<AspirateDispenseArgs>
 ): Command => ({
   command: 'aspirate',
   params: {
@@ -67,10 +64,7 @@ export const aspirate = (
 export const dispense = (
   well: string,
   volume: number,
-  params?: {|
-    pipette?: string,
-    labware?: string,
-  |}
+  params?: $Shape<AspirateDispenseArgs>
 ): Command => ({
   command: 'dispense',
   params: {

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -130,6 +130,43 @@ describe('mix: advanced options', () => {
   const times = 2
   const blowoutLabwareId = 'destPlateId'
 
+  test('flow rate', () => {
+    const ASPIRATE_OFFSET = 11
+    const DISPENSE_OFFSET = 12
+    const ASPIRATE_FLOW_RATE = 3
+    const DISPENSE_FLOW_RATE = 6
+    const args: MixFormData = {
+      ...mixinArgs,
+      volume,
+      times,
+      wells: ['A1'],
+      changeTip: 'once',
+      aspirateOffsetFromBottomMm: ASPIRATE_OFFSET,
+      dispenseOffsetFromBottomMm: DISPENSE_OFFSET,
+      aspirateFlowRateUlSec: ASPIRATE_FLOW_RATE,
+      dispenseFlowRateUlSec: DISPENSE_FLOW_RATE,
+    }
+
+    const aspirateParams = {
+      'flow-rate': ASPIRATE_FLOW_RATE,
+      offsetFromBottomMm: ASPIRATE_OFFSET,
+    }
+    const dispenseParams = {
+      'flow-rate': DISPENSE_FLOW_RATE,
+      offsetFromBottomMm: DISPENSE_OFFSET,
+    }
+
+    const result = mix(args)(robotInitialState)
+    expect(result.commands).toEqual([
+      ...cmd.replaceTipCommands(0),
+      {...cmd.aspirate('A1', volume, aspirateParams)},
+      {...cmd.dispense('A1', volume, dispenseParams)},
+
+      {...cmd.aspirate('A1', volume, aspirateParams)},
+      {...cmd.dispense('A1', volume, dispenseParams)},
+    ])
+  })
+
   test('touch tip (after each dispense)', () => {
     const args: MixFormData = {
       ...mixinArgs,
@@ -138,6 +175,10 @@ describe('mix: advanced options', () => {
       changeTip: 'always',
       touchTip: true,
       wells: ['A1', 'B1', 'C1'],
+      aspirateOffsetFromBottomMm: null,
+      dispenseOffsetFromBottomMm: null,
+      aspirateFlowRateUlSec: null,
+      dispenseFlowRateUlSec: null,
     }
 
     const result = mix(args)(robotInitialState)

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -38,6 +38,8 @@ export type TransferLikeFormDataFields = {
   touchTipAfterAspirateOffsetMmFromBottom?: ?number,
   /** changeTip is interpreted differently by different Step types */
   changeTip: ChangeTipOptions,
+  /** Flow rate in uL/sec for all aspirates */
+  aspirateFlowRateUlSec?: ?number,
   /** offset from bottom of well in mm */
   aspirateOffsetFromBottomMm?: ?number,
 
@@ -46,6 +48,8 @@ export type TransferLikeFormDataFields = {
   touchTipAfterDispense: boolean,
   /** Optional offset for touch tip after dispense (if null, use PD default) */
   touchTipAfterDispenseOffsetMmFromBottom?: ?number,
+  /** Flow rate in uL/sec for all dispenses */
+  dispenseFlowRateUlSec?: ?number,
   /** offset from bottom of well in mm */
   dispenseOffsetFromBottomMm?: ?number,
 }
@@ -118,6 +122,9 @@ export type MixFormData = {
   /** offset from bottom of well in mm */
   aspirateOffsetFromBottomMm?: ?number,
   dispenseOffsetFromBottomMm?: ?number,
+  /** flow rates in uL/sec */
+  aspirateFlowRateUlSec?: ?number,
+  dispenseFlowRateUlSec?: ?number,
 }
 
 export type PauseFormData = {|
@@ -215,6 +222,7 @@ export type AspirateDispenseArgs = {|
   ...PipetteLabwareFields,
   volume: number,
   offsetFromBottomMm?: ?number,
+  'flow-rate'?: ?number,
 |}
 
 export type Command = {|

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -29,10 +29,14 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
 
   const volume = Number(hydratedFormData.volume) || 0
   const times = Number(hydratedFormData.times) || 0
+
+  const aspirateFlowRateUlSec = hydratedFormData['aspirate_flowRate']
+  const dispenseFlowRateUlSec = hydratedFormData['dispense_flowRate']
+
   // NOTE: for mix, there is only one tip offset field,
   // and it applies to both aspirate and dispense
-  const aspirateOffsetFromBottomMm = Number(hydratedFormData['mix_mmFromBottom'])
-  const dispenseOffsetFromBottomMm = Number(hydratedFormData['mix_mmFromBottom'])
+  const aspirateOffsetFromBottomMm = hydratedFormData['mix_mmFromBottom']
+  const dispenseOffsetFromBottomMm = hydratedFormData['mix_mmFromBottom']
 
   // It's radiobutton, so one should always be selected.
   const changeTip = hydratedFormData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
@@ -52,6 +56,8 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
     changeTip,
     blowoutLocation,
     pipette: pipette.id,
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
   }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -31,6 +31,9 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
   const sourceLabware = hydratedFormData['aspirate_labware']
   const destLabware = hydratedFormData['dispense_labware']
 
+  const aspirateFlowRateUlSec = hydratedFormData['aspirate_flowRate']
+  const dispenseFlowRateUlSec = hydratedFormData['dispense_flowRate']
+
   const aspirateOffsetFromBottomMm = hydratedFormData['aspirate_mmFromBottom']
   const dispenseOffsetFromBottomMm = hydratedFormData['dispense_mmFromBottom']
 
@@ -75,6 +78,8 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
     sourceLabware: sourceLabware.id,
     destLabware: destLabware.id,
 
+    aspirateFlowRateUlSec,
+    dispenseFlowRateUlSec,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
 


### PR DESCRIPTION
## overview

Closes #2773

## changelog

* finish implementing flow rate across all step types and "inner mixes"

## review requests

- Flow rate field should affect main aspirate/dispense JSON commands within Transfer/Distribute/Consolidate/Mix steps
- Flow rate field should affect aspirate/dispense rate within "inner mixes" of transfer/consolidate (distribute mixes are deprecated but should work too)
- Please test by inspecting the JSON commands (should say `"flow-rate": 1` in the atomic commands in the file)
- Please test on a robot (no API update required, 3.6.0 is fine)