### PR TITLE
fix(components): remove padding from body of empty AlertItem

### DIFF
--- a/components/src/__tests__/__snapshots__/alerts.test.js.snap
+++ b/components/src/__tests__/__snapshots__/alerts.test.js.snap
@@ -145,12 +145,8 @@ exports[`alerts warning alert with message body renders correctly 1`] = `
       </svg>
     </button>
   </div>
-  <div
-    className="message"
-  >
-    <h3>
-      Title
-    </h3>
-  </div>
+  <h3>
+    Title
+  </h3>
 </div>
 `;

--- a/components/src/alerts/AlertItem.js
+++ b/components/src/alerts/AlertItem.js
@@ -69,11 +69,7 @@ export default function AlertItem (props: AlertProps) {
           <IconButton name='close' onClick={props.onCloseClick} className={styles.close}/>
         )}
       </div>
-      {props.children && (
-        <div className = {styles.message}>
-          {props.children}
-        </div>
-      )}
+      {props.children}
     </div>
   )
 }

--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -61,16 +61,6 @@
   }
 }
 
-.message {
-  padding: 1rem 3rem;
-  background-color: white;
-
-  & a {
-    text-decoration: underline;
-    color: inherit;
-  }
-}
-
 .icon {
   width: 1.5rem;
   margin-right: 0.5rem;

--- a/protocol-designer/src/components/alerts/ErrorContents.js
+++ b/protocol-designer/src/components/alerts/ErrorContents.js
@@ -4,12 +4,13 @@ import i18n from '../../localization'
 import {START_TERMINAL_ITEM_ID} from '../../steplist'
 import type { AlertLevel } from './types'
 import {TerminalItemLink} from '../steplist/TerminalItem'
+import styles from './contents.css'
 
 type ErrorContentsProps = {
   errorType: string,
   level: AlertLevel,
 }
-const ErrorContents = (props: ErrorContentsProps) => {
+const getContents = (props: ErrorContentsProps) => {
   if (props.level === 'timeline') {
     switch (props.errorType) {
       case 'INSUFFICIENT_TIPS':
@@ -20,21 +21,21 @@ const ErrorContents = (props: ErrorContentsProps) => {
           </React.Fragment>
         )
       default:
-        return (
-          <React.Fragment>
-            {i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: ''})}
-          </React.Fragment>
-        )
+        return i18n.t(`alert.timeline.error.${props.errorType}.body`, {defaultValue: null})
     }
   } else if (props.level === 'form') {
-    return (
-      <React.Fragment>
-        {i18n.t(`alert.form.error.${props.errorType}.body`, {defaultValue: ''})}
-      </React.Fragment>
-    )
+    return i18n.t(`alert.form.error.${props.errorType}.body`, {defaultValue: null})
   } else {
     return null
   }
+}
+
+const ErrorContents = (props: ErrorContentsProps) => {
+  const contents = getContents(props)
+  if (!contents) return null
+  return (
+    <div className={styles.message}>{contents}</div>
+  )
 }
 
 export default ErrorContents

--- a/protocol-designer/src/components/alerts/contents.css
+++ b/protocol-designer/src/components/alerts/contents.css
@@ -1,0 +1,11 @@
+@import '@opentrons/components';
+
+.message {
+  padding: 1rem 3rem;
+  background-color: white;
+
+  & a {
+    text-decoration: underline;
+    color: inherit;
+  }
+}


### PR DESCRIPTION
## overview

You get this empty box when an AlertItem has no content.

![empty box](https://user-images.githubusercontent.com/4731953/50786738-5b667300-1282-11e9-8a87-d44c17515c50.png)

This is because AlertItem conditionally wraps its children in a div with the `.message` class if `props.children` is truthy. If you pass in a child component that is designed to return null in some cases, like `const Foo = (props) => titleDisplayMap[props.title] || null`, then `props.children` of `AlertItem` will be truthy, and the padding will be applied.

## changelog

* fix empty box under AlertItem with no body

## review requests

* this is a change to components, but I think it does not affect Run App because Run App does not use the `.message` class from `alerts.css`, and does not use `AlertItem`. Is this right?