### PR TITLE
fix(protocol-designer): migrate old and new step names and descriptions

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -194,8 +194,8 @@ export const savedStepForms = (
       // migrate old kebab-case keys to camelCase
       const cleanedLoadedStepForms = mapValues(loadedStepForms, (stepForm) => ({
         ...omit(stepForm, ['step-name', 'step-details']),
-        stepName: stepForm['step-name'],
-        stepDetails: stepForm['step-details'],
+        stepName: stepForm.stepName || stepForm['step-name'],
+        stepDetails: stepForm.stepDetails || stepForm['step-details'],
       }))
 
       return mapValues(cleanedLoadedStepForms, stepForm => ({


### PR DESCRIPTION
@mcous noticed a bug that caused newly saved step forms to lose some of their metadata on reimport. This fixes that bug.
