### PR TITLE
feat(api): Add json protocol execution to new protocol API

### DIFF
--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -45,27 +45,27 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
 
 .. code-block:: python
 
-    # metadata
-    metadata = {
-        'protocolName': 'My Protocol',
-        'author': 'Name <email@address.com>',
-        'description': 'Simple protocol to get started using OT2',
-        'source': 'Opentrons Protocol Tutorial'
-    }
+  # metadata
+  metadata = {
+      'protocolName': 'My Protocol',
+      'author': 'Name <email@address.com>',
+      'description': 'Simple protocol to get started using OT2',
+      'source': 'Opentrons Protocol Tutorial'
+  }
 
-    # protocol run function
-    def run(protocol_context):
+  # protocol run function
+  def run(protocol_context):
 
-        # labware
-        plate = protocol_context.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
-        tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300_uL', '1')
+      # labware
+      plate = protocol_context.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
+      tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300_uL', '1')
 
-        # pipettes
-        pipette = protocol_context.load_instrument(’p300_single’, ’left’, tip_racks=[tiprack])
+      # pipettes
+      pipette = protocol_context.load_instrument(’p300_single’, ’left’, tip_racks=[tiprack])
 
-        # commands
-        pipette.aspirate(100, plate.wells_by_index()[’A1’])
-        pipette.dispense(100, plate.wells_by_index()[’B2’])
+      # commands
+      pipette.aspirate(100, plate.wells_by_index()[’A1’])
+      pipette.dispense(100, plate.wells_by_index()[’B2’])
 
 
 **********************
@@ -96,9 +96,9 @@ Opentrons API version 4 protocols are structured around a function called ``run(
 1) Remember, track, and check the robot’s state
 2) Expose the functions that make the robot act
 
-This object is called the *protocol context*, and is always an instance of the :py:class:`.ProtocolContext` class. The protocol context plays the same role as the ``robot``, ``labware``, ``instruments``, and ``modules`2` objects in past versions of the API, with one important difference: it is only one object; and because it is passed in to your protocol rather than imported, it is possible for the API to be much more rigorous about separating simulation from reality.
+This object is called the *protocol context*, and is always an instance of the :py:class:`.ProtocolContext` class. The protocol context plays the same role as the ``robot``, ``labware``, ``instruments``, and ``modules`` objects in past versions of the API, with one important difference: it is only one object; and because it is passed in to your protocol rather than imported, it is possible for the API to be much more rigorous about separating simulation from reality.
 
-The key point is that there is no longer any need to `import opentrons` at the top of every protocol, since the *robot* now *runs the protocol*, rather than the *protocol running the robot*.
+The key point is that there is no longer any need to ``import opentrons`` at the top of every protocol, since the *robot* now *runs the protocol*, rather than the *protocol running the robot*.
 
 
 Labware
@@ -106,7 +106,7 @@ Labware
 
 The labware section informs the protocol context what labware is present on the robot’s deck. In this section, you define the tip racks, well plates, troughs, tubes, or anything else you’ve put on the deck.
 
-Each labware is given a name (ex: ``'generic_96_wellPlate_380_uL'``), and the slot on the robot it will be placed (ex: ``'2'``).
+Each labware is given a name (ex: ``'generic_96_wellPlate_380_uL'``), and the slot on the robot it will be placed (ex: ``'2'``). A list of valid labware can be found in :ref:`protocol-api-valid-labware`. In this example, we’ll use ``'generic_96_wellPlate_380_uL'`` (an ANSI standard 96-well plate) and ``'opentrons_96_tiprack_300_uL'``, the Opentrons standard 300 uL tiprack.
 
 From the example above, the "labware" section looked like:
 
@@ -167,6 +167,63 @@ Labware and Wells
 -----------------
 .. automodule:: opentrons.protocol_api.labware
    :members:
+
+
+.. _protocol-api-valid-labware:
+
+Valid Labware
+^^^^^^^^^^^^^
+
+This section lists the names of valid labwares that can be loaded with :py:meth:`.ProtocolContext.load_labware_by_name`, along with the name of the legacy labware definition each is equivalent to (if any).
+
++-------------------------------------------+----------------------------------------+
+| API 4.0 Labware Name                      | API 3.x Labware Name                   |
++===========================================+========================================+
+| biorad_96_wellPlate_pcr_200_uL            | 96-pcr-flat                            |
++-------------------------------------------+----------------------------------------+
+| corning_12_wellPlate_6.9_mL               | 12-well-plate                          |
++-------------------------------------------+----------------------------------------+
+| corning_24_wellPlate_3.4_mL               | 24-well-plate                          |
++-------------------------------------------+----------------------------------------+
+| corning_384_wellPlate_112_uL              | 384-plate                              |
++-------------------------------------------+----------------------------------------+
+| corning_48_wellPlate_1.6_mL               | 48-well-plate                          |
++-------------------------------------------+----------------------------------------+
+| corning_6_wellPlate_16.8_mL               | 6-well-plate                           |
++-------------------------------------------+----------------------------------------+
+| eppendorf_96_tiprack_1000_uL              | --                                     |
++-------------------------------------------+----------------------------------------+
+| eppendorf_96_tiprack_10_uL                | --                                     |
++-------------------------------------------+----------------------------------------+
+| generic_96_wellPlate_380_uL               | 96-flat                                |
++-------------------------------------------+----------------------------------------+
+| opentrons_15_tuberack_15_mL_falcon        | opentrons-tubrack-15ml                 |
++-------------------------------------------+----------------------------------------+
+| opentrons_24_aluminum_tuberack_2_mL       | opentrons-aluminum-block-2ml-eppendorf |
++-------------------------------------------+----------------------------------------+
+| opentrons_24_tuberack_1.5_mL_eppendorf    | opentrons-tuberack-1.5ml-eppendorf     |
++-------------------------------------------+----------------------------------------+
+| opentrons_24_tuberack_2_mL_eppendorf      | opentrons-tuberack-2ml-eppendorf       |
++-------------------------------------------+----------------------------------------+
+| opentrons_24_tuberack_2_mL_screwcap       | opentrons-tuberack-2ml-screwcap        |
++-------------------------------------------+----------------------------------------+
+| opentrons_6_tuberack_50_mL_falcon         | opentrons-tuberack-50ml                |
++-------------------------------------------+----------------------------------------+
+| opentrons_6x15_mL_4x50_mL_tuberack        | opentrons-tuberack-15_50ml             |
++-------------------------------------------+----------------------------------------+
+| opentrons_96_aluminum_biorad_plate_200_uL | opentrons-aluminum-block-96-PCR-plate  |
++-------------------------------------------+----------------------------------------+
+| opentrons_96_aluminum_tuberack_200_uL     | --                                     |
++-------------------------------------------+----------------------------------------+
+| opentrons_96_tiprack_1000_uL              | tiprack-1000ul                         |
++-------------------------------------------+----------------------------------------+
+| opentrons_96_tiprack_10_uL                | tiprack-10ul                           |
++-------------------------------------------+----------------------------------------+
+| opentrons_96_tiprack_300_uL               | opentrons-tiprack-300ul                |
++-------------------------------------------+----------------------------------------+
+| usa_scientific_12_trough_22_mL            | usa_scientific_12_trough_22_mL         |
++-------------------------------------------+----------------------------------------+
+
 
 
 .. _protocol-api-types:

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -41,10 +41,9 @@ class CalibrationManager:
 
         if ff.use_protocol_api_v2():
             mount = Mount[instrument._instrument.mount.upper()]
-            if instrument.tip_racks:
-                tip_length = instrument.tip_racks[0]._container.tip_length
-            else:
-                tip_length = None
+            assert instrument.tip_racks,\
+                'No known tipracks for {}'.format(instrument)
+            tip_length = instrument.tip_racks[0]._container.tip_length
             measured_center = self._hardware.locate_tip_probe_center(
                 mount, tip_length)
         else:

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,3 +1,4 @@
+from opentrons.config import feature_flags as ff
 from opentrons.protocol_api import labware
 from opentrons.legacy_api.containers import Slot, placeable
 
@@ -40,13 +41,16 @@ class Instrument:
         self.name = instrument.name
         self.channels = instrument.channels
         self.mount = instrument.mount
-        self.tip_racks = [
-            Container(container)
-            for container in instrument.tip_racks]
         self.containers = [
             Container(container)
             for container in containers
         ]
+        self.tip_racks = [
+            Container(container)
+            for container in instrument.tip_racks]
+        if ff.use_protocol_api_v2():
+            self.tip_racks.extend([
+                c for c in self.containers if c._container.is_tiprack])
 
 
 class Module:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -187,7 +187,8 @@ class Session(object):
                     API.build_hardware_simulator,
                     instrs,
                     [mod.name()
-                     for mod in self._hardware.attached_modules.values()])
+                     for mod in self._hardware.attached_modules.values()],
+                    strict_attached_instruments=False)
                 sim.home()
                 self._simulating_ctx = ProtocolContext(self._loop,
                                                        sim)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -191,8 +191,14 @@ class Session(object):
                 sim.home()
                 self._simulating_ctx = ProtocolContext(self._loop,
                                                        sim)
-                run_protocol(self._protocol, simulate=True,
-                             context=self._simulating_ctx)
+                if self._is_json_protocol:
+                    run_protocol(protocol_json=self._protocol,
+                                 simulate=True,
+                                 context=self._simulating_ctx)
+                else:
+                    run_protocol(protocol_code=self._protocol,
+                                 simulate=True,
+                                 context=self._simulating_ctx)
                 sim.join()
             else:
                 # TODO (artyom, 20171005): this will go away
@@ -265,7 +271,7 @@ class Session(object):
         self.set_state('running')
         return self
 
-    def run(self):
+    def run(self):  # noqa(C901)
         def on_command(message):
             if message['$'] == 'before':
                 self.log_append()
@@ -288,7 +294,10 @@ class Session(object):
                 ctx = ProtocolContext(loop=self._loop)
                 ctx.connect(self._hardware)
                 ctx.home()
-                run_protocol(self._protocol, context=ctx)
+                if self._is_json_protocol:
+                    run_protocol(protocol_json=self._protocol, context=ctx)
+                else:
+                    run_protocol(protocol_code=self._protocol, context=ctx)
             else:
                 if self._is_json_protocol:
                     execute_protocol(self._protocol)

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -31,8 +31,7 @@ pipette_config = namedtuple(
         'ul_per_mm',
         'quirks',
         'tip_length',  # TODO (andy): remove from pipette, move to tip-rack
-        'display_name',
-        'tip_overlap'
+        'display_name'
     ]
 )
 
@@ -105,8 +104,7 @@ def load(pipette_model: str) -> pipette_config:
         ul_per_mm=cfg.get('ulPerMm'),
         quirks=cfg.get('quirks'),
         tip_length=cfg.get('tipLength'),
-        display_name=cfg.get('displayName'),
-        tip_overlap=cfg.get('tipOverlap')
+        display_name=cfg.get('displayName')
     )
 
     # Verify that stored values agree with calculations

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -97,7 +97,7 @@ DEFAULT_DECK_CALIBRATION = [
 DEFAULT_ACCELERATION = 'M204 S10000 X3000 Y2000 Z1500 A1500 B2000 C2000'
 DEFAULT_STEPS_PER_MM = 'M92 X80.00 Y80.00 Z400 A400 B768 C768'
 # This probe height is ~73 from deck to the top surface of the switch body
-# per CAD; 74.9mm is the nominal for engagement from the switch drawing.
+# per CAD; 74.3mm is the nominal for engagement from the switch drawing.
 # Note that this has a piece-to-piece tolerance stackup of +-1.5mm
 # Switch drawing: https://www.mouser.com/datasheet/2/307/en-d2f-587403.pdf
 # model no D2F-01L

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1156,10 +1156,9 @@ class API(HardwareAPILike):
             pip.remove_tip()
 
         if not tip_length:
-            if not pip.has_tip:
-                tip_length = pip.config.tip_length
-            if not tip_length and pip.has_tip:
-                tip_length = pip._current_tip_length
+            assert pip.has_tip,\
+                'If pipette has no tip a tip length must be specified'
+            tip_length = pip._current_tip_length
 
         # assure_tip lets us make sure we don’t pollute the pipette
         # state even if there’s an exception in tip probe

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -133,7 +133,8 @@ class API(HardwareAPILike):
             attached_instruments: Dict[top_types.Mount, Dict[str, Optional[str]]] = None,  # noqa E501
             attached_modules: List[str] = None,
             config: robot_configs.robot_config = None,
-            loop: asyncio.AbstractEventLoop = None) -> 'API':
+            loop: asyncio.AbstractEventLoop = None,
+            strict_attached_instruments: bool = True) -> 'API':
         """ Build a simulating hardware controller.
 
         This method may be used both on a real robot and on dev machines.
@@ -146,7 +147,8 @@ class API(HardwareAPILike):
             attached_modules = []
         return cls(Simulator(attached_instruments,
                              attached_modules,
-                             config, loop),
+                             config, loop,
+                             strict_attached_instruments),
                    config=config, loop=loop)
 
     def __repr__(self):

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1002,7 +1002,7 @@ class API(HardwareAPILike):
         if aspirate:
             this_pipette.update_config_item('aspirate_flow_rate', aspirate)
         if dispense:
-            this_pipette.update_config_item('dispense_float_rate', dispense)
+            this_pipette.update_config_item('dispense_flow_rate', dispense)
 
     @_log_call
     async def discover_modules(self):

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -97,7 +97,6 @@ class Pipette:
     def current_tip_length(self) -> float:
         """ The length of the current tip attached (0.0 if no tip) """
         return (self._current_tip_length
-                - self._config.tip_overlap
                 - self._instrument_offset.z)
 
     @property

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -36,7 +36,8 @@ class Simulator:
             self,
             attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
             attached_modules: List[str],
-            config, loop) -> None:
+            config, loop,
+            strict_attached_instruments=True) -> None:
         """ Build the simulator.
 
         :param attached_instruments: A dictionary describing the instruments
@@ -59,6 +60,17 @@ class Simulator:
                                  real hardware.
         :param config: The robot config to use
         :param loop: The asyncio event loop to use.
+        :param strict_attached_instruments: This param changes the behavior of
+                                            the instrument cache. If ``True``,
+                                            (default), ``cache_instrument``
+                                            calls requesting instruments not
+                                            in ``attached_instruments`` will
+                                            fail as if the instrument was not
+                                            present. If ``False``, those calls
+                                            will still pass but give a response
+                                            version of 1, while calls
+                                            requesting instruments that _are_
+                                            present get the full number.
         """
         self._config = config
         self._loop = loop
@@ -73,6 +85,7 @@ class Simulator:
         self._lights = {'button': False, 'rails': False}
         self._run_flag = Event()
         self._log = MODULE_LOG.getChild(repr(self))
+        self._strict_attached = bool(strict_attached_instruments)
 
     def move(self, target_position: Dict[str, float],
              home_flagged_axes: bool = True, speed: float = None):
@@ -127,9 +140,14 @@ class Simulator:
             found_model = init_instr.get('model', '')
             if expected_instr and found_model\
                     and not found_model.startswith(expected_instr):
-                raise RuntimeError(
-                    'mount {}: expected instrument {} but got {}'
-                    .format(mount.name, expected_instr, init_instr))
+                if self._strict_attached:
+                    raise RuntimeError(
+                        'mount {}: expected instrument {} but got {}'
+                        .format(mount.name, expected_instr, init_instr))
+                else:
+                    to_return[mount] = {
+                        'model': find_config(expected_instr),
+                        'id': None}
             elif found_model and expected_instr:
                 # Instrument detected matches instrument expected (note:
                 # "instrument detected" means passed as an argument to the

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -94,8 +94,8 @@ def log_init():
                 'handlers': ['serial'],
                 'level': logging.DEBUG
             },
-            'opentrons.protocol_api.contexts': {
-                'handlers': ['api'],
+            'opentrons.protocol_api': {
+                'handlers': ['api', 'debug'],
                 'level': level_value
             },
             'opentrons.hardware_control': {

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -190,15 +190,73 @@ class BCLabware:
     def __init__(self, ctx: ProtocolContext) -> None:
         self._ctx = ctx
 
-    def load(self, *args, **kwargs):
+    LW_NO_EQUIVALENT = {'24-vial-plate', '48-vial-plate', '5ml-3x4',
+                        '96-PCR-tall', '96-deep-well', '96-well-plate-20mm',
+                        'MALDI-plate', 'PCR-strip-tall', 'T25-flask',
+                        'T75-flask', 'alum-block-pcr-strips', 'e-gelgol',
+                        'hampton-1ml-deep-block', 'point',
+                        'opentrons-aluminum-block-PCR-strips-200ul',
+                        'rigaku-compact-crystallization-plate',
+                        'small_vial_rack_16x45', 'temperature-plate',
+                        'tiprack-10ul-H', 'tiprack-200ul',
+                        'trough-12row-short', 'trough-1row-25ml',
+                        'trough-1row-test', 'tube-rack-.75ml',
+                        'tube-rack-2ml-9x9', 'tube-rack-5ml-96',
+                        'tube-rack-80well', 'wheaton_vial_rack',
+                        'tube-rack-15_50ml', 'tube-rack-2ml'}
+    """ Labwares that are no longer supported in this version """
+
+    LW_TRANSLATION = {
+        '12-well-plate': 'corning_12_wellPlate_6.9_mL',
+        '24-well-plate': 'corning_24_wellPlate_3.4_mL',
+        '384-plate': 'corning_384_wellPlate_112_uL',
+        '48-well-plate': 'corning_48_wellPlate_1.6_mL',
+        '6-well-plate': 'corning_6_wellPlate_16.8_mL',
+        '96-PCR-flat': 'biorad_96_wellPlate_pcr_200_uL',
+        '96-flat': 'generic_96_wellPlate_380_uL',
+        'biorad-hardshell-96-PCR': 'biorad_96_wellPlate_pcr_200_uL',
+        'opentrons-aluminum-block-2ml-eppendorf': 'opentrons_24_aluminum_tuberack_2_mL',       # noqa(E501)
+        'opentrons-aluminum-block-2ml-screwcap': 'opentrons_24_aluminum_tuberack_2_mL',        # noqa(E501)
+        'opentrons-aluminum-block-96-PCR-plate': 'opentrons_96_aluminum_biorad_plate_200_uL',  # noqa(E501)
+        'opentrons-tiprack-300ul': 'opentrons_96_tiprack_300_uL',
+        'opentrons-tuberack-1.5ml-eppendorf': 'opentrons_24_tuberack_1.5_mL_eppendorf',        # noqa(E501)
+        'opentrons-tuberack-15_50ml': 'opentrons_6x15_mL_4x50_mL_tuberack',
+        'opentrons-tuberack-15ml': 'opentrons_15_tuberack_15_mL_falcon',
+        'opentrons-tuberack-2ml-eppendorf': 'opentrons_24_tuberack_2_mL_eppendorf',            # noqa(E501)
+        'opentrons-tuberack-2ml-screwcap': 'opentrons_24_tuberack_2_mL_screwcap',              # noqa(E501)
+        'opentrons-tuberack-50ml': 'opentrons_6_tuberack_50_mL_falcon',
+        'tiprack-1000ul': 'opentrons_96_tiprack_1000_uL',
+        'tiprack-10ul': 'opentrons_96_tiprack_10_uL',
+        'trough-12row': 'usa_scientific_12_trough_22_mL'
+    }
+    """ A table mapping old labware names to new labware names"""
+
+    def load(self, container_name, slot, label=None, share=False):
         """ Load a piece of labware by specifying its name and position.
 
         This method calls :py:meth:`.ProtocolContext.load_labware_by_name`;
         see that documentation for more information on arguments and return
         values. Calls to this function should be replaced with calls to
         :py:meth:`.Protocolcontext.load_labware_by_name`.
+
+        In addition, this function contains translations between old
+        labware names and new labware names.
         """
-        return self._ctx.load_labware_by_name(*args, **kwargs)
+        if share:
+            raise NotImplementedError("Sharing not supported")
+
+        try:
+            name = self.LW_TRANSLATION[container_name]
+        except KeyError:
+            if container_name in self.LW_NO_EQUIVALENT:
+                raise NotImplementedError("Labware {} is not supported"
+                                          .format(container_name))
+            elif container_name in ('magdeck', 'tempdeck'):
+                raise NotImplementedError("Module load not yet implemented")
+            else:
+                name = container_name
+
+        return self._ctx.load_labware_by_name(name, slot, label)
 
     def create(self,  *args, **kwargs):
         raise NotImplementedError

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -166,19 +166,25 @@ class ProtocolContext:
         self._hw_manager.reset_hw()
 
     def load_labware(
-            self, labware_obj: Labware, location: types.DeckLocation,
-            label: str = None, share: bool = False) -> Labware:
+            self, labware_obj: Labware,
+            location: types.DeckLocation) -> Labware:
         """ Specify the presence of a piece of labware on the OT2 deck.
 
         This function loads the labware specified by `labware`
         (previously loaded from a configuration file) to the location
         specified by `location`.
+
+        :param Labware labware: The labware object to load
+        :param location: The slot into which to load the labware such as
+                         1 or '1'
+        :type location: int or str
         """
         self._deck_layout[location] = labware_obj
         return labware_obj
 
     def load_labware_by_name(
-            self, labware_name: str, location: types.DeckLocation) -> Labware:
+            self, labware_name: str,
+            location: types.DeckLocation, label: str = None) -> Labware:
         """ A convenience function to specify a piece of labware by name.
 
         For labware already defined by Opentrons, this is a convient way
@@ -187,9 +193,19 @@ class ProtocolContext:
 
         This function returns the created and initialized labware for use
         later in the protocol.
+
+        :param str labware_name: The name of the labware to load
+        :param location: The slot into which to load the labware such as
+                         1 or '1'
+        :type location: int or str
+        :param str label: An optional special name to give the labware. If
+                          specified, this is the name the labware will appear
+                          as in the run log and the calibration view in the
+                          Opentrons app.
         """
         labware = load(labware_name,
-                       self._deck_layout.position_for(location))
+                       self._deck_layout.position_for(location),
+                       label)
         return self.load_labware(labware, location)
 
     def load_module(

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -149,7 +149,7 @@ def load_labware_from_json(
                 raise RuntimeError(
                     "Nothing but the fixed trash may be loaded in slot 12; "
                     "this protocol attempts to load a {} there."
-                    .format(labware_id))
+                    .format(model))
         else:
             labware_def = labware.load_definition_by_name(model)
 

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -1,11 +1,14 @@
 import inspect
+import itertools
 import logging
 import os
 import traceback
 import sys
-from typing import Any, Callable
+from typing import Any, Callable, Dict
 
-from .contexts import ProtocolContext
+from .contexts import ProtocolContext, InstrumentContext
+from . import labware
+from opentrons.types import Point
 
 MODULE_LOG = logging.getLogger(__name__)
 
@@ -107,8 +110,214 @@ def _run_python(proto: Any, context: ProtocolContext):
         raise ExceptionInProtocolError(e, tb, str(e), frame.lineno)
 
 
+def load_pipettes_from_json(
+        ctx: ProtocolContext,
+        protocol: Dict[Any, Any]) -> Dict[str, InstrumentContext]:
+    pipette_data = protocol.get('pipettes', {})
+    pipettes_by_id = {}
+    for pipette_id, props in pipette_data.items():
+        model = props.get('model')
+        mount = props.get('mount')
+
+        # TODO: Ian 2018-11-06 remove this fallback to 'model' when
+        # backwards-compatability for JSON protocols with versioned
+        # pipettes is dropped (next JSON protocol schema major bump)
+        name = props.get('name')
+        if not name:
+            name = model.split('_v')[0]
+
+        instr = ctx.load_instrument(name, mount)
+
+        pipettes_by_id[pipette_id] = instr
+
+    return pipettes_by_id
+
+
+def load_labware_from_json(
+        ctx: ProtocolContext,
+        protocol: Dict[Any, Any]) -> Dict[str, labware.Labware]:
+    data = protocol.get('labware', {})
+    loaded_labware = {}
+    for labware_id, props in data.items():
+        slot = props.get('slot')
+        model = props.get('model')
+        if slot == '12':
+            if model == 'fixed-trash':
+                # pass in the pre-existing fixed-trash
+                loaded_labware[labware_id] = ctx.fixed_trash
+            else:
+                raise RuntimeError(
+                    "Nothing but the fixed trash may be loaded in slot 12; "
+                    "this protocol attempts to load a {} there."
+                    .format(labware_id))
+        else:
+            labware_def = labware.load_definition_by_name(model)
+
+            # Patch in the user-specified display name
+            display_name = props.get('display-name')
+            if display_name:
+                labware_def['metadata']['displayName'] = display_name
+            labware_obj = labware.load_from_definition(
+                labware_def, ctx.deck.position_for(slot))
+            loaded_labware[labware_id] = ctx.load_labware(labware_obj,
+                                                          slot)
+
+    return loaded_labware
+
+
+def _get_location(loaded_labware, command_type, params, default_values):
+    labwareId = params.get('labware')
+    if not labwareId:
+        # not all commands use labware param
+        return None
+    well = params.get('well')
+    plate = loaded_labware.get(labwareId)
+    if not plate:
+        raise ValueError(
+            'Command tried to use labware "{}", but that ID does not exist '
+            'in protocol\'s "labware" section'.format(labwareId))
+
+    # default offset from bottom for aspirate/dispense commands
+    offset_default = default_values.get(
+        '{}-mm-from-bottom'.format(command_type))
+
+    # optional command-specific value, fallback to default
+    offset_from_bottom = params.get(
+        'offsetFromBottomMm', offset_default)
+
+    if offset_from_bottom is None:
+        # not all commands use offsets
+
+        # touch-tip uses offset from top, not bottom, as default
+        # when offsetFromBottomMm command-specific value is unset
+        if command_type == 'touch-tip':
+            # TODO: Ian 2018-10-29 remove this `-1` when
+            # touch-tip-mm-from-top is a required field
+            return plate.wells_by_index()[well].top().move(
+                Point(z=default_values.get('touch-tip-mm-from-top', -1)))
+
+        return plate.wells_by_index()[well]
+
+    return plate.wells_by_index()[well].bottom()\
+                                       .move(Point(z=offset_from_bottom))
+
+
+# TODO (Ian 2018-08-22) once Pipette has more sensible way of managing
+# flow rate value (eg as an argument in aspirate/dispense fns), remove this
+def _set_flow_rate(
+        pipette_name, pipette, command_type, params, default_values):
+    """
+    Set flow rate in uL/mm, to value obtained from command's params,
+    or if unspecified in command params, then from protocol's "default-values".
+    """
+    default_aspirate = default_values.get(
+        'aspirate-flow-rate', {}).get(pipette_name)
+
+    default_dispense = default_values.get(
+        'dispense-flow-rate', {}).get(pipette_name)
+
+    flow_rate_param = params.get('flow-rate')
+
+    if flow_rate_param is not None:
+        if command_type == 'aspirate':
+            pipette.flow_rate = {
+                'aspirate': flow_rate_param,
+                'dispense': default_dispense
+            }
+            return
+        if command_type == 'dispense':
+            pipette.flow_rate = {
+                'aspirate': default_aspirate,
+                'dispense': flow_rate_param
+            }
+            return
+
+    pipette.flow_rate = {
+        'aspirate': default_aspirate,
+        'dispense': default_dispense
+    }
+
+
+def dispatch_json(context: ProtocolContext,  # noqa(C901)
+                  protocol_data: Dict[Any, Any],
+                  instruments: Dict[str, InstrumentContext],
+                  labware: Dict[str, labware.Labware]):
+    subprocedures = [
+        p.get('subprocedure', [])
+        for p in protocol_data.get('procedure', [])]
+
+    default_values = protocol_data.get('default-values', {})
+    flat_subs = itertools.chain.from_iterable(subprocedures)
+
+    for command_item in flat_subs:
+        command_type = command_item.get('command')
+        params = command_item.get('params', {})
+        pipette = instruments.get(params.get('pipette'))
+        protocol_pipette_data = protocol_data\
+            .get('pipettes', {})\
+            .get(params.get('pipette'), {})
+        pipette_name = protocol_pipette_data.get('name')
+
+        if (not pipette_name):
+            # TODO: Ian 2018-11-06 remove this fallback to 'model' when
+            # backwards-compatability for JSON protocols with versioned
+            # pipettes is dropped (next JSON protocol schema major bump)
+            pipette_name = protocol_pipette_data.get('model')
+
+        location = _get_location(labware, command_type, params, default_values)
+        volume = params.get('volume')
+
+        if pipette:
+            # Aspirate/Dispense flow rate must be set each time for commands
+            # which use pipettes right now.
+            # Flow rate is persisted inside the Pipette object
+            # and is settable but not easily gettable
+            _set_flow_rate(
+                pipette_name, pipette, command_type, params, default_values)
+
+        if command_type == 'delay':
+            wait = params.get('wait')
+            if wait is None:
+                raise ValueError('Delay cannot be null')
+            elif wait is True:
+                message = params.get('message', 'Pausing until user resumes')
+                context.pause(msg=message)
+            else:
+                context.delay(seconds=wait)
+
+        elif command_type == 'blowout':
+            pipette.blow_out(location)  # type: ignore
+
+        elif command_type == 'pick-up-tip':
+            pipette.pick_up_tip(location)  # type: ignore
+
+        elif command_type == 'drop-tip':
+            pipette.drop_tip(location)  # type: ignore
+
+        elif command_type == 'aspirate':
+            pipette.aspirate(volume, location)  # type: ignore
+
+        elif command_type == 'dispense':
+            pipette.dispense(volume, location)  # type: ignore
+
+        elif command_type == 'touch-tip':
+            # NOTE: if touch_tip can take a location tuple,
+            # this can be much simpler
+            (well_object, loc_tuple) = location
+
+            # Use the offset baked into the well_object.
+            # Do not allow API to apply its v_offset kwarg default value,
+            # and do not apply the JSON protocol's default offset.
+            z_from_bottom = loc_tuple[2]
+            offset_from_top = (
+                well_object.properties['depth'] - z_from_bottom) * -1
+
+            pipette.touch_tip(  # type: ignore
+                well_object, v_offset=offset_from_top)
+
+
 def run_protocol(protocol_code: Any = None,
-                 protocol_json: str = None,
+                 protocol_json: Dict[Any, Any] = None,
                  simulate: bool = False,
                  context: ProtocolContext = None):
     """ Create a ProtocolRunner instance from one of a variety of protocol
@@ -134,8 +343,11 @@ def run_protocol(protocol_code: Any = None,
     else:
         raise RuntimeError(
             'Will not automatically generate hardware controller')
-    try:
+    if None is not protocol_code:
         _run_python(protocol_code, true_context)
-    except Exception:
-        MODULE_LOG.exception("Exception in protocol")
-        raise
+    elif None is not protocol_json:
+        lw = load_labware_from_json(true_context, protocol_json)
+        ins = load_pipettes_from_json(true_context, protocol_json)
+        dispatch_json(true_context, protocol_json, ins, lw)
+    else:
+        raise RuntimeError("run_protocol must have either code or json")

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -430,11 +430,11 @@ class Labware:
 
     @property
     def tip_length(self) -> float:
-        return self._parameters['tipLength']
+        return self._parameters['tipLength'] - self._parameters['tipOverlap']
 
     @tip_length.setter
     def tip_length(self, length: float):
-        self._parameters['tipLength'] = length
+        self._parameters['tipLength'] = length + self._parameters['tipOverlap']
 
     def next_tip(self, num_tips: int = 1) -> Optional[Well]:
         """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -170,7 +170,9 @@ class Labware:
     tip rack, etc. It defines the physical geometry of the labware, and
     provides methods for accessing wells within the labware.
     """
-    def __init__(self, definition: dict, parent: Location) -> None:
+    def __init__(
+            self, definition: dict,
+            parent: Location, label: str = None) -> None:
         """
         :param definition: A dict representing all required data for a labware,
                            including metadata such as the display name of the
@@ -183,9 +185,14 @@ class Labware:
                        the front and left most point of the outside of the
                        labware is (often the front-left corner of a slot on the
                        deck).
+        :param str label: An optional label to use instead of the displayName
+                          from the definition's metadata element
         """
-        self._display_name = "{} on {}".format(
-            definition['metadata']['displayName'], str(parent.labware))
+        if label:
+            dn = label
+        else:
+            dn = definition['metadata']['displayName']
+        self._display_name = "{} on {}".format(dn, str(parent.labware))
         self._calibrated_offset: Point = Point(0, 0, 0)
         self._wells: List[Well] = []
         # Directly from definition
@@ -689,7 +696,7 @@ def load_definition_by_name(name: str) -> dict:
     return labware_def
 
 
-def load(name: str, parent: Location) -> Labware:
+def load(name: str, parent: Location, label: str = None) -> Labware:
     """
     Return a labware object constructed from a labware definition dict looked
     up by name (definition must have been previously stored locally on the
@@ -701,12 +708,15 @@ def load(name: str, parent: Location) -> Labware:
     :param parent: A :py:class:`.Location` representing the location where
                    the front and left most point of the outside of labware is
                    (often the front-left corner of a slot on the deck).
+    :param str label: An optional label that will override the labware's
+                      display name from its definition
     """
     definition = load_definition_by_name(name)
-    return load_from_definition(definition, parent)
+    return load_from_definition(definition, parent, label)
 
 
-def load_from_definition(definition: dict, parent: Location) -> Labware:
+def load_from_definition(
+        definition: dict, parent: Location, label: str = None) -> Labware:
     """
     Return a labware object constructed from a provided labware definition dict
 
@@ -719,8 +729,10 @@ def load_from_definition(definition: dict, parent: Location) -> Labware:
     :param parent: A :py:class:`.Location` representing the location where
                    the front and left most point of the outside of labware is
                    (often the front-left corner of a slot on the deck).
+    :param str label: An optional label that will override the labware's
+                      display name from its definition
     """
-    labware = Labware(definition, parent)
+    labware = Labware(definition, parent, label)
     load_calibration(labware)
     return labware
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -674,7 +674,7 @@ def _read_file(filepath: str) -> dict:
     return calibration_data
 
 
-def _load_definition_by_name(name: str) -> dict:
+def load_definition_by_name(name: str) -> dict:
     """
     Look up and return a definition by name (name is expected to correspond to
     the filename of the definition, with the .json extension) and return it or
@@ -702,7 +702,7 @@ def load(name: str, parent: Location) -> Labware:
                    the front and left most point of the outside of labware is
                    (often the front-left corner of a slot on the deck).
     """
-    definition = _load_definition_by_name(name)
+    definition = load_definition_by_name(name)
     return load_from_definition(definition, parent)
 
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -67,6 +67,21 @@ class Location(NamedTuple):
     point: Point
     labware: 'Union[Labware, Well, str, ModuleGeometry, None]'
 
+    def move(self, point: Point) -> 'Location':
+        """
+        Alter the point stored in the location while preserving the labware.
+
+        This returns a new Location and does not alter the current one. It
+        should be used like
+
+        .. code-block:: python
+            >>> loc = Location(Point(1, 1, 1), 'Hi')
+            >>> new_loc = loc.move(Point(1, 1, 1))
+            >>> assert loc_2.point == Point(2, 2, 2)  # True
+            >>> assert loc.point == Point(1, 1, 1)  # True
+        """
+        return self._replace(point=self.point + point)
+
 
 class Mount(enum.Enum):
     LEFT = enum.auto()

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -43,10 +43,6 @@ async def test_tip_probe_v2(main_router, model, monkeypatch):
                         'update_instrument_offset', fake_update)
     monkeypatch.setattr(main_router.calibration_manager,
                         'move_to_front', fake_move)
-    main_router.calibration_manager.tip_probe(model.instrument)
-
-    await main_router.wait_until(state('probing'))
-    await main_router.wait_until(state('ready'))
 
     tr = labware.load('opentrons_96_tiprack_300_uL', Location(Point(), 'test'))
     tr.tip_length = 2
@@ -57,18 +53,16 @@ async def test_tip_probe_v2(main_router, model, monkeypatch):
                          model.instrument._context)]
 
     def new_fake_locate(mount, tip_length):
-        assert tip_length == 2
+        assert tip_length == pytest.approx(2)
         return Point(0, 0, 0)
 
     monkeypatch.setattr(main_router.calibration_manager._hardware._api,
                         'locate_tip_probe_center', new_fake_locate)
     main_router.calibration_manager.tip_probe(model.instrument)
     await main_router.wait_until(state('ready'))
-    model.instrument.containers = model.instrument.tip_racks
-    model.instrument.tip_racks = []
 
     def new_fake_locate2(mount, tip_length):
-        assert tip_length is None
+        assert tip_length == pytest.approx(2)
         return Point(0, 0, 0)
 
     monkeypatch.setattr(main_router.calibration_manager._hardware._api,

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -105,6 +105,12 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     # get a RuntimeError
     with pytest.raises(RuntimeError):
         await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
+    # Unless we specifically told the simulator to not strictly enforce
+    # correspondence between expectations and preconfiguration
+    sim = hc.API.build_hardware_simulator(
+        attached_instruments=dummy_instruments,
+        loop=loop, strict_attached_instruments=False)
+    await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
 
 
 async def test_aspirate(dummy_instruments, loop):

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -36,7 +36,7 @@ def test_critical_points():
         tip_length = 25.0
         pip.add_tip(tip_length)
         new = mod_offset._replace(z=mod_offset.z
-                                  - (tip_length - pip._config.tip_overlap))
+                                  - tip_length)
         assert pip.critical_point() == new
         assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_offset
         assert pip.critical_point(types.CriticalPoint.TIP) == new

--- a/api/tests/opentrons/hardware_control/test_tip_probe.py
+++ b/api/tests/opentrons/hardware_control/test_tip_probe.py
@@ -18,20 +18,16 @@ async def test_input_checks(hardware_api, monkeypatch):
 
     await hardware_api.cache_instruments({Mount.RIGHT: 'p300_single'})
     await hardware_api.home()
-    overlap =\
-        hardware_api._attached_instruments[Mount.RIGHT]._config.tip_overlap
-    default_tl = \
-        hardware_api._attached_instruments[Mount.RIGHT]._config.tip_length
-    expected_tl = default_tl - overlap
-    await hardware_api.locate_tip_probe_center(Mount.RIGHT)
-    assert not hardware_api._attached_instruments[Mount.RIGHT].has_tip
 
-    expected_tl = 10 - overlap
+    with pytest.raises(AssertionError):
+        await hardware_api.locate_tip_probe_center(Mount.RIGHT)
+
+    expected_tl = 10
     await hardware_api.locate_tip_probe_center(Mount.RIGHT, 10)
     assert not hardware_api._attached_instruments[Mount.RIGHT].has_tip
 
     await hardware_api.pick_up_tip(Mount.RIGHT, 20)
-    expected_tl = 20-overlap
+    expected_tl = 20
     await hardware_api.locate_tip_probe_center(Mount.RIGHT)
 
     assert hardware_api._attached_instruments[Mount.RIGHT].has_tip
@@ -70,10 +66,8 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
     await hardware_api.home()
 
     center = await hardware_api.locate_tip_probe_center(mount, 30)
-    overlap =\
-        hardware_api._attached_instruments[mount]._config.tip_overlap
     hotspots = robot_configs.calculate_tip_probe_hotspots(
-        30 - overlap, hardware_api._config.tip_probe)
+        30, hardware_api._config.tip_probe)
     assert len(move_calls) == len(hotspots) * 4
     assert len(rel_calls) == len(hotspots)
     move_iter = iter(move_calls)

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -1,4 +1,6 @@
-from opentrons.protocol_api import back_compat  # , ProtocolContext
+import pytest
+
+from opentrons.protocol_api import back_compat, ProtocolContext
 from opentrons.types import Mount
 
 
@@ -38,3 +40,30 @@ def test_add_instrument(loop, monkeypatch):
     back_compat.instruments.P1000_Single('right')
     assert requested_instr == 'p1000_single'
     assert requested_mount == Mount.RIGHT
+
+
+def test_labware_mappings(loop, monkeypatch):
+    lw_name, lw_label = None, None
+
+    def fake_ctx_load(labware_name, location, label=None):
+        nonlocal lw_name
+        nonlocal lw_label
+        lw_name = labware_name
+        lw_label = label
+        return 'heres a fake labware'
+
+    ctx = ProtocolContext(loop)
+    bc = back_compat.BCLabware(ctx)
+    monkeypatch.setattr(ctx, 'load_labware_by_name', fake_ctx_load)
+    obj = bc.load('384-plate', 2, 'hey there')
+    assert obj == 'heres a fake labware'
+    assert lw_name == 'corning_384_wellPlate_112_uL'
+    assert lw_label == 'hey there'
+
+    with pytest.raises(NotImplementedError,
+                       match='Labware 24-vial-plate is not supported'):
+        bc.load('24-vial-plate', 2)
+
+    with pytest.raises(NotImplementedError,
+                       match='Module load not yet implemented'):
+        bc.load('magdeck', 3)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -133,7 +133,7 @@ def test_pick_up_and_drop_tip(loop, load_my_labware):
     instr.pick_up_tip(target_location)
 
     new_offset = model_offset - Point(0, 0,
-                                      tip_length - pipette.config.tip_overlap)
+                                      tip_length)
     assert pipette.critical_point() == new_offset
 
     instr.drop_tip(target_location)
@@ -189,7 +189,7 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
                                          for cmd in ctx.commands()])
 
     new_offset = model_offset - Point(0, 0,
-                                      tip_length1 - pipette.config.tip_overlap)
+                                      tip_length1)
     assert pipette.critical_point() == new_offset
 
     # TODO: remove argument and verify once trash container is added

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -21,7 +21,7 @@ def load_my_labware(monkeypatch):
                              'shared_data/definitions2/{}.json'.format(
                                  labware_name)))
         return labware_def
-    monkeypatch.setattr(papi.labware, '_load_definition_by_name', dummy_load)
+    monkeypatch.setattr(papi.labware, 'load_definition_by_name', dummy_load)
 
 
 def test_load_instrument(loop):

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -1,5 +1,6 @@
 import pytest
 
+from opentrons.types import Point
 from opentrons.protocol_api import execute, ProtocolContext
 
 
@@ -81,3 +82,219 @@ def run(ctx):
             context=ctx)
     assert '[line 5]' in str(e)
     assert 'Exception [line 5]: hi' in str(e)
+
+
+# TODO Ian 2018-11-07 when `model` is dropped, delete its test case
+@pytest.mark.parametrize('protocol_data',
+                         [
+                             # deprecated case
+                             {
+                                 "pipettes": {
+                                     "leftPipetteHere": {
+                                         "mount": "left",
+                                         "model": "p10_single_v1.3"
+                                     }
+                                 }
+                             },
+                             # future case
+                             {
+                                 "pipettes": {
+                                     "leftPipetteHere": {
+                                         "mount": "left",
+                                         "name": "p10_single"
+                                     }
+                                 }
+                             }
+                         ])
+async def test_load_pipettes(loop, protocol_data):
+
+    ctx = ProtocolContext(loop=loop)
+
+    loaded_pipettes = execute.load_pipettes_from_json(ctx, protocol_data)
+    assert 'leftPipetteHere' in loaded_pipettes
+    assert len(loaded_pipettes) == 1
+    pip = loaded_pipettes['leftPipetteHere']
+    assert pip.mount == 'left'
+    assert ctx.loaded_instruments['left'] == pip
+
+
+@pytest.mark.parametrize('command_type', ['aspirate', 'dispense'])
+def test_get_location(loop, command_type):
+    ctx = ProtocolContext(loop=loop)
+    plate = ctx.load_labware_by_name("generic_96_wellPlate_380_uL", 1)
+    well = "B2"
+
+    default_values = {
+        'aspirate-mm-from-bottom': 2,
+        'dispense-mm-from-bottom': 3
+    }
+
+    loaded_labware = {
+        "someLabwareId": plate
+    }
+
+    # test with nonzero and with zero command-specific offset
+    for offset in [5, 0]:
+        command_params = {
+            "labware": "someLabwareId",
+            "well": well,
+            "offsetFromBottomMm": offset
+        }
+        result = execute._get_location(
+            loaded_labware, command_type, command_params, default_values)
+        assert result.labware == plate.wells_by_index()[well]
+        assert result.point\
+            == plate.wells_by_index()[well].bottom().point + Point(z=offset)
+
+    command_params = {
+        "labware": "someLabwareId",
+        "well": well
+    }
+
+    # no command-specific offset, use default
+    result = execute._get_location(
+        loaded_labware, command_type, command_params, default_values)
+    default = default_values['{}-mm-from-bottom'.format(command_type)]
+    assert result.point\
+        == plate.wells_by_index()[well].bottom().point + Point(z=default)
+
+
+def test_load_labware(loop):
+    ctx = ProtocolContext(loop=loop)
+    data = {
+        "labware": {
+            "sourcePlateId": {
+              "slot": "10",
+              "model": "usa_scientific_12_trough_22_mL",
+              "display-name": "Source (Buffer)"
+            },
+            "destPlateId": {
+              "slot": "11",
+              "model": "generic_96_wellPlate_380_uL",
+              "display-name": "Destination Plate"
+            },
+        }
+    }
+    loaded_labware = execute.load_labware_from_json(ctx, data)
+
+    # objects in loaded_labware should be same objs as labware objs in the deck
+    assert loaded_labware['sourcePlateId'] == ctx.loaded_labwares[10]
+    assert loaded_labware['destPlateId'] == ctx.loaded_labwares[11]
+
+
+def test_load_labware_trash(loop):
+    ctx = ProtocolContext(loop=loop)
+    data = {
+        "labware": {
+            "someTrashId": {
+                "slot": "12",
+                "model": "fixed-trash"
+            }
+        }
+    }
+    result = execute.load_labware_from_json(ctx, data)
+
+    assert result['someTrashId'] == ctx.fixed_trash
+
+
+def test_blank_protocol(loop):
+    # Check that this doesn’t throw an exception
+    ctx = ProtocolContext(loop=loop)
+    execute.run_protocol(protocol_json={}, context=ctx)
+
+
+protocol_data = {
+    "default-values": {
+        "aspirate-flow-rate": {
+            "p300_single_v1": 101
+        },
+        "dispense-flow-rate": {
+            "p300_single_v1": 102
+        }
+    },
+    "pipettes": {
+        "pipetteId": {
+            "mount": "left",
+            "model": "p300_single_v1"
+        }
+    },
+    "procedure": [
+        {
+            "subprocedure": [
+                {
+                    "command": "aspirate",
+                    "params": {
+                        "pipette": "pipetteId",
+                        "labware": "sourcePlateId",
+                        "well": "A1",
+                        "volume": 5,
+                        "flow-rate": 123
+                    }
+                },
+                {
+                    "command": "delay",
+                    "params": {
+                        "wait": 42
+                    }
+                },
+                {
+                    "command": "dispense",
+                    "params": {
+                        "pipette": "pipetteId",
+                        "labware": "destPlateId",
+                        "well": "B1",
+                        "volume": 4.5
+                    }
+                },
+            ]
+        }
+    ]
+}
+
+
+def test_dispatch_commands(monkeypatch, loop):
+    ctx = ProtocolContext(loop=loop)
+    cmd = []
+    flow_rates = []
+
+    def mock_sleep(minutes=0, seconds=0):
+        cmd.append(("sleep", seconds))
+
+    def mock_aspirate(volume, location):
+        cmd.append(("aspirate", volume, location))
+
+    def mock_dispense(volume, location):
+        cmd.append(("dispense", volume, location))
+
+    def mock_set_flow_rate(mount, aspirate=None, dispense=None):
+        flow_rates.append((aspirate, dispense))
+
+    insts = execute.load_pipettes_from_json(ctx, protocol_data)
+
+    source_plate = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', '1')
+    dest_plate = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
+
+    loaded_labware = {
+        'sourcePlateId': source_plate,
+        'destPlateId': dest_plate
+    }
+    pipette = insts['pipetteId']
+    monkeypatch.setattr(pipette, 'aspirate', mock_aspirate)
+    monkeypatch.setattr(pipette, 'dispense', mock_dispense)
+    monkeypatch.setattr(ctx._hw_manager.hardware._api, 'set_flow_rate',
+                        mock_set_flow_rate)
+    monkeypatch.setattr(ctx, 'delay', mock_sleep)
+
+    execute.dispatch_json(
+        ctx, protocol_data, insts, loaded_labware)
+
+    assert cmd == [
+        ("aspirate", 5, source_plate.wells_by_index()['A1']),
+        ("sleep", 42),
+        ("dispense", 4.5, dest_plate.wells_by_index()['B1'])
+    ]
+
+    assert flow_rates == [
+        (123, 102),
+        (101, 102)
+    ]

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -173,13 +173,22 @@ def test_load_labware(loop):
               "model": "generic_96_wellPlate_380_uL",
               "display-name": "Destination Plate"
             },
+            "oldPlateId": {
+              "slot": "9",
+              "model": "96-flat",
+              "display-name": "Test Plate"
+            },
         }
     }
     loaded_labware = execute.load_labware_from_json(ctx, data)
 
     # objects in loaded_labware should be same objs as labware objs in the deck
     assert loaded_labware['sourcePlateId'] == ctx.loaded_labwares[10]
+    assert 'Source (Buffer)' in str(loaded_labware['sourcePlateId'])
     assert loaded_labware['destPlateId'] == ctx.loaded_labwares[11]
+    assert 'Destination Plate' in str(loaded_labware['destPlateId'])
+    assert loaded_labware['oldPlateId'].name == 'generic_96_wellPlate_380_uL'
+    assert 'Test Plate' in str(loaded_labware['oldPlateId'])
 
 
 def test_load_labware_trash(loop):

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -96,7 +96,7 @@ def test_basic_arc():
 
 
 def test_no_labware_loc():
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
 
     deck = Deck()
     lw1 = labware.load(labware_name, deck.position_for(1))

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -116,7 +116,7 @@ def test_from_center_cartesian():
 
 def test_backcompat():
     labware_name = 'generic_96_wellPlate_380_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     lw = labware.Labware(labware_def, Location(Point(0, 0, 0), 'Test Slot'))
 
     # Note that this test uses the display name of wells to test for equality,
@@ -161,7 +161,7 @@ def test_backcompat():
 
 def test_well_parent():
     labware_name = 'generic_96_wellPlate_380_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     lw = labware.Labware(labware_def, Location(Point(0, 0, 0), 'Test Slot'))
     parent = Location(Point(7, 8, 9), lw)
     well_name = 'circular_well_json'
@@ -181,7 +181,7 @@ def test_well_parent():
 
 def test_tip_tracking_init():
     labware_name = 'opentrons_96_tiprack_300_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def,
                               Location(Point(0, 0, 0), 'Test Slot'))
     assert tiprack.is_tiprack
@@ -201,7 +201,7 @@ def test_tip_tracking_init():
 
 def test_use_tips():
     labware_name = 'opentrons_96_tiprack_300_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def,
                               Location(Point(0, 0, 0), 'Test Slot'))
     well_list = tiprack.wells()
@@ -240,7 +240,7 @@ def test_use_tips():
 
 def test_select_next_tip():
     labware_name = 'opentrons_96_tiprack_300_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     tiprack = labware.Labware(labware_def,
                               Location(Point(0, 0, 0), 'Test Slot'))
     well_list = tiprack.wells()
@@ -314,7 +314,7 @@ def test_module_load():
 def test_module_load_labware():
     module_names = ['tempdeck', 'magdeck']
     labware_name = 'generic_96_wellPlate_380_uL'
-    labware_def = labware._load_definition_by_name(labware_name)
+    labware_def = labware.load_definition_by_name(labware_name)
     for name in module_names:
         mod = labware.load_module(name, Location(Point(0, 0, 0), 'test'))
         old_z = mod.highest_z

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -21,4 +21,4 @@ def test_loaded(loop):
 
 def test_load_incorrect_definition_by_name():
     with pytest.raises(FileNotFoundError):
-        papi.labware._load_definition_by_name('fake_labware')
+        papi.labware.load_definition_by_name('fake_labware')

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -22,3 +22,9 @@ def test_loaded(loop):
 def test_load_incorrect_definition_by_name():
     with pytest.raises(FileNotFoundError):
         papi.labware.load_definition_by_name('fake_labware')
+
+
+def test_load_label(loop):
+    ctx = papi.ProtocolContext(loop=loop)
+    labware = ctx.load_labware_by_name(labware_name, '1', 'my cool labware')
+    assert 'my cool labware' in str(labware)

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -19,7 +19,8 @@ minimalLabwareDef = {
     "otId": "minimalLabwareDef",
     "parameters": {
         "isTiprack": True,
-        "tipLength": 55.3
+        "tipLength": 55.3,
+        "tipOverlap": 2.8
     },
     "ordering": [["A1"], ["A2"]],
     "wells": {
@@ -132,7 +133,7 @@ def test_load_calibration(monkeypatch, clear_calibration):
                                    Location(Point(0, 0, 0), 'deck'))
 
     test_offset = Point(1, 1, 1)
-    test_tip_length = 34.5
+    test_tip_length = 31.7
 
     labware.save_calibration(test_labware, test_offset)
     labware.save_tip_length(test_labware, test_tip_length)

--- a/shared-data/definitions2/eppendorf_96_tiprack_1000_uL.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_1000_uL.json
@@ -150,6 +150,7 @@
         "isTiprack": true,
         "isMagneticModuleCompatible": false,
         "tipLength": 70.7,
+        "tipOverlap": 0.0,
         "loadName": "eppendorf_96_tiprack_1000_uL"
     },
     "wells": {

--- a/shared-data/definitions2/eppendorf_96_tiprack_10_uL.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_10_uL.json
@@ -150,6 +150,7 @@
         "isTiprack": true,
         "isMagneticModuleCompatible": false,
         "tipLength": 34,
+        "tipOverlap": 1,
         "loadName": "eppendorf_96_tiprack_10_uL"
     },
     "wells": {

--- a/shared-data/definitions2/opentrons_96_tiprack_1000_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_1000_uL.json
@@ -150,6 +150,7 @@
         "isTiprack": true,
         "isMagneticModuleCompatible": false,
         "tipLength": 87.9,
+        "tipOverlap": 11.2,
         "loadName": "opentrons_96_tiprack_1000_uL"
     },
     "wells": {

--- a/shared-data/definitions2/opentrons_96_tiprack_10_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_10_uL.json
@@ -150,6 +150,7 @@
         "isTiprack": true,
         "isMagneticModuleCompatible": false,
         "tipLength": 39.2,
+        "tipOverlap": 6.2,
         "loadName": "opentrons_96_tiprack_10_uL"
     },
     "wells": {

--- a/shared-data/definitions2/opentrons_96_tiprack_300_uL.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_300_uL.json
@@ -152,6 +152,7 @@
         "isTiprack": true,
         "isMagneticModuleCompatible": false,
         "tipLength": 59.17,
+        "tipOverlap": 7.47,
         "loadName": "opentrons_96_tiprack_300_uL"
     },
     "wells": {

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -89,7 +89,11 @@
           "type": "boolean"
         },
         "tipLength": {
-          "description": "Required if labware is tiprack",
+          "description": "Required if labware is tiprack, specifies length of tip from drawing or as measured with calipers",
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "tipOverlap": {
+          "description": "Required if labware is tiprack, specifies the length of the area of the tip that overlaps the nozzle of the pipette",
           "$ref": "#/definitions/positiveNumber"
         },
         "loadName": {

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -5,8 +5,7 @@
     "maxVolume": 10,
     "channels": 1,
     "defaultAspirateFlowRate": 5,
-    "defaultDispenseFlowRate": 10,
-    "tipOverlap": 0
+    "defaultDispenseFlowRate": 10
   },
   "p10_multi": {
     "displayName": "P10 8-Channel",
@@ -14,8 +13,7 @@
     "maxVolume": 10,
     "defaultAspirateFlowRate": 5,
     "defaultDispenseFlowRate": 10,
-    "channels": 8,
-    "tipOverlap": 0
+    "channels": 8
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
@@ -23,8 +21,7 @@
     "defaultDispenseFlowRate": 50,
     "channels": 1,
     "minVolume": 5,
-    "maxVolume": 50,
-    "tipOverlap": 0
+    "maxVolume": 50
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
@@ -32,8 +29,7 @@
     "defaultDispenseFlowRate": 50,
     "channels": 8,
     "minVolume": 5,
-    "maxVolume": 50,
-    "tipOverlap": 0
+    "maxVolume": 50
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
@@ -41,8 +37,7 @@
     "defaultDispenseFlowRate": 300,
     "channels": 1,
     "minVolume": 30,
-    "maxVolume": 300,
-    "tipOverlap": 0
+    "maxVolume": 300
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
@@ -50,8 +45,7 @@
     "defaultDispenseFlowRate": 300,
     "channels": 8,
     "minVolume": 30,
-    "maxVolume": 300,
-    "tipOverlap": 0
+    "maxVolume": 300
   },
   "p1000_single": {
     "displayName": "P1000 Single-channel",
@@ -59,7 +53,6 @@
     "defaultDispenseFlowRate": 1000,
     "channels": 1,
     "minVolume": 100,
-    "maxVolume": 1000,
-    "tipOverlap": 0
+    "maxVolume": 1000
   }
 }

--- a/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
@@ -23,8 +23,7 @@
         "defaultAspirateFlowRate",
         "defaultDispenseFlowRate",
         "maxVolume",
-        "minVolume",
-        "tipOverlap"
+        "minVolume"
       ],
       "additionalProperties": false,
       "properties": {
@@ -33,8 +32,7 @@
         "defaultDispenseFlowRate": {"$ref": "#/definitions/positiveNumber"},
         "displayName": {"type": "string"},
         "maxVolume": {"$ref": "#/definitions/positiveNumber"},
-        "minVolume": {"$ref": "#/definitions/positiveNumber"},
-        "tipOverlap": {"$ref": "#/definitions/positiveNumber"}
+        "minVolume": {"$ref": "#/definitions/positiveNumber"}
       }
     }
   }


### PR DESCRIPTION
Adds json protocol execution to the new protocol API.

Any json protocol that uses the following labware should work:

'12-well-plate',  '24-well-plate',  '384-plate', '48-well-plate', '6-well-plate', '96-PCR-flat', '96-flat', 'biorad-hardshell-96-PCR', 'opentrons-aluminum-block-2ml-eppendorf', 'opentrons-aluminum-block-2ml-screwcap',  'opentrons-aluminum-block-96-PCR-plate', 'opentrons-tiprack-300ul', 'opentrons-tuberack-1.5ml-eppendorf', 'opentrons-tuberack-15_50ml', 'opentrons-tuberack-15ml', 'opentrons-tuberack-2ml-eppendorf',  'opentrons-tuberack-2ml-screwcap, 'opentrons-tuberack-50ml', 'tiprack-1000ul', 'tiprack-10ul', 'trough-12row': 'usa_scientific_12_trough_22_mL'

Closes #2248 