### PR TITLE
refactor(api): Add fixed trash and return tip

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -245,6 +245,7 @@ class API(HardwareAPILike):
             instr_dict = instr.as_dict()
             for key in configs:
                 instruments[mount][key] = instr_dict[key]
+            instruments[mount]['has_tip'] = instr.has_tip
         return instruments
 
     @property

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -132,8 +132,12 @@ class Deck(UserDict):
     def __setitem__(self, key: types.DeckLocation, val: DeckItem) -> None:
         key_int = self._check_name(key)
         if self.data.get(key_int) is not None:
-            raise ValueError('Deck location {} already has an item: {}'
-                             .format(key, self.data[key_int]))
+            if key_int == 12 and \
+                    self.data[key_int].name.split('_')[2] == 'trash':
+                pass
+            else:
+                raise ValueError('Deck location {} already has an item: {}'
+                                 .format(key, self.data[key_int]))
         self.data[key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
 

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -131,9 +131,10 @@ class Deck(UserDict):
 
     def __setitem__(self, key: types.DeckLocation, val: DeckItem) -> None:
         key_int = self._check_name(key)
-        if self.data.get(key_int) is not None:
+        labware = self.data.get(key_int)
+        if labware is not None:
             if key_int == 12 and \
-                    self.data[key_int].name.split('_')[2] == 'trash':
+                    labware.parameters.get('quirk') == 'fixedTrash':
                 pass
             else:
                 raise ValueError('Deck location {} already has an item: {}'

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -133,8 +133,8 @@ class Deck(UserDict):
         key_int = self._check_name(key)
         labware = self.data.get(key_int)
         if labware is not None:
-            if key_int == 12 and labware.parameters.get('quirks'):
-                if labware.parameters.get('quirks')[0] == 'fixedTrash':
+            if key_int == 12:
+                if 'fixedTrash' in labware.parameters.get('quirks', []):
                     pass
                 else:
                     raise ValueError('Deck location {} is for fixed trash only'

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -133,9 +133,12 @@ class Deck(UserDict):
         key_int = self._check_name(key)
         labware = self.data.get(key_int)
         if labware is not None:
-            if key_int == 12 and \
-                    labware.parameters.get('quirk') == 'fixedTrash':
-                pass
+            if key_int == 12 and labware.parameters.get('quirks'):
+                if labware.parameters.get('quirks')[0] == 'fixedTrash':
+                    pass
+                else:
+                    raise ValueError('Deck location {} is for fixed trash only'
+                                     .format(key))
             else:
                 raise ValueError('Deck location {} already has an item: {}'
                                  .format(key, self.data[key_int]))

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -209,6 +209,11 @@ class Labware:
         return self._definition['parameters']['loadName']
 
     @property
+    def parameters(self) -> dict:
+        """Internal properties of a labware including type and quirks"""
+        return self._parameters
+
+    @property
     def magdeck_engage_height(self) -> Optional[float]:
         if not self._parameters['isMagneticModuleCompatible']:
             return None

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -27,7 +27,7 @@ def dummy_instruments():
 instrument_keys = sorted([
     'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
-    'tip_length'])
+    'tip_length', 'has_tip'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/shared-data/definitions2/opentrons_1_trash_0.85_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_0.85_L.json
@@ -32,7 +32,7 @@
         "isTiprack": false,
         "loadName": "opentrons_1_trash_0.85_L",
         "isMagneticModuleCompatible": false,
-        "quirk": "fixedTrash"
+        "quirks": ["fixedTrash"]
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/opentrons_1_trash_0.85_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_0.85_L.json
@@ -31,7 +31,8 @@
         "format": "trash",
         "isTiprack": false,
         "loadName": "opentrons_1_trash_0.85_L",
-        "isMagneticModuleCompatible": false
+        "isMagneticModuleCompatible": false,
+        "quirk": "fixedTrash"
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/opentrons_1_trash_1.1_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_1.1_L.json
@@ -31,7 +31,8 @@
         "format": "trash",
         "isTiprack": false,
         "loadName": "opentrons_1_trash_1.1_L",
-        "isMagneticModuleCompatible": false
+        "isMagneticModuleCompatible": false,
+        "quirk": "fixedTrash"
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/opentrons_1_trash_1.1_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_1.1_L.json
@@ -32,7 +32,7 @@
         "isTiprack": false,
         "loadName": "opentrons_1_trash_1.1_L",
         "isMagneticModuleCompatible": false,
-        "quirk": "fixedTrash"
+        "quirks": ["fixedTrash"]
     },
     "wells": {
         "A1": {

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -77,6 +77,10 @@
           "type": "string",
           "enum": ["96Standard", "384Standard", "trough", "irregular", "trash"]
         },
+        "quirk": {
+          "description": "Property to classify a specific behavior this labware should have",
+          "type": "string"
+        },
         "isTiprack": {
           "description": "Flag marking whether a labware is a tiprack or not",
           "type": "boolean"

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -77,9 +77,12 @@
           "type": "string",
           "enum": ["96Standard", "384Standard", "trough", "irregular", "trash"]
         },
-        "quirk": {
+        "quirks": {
           "description": "Property to classify a specific behavior this labware should have",
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "isTiprack": {
           "description": "Flag marking whether a labware is a tiprack or not",


### PR DESCRIPTION
## overview
Closes #2241. Finish up the reset of tip management by adding a fixed trash and implementing return tip.  

## changelog

- Add `has_tip` key on instrument
- Add trash argument to instrument context
- Implement return tip, trash

## review requests

- Try picking up and dropping tip on robot!
- Code look OK?