### PR TITLE
API: Add ability to use papi2 in protocol

### DIFF
--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -45,6 +45,8 @@ The design goal of the Opentrons API is to make code readable and easy to unders
 
     Use the Opentrons API's labware and instruments
 
+    This protocol is by me; it’s called Opentrons Protocol Tutorial and is used for demonstrating the Opentrons API
+
     Add a 96 well plate, and place it in slot '2' of the robot deck
     Add a 200uL tip rack, and place it in slot '1' of the robot deck
 

--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -1,30 +1,154 @@
 .. _protocol-api:
 
-New Protocol API
+Opentrons API Version 4
 ================
 
+For the OT 1 API, `please go to this link`__
 
-.. _protocol-api-backcompat:
+__ https://docs.opentrons.com/ot1/
 
-Backwards Compatibility
------------------------
+For Version 3 of the OT 2 API, `please go to this link`__
 
-.. automodule:: opentrons.protocol_api.back_compat
+__ https://docs.opentrons.com
 
-.. autoclass:: opentrons.protocol_api.back_compat.BCRobot
-   :members:
+The Opentrons API is a simple framework designed to make writing automated biology lab protocols easy.
 
-.. autoclass:: opentrons.protocol_api.back_compat.BCInstruments
-   :members:
+We’ve designed it in a way we hope is accessible to anyone with basic computer and wetlab skills. As a bench scientist, you should be able to code your automated protocols in a way that reads like a lab notebook.
 
-.. autoclass:: opentrons.protocol_api.back_compat.BCLabware
-   :members:
+`View source code on GitHub`__
 
-.. autoclass:: opentrons.protocol_api.back_compat.BCModules
-   :members:
-
+__ https://github.com/Opentrons/opentrons
 
 .. _protocol-api-robot:
+
+**********************
+
+How it Looks
+---------------
+
+The design goal of the Opentrons API is to make code readable and easy to understand. For example, below is a short set of instruction to transfer from well ``'A1'`` to well ``'B1'`` that even a computer could understand:
+
+.. code-block:: none
+
+    This protocol is by me; it’s called Opentrons Protocol Tutorial and is used for demonstrating the Opentrons API
+
+    Begin the protocol
+
+    Add a 96 well plate, and place it in slot '2' of the robot deck
+    Add a 200uL tip rack, and place it in slot '1' of the robot deck
+
+    Add a single-channel 300uL pipette to the left mount, and tell it to use that tip rack
+
+    Transfer 100uL from the plate's 'A1' well to it's 'B2' well
+
+If we were to rewrite this with the Opentrons API, it would look like the following:
+
+.. code-block:: python
+
+    # metadata
+    metadata = {
+        'protocolName': 'My Protocol',
+        'author': 'Name <email@address.com>',
+        'description': 'Simple protocol to get started using OT2',
+        'source': 'Opentrons Protocol Tutorial'
+    }
+
+    # protocol run function
+    def run(protocol_context):
+
+        # labware
+        plate = protocol_context.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
+        tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300_uL', '1')
+
+        # pipettes
+        pipette = protocol_context.load_instrument(’p300_single’, ’left’, tip_racks=[tiprack])
+
+        # commands
+        pipette.aspirate(100, plate.wells_by_index()[’A1’])
+        pipette.dispense(100, plate.wells_by_index()[’B2’])
+
+
+**********************
+
+How it's Organized
+------------------
+
+When writing protocols using the Opentrons API, there are generally five sections:
+
+1) Metadata
+2) Run function
+3) Labware
+4) Pipettes
+5) Commands
+
+Metadata
+^^^^^^^^
+
+Metadata is a dictionary of data that is read by the server and returned to client applications (such as the Opentrons Run App). It is not needed to run a protocol (and is entirely optional), but if present can help the client application display additional data about the protocol currently being executed.
+
+The fields above ("protocolName", "author", "description", and "source") are the recommended fields, but the metadata dictionary can contain fewer fields, or additional fields as desired (though non-standard fields may not be rendered by the client, depending on how it is designed).
+
+Run Function
+^^^^^^^^^^^^
+
+Opentrons API version 4 protocols are structured around a function called ``run(ctx)``. This function must be named exactly ``run`` and must take exactly one mandatory argument (its name doesn’t matter). When the robot runs a protocol, it will call this function, and pass it an object that does two things:
+
+1) Remember, track, and check the robot’s state
+2) Expose the functions that make the robot act
+
+This object is called the *protocol context*, and is always an instance of the :py:class:`.ProtocolContext` class. The protocol context plays the same role as the ``robot``, ``labware``, ``instruments``, and ``modules`2` objects in past versions of the API, with one important difference: it is only one object; and because it is passed in to your protocol rather than imported, it is possible for the API to be much more rigorous about separating simulation from reality.
+
+The key point is that there is no longer any need to `import opentrons` at the top of every protocol, since the *robot* now *runs the protocol*, rather than the *protocol running the robot*.
+
+
+Labware
+^^^^^^^
+
+The labware section informs the protocol context what labware is present on the robot’s deck. In this section, you define the tip racks, well plates, troughs, tubes, or anything else you’ve put on the deck.
+
+Each labware is given a name (ex: ``'generic_96_wellPlate_380_uL'``), and the slot on the robot it will be placed (ex: ``'2'``).
+
+From the example above, the "labware" section looked like:
+
+.. code-block:: python
+
+    plate = protocol_context.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
+    tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300_uL', '1')
+
+
+and informed the protocol context that the deck contains a 300 uL tiprack in slot 1 and a 96 well plate in slot 2.
+
+
+Pipettes
+^^^^^^^^
+
+Next, pipettes are created and attached to a specific mount on the OT-2 (``'left'`` or ``'right'``).
+
+There are other parameters for pipettes, but the most important are the tip rack(s) it will use during the protocol.
+
+From the example above, the "pipettes" section looked like:
+
+.. code-block:: python
+
+    pipette = protocol_context.load_instrument(’p300_single’, ’left’, tip_racks=[tiprack])
+
+
+Commands
+^^^^^^^^
+
+And finally, the most fun section, the actual protocol commands! The most common commands are ``transfer()``, ``aspirate()``, ``dispense()``, ``pick_up_tip()``, ``drop_tip()``, and much more.
+
+This section can tend to get long, relative to the complexity of your protocol. However, with a better understanding of Python you can learn to compress and simplify even the most complex-seeming protocols.
+
+From the example above, the "commands" section looked like:
+
+.. code-block:: python
+
+    pipette.aspirate(100, plate.wells_by_index()['A1'])
+    pipette.dispense(100, plate.wells_by_index()[’B2’])
+
+which does exactly what it says - aspirate 100 uL from A1 and dispense it all in B2.
+
 
 Robot and Pipette
 -----------------

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,4 +1,4 @@
-from opentrons.legacy_api.containers import Slot
+from opentrons.legacy_api.containers import Slot, placeable
 
 
 def _get_parent_slot(placeable):
@@ -13,11 +13,15 @@ class Container:
     def __init__(self, container, instruments=None):
         instruments = instruments or []
         self._container = container
-
         self.id = id(container)
-        self.name = container.get_name()
-        self.type = container.get_type()
-        self.slot = _get_parent_slot(container).get_name()
+
+        if isinstance(container, placeable.Placeable):
+            self.name = container.get_name()
+            self.type = container.get_type()
+            self.slot = _get_parent_slot(container).get_name()
+        else:
+            self.name = str(container)
+            self.type = container.name
         self.instruments = [
             Instrument(instrument)
             for instrument in instruments]

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -32,10 +32,6 @@ class Instrument:
         self.name = instrument.name
         self.channels = instrument.channels
         self.mount = instrument.mount
-        # Although axis has been deprecated from the instrument
-        # we still need to pass it to the UI for now
-        # Warning: this does not correspond to the Smoothie axis!
-        self.axis = 'a' if self.mount == 'right' else 'b'
         self.tip_racks = [
             Container(container)
             for container in instrument.tip_racks]

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -20,8 +20,9 @@ class Container:
             self.type = container.get_type()
             self.slot = _get_parent_slot(container).get_name()
         else:
-            self.name = str(container)
+            self.name = container.name
             self.type = container.name
+            self.slot = container.parent
         self.instruments = [
             Instrument(instrument)
             for instrument in instruments]

--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -14,7 +14,7 @@ class MainRouter:
             CalibrationManager.TOPIC,
             self._notifications.on_notify)]
 
-        self.session_manager = SessionManager(hardware)
+        self.session_manager = SessionManager(hardware=hardware, loop=loop)
         self.calibration_manager = CalibrationManager(hardware=hardware,
                                                       loop=loop)
 

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -13,7 +13,9 @@ from opentrons.legacy_api.containers.placeable import (
 from opentrons.commands import tree, types
 from opentrons.protocols import execute_protocol
 from opentrons.config import feature_flags as ff
-from opentrons.protocol_api import ProtocolContext, run_protocol, labware
+from opentrons.protocol_api import (ProtocolContext,
+                                    labware,
+                                    run_protocol)
 from opentrons.hardware_control import adapters, API
 from opentrons.types import Location, Point
 
@@ -186,6 +188,7 @@ class Session(object):
                     instrs,
                     [mod.name() for mod in self._hardware.attached_modules])
                 context = ProtocolContext(hardware=sim, loop=self._loop)
+                context.home()
                 run_protocol(self._protocol, simulate=True, context=context)
                 sim.join()
             else:
@@ -281,6 +284,7 @@ class Session(object):
                 self._hardware.cache_instruments()
                 ctx = ProtocolContext(loop=self._loop)
                 ctx.connect(self._hardware)
+                ctx.home()
                 run_protocol(self._protocol, context=ctx)
             else:
                 if self._is_json_protocol:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -443,11 +443,11 @@ def _get_labware(command):
 
     if location:
         if isinstance(location, (Placeable)) or type(location) == tuple:
-            # tyoe()== used here instead of isinstance because a specific
+            # type()== used here instead of isinstance because a specific
             # named tuple like location descends from tuple and therefore
             # passes the check
             containers.append(get_container(location))
-        elif isinstance(location, Location):
+        elif isinstance(location, (Location, labware.Well, labware.Labware)):
             containers.append(_get_new_labware(location))
 
     if locations:

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -2,28 +2,44 @@ from . import types
 from ..broker import broker
 import functools
 import inspect
-from opentrons.legacy_api.containers\
-    import Well, Container, Slot, location_to_list
+from typing import Union
+
+from opentrons.legacy_api.containers import (Well as OldWell,
+                                             Container as OldContainer,
+                                             Slot as OldSlot,
+                                             location_to_list)
+from opentrons.protocol_api.labware import Well, Labware, ModuleGeometry
+from opentrons.types import Location
 
 
-def stringify_location(location):
+def _stringify_new_loc(loc: Location) -> str:
+    if isinstance(loc.labware, str):
+        return loc.parent
+    elif isinstance(loc.labware, (Labware, Well, ModuleGeometry)):
+        return repr(loc.labware)
+    else:
+        return str(loc.point)
+
+
+def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
+                                     OldSlot, None]) -> str:
     def get_slot(location):
         trace = location.get_trace()
         for item in trace:
-            if isinstance(item, Slot):
+            if isinstance(item, OldSlot):
                 return item
 
     type_to_text = {
-        Slot: 'slot',
-        Container: 'container',
-        Well: 'well'
+        OldSlot: 'slot',
+        OldContainer: 'container',
+        OldWell: 'well',
     }
 
     # Coordinates only
-    if location is None:
+    if loc is None:
         return '?'
 
-    location = location_to_list(location)
+    location = location_to_list(loc)
     multiple = len(location) > 1
 
     return '{object_text}{suffix} {first}{last} in "{slot_text}"'.format(
@@ -33,6 +49,14 @@ def stringify_location(location):
             last='...'+location[-1].get_name() if multiple else '',
             slot_text=get_slot(location[0]).get_name()
         )
+
+
+def stringify_location(location: Union[Location, None,
+                                       OldWell, OldContainer, OldSlot]) -> str:
+    if isinstance(location, Location):
+        return _stringify_new_loc(location)
+    else:
+        return _stringify_legacy_loc(location)
 
 
 def make_command(name, payload):
@@ -325,55 +349,58 @@ def resume():
     )
 
 
-def _do_publish(before, after, command, meta=None):
+def do_publish(cmd, f, when, res, meta, *args, **kwargs):
+    """ Implement the publish so it can be called outside the decorator """
     publish_command = functools.partial(
         broker.publish,
         topic=types.COMMAND)
+    call_args = _get_args(f, args, kwargs)
+    command_args = dict(
+        zip(
+            reversed(inspect.getfullargspec(cmd).args),
+            reversed(inspect.getfullargspec(cmd).defaults
+                     or [])))
 
+    # TODO (artyom, 20170927): we are doing this to be able to use
+    # the decorator in Instrument class methods, in which case
+    # self is effectively an instrument.
+    # To narrow the scope of this hack, we are checking if the
+    # command is expecting instrument first.
+    if 'instrument' in inspect.getfullargspec(cmd).args:
+        # We are also checking if call arguments have 'self' and
+        # don't have instruments specified, in which case
+        # instruments should take precedence.
+        if 'self' in call_args and 'instrument' not in call_args:
+            call_args['instrument'] = call_args['self']
+
+    command_args.update({
+        key: call_args[key]
+        for key in
+        (set(inspect.getfullargspec(cmd).args)
+         & call_args.keys())
+    })
+
+    if meta:
+        command_args['meta'] = meta
+
+    payload = cmd(**command_args)
+
+    message = {**payload, '$': when}
+    if when == 'after':
+        message['return'] = res
+    publish_command(
+        message={**payload, '$': when})
+
+
+def _publish_dec(before, after, command, meta=None):
     def decorator(f):
         @functools.wraps(f)
         def decorated(*args, **kwargs):
-            call_args = _get_args(f, args, kwargs)
-            command_args = dict(
-                zip(
-                    reversed(inspect.getfullargspec(command).args),
-                    reversed(inspect.getfullargspec(command).defaults
-                             or [])))
-
-            # TODO (artyom, 20170927): we are doing this to be able to use
-            # the decorator in Instrument class methods, in which case
-            # self is effectively an instrument.
-            # To narrow the scope of this hack, we are checking if the
-            # command is expecting instrument first.
-            if 'instrument' in inspect.getfullargspec(command).args:
-                # We are also checking if call arguments have 'self' and
-                # don't have instruments specified, in which case
-                # instruments should take precedence.
-                if 'self' in call_args and 'instrument' not in call_args:
-                    call_args['instrument'] = call_args['self']
-
-            command_args.update({
-                key: call_args[key]
-                for key in
-                (set(inspect.getfullargspec(command).args)
-                 & call_args.keys())
-            })
-
-            if meta:
-                command_args['meta'] = meta
-
-            payload = command(**command_args)
-
             if before:
-                publish_command(
-                    message={**payload, '$': 'before'})
-
+                do_publish(command, f, 'before', None, meta, *args, **kwargs)
             res = f(*args, **kwargs)
-
             if after:
-                publish_command(
-                    message={**payload, '$': 'after', 'return': res})
-
+                do_publish(command, f, 'after', res, meta, *args, **kwargs)
             return res
         return decorated
 
@@ -390,9 +417,9 @@ class publish:
     Making a simple class with these as attributes does the same thing
     but in a way that mypy can actually verify.
     """
-    before = functools.partial(_do_publish, before=True, after=False)
-    after = functools.partial(_do_publish, before=False, after=True)
-    both = functools.partial(_do_publish, before=True, after=True)
+    before = functools.partial(_publish_dec, before=True, after=False)
+    after = functools.partial(_publish_dec, before=False, after=True)
+    both = functools.partial(_publish_dec, before=True, after=True)
 
 
 def _get_args(f, args, kwargs):

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -12,13 +12,18 @@ from opentrons.protocol_api.labware import Well, Labware, ModuleGeometry
 from opentrons.types import Location
 
 
-def _stringify_new_loc(loc: Location) -> str:
-    if isinstance(loc.labware, str):
-        return loc.parent
-    elif isinstance(loc.labware, (Labware, Well, ModuleGeometry)):
-        return repr(loc.labware)
+def _stringify_new_loc(loc: Union[Location, Well]) -> str:
+    if isinstance(loc, Location):
+        if isinstance(loc.labware, str):
+            return loc.parent
+        elif isinstance(loc.labware, (Labware, Well, ModuleGeometry)):
+            return repr(loc.labware)
+        else:
+            return str(loc.point)
+    elif isinstance(loc, Well):
+        return str(loc)
     else:
-        return str(loc.point)
+        raise TypeError(loc)
 
 
 def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
@@ -53,7 +58,7 @@ def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
 
 def stringify_location(location: Union[Location, None,
                                        OldWell, OldContainer, OldSlot]) -> str:
-    if isinstance(location, Location):
+    if isinstance(location, (Location, Well)):
         return _stringify_new_loc(location)
     else:
         return _stringify_legacy_loc(location)

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -15,7 +15,7 @@ from opentrons.types import Location
 def _stringify_new_loc(loc: Union[Location, Well]) -> str:
     if isinstance(loc, Location):
         if isinstance(loc.labware, str):
-            return loc.parent
+            return loc.labware
         elif isinstance(loc.labware, (Labware, Well, ModuleGeometry)):
             return repr(loc.labware)
         else:

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -31,7 +31,8 @@ pipette_config = namedtuple(
         'ul_per_mm',
         'quirks',
         'tip_length',  # TODO (andy): remove from pipette, move to tip-rack
-        'display_name'
+        'display_name',
+        'tip_overlap'
     ]
 )
 
@@ -104,7 +105,8 @@ def load(pipette_model: str) -> pipette_config:
         ul_per_mm=cfg.get('ulPerMm'),
         quirks=cfg.get('quirks'),
         tip_length=cfg.get('tipLength'),
-        display_name=cfg.get('displayName')
+        display_name=cfg.get('displayName'),
+        tip_overlap=cfg.get('tipOverlap')
     )
 
     # Verify that stored values agree with calculations

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -223,10 +223,10 @@ def _load_json(filename) -> dict:
         with open(filename, 'r') as file:
             res = json.load(file)
     except FileNotFoundError:
-        print('Warning: {0} not found. Loading defaults'.format(filename))
+        log.warning('{0} not found. Loading defaults'.format(filename))
         res = {}
     except json.decoder.JSONDecodeError:
-        print('Error: {0} is corrupt. Loading defaults'.format(filename))
+        log.warning('{0} is corrupt. Loading defaults'.format(filename))
         res = {}
     return res
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -142,6 +142,10 @@ class API(HardwareAPILike):
                              config, loop),
                    config=config, loop=loop)
 
+    def __repr__(self):
+        return '<{} using backend {}>'.format(type(self),
+                                              type(self._backend))
+
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         """ The event loop used by this instance. """

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -634,7 +634,7 @@ class API(HardwareAPILike):
                     deck_max = self._deck_from_smoothie({ax: bound[1]
                                                          for ax, bound
                                                          in bounds.items()})
-                    raise RuntimeError(
+                    self._log.warning(
                         "Out of bounds move: {}={} (transformed: {}) not in"
                         "limits ({}, {}) (transformed: ({}, {})"
                         .format(ax.name,

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -132,7 +132,7 @@ class Controller:
             if expected_instr and\
                (not found_model or not found_model.startswith(expected_instr)):
                 raise RuntimeError(
-                    'mount {}: expected instrument {} but got {}'
+                    'mount {}: instrument {} was requested but {} is present'
                     .format(mount.name, expected_instr, found_model))
             to_return[mount] = {
                 'model': found_model,

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -96,7 +96,7 @@ class Pipette:
         """
         assert tip_length > 0.0, "tip_length must be greater than 0"
         assert not self.has_tip
-        self._current_tip_length = tip_length
+        self._current_tip_length = tip_length - self._config.tip_overlap
 
     def remove_tip(self) -> None:
         """

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -37,6 +37,29 @@ class Simulator:
             attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
             attached_modules: List[str],
             config, loop) -> None:
+        """ Build the simulator.
+
+        :param attached_instruments: A dictionary describing the instruments
+                                     the simulator should consider attached.
+                                     If this argument is specified and
+                                     :py:meth:`get_attached_instruments` is
+                                     called with expectations that do not
+                                     match, the call fails. This is useful for
+                                     making the simulator match the real
+                                     hardware, for instance to check if a
+                                     protocol asks for the right instruments.
+                                     This dict should map mounts to either
+                                     empty dicts or to dicts containing
+                                     'model' and 'id' keys.
+        :param attached_modules: A list of module model names (e.g.
+                                 `'tempdeck'` or `'magdeck'`) representing
+                                 modules the simulator should assume are
+                                 attached. Like `attached_instruments`, used
+                                 to make the simnulator match the setup of the
+                                 real hardware.
+        :param config: The robot config to use
+        :param loop: The asyncio event loop to use.
+        """
         self._config = config
         self._loop = loop
         self._attached_instruments = attached_instruments

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,51 +4,15 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-import logging
-import os
-
 from . import back_compat, labware
 from .contexts import (ProtocolContext,
                        InstrumentContext,
                        TemperatureModuleContext,
                        MagneticModuleContext)
+from .execute import run_protocol
 
 
-MODULE_LOG = logging.getLogger(__name__)
-
-
-def run(protocol_bytes: bytes = None,
-        protocol_json: str = None,
-        simulate: bool = False,
-        context: ProtocolContext = None):
-    """ Create a ProtocolRunner instance from one of a variety of protocol
-    sources.
-
-    :param protocol_bytes: If the protocol is a Python protocol, pass the
-    file contents here.
-    :param protocol_json: If the protocol is a json file, pass the contents
-    here.
-    :param simulate: True to simulate; False to execute. If this is not an
-    OT2, ``simulate`` will be forced ``True``.
-    :param context: The context to use. If ``None``, create a new
-    ProtocolContext.
-    """
-    if not os.environ.get('RUNNING_ON_PI'):
-        simulate = True # noqa - will be used later
-    if None is context and simulate:
-        true_context = ProtocolContext()
-    elif context:
-        true_context = context
-    else:
-        raise RuntimeError(
-            'Will not automatically generate hardware controller')
-    if protocol_bytes:
-        back_compat.run(protocol_bytes, true_context)
-    elif protocol_json:
-        pass
-
-
-__all__ = ['run',
+__all__ = ['run_protocol',
            'ProtocolContext',
            'InstrumentContext',
            'TemperatureModuleContext',

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -96,7 +96,7 @@ class ProtocolContext:
 
         self._hw_manager = ProtocolContext.HardwareManager(hardware)
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
-        self._commands = []
+        self._commands: List[str] = []
         self._unsubscribe_commands = None
         self.clear_commands()
 
@@ -441,8 +441,14 @@ class InstrumentContext:
             raise TypeError(
                 'location should be a Well or Location, but it is {}'
                 .format(location))
-        else:
+        elif self._ctx.location_cache:
             loc = self._ctx.location_cache
+        else:
+            raise RuntimeError(
+                "If aspirate is called without an explicit location, another"
+                " method that moves to a location (such as move_to or "
+                "dispense) must previously have been called so the robot "
+                "knows where it is.")
         cmds.do_publish(cmds.aspirate, self.aspirate, 'before', None, None,
                         self, volume, loc, rate)
         self._hw_manager.hardware.aspirate(self._mount, volume, rate)
@@ -499,8 +505,14 @@ class InstrumentContext:
             raise TypeError(
                 'location should be a Well or Location, but it is {}'
                 .format(location))
-        else:
+        elif self._ctx.location_cache:
             loc = self._ctx.location_cache
+        else:
+            raise RuntimeError(
+                "If dispense is called without an explicit location, another"
+                " method that moves to a location (such as move_to or "
+                "aspirate) must previously have been called so the robot "
+                "knows where it is.")
         cmds.do_publish(cmds.dispense, self.dispense, 'before', None, None,
                         self, volume, loc, rate)
         self._hw_manager.hardware.dispense(self._mount, volume, rate)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
+import time
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from .labware import Well, Labware, load, load_module, ModuleGeometry
-from opentrons import types, hardware_control as hc
+from opentrons import types, hardware_control as hc, broker, commands as cmds
 import opentrons.config.robot_configs as rc
 from opentrons.config import advanced_settings
 from opentrons.hardware_control import adapters, modules
@@ -48,6 +49,29 @@ class ProtocolContext:
         self._location_cache: Optional[types.Location] = None
         self._hardware = self._build_hardware_adapter(self._loop)
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
+        self._commands = []
+        self._unsubscribe_commands = None
+        self.clear_commands()
+
+    def commands(self):
+        return self._commands
+
+    def clear_commands(self):
+        self._commands.clear()
+        if self._unsubscribe_commands:
+            self._unsubscribe_commands()
+
+        def on_command(message):
+            payload = message.get('payload')
+            text = payload.get('text')
+            if text is None:
+                return
+
+            if message['$'] == 'before':
+                self._commands.append(text.format(**payload))
+
+        self._unsubscribe_commands = broker.subscribe(
+            cmds.types.COMMAND, on_command)
 
     def connect(self, hardware: hc.API):
         """ Connect to a running hardware API.
@@ -195,22 +219,42 @@ class ProtocolContext:
         """
         raise NotImplementedError
 
-    def pause(self):
+    @cmds.publish.both(command=cmds.pause)
+    def pause(self, msg):
         """ Pause execution of the protocol until resume is called.
 
-        Note: This function call will not return until the protocol
-        is resumed (presumably by a user in the run app).
+        This function returns immediately, but the next function call that
+        is blocked by a paused robot (anything that involves moving) will
+        not return until :py:meth:`resume` is called.
+
+        :param str msg: A message to echo back to connected clients.
         """
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.resume)
     def resume(self):
-        """ Resume a previously-paused protocol. """
+        """ Resume a previously-paused protocol """
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.comment)
     def comment(self, msg):
         """ Add a user-readable comment string that will be echoed to the
         Opentrons app. """
-        raise NotImplementedError
+        pass
+
+    @cmds.publish.both(command=cmds.delay)
+    def delay(self, seconds=0, minutes=0):
+        """ Delay protocol execution for a specific amount of time.
+
+        :param float seconds: A time to delay in seconds
+        :param float minutes: A time to delay in minutes
+
+        If both `seconds` and `minutes` are specified, they will be added.
+        """
+        delay_time = seconds + minutes*60
+        self.pause()
+        time.sleep(delay_time)
+        self.resume()
 
     @property
     def config(self) -> rc.robot_config:
@@ -344,19 +388,27 @@ class InstrumentContext:
                         .format(volume,
                                 location if location else 'current position',
                                 rate))
+
         if isinstance(location, Well):
             point, well = location.bottom()
-            self.move_to(
-                types.Location(point + types.Point(0, 0,
-                                                   self.well_bottom_clearance),
-                               well))
+            loc = types.Location(
+                point + types.Point(0, 0, self.well_bottom_clearance),
+                well)
+            self.move_to(loc)
         elif isinstance(location, types.Location):
+            loc = location
             self.move_to(location)
         elif location is not None:
             raise TypeError(
                 'location should be a Well or Location, but it is {}'
                 .format(location))
+        else:
+            loc = self._ctx.location_cache
+        cmds.do_publish(cmds.aspirate, self.aspirate, 'before', None, None,
+                        self, volume, loc, rate)
         self._hardware.aspirate(self._mount, volume, rate)
+        cmds.do_publish(cmds.aspirate, self.aspirate, 'after', self, None,
+                        self, volume, loc, rate)
         return self
 
     def dispense(self,
@@ -397,19 +449,27 @@ class InstrumentContext:
                                 rate))
         if isinstance(location, Well):
             point, well = location.bottom()
-            self.move_to(
-                types.Location(point + types.Point(0, 0,
-                                                   self.well_bottom_clearance),
-                               well))
+            loc = types.Location(
+                point + types.Point(0, 0, self.well_bottom_clearance),
+                well)
+            self.move_to(loc)
         elif isinstance(location, types.Location):
+            loc = location
             self.move_to(location)
         elif location is not None:
             raise TypeError(
                 'location should be a Well or Location, but it is {}'
                 .format(location))
+        else:
+            loc = self._ctx.location_cache
+        cmds.do_publish(cmds.dispense, self.dispense, 'before', None, None,
+                        self, volume, loc, rate)
         self._hardware.dispense(self._mount, volume, rate)
+        cmds.do_publish(cmds.dispense, self.dispense, 'after', self, None,
+                        self, volume, loc, rate)
         return self
 
+    @cmds.publish.both(command=cmds.mix)
     def mix(self,
             repetitions: int = 1,
             volume: float = None,
@@ -417,6 +477,7 @@ class InstrumentContext:
             rate: float = 1.0) -> 'InstrumentContext':
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.blow_out)
     def blow_out(self, location: Well = None) -> 'InstrumentContext':
         """
         Blow liquid out of the tip.
@@ -426,6 +487,7 @@ class InstrumentContext:
         """
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.touch_tip)
     def touch_tip(self,
                   location: Well = None,
                   radius: float = 1.0,
@@ -433,11 +495,13 @@ class InstrumentContext:
                   speed: float = 60.0) -> 'InstrumentContext':
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.air_gap)
     def air_gap(self,
                 volume: float = None,
                 height: float = None) -> 'InstrumentContext':
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.return_tip)
     def return_tip(self) -> 'InstrumentContext':
         """
         If a tip is currently attached to the pipette, then it will return the
@@ -456,6 +520,7 @@ class InstrumentContext:
         self.drop_tip(loc.top())
         return self
 
+    @cmds.publish.both(command=cmds.pick_up_tip)
     def pick_up_tip(self, location: types.Location = None,
                     presses: int = 3,
                     increment: float = 1.0) -> 'InstrumentContext':
@@ -519,6 +584,7 @@ class InstrumentContext:
         self._last_tip_picked_up_from = target
         return self
 
+    @cmds.publish.both(command=cmds.drop_tip)
     def drop_tip(self, location: types.Location = None) -> 'InstrumentContext':
         """
         Drop the current tip.
@@ -553,7 +619,12 @@ class InstrumentContext:
 
         :returns: This instance.
         """
+        def home_dummy(mount): pass
+        cmds.do_publish(cmds.home, home_dummy, 'before', None, None,
+                        self._mount.name.lower())
         self._ctx.home()
+        cmds.do_publish(cmds.home, home_dummy, 'after', self, None,
+                        self._mount.name.lower())
         return self
 
     def home_plunger(self) -> 'InstrumentContext':
@@ -564,6 +635,7 @@ class InstrumentContext:
         self._hardware.home_plunger(self.mount)
         return self
 
+    @cmds.publish.both(command=cmds.distribute)
     def distribute(self,
                    volume: float,
                    source: Well,
@@ -571,6 +643,7 @@ class InstrumentContext:
                    *args, **kwargs) -> 'InstrumentContext':
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.consolidate)
     def consolidate(self,
                     volume: float,
                     source: Well,
@@ -578,12 +651,16 @@ class InstrumentContext:
                     *args, **kwargs) -> 'InstrumentContext':
         raise NotImplementedError
 
+    @cmds.publish.both(command=cmds.transfer)
     def transfer(self,
                  volume: float,
                  source: Well,
                  dest: Well,
                  **kwargs) -> 'InstrumentContext':
         raise NotImplementedError
+
+    def delay(self):
+        return self._ctx.delay()
 
     def move_to(self, location: types.Location) -> 'InstrumentContext':
         """ Move the instrument.
@@ -833,6 +910,7 @@ class TemperatureModuleContext(ModuleContext):
         self._loop = loop
         super().__init__(ctx, geometry)
 
+    @cmds.publish.both(command=cmds.tempdeck_set_temp)
     def set_temperature(self, celsius: float):
         """ Set the target temperature, in C.
 
@@ -842,6 +920,7 @@ class TemperatureModuleContext(ModuleContext):
         """
         return self._module.set_temperature(celsius)
 
+    @cmds.publish.both(command=cmds.tempdeck_deactivate)
     def deactivate(self):
         """ Stop heating (or cooling) and turn off the fan.
         """
@@ -878,6 +957,7 @@ class MagneticModuleContext(ModuleContext):
         self._loop = loop
         super().__init__(ctx, geometry)
 
+    @cmds.publish.both(command=cmds.magdeck_calibrate)
     def calibrate(self):
         """ Calibrate the Magnetic Module.
 
@@ -897,6 +977,7 @@ class MagneticModuleContext(ModuleContext):
                 " calling engage().")
         return super().load_labware(labware)
 
+    @cmds.publish.both(command=cmds.magdeck_engage)
     def engage(self, height: float = None, offset: float = None):
         """ Raise the Magnetic Module's magnets.
 
@@ -934,6 +1015,7 @@ class MagneticModuleContext(ModuleContext):
                 .format(self.labware))
         self._module.engage(dist)
 
+    @cmds.publish.both(command=cmds.magdeck_disengage)
     def disengage(self):
         """ Lower the magnets back into the Magnetic Module.
         """

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -346,8 +346,6 @@ class ProtocolContext:
         return self._deck_layout
 
 
-
-
 class InstrumentContext:
     """ A context for a specific pipette or instrument.
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -740,7 +740,7 @@ class InstrumentContext:
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
                 " However, it is a {}".format(location))
 
-        self.move_to(target.top())
+        self.move_to(target.bottom())
         self._hw_manager.hardware.drop_tip(self._mount)
         return self
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -284,7 +284,7 @@ class ProtocolContext:
         raise NotImplementedError
 
     @cmds.publish.both(command=cmds.pause)
-    def pause(self, msg):
+    def pause(self, msg=None):
         """ Pause execution of the protocol until resume is called.
 
         This function returns immediately, but the next function call that
@@ -293,12 +293,12 @@ class ProtocolContext:
 
         :param str msg: A message to echo back to connected clients.
         """
-        raise NotImplementedError
+        self._hw_manager.hardware.pause()
 
     @cmds.publish.both(command=cmds.resume)
     def resume(self):
         """ Resume a previously-paused protocol """
-        raise NotImplementedError
+        self._hw_manager.hardware.resume()
 
     @cmds.publish.both(command=cmds.comment)
     def comment(self, msg):

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -35,7 +35,8 @@ class ProtocolContext:
     """
 
     def __init__(self,
-                 loop: asyncio.AbstractEventLoop = None) -> None:
+                 loop: asyncio.AbstractEventLoop = None,
+                 hardware: hc.API = None) -> None:
         """ Build a :py:class:`.ProtocolContext`.
 
         :param loop: An event loop to use. If not specified, this ctor will
@@ -47,7 +48,7 @@ class ProtocolContext:
             = {mount: None for mount in types.Mount}
         self._last_moved_instrument: Optional[types.Mount] = None
         self._location_cache: Optional[types.Location] = None
-        self._hardware = self._build_hardware_adapter(self._loop)
+        self._hardware = self._build_hardware_adapter(self._loop, hardware)
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
         self._commands = []
         self._unsubscribe_commands = None

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -1,0 +1,79 @@
+import inspect
+import logging
+import os
+from typing import Any, Callable
+
+from .contexts import ProtocolContext
+
+MODULE_LOG = logging.getLogger(__name__)
+
+
+def _runfunc_ok(run_func: Any) -> Callable[[ProtocolContext], None]:
+    if not callable(run_func):
+        raise SyntaxError("No function 'run()' defined")
+    sig = inspect.Signature.from_callable(run_func)
+    if not sig.parameters:
+        raise SyntaxError("Function 'run()' does not take any parameters")
+    if len(sig.parameters) > 1:
+        for name, param in list(sig.parameters.items())[1:]:
+            if param.default == inspect.Parameter.empty:
+                raise SyntaxError(
+                    "Function 'run{}' must be called with more than one "
+                    "argument but would be called as 'run(ctx)'"
+                    .format(str(sig)))
+    return run_func  # type: ignore
+
+
+def _run_python(proto: Any, context: ProtocolContext):
+    new_locs = locals()
+    new_globs = globals()
+    exec(proto, new_globs, new_locs)
+    # If the protocol is written correctly, it will have defined a function
+    # like run(context: ProtocolContext). If so, that function is now in the
+    # current scope.
+    try:
+        _runfunc_ok(new_locs.get('run'))
+    except SyntaxError as se:
+        raise SyntaxError(
+            str(se),
+            "No function run(ctx) defined"
+            "\nA Python protocol for the OT2 must define a function "
+            "called 'run' that takes a single argument - the"
+            "protocol context to call functions on. For instance, "
+            "a run function might look like\n\n"
+            "def run(ctx):\n"
+            "    ctx.comment('hello, world')"
+            "\n\nThis function is called by the robot when the "
+            "robot executes the protol. However, it is not "
+            "present.")
+    new_globs.update(new_locs)
+    exec('run(context)', new_globs, new_locs)
+
+
+def run_protocol(protocol_code: Any = None,
+                 protocol_json: str = None,
+                 simulate: bool = False,
+                 context: ProtocolContext = None):
+    """ Create a ProtocolRunner instance from one of a variety of protocol
+    sources.
+
+    :param protocol_bytes: If the protocol is a Python protocol, pass the
+    file contents here.
+    :param protocol_json: If the protocol is a json file, pass the contents
+    here.
+    :param simulate: True to simulate; False to execute. If this is not an
+    OT2, ``simulate`` will be forced ``True``.
+    :param context: The context to use. If ``None``, create a new
+    ProtocolContext.
+    """
+    if not os.environ.get('RUNNING_ON_PI'):
+        simulate = True # noqa - will be used later
+    if None is context and simulate:
+        true_context = ProtocolContext()
+        MODULE_LOG.info("Generating blank protocol context for simulate")
+    elif context:
+        true_context = context
+    else:
+        raise RuntimeError(
+            'Will not automatically generate hardware controller')
+    _run_python(protocol_code, true_context)

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -127,6 +127,7 @@ def run_protocol(protocol_code: Any = None,
         simulate = True # noqa - will be used later
     if None is context and simulate:
         true_context = ProtocolContext()
+        true_context.home()
         MODULE_LOG.info("Generating blank protocol context for simulate")
     elif context:
         true_context = context

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -154,7 +154,7 @@ class Deck(UserDict):
 
     def position_for(self, key: types.DeckLocation) -> types.Location:
         key_int = self._check_name(key)
-        return types.Location(self._positions[key_int], "Slot " + str(key))
+        return types.Location(self._positions[key_int], str(key))
 
     def recalculate_high_z(self):
         self._highest_z = 0.0

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -160,6 +160,9 @@ class Well:
             return NotImplemented
         return self.top().point == other.top().point
 
+    def __hash__(self):
+        return hash(self.top().point)
+
 
 class Labware:
     """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -7,7 +7,7 @@ import pkgutil
 from collections import defaultdict
 from enum import Enum, auto
 from itertools import takewhile, dropwhile
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 
 from opentrons.types import Location
 from opentrons.types import Point
@@ -200,11 +200,18 @@ class Labware:
                           for well in col]
         self._offset\
             = Point(offset['x'], offset['y'], offset['z']) + parent.point
+        self._parent = parent.labware
         # Applied properties
         self.set_calibration(self._calibrated_offset)
 
         self._pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
         self._definition = definition
+
+    @property
+    def parent(self) -> Union['Labware', 'Well', str, 'ModuleGeometry', None]:
+        """ The parent of this labware. Usually a slot name.
+        """
+        return self._parent
 
     @property
     def name(self) -> str:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -474,7 +474,7 @@ class Labware:
         :param num_channels: The number of channels for the current pipette
         :type num_channels: int
         """
-        assert num_channels > 0
+        assert num_channels > 0, 'Bad call to use_tips: num_channels==0'
         # Select the column of the labware that contains the target well
         target_column: List[Well] = [
             col for col in self.columns() if start_well in col][0]
@@ -488,7 +488,8 @@ class Labware:
         num_tips = min(len(target_column) - well_idx, num_channels)
         target_wells = target_column[well_idx: well_idx + num_tips]
 
-        assert all([well.has_tip for well in target_wells])
+        assert all([well.has_tip for well in target_wells]),\
+            '{} is out of tips'.format(str(self))
 
         for well in target_wells:
             well.has_tip = False

--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -1,7 +1,6 @@
 import asyncio
 import aiohttp
 import functools
-import inspect
 import json
 import logging
 import traceback
@@ -265,17 +264,7 @@ class RPCServer(object):
     def call_and_serialize(self, func, max_depth=0):
         # XXXX: This should really only be called in a new thread (as in
         #       the normal case where it is called in a threadpool)
-        try:
-            check = func.func
-        except AttributeError:
-            check = func
-        check_unwrapped = inspect.unwrap(check)
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        if asyncio.iscoroutinefunction(check_unwrapped):
-            call_result = loop.run_until_complete(func())
-        else:
-            call_result = func()
+        call_result = func()
         serialized, refs = serialize.get_object_tree(
             call_result, max_depth=max_depth)
         self.objects.update(refs)

--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -263,15 +263,16 @@ class RPCServer(object):
             log.exception('Error while processing request')
 
     def call_and_serialize(self, func, max_depth=0):
+        # XXXX: This should really only be called in a new thread (as in
+        #       the normal case where it is called in a threadpool)
         try:
             check = func.func
         except AttributeError:
             check = func
         check_unwrapped = inspect.unwrap(check)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         if asyncio.iscoroutinefunction(check_unwrapped):
-            # XXXX: This should really only be called in a new thread (as in
-            #       the normal case where it is called in a threadpool)
-            loop = asyncio.new_event_loop()
             call_result = loop.run_until_complete(func())
         else:
             call_result = func()

--- a/api/src/opentrons/simulate_protocol.py
+++ b/api/src/opentrons/simulate_protocol.py
@@ -10,5 +10,7 @@ if __name__ == '__main__':
                         type=argparse.FileType('rb'),
                         help='The python protocol file to run')
     args = parser.parse_args()
-    protocol_api.run(protocol_bytes=args.protocol.read(),
-                     simulate=True)
+    print("Running protocol {}".format(args.protocol.name))
+    protocol_api.execute.run_protocol(protocol_code=args.protocol.read(),
+                                      simulate=True)
+    print("Protocol simulation complete: OK")

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -34,6 +34,9 @@ class Point(NamedTuple):
             return NotImplemented
         return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
+    def __str__(self):
+        return '({}, {}, {})'.format(self.x, self.y, self.z)
+
 
 class Location(NamedTuple):
     """ A location to target as a motion in the :ref:`protocol-api`.

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 from functools import partial
 from tests.opentrons.conftest import state
@@ -6,6 +7,7 @@ from opentrons.util import calibration_functions
 state = partial(state, 'calibration')
 
 
+@pytest.mark.api1_only
 async def test_tip_probe(main_router, model):
     with mock.patch(
             'opentrons.util.calibration_functions.probe_instrument'
@@ -30,6 +32,7 @@ async def test_tip_probe(main_router, model):
     await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_correct_hotspots(main_router, model):
 
     robot = model.robot
@@ -91,6 +94,7 @@ async def test_correct_hotspots(main_router, model):
     assert expected == actual
 
 
+@pytest.mark.api1_only
 async def test_move_to_front(main_router, model):
     robot = model.robot
 
@@ -107,6 +111,7 @@ async def test_move_to_front(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_pick_up_tip(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'pick_up_tip') as pick_up_tip:  # NOQA
         main_router.calibration_manager.pick_up_tip(
@@ -120,6 +125,7 @@ async def test_pick_up_tip(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_drop_tip(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'drop_tip') as drop_tip:  # NOQA
         main_router.calibration_manager.drop_tip(
@@ -133,6 +139,7 @@ async def test_drop_tip(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_return_tip(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'return_tip') as return_tip:  # NOQA
         main_router.calibration_manager.return_tip(model.instrument)
@@ -143,6 +150,7 @@ async def test_return_tip(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_home(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'home') as home:
         main_router.calibration_manager.home(
@@ -154,6 +162,7 @@ async def test_home(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_move_to_top(main_router, model):
     with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
         main_router.calibration_manager.move_to(
@@ -166,6 +175,7 @@ async def test_move_to_top(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_jog(main_router, model):
     with mock.patch('opentrons.util.calibration_functions.jog_instrument') as jog:  # NOQA
         for distance, axis in zip((1, 2, 3), 'xyz'):
@@ -189,6 +199,7 @@ async def test_jog(main_router, model):
         await main_router.wait_until(state('ready'))
 
 
+@pytest.mark.api1_only
 async def test_update_container_offset(main_router, model):
     with mock.patch.object(
             model.robot,
@@ -204,6 +215,7 @@ async def test_update_container_offset(main_router, model):
         )
 
 
+@pytest.mark.api1_only
 async def test_jog_calibrate_bottom(
         dummy_db,
         main_router,
@@ -256,6 +268,7 @@ async def test_jog_calibrate_bottom(
     ).all()
 
 
+@pytest.mark.api1_only
 async def test_jog_calibrate_top(
         dummy_db,
         main_router,
@@ -310,6 +323,7 @@ async def test_jog_calibrate_top(
     ).all()
 
 
+@pytest.mark.api1_only
 async def test_jog_calibrate_top_new(
         split_labware_def,
         main_router,

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -203,7 +203,6 @@ async def test_get_instruments_and_containers(labware_setup,
     modules = session.get_modules()
 
     assert [i.name for i in instruments] == ['p50_multi_v1', 'p1000_single_v1']
-    assert [i.axis for i in instruments] == ['a', 'b']
     assert [i.id for i in instruments] == [id(p50), id(p1000)]
     assert [[t.slot for t in i.tip_racks] for i in instruments] == \
         [['1', '4'], ['1', '4']]

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -1,4 +1,3 @@
-import asyncio
 import itertools
 
 import pytest
@@ -382,7 +381,6 @@ print('wat?')
     assert metadata == expected
 
 
-@pytest.mark.api1_only
 async def test_session_metadata(main_router):
     expected = {
         'hello': 'world',
@@ -397,9 +395,12 @@ metadata = {
 'hello': 'world'
 }
 print('wat?')
+
+def run(ctx):
+    print('hi there')
 """
 
-    session = await main_router.session_manager.create(
+    session = main_router.session_manager.create(
         name='<blank>',
         text=prot)
     assert session.metadata == expected

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -15,11 +15,11 @@ state = partial(state, 'session')
 
 
 @pytest.fixture
-async def run_session(request, session_manager):
+def run_session(request, session_manager):
     if not isinstance(session_manager._hardware, Robot):
         pytest.skip('requires api1 only')
         return None
-    return await session_manager.create('dino', 'from opentrons import robot')
+    return session_manager.create('dino', 'from opentrons import robot')
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def labware_setup(hardware):
 
 @pytest.mark.api1_only
 async def test_load_from_text(session_manager, protocol):
-    session = await session_manager.create(name='<blank>', text=protocol.text)
+    session = session_manager.create(name='<blank>', text=protocol.text)
     assert session.name == '<blank>'
 
     acc = []
@@ -73,7 +73,7 @@ async def test_load_from_text(session_manager, protocol):
 
 @pytest.mark.api1_only
 async def test_clear_tips(session_manager, tip_clear_protocol):
-    session = await session_manager.create(
+    session = session_manager.create(
         name='<blank>', text=tip_clear_protocol.text)
 
     assert len(session._instruments) == 1
@@ -90,14 +90,61 @@ async def test_async_notifications(main_router):
     assert res == {'name': 'foo', 'payload': {'bar': 'baz'}}
 
 
-@pytest.mark.api1_only
-async def test_load_protocol_with_error(session_manager):
+def test_load_protocol_with_error(session_manager):
     with pytest.raises(Exception) as e:
-        session = await session_manager.create(name='<blank>', text='blah')
+        session = session_manager.create(name='<blank>', text='blah')
         assert session is None
 
     args, = e.value.args
     assert args == "name 'blah' is not defined"
+
+
+@pytest.mark.api2_only
+@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+async def test_load_and_run_v2(
+            main_router,
+            protocol,
+            protocol_file,
+            loop
+        ):
+    session = main_router.session_manager.create(
+        name='<blank>',
+        text=protocol.text)
+    assert main_router.notifications.queue.qsize() == 1
+    assert session.state == 'loaded'
+    assert session.command_log == {}
+    # main_router.calibration_manager.tip_probe(session.instruments[0])
+
+    def run():
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(session.run())
+
+    task = loop.run_in_executor(executor=None,
+                                func=run)
+
+    await task
+    assert len(session.command_log) == 7
+
+    res = []
+    index = 0
+    async for notification in main_router.notifications:
+        payload = notification['payload']
+        index += 1  # Command log in sync with add-command events emitted
+        if type(payload) is dict:
+            state = payload.get('state')
+        else:
+            state = payload.state
+        res.append(state)
+        if state == 'finished':
+            break
+
+    assert [key for key, _ in itertools.groupby(res)] == \
+        ['loaded', 'probing', 'ready', 'running', 'finished']
+    assert main_router.notifications.queue.qsize() == 0,\
+        'Notification should be empty after receiving "finished" event'
+    session.run()
+    assert len(session.command_log) == 7, \
+        "Clears command log on the next run"
 
 
 @pytest.mark.api1_only
@@ -108,7 +155,7 @@ async def test_load_and_run(
             protocol_file,
             loop
         ):
-    session = await main_router.session_manager.create(
+    session = main_router.session_manager.create(
         name='<blank>',
         text=protocol.text)
     assert main_router.notifications.queue.qsize() == 1
@@ -142,7 +189,7 @@ async def test_load_and_run(
     assert [key for key, _ in itertools.groupby(res)] == \
         ['loaded', 'probing', 'ready', 'running', 'finished']
     assert main_router.notifications.queue.qsize() == 0, 'Notification should be empty after receiving "finished" state change event'  # noqa
-    await session.run()
+    session.run()
     assert len(session.command_log) == 7, \
         "Clears command log on the next run"
 
@@ -190,7 +237,7 @@ async def test_get_instruments_and_containers(labware_setup,
     instruments, containers, modules, interactions = \
         _accumulate([_get_labware(command) for command in commands])
 
-    session = await Session.build_and_prep(name='', text='', hardware=hardware)
+    session = Session.build_and_prep(name='', text='', hardware=hardware)
     # We are calling dedupe directly for testing purposes.
     # Normally it is called from within a session
     session._instruments.extend(_dedupe(instruments))
@@ -271,7 +318,7 @@ def test_get_labware(labware_setup):
 
 @pytest.mark.api1_only
 async def test_session_model_functional(session_manager, protocol):
-    session = await session_manager.create(name='<blank>', text=protocol.text)
+    session = session_manager.create(name='<blank>', text=protocol.text)
     assert [container.name for container in session.containers] == \
            ['tiprack', 'trough', 'plate', 'tall-fixed-trash']
     names = [instrument.name for instrument in session.instruments]
@@ -289,7 +336,7 @@ async def test_drop_tip_with_trash(session_manager, protocol, protocol_file):
     is listed as a container for a protocol, as well as a container
     instruments are interacting with.
     """
-    session = await session_manager.create(name='<blank>', text=protocol.text)
+    session = session_manager.create(name='<blank>', text=protocol.text)
 
     assert 'tall-fixed-trash' in [c.name for c in session.get_containers()]
     containers = sum([i.containers for i in session.get_instruments()], [])
@@ -299,7 +346,7 @@ async def test_drop_tip_with_trash(session_manager, protocol, protocol_file):
 @pytest.mark.api1_only
 async def test_session_create_error(main_router):
     with pytest.raises(SyntaxError):
-        await main_router.session_manager.create(
+        main_router.session_manager.create(
             name='<blank>',
             text='syntax error ;(')
 
@@ -308,7 +355,7 @@ async def test_session_create_error(main_router):
         await main_router.wait_until(lambda _: True)
 
     with pytest.raises(ZeroDivisionError):
-        await main_router.session_manager.create(
+        main_router.session_manager.create(
             name='<blank>',
             text='1/0')
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -179,6 +179,12 @@ def using_api2(loop):
         opentrons.reset_globals()
 
 
+@pytest.fixture
+def ensure_api2(request, loop):
+    with using_api2(loop):
+        yield
+
+
 @contextlib.contextmanager
 def using_api1(loop):
     oldenv = os.environ.get('OT_FF_useProtocolApi2')

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -1,0 +1,12 @@
+from opentrons import types
+
+
+def run(ctx):
+    ctx.home()
+    tr = ctx.load_labware_by_name('Opentrons_96_tiprack_300_uL', 1)
+    right = ctx.load_instrument('p300_single', types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 2)
+    right.pick_up_tip()
+    right.aspirate(10, lw.wells()[0].bottom())
+    right.dispense(10, lw.wells()[1].bottom())
+    right.drop_tip(tr.wells()[-1].top())

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -3,7 +3,7 @@ from opentrons import types
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware_by_name('Opentrons_96_tiprack_300_uL', 1)
+    tr = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', 1)
     right = ctx.load_instrument('p300_single', types.Mount.RIGHT, [tr])
     lw = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', 2)
     right.pick_up_tip()

--- a/api/tests/opentrons/hardware_control/test_adapters.py
+++ b/api/tests/opentrons/hardware_control/test_adapters.py
@@ -8,3 +8,4 @@ def test_synch_adapter(loop):
     synch.cache_instruments({Mount.LEFT: 'p10_single'})
     assert synch.attached_instruments[Mount.LEFT]['name']\
                 .startswith('p10_single')
+    synch.join()

--- a/api/tests/opentrons/hardware_control/test_instantiation.py
+++ b/api/tests/opentrons/hardware_control/test_instantiation.py
@@ -32,7 +32,7 @@ async def test_controller_unique_per_thread(hardware_controller_lockfile,
         loop = asyncio.new_event_loop()
         with pytest.raises(RuntimeError):
             _ = loop.run_until_complete(  # noqa(F841)
-                c.API.build_hardware_controller(loop=loop))
+                hc.API.build_hardware_controller(loop=loop))
 
     thread = threading.Thread(target=_create_in_new_thread)
     thread.start()

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -30,7 +30,8 @@ def test_critical_points():
         assert pip.critical_point(types.CriticalPoint.TIP) == mod_offset
         tip_length = 25.0
         pip.add_tip(tip_length)
-        new = mod_offset._replace(z=mod_offset.z - tip_length)
+        new = mod_offset._replace(z=mod_offset.z
+                                  - (tip_length - pip._config.tip_overlap))
         assert pip.critical_point() == new
         assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_offset
         assert pip.critical_point(types.CriticalPoint.TIP) == new

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -32,7 +32,7 @@ async def test_multi_single(main_router, protocol, protocol_file, dummy_db):
     robot.connect()
     robot.home()
 
-    session = await main_router.session_manager.create(
+    session = main_router.session_manager.create(
         name='<blank>', text=protocol.text)
     await main_router.wait_until(state('session', 'loaded'))
 
@@ -59,7 +59,7 @@ async def test_load_jog_save_run(
     temp = tempfile.gettempdir()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)
 
-    session = await main_router.session_manager.create(
+    session = main_router.session_manager.create(
         name='<blank>', text=protocol.text)
     await main_router.wait_until(state('session', 'loaded'))
 

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -117,7 +117,7 @@ def test_pick_up_and_drop_tip(loop, load_my_labware):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
     tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', 1)
-    tip_lenth = tiprack.tip_length
+    tip_length = tiprack.tip_length
     mount = Mount.LEFT
 
     instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
@@ -129,7 +129,8 @@ def test_pick_up_and_drop_tip(loop, load_my_labware):
 
     instr.pick_up_tip(target_location)
 
-    new_offset = model_offset - Point(0, 0, tip_lenth)
+    new_offset = model_offset - Point(0, 0,
+                                      tip_length - pipette.config.tip_overlap)
     assert pipette.critical_point() == new_offset
 
     instr.drop_tip(target_location)
@@ -166,10 +167,10 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
     ctx.home()
 
     tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', 1)
-    tip_lenth1 = tiprack1.tip_length
+    tip_length1 = tiprack1.tip_length
 
     tiprack2 = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', 2)
-    tip_length2 = tip_lenth1 + 1.0
+    tip_length2 = tip_length1 + 1.0
     tiprack2.tip_length = tip_length2
 
     mount = Mount.LEFT
@@ -186,7 +187,8 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
     assert 'picking up tip' in ','.join([cmd.lower()
                                          for cmd in ctx.commands()])
 
-    new_offset = model_offset - Point(0, 0, tip_lenth1)
+    new_offset = model_offset - Point(0, 0,
+                                      tip_length1 - pipette.config.tip_overlap)
     assert pipette.critical_point() == new_offset
 
     # TODO: remove argument and verify once trash container is added

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -182,6 +182,9 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
 
     instr.pick_up_tip()
 
+    assert 'picking up tip' in ','.join([cmd.lower()
+                                         for cmd in ctx.commands()])
+
     new_offset = model_offset - Point(0, 0, tip_lenth1)
     assert pipette.critical_point() == new_offset
 
@@ -237,6 +240,7 @@ def test_aspirate(loop, load_my_labware, monkeypatch):
     monkeypatch.setattr(ctx._hardware._api, 'move_to', fake_move)
 
     instr.aspirate(2.0, lw.wells()[0].bottom())
+    assert 'aspirating' in ','.join([cmd.lower() for cmd in ctx.commands()])
 
     assert asp_called_with == (Mount.RIGHT, 2.0, 1.0)
     assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom().point)
@@ -274,7 +278,7 @@ def test_dispense(loop, load_my_labware, monkeypatch):
     monkeypatch.setattr(ctx._hardware._api, 'move_to', fake_move)
 
     instr.dispense(2.0, lw.wells()[0].bottom())
-
+    assert 'dispensing' in ','.join([cmd.lower() for cmd in ctx.commands()])
     assert disp_called_with == (Mount.RIGHT, 2.0, 1.0)
     assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom().point)
 
@@ -304,10 +308,14 @@ def test_tempdeck(loop, monkeypatch):
     assert ctx.deck[1] == mod._geometry
     assert mod.target is None
     mod.set_temperature(20)
-    assert mod.target == 20
+    assert 'setting temperature' in ','.join([cmd.lower()
+                                              for cmd in ctx.commands()])
     mod.wait_for_temp()
+    assert mod.target == 20
     assert mod.temperature == 20
     mod.deactivate()
+    assert 'deactivating temperature' in ','.join([cmd.lower()
+                                                   for cmd in ctx.commands()])
     assert mod.target is None
     mod.set_temperature(0)
     assert mod.target == 0
@@ -322,10 +330,16 @@ def test_magdeck(loop, monkeypatch):
     with pytest.raises(ValueError):
         mod.engage()
     mod.engage(2)
+    assert 'engaging magnetic' in ','.join([cmd.lower()
+                                            for cmd in ctx.commands()])
     assert mod.status == 'engaged'
     mod.disengage()
+    assert 'disengaging magnetic' in ','.join([cmd.lower()
+                                               for cmd in ctx.commands()])
     assert mod.status == 'disengaged'
     mod.calibrate()
+    assert 'calibrating magnetic' in ','.join([cmd.lower()
+                                               for cmd in ctx.commands()])
 
 
 def test_module_load_labware(loop, monkeypatch):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -141,7 +141,6 @@ def test_return_tip(loop, load_my_labware):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
     tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', 1)
-    tip_lenth = tiprack.tip_length
     mount = Mount.LEFT
 
     instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
@@ -149,17 +148,16 @@ def test_return_tip(loop, load_my_labware):
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._hardware._attached_instruments[mount]
-    model_offset = Point(*pipette.config.model_offset)
+    pipette: Pipette\
+        = ctx._hw_manager.hardware._attached_instruments[mount]
 
     target_location = tiprack.wells_by_index()['A1'].top()
     instr.pick_up_tip(target_location)
 
-    new_offset = model_offset - Point(0, 0, tip_lenth)
-    assert pipette.critical_point() == new_offset
+    assert pipette.has_tip
 
     instr.return_tip()
-    assert pipette.critical_point() == model_offset
+    assert not pipette.has_tip
 
 
 def test_pick_up_tip_no_location(loop, load_my_labware):

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -1,0 +1,47 @@
+import pytest
+
+from opentrons.protocol_api import execute, ProtocolContext
+
+
+def test_api2_runfunc():
+    def noargs():
+        pass
+
+    with pytest.raises(SyntaxError):
+        execute._runfunc_ok(noargs)
+
+    def twoargs(a, b):
+        pass
+
+    with pytest.raises(SyntaxError):
+        execute._runfunc_ok(twoargs)
+
+    def two_with_default(a, b=2):
+        pass
+
+    assert execute._runfunc_ok(two_with_default) == two_with_default
+
+    def one_with_default(a=2):
+        pass
+
+    assert execute._runfunc_ok(one_with_default) == one_with_default
+
+    def starargs(*args):
+        pass
+
+    assert execute._runfunc_ok(starargs) == starargs
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+def test_execute_ok(protocol, protocol_file, ensure_api2, loop):
+    proto = compile(protocol.text, protocol.filename, 'exec')
+    ctx = ProtocolContext(loop)
+    execute.run_protocol(protocol_code=proto, context=ctx)
+
+
+def test_bad_protocol(ensure_api2, loop):
+    ctx = ProtocolContext(loop)
+    with pytest.raises(SyntaxError):
+        execute.run_protocol(protocol_code='print hi', context=ctx)
+    with pytest.raises(SyntaxError):
+        execute.run_protocol(protocol_code='print("hi"")', context=ctx)

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -284,6 +284,7 @@ async def test_notifications(session, root):
         'data': 'Done!'}
 
 
+@pytest.mark.api1_only
 @pytest.mark.parametrize('root', [TickTock()])
 async def test_concurrent_calls(session, root):
     await session.socket.receive_json()  # Skip init
@@ -401,6 +402,7 @@ def message_key(message):
     return str(meta.get('type')) + meta.get('token', '') + str(data)
 
 
+@pytest.mark.api1_only
 @pytest.mark.parametrize('root', [TickTock()])
 async def test_concurrent_and_disconnect(loop, root, session, connect):  # noqa C901
     n_sockets = 20

--- a/shared-data/definitions2/eppendorf_96_tiprack_1000_uL.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_1000_uL.json
@@ -121,7 +121,7 @@
             "H12"
         ]
     ],
-    "otId": "00b782e0-f4d8-11e8-83b8-c3ba5d2a3baa",
+    "otId": "60344120-ffde-11e8-abfa-95044b186e81",
     "deprecated": false,
     "metadata": {
         "displayName": "epT.I.P.S. 50-1000 uL tiprack",
@@ -155,867 +155,867 @@
     "wells": {
         "H1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 14.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 23.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 32.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 41.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 50.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 59.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 68.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 77.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 86.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 95.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 104.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         },
         "H12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 11.24,
-            "z": 121.9
+            "z": 56.9
         },
         "G12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 20.24,
-            "z": 121.9
+            "z": 56.9
         },
         "F12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 29.24,
-            "z": 121.9
+            "z": 56.9
         },
         "E12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 38.24,
-            "z": 121.9
+            "z": 56.9
         },
         "D12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 47.24,
-            "z": 121.9
+            "z": 56.9
         },
         "C12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 56.24,
-            "z": 121.9
+            "z": 56.9
         },
         "B12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 65.24,
-            "z": 121.9
+            "z": 56.9
         },
         "A12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 65,
             "diameter": 8.8,
             "totalLiquidVolume": 1000,
             "x": 113.38,
             "y": 74.24,
-            "z": 121.9
+            "z": 56.9
         }
     },
     "brand": {

--- a/shared-data/definitions2/eppendorf_96_tiprack_10_uL.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_10_uL.json
@@ -121,7 +121,7 @@
             "H12"
         ]
     ],
-    "otId": "6cb54d80-f4d6-11e8-83b8-c3ba5d2a3baa",
+    "otId": "39e71160-ffdd-11e8-abfa-95044b186e81",
     "deprecated": false,
     "metadata": {
         "displayName": "epT.I.P.S. 0.1-10 uL tiprack",
@@ -155,867 +155,867 @@
     "wells": {
         "H1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         },
         "H12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 11.24,
-            "z": 65.4
+            "z": 35.4
         },
         "G12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 20.24,
-            "z": 65.4
+            "z": 35.4
         },
         "F12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 29.24,
-            "z": 65.4
+            "z": 35.4
         },
         "E12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 38.24,
-            "z": 65.4
+            "z": 35.4
         },
         "D12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 47.24,
-            "z": 65.4
+            "z": 35.4
         },
         "C12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 56.24,
-            "z": 65.4
+            "z": 35.4
         },
         "B12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 65.24,
-            "z": 65.4
+            "z": 35.4
         },
         "A12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 30,
             "diameter": 6,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 74.24,
-            "z": 65.4
+            "z": 35.4
         }
     },
     "brand": {

--- a/shared-data/definitions2/opentrons_96_tiprack_1000_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_1000_uL.json
@@ -121,7 +121,7 @@
             "H12"
         ]
     ],
-    "otId": "e5494340-f8ab-11e8-8bbb-13a62d96b9ed",
+    "otId": "d4e462c0-ffde-11e8-abfa-95044b186e81",
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons GEB 1000uL Tiprack",
@@ -155,867 +155,867 @@
     "wells": {
         "H1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 14.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 23.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 32.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 41.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 50.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 59.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 68.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 77.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 86.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 95.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 104.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         },
         "H12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 11.2,
-            "z": 100.25
+            "z": 18.25
         },
         "G12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 20.2,
-            "z": 100.25
+            "z": 18.25
         },
         "F12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 29.2,
-            "z": 100.25
+            "z": 18.25
         },
         "E12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 38.2,
-            "z": 100.25
+            "z": 18.25
         },
         "D12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 47.2,
-            "z": 100.25
+            "z": 18.25
         },
         "C12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 56.2,
-            "z": 100.25
+            "z": 18.25
         },
         "B12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 65.2,
-            "z": 100.25
+            "z": 18.25
         },
         "A12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 82,
             "diameter": 7.46,
             "totalLiquidVolume": 1000,
             "x": 113.2,
             "y": 74.2,
-            "z": 100.25
+            "z": 18.25
         }
     },
     "brand": {

--- a/shared-data/definitions2/opentrons_96_tiprack_10_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_10_uL.json
@@ -121,7 +121,7 @@
             "H12"
         ]
     ],
-    "otId": "0b628840-f7dd-11e8-8c0a-c59644a278bb",
+    "otId": "88154cc0-ffde-11e8-abfa-95044b186e81",
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons GEB 10uL Tiprack",
@@ -155,867 +155,867 @@
     "wells": {
         "H1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A1": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 14.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A2": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 23.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A3": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 32.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A4": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 41.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A5": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 50.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A6": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 59.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A7": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 68.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A8": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 77.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A9": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 86.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A10": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 95.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A11": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 104.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         },
         "H12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 11.25,
-            "z": 56.25
+            "z": 22.25
         },
         "G12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 20.25,
-            "z": 56.25
+            "z": 22.25
         },
         "F12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 29.25,
-            "z": 56.25
+            "z": 22.25
         },
         "E12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 38.25,
-            "z": 56.25
+            "z": 22.25
         },
         "D12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 47.25,
-            "z": 56.25
+            "z": 22.25
         },
         "C12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 56.25,
-            "z": 56.25
+            "z": 22.25
         },
         "B12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 65.25,
-            "z": 56.25
+            "z": 22.25
         },
         "A12": {
             "shape": "circular",
-            "depth": 0,
+            "depth": 34,
             "diameter": 3.46,
             "totalLiquidVolume": 10,
             "x": 113.38,
             "y": 74.25,
-            "z": 56.25
+            "z": 22.25
         }
     },
     "brand": {

--- a/shared-data/definitions2/opentrons_96_tiprack_300_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_300_uL.json
@@ -121,18 +121,20 @@
             "H12"
         ]
     ],
-    "otId": "198c7270-d607-11e8-9680-dd4ac81bb1e3",
+    "otId": "3d278f00-ffe0-11e8-abfa-95044b186e81",
     "deprecated": false,
     "metadata": {
-        "displayName": "Opentrons GEB 300ul tiprack",
-        "displayCategory": "tiprack",
+        "displayName": "Opentrons GEB 300uL Tiprack",
         "displayVolumeUnits": "uL",
         "displayLengthUnits": "mm",
+        "displayCategory": "tiprack",
         "tags": [
+            "GEB",
             "tiprack",
+            "300uL",
+            "Opentrons",
             "p300",
-            "p50",
-            "opentrons"
+            "p50"
         ]
     },
     "cornerOffsetFromSlot": {
@@ -148,874 +150,874 @@
     "parameters": {
         "format": "96Standard",
         "isTiprack": true,
+        "isMagneticModuleCompatible": false,
         "tipLength": 59.17,
-        "loadName": "opentrons_96_tiprack_300_uL",
-        "isMagneticModuleCompatible": false
+        "loadName": "opentrons_96_tiprack_300_uL"
     },
     "wells": {
         "H1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A1": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 14.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A2": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 23.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A3": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 32.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A4": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 41.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A5": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 50.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A6": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 59.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A7": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 68.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A8": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 77.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A9": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 86.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A10": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 95.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A11": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 104.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         },
         "H12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 11.2,
-            "z": 64.48
+            "z": 10.48
         },
         "G12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 20.2,
-            "z": 64.48
+            "z": 10.48
         },
         "F12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 29.2,
-            "z": 64.48
+            "z": 10.48
         },
         "E12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 38.2,
-            "z": 64.48
+            "z": 10.48
         },
         "D12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 47.2,
-            "z": 64.48
+            "z": 10.48
         },
         "C12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 56.2,
-            "z": 64.48
+            "z": 10.48
         },
         "B12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 65.2,
-            "z": 64.48
+            "z": 10.48
         },
         "A12": {
-            "depth": 0,
             "shape": "circular",
+            "depth": 54,
             "diameter": 5,
             "totalLiquidVolume": 300,
             "x": 113.33,
             "y": 74.2,
-            "z": 64.48
+            "z": 10.48
         }
     },
     "brand": {

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -5,7 +5,8 @@
     "maxVolume": 10,
     "channels": 1,
     "defaultAspirateFlowRate": 5,
-    "defaultDispenseFlowRate": 10
+    "defaultDispenseFlowRate": 10,
+    "tipOverlap": 0
   },
   "p10_multi": {
     "displayName": "P10 8-Channel",
@@ -13,7 +14,8 @@
     "maxVolume": 10,
     "defaultAspirateFlowRate": 5,
     "defaultDispenseFlowRate": 10,
-    "channels": 8
+    "channels": 8,
+    "tipOverlap": 0
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
@@ -21,7 +23,8 @@
     "defaultDispenseFlowRate": 50,
     "channels": 1,
     "minVolume": 5,
-    "maxVolume": 50
+    "maxVolume": 50,
+    "tipOverlap": 0
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
@@ -29,7 +32,8 @@
     "defaultDispenseFlowRate": 50,
     "channels": 8,
     "minVolume": 5,
-    "maxVolume": 50
+    "maxVolume": 50,
+    "tipOverlap": 0
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
@@ -37,7 +41,8 @@
     "defaultDispenseFlowRate": 300,
     "channels": 1,
     "minVolume": 30,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "tipOverlap": 7
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
@@ -45,7 +50,8 @@
     "defaultDispenseFlowRate": 300,
     "channels": 8,
     "minVolume": 30,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "tipOverlap": 7
   },
   "p1000_single": {
     "displayName": "P1000 Single-channel",
@@ -53,6 +59,7 @@
     "defaultDispenseFlowRate": 1000,
     "channels": 1,
     "minVolume": 100,
-    "maxVolume": 1000
+    "maxVolume": 1000,
+    "tipOverlap": 0
   }
 }

--- a/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
@@ -23,7 +23,8 @@
         "defaultAspirateFlowRate",
         "defaultDispenseFlowRate",
         "maxVolume",
-        "minVolume"
+        "minVolume",
+        "tipOverlap"
       ],
       "additionalProperties": false,
       "properties": {
@@ -32,7 +33,8 @@
         "defaultDispenseFlowRate": {"$ref": "#/definitions/positiveNumber"},
         "displayName": {"type": "string"},
         "maxVolume": {"$ref": "#/definitions/positiveNumber"},
-        "minVolume": {"$ref": "#/definitions/positiveNumber"}
+        "minVolume": {"$ref": "#/definitions/positiveNumber"},
+        "tipOverlap": {"$ref": "#/definitions/positiveNumber"}
       }
     }
   }


### PR DESCRIPTION
This PR adds the ability to run python protocols using the new protocol api as defined in #2247 

There needs to be more documentation done and a slight amount more testing, but I'm putting up the PR to get wider feedback on the structure of the code and smaller tests that people can run for both passing and failing new protocols.

From a user perspective, the big change is that protocols should now be structured to have a function at the top level named run() that takes a context, like such:

```
def run(ctx):
  ctx.comment("hi")
```

That ctx (it doesn't need to be called this, only the name of the function is mandatory) is the ProtocolContext instance that methods are called on, so for instance

```
def run(ctx):
  instr = ctx.load_instrument('p300_single', Mount.RIGHT)
```

There should be well defined and literate exception methods for basic failures like not having a run method, and other exceptions should have the line number of the protocol file that causes them.

The biggest new issues that this brings up are small affordances that you tend to notice while writing the new protocols. In particular:
- We should really have protocol API commands take wells as well as locations, it's not much fun to type out `.top()` or `.bottom()` every time
- We should avoid making the use of the types in `opentrons.types` mandatory because as of right now, since the context is passed in you don't have to import anything at all; making you import `opentrons.types.Mount` in every protocol just to be able to spell an instrument mount correctly feels uselessly formulaic
- This may be the hour to make a pass over the context methods and make sure that they return literate and informative exceptions for basic mistakes like mixing up the order of arguments or making common typos

## Review requests
- Look over the code
- Write some protocols! 
   - write ones that work
   - write ones that are structured wrong (no run method, run method has the wrong number of arguments)
   - write ones that are structured right but don't work (call nonexistent context methods, mix up the order of arguments)
- Look for basic stuff like the run log being formatted correctly and the robot moving to the right place
