### PR TITLE
feat(protocol-designer): add perSource/perDest changeTip options to transfer.js

### DIFF
--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -1,5 +1,4 @@
 // @flow
-import flatten from 'lodash/flatten'
 import zip from 'lodash/zip'
 import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
@@ -199,7 +198,7 @@ const transfer = (data: TransferFormData): CompoundCommandCreator => (prevRobotS
           prevSourceWell = sourceWell
           prevDestWell = destWell
 
-          return [...innerAcc, ...flatten(nextCommands)]
+          return [...innerAcc, ...nextCommands]
         }, [])
 
       return [...outerAcc, ...commands]

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -269,6 +269,82 @@ describe('single transfer exceeding pipette max', () => {
     ))
   })
 
+  test('changeTip="perSource"', () => {
+    transferArgs = {
+      ...transferArgs,
+      sourceWells: ['A1', 'A1', 'A2'],
+      destWells: ['B1', 'B2', 'B2'],
+      changeTip: 'perSource',
+    }
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 300),
+      cmd.dispense('B1', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A1', 50),
+      cmd.dispense('B1', 50, {labware: 'destPlateId'}),
+
+      // same source, different dest: no change
+      cmd.aspirate('A1', 300),
+      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A1', 50),
+      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+
+      // new source, different dest: change tip
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('B1'),
+
+      cmd.aspirate('A2', 300),
+      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A2', 50),
+      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+    ])
+  })
+
+  test('changeTip="perDest"', () => {
+    // NOTE: same wells as perSource test
+    transferArgs = {
+      ...transferArgs,
+      sourceWells: ['A1', 'A1', 'A2'],
+      destWells: ['B1', 'B2', 'B2'],
+      changeTip: 'perDest',
+    }
+
+    const result = transfer(transferArgs)(robotInitialState)
+    expect(result.commands).toEqual([
+      cmd.pickUpTip('A1'),
+
+      cmd.aspirate('A1', 300),
+      cmd.dispense('B1', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A1', 50),
+      cmd.dispense('B1', 50, {labware: 'destPlateId'}),
+
+      // same source, different dest: change tip
+      cmd.dropTip('A1'),
+      cmd.pickUpTip('B1'),
+
+      cmd.aspirate('A1', 300),
+      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A1', 50),
+      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+
+      // different source, same dest: no change
+
+      cmd.aspirate('A2', 300),
+      cmd.dispense('B2', 300, {labware: 'destPlateId'}),
+
+      cmd.aspirate('A2', 50),
+      cmd.dispense('B2', 50, {labware: 'destPlateId'}),
+    ])
+  })
+
   test('changeTip="never"', () => {
     transferArgs = {
       ...transferArgs,


### PR DESCRIPTION
## overview

> Support "change tip per source" / "change tip per dest" in Transfer command creator, write tests

Serves as its own ticket

## changelog

* implement changeTip options perSource and perDest for transfer command creator

## review requests

PD should work the same, in the now-outdated Transfer form there's no option for perSource/perDest so this won't be accessible until new flexible steps form

Code + tests review