### PR TITLE
fix(api): Add gpio.set_button_light() to QC tools scripts, so they wo…

### DIFF
--- a/api/src/opentrons/tools/factory_test.py
+++ b/api/src/opentrons/tools/factory_test.py
@@ -6,6 +6,7 @@ import subprocess
 
 from opentrons import robot
 from opentrons.util import environment
+from opentrons.drivers.rpi_drivers import gpio
 
 
 RESULT_SPACE = '\t- {}'
@@ -53,7 +54,7 @@ def _erase_data(filepath):
 
 def _reset_lights():
     robot._driver.turn_off_rail_lights()
-    robot._driver._set_button_light(blue=True)
+    gpio.set_button_light(blue=True)
 
 
 def _get_state_of_inputs():
@@ -84,7 +85,7 @@ def _set_lights(state):
         green = True
     if state['button']:
         blue = True
-    robot._driver._set_button_light(red=red, green=green, blue=blue)
+    gpio.set_button_light(red=red, green=green, blue=blue)
 
 
 def run_quiet_process(command):

--- a/api/src/opentrons/tools/gantry_test.py
+++ b/api/src/opentrons/tools/gantry_test.py
@@ -10,6 +10,7 @@ Author: Carlos Fernandez
 import optparse
 
 from opentrons import robot
+from opentrons.drivers.rpi_drivers import gpio
 from opentrons.drivers.smoothie_drivers.driver_3_0 import \
     SmoothieError, DEFAULT_AXES_SPEED
 
@@ -135,7 +136,7 @@ if __name__ == '__main__':
         robot.home()
         run_x_axis(num_cycles, b_x_max, b_y_max, tolerance_mm)
         run_y_axis(num_cycles, b_x_max, b_y_max, tolerance_mm)
-        robot._driver._set_button_light(red=False, green=True, blue=False)
+        gpio.set_button_light(red=False, green=True, blue=False)
         print("PASS")
         _exit_test()
     except KeyboardInterrupt:


### PR DESCRIPTION
## overview

QC tests that set the button's LED now use the updated `gpio.set_button_light()` to set the color.