### PR TITLE
fix(protocol-designer): fix bug where new protocol w 1 pipette deleted fixedTrash

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -198,22 +198,23 @@ export const containers = handleActions({
     state: ContainersState,
     action: {payload: NewProtocolFields}
   ): ContainersState => {
-    const initialTipracks = [action.payload.left, action.payload.right].reduce((acc, mount) => {
+    const nextState = [action.payload.left, action.payload.right].reduce((acc: ContainersState, mount): ContainersState => {
       if (mount.tiprackModel) {
         const id = `${uuid()}:${String(mount.tiprackModel)}`
         return {
           ...acc,
           [id]: {
-            slot: nextEmptySlot(_loadedContainersBySlot(acc || {})),
+            slot: nextEmptySlot(_loadedContainersBySlot(acc)),
             type: mount.tiprackModel,
-            disambiguationNumber: getNextDisambiguationNumber(acc || {}, String(mount.tiprackModel)),
+            disambiguationNumber: getNextDisambiguationNumber(acc, String(mount.tiprackModel)),
             id,
-            name: null, // create with null name, so we force explicit naming.
+            name: null,
           },
         }
       }
+      return acc
     }, state)
-    return initialTipracks || {}
+    return nextState
   },
 }, initialLabwareState)
 


### PR DESCRIPTION
## overview

Started this week by finding that with new protocols using one pipette, adding any kind of step except pause causes a whitescreening exception from the step-gen timeline :grimacing:

Used git-bisect to find that this exception is due to a sneaky bug in #2750 which caused fixedTrash to be deleted from Redux labware state when only one pipette was assigned. Without fixedTrash, any step that drops a tip or otherwise interacts with fixedTrash will cause PD to whitescreen (attempts to access labwareById.fixedTrash.A1 in the liquid update fns, fixedTrash is undefined)

Also fixes related bug where no tiprack was being auto-added when you only had one pipette in a new protocol.

## review requests

- [ ] with only one pipette (left or right), tiprack should be created
- [ ] with one pipette, saving a step (eg Transfer) should not cause PD to whitescreen (and if you peep w/ redux devtools, `fixedTrash` should not be removed from the `labwareIngred.containers` reducer)
- [ ] with 2 pipettes, existing behavior should still happen