### PR TITLE
refactor(components): Move ModuleNameOverlay from app to library

### DIFF
--- a/app/src/components/DeckMap/LabwareItem.js
+++ b/app/src/components/DeckMap/LabwareItem.js
@@ -8,13 +8,13 @@ import type {LabwareComponentProps} from '@opentrons/components'
 
 import {
   ContainerNameOverlay,
+  ModuleNameOverlay,
   LabwareContainer,
   Labware as LabwareComponent,
   humanizeLabwareType,
 } from '@opentrons/components'
 
 import LabwareSpinner from './LabwareSpinner'
-import ModuleNameOverlay from './ModuleNameOverlay'
 import styles from './styles.css'
 
 export type LabwareItemProps = LabwareComponentProps & {

--- a/app/src/components/DeckMap/LabwareItem.js
+++ b/app/src/components/DeckMap/LabwareItem.js
@@ -56,7 +56,6 @@ export default function LabwareItem (props: LabwareItemProps) {
         )}
 
         {!showSpinner && module && (
-          // TODO(mc, 2018-07-23): displayName?
           <ModuleNameOverlay name={module.name} />
         )}
 

--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -4,7 +4,6 @@ import React from 'react'
 import {Deck} from '@opentrons/components'
 import ConnectedSlotItem from './ConnectedSlotItem'
 import LabwareItem from './LabwareItem'
-import ModuleNameOverlay from './ModuleNameOverlay'
 
 import styles from './styles.css'
 
@@ -18,5 +17,5 @@ export default function DeckMap () {
   )
 }
 
-export {LabwareItem, ModuleNameOverlay}
+export {LabwareItem}
 export type {LabwareItemProps} from './LabwareItem'

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -46,7 +46,7 @@ function ProtocolModulesCard (props: Props) {
 
   const moduleInfo = modules.map(module => {
     const displayName =
-      module.name === 'tempdeck' ? 'Temperature Module' : 'Magnetic Bead Module'
+      module.name === 'tempdeck' ? 'Temperature Module' : 'Magnetic Module'
 
     const actualModel =
       actualModules && actualModules.modules.find(m => m.name === module.name)

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
+import {getModuleDisplayName} from '@opentrons/shared-data'
 import {selectors as robotSelectors} from '../../robot'
 import {
   makeGetRobotModules,
@@ -45,8 +46,7 @@ function ProtocolModulesCard (props: Props) {
   if (modules.length < 1) return null
 
   const moduleInfo = modules.map(module => {
-    const displayName =
-      module.name === 'tempdeck' ? 'Temperature Module' : 'Magnetic Module'
+    const displayName = getModuleDisplayName(module.name)
 
     const actualModel =
       actualModules && actualModules.modules.find(m => m.name === module.name)

--- a/app/src/components/ModuleItem/ModuleInfo.js
+++ b/app/src/components/ModuleItem/ModuleInfo.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react'
 
-import type {Module} from '../../http-api-client'
-
+import {getModuleDisplayName} from '@opentrons/shared-data'
 import {LabeledValue} from '@opentrons/components'
+
+import type {Module} from '../../http-api-client'
 
 import styles from './styles.css'
 
@@ -12,7 +13,8 @@ type Props = {
 }
 
 export default function ModuleInfo (props: Props) {
-  const {displayName, serial, status, fwVersion} = props.module
+  const {name, serial, status, fwVersion} = props.module
+  const displayName = getModuleDisplayName(name)
   return (
     <div className={styles.module_info}>
       <div className={styles.grid_50} >

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 
+import {getModuleDisplayName} from '@opentrons/shared-data'
 import {getConnectedRobot} from '../../discovery'
 import {
   fetchModules,
@@ -53,9 +54,10 @@ class TempDeckStatusCard extends React.Component<Props> {
     // again once we've received the response from the last call
     const currentTemp = (tempdeckData && tempdeckData.data.currentTemp) || tempdeck.data.currentTemp
     const targetTemp = (tempdeckData && tempdeckData.data.targetTemp) || tempdeck.data.targetTemp
+    const displayName = getModuleDisplayName(tempdeck.name)
     return (
       <IntervalWrapper refresh={fetchModuleData} interval={POLL_TEMPDECK_INTERVAL_MS}>
-        <StatusCard title={tempdeck.displayName}>
+        <StatusCard title={displayName}>
           <CardContentRow>
             <StatusItem status={(tempdeckData && tempdeckData.status) || tempdeck.status } />
           </CardContentRow>

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,7 +1,7 @@
 // @flow
 // common robot types
-import type {PipetteChannels} from '@opentrons/shared-data'
-import type {ModuleType, Mount} from '@opentrons/components'
+import type {PipetteChannels, ModuleType} from '@opentrons/shared-data'
+import type {Mount} from '@opentrons/components'
 import typeof reducer from './reducer'
 
 export type State = $Call<reducer>

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -2,6 +2,8 @@
 import * as React from 'react'
 import cx from 'classnames'
 
+import {getModuleDisplayName} from '@opentrons/shared-data'
+
 import {Icon} from '../icons'
 import LabwareContainer from './LabwareContainer'
 import {CenteredTextSvg} from '../CenteredTextSvg'
@@ -42,6 +44,7 @@ export default function Module (props: Props) {
 function ModuleItemContents (props: Props) {
   // TODO(mc, 2018-07-23): displayName?
   const {mode, name} = props
+  const displayName = getModuleDisplayName(name)
 
   if (!mode || mode === 'default') {
     // generic/empty display - just show USB icon
@@ -60,10 +63,10 @@ function ModuleItemContents (props: Props) {
     ? (
       <React.Fragment>
         <tspan x='55%' dy='-6'>Missing:</tspan>
-        <tspan x='55%' dy='12'>{name}</tspan>
+        <tspan x='55%' dy='12'>{displayName}</tspan>
       </React.Fragment>
     )
-    : (<tspan x='55%'>{name}</tspan>)
+    : (<tspan x='55%'>{displayName}</tspan>)
 
   const iconClassName = cx(styles.module_review_icon, {
     [styles.module_review_icon_missing]: mode === 'missing',

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -2,14 +2,12 @@
 import * as React from 'react'
 import cx from 'classnames'
 
-import {getModuleDisplayName} from '@opentrons/shared-data'
+import {getModuleDisplayName, type ModuleType} from '@opentrons/shared-data'
 
 import {Icon} from '../icons'
 import LabwareContainer from './LabwareContainer'
 import {CenteredTextSvg} from '../CenteredTextSvg'
 import styles from './Module.css'
-
-export type ModuleType = 'magdeck' | 'tempdeck'
 
 export type Props = {
   /** name of module, eg 'magdeck' or 'tempdeck' */
@@ -30,11 +28,11 @@ export default function Module (props: Props) {
     <LabwareContainer {...DIMENSIONS}>
       <rect
         className={styles.module}
-        rx='6'
-        ry='6'
-        width='100%'
-        height='100%'
-        fill='#000'
+        rx="6"
+        ry="6"
+        width="100%"
+        height="100%"
+        fill="#000"
       />
       <ModuleItemContents {...props} />
     </LabwareContainer>
@@ -49,24 +47,23 @@ function ModuleItemContents (props: Props) {
   if (!mode || mode === 'default') {
     // generic/empty display - just show USB icon
     return (
-      <Icon
-        className={styles.module_icon}
-        x='8'
-        y='20'
-        width='16'
-        name='usb'
-      />
+      <Icon className={styles.module_icon} x="8" y="20" width="16" name="usb" />
     )
   }
 
-  const message = (mode === 'missing')
-    ? (
+  const message =
+    mode === 'missing' ? (
       <React.Fragment>
-        <tspan x='55%' dy='-6'>Missing:</tspan>
-        <tspan x='55%' dy='12'>{displayName}</tspan>
+        <tspan x="55%" dy="-6">
+          Missing:
+        </tspan>
+        <tspan x="55%" dy="12">
+          {displayName}
+        </tspan>
       </React.Fragment>
+    ) : (
+      <tspan x="55%">{displayName}</tspan>
     )
-    : (<tspan x='55%'>{displayName}</tspan>)
 
   const iconClassName = cx(styles.module_review_icon, {
     [styles.module_review_icon_missing]: mode === 'missing',
@@ -74,18 +71,18 @@ function ModuleItemContents (props: Props) {
   })
 
   const iconNameByMode = {
-    'missing': 'alert-circle',
-    'present': 'check-circle',
-    'info': 'usb',
+    missing: 'alert-circle',
+    present: 'check-circle',
+    info: 'usb',
   }
 
   return (
     <React.Fragment>
       <Icon
         className={iconClassName}
-        x='8'
-        y='0'
-        width='16'
+        x="8"
+        y="0"
+        width="16"
         name={iconNameByMode[mode]}
       />
       <CenteredTextSvg className={styles.module_review_text} text={message} />

--- a/components/src/deck/ModuleNameOverlay.js
+++ b/components/src/deck/ModuleNameOverlay.js
@@ -1,15 +1,18 @@
 // @flow
 import * as React from 'react'
 
+import {getModuleDisplayName} from '@opentrons/shared-data'
+
 import styles from './Module.css'
 
 type Props = {name: string}
 
-// TODO (ka 2019-1-7): should these be optionally overridden with props?
+// TODO (ka 2019-1-7): eventually add option to override with props
 const HEIGHT = 20
 const PADDING_LEFT = 4
 
 export default function ModuleNameOverlay (props: Props) {
+  const displayName = getModuleDisplayName(props.name)
   return (
     <React.Fragment>
       <rect
@@ -23,7 +26,7 @@ export default function ModuleNameOverlay (props: Props) {
         x={PADDING_LEFT}
         y={HEIGHT / 2}
       >
-        {props.name}
+        {displayName}
       </text>
     </React.Fragment>
   )

--- a/components/src/deck/ModuleNameOverlay.js
+++ b/components/src/deck/ModuleNameOverlay.js
@@ -1,10 +1,11 @@
 // @flow
 import * as React from 'react'
 
-import styles from './styles.css'
+import styles from './Module.css'
 
 type Props = {name: string}
 
+// TODO (ka 2019-1-7): should these be optionally overridden with props?
 const HEIGHT = 20
 const PADDING_LEFT = 4
 

--- a/components/src/deck/ModuleNameOverlay.js
+++ b/components/src/deck/ModuleNameOverlay.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from 'react'
 
-import {getModuleDisplayName} from '@opentrons/shared-data'
+import {getModuleDisplayName, type ModuleType} from '@opentrons/shared-data'
 
 import styles from './Module.css'
 
-type Props = {name: string}
+type Props = {name: ModuleType}
 
 // TODO (ka 2019-1-7): eventually add option to override with props
 const HEIGHT = 20
@@ -17,12 +17,12 @@ export default function ModuleNameOverlay (props: Props) {
     <React.Fragment>
       <rect
         className={styles.module_name_overlay}
-        width='100%'
+        width="100%"
         height={HEIGHT}
       />
       <text
         className={styles.module_name_text}
-        dominantBaseline='central'
+        dominantBaseline="central"
         x={PADDING_LEFT}
         y={HEIGHT / 2}
       >

--- a/components/src/deck/index.js
+++ b/components/src/deck/index.js
@@ -9,7 +9,6 @@ import Tip from './Tip'
 import type {SingleWell} from './Well'
 import Module from './Module'
 import ModuleNameOverlay from './ModuleNameOverlay'
-import type {ModuleType} from './Module'
 
 import {ContainerNameOverlay} from './ContainerNameOverlay'
 import {EmptyDeckSlot} from './EmptyDeckSlot'
@@ -33,7 +32,4 @@ export {
   Tip,
 }
 
-export type {
-  SingleWell,
-  ModuleType,
-}
+export type {SingleWell}

--- a/components/src/deck/index.js
+++ b/components/src/deck/index.js
@@ -8,6 +8,7 @@ import Well from './Well'
 import Tip from './Tip'
 import type {SingleWell} from './Well'
 import Module from './Module'
+import ModuleNameOverlay from './ModuleNameOverlay'
 import type {ModuleType} from './Module'
 
 import {ContainerNameOverlay} from './ContainerNameOverlay'
@@ -26,6 +27,7 @@ export {
   LabwareOutline,
   LabwareLabels,
   Module,
+  ModuleNameOverlay,
   SlotOverlay,
   Well,
   Tip,

--- a/protocol-library-kludge/src/URLDeck.js
+++ b/protocol-library-kludge/src/URLDeck.js
@@ -2,17 +2,15 @@
 import React from 'react'
 import startCase from 'lodash/startCase'
 import styles from './URLDeck.css'
+
 import {
   ContainerNameOverlay,
   Deck,
   Labware,
   Module,
 } from '@opentrons/components'
-import type {
-  DeckSlot,
-  LabwareComponentProps,
-  ModuleType,
-} from '@opentrons/components'
+import type {DeckSlot, LabwareComponentProps} from '@opentrons/components'
+import type {ModuleType} from '@opentrons/shared-data'
 
 // URI-encoded JSON expected as URL param "data" (eg `?data=...`)
 type UrlData = {
@@ -76,7 +74,7 @@ export default class URLDeck extends React.Component<{}> {
     }
 
     if (moduleData) {
-      module = <Module mode='default' name='tempdeck' />
+      module = <Module mode="default" name="tempdeck" />
     }
 
     return (

--- a/shared-data/js/index.js
+++ b/shared-data/js/index.js
@@ -12,6 +12,7 @@ export * from './helpers'
 export * from './pipettes'
 export * from './types'
 export * from './labwareTools'
+export * from './modules'
 
 export {
   getLabware,

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -1,0 +1,9 @@
+// @flow
+import moduleSpecs from '../robot-data/moduleSpecs.json'
+
+// use a name like 'magdeck' to get displayName for app
+export function getModuleDisplayName (name: string): ?string {
+  const displayName = moduleSpecs[name].displayName
+
+  return displayName
+}

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -4,7 +4,7 @@ import moduleSpecs from '../robot-data/moduleSpecs.json'
 export type ModuleType = 'magdeck' | 'tempdeck'
 
 // use a name like 'magdeck' to get displayName for app
-export function getModuleDisplayName (name: 'magdeck' | 'tempdeck'): string {
+export function getModuleDisplayName (name: ModuleType): string {
   const displayName = moduleSpecs[name].displayName
 
   return displayName

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -1,8 +1,10 @@
 // @flow
 import moduleSpecs from '../robot-data/moduleSpecs.json'
 
+export type ModuleType = 'magdeck' | 'tempdeck'
+
 // use a name like 'magdeck' to get displayName for app
-export function getModuleDisplayName (name: string): ?string {
+export function getModuleDisplayName (name: 'magdeck' | 'tempdeck'): string {
   const displayName = moduleSpecs[name].displayName
 
   return displayName


### PR DESCRIPTION
## overview
This PR serves as an bug report and a bug fix.

## previous behavior
When the `DeckMap` related `Module` component and styles were moved from the app to the component library, we missed the `ModuleNameOverlay`. This resulted in the app rendering the component without its applied styles.
<img width="1025" alt="screen shot 2019-01-07 at 10 37 46 am" src="https://user-images.githubusercontent.com/3430313/50779137-97430d80-126d-11e9-919f-1f4e480ad45d.png">


## bug fix
`ModuleNameOverlay` is now part of the Components Library rather than the app and is rendering with styles from Modules.css.
<img width="1025" alt="screen shot 2019-01-07 at 10 38 15 am" src="https://user-images.githubusercontent.com/3430313/50779157-a1fda280-126d-11e9-9253-69af1d5d73ac.png">

## changelog

- refactor(components): Move ModuleNameOverlay from app to library
- feature(shared-data): Add getModuleDisplayName method and implement in comp lib modules components

## review requests

HEIGHT and PADDING_LEFT are hardcoded for now. Should we bother to implement an optional override with props at this time? See my TODO.

Upload a protocol with a module.

- [ ] Module not detected modal (calibrate labware) renders as expected
- [ ] Module detected modal (calibrate labware) renders as expected
- [ ] Module with labware and labels renders as expected in `ReviewDeckModal`

calibrate tripracks so that module is not disabled on the deck. 
click back to hide jog modal and view deckmap 
- [ ] Module with labware and labels renders as expected

- [ ] Render displayName (Magnetic Module or Temperature Module) not name in UI
*Note: this should be the case everywhere except in `InstrumentSettingsPage` where API display name is mismatched. TODO: revisit this with Sanniti*
