### PR TITLE
fix(shared-data): add tests to ensure labware filename matches name/loadName

### DIFF
--- a/shared-data/definitions/opentrons-aluminum-block-PCR-strips-200ul.json
+++ b/shared-data/definitions/opentrons-aluminum-block-PCR-strips-200ul.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "name": "opentrons-aluminum-block-PCR-strips",
+    "name": "opentrons-aluminum-block-PCR-strips-200ul",
     "format": "96-standard",
     "displayCategory": "well-plate"
   },

--- a/shared-data/definitions/opentrons-tiprack-300ul.json
+++ b/shared-data/definitions/opentrons-tiprack-300ul.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "name": "GEB-tiprack-300ul",
+    "name": "opentrons-tiprack-300ul",
     "format": "96-standard",
     "tipVolume": 300,
     "displayCategory": "tiprack",

--- a/shared-data/js/__tests__/definition-schema.test.js
+++ b/shared-data/js/__tests__/definition-schema.test.js
@@ -69,13 +69,17 @@ describe('test schemas of all definitions', () => {
   })
 
   labwarePaths.forEach(labwarePath => {
-    test(path.parse(labwarePath).name, () => {
-      const labware = require(labwarePath)
-      const valid = validate(labware)
+    const filename = path.parse(labwarePath).name
+    const labwareDef = require(labwarePath)
+    test(filename, () => {
+      const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
+    })
+    test(`file name matches metadata.name: ${filename}`, () => {
+      expect(labwareDef.metadata.name).toEqual(filename)
     })
   })
 })

--- a/shared-data/js/__tests__/definition2-schema.test.js
+++ b/shared-data/js/__tests__/definition2-schema.test.js
@@ -54,13 +54,17 @@ describe('test schemas of all definitions', () => {
   })
 
   labwarePaths.forEach(labwarePath => {
-    test(path.parse(labwarePath).name, () => {
-      const labware = require(labwarePath)
-      const valid = validate(labware)
+    const filename = path.parse(labwarePath).name
+    const labwareDef = require(labwarePath)
+    test(filename, () => {
+      const valid = validate(labwareDef)
       const validationErrors = validate.errors
 
       expect(validationErrors).toBe(null)
       expect(valid).toBe(true)
+    })
+    test(`file name matches loadName: ${filename}`, () => {
+      expect(labwareDef.parameters.loadName).toEqual(filename)
     })
   })
 })


### PR DESCRIPTION
## overview

This does not touch defs in `definitions2/`, only `definitions/`.

This fixes 2 "old" `definitions/` - specifically, during a PD refactor I found that 300uL tipracks weren't rendering correctly, and this is because some new code expects that the `metadata.name` in a given definition is the same string that is used to get that definition via the `getLabware` fn. For `opentrons-tiprack-300ul` and the other one, that expectation did not hold. So let's have the tests ensure consistency!

## changelog

* add tests to ensure filename matches name or loadName
* fix opentrons-tiprack-300ul and opentrons-aluminum-block-PCR-strips-200ul names

## review requests

- Won't break anything, right?