### PR TITLE
feat(app): Add opt-in modal for new p10s

### DIFF
--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -15,9 +15,7 @@ import type {Config} from '@opentrons/app/src/config'
 
 // make sure all arguments are included in production
 // $FlowFixMe: process.defaultApp exists in electron
-const argv = process.defaultApp
-  ? process.argv.slice(2)
-  : process.argv.slice(1)
+const argv = process.defaultApp ? process.argv.slice(2) : process.argv.slice(1)
 
 const PARSE_ARGS_OPTS = {
   envPrefix: 'OT_APP',
@@ -62,6 +60,8 @@ const DEFAULTS: Config = {
     optedIn: false,
     seenOptIn: false,
   },
+
+  p10WarningSeen: {},
 
   // user support (intercom)
   support: {

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -3,16 +3,19 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
+import {reduce, get} from 'lodash'
 
 import {
   fetchSettings,
   setSettings,
   makeGetRobotSettings,
 } from '../../http-api-client'
+import {getConfig, updateConfig} from '../../config'
 import {CONNECTABLE} from '../../discovery'
 import {downloadLogs} from '../../shell'
 import {RefreshCard} from '@opentrons/components'
 import {LabeledButton, LabeledToggle} from '../controls'
+import OptInPipetteModal from './OptInPipetteModal'
 
 import type {State, Dispatch} from '../../types'
 import type {ViewableRobot} from '../../discovery'
@@ -23,12 +26,16 @@ type OP = {
   resetUrl: string,
 }
 
-type SP = {|settings: Array<Setting>|}
+type SP = {|
+  settings: Array<Setting>,
+  showP10Warning: boolean,
+|}
 
 type DP = {|
   fetch: () => mixed,
   set: (id: string, value: boolean) => mixed,
   download: () => mixed,
+  setP10WarningSeen: () => mixed,
 |}
 
 type Props = {...$Exact<OP>, ...SP, ...DP}
@@ -42,6 +49,7 @@ type BooleanSettingProps = {
 }
 
 const TITLE = 'Advanced Settings'
+const P10_OPT_IN_SETTING_ID = 'useNewP10Aspiration'
 
 export default connect(
   makeMapStateToProps,
@@ -65,11 +73,19 @@ class BooleanSettingToggle extends React.Component<BooleanSettingProps> {
 }
 
 function AdvancedSettingsCard (props: Props) {
-  const {settings, set, fetch, download, resetUrl} = props
+  const {
+    settings,
+    set,
+    fetch,
+    download,
+    resetUrl,
+    showP10Warning,
+    setP10WarningSeen,
+  } = props
   const {name, health, status} = props.robot
   const disabled = status !== CONNECTABLE
   const logsAvailable = health && health.logs
-
+  const setP10Setting = () => set(P10_OPT_IN_SETTING_ID, true)
   return (
     <RefreshCard
       watch={name}
@@ -99,31 +115,62 @@ function AdvancedSettingsCard (props: Props) {
       >
         <p>Restore robot to factory configuration</p>
       </LabeledButton>
+      {showP10Warning && (
+        <OptInPipetteModal
+          setP10Setting={setP10Setting}
+          setP10WarningSeen={setP10WarningSeen}
+        />
+      )}
       {settings.map(s => <BooleanSettingToggle {...s} key={s.id} set={set} />)}
     </RefreshCard>
   )
 }
 
+const seenP10WarningConfigPath = (name: string) => `p10WarningSeen.${name}`
+
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getRobotSettings = makeGetRobotSettings()
 
   return (state, ownProps) => {
-    const settingsRequest = getRobotSettings(state, ownProps.robot)
+    const {robot} = ownProps
+    const config = getConfig(state)
+    const settingsRequest = getRobotSettings(state, robot)
     const settings =
       settingsRequest &&
       settingsRequest.response &&
       settingsRequest.response.settings
 
-    return {settings: settings || []}
+    const p10OptedIn = reduce(
+      settings,
+      (result, setting) => {
+        if (setting.id === P10_OPT_IN_SETTING_ID) return setting.value
+        return result
+      },
+      null
+    )
+
+    const seenP10Warning = get(config, seenP10WarningConfigPath(robot.name))
+
+    return {
+      settings: settings || [],
+      showP10Warning: !seenP10Warning && p10OptedIn === false,
+    }
   }
 }
 
 function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
   const {robot} = ownProps
-
+  const setP10WarningSeen = () =>
+    dispatch(updateConfig(seenP10WarningConfigPath(robot.name), true))
   return {
     fetch: () => dispatch(fetchSettings(robot)),
-    set: (id, value) => dispatch(setSettings(robot, {id, value})),
+    set: (id, value) => {
+      if (id === P10_OPT_IN_SETTING_ID) {
+        setP10WarningSeen()
+      }
+      dispatch(setSettings(robot, {id, value}))
+    },
     download: () => dispatch(downloadLogs(robot)),
+    setP10WarningSeen,
   }
 }

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -3,7 +3,8 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
-import {reduce, get} from 'lodash'
+import get from 'lodash/get'
+import reduce from 'lodash/reduce'
 
 import {
   fetchSettings,
@@ -121,7 +122,9 @@ function AdvancedSettingsCard (props: Props) {
           setP10WarningSeen={setP10WarningSeen}
         />
       )}
-      {settings.map(s => <BooleanSettingToggle {...s} key={s.id} set={set} />)}
+      {settings.map(s => (
+        <BooleanSettingToggle {...s} key={s.id} set={set} />
+      ))}
     </RefreshCard>
   )
 }

--- a/app/src/components/RobotSettings/OptInPipetteModal/index.js
+++ b/app/src/components/RobotSettings/OptInPipetteModal/index.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react'
+import {AlertModal} from '@opentrons/components'
+import {Portal} from '../../portal'
+import styles from './styles.css'
+type Props = {
+  setP10Setting: () => mixed,
+  setP10WarningSeen: () => mixed,
+}
+
+export default function OptInModal (props: Props) {
+  const {setP10Setting, setP10WarningSeen} = props
+  const HEADING = 'Updated P10 Single Pipette Calibration'
+  const buttons = [
+    {onClick: setP10WarningSeen, children: 'not now'},
+    {
+      onClick: setP10Setting,
+      children: 'Update Pipette Function',
+      className: styles.width_auto,
+    },
+  ]
+  return (
+    <Portal>
+      <AlertModal heading={HEADING} buttons={buttons} alertOverlay>
+        <p>
+          This release includes a refinement to the aspiration function of the
+          P10 single-channel pipette based on an expanded data set.
+        </p>
+
+        <p>
+          Note this is a small but material change to the P10&apos;s pipetting
+          performance, in particular decreasing the low-volume µl-to-mm
+          conversion factor to address under-aspiration issues.
+        </p>
+
+        <p>
+          We recommend accepting this change, unless you are an advanced user
+          who has manually modified your P10S pipette&apos;s µl-to-mm conversion
+          factor
+        </p>
+
+        <p>
+          To use the updated calibration, click &quot;Update P10 Pipette
+          Function&quot;.
+        </p>
+        <p>
+          To temporarily continue using your current calibration, click
+          &quot;Not Now&quot;.
+        </p>
+
+        <p>
+          Please note you can change your selection in the &apos;Advanced
+          Settings&apos; menu. As always, please reach out to our team with any
+          questions.
+        </p>
+      </AlertModal>
+    </Portal>
+  )
+}

--- a/app/src/components/RobotSettings/OptInPipetteModal/index.js
+++ b/app/src/components/RobotSettings/OptInPipetteModal/index.js
@@ -10,7 +10,7 @@ type Props = {
 
 export default function OptInModal (props: Props) {
   const {setP10Setting, setP10WarningSeen} = props
-  const HEADING = 'Updated P10 Single Pipette Calibration'
+  const HEADING = 'Update available for P10 single-channel pipette'
   const buttons = [
     {onClick: setP10WarningSeen, children: 'not now'},
     {
@@ -23,35 +23,31 @@ export default function OptInModal (props: Props) {
     <Portal>
       <AlertModal heading={HEADING} buttons={buttons} alertOverlay>
         <p>
-          This release includes a refinement to the aspiration function of the
-          P10 single-channel pipette based on an expanded data set.
+          <strong>
+            There is an updated aspiration function available for the P10
+            single-channel pipette.
+          </strong>
         </p>
 
         <p>
-          Note this is a small but material change to the P10&apos;s pipetting
-          performance, in particular decreasing the low-volume µl-to-mm
-          conversion factor to address under-aspiration issues.
+          This is a small but material change to the P10&apos;s pipetting
+          performance based on an expanded data set. In particular, it decreases
+          the low-volume µl-to-mm conversion factor to address under-aspiration
+          issues.
         </p>
 
         <p>
-          We recommend accepting this change, unless you are an advanced user
-          who has manually modified your P10S pipette&apos;s µl-to-mm conversion
-          factor
+          <strong>
+            We strongly recommend you update your pipette function
+          </strong>
+          , unless you are an advanced user who has manually modified your P10S
+          pipette&apos;s µl-to-mm conversion factor.
         </p>
 
-        <p>
-          To use the updated calibration, click &quot;Update P10 Pipette
-          Function&quot;.
-        </p>
-        <p>
-          To temporarily continue using your current calibration, click
-          &quot;Not Now&quot;.
-        </p>
-
-        <p>
-          Please note you can change your selection in the &apos;Advanced
-          Settings&apos; menu. As always, please reach out to our team with any
-          questions.
+        <p className={styles.footer}>
+          * This setting can be changed in your robot&apos;s &quot;Advanced
+          Settings&quot; menu. If you have any questions, please contact our
+          Support Team.
         </p>
       </AlertModal>
     </Portal>

--- a/app/src/components/RobotSettings/OptInPipetteModal/styles.css
+++ b/app/src/components/RobotSettings/OptInPipetteModal/styles.css
@@ -1,0 +1,6 @@
+@import '@opentrons/components';
+
+.width_auto {
+  width: auto;
+  padding: 0.5rem 2rem;
+}

--- a/app/src/components/RobotSettings/OptInPipetteModal/styles.css
+++ b/app/src/components/RobotSettings/OptInPipetteModal/styles.css
@@ -4,3 +4,7 @@
   width: auto;
   padding: 0.5rem 2rem;
 }
+
+.footer {
+  font-style: italic;
+}

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -46,6 +46,10 @@ export type Config = {
     seenOptIn: boolean,
   },
 
+  p10WarningSeen: {
+    [id: string]: ?boolean,
+  },
+
   support: {
     userId: string,
     createdAt: number,


### PR DESCRIPTION
## overview

This PR closes #2793

## changelog

- feat(app): Add opt-in modal for new p10s

## review requests

- [ ] If p10 advanced settings is toggled off, show opt in modal
- [ ] If p10 advanced settings is toggled on, do not show opt in modal
  - [ ] Toggling p10 advanced setting for this robot back to off does not show opt in modal
** quit app, relaunch and view previous robot with opt in modal already seen **
- [ ] p10 opt in modal does not show if [not now] was clicked in previous app session
