### PR TITLE
fix(app): Show main nav notification dot for updatable connected robot

### DIFF
--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -8,8 +8,8 @@ import {
   selectors as robotSelectors,
   constants as robotConstants,
 } from '../../robot'
-import {getConnectedRobot} from '../../discovery'
-import {makeGetRobotUpdateInfo} from '../../http-api-client'
+
+import {getConnectedRobotUpgradeAvailable} from '../../http-api-client'
 import {getAvailableShellUpdate} from '../../shell'
 import {NavButton} from '@opentrons/components'
 
@@ -25,15 +25,12 @@ export default withRouter(connect(mapStateToProps)(NavButton))
 
 function mapStateToProps (state: State, ownProps: OP): Props {
   const {name} = ownProps
-  const robot = getConnectedRobot(state)
-  const getUpdateInfo = makeGetRobotUpdateInfo()
-  const upgradable = robot && getUpdateInfo(state, robot).type === 'upgrade'
   const isProtocolLoaded = robotSelectors.getSessionIsLoaded(state)
   const isProtocolRunning = robotSelectors.getIsRunning(state)
   const isProtocolDone = robotSelectors.getIsDone(state)
   const isConnected =
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
-  const robotNotification = (isConnected && upgradable) || false
+  const robotNotification = getConnectedRobotUpgradeAvailable(state)
   const moreNotification = getAvailableShellUpdate(state) != null
 
   switch (name) {

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -8,7 +8,8 @@ import {
   selectors as robotSelectors,
   constants as robotConstants,
 } from '../../robot'
-import {getAnyRobotUpdateAvailable} from '../../http-api-client'
+import {getConnectedRobot} from '../../discovery'
+import {makeGetRobotUpdateInfo} from '../../http-api-client'
 import {getAvailableShellUpdate} from '../../shell'
 import {NavButton} from '@opentrons/components'
 
@@ -24,12 +25,15 @@ export default withRouter(connect(mapStateToProps)(NavButton))
 
 function mapStateToProps (state: State, ownProps: OP): Props {
   const {name} = ownProps
+  const robot = getConnectedRobot(state)
+  const getUpdateInfo = makeGetRobotUpdateInfo()
+  const upgradable = robot && getUpdateInfo(state, robot).type === 'upgrade'
   const isProtocolLoaded = robotSelectors.getSessionIsLoaded(state)
   const isProtocolRunning = robotSelectors.getIsRunning(state)
   const isProtocolDone = robotSelectors.getIsDone(state)
   const isConnected =
     robotSelectors.getConnectionStatus(state) === robotConstants.CONNECTED
-  const robotNotification = getAnyRobotUpdateAvailable(state)
+  const robotNotification = (isConnected && upgradable) || false
   const moreNotification = getAvailableShellUpdate(state) != null
 
   switch (name) {

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -10,7 +10,6 @@ import {
   makeGetRobotIgnoredUpdateRequest,
   makeGetRobotUpdateRequest,
   makeGetRobotRestartRequest,
-  getAnyRobotUpdateAvailable,
   restartRobotServer,
   fetchIgnoredUpdate,
   setIgnoredUpdate,
@@ -127,22 +126,6 @@ describe('server API client', () => {
       expect(getIngoredUpdate(state, {name: 'foo'})).toEqual({
         inProgress: false,
       })
-    })
-
-    // TODO(mc, 2018-09-25): re-evaluate this selector
-    test.skip('getAnyRobotUpdateAvailable is true if any robot has update', () => {
-      state.api.server.anotherBot = {availableUpdate: null}
-      expect(getAnyRobotUpdateAvailable(state)).toBe(true)
-
-      state = {
-        api: {
-          server: {
-            ...state.api.server,
-            [robot.name]: {availableUpdate: null},
-          },
-        },
-      }
-      expect(getAnyRobotUpdateAvailable(state)).toBe(false)
     })
   })
 

--- a/app/src/http-api-client/__tests__/server.test.js
+++ b/app/src/http-api-client/__tests__/server.test.js
@@ -13,6 +13,7 @@ import {
   restartRobotServer,
   fetchIgnoredUpdate,
   setIgnoredUpdate,
+  getConnectedRobotUpgradeAvailable,
   reducer,
 } from '..'
 
@@ -92,6 +93,17 @@ describe('server API client', () => {
       expect(getRobotUpdateInfo(state, {name: 'foo'})).toEqual({
         version,
         type: null,
+      })
+
+      test('getConnectedRobotUpgradeAvailable', () => {
+        robot = setCurrent(robot, '3.0.0')
+        expect(getConnectedRobotUpgradeAvailable(state)).toEqual(true)
+
+        robot = setCurrent(robot, '4.0.0')
+        expect(getConnectedRobotUpgradeAvailable(state)).toEqual(false)
+
+        robot = setCurrent(robot, '5.0.0')
+        expect(getConnectedRobotUpgradeAvailable(state)).toEqual(false)
       })
     })
 

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -6,7 +6,8 @@ import semver from 'semver'
 import {chainActions} from '../util'
 import client, {FetchError} from './client'
 import {fetchHealth} from './health'
-import {getRobotApiVersion} from '../discovery'
+import {getRobotApiVersion, getConnectedRobot} from '../discovery'
+
 import {
   getApiUpdateVersion,
   getApiUpdateFilename,
@@ -306,6 +307,18 @@ export const makeGetRobotIgnoredUpdateRequest = () => {
     )
 
   return selector
+}
+
+export function getConnectedRobotUpgradeAvailable (state: State) {
+  const connectedRobot = getConnectedRobot(state)
+  if (!connectedRobot) {
+    return false
+  }
+  const currentVersion = getRobotApiVersion(connectedRobot)
+  const updateVersion = getApiUpdateVersion(state)
+  const current = semver.valid(currentVersion)
+  const upgradeAvailable = current && semver.gt(updateVersion, current)
+  return upgradeAvailable
 }
 
 function selectServerState (state: State) {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -251,28 +251,45 @@ export type RobotUpdateType = 'upgrade' | 'downgrade' | null
 
 export type RobotUpdateInfo = {version: string, type: RobotUpdateType}
 
+const compareCurrentVersionToUpdate = (
+  currentVersion: ?string,
+  updateVersion: string
+): RobotUpdateInfo => {
+  const current = semver.valid(currentVersion)
+  let type = null
+
+  if (current && semver.gt(updateVersion, currentVersion)) {
+    type = 'upgrade'
+  } else if (current && semver.lt(updateVersion, currentVersion)) {
+    type = 'downgrade'
+  }
+
+  return {version: updateVersion, type: type}
+}
+
 export const makeGetRobotUpdateInfo = () => {
   const selector: OutputSelector<State,
     AnyRobot,
     RobotUpdateInfo> = createSelector(
       (_, robot) => getRobotApiVersion(robot),
       getApiUpdateVersion,
-      (currentVersion, updateVersion) => {
-        const current = semver.valid(currentVersion)
-        const upgrade = current && semver.gt(updateVersion, current)
-        const downgrade = current && semver.lt(updateVersion, current)
-        let type
-        if (!upgrade && !downgrade) {
-          type = null
-        } else {
-          type = upgrade ? 'upgrade' : 'downgrade'
-        }
-        return {version: updateVersion, type: type}
-      }
+      compareCurrentVersionToUpdate
     )
 
   return selector
 }
+
+export const getConnectedRobotUpgradeAvailable: OutputSelector<State,
+  void,
+  boolean> = createSelector(
+    getConnectedRobot,
+    getApiUpdateVersion,
+    (robot, updateVersion) => {
+      const currentVersion = robot && getRobotApiVersion(robot)
+      const info = compareCurrentVersionToUpdate(currentVersion, updateVersion)
+      return info.type === 'upgrade'
+    }
+  )
 
 // TODO(mc, 2018-09-25): this is broken until some planned discovery work is
 // done for https://github.com/Opentrons/opentrons/milestone/68
@@ -307,18 +324,6 @@ export const makeGetRobotIgnoredUpdateRequest = () => {
     )
 
   return selector
-}
-
-export function getConnectedRobotUpgradeAvailable (state: State) {
-  const connectedRobot = getConnectedRobot(state)
-  if (!connectedRobot) {
-    return false
-  }
-  const currentVersion = getRobotApiVersion(connectedRobot)
-  const updateVersion = getApiUpdateVersion(state)
-  const current = semver.valid(currentVersion)
-  const upgradeAvailable = current && semver.gt(updateVersion, current)
-  return upgradeAvailable
 }
 
 function selectServerState (state: State) {

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -308,13 +308,6 @@ export const makeGetRobotIgnoredUpdateRequest = () => {
   return selector
 }
 
-// TODO(mc, 2018-10-10): this selector is broken
-export const getAnyRobotUpdateAvailable: OutputSelector<State,
-  void,
-  boolean> = createSelector(selectServerState, state =>
-    Object.keys(state).some(name => state[name].availableUpdate)
-  )
-
 function selectServerState (state: State) {
   return state.api.server
 }


### PR DESCRIPTION
## overview

closes #2642

## changelog

- fix(app): Show main nav notification dot for updatable connected robot
- remove broken `getAnyRobotUpdateAvailable` selector and tests

## review requests
- open app
- [ ] App opens and no notification dot on robots tab

- connect to a robot with an available update
- [ ] robots tab displays notification dot

- navigate to upload or other page with a robot connected
- [ ] robots tab still displays notification dot