### PR TITLE
fix(api): Do not overwrite settings every time we get config files

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -79,7 +79,7 @@ def get_config_index() -> dict:
     file_path = os.path.join(base_path, index_filename)
     with open(file_path) as base_config_file:
         res = json.load(base_config_file)
-    defaults = _generate_base_config()[1]
+    defaults = _generate_base_config(skip_usb=True)[1]
     for key, default_val in defaults.items():
         if key not in res.keys():
             res[key] = default_val

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -973,7 +973,7 @@ class Robot():
         `robot.update_config(name='Grace Hopper')` will update the `name` key
         of the configuration.
         """
-        self.config._replace(**kwargs)
+        self.config = self.config._replace(**kwargs)
 
     async def update_firmware(self,
                               filename,


### PR DESCRIPTION
opentrons.config._generate_base_config(), in addition to generating and
returning defaults, will _write_ those defaults to the appropriate places unless
the skip_usb flag is set. In get_config_index(), which is mostly intended to
just find the config files, it uses generate_base_config to generate the config
but does not intend to write it. We therefore need to explicitly tell
_generate_base_config to not overwrite anything.

## Review requests

Check that the logic makes sense.

To see if it worked, make an edit (any edit) in settings files on the usb drive, then save and restart the robot. Once it boots, the changes should still be there.