### PR TITLE
feat(api): Add metadata to session for Python protocols

### DIFF
--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -59,9 +59,17 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
     # imports
     from opentrons import labware, instruments
 
+    # metadata
+    metadata = {
+        'protocolName': 'My Protocol',
+        'author': 'Name <email@address.com>',
+        'description': 'Simple protocol to get started using OT2',
+        'source': 'Opentrons Protocol Tutorial'
+    }
+
     # labware
     plate = labware.load('96-flat', '2')
-    tiprack = labware.load('tiprack-200ul', '1')
+    tiprack = labware.load('opentrons-tiprack-300ul', '1')
 
     # pipettes
     pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
@@ -74,12 +82,13 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
 How it's Organized
 ------------------
 
-When writing protocols using the Opentrons API, there are generally three sections:
+When writing protocols using the Opentrons API, there are generally five sections:
 
 1) Imports
-2) Labware
-3) Pipettes
-4) Commands
+2) Metadata
+3) Labware
+4) Pipettes
+5) Commands
 
 Imports
 ^^^^^^^
@@ -92,6 +101,13 @@ From the example above, the "imports" section looked like:
 
     from opentrons import labware, instruments
 
+
+Metadata
+^^^^^^^^
+
+Metadata is a dictionary of data that is read by the server and returned to client applications (such as the Opentrons Run App). It is not needed to run a protocol (and is entirely optional), but if present can help the client application display additional data about the protocol currently being executed.
+
+The fields above ("protocolName", "author", "description", and "source") are the recommended fields, but the metadata dictionary can contain fewer fields, or additional fields as desired (though non-standard fields may not be rendered by the client, depending on how it is designed).
 
 Labware
 ^^^^^^^

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -349,13 +349,12 @@ class Session(object):
             self._hardware.home_z()
 
 
-def extract_metadata(parsed: ast.Module) -> dict:
+def extract_metadata(parsed):
     metadata = {}
-    assigns = [obj for obj in parsed.body if
-               isinstance(obj, ast.Assign)]
+    assigns = [
+        obj for obj in parsed.body if isinstance(obj, ast.Assign)]
     for obj in assigns:
-        if obj.targets[0].id == 'metadata' and isinstance(obj.value,
-                                                          ast.Dict):
+        if obj.targets[0].id == 'metadata' and isinstance(obj.value, ast.Dict):
             keys = [k.s for k in obj.value.keys]
             values = [v.s for v in obj.value.values]
             metadata = dict(zip(keys, values))

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -801,7 +801,7 @@ class TemperatureModuleContext(ModuleContext):
     def __init__(self, ctx: ProtocolContext,
                  hw_module: modules.tempdeck.TempDeck,
                  geometry: ModuleGeometry,
-                 loop: asyncio.AbstractEventLoop):
+                 loop: asyncio.AbstractEventLoop) -> None:
         self._module = hw_module
         self._loop = loop
         super().__init__(ctx, geometry)

--- a/api/tests/opentrons/data/Everything_Test_Software.py
+++ b/api/tests/opentrons/data/Everything_Test_Software.py
@@ -8,6 +8,13 @@ may show up in a users' 'workflow'
 3. Tests different constructor set-ups
 """
 
+metadata = {
+    'protocolName': 'Everything Test',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A protocol for exercising the API',
+    'source': 'Opentrons Repository'
+}
+
 # Labware Set-up
 # Test whether slot naming conventions hold true
 tiprack = labware.load('tiprack-200ul', '1')

--- a/api/tests/opentrons/data/bradford_assay.py
+++ b/api/tests/opentrons/data/bradford_assay.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Bradford Assay',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A protien quantification assay',
+    'source': 'Opentrons Repository'
+}
+
 tiprack = containers.load('tiprack-200ul', '9')
 tiprack2 = containers.load('tiprack-200ul', '11')
 

--- a/api/tests/opentrons/data/calibration-validation.py
+++ b/api/tests/opentrons/data/calibration-validation.py
@@ -1,6 +1,13 @@
 # validate labware calibration instrument selection
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Calibration Validation',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'For validating the accuracy of a pipette',
+    'source': 'Opentrons Repository'
+}
+
 tiprack_s1 = containers.load('tiprack-200ul', '6', label='s1')
 tiprack_s2 = containers.load('tiprack-200ul', '3', label='s2')
 

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -1,5 +1,11 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Dinosaur',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'Simple protocol to draw a dinosaur in a 96 well plate',
+    'source': 'Opentrons Repository'
+}
 
 # a 12 row trough for sources, and 96 well plate for output
 trough = containers.load('trough-12row', '3', 'trough')

--- a/api/tests/opentrons/data/multi-only.py
+++ b/api/tests/opentrons/data/multi-only.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Multi-only',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A protocol that only uses an 8-channel pipette',
+    'source': 'Opentrons Repository'
+}
+
 tiprack = containers.load('tiprack-200ul', '8')
 trough = containers.load('trough-12row', '9')
 

--- a/api/tests/opentrons/data/multi-single.py
+++ b/api/tests/opentrons/data/multi-single.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Multi/Single',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A protocol that uses both 8- and 1-channel pipettes',
+    'source': 'Opentrons Repository'
+}
+
 # from opentrons import robot
 # robot.connect()
 # robot.home()

--- a/api/tests/opentrons/data/no_clear_tips.py
+++ b/api/tests/opentrons/data/no_clear_tips.py
@@ -1,5 +1,11 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'No-clear-tips',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A test protocol that does not drop tips at the end',
+    'source': 'Opentrons Repository'
+}
 
 # a 12 row trough for sources, and 96 well plate for output
 trough = containers.load('trough-12row', '3', 'trough')

--- a/api/tests/opentrons/data/pickup-accuracy.py
+++ b/api/tests/opentrons/data/pickup-accuracy.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Pickup accuracy',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A protocol for testing pick up and drop tip',
+    'source': 'Opentrons Repository'
+}
+
 # from opentrons import robot
 # robot.connect()
 # robot.home()

--- a/api/tests/opentrons/data/smoke.py
+++ b/api/tests/opentrons/data/smoke.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments
 
+metadata = {
+    'protocolName': 'Smoke',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'Simple protocol to test the server',
+    'source': 'Opentrons Repository'
+}
+
 tiprack = containers.load('tiprack-200ul', '8')
 plate = containers.load('96-PCR-flat', '5')
 

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -1,5 +1,12 @@
 from opentrons import containers, instruments, robot
 
+metadata = {
+    'protocolName': 'Testosaur',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'A variant on "Dinosaur" for testing',
+    'source': 'Opentrons Repository'
+}
+
 p200rack = containers.load('tiprack-200ul', '5', 'tiprack')
 
 # create a p200 pipette on robot axis B


### PR DESCRIPTION
## overview

Add metadata to session for Python protocols. Closes #2616

## changelog

- Add metadata to session for Python protocols

## review requests

Test on your robot (upload a protocol without and with a top-level variable named `metadata`, such as the one below).

```
from opentrons import instruments, labware

metadata = {
  'this': 'that',
  'what?': 'no'
}

tiprack = labware.load('opentrons-tiprack-300ul', '1')
plate = labware.load('96-plate', '2')

pip = instruments.P300_Multi(mount='right', tip_racks=[tiprack])
pip.pick_up_tip()
for well_idx in range(len(plate)):
pip.aspirate(30, plate.wells()[well_idx])
pip.dispense(30, plate.wells()[well_idx])
pip.return_tip()
```
