### PR TITLE
fix(protocol-designer): fix when add liquid hint is shown

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -9,7 +9,6 @@ import mapValues from 'lodash/mapValues'
 import max from 'lodash/max'
 import pickBy from 'lodash/pickBy'
 import reduce from 'lodash/reduce'
-import isEmpty from 'lodash/isEmpty'
 
 import {sortedSlotnames, FIXED_TRASH_ID} from '../../constants.js'
 import {uuid} from '../../utils'
@@ -285,6 +284,11 @@ export const ingredLocations = handleActions({
       mapValues(labwareContents, well =>
         omit(well, liquidGroupId)))
   },
+  DELETE_CONTAINER: (
+    state: LocationsState,
+    action: ActionType<typeof actions.deleteContainer>
+  ): LocationsState =>
+    omit(state, action.payload.containerId),
   LOAD_FILE: (state: LocationsState, action: LoadFileAction): LocationsState =>
     getPDMetadata(action.payload).ingredLocations,
 }, {})
@@ -488,8 +492,6 @@ const getLabwareSelectionMode: Selector<boolean> = createSelector(
 
 const getSlotToMoveFrom = (state: BaseState) => rootSelector(state).moveLabwareMode
 
-const getDeckHasLiquid = (state: BaseState) => !isEmpty(getLiquidGroupsById(state))
-
 const getLiquidGroupsOnDeck: Selector<Array<string>> = createSelector(
   getLiquidsByLabwareId,
   (ingredLocationsByLabware) => {
@@ -505,6 +507,11 @@ const getLiquidGroupsOnDeck: Selector<Array<string>> = createSelector(
     )
     return [...liquidGroups]
   }
+)
+
+const getDeckHasLiquid: Selector<boolean> = createSelector(
+  getLiquidGroupsOnDeck,
+  (liquidGroups) => liquidGroups.length > 0
 )
 
 // TODO: prune selectors


### PR DESCRIPTION
## overview

Before, "add liquid" hint was shown when user skipped creating liquids. Now it is shown when user
specifically doesn't have any liquids on the deck in initial deck setup

Closes #2777

## changelog

* Before, "add liquid" hint was shown when user skipped creating liquids. Now it is shown when user specifically doesn't have any liquids on the deck in initial deck setup
* fix mostly-asymptomatic bug: deleting labware now deletes it from ingredLocations reducer

## review requests

Modal should show up if user attempts to make a (non-Pause) step and:
- [ ] has failed to add liquids to protocol
- [ ] has failed to place liquids in at least 1 piece of labware

Note that if you do this more complex flow that makes you wind up getting no liquids on your deck starting state:

1) create liquids
2) add some to the deck
3) delete all liquids on deck from the labware, or delete the labware itself from the deck 
4) create a step (non-Pause)

...it should give you the hint, since there are no liquids on your deck.