### PR TITLE
feat(app): Display Python protocol metadata in the app

### DIFF
--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -64,7 +64,6 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
         'protocolName': 'My Protocol',
         'author': 'Name <email@address.com>',
         'description': 'Simple protocol to get started using OT2',
-        'source': 'Opentrons Protocol Tutorial'
     }
 
     # labware
@@ -105,9 +104,11 @@ From the example above, the "imports" section looked like:
 Metadata
 ^^^^^^^^
 
-Metadata is a dictionary of data that is read by the server and returned to client applications (such as the Opentrons Run App). It is not needed to run a protocol (and is entirely optional), but if present can help the client application display additional data about the protocol currently being executed.
+Metadata is a dictionary of data that is read by the server and returned to client applications (such as the Opentrons App). It is not needed to run a protocol (and is entirely optional), but if present can help the client application display additional data about the protocol currently being executed.
 
-The fields above ("protocolName", "author", "description", and "source") are the recommended fields, but the metadata dictionary can contain fewer fields, or additional fields as desired (though non-standard fields may not be rendered by the client, depending on how it is designed).
+The fields above ("protocolName", "author", and "description") are the recommended fields, but the metadata dictionary can contain fewer or additional fields as desired (though non-standard fields may not be rendered by the client, depending on how it is designed).
+
+You may see a metadata field called "source" in protocols you download directly from Opentrons. The "source" field is used for anonymously tracking protocol usage if you opt-in to analytics in the Opentrons App. For example, protocols from the Opentrons Protocol Library may have "source" set to "Opentrons Protocol Library". You shouldn't define "source" in your own protocols.
 
 Labware
 ^^^^^^^

--- a/app/src/components/UploadError/styles.css
+++ b/app/src/components/UploadError/styles.css
@@ -16,6 +16,7 @@
   @apply --font-body-2-dark;
 
   margin-left: 2rem;
+  padding-bottom: 2rem;
   max-width: 24rem;
 }
 
@@ -23,6 +24,7 @@
 .error_message {
   font-weight: var(--fw-semibold);
   margin-bottom: 0.75rem;
+  white-space: pre-wrap;
 }
 
 .error_icon,

--- a/app/src/protocol/__tests__/reducer.test.js
+++ b/app/src/protocol/__tests__/reducer.test.js
@@ -51,6 +51,27 @@ describe('protocolReducer', () => {
       },
     },
     {
+      name: 'handles robot:SESSION_RESPONSE with Python protocol metadata',
+      action: {
+        type: 'robot:SESSION_RESPONSE',
+        payload: {
+          name: 'foo.py',
+          protocolText: '# foo.py',
+          metadata: {'protocol-name': 'foo'},
+        },
+      },
+      initialState: {file: null, contents: null, data: null},
+      expectedState: {
+        file: {
+          name: 'foo.py',
+          type: 'text/x-python-script',
+          lastModified: null,
+        },
+        contents: '# foo.py',
+        data: {metadata: {'protocol-name': 'foo'}},
+      },
+    },
+    {
       name: 'handles robot:DISCONNECT by clearing state',
       action: {type: 'robot:DISCONNECT_RESPONSE'},
       initialState: {file: {name: 'proto.py'}, contents: 'foo', data: {}},

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -70,14 +70,14 @@ export function protocolReducer (
       return {...state, ...action.payload}
 
     case 'robot:SESSION_RESPONSE': {
-      const {name, protocolText: contents} = action.payload
+      const {name, metadata, protocolText: contents} = action.payload
       const file =
         !state.file || name !== state.file.name
           ? {name, type: filenameToType(name), lastModified: null}
           : state.file
       const data =
-        !state.contents || contents !== state.contents
-          ? parseProtocolData(file, contents)
+        !state.data || contents !== state.contents
+          ? parseProtocolData(file, contents, metadata)
           : state.data
 
       return {file, contents, data}

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -8,7 +8,8 @@ import type {ProtocolFile, ProtocolData} from './types'
 
 const log = createLogger(__filename)
 
-const MIME_TYPE_JSON = 'application/json'
+export const MIME_TYPE_JSON = 'application/json'
+export const MIME_TYPE_PYTHON = 'text/x-python-script'
 
 export function fileToProtocolFile (file: File): ProtocolFile {
   return {
@@ -21,7 +22,9 @@ export function fileToProtocolFile (file: File): ProtocolFile {
 
 export function parseProtocolData (
   file: ProtocolFile,
-  contents: string
+  contents: string,
+  // optional Python protocol metadata
+  metadata: ?$PropertyType<ProtocolData, 'metadata'>
 ): ?ProtocolData {
   if (fileIsJson(file)) {
     try {
@@ -30,6 +33,9 @@ export function parseProtocolData (
       // TODO(mc, 2018-09-05): surface parse error to user prior to upload
       log.warn('Failed to parse JSON', {contents, message: e.message})
     }
+  } else if (metadata) {
+    // grab Python protocol metadata, if any
+    return {metadata}
   }
 
   return null
@@ -37,6 +43,7 @@ export function parseProtocolData (
 
 export function filenameToType (name: string): ?string {
   if (name.endsWith('.json')) return MIME_TYPE_JSON
+  if (name.endsWith('.py')) return MIME_TYPE_PYTHON
   return null
 }
 

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -1,6 +1,8 @@
 // @flow
 // robot actions and action types
 import {_NAME as NAME} from './constants'
+
+import type {ProtocolData} from '../protocol'
 import type {Mount, Slot, Axis, Direction, SessionUpdate} from './types'
 
 // TODO(mc, 2017-11-22): rename this function to actionType
@@ -128,6 +130,7 @@ export type SessionResponseAction = {|
   payload: {|
     name: string,
     protocolText: string,
+    metadata?: ?$PropertyType<ProtocolData, 'metadata'>,
   |},
 |}
 

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -3,6 +3,9 @@
 // TODO(mc, 2018-01-26): typecheck with flow
 import {push} from 'react-router-redux'
 import find from 'lodash/find'
+import kebabCase from 'lodash/kebabCase'
+import mapKeys from 'lodash/mapKeys'
+import pick from 'lodash/pick'
 
 import RpcClient from '../../rpc/client'
 import {actions, actionTypes} from '../actions'
@@ -432,6 +435,17 @@ export default function client (dispatch) {
       }
 
       if (apiSession.name) update.name = apiSession.name
+
+      // strip RPC cruft and map to JSON protocol data shape
+      // pick + mapKeys guard against bad input shape and/or type
+      if (apiSession.metadata) {
+        update.metadata = pick(
+          // TODO(mc, 2018-12-10): switch to camelCase when JSON protocols do
+          mapKeys(apiSession.metadata, (value, key) => kebabCase(key)),
+          // TODO(mc, 2018-12-10): codify "source" in JSON protocol schema
+          ['protocol-name', 'description', 'author', 'source']
+        )
+      }
 
       dispatch(actions.sessionResponse(null, update))
     } catch (error) {

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -458,6 +458,30 @@ describe('api client', () => {
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
 
+    test('maps api metadata to session metadata', () => {
+      const expected = actions.sessionResponse(null, expect.objectContaining({
+        metadata: {
+          'protocol-name': 'foo',
+          description: 'bar',
+          author: 'baz',
+          source: 'qux',
+        },
+      }))
+
+      session.metadata = {
+        _id: 1234,
+        some: () => {},
+        rpc: () => {},
+        cruft: () => {},
+        protocolName: 'foo',
+        description: 'bar',
+        author: 'baz',
+        source: 'qux',
+      }
+
+      return sendConnect().then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
     test('sends error if received malformed session from API', () => {
       const expected = actions.sessionResponse(expect.anything())
 


### PR DESCRIPTION
Closes #2617. See ticket for background and acceptance criteria

![2018-12-11 12 31 41](https://user-images.githubusercontent.com/2963448/49818503-e403f900-fd40-11e8-9fb9-ebb275e58b8a.gif)

## changelog

- feat(app): Display Python protocol metadata in the app 
    - Also updated API docs with changes mentioned in #2799 
    - Also also snuck in the whitespace fix for protocol upload errors

## review requests

- [x] Opening a Python protocol with `metadata` dict renders metadata in app
- [x] Re-opening a Python protocol without changes renders metadata
- [x] Re-opening a Python protocol with changes renders metadata
- [x] Connecting to a robot with an already loaded Python protocol renders metadata
- [x] Re-do tests above with JSON protocol to check for regressions