### PR TITLE
refactor(protocol-designer): sync pipette locations in new initial deck setup step

### DIFF
--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -6,7 +6,8 @@ import type {BaseState} from '../types'
 import FilePage from '../components/FilePage'
 import {actions, selectors as fileSelectors} from '../file-data'
 import {actions as pipetteActions, selectors as pipetteSelectors} from '../pipettes'
-import {actions as stepFormActions, selectors as stepFormSelectors} from '../step-forms'
+import {selectors as stepFormSelectors} from '../step-forms'
+import {actions as steplistActions} from '../steplist'
 import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
 import type {InitialDeckSetup} from '../step-forms'
 import type {FileMetadataFields} from '../file-data'
@@ -39,6 +40,7 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
     if (!pipette.mount) return pipette.mount
     return pipette.mount === 'left' ? 'right' : 'left'
   })
+  console.log({_initialDeckSetup})
   return {
     ...passThruProps,
     ...dispatchProps,
@@ -46,9 +48,9 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
     saveFileMetadata: (nextFormValues: FileMetadataFields) =>
       dispatch(actions.saveFileMetadata(nextFormValues)),
     swapPipettes: () => {
-      dispatch(stepFormActions.movePipettes({
+      dispatch(steplistActions.changeSavedStepForm({
         stepId: INITIAL_DECK_SETUP_STEP_ID,
-        update: swapPipetteUpdate,
+        update: {pipetteLocationUpdate: swapPipetteUpdate},
       }))
       dispatch(pipetteActions.swapPipettes())
     },

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -40,7 +40,6 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
     if (!pipette.mount) return pipette.mount
     return pipette.mount === 'left' ? 'right' : 'left'
   })
-  console.log({_initialDeckSetup})
   return {
     ...passThruProps,
     ...dispatchProps,

--- a/protocol-designer/src/containers/ConnectedNewFileModal.js
+++ b/protocol-designer/src/containers/ConnectedNewFileModal.js
@@ -2,10 +2,17 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
-import type {BaseState} from '../types'
+import mapValues from 'lodash/mapValues'
+import uniq from 'lodash/uniq'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
+import {uuid} from '../utils'
 import i18n from '../localization'
 import {selectors, actions as navigationActions} from '../navigation'
 import {actions as fileActions, selectors as loadFileSelectors} from '../load-file'
+import * as labwareIngredActions from '../labware-ingred/actions'
+import {actions as stepFormActions} from '../step-forms'
+import {actions as steplistActions} from '../steplist'
+import type {BaseState} from '../types'
 import type {NewProtocolFields} from '../load-file'
 
 import NewFileModal from '../components/modals/NewFileModal'
@@ -33,7 +40,51 @@ function mapStateToProps (state: BaseState): SP {
 function mapDispatchToProps (dispatch: Dispatch<*>): DP {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
-    _createNewProtocol: fields => { dispatch(fileActions.createNewProtocol(fields)) },
+    _createNewProtocol: fields => {
+      dispatch(fileActions.createNewProtocol(fields))
+      // TODO: Ian 2018-12-17 after old rerefactor, change NewProtocolFields type
+      // to have `{pipettes: {[pipetteId: string]: {name: string, tiprackModel: string, mount: Mount}}`
+      // instead of left/right keys
+      type PipettesWithMount = {[pipetteId: string]: {name: string, tiprackModel: string, mount: string}}
+      const mounts = ['left', 'right']
+      const pipettes: PipettesWithMount = mounts.reduce((acc, mount) => {
+        const pip = fields[mount]
+        if (pip && pip.pipetteModel && pip.tiprackModel) {
+          return {
+            ...acc,
+            [uuid()]: {
+              name: pip.pipetteModel,
+              tiprackModel: pip.tiprackModel,
+              mount,
+            },
+          }
+        }
+        return acc
+      }, {})
+
+      // create new pipette entities
+      // TODO: Ian 2018-12-17 clean up types to createPipettes action
+      dispatch(stepFormActions.createPipettes(mapValues(pipettes, (p: $Values<PipettesWithMount>) => ({
+        name: p.name,
+        tiprackModel: p.tiprackModel,
+      }))))
+
+      // update pipette locations in initial deck setup step
+      dispatch(steplistActions.changeSavedStepForm({
+        stepId: INITIAL_DECK_SETUP_STEP_ID,
+        update: {
+          pipetteLocationUpdate: mapValues(pipettes, (p: $Values<PipettesWithMount>) => p.mount),
+        },
+      }))
+
+      // auto-generate tipracks for pipettes
+      const newTiprackModels = uniq(Object.values(pipettes)
+        .map((pipette: any) => pipette.tiprackModel))
+
+      newTiprackModels.forEach(tiprackModel => {
+        dispatch(labwareIngredActions.createContainer({containerType: tiprackModel}))
+      })
+    },
   }
 }
 

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -28,8 +28,8 @@ export type FlowRateForPipettes = {
 }
 
 export type PDMetadata = {
-  // pipetteId to tiprackModel. may be unassigned
-  pipetteTiprackAssignments: {[pipetteId: string]: ?string},
+  // pipetteId to tiprackModel
+  pipetteTiprackAssignments: {[pipetteId: string]: string},
 
   dismissedWarnings: $PropertyType<DismissRoot, 'dismissedWarnings'>,
 

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -37,7 +37,6 @@ export type StepFieldName =
   | 'dispense_wellOrder_second'
   | 'dispense_wells'
   | 'labware'
-  | 'labwareLocationUpdate'
   | 'pauseForAmountOfTime'
   | 'pauseHour'
   | 'pauseMessage'

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -37,6 +37,7 @@ export type StepFieldName =
   | 'dispense_wellOrder_second'
   | 'dispense_wells'
   | 'labware'
+  | 'labwareLocationUpdate'
   | 'pauseForAmountOfTime'
   | 'pauseHour'
   | 'pauseMessage'

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -56,7 +56,7 @@ export const drillUpFromLabware = createAction(
 // ==== Create/delete/modify labware =====
 
 type CreateContainerArgs = {
-  slot: DeckSlot,
+  slot?: DeckSlot,
   containerType: string,
 }
 

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -3,9 +3,7 @@ import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 
 import {selectors} from './reducers'
-import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
 import {uuid} from '../utils'
-import type {ChangeSavedStepFormAction} from '../steplist/actions'
 import type {GetState} from '../types'
 import type {IngredInputs} from './types'
 import type {DeckSlot} from '@opentrons/components'
@@ -63,9 +61,8 @@ type CreateContainerArgs = {
 export type CreateContainerAction = {
   type: 'CREATE_CONTAINER',
   payload: {
-    ...$Exact<CreateContainerArgs>,
     id: string,
-  },
+  } & CreateContainerArgs,
 }
 
 export const createContainer = createAction(
@@ -114,42 +111,14 @@ export type MoveLabware = {
   },
 }
 
-export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<*>, getState: GetState) => {
+export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
   const state = getState()
   const fromSlot = selectors.getSlotToMoveFrom(state)
-
-  // TODO: Ian 2018-12-13 this is a HACK during the refactor.
-  // Make this a selector in step-forms/ (and move this action to step-forms/)
-  // Also, 'moveLabware' should probably act on labwareId, not slot,
-  // especially if labware can share slots in the future
-  const prevLabwareLocations = state.stepForms.savedStepForms[INITIAL_DECK_SETUP_STEP_ID] &&
-    state.stepForms.savedStepForms[INITIAL_DECK_SETUP_STEP_ID].labwareLocationUpdate
-  const allLabwareIds = Object.keys(prevLabwareLocations || {})
-  // assumes 1 labware per slot:
-  const fromLabwareId: ?string = allLabwareIds.filter(id => prevLabwareLocations[id] === fromSlot)[0]
-
   if (fromSlot) {
-    if (fromLabwareId) {
-      const updateInitialDeckSetupStep: ChangeSavedStepFormAction = {
-        type: 'CHANGE_SAVED_STEP_FORM',
-        payload: {
-          stepId: INITIAL_DECK_SETUP_STEP_ID,
-          update: {
-            labwareLocationUpdate: {
-              [fromLabwareId]: toSlot,
-            },
-          },
-        },
-      }
-      dispatch(updateInitialDeckSetupStep)
-    }
-
-    // TODO: Ian 2018-12-13 after step-forms refactor, MOVE_LABWARE can be removed.
-    const moveLabwareAction: MoveLabware = {
+    return dispatch({
       type: 'MOVE_LABWARE',
       payload: {fromSlot, toSlot},
-    }
-    dispatch(moveLabwareAction)
+    })
   }
 }
 

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -61,8 +61,9 @@ type CreateContainerArgs = {
 export type CreateContainerAction = {
   type: 'CREATE_CONTAINER',
   payload: {
+    ...$Exact<CreateContainerArgs>,
     id: string,
-  } & CreateContainerArgs,
+  },
 }
 
 export const createContainer = createAction(

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -3,7 +3,9 @@ import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 
 import {selectors} from './reducers'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
 import {uuid} from '../utils'
+import type {ChangeSavedStepFormAction} from '../steplist/actions'
 import type {GetState} from '../types'
 import type {IngredInputs} from './types'
 import type {DeckSlot} from '@opentrons/components'
@@ -112,14 +114,43 @@ export type MoveLabware = {
   },
 }
 
-export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<MoveLabware>, getState: GetState) => {
+export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<*>, getState: GetState) => {
   const state = getState()
   const fromSlot = selectors.getSlotToMoveFrom(state)
+
+  // TODO: Ian 2018-12-13 this is a HACK during the refactor.
+  // Make this a selector in step-forms/ (and move this action to step-forms/)
+  // Also, 'moveLabware' should probably act on labwareId, not slot,
+  // especially if labware can share slots in the future
+  const prevLabwareLocations = state.stepForms.savedStepForms[INITIAL_DECK_SETUP_STEP_ID] &&
+    state.stepForms.savedStepForms[INITIAL_DECK_SETUP_STEP_ID].labwareLocationUpdate
+  const allLabwareIds = Object.keys(prevLabwareLocations || {})
+  // assumes 1 labware per slot:
+  const fromLabwareId: ?string = allLabwareIds.filter(id => prevLabwareLocations[id] === fromSlot)[0]
+
   if (fromSlot) {
-    return dispatch({
+    if (fromLabwareId) {
+      // WARNING: Ian 2018-12-13 during REFACTOR, this affects the legact `steplist.savedForms` reducer. but I don't see any problems since it's not in orderedSteps?
+      const updateInitialDeckSetupStep: ChangeSavedStepFormAction = {
+        type: 'CHANGE_SAVED_STEP_FORM',
+        payload: {
+          stepId: INITIAL_DECK_SETUP_STEP_ID,
+          update: {
+            labwareLocationUpdate: {
+              [fromLabwareId]: toSlot,
+            },
+          },
+        },
+      }
+      dispatch(updateInitialDeckSetupStep)
+    }
+
+    // TODO: Ian 2018-12-13 after step-forms refactor, MOVE_LABWARE can be removed.
+    const moveLabwareAction: MoveLabware = {
       type: 'MOVE_LABWARE',
       payload: {fromSlot, toSlot},
-    })
+    }
+    dispatch(moveLabwareAction)
   }
 }
 

--- a/protocol-designer/src/labware-ingred/actions.js
+++ b/protocol-designer/src/labware-ingred/actions.js
@@ -130,7 +130,6 @@ export const moveLabware = (toSlot: DeckSlot) => (dispatch: Dispatch<*>, getStat
 
   if (fromSlot) {
     if (fromLabwareId) {
-      // WARNING: Ian 2018-12-13 during REFACTOR, this affects the legact `steplist.savedForms` reducer. but I don't see any problems since it's not in orderedSteps?
       const updateInitialDeckSetupStep: ChangeSavedStepFormAction = {
         type: 'CHANGE_SAVED_STEP_FORM',
         payload: {

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -30,7 +30,7 @@ import type {
 import * as actions from '../actions'
 import {getPDMetadata} from '../../file-types'
 import type {BaseState, Options} from '../../types'
-import type {LoadFileAction, CreateNewProtocolAction} from '../../load-file'
+import type {LoadFileAction} from '../../load-file'
 import type {
   RemoveWellsContents,
   DeleteLiquidGroup,
@@ -192,22 +192,6 @@ export const containers = handleActions({
         },
       }
     }, {})
-  },
-  CREATE_NEW_PROTOCOL: (state: ContainersState, action: CreateNewProtocolAction): ContainersState => {
-    const nextState = action.payload.tipracks.reduce((acc: ContainersState, tiprack): ContainersState => {
-      const {id, model} = tiprack
-      return {
-        ...acc,
-        [id]: {
-          slot: nextEmptySlot(_loadedContainersBySlot(acc)),
-          type: model,
-          disambiguationNumber: getNextDisambiguationNumber(acc, String(model)),
-          id,
-          name: null,
-        },
-      }
-    }, state)
-    return nextState
   },
 }, initialLabwareState)
 

--- a/protocol-designer/src/pipettes/actions.js
+++ b/protocol-designer/src/pipettes/actions.js
@@ -1,8 +1,11 @@
 // @flow
-import type {UpdatePipettesAction, PipettesByMount} from './types'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
+import type {SwapPipettesAction, UpdatePipettesAction, PipettesByMount} from './types'
+import type {StepIdType} from '../form-types'
 
-export const swapPipettes = () => ({
+export const swapPipettes = (stepId: StepIdType = INITIAL_DECK_SETUP_STEP_ID): SwapPipettesAction => ({
   type: 'SWAP_PIPETTES',
+  payload: {stepId},
 })
 
 export const updatePipettes = (pipettesByMount: PipettesByMount): UpdatePipettesAction => ({

--- a/protocol-designer/src/pipettes/types.js
+++ b/protocol-designer/src/pipettes/types.js
@@ -2,10 +2,16 @@
 
 import type {PipetteData} from '../step-generation'
 import type {PipetteFields} from '../load-file'
+import type {StepIdType} from '../form-types'
 
 export type PipettesByMount = {
   left?: ?PipetteData,
   right?: ?PipetteData,
+}
+
+export type SwapPipettesAction = {
+  type: 'SWAP_PIPETTES',
+  payload: {stepId: StepIdType}, // manualIntervention step to swap pipettes on
 }
 
 export type UpdatePipettesAction = {

--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,0 +1,16 @@
+// @flow
+import type {Mount} from '@opentrons/components'
+import type {StepIdType} from '../../form-types'
+
+type MovePipettesPayload = {
+  stepId: StepIdType,
+  update: {[pipetteId: string]: ?Mount},
+}
+export type MovePipettesAction = {
+  type: 'MOVE_PIPETTES',
+  payload: MovePipettesPayload,
+}
+export const movePipettes = (payload: MovePipettesPayload): MovePipettesAction => ({
+  type: 'MOVE_PIPETTES',
+  payload,
+})

--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,16 +1,38 @@
 // @flow
-import type {Mount} from '@opentrons/components'
-import type {StepIdType} from '../../form-types'
 
-type MovePipettesPayload = {
-  stepId: StepIdType,
-  update: {[pipetteId: string]: ?Mount},
+export type CreatePipettesAction = {
+  type: 'CREATE_PIPETTES',
+  payload: {
+    [pipetteId: string]: {
+      name: string,
+      tiprackModel: string, // TODO: Ian 2018-12-17 this matches old var, but labware "model/type/name" is inconsistent and needs to be standardized
+    },
+  },
 }
-export type MovePipettesAction = {
-  type: 'MOVE_PIPETTES',
-  payload: MovePipettesPayload,
+
+export const createPipettes = (payload: $PropertyType<CreatePipettesAction, 'payload'>): CreatePipettesAction => ({
+  type: 'CREATE_PIPETTES',
+  payload,
+})
+
+export type DeletePipettesAction = {
+  type: 'DELETE_PIPETTES',
+  payload: Array<string>, // pipette ids to delete, order doesn't matter
 }
-export const movePipettes = (payload: MovePipettesPayload): MovePipettesAction => ({
-  type: 'MOVE_PIPETTES',
+
+export const deletePipettes = (payload: $PropertyType<DeletePipettesAction, 'payload'>): DeletePipettesAction => ({
+  type: 'DELETE_PIPETTES',
+  payload,
+})
+
+export type ModifyPipettesTiprackAssignmentAction = {
+  type: 'MODIFY_PIPETTES_TIPRACK_ASSIGNMENT',
+  payload: {
+    [pipetteId: string]: string, // new assigned tiprack model
+  },
+}
+
+export const modifyPipettesTiprackAssignment = (payload: $PropertyType<ModifyPipettesTiprackAssignmentAction, 'payload'>): ModifyPipettesTiprackAssignmentAction => ({
+  type: 'MODIFY_PIPETTES_TIPRACK_ASSIGNMENT',
   payload,
 })

--- a/protocol-designer/src/step-forms/index.js
+++ b/protocol-designer/src/step-forms/index.js
@@ -3,12 +3,15 @@
 import rootReducer from './reducers'
 import type {RootState} from './reducers'
 import * as selectors from './selectors'
+import * as actions from './actions'
 export * from './utils'
+export * from './types'
 
 export type {
   RootState,
 }
 export {
   rootReducer,
+  actions,
   selectors,
 }

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -76,6 +76,7 @@ const initialDeckSetupStepForm: FormData = {
   labwareLocationUpdate: {
     [FIXED_TRASH_ID]: '12',
   },
+  pipetteLocationUpdate: {}, // TODO SOON Ian 2018-12-13 sync pipette location with LOAD_FILE, SWAP_PIPETTE, UPDATE_PIPETTES, and CREATE_NEW_PROTOCOL.
 }
 
 const initialSavedStepFormsState: SavedStepFormState = {
@@ -96,7 +97,7 @@ function _migratePreDeckSetupStep (fileData: ProtocolFile): FormData {
 // TODO Ian 2018-12-13 replace the other savedStepForms with this new one
 const savedStepForms = (
   state: AllStepsState,
-  action: SaveStepFormAction | DeleteStepAction | LoadFileAction | DeleteContainerAction
+  action: SaveStepFormAction | DeleteStepAction | LoadFileAction | CreateContainerAction | DeleteContainerAction
 ) => {
   const {savedStepForms} = state
   switch (action.type) {
@@ -123,8 +124,34 @@ const savedStepForms = (
         ...getDefaultsForStepType(stepForm.stepType),
         ...stepForm,
       }))
+    // TODO: Ian 2018-12-13 make the createLabware thunk separate into 2 actions:
+    // create labware, then edit initial deck setup step form. This reducer will not have to handle CREATE_CONTAINER
+    case 'CREATE_CONTAINER':
+    // auto-update initial deck setup state.
+      const prevInitialDeckSetupStep = savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+      const {id, slot} = action.payload
+      return {
+        ...state,
+        [INITIAL_DECK_SETUP_STEP_ID]: {
+          ...prevInitialDeckSetupStep,
+          labwareLocationUpdate: {
+            ...prevInitialDeckSetupStep.labwareLocationUpdate,
+            [id]: slot,
+          },
+        },
+      }
     case 'DELETE_CONTAINER':
       return mapValues(savedStepForms, savedForm => {
+        if (
+          action.type === 'DELETE_CONTAINER' && // TODO Ian 2018-12-13 flow is not doing a good job understanding this switch-case
+          savedForm.stepType === 'manualIntervention'
+        ) {
+          // remove instances of labware from all manualIntervention steps
+          return {
+            ...savedForm,
+            labwareLocationUpdate: omit(savedForm.labwareLocationUpdate, action.payload.containerId),
+          }
+        }
         const deleteLabwareUpdate = reduce(savedForm, (acc, value, fieldName) => {
           if (value === action.payload.containerId) {
             const formLabwareFieldUpdate = {[fieldName]: null}

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -35,6 +35,9 @@ import type {
 import type {
   SaveMoreOptionsModal,
 } from '../../ui/steps/actions'
+import type {
+  MovePipettesAction,
+} from '../actions'
 
 type FormState = FormData | null
 
@@ -79,7 +82,7 @@ const initialDeckSetupStepForm: FormData = {
   labwareLocationUpdate: {
     [FIXED_TRASH_ID]: '12',
   },
-  pipetteLocationUpdate: {}, // TODO SOON Ian 2018-12-13 sync pipette location with LOAD_FILE, SWAP_PIPETTE, UPDATE_PIPETTES, and CREATE_NEW_PROTOCOL.
+  pipetteLocationUpdate: {}, // TODO SOON Ian 2018-12-13 sync pipette location with LOAD_FILE, MOVE_PIPETTES, UPDATE_PIPETTES, and CREATE_NEW_PROTOCOL.
 }
 
 const initialSavedStepFormsState: SavedStepFormState = {
@@ -107,7 +110,7 @@ function _migratePreDeckSetupStep (fileData: ProtocolFile): FormData {
 // TODO Ian 2018-12-13 replace the other savedStepForms with this new one
 const savedStepForms = (
   rootState: RootState,
-  action: SaveStepFormAction | DeleteStepAction | LoadFileAction | CreateContainerAction | DeleteContainerAction
+  action: SaveStepFormAction | DeleteStepAction | LoadFileAction | CreateContainerAction | DeleteContainerAction | MovePipettesAction
 ) => {
   const {savedStepForms} = rootState
   switch (action.type) {
@@ -180,20 +183,20 @@ const savedStepForms = (
           ...deleteLabwareUpdate,
         }
       })
-    case 'SWAP_PIPETTES':
-      const formToSwap = savedStepForms[action.payload.stepId]
+    case 'MOVE_PIPETTES':
+      const formToMove = savedStepForms[action.payload.stepId]
       assert(
-        formToSwap && formToSwap.stepType === 'manualIntervention',
-        'expected SWAP_PIPETTES to reference a manualIntervention step')
-      const swappedPipetteLocations = mapValues(formToSwap.pipetteLocationUpdate, (mount: ?string) => {
-        if (!mount) return mount
-        return mount === 'left' ? 'right' : 'left'
-      })
+        formToMove && formToMove.stepType === 'manualIntervention',
+        'expected MOVE_PIPETTES to reference a manualIntervention step')
+
       return {
         ...savedStepForms,
         [action.payload.stepId]: {
-          ...formToSwap,
-          pipetteLocationUpdate: swappedPipetteLocations,
+          ...formToMove,
+          pipetteLocationUpdate: {
+            ...formToMove.pipetteLocationUpdate,
+            ...action.payload.update,
+          },
         },
       }
     case 'CHANGE_SAVED_STEP_FORM':

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -70,6 +70,7 @@ const unsavedForm = (rootState: RootState, action: UnsavedFormActions): FormStat
       }
     case 'POPULATE_FORM': return action.payload
     case 'CANCEL_STEP_FORM': return null
+    case 'SELECT_TERMINAL_ITEM': return null
     case 'SAVE_STEP_FORM': return null
     case 'DELETE_STEP': return null
     // save the modal state into the unsavedForm --

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -2,6 +2,7 @@
 import {handleActions} from 'redux-actions'
 import type {ActionType} from 'redux-actions'
 import mapValues from 'lodash/mapValues'
+import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import reduce from 'lodash/reduce'
 
@@ -172,10 +173,25 @@ const savedStepForms = (
       })
     case 'CHANGE_SAVED_STEP_FORM':
       // TODO Ian 2018-12-13 do handleFormChange here with full state
+      const {stepId} = action.payload
+      const previousForm = savedStepForms[stepId]
+      if (previousForm.stepType === 'manualIntervention') {
+        // since manualIntervention steps are nested, use a recursive merge
+        return {
+          ...savedStepForms,
+          [stepId]: merge(
+            {},
+            previousForm,
+            action.payload.update,
+          ),
+        }
+      }
+      // other step form types are not designed to be deeply merged
+      // (eg `wells` arrays should be reset, not appended to)
       return {
         ...savedStepForms,
-        [action.payload.stepId]: {
-          ...(action.payload.stepId != null ? savedStepForms[action.payload.stepId] : {}),
+        [stepId]: {
+          ...previousForm,
           ...action.payload.update,
         },
       }

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -45,12 +45,13 @@ type UnsavedFormActions =
   | SaveStepFormAction
   | DeleteStepAction
   | SaveMoreOptionsModal
-const unsavedForm = (state: FormState = null, action: UnsavedFormActions): FormState => {
+const unsavedForm = (rootState: RootState, action: UnsavedFormActions): FormState => {
+  const unsavedFormState = rootState.unsavedForm
   switch (action.type) {
     case 'CHANGE_FORM_INPUT':
       // TODO: Ian 2018-12-13 use handleFormChange
       return {
-        ...state,
+        ...unsavedFormState,
         ...action.payload.update,
       }
     case 'POPULATE_FORM': return action.payload
@@ -60,9 +61,9 @@ const unsavedForm = (state: FormState = null, action: UnsavedFormActions): FormS
     // save the modal state into the unsavedForm --
     // it was 2 levels away from savedStepForms, now it's one level away
     case 'SAVE_MORE_OPTIONS_MODAL':
-      return {...state, ...action.payload}
+      return {...unsavedFormState, ...action.payload}
     default:
-      return state
+      return unsavedFormState
   }
 }
 
@@ -96,10 +97,10 @@ function _migratePreDeckSetupStep (fileData: ProtocolFile): FormData {
 
 // TODO Ian 2018-12-13 replace the other savedStepForms with this new one
 const savedStepForms = (
-  state: AllStepsState,
+  rootState: RootState,
   action: SaveStepFormAction | DeleteStepAction | LoadFileAction | CreateContainerAction | DeleteContainerAction
 ) => {
-  const {savedStepForms} = state
+  const {savedStepForms} = rootState
   switch (action.type) {
     case 'SAVE_STEP_FORM':
       return {
@@ -131,7 +132,7 @@ const savedStepForms = (
       const prevInitialDeckSetupStep = savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
       const {id, slot} = action.payload
       return {
-        ...state,
+        ...savedStepForms,
         [INITIAL_DECK_SETUP_STEP_ID]: {
           ...prevInitialDeckSetupStep,
           labwareLocationUpdate: {
@@ -265,7 +266,7 @@ const pipetteInvariantProperties = handleActions({
   },
 }, {})
 
-type AllStepsState = {
+export type RootState = {
   labwareInvariantProperties: LabwareState,
   pipetteInvariantProperties: PipetteState,
   savedStepForms: SavedStepFormState,
@@ -274,24 +275,20 @@ type AllStepsState = {
 
 // TODO Ian 2018-12-13: find some existing util to do this nested version of combineReducers
 // which avoids: 1) duplicating specifying initial state and 2) returning a new object when there's no change
-const initialAllStepsState: AllStepsState = {
+const initialRootState: RootState = {
   labwareInvariantProperties: initialLabwareState,
   pipetteInvariantProperties: {},
   savedStepForms: initialSavedStepFormsState,
   unsavedForm: null,
 }
-// TODO Ian 2018-12-13 remove this 'any' type
-const allSteps = (state: AllStepsState = initialAllStepsState, action: any) => {
+// TODO: Ian 2018-12-13 remove this 'any' type
+const rootReducer = (state: RootState = initialRootState, action: any) => {
   return {
     labwareInvariantProperties: labwareInvariantProperties(state.labwareInvariantProperties, action),
     pipetteInvariantProperties: pipetteInvariantProperties(state.pipetteInvariantProperties, action),
     savedStepForms: savedStepForms(state, action),
-    unsavedFrom: unsavedForm(state.unsavedForm, action),
+    unsavedForm: unsavedForm(state, action),
   }
 }
-
-export type RootState = AllStepsState
-
-const rootReducer = allSteps
 
 export default rootReducer

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -1,2 +1,46 @@
 // @flow
+import assert from 'assert'
+import mapValues from 'lodash/mapValues'
+import {createSelector} from 'reselect'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
+import type {InitialDeckSetup} from '../types'
+import type {RootState} from '../reducers'
+import type {BaseState, Selector} from '../../types'
 // TODO: Ian 2018-12-13 make selectors
+
+const rootSelector = (state: BaseState): RootState => state.stepForms
+
+// TODO: Ian 2018-12-14 type properly
+export const getLabwareInvariantProperties: Selector<*> = createSelector(
+  rootSelector,
+  (state) => state.labwareInvariantProperties
+)
+
+// TODO: Ian 2018-12-14 type properly
+export const getPipetteInvariantProperties: Selector<*> = createSelector(
+  rootSelector,
+  (state) => state.pipetteInvariantProperties
+)
+
+// TODO: Ian 2018-12-14 type properly
+export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
+  rootSelector,
+  getLabwareInvariantProperties,
+  getPipetteInvariantProperties,
+  (state, labwareInvariantProperties, pipetteInvariantProperties) => {
+    const initialSetupStep = state.savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+    assert(
+      initialSetupStep && initialSetupStep.stepType === 'manualIntervention',
+      'expected initial deck setup step to be "manualIntervention" step')
+    const labwareLocations = (initialSetupStep && initialSetupStep.labwareLocationUpdate) || {}
+    const pipetteLocations = (initialSetupStep && initialSetupStep.pipetteLocationUpdate) || {}
+    return {
+      labware: mapValues(labwareLocations, (slot, labwareId) => {
+        return {slot, ...labwareInvariantProperties[labwareId]}
+      }),
+      pipettes: mapValues(pipetteLocations, (mount, pipetteId) => {
+        return {mount, ...pipetteInvariantProperties[pipetteId]}
+      }),
+    }
+  }
+)

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -1,6 +1,5 @@
 // @flow
 
-// TODO IMMEDIATELY standardize type vs model vs name for labware and pipettes >:(
 export type InitialDeckSetup = {
   labware: {[labwareId: string]: {
     type: string,
@@ -8,9 +7,24 @@ export type InitialDeckSetup = {
   }},
   pipettes: {
     [pipetteId: string]: {
-      model: string,
+      model: string, // TODO: Ian 2018-12-17 make pipettes always name, never model. This is vestige of when pipettes had both name and model
       mount: string,
-      tiprackType: string,
+      tiprackModel: string,
     },
   },
+}
+
+// "entities" have only properties that are time-invariant
+
+export type PipetteEntities = {
+  [pipetteId: string]: {|
+    name: string,
+    tiprackModel: string,
+  |},
+}
+
+export type LabwareEntities = {
+  [labwareId: string]: {|
+    type: string,
+  |},
 }

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -1,0 +1,16 @@
+// @flow
+
+// TODO IMMEDIATELY standardize type vs model vs name for labware and pipettes >:(
+export type InitialDeckSetup = {
+  labware: {[labwareId: string]: {
+    type: string,
+    slot: string,
+  }},
+  pipettes: {
+    [pipetteId: string]: {
+      model: string,
+      mount: string,
+      tiprackType: string,
+    },
+  },
+}

--- a/protocol-designer/src/steplist/actions/types.js
+++ b/protocol-designer/src/steplist/actions/types.js
@@ -12,7 +12,7 @@ export type ChangeFormPayload = {
 }
 
 export type ChangeSavedFormPayload = {
-  stepId?: string,
+  stepId: string,
   update: {
     [StepFieldName]: ?mixed, // string | boolean | Array<string> | null,
   },

--- a/protocol-designer/src/steplist/reducers.js
+++ b/protocol-designer/src/steplist/reducers.js
@@ -7,13 +7,13 @@ import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 
 import {getPDMetadata} from '../file-types'
+import {getDefaultsForStepType} from './formLevel'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
 
 import type {StepItemData} from './types'
-import {INITIAL_DECK_SETUP_STEP_ID} from '../constants'
 import type {LoadFileAction} from '../load-file'
 import type {DeleteContainerAction} from '../labware-ingred/actions'
 import type {FormData, StepIdType} from '../form-types'
-import {getDefaultsForStepType} from './formLevel'
 
 import type {
   AddStepAction,


### PR DESCRIPTION
## overview

Fixes up previous PR so that pipette info and location is synced correctly, with CRUD-style pipette actions instead.

Also CREATE_CONTAINER has `slot` made optional, if you leave it out the reducer (old: labwareIngred.containers, new: inside initial deck setup step form) will use the next available slot, or ignore the action.

And `orderedSteps` has been copied over into stepForms.orderedSteps, so now all the non-ui reducers in `step-forms/reducers` are redundant and we can start re-routing the selectors

## changelog

* deprecate editPipettes thunk, make alternative in mergeProps of EditPipettesModal
* createNewProtocol no longer responsible for creating the pipettes - that's handled in ConnectedNewFileModal DTP

## review requests

<!--
  Describe any requests for your reviewers here.
-->
