### PR TITLE
fix(protocol-designer): fix regression of #2370

### DIFF
--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -25,7 +25,7 @@ function Nav (props: Props) {
             iconName='ot-file'
             title={i18n.t('nav.tab_name.file')}
             selected={props.currentPage === 'file-splash' || props.currentPage === 'file-detail'}
-            onClick={props.handleClick('file-detail')} />
+            onClick={props.handleClick(noCurrentProtocol ? 'file-splash' : 'file-detail')} />
           <NavTab
             iconName='water'
             title={i18n.t('nav.tab_name.liquids')}


### PR DESCRIPTION
## overview

In staging, clicking settings then back to main page doesn't take you back to the splash, but takes you to file details. This is a fix!

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
