### PR TITLE
fix(protocol-designer): fix swap pipettes button dispatch

### DIFF
--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -32,7 +32,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
   goToNextPage: () => dispatch(navActions.navigateToPage('liquids')),
   saveFileMetadata: (nextFormValues: FileMetadataFields) =>
     dispatch(actions.saveFileMetadata(nextFormValues)),
-  swapPipettes: () => dispatch(pipetteActions.swapPipettes),
+  swapPipettes: () => dispatch(pipetteActions.swapPipettes()),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilePage)


### PR DESCRIPTION
## overview

I forgot a set of parentheses in #2754 

## changelog

* add parentheses so swap pipette works again

## review requests

- [ ] Swap pipettes button should work now