### PR TITLE
fixup(release): Add user facing changelog edits for 3.6.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,17 +216,18 @@ Our release process is still a work-in-progress. All projects are currently vers
 
 1.  `make bump` (see details below)
 2.  Inspect version bumps and changelogs
-3.  `git add --all`
-4.  `git cz`
+3.  Edit the user-facing changelog at `app-shell/build/release-notes.md` to add the new notes
+4.  `git add --all`
+5.  `git cz`
     - Type: `chore`
     - Scope: `release`
     - Message: `${version}`
-5.  Open a PR into `edge`
-6.  Squash merge the PR once approved
-7.  Verify that CI is green on `edge` and test the build artifacts
-8.  Pull latest `edge` to your machine
-9.  `git tag -a v${version} -m 'chore(release): ${version}'`
-10. `git push --tags`
+6.  Open a PR into `edge`
+7.  Squash merge the PR once approved
+8.  Verify that CI is green on `edge` and test the build artifacts
+9.  Pull latest `edge` to your machine
+10.  `git tag -a v${version} -m 'chore(release): ${version}'`
+11. `git push --tags`
 
 #### `make bump` usage
 
@@ -250,7 +251,7 @@ make bump
 # equivalent to above
 make bump opts="--preid=alpha --cd-version=prerelease"
 
-# bump to a beta version
+# bump to a beta version, the standard practice for a new release
 make bump opts="--preid=beta"
 
 # prerelease minor version bump (e.g. 3.0.0 -> 3.1.0-alpha.0)
@@ -261,6 +262,9 @@ make bump opts="--cd-version=minor"
 
 # bump to an explicit version
 make bump opts="--repo-version=42.0.0"
+
+# bump a patch version, e.g. for a hotfix that does not require a beta
+make bump opts="--cd-version=patch"
 ```
 
 We use [lerna][], a monorepo management tool, to work with our various projects. You can use lerna to do things like see which projects have changed since the last release, or run a command in every project directory. To run a one-off lerna command, use:

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -1,4 +1,4 @@
-# Changes from 3.5.1 to 3.6.3
+# Changes from 3.5.1 to 3.6.4
 
 For more details, please see the full [technical change log][changelog]
 
@@ -39,7 +39,7 @@ executing, but it does not ([#2020][2020])
 <!-- start:@opentrons/api -->
 ## OT2 and Protocol API
 
-**Important**: This release updates the calibration of the P10 single pipette.
+**Important**: This release includes version 3.6.3, which updates the calibration of the P10 single pipette.
 
 This update includes a refinement to the aspiration function of the P10 single-channel pipette based on an expanded data set. The updated configuration is available as an **opt-in** in the "Advanced Settings" section of your robot's settings page.
 
@@ -49,10 +49,10 @@ As always, please reach out to our team with any questions.
 
 ### Bug fixes
 
-- **Updated the configuration of the P10 single based on an expanded dataset**
+- **Updated the configuration of the P1000 single based on an expanded dataset**
+- Updated the configuration of the P10 single based on an expanded dataset
 - Fixed a bug that was overwriting robot configuration with defaults when using the internal USB flash drive for configuration storage
 - Fixed the iteration order of labware created with `labware.create` to match documentation
-- Fixed various misconfigurations with pipette motor current/position settings
 
 ### New features
 
@@ -66,8 +66,6 @@ metadata = {
     'protocolName': 'My Protocol',
     'description': 'This protocol is mine and it is good',
 }
-
-# ...
 ```
 
 ### Known issues
@@ -78,6 +76,25 @@ metadata = {
     2. Jog the pipette up until there is enough room to insert the plate
     3. Insert plate and calibrate normally
         - After the plate has been calibrated once, the issue will not reoccur
+- Extremely long aspirations and dispenses can incorrectly trigger a serial timeout issue. If you see such an issue, make sure your protocol’s combination of aspirate/dispense speeds and aspirate/dispense volumes does not include a command that will take more than 30 seconds.
+- Python protocols that contain code in the top level assigning to the result of an index, for instance:
+
+```
+some_dict = {'hi': 2}
+some_dict[0] = True  # This will cause an error
+```
+
+If this kind of code is necessary, please structure it in a function:
+
+```
+def build_some_dict():
+    some_dict = {'hi': 2}
+    some_dict[0] = True
+    return some_dict
+```
+
+which avoids the issue.
+
 
 
 <!-- end:@opentrons/api -->


### PR DESCRIPTION
This adds the user-facing changelog for the new release. It also adds a note in contributing to do this.

## Review

Pull, `make -C app dev`, connect to a robot that needs to be updated and check that the release notes are right