### PR TITLE
Release: 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+
+### Bug Fixes
+
+* **api:** Fix extract metadata ([#2833](https://github.com/opentrons/opentrons/issues/2833)) ([0930915](https://github.com/opentrons/opentrons/commit/0930915))
+* **api:** Remove the intermingled old aspirate function from p10s ([#2839](https://github.com/opentrons/opentrons/issues/2839)) ([696184c](https://github.com/opentrons/opentrons/commit/696184c))
+* **protocol-designer:** ensure pipettes are removed from step forms when nuked ([#2813](https://github.com/opentrons/opentrons/issues/2813)) ([46fee8b](https://github.com/opentrons/opentrons/commit/46fee8b))
+
+
+### Features
+
+* **protocol-designer:** display timeline and form alerts in same fashion ([#2817](https://github.com/opentrons/opentrons/issues/2817)) ([e27d2ae](https://github.com/opentrons/opentrons/commit/e27d2ae)), closes [#1990](https://github.com/opentrons/opentrons/issues/1990)
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/api/src/opentrons/CHANGELOG.md
+++ b/api/src/opentrons/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+
+### Bug Fixes
+
+* **api:** Fix extract metadata ([#2833](https://github.com/Opentrons/opentrons/issues/2833)) ([0930915](https://github.com/Opentrons/opentrons/commit/0930915))
+* **api:** Remove the intermingled old aspirate function from p10s ([#2839](https://github.com/Opentrons/opentrons/issues/2839)) ([696184c](https://github.com/Opentrons/opentrons/commit/696184c))
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/api/src/opentrons/package.json
+++ b/api/src/opentrons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/api-server",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Opentrons API server application",
   "repository": {
     "type": "git",

--- a/app-shell/CHANGELOG.md
+++ b/app-shell/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/app-shell
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -50,6 +50,7 @@ As always, please reach out to our team with any questions.
 ### Bug fixes
 
 - Fixed a bug causing a very incorrect aspirate function when the "Use New P10 Single Calibration" advanced option was selected
+- Fixed a bug causing errors in protocols that assigned to a dictionary or list at the top level (caused by metadata parsing)
 - Updated the configuration of the P1000 single based on an expanded dataset
 - Updated the configuration of the P10 single based on an expanded dataset
 - Fixed a bug that was overwriting robot configuration with defaults when using the internal USB flash drive for configuration storage
@@ -78,23 +79,6 @@ metadata = {
     3. Insert plate and calibrate normally
         - After the plate has been calibrated once, the issue will not reoccur
 - Extremely long aspirations and dispenses can incorrectly trigger a serial timeout issue. If you see such an issue, make sure your protocol’s combination of aspirate/dispense speeds and aspirate/dispense volumes does not include a command that will take more than 30 seconds.
-- Python protocols that contain code in the top level assigning to the result of an index, for instance:
-
-```
-some_dict = {'hi': 2}
-some_dict[0] = True  # This will cause an error
-```
-
-If this kind of code is necessary, please structure it in a function:
-
-```
-def build_some_dict():
-    some_dict = {'hi': 2}
-    some_dict[0] = True
-    return some_dict
-```
-
-which avoids the issue.
 
 
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -49,8 +49,9 @@ As always, please reach out to our team with any questions.
 
 ### Bug fixes
 
-- Fixed a bug causing a very incorrect aspirate function when the "Use New P10 Single Calibration" advanced option was selected
-- Fixed a bug causing errors in protocols that assigned to a dictionary or list at the top level (caused by metadata parsing)
+- **Fixed a bug causing a very incorrect aspirate function when the "Use New P10 Single Calibration" advanced option was selected**
+  - This bug was introduced in version 3.6.2 and fixed in version 3.6.5
+- **Fixed a bug causing errors in protocols that assigned to a dictionary or list at the top level (caused by metadata parsing)**
 - Updated the configuration of the P1000 single based on an expanded dataset
 - Updated the configuration of the P10 single based on an expanded dataset
 - Fixed a bug that was overwriting robot configuration with defaults when using the internal USB flash drive for configuration storage

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -1,4 +1,4 @@
-# Changes from 3.5.1 to 3.6.4
+# Changes from 3.5.1 to 3.6.5
 
 For more details, please see the full [technical change log][changelog]
 
@@ -49,7 +49,8 @@ As always, please reach out to our team with any questions.
 
 ### Bug fixes
 
-- **Updated the configuration of the P1000 single based on an expanded dataset**
+- Fixed a bug causing a very incorrect aspirate function when the "Use New P10 Single Calibration" advanced option was selected
+- Updated the configuration of the P1000 single based on an expanded dataset
 - Updated the configuration of the P10 single based on an expanded dataset
 - Fixed a bug that was overwriting robot configuration with defaults when using the internal USB flash drive for configuration storage
 - Fixed the iteration order of labware created with `labware.create` to match documentation

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentrons/app-shell",
   "productName": "Opentrons",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Opentrons desktop application",
   "main": "lib/main.js",
   "scripts": {
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "devDependencies": {
-    "@opentrons/app": "3.6.4"
+    "@opentrons/app": "3.6.5"
   },
   "dependencies": {
-    "@opentrons/discovery-client": "3.6.4",
+    "@opentrons/discovery-client": "3.6.5",
     "@thi.ng/paths": "^1.6.5",
     "dateformat": "^3.0.3",
     "electron-debug": "^2.0.0",

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/app
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/app",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Opentrons desktop application UI",
   "main": "src/index.js",
   "repository": {
@@ -21,8 +21,8 @@
     "flow-typed": "^2.5.1"
   },
   "dependencies": {
-    "@opentrons/components": "3.6.4",
-    "@opentrons/shared-data": "3.6.4",
+    "@opentrons/components": "3.6.5",
+    "@opentrons/shared-data": "3.6.5",
     "@thi.ng/paths": "^1.6.5",
     "classnames": "^2.2.5",
     "events": "^3.0.0",

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/components
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/components",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "React components library for Opentrons' projects",
   "main": "src/index.js",
   "style": "src/index.css",

--- a/discovery-client/CHANGELOG.md
+++ b/discovery-client/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/discovery-client
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/discovery-client",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Node.js client for discovering Opentrons robots on the network",
   "main": "lib/index.js",
   "bin": {

--- a/labware-designer/CHANGELOG.md
+++ b/labware-designer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package labware-designer
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -10,7 +10,7 @@
   "name": "labware-designer",
   "productName": "Opentrons Labware Designer",
   "private": true,
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Labware Designer",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/shared-data": "3.6.4"
+    "@opentrons/shared-data": "3.6.5"
   },
   "devDependencies": {
     "flow-bin": "^0.82.0",

--- a/lerna.json
+++ b/lerna.json
@@ -12,5 +12,5 @@
   },
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.6.4"
+  "version": "3.6.5"
 }

--- a/protocol-designer/CHANGELOG.md
+++ b/protocol-designer/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+
+### Bug Fixes
+
+* **protocol-designer:** ensure pipettes are removed from step forms when nuked ([#2813](https://github.com/Opentrons/opentrons/issues/2813)) ([46fee8b](https://github.com/Opentrons/opentrons/commit/46fee8b))
+
+
+### Features
+
+* **protocol-designer:** display timeline and form alerts in same fashion ([#2817](https://github.com/Opentrons/opentrons/issues/2817)) ([e27d2ae](https://github.com/Opentrons/opentrons/commit/e27d2ae)), closes [#1990](https://github.com/Opentrons/opentrons/issues/1990)
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -10,7 +10,7 @@
   "name": "protocol-designer",
   "productName": "Opentrons Protocol Designer Prototype",
   "private": true,
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Protocol designer app",
   "main": "src/index.js",
   "bugs": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.6.4",
+    "@opentrons/components": "3.6.5",
     "classnames": "^2.2.5",
     "formik": "^1.3.1",
     "i18next": "^11.5.0",

--- a/protocol-library-kludge/CHANGELOG.md
+++ b/protocol-library-kludge/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package protocol-library-kludge
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -9,7 +9,7 @@
   },
   "name": "protocol-library-kludge",
   "private": true,
-  "version": "3.6.4",
+  "version": "3.6.5",
   "productName": "Opentrons Protocol Library",
   "description": "Protocol library stuff (WIP)",
   "main": "src/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons",
   "license": "Apache-2.0",
   "dependencies": {
-    "@opentrons/components": "3.6.4",
+    "@opentrons/components": "3.6.5",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "react": "^16.6.3",

--- a/shared-data/CHANGELOG.md
+++ b/shared-data/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/shared-data
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/shared-data",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Default labware definitions for Opentrons robots",
   "repository": {
     "type": "git",

--- a/update-server/otupdate/CHANGELOG.md
+++ b/update-server/otupdate/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/update-server
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/update-server/otupdate/package.json
+++ b/update-server/otupdate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/update-server",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Update server for Opentrons robots",
   "repository": {
     "type": "git",

--- a/webpack-config/CHANGELOG.md
+++ b/webpack-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.6.5"></a>
+## [3.6.5](https://github.com/Opentrons/opentrons/compare/v3.6.4...v3.6.5) (2018-12-18)
+
+**Note:** Version bump only for package @opentrons/webpack-config
+
+
+
+
+
 <a name="3.6.4"></a>
 ## [3.6.4](https://github.com/Opentrons/opentrons/compare/v3.6.3...v3.6.4) (2018-12-17)
 

--- a/webpack-config/package.json
+++ b/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentrons/webpack-config",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Shareable pieces of webpack configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Supercedes https://github.com/Opentrons/opentrons/pull/2840 with correct name

Hotfix 3.6.5.

This contains a fix for a very incorrect aspirate function for the p10 single when the new feature flag was ticked; this was caused by me incorrectly copy pasting the diff of the commit that reverted the change in the config to the code.

## Review request

Check out the changelogs (including the manually edited one in app-shell/build which I remembered this time)