### PR TITLE
feat(protocol-designer): scroll to top of page when step created/selected

### DIFF
--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-
+import cx from 'classnames'
 import ConnectedMoreOptionsModal from '../containers/ConnectedMoreOptionsModal'
 import ConnectedNav from '../containers/ConnectedNav'
 import ConnectedSidebar from '../containers/ConnectedSidebar'
@@ -11,7 +11,7 @@ import FileUploadErrorModal from './modals/FileUploadErrorModal'
 import AnalyticsModal from './modals/AnalyticsModal'
 import {PortalRoot as MainPageModalPortalRoot} from '../components/portals/MainPageModalPortal'
 import {PortalRoot as TopPortalRoot} from './portals/TopPortal'
-
+import {SCROLL_ON_SELECT_STEP_CLASSNAME} from '../steplist/actions'
 import styles from './ProtocolEditor.css'
 
 const SelectorDebugger = process.env.NODE_ENV === 'development'
@@ -26,7 +26,7 @@ export default function ProtocolEditor () {
       <div className={styles.wrapper}>
         <ConnectedNav />
         <ConnectedSidebar />
-        <div className={styles.main_page_wrapper}>
+        <div className={cx(styles.main_page_wrapper, SCROLL_ON_SELECT_STEP_CLASSNAME)}>
           <ConnectedTitleBar />
 
           <div className={styles.main_page_content}>

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -1,4 +1,5 @@
 // @flow
+import forEach from 'lodash/forEach'
 import handleFormChange from './handleFormChange'
 import {uuid} from '../../utils'
 import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
@@ -6,9 +7,10 @@ import * as pipetteSelectors from '../../pipettes/selectors'
 import {selectors as steplistSelectors} from '../../steplist'
 import {actions as tutorialActions} from '../../tutorial'
 import {getNextDefaultPipetteId, generateNewForm} from '../formLevel'
-
 import type {StepType, StepIdType, FormData} from '../../form-types'
 import type {BaseState, GetState, ThunkAction, ThunkDispatch} from '../../types'
+
+export const SCROLL_ON_SELECT_STEP_CLASSNAME = 'scroll_on_select_step'
 
 export type SelectStepAction = {
   type: 'SELECT_STEP',
@@ -85,6 +87,12 @@ export const selectStep = (stepId: StepIdType, newStepType?: StepType): ThunkAct
       type: 'POPULATE_FORM',
       payload: formData,
     })
+
+    // scroll to top of all elements with the special class
+    forEach(
+      global.document.getElementsByClassName(SCROLL_ON_SELECT_STEP_CLASSNAME),
+      elem => { elem.scrollTop = 0 }
+    )
   }
 
 // addStep thunk adds an incremental integer ID for Step reducers.


### PR DESCRIPTION
## overview

Closes #2767 - when you click a step in the steplist (whether it's already selected or not), or if you create a new step, the main page should scroll to the top, showing the full form.

## changelog


## review requests

* Not too too hacky for a temporary fix?
* Works in all useful cases?
* Form-level warnings (eg, recommended disposal vol) scroll into view correctly?