### PR TITLE
fix(components): remove padding from empty AlertItems

### DIFF
--- a/components/src/alerts/alerts.css
+++ b/components/src/alerts/alerts.css
@@ -69,6 +69,10 @@
     text-decoration: underline;
     color: inherit;
   }
+
+  &:empty {
+    padding: 0;
+  }
 }
 
 .icon {


### PR DESCRIPTION
## overview

This PR is an alternative to now-closed #2889 - which broke Run App!

You get this empty box when an AlertItem has no content.

![empty box](https://user-images.githubusercontent.com/4731953/50786738-5b667300-1282-11e9-8a87-d44c17515c50.png)

This is because AlertItem conditionally wraps its children in a div with the `.message` class if `props.children` is truthy. If you pass in a child component that is designed to return null in some cases, like `const Foo = (props) => titleDisplayMap[props.title] || null`, then `props.children` of `AlertItem` will be truthy, and the padding will be applied.

## changelog

* fix empty box under AlertItem with no body

## review requests

* is this OK in Run App? The SessionAlert looks OK but I'm not sure how to get to other ones
* PD AlertItems show correctly: both with title only, no content (eg make a Mix with volume larger than pipette max to get "volume greater than pipette volume") and when it includes content (eg make a step and delete all tipracks  to get "Not enough tips" error)