### PR TITLE
fix(docs): Fix broken support article link

### DIFF
--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -31,7 +31,7 @@ __ https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#development-
 
 or this `support article`__
 
-__ https://support.opentrons.com/ot-2/getting-started-software-setup/installing-the-opentrons-api-on-your-computer
+__ https://support.opentrons.com/ot-2/getting-started-software-setup/installing-the-opentrons-api-on-your-computer-for-simulation
 
 
 **********************


### PR DESCRIPTION
## overview

Super quick link fix for docs.opentrons.com.

## changelog
- Update a support article link

## review requests
Go to link?