### PR TITLE
feat(api): api2: Move multichannel center for certain labwares

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -121,7 +121,9 @@ class CalibrationManager:
         log.info('Moving {}'.format(instrument.name))
         self._set_state('moving')
         if ff.use_protocol_api_v2():
-            current = self._hardware.gantry_position(Mount[inst.mount.upper()])
+            current = self._hardware.gantry_position(
+                Mount[inst.mount.upper()],
+                critical_point=CriticalPoint.NOZZLE)
             dest = instrument._context.deck.position_for(5)\
                                            .point._replace(z=150)
             self._hardware.move_to(Mount[inst.mount.upper()],
@@ -193,7 +195,12 @@ class CalibrationManager:
         inst = instrument._instrument
         log.info('Updating {} in {}'.format(container.name, container.slot))
         if ff.use_protocol_api_v2():
-            here = self._hardware.gantry_position(Mount[inst.mount.upper()])
+            if 'centerMultichannelOnWells' in container._container.quirks:
+                cp = CriticalPoint.XY_CENTER
+            else:
+                cp = None
+            here = self._hardware.gantry_position(Mount[inst.mount.upper()],
+                                                  critical_point=cp)
             # Reset calibration so we don’t actually calibrate the offset
             # relative to the old calibration
             container._container.set_calibration(Point(0, 0, 0))

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -42,6 +42,37 @@ class HardwareAPILike:
 
 
 class CriticalPoint(enum.Enum):
+    """ Possibilities for the point to move in a move call.
+
+    The active critical point determines the offsets that are added to the
+    gantry position when moving a pipette around.
+    """
     MOUNT = enum.auto()
+    """
+    For legacy reasons, the position of the end of a P300 single. The default
+    when no pipette is attached, and used for consistent behavior in certain
+    contexts (like change pipette) when a variety of different pipettes might
+    be attached.
+    """
+
     NOZZLE = enum.auto()
+    """
+    The end of the nozzle of a single pipette or the end of the back-most
+    nozzle of a multipipette. Only relevant when a pipette is present.
+    """
+
     TIP = enum.auto()
+    """
+    The end of the tip of a single pipette or the end of the back-most
+    tip of a multipipette. Only relevant when a pipette is present and
+    a tip with known tip length is attached.
+    """
+
+    XY_CENTER = enum.auto()
+    """
+    Separately from the z component of the critical point, XY_CENTER means
+    the critical point under consideration is the XY center of the pipette.
+    This changes nothing for single pipettes, but makes multipipettes
+    move their centers - so between channels 4 and 5 - to the specified
+    point.
+    """

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -560,10 +560,13 @@ class InstrumentContext:
                                 location if location else 'current position',
                                 rate))
         if isinstance(location, Well):
-            point, well = location.bottom()
-            loc = types.Location(
-                point + types.Point(0, 0, self.well_bottom_clearance),
-                well)
+            if 'fixedTrash' in quirks_from_any_parent(location):
+                loc = location.top()
+            else:
+                point, well = location.bottom()
+                loc = types.Location(
+                    point + types.Point(0, 0, self.well_bottom_clearance),
+                    well)
             self.move_to(loc)
         elif isinstance(location, types.Location):
             loc = location
@@ -782,11 +785,14 @@ class InstrumentContext:
                     "dropped. The passed location, however, is in "
                     "reference to {}".format(location.labware))
         elif location and isinstance(location, Well):
-            bot = location.bottom()
-            target = bot._replace(point=bot.point._replace(z=bot.point.z + 10))
+            if 'fixedTrash' in quirks_from_any_parent(location):
+                target = location.top()
+            else:
+                bot = location.bottom()
+                target = bot._replace(
+                    point=bot.point._replace(z=bot.point.z + 10))
         elif not location:
-            loc = self.trash_container.wells()[0].bottom()
-            target = loc._replace(point=loc.point._replace(z=loc.point.z + 10))
+            target = self.trash_container.wells()[0].top()
         else:
             raise TypeError(
                 "If specified, location should be an instance of "

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -190,6 +190,11 @@ def _get_location_with_offset(loaded_labware: Dict[str, labware.Labware],
                               params: Dict[str, Any],
                               default_values: Dict[str, float]) -> Location:
     well = _get_well(loaded_labware, params)
+
+    # Never move to the bottom of the fixed trash
+    if 'fixedTrash' in labware.quirks_from_any_parent(well):
+        return well.top()
+
     offset_from_bottom = _get_bottom_offset(
         command_type, params, default_values)
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -231,6 +231,11 @@ class Labware:
         return self._parameters
 
     @property
+    def quirks(self) -> List[str]:
+        """ Quirks specific to this labware. """
+        return self.parameters.get('quirks', [])
+
+    @property
     def magdeck_engage_height(self) -> Optional[float]:
         if not self._parameters['isMagneticModuleCompatible']:
             return None
@@ -789,7 +794,7 @@ def quirks_from_any_parent(
     """ Walk the tree of wells and labwares and extract quirks """
     def recursive_get_quirks(obj, found):
         if isinstance(obj, Labware):
-            return found + obj.parameters.get('quirks', [])
+            return found + obj.quirks
         elif isinstance(obj, Well):
             return recursive_get_quirks(obj.parent, found)
         else:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -782,3 +782,16 @@ def load_module(name: str, parent: Location) -> ModuleGeometry:
     module_def = json.loads(  # type: ignore
         pkgutil.get_data('opentrons', def_path))
     return load_module_from_definition(module_def[name], parent)
+
+
+def quirks_from_any_parent(
+        loc: Union[Labware, Well, str, ModuleGeometry, None]) -> List[str]:
+    """ Walk the tree of wells and labwares and extract quirks """
+    def recursive_get_quirks(obj, found):
+        if isinstance(obj, Labware):
+            return found + obj.parameters.get('quirks', [])
+        elif isinstance(obj, Well):
+            return recursive_get_quirks(obj.parent, found)
+        else:
+            return found
+    return recursive_get_quirks(loc, [])

--- a/shared-data/definitions2/opentrons_1_trash_0.85_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_0.85_L.json
@@ -32,7 +32,7 @@
         "isTiprack": false,
         "loadName": "opentrons_1_trash_0.85_L",
         "isMagneticModuleCompatible": false,
-        "quirks": ["fixedTrash"]
+        "quirks": ["fixedTrash", "centerMultichannelOnWells"]
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/opentrons_1_trash_1.1_L.json
+++ b/shared-data/definitions2/opentrons_1_trash_1.1_L.json
@@ -32,7 +32,7 @@
         "isTiprack": false,
         "loadName": "opentrons_1_trash_1.1_L",
         "isMagneticModuleCompatible": false,
-        "quirks": ["fixedTrash"]
+        "quirks": ["fixedTrash", "centerMultichannelOnWells"]
     },
     "wells": {
         "A1": {

--- a/shared-data/definitions2/usa_scientific_12_trough_22_mL.json
+++ b/shared-data/definitions2/usa_scientific_12_trough_22_mL.json
@@ -59,7 +59,8 @@
         "format": "trough",
         "isTiprack": false,
         "isMagneticModuleCompatible": false,
-        "loadName": "usa_scientific_12_trough_22_mL"
+        "loadName": "usa_scientific_12_trough_22_mL",
+        "quirks": ["centerMultichannelOnWells"]
     },
     "wells": {
         "A1": {


### PR DESCRIPTION
Some labwares, like the fixed trash or troughs, have large wells that are
intended to fit all nozzles of a multichannel pipette. Currently, the system
incorrectly moves the backmost nozzle or tip of a multichannel pipette to
the center of such a well, leaving the front 4 or so channels below the bottom
of the well.

To fix this, we define a new labware quirk, ’centerMultichannelOnWells’, and a
new critical point option, CriticalPoint.XY_CENTER. If CriticalPoint.XY_CENTER
is passed to hardware_control.API.move_to, the system will use the normal z
offset determination but ignore the model offset, thus moving the center of the
pipette even if it’s a multichannel. The protocol context will see the quirks in
the labware and pass the critical point override if necessary.

Some extra complexity is necessary in the protocol api layer to prevent
undesired combined XYZ motion in arc moves; we should in general only switch
between XY_CENTER and no CP override when we are intending to move in XY, and
this goes both for going from no override to XY_CENTER and from XY_CENTER to the
reverse. This logic is in InstrumentContext.move_to and relies on finding the
centerMultichannelOnWells quirk in both the destination labware and the source
labware in the location cache.

Closes #2892
