### PR TITLE
fix(api): Fix extract metadata

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -355,9 +355,9 @@ def extract_metadata(parsed):
         obj for obj in parsed.body if isinstance(obj, ast.Assign)]
     for obj in assigns:
         print(obj.targets[0])
-        if obj.targets[0].id == 'metadata' \
-                and isinstance(obj.value, ast.Dict) \
-                and isinstance(obj.targets[0], ast.Name):
+        if isinstance(obj.targets[0], ast.Name) \
+                and obj.targets[0].id == 'metadata' \
+                and isinstance(obj.value, ast.Dict):
             keys = [k.s for k in obj.value.keys]
             values = [v.s for v in obj.value.values]
             metadata = dict(zip(keys, values))

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -354,7 +354,10 @@ def extract_metadata(parsed):
     assigns = [
         obj for obj in parsed.body if isinstance(obj, ast.Assign)]
     for obj in assigns:
-        if obj.targets[0].id == 'metadata' and isinstance(obj.value, ast.Dict):
+        print(obj.targets[0])
+        if obj.targets[0].id == 'metadata' \
+                and isinstance(obj.value, ast.Dict) \
+                and isinstance(obj.targets[0], ast.Name):
             keys = [k.s for k in obj.value.keys]
             values = [v.s for v in obj.value.values]
             metadata = dict(zip(keys, values))

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -333,7 +333,13 @@ metadata = {
 'what?': 'no',
 'hello': 'world'
 }
+fakedata = {
+'who?': 'me',
+'what?': 'green eggs'
+}
 print('wat?')
+metadata['hello'] = 'moon'
+fakedata['what?'] = 'ham'
 """
 
     parsed = ast.parse(prot, filename='testy', mode='exec')


### PR DESCRIPTION
## overview
There was a bug discovered in 3.6.2 and later in which any left hand assignment (or subscript) such as:
```
plate.properties['height'] = height
```
would result in an error such as:
![image](https://user-images.githubusercontent.com/31892318/50115242-c806c880-0214-11e9-9ff6-1b0d803314a2.png)

## changelog

- Check that an ast object is specifically a Name expression
- Add a left hand assignment and make sure it does not work or result in an error

## review requests

Pls do a before/after test with this protocol
```
from opentrons import labware, instruments, modules

mag_deck = modules.load('magdeck', '1')
output_plate = labware.load('biorad-hardshell-96-PCR', '1', share=True)

output_plate.properties['height'] = 46
for well in output_plate.wells():
    well.properties['height'] = 46
```
