### PR TITLE
fix(api): Flush and sync config file writes immediately

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from copy import copy
 from opentrons.config import get_config_index
 
@@ -54,7 +55,9 @@ settings = [
     Setting(
         _id='useProtocolApi2',
         title='Use Protocol API version 2',
-        description='Use new implementation of protocol API. This should not be activated except by developers.' # noqa
+        description='Use new implementation of protocol API. This should not'
+                    ' be activated except by developers or testers. Please'
+                    ' power cycle the robot after changing this setting.'
     ),
     Setting(
         _id='useNewP10Aspiration',
@@ -151,6 +154,8 @@ def _write_settings_file(data: dict, settings_file: str):
     try:
         with open(settings_file, 'w') as fd:
             json.dump(data, fd)
+            fd.flush()
+            os.fsync(fd.fileno())
     except OSError:
         log.exception('Failed to write advanced settings file to: {}'.format(
             settings_file))

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -327,6 +327,8 @@ def _save_json(data, filename):
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, 'w') as file:
             json.dump(data, file, sort_keys=True, indent=4)
+            file.flush()
+            os.fsync(file.fileno())
         return data
     except OSError:
         log.exception('Write failed with exception:')


### PR DESCRIPTION
Currently, we just write config files and trust the OS to flush them.
Unfortunately, for certain workflows the user will immediate powercycle the
robot after changing a setting, and in this case the file has sometimes not been
syncd. Force sync immediately when hanging configs.
