### PR TITLE
fix(protocol-designer): fix changeTip once bug in distribute step

### DIFF
--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -57,9 +57,16 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
 
   if (maxWellsPerChunk === 0) {
     // distribute vol exceeds pipette vol, break up into 1 transfer per dest well
-    const transferCommands = data.destWells.map((destWell) => {
+    const transferCommands = data.destWells.map((destWell, wellIndex) => {
+      let changeTip = data.changeTip
+      // 'once' means 'once per all inner transfers'
+      // so it should only apply to the first inner transfer
+      if (data.changeTip === 'once') {
+        changeTip = (wellIndex === 0) ? 'once' : 'never'
+      }
       const transferData: TransferFormData = {
         ...(data: TransferLikeFormDataFields),
+        changeTip,
         stepType: 'transfer',
         sourceWells: [data.sourceWell],
         destWells: [destWell],

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -490,9 +490,6 @@ describe('distribute volume exceeds pipette max volume', () => {
       dispense('A2', 50),
 
       // A2 done, move to A3
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('B1'),
-
       cmd.aspirate('A1', 300),
       dispense('A3', 300),
       cmd.aspirate('A1', 50),


### PR DESCRIPTION
## overview

Closes #2748 - see my comment in that ticket for explanation of problem

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- When Volume of a Distribute exceeds the pipette/tip capacity, change tip "once" should use one tip throughout the entire step