### PR TITLE
feat(protocol-designer): new placeholder form for moveLiquid stepType

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -1,9 +1,8 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {HoverTooltip, PrimaryButton} from '@opentrons/components'
-
 import i18n from '../localization'
+import {HoverTooltip, PrimaryButton} from '@opentrons/components'
 import {actions as steplistActions} from '../steplist'
 import {stepIconsByType, type StepType} from '../form-types'
 import type {ThunkDispatch} from '../types'
@@ -25,7 +24,8 @@ class StepCreationButton extends React.Component<DP, State> {
   }
 
   render () {
-    const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause']
+    // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
+    const supportedSteps = ['transfer', 'distribute', 'consolidate', 'mix', 'pause', 'moveLiquid']
 
     return (
       <div className={styles.list_item_button} onMouseLeave={this.handleMouseLeave}>
@@ -47,7 +47,7 @@ class StepCreationButton extends React.Component<DP, State> {
                     hoverTooltipHandlers={hoverTooltipHandlers}
                     onClick={this.props.makeAddStep(stepType)}
                     iconName={stepIconsByType[stepType]}>
-                    {stepType}
+                    {i18n.t(`button.stepType.${stepType}`, stepType)}
                   </PrimaryButton>
                 )}
               </HoverTooltip>

--- a/protocol-designer/src/components/StepEditForm/MoveLiquidForm.js
+++ b/protocol-designer/src/components/StepEditForm/MoveLiquidForm.js
@@ -1,0 +1,190 @@
+// @flow
+import * as React from 'react'
+import {FormGroup, HoverTooltip, CheckboxField} from '@opentrons/components'
+
+import i18n from '../../localization'
+import {
+  StepInputField,
+  StepCheckboxRow,
+  PipetteField,
+  BlowoutLocationDropdown,
+  LabwareDropdown,
+  ChangeTipField,
+} from './formFields'
+
+import StepField from './StepFormField'
+import TipPositionInput from './TipPositionInput'
+import getTooltipForField from './getTooltipForField'
+import FlowRateField from './FlowRateField'
+import WellSelectionInput from './WellSelectionInput'
+import WellOrderInput from './WellOrderInput'
+import formStyles from '../forms.css'
+import styles from './StepEditForm.css'
+import FormSection from './FormSection'
+import type {FocusHandlers} from './index'
+import type {StepType, HydratedMoveLiquidFormDataLegacy} from '../../form-types'
+
+type MoveLiquidFormProps = {
+  focusHandlers: FocusHandlers,
+  stepType: StepType,
+  formData: HydratedMoveLiquidFormDataLegacy,
+}
+
+const MoveLiquidForm = (props: MoveLiquidFormProps) => {
+  const {focusHandlers, stepType} = props
+  const {path} = props.formData
+  return (
+    <React.Fragment>
+      <FormSection
+        sectionName={i18n.t('form.step_edit_form.section.aspirate')}
+        headerRow={(
+          <div className={formStyles.row_wrapper}>
+            <FormGroup label="Labware:" className={styles.labware_field}>
+              <LabwareDropdown name="aspirate_labware" {...focusHandlers} />
+            </FormGroup>
+            <WellSelectionInput
+              name="aspirate_wells"
+              labwareFieldName="aspirate_labware"
+              pipetteFieldName="pipette"
+              {...focusHandlers} />
+            <PipetteField name="pipette" stepType={stepType} {...focusHandlers} />
+            {path === 'multiAspirate' &&
+              <FormGroup label='Volume:' className={styles.volume_field}>
+                <StepInputField name="volume" units='μL' {...focusHandlers} />
+              </FormGroup>
+            }
+          </div>
+        )}>
+
+        <div className={formStyles.row_wrapper}>
+          <div className={styles.left_settings_column}>
+            <FormGroup label='TECHNIQUE'>
+              <StepCheckboxRow name="preWetTip" label="Pre-wet tip" />
+              <StepCheckboxRow name="aspirate_touchTip_checkbox" label="Touch tip">
+                <TipPositionInput fieldName="aspirate_touchTipMmFromBottom" />
+              </StepCheckboxRow>
+
+              <StepCheckboxRow disabled tooltipComponent={i18n.t('tooltip.not_in_beta')} name="aspirate_airGap_checkbox" label="Air Gap">
+                <StepInputField disabled name="aspirate_airGap_volume" units="μL" {...focusHandlers} />
+              </StepCheckboxRow>
+
+              <StepCheckboxRow name="aspirate_mix_checkbox" label='Mix'>
+                <StepInputField name="aspirate_mix_volume" units='μL' {...focusHandlers} />
+                <StepInputField name="aspirate_mix_times" units='Times' {...focusHandlers} />
+              </StepCheckboxRow>
+              {stepType === 'distribute' &&
+                <StepField
+                  name="aspirate_disposalVol_checkbox"
+                  render={({value, updateValue}) => (
+                    <React.Fragment>
+                      <div className={styles.field_row}>
+                        <CheckboxField
+                          label="Disposal Volume"
+                          value={!!value}
+                          onChange={(e: SyntheticInputEvent<*>) => updateValue(!value)} />
+                        {value
+                          ? <div>
+                            <StepInputField name="aspirate_disposalVol_volume" units="μL" {...focusHandlers} />
+                          </div>
+                          : null}
+                      </div>
+                      {value
+                        ? <div className={styles.field_row}>
+                          <div className={styles.sub_select_label}>Blowout</div>
+                          <BlowoutLocationDropdown
+                            name="blowout_location"
+                            className={styles.full_width}
+                            includeSourceWell
+                            {...focusHandlers} />
+                        </div>
+                        : null
+                      }
+                    </React.Fragment>
+                  )} />
+              }
+            </FormGroup>
+          </div>
+          <div className={styles.middle_settings_column}>
+            <ChangeTipField stepType={stepType} name="changeTip" />
+            <TipPositionInput fieldName="aspirate_mmFromBottom" />
+          </div>
+          <div className={styles.right_settings_column}>
+            {stepType !== 'distribute' && <WellOrderInput prefix="aspirate" />}
+            <FlowRateField
+              name='aspirate_flowRate'
+              pipetteFieldName='pipette'
+              flowRateType='aspirate' />
+          </div>
+        </div>
+      </FormSection>
+
+      <FormSection
+        sectionName={i18n.t('form.step_edit_form.section.dispense')}
+        headerRow={(
+          <div className={formStyles.row_wrapper}>
+            <FormGroup label='Labware:' className={styles.labware_field}>
+              <LabwareDropdown name="dispense_labware" {...focusHandlers} />
+            </FormGroup>
+            <WellSelectionInput
+              name="dispense_wells"
+              labwareFieldName="dispense_labware"
+              pipetteFieldName="pipette"
+              {...focusHandlers} />
+            {(stepType === 'transfer' || stepType === 'distribute') && (
+              // TODO: Ian 2018-08-30 make volume field not be a one-off
+              <HoverTooltip
+                tooltipComponent={getTooltipForField(stepType, 'volume')}
+                placement='top-start'>
+                {(hoverTooltipHandlers) =>
+                  <FormGroup
+                    label='Volume:'
+                    className={styles.volume_field}
+                    hoverTooltipHandlers={hoverTooltipHandlers}>
+                    <StepInputField name="volume" units="μL" {...focusHandlers} />
+                  </FormGroup>
+                }
+              </HoverTooltip>
+            )}
+          </div>
+        )}>
+
+        <div className={formStyles.row_wrapper}>
+          <div className={styles.left_settings_column}>
+            <FormGroup label='TECHNIQUE'>
+              <StepCheckboxRow name="dispense_touchTip_checkbox" label="Touch tip">
+                <TipPositionInput fieldName="dispense_touchTipMmFromBottom" />
+              </StepCheckboxRow>
+              <StepCheckboxRow name="dispense_mix_checkbox" label='Mix'>
+                <StepInputField name="dispense_mix_volume" units="μL" {...focusHandlers} />
+                <StepInputField name="dispense_mix_times" units="Times" {...focusHandlers} />
+              </StepCheckboxRow>
+              {stepType !== 'distribute' &&
+                <StepCheckboxRow name='blowout_checkbox' label='Blow out'>
+                  <BlowoutLocationDropdown
+                    name="blowout_location"
+                    className={styles.full_width}
+                    includeSourceWell={stepType === 'transfer'}
+                    includeDestWell
+                    {...focusHandlers} />
+                </StepCheckboxRow>
+              }
+            </FormGroup>
+          </div>
+          <div className={styles.middle_settings_column}>
+            <TipPositionInput fieldName="dispense_mmFromBottom" />
+          </div>
+          <div className={styles.right_settings_column}>
+            {stepType !== 'consolidate' && <WellOrderInput prefix="dispense" />}
+            <FlowRateField
+              name='dispense_flowRate'
+              pipetteFieldName='pipette'
+              flowRateType='dispense'
+            />
+          </div>
+        </div>
+      </FormSection>
+    </React.Fragment>
+  )
+}
+
+export default MoveLiquidForm

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -17,17 +17,18 @@ import styles from './StepEditForm.css'
 import FormAlerts from './FormAlerts'
 import MixForm from './MixForm'
 import TransferLikeForm from './TransferLikeForm'
+import MoveLiquidForm from './MoveLiquidForm'
 import PauseForm from './PauseForm'
 import ConfirmDeleteModal from './ConfirmDeleteModal'
 import ButtonRow from './ButtonRow'
 
-type StepForm = typeof MixForm | typeof PauseForm | typeof TransferLikeForm
-const STEP_FORM_MAP: {[StepType]: StepForm} = {
+const STEP_FORM_MAP: {[StepType]: *} = {
   mix: MixForm,
   pause: PauseForm,
   transfer: TransferLikeForm,
   consolidate: TransferLikeForm,
   distribute: TransferLikeForm,
+  moveLiquid: MoveLiquidForm,
 }
 
 export type FocusHandlers = {
@@ -141,7 +142,8 @@ class StepEditForm extends React.Component<Props, StepEditFormState> {
         <FormAlerts focusedField={this.state.focusedField} dirtyFields={this.state.dirtyFields} />
         <div className={cx(formStyles.form, styles[formData.stepType])}>
           <FormComponent
-            stepType={formData.stepType}
+            stepType={formData.stepType} // TODO: Ian 2019-01-17 deprecate passing this during #2916, it's in formData
+            formData={formData}
             focusHandlers={{
               focusedField: this.state.focusedField,
               dirtyFields: this.state.dirtyFields,

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -1,5 +1,6 @@
 // @flow
 import type {IconName} from '@opentrons/components'
+import type {LabwareDefinition, PipetteNameSpecs} from '@opentrons/shared-data'
 import type {ChangeTipOptions} from './step-generation'
 
 export type StepIdType = string
@@ -15,19 +16,19 @@ export type StepFieldName =
   | 'aspirate_mix_checkbox'
   | 'aspirate_mix_times'
   | 'aspirate_mix_volume'
-  | 'aspirate_preWetTip'
-  | 'aspirate_touchTip'
+  | 'aspirate_touchTip_checkbox'
   | 'aspirate_touchTipMmFromBottom'
   | 'aspirate_mmFromBottom'
   | 'aspirate_wellOrder_first'
   | 'aspirate_wellOrder_second'
   | 'aspirate_wells'
+  | 'aspirate_wells_grouped'
+  | 'blowout_checkbox'
+  | 'blowout_location'
   | 'changeTip'
-  | 'dispense_blowout_checkbox'
-  | 'dispense_blowout_location'
   | 'dispense_flowRate'
   | 'dispense_labware'
-  | 'dispense_touchTip'
+  | 'dispense_touchTip_checkbox'
   | 'dispense_mix_checkbox'
   | 'dispense_mix_times'
   | 'dispense_mix_volume'
@@ -38,25 +39,33 @@ export type StepFieldName =
   | 'dispense_wells'
   | 'labware'
   | 'labwareLocationUpdate'
+  | 'mix_mmFromBottom'
+  | 'mix_touchTipMmFromBottom'
+  | 'path'
   | 'pauseForAmountOfTime'
   | 'pauseHour'
   | 'pauseMessage'
   | 'pauseMinute'
   | 'pauseSecond'
+  | 'preWetTip'
   | 'pipette'
   | 'stepDetails'
   | 'stepName'
   | 'times'
-  | 'mix_mmFromBottom'
-  | 'mix_touchTipMmFromBottom'
   | 'touchTip'
   | 'volume'
   | 'wells'
   // deck setup form fields
   | 'labwareLocationUpdate'
   | 'pipetteLocationUpdate'
+  // TODO: Ian 2019-01-17 below are DEPRECATED remove in #2916 (make sure to account for this in migration #2917)
+  | 'aspirate_preWetTip'
+  | 'aspirate_touchTip'
+  | 'dispense_blowout_checkbox'
+  | 'dispense_blowout_location'
+  | 'dispense_touchTip'
 
-// TODO Ian 2018-01-16 factor out to some constants.js ?
+// TODO Ian 2019-01-16 factor out to some constants.js ? See #2926
 export const stepIconsByType: {[string]: IconName} = {
   'transfer': 'ot-transfer',
   'distribute': 'ot-distribute',
@@ -64,6 +73,7 @@ export const stepIconsByType: {[string]: IconName} = {
   'mix': 'ot-mix',
   'pause': 'pause',
   'manualIntervention': 'pause', // TODO Ian 2018-12-13 pause icon for this is a placeholder
+  'moveLiquid': 'ot-transfer',
 }
 
 export type StepType = $Keys<typeof stepIconsByType>
@@ -160,6 +170,65 @@ export type BlankForm = {
   ...AnnotationFields,
   stepType: StepType,
   id: StepIdType,
+}
+
+// TODO: Ian 2019-01-15 these HydratedLabware / HydratedPipette types are a placeholder. Should be used in form hydration.
+type HydratedLabware = {id: string, type: string, def: LabwareDefinition}
+type HydratedPipette = {id: string, model: string, spec: PipetteNameSpecs}
+// TODO: this is the type we are aiming for
+
+export type HydratedMoveLiquidFormData = {
+  id: string,
+  stepType: 'moveLiquid',
+  stepName: string,
+  description: ?string,
+
+  fields: {
+    pipette: HydratedPipette,
+    volume: number,
+    path: PathOption,
+    changeTip: ChangeTipOptions,
+    aspirate_wells_grouped: ?boolean,
+    preWetTip: ?boolean,
+
+    aspirate_labware: HydratedLabware,
+    aspirate_wells: Array<string>,
+    aspirate_wellOrder_first: WellOrderOption,
+    aspirate_wellOrder_second: WellOrderOption,
+    aspirate_flowRate: ?number,
+    aspirate_mmFromBottom: ?number,
+    aspirate_touchTip_checkbox: ?boolean,
+    aspirate_touchTip_mmFromBottom: ?number,
+    aspirate_mix_checkbox: ?boolean,
+    aspirate_mix_volume: ?number,
+    aspirate_mix_times: ?number,
+
+    dispense_labware: HydratedLabware,
+    dispense_wells: Array<string>,
+    dispense_wellOrder_first: WellOrderOption,
+    dispense_wellOrder_second: WellOrderOption,
+    dispense_flowRate: ?number,
+    dispense_mmFromBottom: ?number,
+    dispense_touchTip_checkbox: ?boolean,
+    dispense_touchTip_mmFromBottom: ?number,
+    dispense_mix_checkbox: ?boolean,
+    dispense_mix_volume: ?number,
+    dispense_mix_times: ?number,
+
+    disposalVolume_checkbox: ?boolean,
+    disposalVolume_volume: ?number,
+    blowout_checkbox: ?boolean,
+    blowout_location: ?string, // labwareId or 'SOURCE_WELL' or 'DEST_WELL'
+  },
+}
+
+// TODO: Ian 2019-01-17 Moving away from this and towards nesting all form fields
+// inside `fields` key, but deprecating transfer/consolidate/distribute is a pre-req
+export type HydratedMoveLiquidFormDataLegacy = {
+  ...AnnotationFields,
+  id: string,
+  stepType: 'moveLiquid',
+  ...$Exact<$PropertyType<HydratedMoveLiquidFormData, 'fields'>>,
 }
 
 // fields used in TipPositionInput

--- a/protocol-designer/src/localization/en/button.json
+++ b/protocol-designer/src/localization/en/button.json
@@ -15,5 +15,10 @@
   "restored": "restored",
   "save": "save",
   "swap": "swap",
-  "yes": "yes"
+  "yes": "yes",
+
+  "stepType": {
+    "transfer": "OLD transfer",
+    "moveLiquid": "transfer"
+  }
 }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -7,7 +7,8 @@
     "distribute": "One well to multiple wells",
     "consolidate": "Multiple wells to one well",
     "mix": "Mix content of wells",
-    "pause": "OT-2 will pause before proceeding"
+    "pause": "OT-2 will pause before proceeding",
+    "moveLiquid": "Move liquid! TODO IMMEDIATELY real copy here"
   },
 
   "step_fields": {

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -7,6 +7,7 @@ import reduce from 'lodash/reduce'
 import some from 'lodash/some'
 import {createSelector} from 'reselect'
 import {getPipetteNameSpecs, getLabware} from '@opentrons/shared-data'
+import i18n from '../../localization'
 import {INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
 import {
   generateNewForm,
@@ -339,7 +340,7 @@ export const getAllSteps: Selector<{[stepId: StepIdType]: StepItemData}> = creat
         return {
           ...steps[id],
           formData: savedForm,
-          title: savedForm ? savedForm.stepName : step.stepType,
+          title: savedForm ? savedForm.stepName : i18n.t(`button.stepType.${step.stepType}`),
           description: savedForm ? savedForm.stepDetails : null,
         }
       }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -146,7 +146,7 @@ export type CommandCreatorData =
   | PauseFormData
   | TransferFormData
 
-// TODO: Ian 2018-01-07 with multiple deck setup steps, we might want to
+// TODO: Ian 2019-01-07 with multiple deck setup steps, we might want to
 // separate 'entities' from 'locations' for pipettes/labware, and remove
 // 'entities' (pipette name / labware type) from the timeline to protect it
 // from being different btw frames

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -27,7 +27,8 @@ export const addStep = (payload: {stepType: StepType}) =>
       },
     })
     const deckHasLiquid = labwareIngredsSelectors.getDeckHasLiquid(state)
-    const stepNeedsLiquid = ['transfer', 'distribute', 'consolidate', 'mix'].includes(payload.stepType)
+    // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
+    const stepNeedsLiquid = ['transfer', 'distribute', 'consolidate', 'mix', 'moveLiquid'].includes(payload.stepType)
     if (stepNeedsLiquid && !deckHasLiquid) {
       dispatch(tutorialActions.addHint('add_liquids_and_labware'))
     }

--- a/protocol-designer/src/steplist/formLevel/generateNewForm.js
+++ b/protocol-designer/src/steplist/formLevel/generateNewForm.js
@@ -1,5 +1,5 @@
 // @flow
-import startCase from 'lodash/startCase'
+import i18n from '../../localization'
 import getDefaultsForStepType from './getDefaultsForStepType'
 import type {
   StepType,
@@ -19,7 +19,7 @@ export default function generateNewForm (args: NewFormArgs): FormData {
   const baseForm: BlankForm = {
     id: stepId,
     stepType: stepType,
-    stepName: startCase(stepType),
+    stepName: i18n.t(`button.stepType.${stepType}`),
     stepDetails: '',
   }
 

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -9,6 +9,7 @@ import {
 } from '../../constants'
 import type {StepType, StepFieldName} from '../../form-types'
 
+// TODO: Ian 2019-01-17 move this somewhere more central - see #2926
 export default function getDefaultsForStepType (stepType: StepType): {[StepFieldName]: any} {
   switch (stepType) {
     case 'transfer':
@@ -73,6 +74,32 @@ export default function getDefaultsForStepType (stepType: StepType): {[StepField
         'dispense_wells': [],
         'pipette': null,
         'volume': undefined,
+      }
+    case 'moveLiquid':
+      return {
+        pipette: null,
+        volume: undefined, // TODO IMMEDIATELY why not null?
+        changeTip: DEFAULT_CHANGE_TIP_OPTION,
+        path: 'single', // TODO IMMEDIATELY move out to DEFAULT_PATH_OPTION
+        aspirate_wells_grouped: false,
+
+        aspirate_labware: null,
+        aspirate_wells: [],
+        aspirate_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        aspirate_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        aspirate_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        aspirate_touchTip_checkbox: false,
+
+        dispense_labware: null,
+        dispense_wells: [],
+        dispense_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        dispense_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        dispense_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+        dispense_touchTip_checkbox: false,
+
+        blowout_checkbox: false,
+        blowout_location: FIXED_TRASH_ID,
+        preWetTip: false,
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -19,7 +19,7 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const orderFirst = hydratedFormData.aspirate_wellOrder_first
   const orderSecond = hydratedFormData.aspirate_wellOrder_second
 
-  // TODO: Ian 2018-01-15 use getOrderedWells instead of orderWells to avoid this duplicated code
+  // TODO: Ian 2019-01-15 use getOrderedWells instead of orderWells to avoid this duplicated code
   const labwareDef = labware && getLabware(labware.type)
   if (labwareDef) {
     const allWellsOrdered = orderWells(labwareDef.ordering, orderFirst, orderSecond)

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -6,15 +6,11 @@ import {
 } from '../../../step-generation/utils'
 import {getOrderedWells} from '../../utils'
 
-import type {
-  PathOption,
-  WellOrderOption,
-} from '../../../form-types'
+import type {HydratedMoveLiquidFormData} from '../../../form-types'
 import type {
   ConsolidateFormData,
   DistributeFormData,
   TransferFormData,
-  ChangeTipOptions,
   MixArgs,
 } from '../../../step-generation'
 
@@ -39,54 +35,6 @@ export function getMixData (
 }
 
 type MoveLiquidStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
-
-// TODO: Ian 2018-01-15 once this function gets connected, move these
-// 3 type defs somewhere else and import them.
-type HydratedLabware = {id: string, type: string}
-type HydratedPipette = {id: string, model: string}
-type HydratedMoveLiquidFormData = {
-  stepType: 'moveLiquid',
-  stepName: string,
-  description: ?string,
-
-  fields: {
-    pipette: HydratedPipette,
-    volume: number,
-    path: PathOption,
-    changeTip: ChangeTipOptions,
-    aspirate_wells_grouped: ?boolean,
-    preWetTip: ?boolean,
-
-    aspirate_labware: HydratedLabware,
-    aspirate_wells: Array<string>,
-    aspirate_wellOrder_first: WellOrderOption,
-    aspirate_wellOrder_second: WellOrderOption,
-    aspirate_flowRate: ?number,
-    aspirate_mmFromBottom: ?number,
-    aspirate_touchTip_checkbox: ?boolean,
-    aspirate_touchTip_mmFromBottom: ?number,
-    aspirate_mix_checkbox: ?boolean,
-    aspirate_mix_volume: ?number,
-    aspirate_mix_times: ?number,
-
-    dispense_labware: HydratedLabware,
-    dispense_wells: Array<string>,
-    dispense_wellOrder_first: WellOrderOption,
-    dispense_wellOrder_second: WellOrderOption,
-    dispense_flowRate: ?number,
-    dispense_mmFromBottom: ?number,
-    dispense_touchTip_checkbox: ?boolean,
-    dispense_touchTip_mmFromBottom: ?number,
-    dispense_mix_checkbox: ?boolean,
-    dispense_mix_volume: ?number,
-    dispense_mix_times: ?number,
-
-    disposalVolume_checkbox: ?boolean,
-    disposalVolume_volume: ?number,
-    blowout_checkbox: ?boolean,
-    blowout_location: ?string, // labwareId or 'SOURCE_WELL' or 'DEST_WELL'
-  },
-}
 
 const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): MoveLiquidStepArgs => {
   assert(


### PR DESCRIPTION
## overview

First step toward #2909 - making a PR so we can parallelize the rest of this work.

This PR just lets you make a `moveLiquid` step. It won't validate or save yet. The form is pretty much a copy of TransferLikeForm, except it has the fields available to it (notably `path`) and its form fields are the updated ones from the spreadsheet where the field name differs from the previous ones.

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- [ ] Code review
- [ ] Can make a step without it crashing