### PR TITLE
feat(protocol-designer): avoid aspirate/dispense below pipette min volume

### DIFF
--- a/protocol-designer/src/components/alerts/ErrorContents.js
+++ b/protocol-designer/src/components/alerts/ErrorContents.js
@@ -22,7 +22,7 @@ const ErrorContents = (props: ErrorContentsProps) => {
       default:
         return (
           <React.Fragment>
-            {i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: ''})}
+            {i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: ''}) || null}
           </React.Fragment>
         )
     }

--- a/protocol-designer/src/components/alerts/ErrorContents.js
+++ b/protocol-designer/src/components/alerts/ErrorContents.js
@@ -22,7 +22,7 @@ const ErrorContents = (props: ErrorContentsProps) => {
       default:
         return (
           <React.Fragment>
-            {i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: ''}) || null}
+            {i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: ''})}
           </React.Fragment>
         )
     }

--- a/protocol-designer/src/components/steplist/utils.js
+++ b/protocol-designer/src/components/steplist/utils.js
@@ -1,7 +1,7 @@
 // @flow
 import round from 'lodash/round'
 
-const VOLUME_SIG_DIGITS_DEFAULT = 1
+const VOLUME_SIG_DIGITS_DEFAULT = 2
 
 export function formatVolume (inputVolume: ?string | ?number, sigDigits?: number = VOLUME_SIG_DIGITS_DEFAULT): string {
   if (typeof inputVolume === 'number') {

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -59,14 +59,14 @@ export const getTimelineWarningsForSelectedStep: Selector<Array<CommandCreatorWa
   getTimelineWarningsPerStep,
   stepsSelectors.getSelectedStepId,
   (warningsPerStep, stepId) =>
-    (stepId && warningsPerStep[stepId]) || []
+    (stepId != null && warningsPerStep[stepId]) || []
 )
 
 export const getDismissedFormWarningsForSelectedStep: Selector<Array<FormWarning>> = createSelector(
   getDismissedFormWarnings,
   stepsSelectors.getSelectedStepId,
   (dismissedWarnings, stepId) =>
-    (stepId && dismissedWarnings[stepId]) || []
+    (stepId != null && dismissedWarnings[stepId]) || []
 )
 
 /** Non-dismissed form-level warnings for selected step */

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -1,6 +1,7 @@
 // @flow
 import flatMap from 'lodash/flatMap'
 import zip from 'lodash/zip'
+import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import {getPipetteWithTipMaxVol} from '../../robotStateSelectors'
 import type {TransferFormData, RobotState, CommandCreator, CompoundCommandCreator} from '../../types'
@@ -32,7 +33,9 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
   const actionName = 'transfer'
 
   const pipetteData = prevRobotState.pipettes[data.pipette]
-  if (!pipetteData) {
+  const pipetteSpec = pipetteData && pipetteData.name && getPipetteNameSpecs(pipetteData.name)
+
+  if (!pipetteData || !pipetteSpec) {
     // bail out before doing anything else
     return [(_robotState) => ({
       errors: [errorCreators.pipetteDoesNotExist({actionName, pipette: data.pipette})],
@@ -47,6 +50,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
   } = data
 
   const effectiveTransferVol = getPipetteWithTipMaxVol(data.pipette, prevRobotState)
+  const pipetteMinVol = pipetteSpec.minVolume
 
   const chunksPerSubTransfer = Math.ceil(
     data.volume / effectiveTransferVol
@@ -54,9 +58,18 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
   const lastSubTransferVol = data.volume - ((chunksPerSubTransfer - 1) * effectiveTransferVol)
 
   // volume of each chunk in a sub-transfer
-  const subTransferVolumes: Array<number> = Array(chunksPerSubTransfer - 1)
+  let subTransferVolumes: Array<number> = Array(chunksPerSubTransfer - 1)
     .fill(effectiveTransferVol)
     .concat(lastSubTransferVol)
+
+  if (chunksPerSubTransfer > 1 && lastSubTransferVol < pipetteMinVol) {
+    // last chunk volume is below pipette min, split the last
+    const splitLastVol = (effectiveTransferVol + lastSubTransferVol) / 2
+    subTransferVolumes = Array(chunksPerSubTransfer - 2)
+      .fill(effectiveTransferVol)
+      .concat(splitLastVol)
+      .concat(splitLastVol)
+  }
 
   const sourceDestPairs = zip(data.sourceWells, data.destWells)
   const commandCreators = flatMap(

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -299,6 +299,41 @@ describe('single transfer exceeding pipette max', () => {
       expectedFinalLiquidState
     ))
   })
+
+  test('split up volume without going below pipette min', () => {
+    transferArgs = {
+      ...transferArgs,
+      volume: 629,
+      changeTip: 'never', // don't test tip use here
+    }
+    // begin with tip on pipette
+    robotInitialState.tipState.pipettes.p300SingleId = true
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      cmd.aspirate('A1', 300),
+      cmd.dispense('A3', 300, {labware: 'destPlateId'}),
+      // last 2 chunks split evenly
+      cmd.aspirate('A1', 164.5),
+      cmd.dispense('A3', 164.5, {labware: 'destPlateId'}),
+      cmd.aspirate('A1', 164.5),
+      cmd.dispense('A3', 164.5, {labware: 'destPlateId'}),
+
+      cmd.aspirate('B1', 300),
+      cmd.dispense('B3', 300, {labware: 'destPlateId'}),
+      // last 2 chunks split evenly
+      cmd.aspirate('B1', 164.5),
+      cmd.dispense('B3', 164.5, {labware: 'destPlateId'}),
+      cmd.aspirate('B1', 164.5),
+      cmd.dispense('B3', 164.5, {labware: 'destPlateId'}),
+    ])
+
+    expect(result.robotState.liquidState).toEqual(merge(
+      {},
+      robotInitialState.liquidState,
+      expectedFinalLiquidState
+    ))
+  })
 })
 
 describe('advanced options', () => {

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -306,6 +306,7 @@ describe('single transfer exceeding pipette max', () => {
       volume: 629,
       changeTip: 'never', // don't test tip use here
     }
+
     // begin with tip on pipette
     robotInitialState.tipState.pipettes.p300SingleId = true
 
@@ -327,12 +328,6 @@ describe('single transfer exceeding pipette max', () => {
       cmd.aspirate('B1', 164.5),
       cmd.dispense('B3', 164.5, {labware: 'destPlateId'}),
     ])
-
-    expect(result.robotState.liquidState).toEqual(merge(
-      {},
-      robotInitialState.liquidState,
-      expectedFinalLiquidState
-    ))
   })
 })
 

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -301,11 +301,14 @@ describe('single transfer exceeding pipette max', () => {
   })
 
   test('split up volume without going below pipette min', () => {
-    transferArgs = {
+    // TODO: Ian 2019-01-04 for some reason, doing transferArgs = {...transferArgs, ...etc}
+    // works everywhere but here - here, it makes Jest fail with "Jest encountered an unexpected token"
+    const _transferArgs = {
       ...transferArgs,
       volume: 629,
       changeTip: 'never', // don't test tip use here
     }
+    transferArgs = _transferArgs
 
     // begin with tip on pipette
     robotInitialState.tipState.pipettes.p300SingleId = true

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -22,11 +22,11 @@ const FIELD_ERRORS: {[FieldError]: string} = {
 /*******************
 ** Error Checkers **
 ********************/
-type errorChecker = (value: mixed) => ?string
+type ErrorChecker = (value: mixed) => ?string
 
 export const requiredField = (value: mixed): ?string => !value ? FIELD_ERRORS.REQUIRED : null
 export const nonZero = (value: mixed) => (value && Number(value) === 0) ? FIELD_ERRORS.NON_ZERO : null
-export const minimumWellCount = (minimum: number): errorChecker => (wells: mixed): ?string => (
+export const minimumWellCount = (minimum: number): ErrorChecker => (wells: mixed): ?string => (
   (isArray(wells) && (wells.length < minimum)) ? `${minimum} ${FIELD_ERRORS.UNDER_WELL_MINIMUM}` : null
 )
 
@@ -34,7 +34,7 @@ export const minimumWellCount = (minimum: number): errorChecker => (wells: mixed
 **     Helpers    **
 ********************/
 
-export const composeErrors = (...errorCheckers: Array<errorChecker>) => (value: mixed): Array<string> => (
+export const composeErrors = (...errorCheckers: Array<ErrorChecker>) => (value: mixed): Array<string> => (
   errorCheckers.reduce((accumulatedErrors, errorChecker) => {
     const possibleError = errorChecker(value)
     return possibleError ? [...accumulatedErrors, possibleError] : accumulatedErrors

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -12,6 +12,7 @@ import {
 } from './errors'
 import {
   composeWarnings,
+  belowPipetteMinimumVolume,
   maxDispenseWellVolume,
   minDisposalVolume,
   type FormWarning,
@@ -26,19 +27,22 @@ export {default as stepFormToArgs} from './stepFormToArgs'
 
 type FormHelpers = {getErrors?: (mixed) => Array<FormError>, getWarnings?: (mixed) => Array<FormWarning>}
 const stepFormHelperMap: {[StepType]: FormHelpers} = {
-  mix: {getErrors: composeErrors(incompatibleLabware)},
+  mix: {
+    getErrors: composeErrors(incompatibleLabware),
+    getWarnings: composeWarnings(belowPipetteMinimumVolume),
+  },
   pause: {getErrors: composeErrors(pauseForTimeOrUntilTold)},
   transfer: {
     getErrors: composeErrors(incompatibleAspirateLabware, incompatibleDispenseLabware, wellRatioTransfer),
-    getWarnings: composeWarnings(maxDispenseWellVolume),
+    getWarnings: composeWarnings(belowPipetteMinimumVolume, maxDispenseWellVolume),
   },
   consolidate: {
     getErrors: composeErrors(incompatibleAspirateLabware, incompatibleDispenseLabware, wellRatioConsolidate),
-    getWarnings: composeWarnings(maxDispenseWellVolume),
+    getWarnings: composeWarnings(belowPipetteMinimumVolume, maxDispenseWellVolume),
   },
   distribute: {
     getErrors: composeErrors(incompatibleAspirateLabware, incompatibleDispenseLabware, wellRatioDistribute),
-    getWarnings: composeWarnings(maxDispenseWellVolume, minDisposalVolume),
+    getWarnings: composeWarnings(belowPipetteMinimumVolume, maxDispenseWellVolume, minDisposalVolume),
   },
 }
 

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -9,6 +9,7 @@ import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 ********************/
 
 export type FormWarningType =
+  | 'BELOW_PIPETTE_MINIMUM_VOLUME'
   | 'OVER_MAX_WELL_VOLUME'
   | 'BELOW_MIN_DISPOSAL_VOLUME'
 
@@ -20,6 +21,11 @@ export type FormWarning = {
 }
 // TODO: Ian 2018-12-06 use i18n for title/body text
 const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {
+  BELOW_PIPETTE_MINIMUM_VOLUME: {
+    type: 'BELOW_PIPETTE_MINIMUM_VOLUME',
+    title: 'Specified volume is below pipette minimum',
+    dependentFields: ['pipette', 'volume'],
+  },
   OVER_MAX_WELL_VOLUME: {
     type: 'OVER_MAX_WELL_VOLUME',
     title: 'Dispense volume will overflow a destination well',
@@ -45,6 +51,13 @@ export type WarningChecker = (mixed) => ?FormWarning
 ********************/
 // TODO: real HydratedFormData type
 type HydratedFormData = any
+
+export const belowPipetteMinimumVolume = (fields: HydratedFormData): ?FormWarning => {
+  const {pipette, volume} = fields
+  const pipetteSpecs = getPipetteNameSpecs(pipette.model)
+  if (!pipetteSpecs) return null
+  return volume < pipetteSpecs.minVolume ? FORM_WARNINGS.BELOW_PIPETTE_MINIMUM_VOLUME : null
+}
 
 export const maxDispenseWellVolume = (fields: HydratedFormData): ?FormWarning => {
   const {dispense_labware, dispense_wells, volume} = fields

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {getWellTotalVolume, getPipetteNameSpecs} from '@opentrons/shared-data'
+import {getWellTotalVolume} from '@opentrons/shared-data'
 import type {StepFieldName} from '../../form-types'
 import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
 
@@ -54,9 +54,8 @@ type HydratedFormData = any
 
 export const belowPipetteMinimumVolume = (fields: HydratedFormData): ?FormWarning => {
   const {pipette, volume} = fields
-  const pipetteSpecs = getPipetteNameSpecs(pipette.model)
-  if (!pipetteSpecs) return null
-  return volume < pipetteSpecs.minVolume ? FORM_WARNINGS.BELOW_PIPETTE_MINIMUM_VOLUME : null
+  if (!(pipette && pipette.spec)) return null
+  return volume < pipette.spec.minVolume ? FORM_WARNINGS.BELOW_PIPETTE_MINIMUM_VOLUME : null
 }
 
 export const maxDispenseWellVolume = (fields: HydratedFormData): ?FormWarning => {
@@ -71,11 +70,10 @@ export const maxDispenseWellVolume = (fields: HydratedFormData): ?FormWarning =>
 
 export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   const {aspirate_disposalVol_checkbox, aspirate_disposalVol_volume, pipette} = fields
-  const pipetteSpecs = pipette && getPipetteNameSpecs(pipette.model)
-  if (!pipette || !pipetteSpecs) return null
+  if (!(pipette && pipette.spec)) return null
   const isUnselected = !aspirate_disposalVol_checkbox || !aspirate_disposalVol_volume
   if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
-  const isBelowMin = aspirate_disposalVol_volume < (pipetteSpecs.minVolume)
+  const isBelowMin = aspirate_disposalVol_volume < (pipette.spec.minVolume)
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
 }
 


### PR DESCRIPTION
## overview

Closes #1603

## changelog

* break up transfers so no chunk goes under min volume
* change steplist volumes to use 2 significant digits
* form-level warning when specified volume is below pipette min

## open question

Should there be timeline-level warnings when you put in a volume that's below the pipette minimum? Eg if you try to transfer/distribute/consolidate/mix 10uL with a P300 etc?

## review requests

NOTE: this does not fix the existing bug where newly-made forms don't show form-level errors related to auto-filled fields (like `pipette` field). It's happening because the field is seen as pristine but isn't. I'd like to do that in a separate PR - ticket #2883.

* (As long as you touch the Pipette field b/c of the bug) setting the Volume field to a value below the pipette minimum volume gives you a form-level warning.
  - [ ] Transfer
  - [ ] Distribute
  - [ ] Consolidate
  - [ ] Mix

- [ ] A Transfer which gets split up b/c its volume exceeds the pipette capacity (eg 10.5uL or whatever with a P10) will create substeps that are always above the pipette minimum. The algorithm used is the same the Python API uses: use full max volume until the last 2 substeps, where you divide the remainder equally across those last 2. As another example, a 929 with a P300 (min vol 30) splits it like: `300, 300, 164.5, 164.5`.

- [ ] A Distribute which gets split up b/c its volume exceeds the pipette capacity behaves the same as a Transfer as described above.

- [ ] Significant figures shown in substeps seems reasonable? I changed it to 2 decimals after talking with @pantslakz b/c with a P10, 10.5 will get split up into `5.25, 5.25` and seeing it as `5.3, 5.3` might confuse people