### PR TITLE
fix(shared-data): fix irregular labware generator

### DIFF
--- a/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
+++ b/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
@@ -19,7 +19,7 @@
             "B4"
         ]
     ],
-    "otId": "e6488590-e388-11e8-b14b-2f570f23ab54",
+    "otId": "f65f2960-0f76-11e9-8659-e18ed15996f5",
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons 15x50mL tuberack",
@@ -46,10 +46,10 @@
         "overallHeight": 123.76
     },
     "parameters": {
-        "isTiprack": false,
         "format": "irregular",
-        "loadName": "opentrons_6x15_mL_4x50_mL_tuberack",
-        "isMagneticModuleCompatible": false
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "Opentrons_6x15_mL_4x50_mL_tuberack"
     },
     "wells": {
         "A1": {
@@ -58,7 +58,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 13.88,
-            "y": 17.75,
+            "y": 92.75,
             "z": 5.78
         },
         "B1": {
@@ -67,7 +67,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 13.88,
-            "y": 42.75,
+            "y": 67.75,
             "z": 5.78
         },
         "C1": {
@@ -76,7 +76,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 13.88,
-            "y": 67.75,
+            "y": 42.75,
             "z": 5.78
         },
         "A2": {
@@ -85,7 +85,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 38.88,
-            "y": 17.75,
+            "y": 92.75,
             "z": 5.78
         },
         "B2": {
@@ -94,7 +94,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 38.88,
-            "y": 42.75,
+            "y": 67.75,
             "z": 5.78
         },
         "C2": {
@@ -103,7 +103,7 @@
             "shape": "circular",
             "depth": 117.98,
             "x": 38.88,
-            "y": 67.75,
+            "y": 42.75,
             "z": 5.78
         },
         "A3": {
@@ -112,7 +112,7 @@
             "shape": "circular",
             "depth": 113.85,
             "x": 71.38,
-            "y": 25.25,
+            "y": 95.25,
             "z": 5.95
         },
         "B3": {
@@ -130,7 +130,7 @@
             "shape": "circular",
             "depth": 113.85,
             "x": 106.38,
-            "y": 25.25,
+            "y": 95.25,
             "z": 5.95
         },
         "B4": {
@@ -144,7 +144,6 @@
         }
     },
     "brand": {
-        "brand": "Opentrons",
-        "brandId": ["352096", "352070"]
+        "brand": "Opentrons"
     }
 }

--- a/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
+++ b/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
@@ -49,7 +49,7 @@
         "format": "irregular",
         "isTiprack": false,
         "isMagneticModuleCompatible": false,
-        "loadName": "Opentrons_6x15_mL_4x50_mL_tuberack"
+        "loadName": "opentrons_6x15_mL_4x50_mL_tuberack"
     },
     "wells": {
         "A1": {
@@ -144,6 +144,7 @@
         }
     },
     "brand": {
-        "brand": "Opentrons"
+        "brand": "Opentrons",
+        "brandId": ["352096", "352070"]
     }
 }

--- a/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
+++ b/shared-data/definitions2/opentrons_6x15_mL_4x50_mL_tuberack.json
@@ -52,95 +52,95 @@
         "loadName": "opentrons_6x15_mL_4x50_mL_tuberack"
     },
     "wells": {
-        "A1": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 13.88,
-            "y": 92.75,
-            "z": 5.78
-        },
-        "B1": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 13.88,
-            "y": 67.75,
-            "z": 5.78
-        },
-        "C1": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 13.88,
-            "y": 42.75,
-            "z": 5.78
-        },
-        "A2": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 38.88,
-            "y": 92.75,
-            "z": 5.78
-        },
-        "B2": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 38.88,
-            "y": 67.75,
-            "z": 5.78
-        },
-        "C2": {
-            "totalLiquidVolume": 15,
-            "diameter": 14.5,
-            "shape": "circular",
-            "depth": 117.98,
-            "x": 38.88,
-            "y": 42.75,
-            "z": 5.78
-        },
-        "A3": {
-            "totalLiquidVolume": 50,
-            "diameter": 26.45,
-            "shape": "circular",
-            "depth": 113.85,
-            "x": 71.38,
-            "y": 95.25,
-            "z": 5.95
-        },
-        "B3": {
-            "totalLiquidVolume": 50,
-            "diameter": 26.45,
-            "shape": "circular",
-            "depth": 113.85,
-            "x": 71.38,
-            "y": 60.25,
-            "z": 5.95
-        },
-        "A4": {
-            "totalLiquidVolume": 50,
-            "diameter": 26.45,
-            "shape": "circular",
-            "depth": 113.85,
-            "x": 106.38,
-            "y": 95.25,
-            "z": 5.95
-        },
-        "B4": {
-            "totalLiquidVolume": 50,
-            "diameter": 26.45,
-            "shape": "circular",
-            "depth": 113.85,
-            "x": 106.38,
-            "y": 60.25,
-            "z": 5.95
+          "A1": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 13.88,
+              "y": 67.75,
+              "z": 5.78
+          },
+          "B1": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 13.88,
+              "y": 42.75,
+              "z": 5.78
+          },
+          "C1": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 13.88,
+              "y": 17.75,
+              "z": 5.78
+          },
+          "A2": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 38.88,
+              "y": 67.75,
+              "z": 5.78
+          },
+          "B2": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 38.88,
+              "y": 42.75,
+              "z": 5.78
+          },
+          "C2": {
+              "totalLiquidVolume": 15,
+              "diameter": 14.5,
+              "shape": "circular",
+              "depth": 117.98,
+              "x": 38.88,
+              "y": 17.75,
+              "z": 5.78
+          },
+          "A3": {
+              "totalLiquidVolume": 50,
+              "diameter": 26.45,
+              "shape": "circular",
+              "depth": 113.85,
+              "x": 71.38,
+              "y": 60.25,
+              "z": 5.95
+          },
+          "B3": {
+              "totalLiquidVolume": 50,
+              "diameter": 26.45,
+              "shape": "circular",
+              "depth": 113.85,
+              "x": 71.38,
+              "y": 25.25,
+              "z": 5.95
+          },
+          "A4": {
+              "totalLiquidVolume": 50,
+              "diameter": 26.45,
+              "shape": "circular",
+              "depth": 113.85,
+              "x": 106.38,
+              "y": 60.25,
+              "z": 5.95
+          },
+          "B4": {
+              "totalLiquidVolume": 50,
+              "diameter": 26.45,
+              "shape": "circular",
+              "depth": 113.85,
+              "x": 106.38,
+              "y": 25.25,
+              "z": 5.95
         }
     },
     "brand": {

--- a/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
+++ b/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
@@ -99,10 +99,10 @@
         "overallHeight": 64.48
     },
     "parameters": {
-        "isTiprack": false,
         "format": "irregular",
-        "loadName": "generic_50x3_mL_5x10_mL_irregular",
-        "isMagneticModuleCompatible": false
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "generic_50x3_mL_5x10_mL_irregular"
     },
     "wells": {
         "A1": {
@@ -111,7 +111,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C1": {
@@ -120,7 +120,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E1": {
@@ -129,7 +129,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G1": {
@@ -138,7 +138,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I1": {
@@ -147,7 +147,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A2": {
@@ -156,7 +156,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C2": {
@@ -165,7 +165,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E2": {
@@ -174,7 +174,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G2": {
@@ -183,7 +183,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I2": {
@@ -192,7 +192,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A3": {
@@ -201,7 +201,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C3": {
@@ -210,7 +210,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E3": {
@@ -219,7 +219,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G3": {
@@ -228,7 +228,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I3": {
@@ -237,7 +237,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A4": {
@@ -246,7 +246,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C4": {
@@ -255,7 +255,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E4": {
@@ -264,7 +264,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G4": {
@@ -273,7 +273,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I4": {
@@ -282,7 +282,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A5": {
@@ -291,7 +291,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C5": {
@@ -300,7 +300,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E5": {
@@ -309,7 +309,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G5": {
@@ -318,7 +318,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I5": {
@@ -327,7 +327,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A6": {
@@ -336,7 +336,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C6": {
@@ -345,7 +345,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E6": {
@@ -354,7 +354,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G6": {
@@ -363,7 +363,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I6": {
@@ -372,7 +372,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A7": {
@@ -381,7 +381,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C7": {
@@ -390,7 +390,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E7": {
@@ -399,7 +399,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G7": {
@@ -408,7 +408,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I7": {
@@ -417,7 +417,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A8": {
@@ -426,7 +426,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C8": {
@@ -435,7 +435,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E8": {
@@ -444,7 +444,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G8": {
@@ -453,7 +453,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I8": {
@@ -462,7 +462,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A9": {
@@ -471,7 +471,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C9": {
@@ -480,7 +480,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E9": {
@@ -489,7 +489,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G9": {
@@ -498,7 +498,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I9": {
@@ -507,7 +507,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "A10": {
@@ -516,7 +516,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 10,
+            "y": 35,
             "z": 58.94
         },
         "C10": {
@@ -525,7 +525,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 15,
+            "y": 30,
             "z": 58.94
         },
         "E10": {
@@ -534,7 +534,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 20,
+            "y": 25,
             "z": 58.94
         },
         "G10": {
@@ -543,7 +543,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "I10": {
@@ -552,7 +552,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 30,
+            "y": 15,
             "z": 58.94
         },
         "B1": {
@@ -561,7 +561,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 15,
-            "y": 15,
+            "y": 20,
             "z": 48.94
         },
         "B2": {
@@ -570,7 +570,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 25,
-            "y": 15,
+            "y": 20,
             "z": 48.94
         },
         "B3": {
@@ -579,7 +579,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 35,
-            "y": 15,
+            "y": 20,
             "z": 48.94
         },
         "B4": {
@@ -588,7 +588,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 45,
-            "y": 15,
+            "y": 20,
             "z": 48.94
         },
         "B5": {
@@ -597,7 +597,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 55,
-            "y": 15,
+            "y": 20,
             "z": 48.94
         }
     }

--- a/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
+++ b/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
@@ -111,7 +111,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C1": {
@@ -120,7 +120,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E1": {
@@ -129,7 +129,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G1": {
@@ -138,7 +138,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I1": {
@@ -147,7 +147,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 10,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A2": {
@@ -156,7 +156,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C2": {
@@ -165,7 +165,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E2": {
@@ -174,7 +174,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G2": {
@@ -183,7 +183,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I2": {
@@ -192,7 +192,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 20,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A3": {
@@ -201,7 +201,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C3": {
@@ -210,7 +210,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E3": {
@@ -219,7 +219,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G3": {
@@ -228,7 +228,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I3": {
@@ -237,7 +237,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 30,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A4": {
@@ -246,7 +246,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C4": {
@@ -255,7 +255,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E4": {
@@ -264,7 +264,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G4": {
@@ -273,7 +273,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I4": {
@@ -282,7 +282,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 40,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A5": {
@@ -291,7 +291,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C5": {
@@ -300,7 +300,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E5": {
@@ -309,7 +309,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G5": {
@@ -318,7 +318,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I5": {
@@ -327,7 +327,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 50,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A6": {
@@ -336,7 +336,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C6": {
@@ -345,7 +345,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E6": {
@@ -354,7 +354,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G6": {
@@ -363,7 +363,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I6": {
@@ -372,7 +372,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 60,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A7": {
@@ -381,7 +381,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C7": {
@@ -390,7 +390,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E7": {
@@ -399,7 +399,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G7": {
@@ -408,7 +408,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I7": {
@@ -417,7 +417,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 70,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A8": {
@@ -426,7 +426,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C8": {
@@ -435,7 +435,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E8": {
@@ -444,7 +444,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G8": {
@@ -453,7 +453,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I8": {
@@ -462,7 +462,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 80,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A9": {
@@ -471,7 +471,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C9": {
@@ -480,7 +480,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E9": {
@@ -489,7 +489,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G9": {
@@ -498,7 +498,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I9": {
@@ -507,7 +507,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 90,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "A10": {
@@ -516,7 +516,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 35,
+            "y": 30,
             "z": 58.94
         },
         "C10": {
@@ -525,7 +525,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 30,
+            "y": 25,
             "z": 58.94
         },
         "E10": {
@@ -534,7 +534,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 25,
+            "y": 20,
             "z": 58.94
         },
         "G10": {
@@ -543,7 +543,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 20,
+            "y": 15,
             "z": 58.94
         },
         "I10": {
@@ -552,7 +552,7 @@
             "diameter": 10,
             "totalLiquidVolume": 3,
             "x": 100,
-            "y": 15,
+            "y": 10,
             "z": 58.94
         },
         "B1": {
@@ -561,7 +561,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 15,
-            "y": 20,
+            "y": 15,
             "z": 48.94
         },
         "B2": {
@@ -570,7 +570,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 25,
-            "y": 20,
+            "y": 15,
             "z": 48.94
         },
         "B3": {
@@ -579,7 +579,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 35,
-            "y": 20,
+            "y": 15,
             "z": 48.94
         },
         "B4": {
@@ -588,7 +588,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 45,
-            "y": 20,
+            "y": 15,
             "z": 48.94
         },
         "B5": {
@@ -597,7 +597,7 @@
             "diameter": 15,
             "totalLiquidVolume": 10,
             "x": 55,
-            "y": 20,
+            "y": 15,
             "z": 48.94
         }
     }

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -137,7 +137,7 @@ function determineLayout (
   wells: Array<Well>): {[wellName: string]: Well} {
   const wellMap = {}
   grids.forEach((gridObj, gridIdx) => {
-    const reverseRowIdx = range(gridObj.row, 0)
+    const reverseRowIdx = range(gridObj.row - 1, -1)
     range(gridObj.column).forEach(colIdx => {
       range(gridObj.row).forEach(rowIdx => {
         const wellName = _irregularWellName(rowIdx, colIdx, gridStart[gridIdx])

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -138,7 +138,7 @@ function determineLayout (
   const wellMap = {}
   grids.forEach((gridObj, gridIdx) => {
     range(gridObj.column).forEach(colIdx => {
-      range(gridObj.row).forEach(rowIdx => {
+      range(gridObj.row, 0).forEach(rowIdx => {
         const wellName = _irregularWellName(rowIdx, colIdx, gridStart[gridIdx])
         wellMap[wellName] = _calculateWellCoord(rowIdx, colIdx, spacing[gridIdx], offset[gridIdx], wells[gridIdx])
       })

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -137,10 +137,11 @@ function determineLayout (
   wells: Array<Well>): {[wellName: string]: Well} {
   const wellMap = {}
   grids.forEach((gridObj, gridIdx) => {
+    const reverseRowIdx = range(gridObj.row, 0)
     range(gridObj.column).forEach(colIdx => {
-      range(gridObj.row, 0).forEach(rowIdx => {
+      range(gridObj.row).forEach(rowIdx => {
         const wellName = _irregularWellName(rowIdx, colIdx, gridStart[gridIdx])
-        wellMap[wellName] = _calculateWellCoord(rowIdx, colIdx, spacing[gridIdx], offset[gridIdx], wells[gridIdx])
+        wellMap[wellName] = _calculateWellCoord(reverseRowIdx[rowIdx], colIdx, spacing[gridIdx], offset[gridIdx], wells[gridIdx])
       })
     })
   })


### PR DESCRIPTION
## overview
Closes #2781. During labware testing, it was discovered that row coordinates were reversed from what they should be. So entering well 'A1' would result in the pipette moving to well 'C1' instead.

## changelog

- Add reversed list of row index to create coordinate
- Fix failing tests
- Re-do 15_50 definition

Here are the parameters for reference:
```
metadata : {"displayName": "Opentrons 15x50mL tuberack", "displayCategory": "tuberack", "displayVolumeUnits": "mL", "displayLengthUnits": "mm", "tags": ["opentrons", "modular", "tuberack", "15", "mL", "50"]},

offset : [{x: 13.875, y: 17.75, z: 123.76}, {x: 71.375, y: 25.25, z: 119.8}],

grid : [{row: 3, column: 2}, {row: 2, column: 2}],

spacing : [{row: 25, column: 25}, {row: 35, column: 35}],

dimensions : {overallLength: 127.75, overallWidth: 85.5, overallHeight: 123.76},

well : [{totalLiquidVolume: 15, diameter: 14.5, shape: "circular", depth: 117.98}, {totalLiquidVolume: 50, diameter: 26.45, shape: "circular", depth: 113.85}],

gridStart : [{rowStart: 'A', colStart: '1', rowStride: 1, colStride: 1}, {rowStart: 'A', colStart: '3', rowStride: 1, colStride: 1}],

parameters = {format: "irregular", isTiprack: false, isMagneticModuleCompatible: false},

brand : {brand: "Opentrons"}
```

## review requests

Test on robot when you have a free moment
