### PR TITLE
fix(protocol-designer): fix distribute aspirate touchtip offset

### DIFF
--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -138,7 +138,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
             pipette: data.pipette,
             labware: data.sourceLabware,
             well: data.sourceWell,
-            offsetFromBottomMm: data.touchTipAfterDispenseOffsetMmFromBottom,
+            offsetFromBottomMm: data.touchTipAfterAspirateOffsetMmFromBottom,
           }),
         ]
         : []


### PR DESCRIPTION
in Distribute, aspirate sections's touch tip offset was reading from the dispense field. Fixed!