### PR TITLE
refactor(protocol-designer): remove pipette spec from RobotState

### DIFF
--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -23,7 +23,7 @@ function mapStateToProps (state: BaseState): SP {
   const props = (labwareData)
     ? {
       labwareType: labwareData.type,
-      nickname: labwareData.name || 'Unnamed Labware',
+      nickname: labwareData.nickname || 'Unnamed Labware',
     }
     : {
       labwareType: '?',

--- a/protocol-designer/src/components/steplist/MixHeader.js
+++ b/protocol-designer/src/components/steplist/MixHeader.js
@@ -23,7 +23,7 @@ export default function MixHeader (props: Props) {
         tooltipComponent={<LabwareTooltipContents labware={labware} />}>
         {(hoverTooltipHandlers) => (
           <span {...hoverTooltipHandlers} className={cx(styles.emphasized_cell, styles.labware_display_name)}>
-            {labware && labware.name}
+            {labware && labware.nickname}
           </span>
         )}
       </HoverTooltip>

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -47,7 +47,7 @@ function mapStateToProps (state: BaseState): SP {
   const selectedStep = stepsSelectors.getSelectedStep(state)
   const selectedTerminalId = stepsSelectors.getSelectedTerminalItemId(state)
   const labware = labwareIngredSelectors.getSelectedLabware(state)
-  const labwareNames = labwareIngredSelectors.getLabwareNames(state)
+  const labwareNames = labwareIngredSelectors.getLabwareNicknamesById(state)
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
   const liquidPlacementMode = !!labwareIngredSelectors.getSelectedLabware(state)
@@ -87,7 +87,7 @@ function mapStateToProps (state: BaseState): SP {
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
           const drilledDownLabware = labwareIngredSelectors.getLabwareById(state)[drilledDownLabwareId]
-          title = drilledDownLabware && drilledDownLabware.name
+          title = drilledDownLabware && drilledDownLabware.nickname
           subtitle = drilledDownLabware && humanizeLabwareType(drilledDownLabware.type)
         }
       } else if (selectedStep) {

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -53,7 +53,7 @@ type SP = $Diff<Props, {...DP, ...MP}>
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {slot} = ownProps
   const container = selectors.containersBySlot(state)[ownProps.slot]
-  const labwareNames = selectors.getLabwareNames(state)
+  const labwareNames = selectors.getLabwareNicknamesById(state)
 
   const containerType = container && container.type
   const containerId = container && container.id

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -109,7 +109,7 @@ const initialLabwareState: ContainersState = {
     id: FIXED_TRASH_ID,
     type: 'fixed-trash',
     disambiguationNumber: 1,
-    name: 'Trash',
+    nickname: 'Trash',
     slot: '12',
   },
 }
@@ -138,7 +138,7 @@ export const containers = handleActions({
         type: action.payload.containerType,
         disambiguationNumber: getNextDisambiguationNumber(state, action.payload.containerType),
         id,
-        name: null, // create with null name, so we force explicit naming.
+        nickname: null, // create with null name, so we force explicit naming.
       },
     }
   },
@@ -187,7 +187,7 @@ export const containers = handleActions({
           slot: fileLabware.slot,
           id,
           type: fileLabware.model,
-          name: fileLabware['display-name'],
+          nickname: fileLabware['display-name'],
           disambiguationNumber: getNextDisambiguationNumber(acc, fileLabware.model),
         },
       }
@@ -306,7 +306,7 @@ const getLabwareById: Selector<{[labwareId: string]: ?Labware}> = createSelector
   rootState => rootState.containers
 )
 
-const getLabwareNames: Selector<{[labwareId: string]: string}> = createSelector(
+const getLabwareNicknamesById: Selector<{[labwareId: string]: string}> = createSelector(
   getLabwareById,
   (labwareById) => mapValues(
     labwareById,
@@ -362,7 +362,7 @@ const loadedContainersBySlot = createSelector(
 /** Returns options for dropdowns, excluding tiprack labware */
 const labwareOptions: Selector<Options> = createSelector(
   getLabwareById,
-  getLabwareNames,
+  getLabwareNicknamesById,
   (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
     const isTiprack = getIsTiprack(labware.type)
     if (!labware.type || isTiprack) {
@@ -382,7 +382,7 @@ const DISPOSAL_LABWARE_TYPES = ['trash-box', 'fixed-trash']
 /** Returns options for disposal (e.g. fixed trash and trash box) */
 const disposalLabwareOptions: Selector<Options> = createSelector(
   getLabwareById,
-  getLabwareNames,
+  getLabwareNicknamesById,
   (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
     if (!labware.type || !DISPOSAL_LABWARE_TYPES.includes(labware.type)) {
       return acc
@@ -500,7 +500,7 @@ export const selectors = {
   getLiquidsByLabwareId,
   getLiquidNamesById,
   getLabwareById,
-  getLabwareNames,
+  getLabwareNicknamesById,
   getLabwareSelectionMode,
   getLabwareTypes,
   getLiquidSelectionOptions,

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -9,6 +9,7 @@ import type {LabwareData, LocationLiquidState} from '../step-generation'
 export type Labware = {|
   ...LabwareData,
   id: string,
+  nickname?: string,
   disambiguationNumber: number,
 |}
 

--- a/protocol-designer/src/labware-ingred/utils.js
+++ b/protocol-designer/src/labware-ingred/utils.js
@@ -3,5 +3,5 @@ import {humanizeLabwareType} from '@opentrons/components'
 import type {Labware} from './types'
 
 export const labwareToDisplayName = (l: Labware) => (
-  l.name || `${humanizeLabwareType(l.type)} (${l.disambiguationNumber})`
+  l.nickname || `${humanizeLabwareType(l.type)} (${l.disambiguationNumber})`
 )

--- a/protocol-designer/src/step-generation/commandCreators/atomic/blowout.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/blowout.js
@@ -11,7 +11,7 @@ const blowout = (args: PipetteLabwareFields): CommandCreator => (prevRobotState:
   const actionName = 'blowout'
   let errors: Array<CommandCreatorError> = []
 
-  const pipetteData = prevRobotState.instruments[pipette]
+  const pipetteData = prevRobotState.pipettes[pipette]
 
   // TODO Ian 2018-04-30 this logic using command creator args + robotstate to push errors
   // is duplicated across several command creators (eg aspirate & blowout overlap).

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
@@ -45,7 +45,7 @@ const dispense = (args: AspirateDispenseArgs): CommandCreator => (prevRobotState
       ...prevRobotState,
       liquidState: updateLiquidState({
         pipetteId: pipette,
-        pipetteData: prevRobotState.instruments[pipette],
+        pipetteData: prevRobotState.pipettes[pipette],
         labwareId: labware,
         labwareType: prevRobotState.labware[labware].type,
         volume,

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dropAllTips.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dropAllTips.js
@@ -7,7 +7,7 @@ import dropTip from './dropTip'
   * If no tips are attached to a pipette, do nothing.
   */
 const dropAllTips = (): CommandCreator => (prevRobotState: RobotState) => {
-  const pipetteIds = Object.keys(prevRobotState.instruments)
+  const pipetteIds = Object.keys(prevRobotState.pipettes)
   const commandCreators = pipetteIds.map(pipetteId => dropTip(pipetteId))
   return reduceCommandCreators(commandCreators)(prevRobotState)
 }

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dropTip.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dropTip.js
@@ -34,7 +34,7 @@ const dropTip = (pipetteId: string): CommandCreator => (prevRobotState: RobotSta
       ...nextRobotState,
       liquidState: updateLiquidState({
         pipetteId: pipetteId,
-        pipetteData: prevRobotState.instruments[pipetteId],
+        pipetteData: prevRobotState.pipettes[pipetteId],
         labwareId: FIXED_TRASH_ID,
         labwareType: 'fixed-trash',
         useFullVolume: true,

--- a/protocol-designer/src/step-generation/commandCreators/atomic/touchTip.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/touchTip.js
@@ -8,7 +8,7 @@ const touchTip = (args: TouchTipArgs): CommandCreator => (prevRobotState: RobotS
   const actionName = 'touchTip'
   const {pipette, labware, well, offsetFromBottomMm} = args
 
-  const pipetteData = prevRobotState.instruments[pipette]
+  const pipetteData = prevRobotState.pipettes[pipette]
 
   let errors: Array<CommandCreatorError> = []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -27,7 +27,7 @@ const consolidate = (data: ConsolidateFormData): CompoundCommandCreator => (prev
   */
   const actionName = 'consolidate'
 
-  const pipetteData = prevRobotState.instruments[data.pipette]
+  const pipetteData = prevRobotState.pipettes[data.pipette]
   if (!pipetteData) {
     // bail out before doing anything else
     return [(_robotState) => ({

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -31,7 +31,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
   // TODO Ian 2018-05-03 next ~20 lines match consolidate.js
   const actionName = 'distribute'
 
-  const pipetteData = prevRobotState.instruments[data.pipette]
+  const pipetteData = prevRobotState.pipettes[data.pipette]
   if (!pipetteData) {
     // bail out before doing anything else
     return [(_robotState) => ({

--- a/protocol-designer/src/step-generation/commandCreators/compound/mix.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/mix.js
@@ -61,7 +61,7 @@ const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: Robo
   } = data
 
   // Errors
-  if (!prevRobotState.instruments[pipette]) {
+  if (!prevRobotState.pipettes[pipette]) {
     // bail out before doing anything else
     return [(_robotState) => ({
       errors: [errorCreators.pipetteDoesNotExist({actionName, pipette})],

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -31,7 +31,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
   // TODO Ian 2018-04-02 following ~10 lines are identical to first lines of consolidate.js...
   const actionName = 'transfer'
 
-  const pipetteData = prevRobotState.instruments[data.pipette]
+  const pipetteData = prevRobotState.pipettes[data.pipette]
   if (!pipetteData) {
     // bail out before doing anything else
     return [(_robotState) => ({

--- a/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
+++ b/protocol-designer/src/step-generation/dispenseUpdateLiquidState.js
@@ -3,6 +3,7 @@ import assert from 'assert'
 import cloneDeep from 'lodash/cloneDeep'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import {splitLiquid, mergeLiquid, getWellsForTips, getLocationTotalVolume} from './utils'
 import type {RobotState, LocationLiquidState, PipetteData, SourceAndDest} from './types'
 
@@ -22,7 +23,10 @@ export default function updateLiquidState (
 ): LiquidState {
   // TODO: Ian 2018-06-14 return same shape as aspirateUpdateLiquidState fn: {liquidState, warnings}.
   const {pipetteId, pipetteData, volume, useFullVolume, labwareId, labwareType, well} = args
-
+  const pipetteSpec = getPipetteNameSpecs(pipetteData.name)
+  if (!pipetteSpec) {
+    throw Error(`No pipette spec found for pipette ${pipetteData.name}, could not updateLiquidState`)
+  }
   assert(
     !(useFullVolume && typeof volume === 'number'),
     'dispenseUpdateLiquidState takes either `volume` or `useFullVolume`, but got both')
@@ -30,7 +34,7 @@ export default function updateLiquidState (
     'in dispenseUpdateLiquidState, either volume or useFullVolume are required')
 
   const {wellsForTips, allWellsShared} = getWellsForTips(
-    pipetteData.channels, labwareType, well)
+    pipetteSpec.channels, labwareType, well)
 
   // remove liquid from pipette tips,
   // create intermediate object where sources are updated tip liquid states

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -25,7 +25,7 @@ export function noTipOnPipette (args: {
 export function pipetteDoesNotExist (args: {actionName: string, pipette: string}): CommandCreatorError {
   const {actionName, pipette} = args
   return {
-    message: `Attempted to ${actionName} with pipette id "${pipette}", this pipette was not found under "instruments"`,
+    message: `Attempted to ${actionName} with pipette id "${pipette}", this pipette was not found under "pipettes"`,
     type: 'PIPETTE_DOES_NOT_EXIST',
   }
 }

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/forAspirateDispense.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/forAspirateDispense.js
@@ -2,6 +2,7 @@
 import range from 'lodash/range'
 import isEmpty from 'lodash/isEmpty'
 import {mergeLiquid, splitLiquid, getWellsForTips, totalVolume} from '../utils'
+import {getPipetteSpecFromId} from '../robotStateSelectors'
 import * as warningCreators from '../warningCreators'
 import type {
   RobotState,
@@ -18,10 +19,10 @@ export default function getNextRobotStateAndWarningsForAspDisp (
   const {pipette: pipetteId, volume, labware: labwareId, well} = args
 
   const {liquidState: prevLiquidState} = prevRobotState
-  const pipetteData = prevRobotState.instruments[pipetteId]
+  const pipetteSpec = getPipetteSpecFromId(pipetteId, prevRobotState)
   const labwareType = prevRobotState.labware[labwareId].type
 
-  const {wellsForTips} = getWellsForTips(pipetteData.channels, labwareType, well)
+  const {wellsForTips} = getWellsForTips(pipetteSpec.channels, labwareType, well)
 
   // Blend tip's liquid contents (if any) with liquid of the source
   // to update liquid state in all pipette tips
@@ -29,7 +30,7 @@ export default function getNextRobotStateAndWarningsForAspDisp (
     pipetteLiquidState: SingleLabwareLiquidState,
     pipetteWarnings: Array<CommandCreatorWarning>,
   }
-  const {pipetteLiquidState, pipetteWarnings} = range(pipetteData.channels).reduce(
+  const {pipetteLiquidState, pipetteWarnings} = range(pipetteSpec.channels).reduce(
     (acc: PipetteLiquidStateAcc, tipIndex) => {
       const prevTipLiquidState = prevLiquidState.pipettes[pipetteId][tipIndex.toString()]
       const prevSourceLiquidState = prevLiquidState.labware[labwareId][wellsForTips[tipIndex]]

--- a/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/aspirate.test.js
@@ -95,7 +95,7 @@ describe('aspirate', () => {
   })
 
   test('aspirate with volume > tip max volume should throw error', () => {
-    robotStateWithTip.instruments['p300SingleId'].tiprackModel = 'tiprack-200ul'
+    robotStateWithTip.pipettes['p300SingleId'].tiprackModel = 'tiprack-200ul'
     const result = aspirateWithErrors({
       pipette: 'p300SingleId',
       volume: 201,
@@ -111,7 +111,7 @@ describe('aspirate', () => {
 
   test('aspirate with volume > pipette max volume should throw error', () => {
     // NOTE: assigning p300 to a 1000uL tiprack is nonsense, just for this test
-    robotStateWithTip.instruments['p300SingleId'].tiprackModel = 'tiprack-1000ul'
+    robotStateWithTip.pipettes['p300SingleId'].tiprackModel = 'tiprack-1000ul'
     const result = aspirateWithErrors({
       pipette: 'p300SingleId',
       volume: 301,

--- a/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/blowout.test.js
@@ -115,7 +115,7 @@ describe('blowout', () => {
         useFullVolume: true,
         well: 'A1',
         labwareType: 'trough-12row',
-        pipetteData: robotStateWithTip.instruments.p300SingleId,
+        pipetteData: robotStateWithTip.pipettes.p300SingleId,
       }, robotStateWithTip.liquidState)
 
       expect(result.robotState.liquidState).toBe(mockLiquidReturnValue)

--- a/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/consolidate.test.js
@@ -41,7 +41,7 @@ const robotInitialStateNoLiquidState = createRobotStateFixture({
 const emptyLiquidState = createEmptyLiquidState({
   sourcePlateType: 'trough-12row',
   destPlateType: '96-flat',
-  pipettes: robotInitialStateNoLiquidState.instruments,
+  pipettes: robotInitialStateNoLiquidState.pipettes,
 })
 
 const robotStatePickedUpOneTipNoLiquidState = merge(

--- a/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dispense.test.js
@@ -165,7 +165,7 @@ describe('dispense', () => {
           volume: 152,
           well: 'A1',
           labwareType: 'trough-12row',
-          pipetteData: robotStateWithTip.instruments.p300SingleId,
+          pipetteData: robotStateWithTip.pipettes.p300SingleId,
         },
         robotStateWithTip.liquidState
       )

--- a/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropAllTips.test.js
@@ -29,7 +29,7 @@ function expectNoTipsRemaining (robotState: RobotState) {
 
 describe('drop all tips', () => {
   test('should do nothing with no pipettes', () => {
-    initialRobotState.instruments = {}
+    initialRobotState.pipettes = {}
     initialRobotState.tipState.pipettes = {}
 
     const result = dropAllTips()(initialRobotState)

--- a/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/dropTip.test.js
@@ -129,7 +129,7 @@ describe('dropTip', () => {
           useFullVolume: true,
           well: 'A1',
           labwareType: 'fixed-trash',
-          pipetteData: robotStateWithTip.instruments.p300MultiId,
+          pipetteData: robotStateWithTip.pipettes.p300MultiId,
         },
         robotStateWithTip.liquidState
       )

--- a/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/robotStateSelectors.test.js
@@ -8,36 +8,35 @@ const basicLiquidState = {
   labware: {},
 }
 
+let _pipettesState
+
+beforeEach(() => {
+  _pipettesState = {
+    p300SingleId: p300Single,
+    p300MultiId: p300Multi,
+  }
+})
 describe('sortLabwareBySlot', () => {
   test('sorts all labware by slot', () => {
     // TODO use a fixture, standardize
-    const _instrumentsState = {
-      p300SingleId: p300Single,
-      p300MultiId: p300Multi,
-    }
-
     const robotState = {
-      instruments: _instrumentsState,
+      pipettes: _pipettesState,
       labware: {
         six: {
           slot: '6',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         one: {
           slot: '1',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack',
         },
         eleven: {
           slot: '11',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack',
         },
         two: {
           slot: '2',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
       },
       tipState: {
@@ -51,7 +50,7 @@ describe('sortLabwareBySlot', () => {
       liquidState: createEmptyLiquidState({
         sourcePlateType: '96-flat',
         destPlateType: '96-flat',
-        pipettes: _instrumentsState,
+        pipettes: _pipettesState,
       }),
     }
     expect(sortLabwareBySlot(robotState)).toEqual(['one', 'two', 'six', 'eleven'])
@@ -59,9 +58,7 @@ describe('sortLabwareBySlot', () => {
 
   test('with no labware, return empty array', () => {
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {},
       tipState: {
         tipracks: {
@@ -73,9 +70,7 @@ describe('sortLabwareBySlot', () => {
       },
       liquidState: {
         pipettes: {},
-        labware: {
-          p300SingleId: {'0': {}},
-        },
+        labware: {},
       },
     }
     expect(sortLabwareBySlot(robotState)).toEqual([])
@@ -121,29 +116,23 @@ describe('getNextTiprack - single-channel', () => {
   test('single tiprack, missing A1', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '11',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -160,7 +149,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Single, robotState)
+    const result = getNextTiprack('p300SingleId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('B1')
@@ -169,24 +158,19 @@ describe('getNextTiprack - single-channel', () => {
   test('single tiprack, empty, should return null', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -198,7 +182,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Single, robotState)
+    const result = getNextTiprack('p300SingleId', robotState)
 
     expect(result).toEqual(null)
   })
@@ -206,34 +190,27 @@ describe('getNextTiprack - single-channel', () => {
   test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 11',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -252,7 +229,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Single, robotState)
+    const result = getNextTiprack('p300SingleId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -261,34 +238,27 @@ describe('getNextTiprack - single-channel', () => {
   test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 11',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -309,7 +279,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Single, robotState)
+    const result = getNextTiprack('p300SingleId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('B1')
@@ -318,34 +288,27 @@ describe('getNextTiprack - single-channel', () => {
   test('multiple tipracks, all empty, should return null', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack11Id: {
           slot: '11',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 11',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -364,7 +327,7 @@ describe('getNextTiprack - single-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Single, robotState)
+    const result = getNextTiprack('p300SingleId', robotState)
 
     expect(result).toBe(null)
   })
@@ -374,29 +337,23 @@ describe('getNextTiprack - 8-channel', () => {
   test('single tiprack, totally full', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -410,7 +367,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -419,29 +376,23 @@ describe('getNextTiprack - 8-channel', () => {
   test('single tiprack, partially full', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -460,7 +411,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A3')
@@ -468,24 +419,19 @@ describe('getNextTiprack - 8-channel', () => {
 
   test('single tiprack, empty, should return null', () => {
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -497,7 +443,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result).toEqual(null)
   })
@@ -505,29 +451,23 @@ describe('getNextTiprack - 8-channel', () => {
   test('single tiprack, a well missing from each column, should return null', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         sourcePlateId: {
           slot: '10',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -555,7 +495,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result).toEqual(null)
   })
@@ -563,39 +503,31 @@ describe('getNextTiprack - 8-channel', () => {
   test('multiple tipracks, all full, should return the filled tiprack in the lowest slot', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 10',
         },
         sourcePlateId: {
           slot: '9',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -617,7 +549,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack2Id')
     expect(result && result.well).toEqual('A1')
@@ -626,39 +558,31 @@ describe('getNextTiprack - 8-channel', () => {
   test('multiple tipracks, some partially full, should return the filled tiprack in the lowest slot', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 10',
         },
         sourcePlateId: {
           slot: '9',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -707,7 +631,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result && result.tiprackId).toEqual('tiprack10Id')
     expect(result && result.well).toEqual('A2')
@@ -716,39 +640,31 @@ describe('getNextTiprack - 8-channel', () => {
   test('multiple tipracks, all empty, should return null', () => {
     // TODO use a fixture, standardize
     const robotState = {
-      instruments: {
-        p300SingleId: p300Single,
-      },
+      pipettes: _pipettesState,
       labware: {
         tiprack2Id: {
           slot: '2',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 2',
         },
         tiprack3Id: {
           slot: '3',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 3',
         },
         tiprack10Id: {
           slot: '10',
           type: 'opentrons-tiprack-300ul',
-          name: 'Tip rack 10',
         },
         sourcePlateId: {
           slot: '9',
           type: 'trough-12row',
-          name: 'Source (Buffer)',
         },
         destPlateId: {
           slot: '1',
           type: '96-flat',
-          name: 'Destination Plate',
         },
         trashId: {
           slot: '12',
           type: 'fixed-trash',
-          name: 'Trash',
         },
       },
       tipState: {
@@ -806,7 +722,7 @@ describe('getNextTiprack - 8-channel', () => {
       liquidState: basicLiquidState,
     }
 
-    const result = getNextTiprack(p300Multi, robotState)
+    const result = getNextTiprack('p300MultiId', robotState)
 
     expect(result).toEqual(null)
   })

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {DeckSlot, Mount, Channels} from '@opentrons/components'
+import type {DeckSlot, Mount} from '@opentrons/components'
 
 // ===== MIX-IN TYPES =====
 
@@ -146,19 +146,18 @@ export type CommandCreatorData =
   | PauseFormData
   | TransferFormData
 
-// TODO: Ian 2018-12-20 replace `PipetteData` with something like `PipetteOnDeck` type
-export type PipetteData = {| // TODO refactor all 'pipette fields', split PipetteData into its own export type
-  id: string, // TODO PipetteId export type here instead of string?
+// TODO: Ian 2018-01-07 with multiple deck setup steps, we might want to
+// separate 'entities' from 'locations' for pipettes/labware, and remove
+// 'entities' (pipette name / labware type) from the timeline to protect it
+// from being different btw frames
+export type PipetteData = {|
+  name: string,
   mount: Mount,
-  model: string, // TODO Ian 2018-11-05 rename 'model' to 'name' when breaking change is made in JSON protocols
-  maxVolume: number,
-  channels: Channels,
   tiprackModel: string, // NOTE: this will go away when tiprack choice-per-step and/or tiprack sharing is implemented
 |}
 
 export type LabwareData = {|
   type: string, // TODO Ian 2018-04-17 keys from JSON. Also, rename 'type' to 'model' (or something??)
-  name: ?string, // user-defined nickname
   slot: DeckSlot,
 |}
 
@@ -175,9 +174,9 @@ export type LabwareLiquidState = {[labwareId: string]: SingleLabwareLiquidState}
 
 export type SourceAndDest = {|source: LocationLiquidState, dest: LocationLiquidState|}
 
-// TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": RobotSimulationState?
+// TODO Ian 2018-02-09 Rename this so it's less ambigious with what we call "robot state": `TimelineFrame`?
 export type RobotState = {|
-  instruments: { // TODO Ian 2018-05-23 rename this 'pipettes' to match tipState (& to disambiguate from future 'modules')
+  pipettes: {
     [instrumentId: string]: PipetteData,
   },
   labware: {
@@ -211,7 +210,6 @@ export type PipetteLabwareFields = {|
   pipette: string,
   labware: string,
   well: string,
-  /* TODO optional uL/sec (or uL/minute???) speed here */
 |}
 
 export type TouchTipArgs = {|

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -41,15 +41,15 @@ function _getSelectedWellsForStep (
   }
 
   const pipetteId = form.pipette
-  const pipetteChannels = StepGeneration.getPipetteChannels(pipetteId, robotState)
+  const pipetteSpec = StepGeneration.getPipetteSpecFromId(pipetteId, robotState)
   const labwareType = StepGeneration.getLabwareType(labwareId, robotState)
 
-  if (!pipetteChannels || !labwareType) {
+  if (!pipetteSpec || !labwareType) {
     return []
   }
 
   const getWells = (wells: Array<string>) =>
-    _wellsForPipette(pipetteChannels, labwareType, wells)
+    _wellsForPipette(pipetteSpec.channels, labwareType, wells)
 
   let wells = []
 

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -35,18 +35,18 @@ function getTipHighlighted (
       const commandWellName = c.params.well
       const pipetteId = c.params.pipette
       const labwareType = StepGeneration.getLabwareType(labwareId, robotState)
-      const channels = StepGeneration.getPipetteChannels(pipetteId, robotState)
+      const pipetteSpec = StepGeneration.getPipetteSpecFromId(pipetteId, robotState)
 
       if (!labwareType) {
         console.error(`Labware ${labwareId} missing labwareType. Could not get tip highlight state`)
         return false
-      } else if (channels === 1) {
+      } else if (pipetteSpec.channels === 1) {
         return commandWellName === wellName
-      } else if (channels === 8) {
+      } else if (pipetteSpec.channels === 8) {
         const wellSet = getWellSetForMultichannel(labwareType, commandWellName)
         return Boolean(wellSet && wellSet.includes(wellName))
       } else {
-        console.error(`Unexpected number of channels: ${channels || '?'}. Could not get tip highlight state`)
+        console.error(`Unexpected number of channels: ${pipetteSpec.channels || '?'}. Could not get tip highlight state`)
         return false
       }
     }


### PR DESCRIPTION
## overview

Gets rid of duplicated sources of truth in RobotState, and resolves some "rename _ to _" TODOs.

## changelog

* always get pipette spec data from shared-data specs, do not store in RobotState
* rename `instruments` to `pipettes` in RobotState
* rename `pipette.model` to `pipette.name` in RobotState
* rename `displayLabware.name` to `displayLabware.nickname` for Labware type

## review requests

* should be backwards compatible (actually, no changes in file whatsoever)
* shouldn't break anything (test especially around deleting pipettes / labware)