### PR TITLE
refactor(protocol-designer): wire up step ui actions and remove old

### DIFF
--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -3,10 +3,8 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {AlertModal, CheckboxField, OutlineButton} from '@opentrons/components'
 import i18n from '../../localization'
-import {
-  actions as steplistActions,
-  type TerminalItemId,
-} from '../../steplist'
+import {actions as stepsActions} from '../../ui/steps'
+import type {TerminalItemId} from '../../steplist'
 import {actions, selectors} from '../../tutorial'
 import {Portal} from '../portals/MainPageModalPortal'
 import styles from './hints.css'
@@ -108,7 +106,7 @@ const mapStateToProps = (state: BaseState): SP => ({
 })
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
   removeHint: (hint, rememberDismissal) => dispatch(actions.removeHint(hint, rememberDismissal)),
-  selectTerminalItem: (terminalId) => dispatch(steplistActions.selectTerminalItem(terminalId)),
+  selectTerminalItem: (terminalId) => dispatch(stepsActions.selectTerminalItem(terminalId)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Hints)

--- a/protocol-designer/src/components/StepEditForm/ButtonRow.js
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow.js
@@ -3,8 +3,8 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {OutlineButton, PrimaryButton} from '@opentrons/components'
 
-import {actions} from '../../steplist'
-import {selectors as stepsSelectors} from '../../ui/steps'
+import {actions as steplistActions} from '../../steplist'
+import {actions as stepsActions, selectors as stepsSelectors} from '../../ui/steps'
 import type {BaseState, ThunkDispatch} from '../../types'
 import styles from './StepEditForm.css'
 import formStyles from '../Form.css'
@@ -35,9 +35,9 @@ const STP = (state: BaseState): SP => ({
 })
 
 const DTP = (dispatch: ThunkDispatch<*>): DP => ({
-  onCancel: () => dispatch(actions.cancelStepForm()),
-  onSave: () => dispatch(actions.saveStepForm()),
-  onClickMoreOptions: () => dispatch(actions.openMoreOptionsModal()),
+  onCancel: () => dispatch(steplistActions.cancelStepForm()),
+  onSave: () => dispatch(steplistActions.saveStepForm()),
+  onClickMoreOptions: () => dispatch(stepsActions.openMoreOptionsModal()),
 })
 
 export default connect(STP, DTP)(ButtonRow)

--- a/protocol-designer/src/components/StepEditForm/FormSection.js
+++ b/protocol-designer/src/components/StepEditForm/FormSection.js
@@ -6,8 +6,7 @@ import cx from 'classnames'
 import {IconButton, HoverTooltip} from '@opentrons/components'
 
 import i18n from '../../localization'
-import {selectors as stepsSelectors} from '../../ui/steps'
-import {collapseFormSection} from '../../steplist/actions'
+import {selectors as stepsSelectors, actions as stepsActions} from '../../ui/steps'
 import type {BaseState, ThunkDispatch} from '../../types'
 import styles from './FormSection.css'
 
@@ -57,7 +56,7 @@ const FormSectionSTP = (state: BaseState, ownProps: OP) => ({
   collapsed: stepsSelectors.getFormSectionCollapsed(state)[ownProps.sectionName],
 })
 const FormSectionDTP = (dispatch: ThunkDispatch<*>, ownProps: OP) => ({
-  onCollapseToggle: () => dispatch(collapseFormSection(ownProps.sectionName)),
+  onCollapseToggle: () => dispatch(stepsActions.collapseFormSection(ownProps.sectionName)),
 })
 const ConnectedFormSection = connect(FormSectionSTP, FormSectionDTP)(FormSection)
 

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionInput.js
@@ -4,8 +4,7 @@ import {connect} from 'react-redux'
 import {FormGroup, InputField} from '@opentrons/components'
 import WellSelectionModal from './WellSelectionModal'
 import {Portal} from '../../portals/MainPageModalPortal'
-import {actions as steplistActions} from '../../../steplist'
-import {selectors as stepsSelectors} from '../../../ui/steps'
+import {actions as stepsActions, selectors as stepsSelectors} from '../../../ui/steps'
 import styles from '../StepEditForm.css'
 
 import type {Dispatch} from 'redux'
@@ -86,8 +85,8 @@ const mapStateToProps = (state: BaseState): SP => ({
   wellSelectionLabwareKey: stepsSelectors.getWellSelectionLabwareKey(state),
 })
 const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
-  onOpen: key => dispatch(steplistActions.setWellSelectionLabwareKey(key)),
-  onClose: () => dispatch(steplistActions.clearWellSelectionLabwareKey()),
+  onOpen: key => dispatch(stepsActions.setWellSelectionLabwareKey(key)),
+  onClose: () => dispatch(stepsActions.clearWellSelectionLabwareKey()),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(WellSelectionInput)

--- a/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.js
@@ -3,10 +3,8 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import type {ThunkDispatch} from '../../../types'
-import {
-  actions as steplistActions,
-  type TerminalItemId,
-} from '../../../steplist'
+import {actions as stepsActions} from '../../../ui/steps'
+import {type TerminalItemId} from '../../../steplist'
 import i18n from '../../../localization'
 import styles from './styles.css'
 
@@ -30,6 +28,6 @@ class TerminalItemLink extends React.Component<OP & DP> {
 }
 
 const mapDTP = (dispatch: ThunkDispatch<*>): DP => ({
-  selectTerminalItem: (terminalId) => dispatch(steplistActions.selectTerminalItem(terminalId)),
+  selectTerminalItem: (terminalId) => dispatch(stepsActions.selectTerminalItem(terminalId)),
 })
 export default connect(null, mapDTP)(TerminalItemLink)

--- a/protocol-designer/src/components/steplist/TerminalItem/index.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.js
@@ -3,12 +3,8 @@ import {connect} from 'react-redux'
 import * as React from 'react'
 import type {BaseState, ThunkDispatch} from '../../../types'
 
-import {
-  actions as steplistActions,
-  type TerminalItemId,
-} from '../../../steplist'
-
-import {selectors as stepsSelectors} from '../../../ui/steps'
+import type {TerminalItemId} from '../../../steplist'
+import {selectors as stepsSelectors, actions as stepsActions} from '../../../ui/steps'
 import {PDTitledList} from '../../lists'
 export {default as TerminalItemLink} from './TerminalItemLink'
 
@@ -43,9 +39,9 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: ThunkDispatch<*>}
     ...stateProps,
     title,
     children,
-    onClick: () => dispatch(steplistActions.selectTerminalItem(id)),
-    onMouseEnter: () => dispatch(steplistActions.hoverOnTerminalItem(id)),
-    onMouseLeave: () => dispatch(steplistActions.hoverOnTerminalItem(null)),
+    onClick: () => dispatch(stepsActions.selectTerminalItem(id)),
+    onMouseEnter: () => dispatch(stepsActions.hoverOnTerminalItem(id)),
+    onMouseLeave: () => dispatch(stepsActions.hoverOnTerminalItem(null)),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
+++ b/protocol-designer/src/containers/ConnectedMoreOptionsModal.js
@@ -5,10 +5,6 @@ import {connect} from 'react-redux'
 import MoreOptionsModal from '../components/modals/MoreOptionsModal'
 
 import {actions as stepsActions, selectors} from '../ui/steps'
-import {
-  cancelMoreOptionsModal,
-  changeMoreOptionsModalInput,
-} from '../steplist/actions'
 
 import type {BaseState, ThunkDispatch} from '../types'
 
@@ -22,15 +18,15 @@ function mapStateToProps (state: BaseState) {
 
 function mapDispatchToProps (dispatch: ThunkDispatch<*>) {
   return {
-    onCancel: () => dispatch(cancelMoreOptionsModal()),
+    onCancel: () => dispatch(stepsActions.cancelMoreOptionsModal()),
     onSave: () => dispatch(stepsActions.saveMoreOptionsModal()),
 
     handleChange: (accessor: string) => (e: SyntheticInputEvent<*>) => {
       // NOTE this is similar to ConnectedStepEdit form, is it possible to make a more general reusable fn?
-      dispatch(changeMoreOptionsModalInput({update: {[accessor]: e.target.value}}))
+      dispatch(stepsActions.changeMoreOptionsModalInput({update: {[accessor]: e.target.value}}))
     },
 
-    onClickAway: () => dispatch(cancelMoreOptionsModal()),
+    onClickAway: () => dispatch(stepsActions.cancelMoreOptionsModal()),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -5,11 +5,10 @@ import isEmpty from 'lodash/isEmpty'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import type {SubstepIdentifier} from '../steplist/types'
-import {hoverOnSubstep, selectStep, hoverOnStep, toggleStepCollapsed} from '../steplist/actions'
 import * as substepSelectors from '../top-selectors/substeps'
 import {selectors as dismissSelectors} from '../dismiss'
 import {selectors as steplistSelectors} from '../steplist'
-import {selectors as stepsSelectors} from '../ui/steps'
+import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import {selectors as fileDataSelectors} from '../file-data'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 why is importing StepItem from index.js not working?
@@ -72,12 +71,12 @@ function mapDispatchToProps (dispatch: ThunkDispatch<*>, ownProps: OP): DP {
   const {stepId} = ownProps
 
   return {
-    handleSubstepHover: (payload: SubstepIdentifier) => dispatch(hoverOnSubstep(payload)),
+    handleSubstepHover: (payload: SubstepIdentifier) => dispatch(stepsActions.hoverOnSubstep(payload)),
 
-    onStepClick: () => dispatch(selectStep(stepId)),
-    onStepItemCollapseToggle: () => dispatch(toggleStepCollapsed(stepId)),
-    onStepHover: () => dispatch(hoverOnStep(stepId)),
-    onStepMouseLeave: () => dispatch(hoverOnStep(null)),
+    onStepClick: () => dispatch(stepsActions.selectStep(stepId)),
+    onStepItemCollapseToggle: () => dispatch(stepsActions.toggleStepCollapsed(stepId)),
+    onStepHover: () => dispatch(stepsActions.hoverOnStep(stepId)),
+    onStepMouseLeave: () => dispatch(stepsActions.hoverOnStep(null)),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -8,8 +8,8 @@ import styles from './TitleBar.css'
 import i18n from '../localization'
 import {START_TERMINAL_TITLE, END_TERMINAL_TITLE} from '../constants'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
-import {selectors as stepsSelectors} from '../ui/steps'
-import {actions as steplistActions, END_TERMINAL_ITEM_ID, START_TERMINAL_ITEM_ID} from '../steplist'
+import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
+import {END_TERMINAL_ITEM_ID, START_TERMINAL_ITEM_ID} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
 import {closeIngredientSelector} from '../labware-ingred/actions'
 import {stepIconsByType} from '../form-types'
@@ -121,7 +121,7 @@ function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Pr
     if (_liquidPlacementMode) {
       onBackClick = () => dispatch(closeIngredientSelector())
     } else if (_wellSelectionMode) {
-      onBackClick = () => dispatch(steplistActions.clearWellSelectionLabwareKey())
+      onBackClick = () => dispatch(stepsActions.clearWellSelectionLabwareKey())
     } else if (props.backButtonLabel) {
       onBackClick = () => {}
     }

--- a/protocol-designer/src/containers/StepCreationButton.js
+++ b/protocol-designer/src/containers/StepCreationButton.js
@@ -3,8 +3,8 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import StepCreationButton from '../components/StepCreationButton'
 
-import {addStep, expandAddStepButton} from '../steplist/actions'
-import {selectors as stepsSelectors} from '../ui/steps'
+import {addStep} from '../steplist/actions'
+import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import type {StepType} from '../form-types'
 import type {BaseState, ThunkDispatch} from '../types'
 
@@ -25,8 +25,8 @@ function mapStateToProps (state: BaseState): StateProps {
 function mapDispatchToProps (dispatch: ThunkDispatch<*>): DispatchProps {
   return {
     onStepClick: (stepType: StepType) => () => dispatch(addStep({stepType})),
-    onExpandClick: () => dispatch(expandAddStepButton(true)),
-    onClickAway: () => dispatch(expandAddStepButton(false)),
+    onExpandClick: () => dispatch(stepsActions.expandAddStepButton(true)),
+    onClickAway: () => dispatch(stepsActions.expandAddStepButton(false)),
   }
 }
 

--- a/protocol-designer/src/steplist/actions/actions.js
+++ b/protocol-designer/src/steplist/actions/actions.js
@@ -3,27 +3,18 @@ import type {Dispatch} from 'redux'
 
 import {selectors} from '../index'
 import {selectors as stepsSelectors} from '../../ui/steps'
-import type {StepType, StepIdType, FormModalFields, FormData} from '../../form-types'
+import type {StepType, StepIdType, FormData} from '../../form-types'
 import type {ChangeFormPayload, ChangeSavedFormPayload} from './types'
-import type {TerminalItemId, SubstepIdentifier, FormSectionNames} from '../types'
-import type {GetState, ThunkAction, ThunkDispatch} from '../../types'
+import type {GetState, ThunkDispatch} from '../../types'
 import handleFormChange from './handleFormChange'
 
-export type ChangeSavedStepFormAction = {
-  type: 'CHANGE_SAVED_STEP_FORM',
-  payload: ChangeSavedFormPayload,
-}
-
+export type ChangeSavedStepFormAction = {type: 'CHANGE_SAVED_STEP_FORM', payload: ChangeSavedFormPayload}
 export const changeSavedStepForm = (payload: ChangeSavedFormPayload) => ({
   type: 'CHANGE_SAVED_STEP_FORM',
   payload,
 })
 
-export type ChangeFormInputAction = {
-  type: 'CHANGE_FORM_INPUT',
-  payload: ChangeFormPayload,
-}
-
+export type ChangeFormInputAction = {type: 'CHANGE_FORM_INPUT', payload: ChangeFormPayload}
 export const changeFormInput = (payload: ChangeFormPayload) =>
   (dispatch: ThunkDispatch<ChangeFormInputAction>, getState: GetState) => {
     const unsavedForm = selectors.getUnsavedForm(getState())
@@ -35,90 +26,19 @@ export const changeFormInput = (payload: ChangeFormPayload) =>
 
 // Populate form with selected action (only used in thunks)
 
-export type PopulateFormAction = {
-  type: 'POPULATE_FORM',
-  payload: FormData,
-}
+export type PopulateFormAction = {type: 'POPULATE_FORM', payload: FormData}
 
 // Create new step
 
-export type AddStepAction = {
-  type: 'ADD_STEP',
-  payload: {
-    id: StepIdType,
-    stepType: StepType,
-  },
-}
+export type AddStepAction = {type: 'ADD_STEP', payload: {id: StepIdType, stepType: StepType }}
 
-export type DeleteStepAction = {
-  type: 'DELETE_STEP',
-  payload: StepIdType,
-}
-
+export type DeleteStepAction = {type: 'DELETE_STEP', payload: StepIdType}
 export const deleteStep = (stepId: StepIdType) => ({
   type: 'DELETE_STEP',
   payload: stepId,
 })
 
-type ExpandAddStepButtonAction = {
-  type: 'EXPAND_ADD_STEP_BUTTON',
-  payload: boolean,
-}
-
-export const expandAddStepButton = (payload: boolean): ExpandAddStepButtonAction => ({
-  type: 'EXPAND_ADD_STEP_BUTTON',
-  payload,
-})
-
-type ToggleStepCollapsedAction = {
-  type: 'TOGGLE_STEP_COLLAPSED',
-  payload: StepIdType,
-}
-
-export const toggleStepCollapsed = (stepId: StepIdType): ToggleStepCollapsedAction => ({
-  type: 'TOGGLE_STEP_COLLAPSED',
-  payload: stepId,
-})
-
-export const hoverOnSubstep = (payload: SubstepIdentifier): * => ({
-  type: 'HOVER_ON_SUBSTEP',
-  payload: payload,
-})
-
-export type SelectTerminalItemAction = {
-  type: 'SELECT_TERMINAL_ITEM',
-  payload: TerminalItemId,
-}
-
-export const selectTerminalItem = (terminalId: TerminalItemId): ThunkAction<*> =>
-  (dispatch: ThunkDispatch<*>, getState: GetState) => {
-    const selectTerminalItemAction: SelectTerminalItemAction = {
-      type: 'SELECT_TERMINAL_ITEM',
-      payload: terminalId,
-    }
-
-    dispatch(cancelStepForm())
-    dispatch(selectTerminalItemAction)
-  }
-
-// TODO: Ian 2018-07-31 types aren't being inferred by ActionType in hoveredItem reducer...
-export const hoverOnStep = (stepId: ?StepIdType) => ({
-  type: 'HOVER_ON_STEP',
-  payload: stepId,
-})
-
-export const hoverOnTerminalItem = (terminalId: ?TerminalItemId) => ({
-  type: 'HOVER_ON_TERMINAL_ITEM',
-  payload: terminalId,
-})
-
-export type SaveStepFormAction = {
-  type: 'SAVE_STEP_FORM',
-  payload: {
-    id: StepIdType,
-  },
-}
-
+export type SaveStepFormAction = {type: 'SAVE_STEP_FORM', payload: {id: StepIdType}}
 export const saveStepForm = () =>
   (dispatch: Dispatch<*>, getState: GetState) => {
     const state = getState()
@@ -131,80 +51,10 @@ export const saveStepForm = () =>
     }
   }
 
-export function cancelStepForm () {
-  return {
-    type: 'CANCEL_STEP_FORM',
-    payload: null,
-  }
-}
+export type CancelStepFormAction = {type: 'CANCEL_STEP_FORM', payload: null}
+export const cancelStepForm = () => ({type: 'CANCEL_STEP_FORM', payload: null})
 
-export type CollapseFormSectionAction = {type: 'COLLAPSE_FORM_SECTION', payload: FormSectionNames}
-export function collapseFormSection (payload: FormSectionNames): CollapseFormSectionAction {
-  return {
-    type: 'COLLAPSE_FORM_SECTION',
-    payload,
-  }
-}
-
-// ========= MORE OPTIONS MODAL =======
-// Effectively another unsaved form, that saves to unsavedForm's "hidden" fields
-
-// Populate newly-opened options modal with fields from unsaved form
-export type OpenMoreOptionsModal = {
-  type: 'OPEN_MORE_OPTIONS_MODAL',
-  payload: FormModalFields,
-}
-export const openMoreOptionsModal = () => (dispatch: Dispatch<*>, getState: GetState) => {
-  dispatch({
-    type: 'OPEN_MORE_OPTIONS_MODAL',
-    payload: selectors.getUnsavedForm(getState()), // TODO only pull in relevant fields?
-  })
-}
-
-export const cancelMoreOptionsModal = () => ({
-  type: 'CANCEL_MORE_OPTIONS_MODAL',
-  payload: null,
-})
-
-export type ChangeMoreOptionsModalInputAction = {
-  type: 'CHANGE_MORE_OPTIONS_MODAL_INPUT',
-  payload: ChangeFormPayload,
-}
-
-export const changeMoreOptionsModalInput = (payload: ChangeFormPayload): ChangeMoreOptionsModalInputAction => ({
-  type: 'CHANGE_MORE_OPTIONS_MODAL_INPUT',
-  payload,
-})
-
-// export type SaveMoreOptionsModal = {
-//   type: 'SAVE_MORE_OPTIONS_MODAL',
-//   payload: any, // TODO
-// }
-
-// export const saveMoreOptionsModal = () => (dispatch: Dispatch<*>, getState: GetState) => {
-//   dispatch({
-//     type: 'SAVE_MORE_OPTIONS_MODAL',
-//     payload: selectors.getFormModalData(getState()),
-//   })
-// }
-
-export const setWellSelectionLabwareKey = (labwareName: ?string): * => ({
-  type: 'SET_WELL_SELECTION_LABWARE_KEY',
-  payload: labwareName,
-})
-
-export const clearWellSelectionLabwareKey = (): * => ({
-  type: 'CLEAR_WELL_SELECTION_LABWARE_KEY',
-  payload: null,
-})
-
-export type ReorderStepsAction = {
-  type: 'REORDER_STEPS',
-  payload: {
-    stepIds: Array<StepIdType>,
-  },
-}
-
+export type ReorderStepsAction = {type: 'REORDER_STEPS', payload: {stepIds: Array<StepIdType>}}
 export const reorderSteps = (stepIds: Array<StepIdType>): ReorderStepsAction => ({
   type: 'REORDER_STEPS',
   payload: {stepIds},

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -1,15 +1,12 @@
 // @flow
-import forEach from 'lodash/forEach'
-import handleFormChange from './handleFormChange'
 import {uuid} from '../../utils'
 import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
-import * as pipetteSelectors from '../../pipettes/selectors'
 import {selectors as steplistSelectors} from '../../steplist'
-import {selectors as stepsSelectors} from '../../ui/steps'
+import {selectors as stepsSelectors, actions as stepsActions} from '../../ui/steps'
 import {actions as tutorialActions} from '../../tutorial'
-import {getNextDefaultPipetteId, generateNewForm} from '../formLevel'
+import {generateNewForm} from '../formLevel'
 import type {StepType, StepIdType, FormData} from '../../form-types'
-import type {BaseState, GetState, ThunkAction, ThunkDispatch} from '../../types'
+import type {BaseState, GetState, ThunkDispatch} from '../../types'
 
 export const SCROLL_ON_SELECT_STEP_CLASSNAME = 'scroll_on_select_step'
 
@@ -45,57 +42,6 @@ export function getStepFormData (state: BaseState, stepId: StepIdType, newStepTy
   })
 }
 
-// NOTE: 'newStepType' arg is only used when generating a new step
-export const selectStep = (stepId: StepIdType, newStepType?: StepType): ThunkAction<*> =>
-  (dispatch: ThunkDispatch<*>, getState: GetState) => {
-    const selectStepAction: SelectStepAction = {
-      type: 'SELECT_STEP',
-      payload: stepId,
-    }
-
-    dispatch(selectStepAction)
-
-    const state = getState()
-    let formData = getStepFormData(state, stepId, newStepType)
-
-    const defaultPipetteId = getNextDefaultPipetteId(
-      steplistSelectors.getSavedForms(state),
-      steplistSelectors.getOrderedSteps(state),
-      pipetteSelectors.getEquippedPipettes(state),
-    )
-
-    // For a pristine step, if there is a `pipette` field in the form
-    // (added by upstream `getDefaultsForStepType` fn),
-    // then set `pipette` field of new steps to the next default pipette id.
-    //
-    // In order to trigger dependent field changes (eg default disposal volume),
-    // update the form thru handleFormChange.
-    const formHasPipetteField = formData && 'pipette' in formData
-    if (newStepType && formHasPipetteField && defaultPipetteId) {
-      const updatePayload = {update: {pipette: defaultPipetteId}}
-      const updatedFields = handleFormChange(
-        updatePayload,
-        formData,
-        getState).update
-
-      formData = {
-        ...formData,
-        ...updatedFields,
-      }
-    }
-
-    dispatch({
-      type: 'POPULATE_FORM',
-      payload: formData,
-    })
-
-    // scroll to top of all elements with the special class
-    forEach(
-      global.document.getElementsByClassName(SCROLL_ON_SELECT_STEP_CLASSNAME),
-      elem => { elem.scrollTop = 0 }
-    )
-  }
-
 // addStep thunk adds an incremental integer ID for Step reducers.
 export const addStep = (payload: {stepType: StepType}) =>
   (dispatch: ThunkDispatch<*>, getState: GetState) => {
@@ -114,7 +60,7 @@ export const addStep = (payload: {stepType: StepType}) =>
     if (stepNeedsLiquid && !deckHasLiquid) {
       dispatch(tutorialActions.addHint('add_liquids_and_labware'))
     }
-    dispatch(selectStep(stepId, stepType))
+    dispatch(stepsActions.selectStep(stepId, stepType))
   }
 
 export type ReorderSelectedStepAction = {


### PR DESCRIPTION
Continuing to move the ui state management away from the protocol data that is stored with the
steplist, this branch deprecates the old steplist actions and wires up their uses to the new
ui.steps equivalents