### PR TITLE
feat(api): give QC tools an optional arg for com port

### DIFF
--- a/api/src/opentrons/tools/gantry_test.py
+++ b/api/src/opentrons/tools/gantry_test.py
@@ -7,6 +7,7 @@ with Max speed. This will result to a good assembly vs a bad assembly process.
 
 Author: Carlos Fernandez
 """
+import optparse
 
 from opentrons import robot
 from opentrons.drivers.smoothie_drivers.driver_3_0 import \
@@ -102,6 +103,20 @@ def run_y_axis(cycles, x_max, y_max, tolerance):
             robot._driver.home('Y')  # we tell it to home Y manually
 
 
+def connect_to_port():
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option(
+        "-p", "--p", dest="port", default='',
+        type='str', help='serial port of the smoothie'
+    )
+
+    options, _ = parser.parse_args(args=None, values=None)
+    if options.port:
+        robot.connect(options.port)
+    else:
+        robot.connect()
+
+
 def _exit_test():
     robot._driver._smoothie_reset()
     robot._driver._setup()
@@ -116,7 +131,7 @@ if __name__ == '__main__':
     tolerance_mm = 0.5
 
     try:
-        robot.connect()
+        connect_to_port()
         robot.home()
         run_x_axis(num_cycles, b_x_max, b_y_max, tolerance_mm)
         run_y_axis(num_cycles, b_x_max, b_y_max, tolerance_mm)

--- a/api/src/opentrons/tools/overnight_test.py
+++ b/api/src/opentrons/tools/overnight_test.py
@@ -11,6 +11,7 @@ Example of calling this script:
 
 '''
 
+import optparse
 import time
 import logging
 
@@ -212,11 +213,25 @@ def test_axis(driver, logger, axis):
     driver.set_speed(DEFAULT_AXES_SPEED)
 
 
+def connect_to_port():
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option(
+        "-p", "--p", dest="port", default='',
+        type='str', help='serial port of the smoothie'
+    )
+
+    options, _ = parser.parse_args(args=None, values=None)
+    if options.port:
+        robot.connect(options.port)
+    else:
+        robot.connect()
+
+
 if __name__ == '__main__':
     logger = setup_logging()
     logger.info('Starting 24-hours Test')
     try:
-        robot.connect()
+        connect_to_port()
         driver = robot._driver
         button_green()
         attempt_homing(robot._driver, logger)

--- a/api/src/opentrons/tools/write_pipette_memory.py
+++ b/api/src/opentrons/tools/write_pipette_memory.py
@@ -41,9 +41,20 @@ def connect_to_robot():
     Connect over Serial to the Smoothieware motor driver
     '''
     print()
+    import optparse
     from opentrons import robot
     print('Connecting to robot...')
-    robot.connect()
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option(
+        "-p", "--p", dest="port", default='',
+        type='str', help='serial port of the smoothie'
+    )
+
+    options, _ = parser.parse_args(args=None, values=None)
+    if options.port:
+        robot.connect(options.port)
+    else:
+        robot.connect()
     return robot
 
 


### PR DESCRIPTION
## overview

Some computers during QC do not auto-detect the com port. This PR adds an optional arg to QC scripts to specify the com port.
