### PR TITLE
refactor(protocol-designer): rename orderedSteps -> orderedStepIds

### DIFF
--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
@@ -119,8 +119,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
 
   const stepId = stepsSelectors.getSelectedStepId(state)
-  const orderedSteps = stepFormSelectors.getOrderedSteps(state)
-  const timelineIdx = orderedSteps.findIndex(id => id === stepId)
+  const orderedStepIds = stepFormSelectors.getOrderedStepIds(state)
+  const timelineIdx = orderedStepIds.findIndex(id => id === stepId)
   const allWellContentsForStep = allWellContentsForSteps[timelineIdx]
   const formData = stepFormSelectors.getUnsavedForm(state)
   const ingredNames = selectors.getLiquidNamesById(state)

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -21,7 +21,7 @@ type Props = ElementProps<typeof FilePipettesModal>
 
 type SP = {
   _prevPipettes: {[pipetteId: string]: PipetteOnDeck},
-  _orderedSteps: Array<StepIdType>,
+  _orderedStepIds: Array<StepIdType>,
 }
 
 type OP = {
@@ -33,7 +33,7 @@ const mapSTP = (state: BaseState): SP => {
   return {
     initialPipetteValues: initialPipettes,
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
-    _orderedSteps: stepFormSelectors.getOrderedSteps(state),
+    _orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
   }
 }
 
@@ -49,7 +49,7 @@ const mapSTP = (state: BaseState): SP => {
 // Currently, PD's Edit Pipettes functionality is doing several of these steps
 // in one click (create, change manualIntervention step, substitute pipettes
 // across all steps, delete pipettes), which is why it's so funky!
-const makeUpdatePipettes = (prevPipettes, orderedSteps, dispatch, closeModal) =>
+const makeUpdatePipettes = (prevPipettes, orderedStepIds, dispatch, closeModal) =>
   ({pipettes: newPipetteArray}) => {
     const prevPipetteIds = Object.keys(prevPipettes)
     let usedPrevPipettes: Array<string> = [] // IDs of pipettes in prevPipettes that were already put into nextPipettes
@@ -98,12 +98,12 @@ const makeUpdatePipettes = (prevPipettes, orderedSteps, dispatch, closeModal) =>
     }, {})
 
     // substitute deleted pipettes with new pipettes on the same mount, if any
-    if (!isEmpty(substitutionMap) && orderedSteps.length > 0) {
+    if (!isEmpty(substitutionMap) && orderedStepIds.length > 0) {
       // NOTE: using start/end here is meant to future-proof this action for multi-step editing
       dispatch(stepFormActions.substituteStepFormPipettes({
         substitutionMap,
-        startStepId: orderedSteps[0],
-        endStepId: last(orderedSteps),
+        startStepId: orderedStepIds[0],
+        endStepId: last(orderedStepIds),
       }))
     }
 
@@ -117,8 +117,8 @@ const makeUpdatePipettes = (prevPipettes, orderedSteps, dispatch, closeModal) =>
 
 const mergeProps = (stateProps: SP, dispatchProps: {dispatch: ThunkDispatch<*>}, ownProps: OP): Props => {
   const {dispatch} = dispatchProps
-  const {_prevPipettes, _orderedSteps, ...passThruStateProps} = stateProps
-  const updatePipettes = makeUpdatePipettes(_prevPipettes, _orderedSteps, dispatch, ownProps.closeModal)
+  const {_prevPipettes, _orderedStepIds, ...passThruStateProps} = stateProps
+  const updatePipettes = makeUpdatePipettes(_prevPipettes, _orderedStepIds, dispatch, ownProps.closeModal)
 
   return {
     ...ownProps,

--- a/protocol-designer/src/components/steplist/DraggableStepItems.js
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.js
@@ -59,7 +59,7 @@ const collectStepTarget = (connect) => ({
 const DragDropStepItem = DropTarget(DND_TYPES.STEP_ITEM, stepItemTarget, collectStepTarget)(DraggableStepItem)
 
 type StepItemsProps = {
-  orderedSteps: Array<StepIdType>,
+  orderedStepIds: Array<StepIdType>,
   reorderSteps: (Array<StepIdType>) => mixed,
   isOver: boolean,
   connectDropTarget: mixed => React.Element<any>,
@@ -68,11 +68,11 @@ type StepItemsState = {stepIds: Array<StepIdType>}
 class StepItems extends React.Component<StepItemsProps, StepItemsState> {
   constructor (props) {
     super(props)
-    this.state = {stepIds: this.props.orderedSteps}
+    this.state = {stepIds: this.props.orderedStepIds}
   }
 
   onDrag = () => {
-    this.setState({stepIds: this.props.orderedSteps})
+    this.setState({stepIds: this.props.orderedStepIds})
   }
 
   submitReordering = () => {
@@ -102,7 +102,7 @@ class StepItems extends React.Component<StepItemsProps, StepItemsState> {
   )
 
   render () {
-    const currentIds = this.props.isOver ? this.state.stepIds : this.props.orderedSteps
+    const currentIds = this.props.isOver ? this.state.stepIds : this.props.orderedStepIds
     return this.props.connectDropTarget(
       <div>
         <ContextMenu>
@@ -125,7 +125,7 @@ class StepItems extends React.Component<StepItemsProps, StepItemsState> {
 
 const listTarget = {
   drop: (props, monitor, component) => {
-    if (!isEqual(props.orderedSteps, component.state.stepIds)) {
+    if (!isEqual(props.orderedStepIds, component.state.stepIds)) {
       component.submitReordering()
     }
   },

--- a/protocol-designer/src/components/steplist/StepList.js
+++ b/protocol-designer/src/components/steplist/StepList.js
@@ -13,7 +13,7 @@ import {PortalRoot} from './TooltipPortal'
 import DraggableStepItems from './DraggableStepItems'
 
 type Props = {
-  orderedSteps: Array<StepIdType>,
+  orderedStepIds: Array<StepIdType>,
   reorderSelectedStep: (delta: number) => mixed,
   reorderSteps: (Array<StepIdType>) => mixed,
 }
@@ -51,7 +51,7 @@ export default class StepList extends React.Component<Props> {
           title='Protocol Timeline'>
           <StartingDeckStateTerminalItem />
           <DraggableStepItems
-            orderedSteps={this.props.orderedSteps.slice()}
+            orderedStepIds={this.props.orderedStepIds.slice()}
             reorderSteps={this.props.reorderSteps} />
           <StepCreationButton />
           <TerminalItem id={END_TERMINAL_ITEM_ID} title={END_TERMINAL_TITLE} />

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -17,14 +17,14 @@ import {StepList} from '../components/steplist'
 type Props = React.ElementProps<typeof StepList>
 
 type SP = {
-  orderedSteps: $PropertyType<Props, 'orderedSteps'>,
+  orderedStepIds: $PropertyType<Props, 'orderedStepIds'>,
 }
 
 type DP = $Diff<Props, SP>
 
 function mapStateToProps (state: BaseState): SP {
   return {
-    orderedSteps: stepFormSelectors.getOrderedSteps(state),
+    orderedStepIds: stepFormSelectors.getOrderedStepIds(state),
   }
 }
 

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -63,9 +63,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   } else {
     const stepId = activeItem.id
     // TODO: Ian 2018-07-31 replace with util function, "findIndexOrNull"?
-    const orderedSteps = stepFormSelectors.getOrderedSteps(state)
-    const timelineIdx = orderedSteps.includes(stepId)
-      ? orderedSteps.findIndex(id => id === stepId)
+    const orderedStepIds = stepFormSelectors.getOrderedStepIds(state)
+    const timelineIdx = orderedStepIds.includes(stepId)
+      ? orderedStepIds.findIndex(id => id === stepId)
       : null
 
     // shows liquids the current step in timeline

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -32,9 +32,9 @@ export const getDismissedTimelineWarnings: Selector<DismissedWarningsAllSteps<Co
 export const getTimelineWarningsPerStep: Selector<DismissedWarningsAllSteps<CommandCreatorWarning>> = createSelector(
   getDismissedTimelineWarnings,
   timelineWarningsPerStep,
-  stepFormSelectors.getOrderedSteps,
-  (dismissedWarnings, warningsPerStep, orderedSteps) => {
-    return orderedSteps.reduce(
+  stepFormSelectors.getOrderedStepIds,
+  (dismissedWarnings, warningsPerStep, orderedStepIds) => {
+    return orderedStepIds.reduce(
       (stepAcc: DismissedWarningsAllSteps<CommandCreatorWarning>, stepId) => {
         const warningsForCurrentStep = warningsPerStep[stepId]
         const dismissedWarningsForStep = dismissedWarnings[stepId] || []

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -144,10 +144,10 @@ function compoundCommandCreatorFromStepArgs (stepArgs: StepGeneration.CommandCre
 // exposes errors and last valid robotState
 export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   getInitialRobotState,
-  (allStepArgsAndErrors, orderedSteps, initialRobotState) => {
-    const allStepArgs: Array<StepGeneration.CommandCreatorData | null> = orderedSteps.map(stepId => {
+  (allStepArgsAndErrors, orderedStepIds, initialRobotState) => {
+    const allStepArgs: Array<StepGeneration.CommandCreatorData | null> = orderedStepIds.map(stepId => {
       return (allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs) || null
     })
 
@@ -207,10 +207,10 @@ export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSe
 
 type WarningsPerStep = {[stepId: number | string]: ?Array<StepGeneration.CommandCreatorWarning>}
 export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector(
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   getRobotStateTimeline,
-  (orderedSteps, timeline) => timeline.timeline.reduce((acc: WarningsPerStep, frame, timelineIndex) => {
-    const stepId = orderedSteps[timelineIndex]
+  (orderedStepIds, timeline) => timeline.timeline.reduce((acc: WarningsPerStep, frame, timelineIndex) => {
+    const stepId = orderedStepIds[timelineIndex]
 
     // remove warnings of duplicate 'type'. chosen arbitrarily
     return {
@@ -221,14 +221,14 @@ export const timelineWarningsPerStep: Selector<WarningsPerStep> = createSelector
 )
 
 export const getErrorStepId: Selector<?StepIdType> = createSelector(
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   getRobotStateTimeline,
-  (orderedSteps, timeline) => {
+  (orderedStepIds, timeline) => {
     const hasErrors = timeline.errors && timeline.errors.length > 0
     if (hasErrors) {
       // the frame *after* the last frame in the timeline is the error-throwing one
       const errorIndex = timeline.timeline.length
-      const errorStepId = orderedSteps[errorIndex]
+      const errorStepId = orderedStepIds[errorIndex]
       return errorStepId
     }
     return null

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -41,7 +41,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   ingredSelectors.getLiquidGroupsById,
   ingredSelectors.getLiquidsByLabwareId,
   stepFormSelectors.getSavedStepForms,
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   stepFormSelectors.getPipetteEntities,
   (
     fileMetadata,
@@ -51,7 +51,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
     ingredients,
     ingredLocations,
     savedStepForms,
-    orderedSteps,
+    orderedStepIds,
     pipetteInvariantProperties,
   ) => {
     const {author, description, created} = fileMetadata
@@ -82,7 +82,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
     // TODO: Ian 2018-07-10 allow user to save steps in JSON file, even if those
     // step never have saved forms.
     // (We could just export the `steps` reducer, but we've sunset it)
-    const savedOrderedSteps = orderedSteps.filter(stepId => savedStepForms[stepId])
+    const savedOrderedStepIds = orderedStepIds.filter(stepId => savedStepForms[stepId])
 
     return {
       'protocol-schema': protocolSchemaVersion,
@@ -115,7 +115,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
           ingredients,
           ingredLocations,
           savedStepForms,
-          orderedSteps: savedOrderedSteps,
+          orderedStepIds: savedOrderedStepIds,
         },
       },
 

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -37,7 +37,7 @@ export type PDMetadata = {
   ingredLocations: $PropertyType<IngredRoot, 'ingredLocations'>,
 
   savedStepForms: $PropertyType<StepformRoot, 'savedStepForms'>,
-  orderedSteps: $PropertyType<StepformRoot, 'orderedSteps'>,
+  orderedStepIds: $PropertyType<StepformRoot, 'orderedStepIds'>,
 }
 
 // A JSON protocol

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -84,7 +84,7 @@ export const unsavedForm = (rootState: RootState, action: UnsavedFormActions): F
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
       // only substitute unsaved step form if its ID is in the start-end range
       const {substitutionMap, startStepId, endStepId} = action.payload
-      const stepIdsToUpdate = getIdsInRange(rootState.orderedSteps, startStepId, endStepId)
+      const stepIdsToUpdate = getIdsInRange(rootState.orderedStepIds, startStepId, endStepId)
 
       if (
         unsavedFormState &&
@@ -278,7 +278,7 @@ export const savedStepForms = (
     }
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
       const {startStepId, endStepId, substitutionMap} = action.payload
-      const stepIdsToUpdate = getIdsInRange(rootState.orderedSteps, startStepId, endStepId)
+      const stepIdsToUpdate = getIdsInRange(rootState.orderedStepIds, startStepId, endStepId)
       const savedStepsUpdate = stepIdsToUpdate.reduce((acc, stepId) => {
         const prevStepForm = savedStepForms[stepId]
 
@@ -402,16 +402,16 @@ export const pipetteInvariantProperties = handleActions({
   },
 }, initialPipetteState)
 
-type OrderedStepsState = Array<StepIdType>
-const initialOrderedStepsState = []
-export const orderedSteps = handleActions({
-  ADD_STEP: (state: OrderedStepsState, action: AddStepAction) =>
+type OrderedStepIdsState = Array<StepIdType>
+const initialOrderedStepIdsState = []
+export const orderedStepIds = handleActions({
+  ADD_STEP: (state: OrderedStepIdsState, action: AddStepAction) =>
     [...state, action.payload.id],
-  DELETE_STEP: (state: OrderedStepsState, action: DeleteStepAction) =>
+  DELETE_STEP: (state: OrderedStepIdsState, action: DeleteStepAction) =>
     state.filter(stepId => stepId !== action.payload),
-  LOAD_FILE: (state: OrderedStepsState, action: LoadFileAction): OrderedStepsState =>
-    getPDMetadata(action.payload).orderedSteps,
-  REORDER_SELECTED_STEP: (state: OrderedStepsState, action: ReorderSelectedStepAction): OrderedStepsState => {
+  LOAD_FILE: (state: OrderedStepIdsState, action: LoadFileAction): OrderedStepIdsState =>
+    getPDMetadata(action.payload).orderedStepIds,
+  REORDER_SELECTED_STEP: (state: OrderedStepIdsState, action: ReorderSelectedStepAction): OrderedStepIdsState => {
     // TODO: BC 2018-11-27 make util function for reordering and use it everywhere
     const {delta, stepId} = action.payload
     const stepsWithoutSelectedStep = state.filter(s => s !== stepId)
@@ -426,7 +426,7 @@ export const orderedSteps = handleActions({
       ...stepsWithoutSelectedStep.slice(nextIndex),
     ]
   },
-  DUPLICATE_STEP: (state: OrderedStepsState, action: DuplicateStepAction): OrderedStepsState => {
+  DUPLICATE_STEP: (state: OrderedStepIdsState, action: DuplicateStepAction): OrderedStepIdsState => {
     const {stepId, duplicateStepId} = action.payload
     const selectedIndex = state.findIndex(s => s === stepId)
 
@@ -436,10 +436,10 @@ export const orderedSteps = handleActions({
       ...state.slice(selectedIndex + 1, state.length),
     ]
   },
-  REORDER_STEPS: (state: OrderedStepsState, action: ReorderStepsAction): OrderedStepsState => (
+  REORDER_STEPS: (state: OrderedStepIdsState, action: ReorderStepsAction): OrderedStepIdsState => (
     action.payload.stepIds
   ),
-}, initialOrderedStepsState)
+}, initialOrderedStepIdsState)
 
 // TODO: Ian 2018-12-19 DEPRECATED. This should be removed soon, but we need it until we
 // move to not having "pristine" steps
@@ -452,11 +452,11 @@ export const legacySteps = handleActions({
   }),
   DELETE_STEP: (state, action: DeleteStepAction) => omit(state, action.payload.toString()),
   LOAD_FILE: (state: LegacyStepsState, action: LoadFileAction): LegacyStepsState => {
-    const {savedStepForms, orderedSteps} = getPDMetadata(action.payload)
-    return orderedSteps.reduce((acc: LegacyStepsState, stepId) => {
+    const {savedStepForms, orderedStepIds} = getPDMetadata(action.payload)
+    return orderedStepIds.reduce((acc: LegacyStepsState, stepId) => {
       const stepForm = savedStepForms[stepId]
       if (!stepForm) {
-        console.warn(`Step id ${stepId} found in orderedSteps but not in savedStepForms`)
+        console.warn(`Step id ${stepId} found in orderedStepIds but not in savedStepForms`)
         return acc
       }
       return {
@@ -478,7 +478,7 @@ export const legacySteps = handleActions({
 }, initialLegacyStepState)
 
 export type RootState = {
-  orderedSteps: OrderedStepsState,
+  orderedStepIds: OrderedStepIdsState,
   labwareInvariantProperties: LabwareEntities,
   pipetteInvariantProperties: PipetteInvariantState,
   legacySteps: LegacyStepsState,
@@ -492,7 +492,7 @@ export type RootState = {
 const rootReducer = (state: RootState, action: any) => {
   const prevStateFallback = state || {}
   const nextState = {
-    orderedSteps: orderedSteps(prevStateFallback.orderedSteps, action),
+    orderedStepIds: orderedStepIds(prevStateFallback.orderedStepIds, action),
     labwareInvariantProperties: labwareInvariantProperties(prevStateFallback.labwareInvariantProperties, action),
     pipetteInvariantProperties: pipetteInvariantProperties(prevStateFallback.pipetteInvariantProperties, action),
     legacySteps: legacySteps(prevStateFallback.legacySteps, action),

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -171,9 +171,9 @@ export const getUnsavedForm: Selector<?FormData> = createSelector(
   (state) => state.unsavedForm
 )
 
-export const getOrderedSteps: Selector<Array<StepIdType>> = createSelector(
+export const getOrderedStepIds: Selector<Array<StepIdType>> = createSelector(
   rootSelector,
-  (state) => state.orderedSteps
+  (state) => state.orderedStepIds
 )
 
 export const getSavedStepForms: Selector<*> = createSelector(
@@ -182,10 +182,10 @@ export const getSavedStepForms: Selector<*> = createSelector(
 )
 
 const getOrderedSavedForms: Selector<Array<FormData>> = createSelector(
-  getOrderedSteps,
+  getOrderedStepIds,
   getSavedStepForms,
-  (orderedSteps, savedStepForms) => {
-    return orderedSteps
+  (orderedStepIds, savedStepForms) => {
+    return orderedStepIds
       .map(stepId => savedStepForms[stepId])
       .filter(form => form && form.id != null) // NOTE: for old protocols where stepId could === 0, need to do != null here
   }

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {legacySteps as steps, orderedSteps} from '../reducers'
+import {legacySteps as steps, orderedStepIds} from '../reducers'
 
 describe('steps reducer', () => {
   test('initial add step', () => {
@@ -42,14 +42,14 @@ describe('steps reducer', () => {
   })
 })
 
-describe('orderedSteps reducer', () => {
+describe('orderedStepIds reducer', () => {
   test('initial add step', () => {
     const state = []
     const action = {
       type: 'ADD_STEP',
       payload: {id: '123', stepType: 'transfer'},
     }
-    expect(orderedSteps(state, action)).toEqual(['123'])
+    expect(orderedStepIds(state, action)).toEqual(['123'])
   })
 
   test('second add step', () => {
@@ -58,7 +58,7 @@ describe('orderedSteps reducer', () => {
       type: 'ADD_STEP',
       payload: {id: '22', stepType: 'transfer'},
     }
-    expect(orderedSteps(state, action)).toEqual(['123', '22'])
+    expect(orderedStepIds(state, action)).toEqual(['123', '22'])
   })
 
   describe('reorder steps', () => {
@@ -138,7 +138,7 @@ describe('orderedSteps reducer', () => {
           type: 'REORDER_SELECTED_STEP',
           payload,
         }
-        expect(orderedSteps(state, action)).toEqual(expected)
+        expect(orderedStepIds(state, action)).toEqual(expected)
       })
     })
   })

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -14,8 +14,8 @@ export const pipetteModelToName = (model: string) =>
 export function getIdsInRange<T: string | number> (orderedIds: Array<T>, startId: T, endId: T): Array<T> {
   const startIdx = orderedIds.findIndex(id => id === startId)
   const endIdx = orderedIds.findIndex(id => id === endId)
-  assert(startIdx !== -1, `start step "${String(startId)}" does not exist in orderedSteps`)
-  assert(endIdx !== -1, `end step "${String(endId)}" does not exist in orderedSteps`)
+  assert(startIdx !== -1, `start step "${String(startId)}" does not exist in orderedStepIds`)
+  assert(endIdx !== -1, `end step "${String(endId)}" does not exist in orderedStepIds`)
   assert(endIdx >= startIdx, `expected end index to be greater than or equal to start index, got "${startIdx}", "${endIdx}"`)
   return orderedIds.slice(startIdx, endIdx + 1)
 }

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/index.js
@@ -12,10 +12,10 @@ import type {StepIdType, FormData} from '../../../form-types'
   * the 'left' pipette (or 'right' if there is no 'left' ) */
 export default function getNextDefaultPipetteId (
   savedForms: {[StepIdType]: FormData},
-  orderedSteps: Array<StepIdType>,
+  orderedStepIds: Array<StepIdType>,
   equippedPipettesById: {[pipetteId: string]: PipetteOnDeck}
 ): string {
-  const prevPipetteSteps = orderedSteps
+  const prevPipetteSteps = orderedStepIds
     .map(stepId => savedForms[stepId])
     .filter(form => form && form.pipette)
 

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultPipetteId/test/getNextDefaultPipetteId.test.js
@@ -22,11 +22,11 @@ describe('getNextDefaultPipetteId', () => {
     testCases.forEach(({testMsg, equippedPipettesById, expected}) => {
       test(testMsg, () => {
         const savedForms = {}
-        const orderedSteps = []
+        const orderedStepIds = []
 
         const result = getNextDefaultPipetteId(
           savedForms,
-          orderedSteps,
+          orderedStepIds,
           equippedPipettesById)
 
         expect(result).toBe(expected)
@@ -38,32 +38,32 @@ describe('getNextDefaultPipetteId', () => {
     const testCases = [
       {
         testMsg: 'last used pipette',
-        orderedSteps: ['a', 'a', 'b'],
+        orderedStepIds: ['a', 'a', 'b'],
         expected: 'pipetteId_B',
       },
       {
         testMsg: 'no previous forms use pipettes',
-        orderedSteps: ['x', 'x', 'x'],
+        orderedStepIds: ['x', 'x', 'x'],
         expected: 'defaultId',
       },
       {
         testMsg: 'mix of steps with and without pipettes',
-        orderedSteps: ['x', 'a', 'x'],
+        orderedStepIds: ['x', 'a', 'x'],
         expected: 'pipetteId_A',
       },
       {
         testMsg: 'missing steps (no key in savedForms)',
-        orderedSteps: ['missingStep', 'a', 'missingStep', 'b', 'missingStep'],
+        orderedStepIds: ['missingStep', 'a', 'missingStep', 'b', 'missingStep'],
         expected: 'pipetteId_B',
       },
       {
         testMsg: 'only missing steps',
-        orderedSteps: ['missingStep', 'missingStep'],
+        orderedStepIds: ['missingStep', 'missingStep'],
         expected: 'defaultId',
       },
     ]
 
-    testCases.forEach(({testMsg, orderedSteps, expected}) => {
+    testCases.forEach(({testMsg, orderedStepIds, expected}) => {
       test(testMsg, () => {
         const savedForms = {
           a: {pipette: 'pipetteId_A'},
@@ -75,7 +75,7 @@ describe('getNextDefaultPipetteId', () => {
 
         const result = getNextDefaultPipetteId(
           savedForms,
-          orderedSteps,
+          orderedStepIds,
           equippedPipettesById)
 
         expect(result).toBe(expected)

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -141,11 +141,11 @@ export const wellHighlightsByLabwareId: Selector<AllWellHighlightsAllLabware> = 
   stepsSelectors.getHoveredStepId,
   stepsSelectors.getHoveredSubstep,
   allSubsteps,
-  stepFormSelectors.getOrderedSteps,
-  (robotStateTimeline, allStepArgsAndErrors, hoveredStepId, hoveredSubstep, allSubsteps, orderedSteps) => {
+  stepFormSelectors.getOrderedStepIds,
+  (robotStateTimeline, allStepArgsAndErrors, hoveredStepId, hoveredSubstep, allSubsteps, orderedStepIds) => {
     const timeline = robotStateTimeline.timeline
     const stepId = hoveredStepId
-    const timelineIndex = orderedSteps.findIndex(i => i === stepId)
+    const timelineIndex = orderedStepIds.findIndex(i => i === stepId)
     const frame = timeline[timelineIndex]
     const robotState = frame && frame.robotState
     const stepArgs = stepId != null && allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -18,20 +18,20 @@ export const allSubsteps: Selector<AllSubsteps> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
   stepFormSelectors.getInitialDeckSetup,
   labwareIngredSelectors.getLabwareTypes,
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.getInitialRobotState,
   (
     allStepArgsAndErrors,
     initialDeckSetup,
     allLabwareTypes,
-    orderedSteps,
+    orderedStepIds,
     robotStateTimeline,
     _initialRobotState,
   ) => {
     const timeline = [{robotState: _initialRobotState}, ...robotStateTimeline.timeline]
     const allPipetteData = initialDeckSetup.pipettes
-    return orderedSteps.reduce((acc: AllSubsteps, stepId, timelineIndex) => {
+    return orderedStepIds.reduce((acc: AllSubsteps, stepId, timelineIndex) => {
       const robotState = timeline[timelineIndex] && timeline[timelineIndex].robotState
 
       const substeps = generateSubsteps(

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -88,7 +88,7 @@ const getLastValidTips: GetTipSelector = createSelector(
 )
 
 export const getTipsForCurrentStep: GetTipSelector = createSelector(
-  stepFormSelectors.getOrderedSteps,
+  stepFormSelectors.getOrderedStepIds,
   fileDataSelectors.getRobotStateTimeline,
   stepsSelectors.getHoveredStepId,
   stepsSelectors.getActiveItem,
@@ -97,7 +97,7 @@ export const getTipsForCurrentStep: GetTipSelector = createSelector(
   getLabwareIdProp,
   stepsSelectors.getHoveredSubstep,
   getAllSubsteps,
-  (orderedSteps, robotStateTimeline, hoveredStepId, activeItem, initialTips, lastValidTips, labwareId, hoveredSubstepIdentifier, allSubsteps) => {
+  (orderedStepIds, robotStateTimeline, hoveredStepId, activeItem, initialTips, lastValidTips, labwareId, hoveredSubstepIdentifier, allSubsteps) => {
     if (!activeItem.isStep) {
       const terminalId = activeItem.id
       if (terminalId === START_TERMINAL_ITEM_ID) {
@@ -113,8 +113,8 @@ export const getTipsForCurrentStep: GetTipSelector = createSelector(
     const stepId = activeItem.id
     const hovered = stepId === hoveredStepId
     const timeline = robotStateTimeline.timeline
-    const timelineIdx = orderedSteps.includes(stepId)
-      ? orderedSteps.findIndex(id => id === stepId)
+    const timelineIdx = orderedStepIds.includes(stepId)
+      ? orderedStepIds.findIndex(id => id === stepId)
       : null
 
     if (timelineIdx == null) {

--- a/protocol-designer/src/ui/steps/actions.js
+++ b/protocol-designer/src/ui/steps/actions.js
@@ -76,7 +76,7 @@ export const selectStep = (stepId: StepIdType, newStepType?: StepType): ThunkAct
 
     const defaultPipetteId = getNextDefaultPipetteId(
       stepFormSelectors.getSavedStepForms(state),
-      stepFormSelectors.getOrderedSteps(state),
+      stepFormSelectors.getOrderedStepIds(state),
       stepFormSelectors.getInitialDeckSetup(state).pipettes,
     )
 

--- a/protocol-designer/src/ui/steps/reducers.js
+++ b/protocol-designer/src/ui/steps/reducers.js
@@ -37,7 +37,7 @@ const collapsedSteps: Reducer<CollapsedStepsState, *> = handleActions({
   }),
   LOAD_FILE: (state: CollapsedStepsState, action: LoadFileAction) =>
     // default all steps to collapsed
-    getPDMetadata(action.payload).orderedSteps.reduce(
+    getPDMetadata(action.payload).orderedStepIds.reduce(
       (acc: CollapsedStepsState, stepId) => ({...acc, [stepId]: true}),
       {}
     ),

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -24,10 +24,10 @@ const rootSelector = (state: BaseState): StepsState => state.ui.steps
 /** fallbacks for selectedItem reducer, when null */
 const getNonNullSelectedItem: Selector<SelectableItem> = createSelector(
   rootSelector,
-  stepFormSelectors.getOrderedSteps,
-  (state, orderedSteps) => {
+  stepFormSelectors.getOrderedStepIds,
+  (state, orderedStepIds) => {
     if (state.selectedItem != null) return state.selectedItem
-    if (orderedSteps.length > 0) return {isStep: true, id: last(orderedSteps)}
+    if (orderedStepIds.length > 0) return {isStep: true, id: last(orderedStepIds)}
     return initialSelectedItemState
   }
 )


### PR DESCRIPTION
## overview

Closes #2856

This is just a find-and-replace, merge other PRs before this one. If this PR needs to be rebased, don't bother, just redo the find-and-replace and force push to this PR.

## changelog

* find-and-replace `orderedSteps` -> `orderedStepIds`; `OrderedSteps` -> `OrderedStepIds`

## review requests

* Doesn't break anything
* Code review