### PR TITLE
feat(app): Configure analytics to send Python and JSON protocol info

### DIFF
--- a/app/src/analytics/README.md
+++ b/app/src/analytics/README.md
@@ -25,7 +25,11 @@ const store = createStore(reducer, middleware)
 For a given Redux action, add a `case` to the `action.type` switch in [`app/src/analytics/make-event.js`](./make-event.js). `makeEvent` will be passed the full state and the action. Any new case should return either `null` or an object `{name: string, properties: {}}`
 
 ```js
-export default function makeEvent (state: State, action: Action): ?Event {
+export default function makeEvent (
+  action: Action,
+  nextState: State,
+  prevState: State
+): null | AnalyticsEvent | Promise<AnalyticsEvent | null> {
   switch (action.type) {
     // ...
     case 'some-action-type':
@@ -37,3 +41,32 @@ export default function makeEvent (state: State, action: Action): ?Event {
   return null
 }
 ```
+
+## events
+
+| name                     | redux action                   | payload                                 |
+| ------------------------ | ------------------------------ | --------------------------------------- |
+| `robotConnect`           | `robot:CONNECT_RESPONSE`       | success, method, error                  |
+| `protocolUploadRequest`  | `protocol:UPLOAD`              | protocol data                           |
+| `protocolUploadResponse` | `robot:SESSION_RESPONSE/ERROR` | protocol data, success, error           |
+| `runStart`               | `robot:RUN`                    | protocol data                           |
+| `runFinish`              | `robot:RUN_RESPONSE`           | protocol data, success, error, run time |
+| `runPause`               | `robot:PAUSE`                  | protocol, run time data                 |
+| `runResume`              | `robot:RESUME`                 | protocol, run time data                 |
+| `runCancel`              | `robot:CANCEL`                 | protocol, run time data                 |
+
+### hashing
+
+Some payload fields are [hashed][] for user anonymity while preserving our ability to disambiguate unique values. Fields are hashed with the SHA-256 algorithm and are noted as such in this section.
+
+### protocol data sent
+
+- Protocol type (Python or JSON)
+- Application Name (e.g. "Opentrons Protocol Designer")
+- Application Version
+- Protocol `metadata.source`
+- Protocol `metadata.protocolName`
+- Protocol `metadata.author` (hashed for anonymity)
+- Protocol `metadata.protocolText` (hashed for anonymity)
+
+[hashed]: https://en.wikipedia.org/wiki/Hash_function

--- a/app/src/analytics/hash.js
+++ b/app/src/analytics/hash.js
@@ -1,0 +1,22 @@
+// @flow
+// hash strings for an amount of anonymity
+// note: values will be _hashed_, not _enctrypted_; hashed values should not be
+// considered secure nor should they ever be released publicly
+const ALGORITHM = 'SHA-256'
+
+export default function hash (source: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(source)
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+  return global.crypto.subtle
+    .digest(ALGORITHM, data)
+    .then((digest: ArrayBuffer) => arrayBufferToHex(digest))
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#Converting_a_digest_to_a_hex_string
+function arrayBufferToHex (source: ArrayBuffer): string {
+  const bytes = new Uint8Array(source)
+
+  return [...bytes].map(b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -1,0 +1,52 @@
+// @flow
+import {createSelector} from 'reselect'
+
+import {
+  getProtocolType,
+  getProtocolCreatorApp,
+  getProtocolName,
+  getProtocolSource,
+  getProtocolAuthor,
+  getProtocolContents,
+} from '../protocol'
+
+import hash from './hash'
+
+import type {OutputSelector} from 'reselect'
+import type {State} from '../types'
+import type {ProtocolAnalyticsData} from './types'
+
+type ProtocolDataSelector = OutputSelector<State, void, ProtocolAnalyticsData>
+
+const _getUnhashedProtocolAnalyticsData: ProtocolDataSelector = createSelector(
+  getProtocolType,
+  getProtocolCreatorApp,
+  getProtocolName,
+  getProtocolSource,
+  getProtocolAuthor,
+  getProtocolContents,
+  (type, app, name, source, author, contents) => ({
+    protocolType: type || '',
+    protocolAppName: app.name || '',
+    protocolAppVersion: app.version || '',
+    protocolName: name || '',
+    protocolSource: source || '',
+    protocolAuthor: author || '',
+    protocolText: contents || '',
+  })
+)
+
+// TODO(mc, 2019-01-22): it would be good to have some way of caching these
+// hashes; reselect isn't geared towards async, so perhaps RxJS / observables?
+export function getProtocolAnalyticsData (
+  state: State
+): Promise<ProtocolAnalyticsData> {
+  const data = _getUnhashedProtocolAnalyticsData(state)
+  const hashTasks = [hash(data.protocolAuthor), hash(data.protocolText)]
+
+  return Promise.all(hashTasks).then(result => {
+    const [protocolAuthor, protocolText] = result
+
+    return {...data, protocolAuthor, protocolText}
+  })
+}

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -1,0 +1,16 @@
+// @flow
+
+export type ProtocolAnalyticsData = {
+  protocolType: string,
+  protocolAppName: string,
+  protocolAppVersion: string,
+  protocolSource: string,
+  protocolName: string,
+  protocolAuthor: string,
+  protocolText: string,
+}
+
+export type AnalyticsEvent = {|
+  name: string,
+  properties: {},
+|}

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -8,12 +8,18 @@ import {
   fileToProtocolFile,
   parseProtocolData,
   fileIsJson,
-  filenameToType,
+  fileToType,
+  filenameToMimeType,
 } from './protocol-data'
 
 import type {OutputSelector} from 'reselect'
 import type {State, Action, ThunkAction} from '../types'
-import type {ProtocolState, ProtocolFile, ProtocolData} from './types'
+import type {
+  ProtocolState,
+  ProtocolFile,
+  ProtocolData,
+  ProtocolType,
+} from './types'
 
 export * from './types'
 
@@ -73,7 +79,7 @@ export function protocolReducer (
       const {name, metadata, protocolText: contents} = action.payload
       const file =
         !state.file || name !== state.file.name
-          ? {name, type: filenameToType(name), lastModified: null}
+          ? {name, type: filenameToMimeType(name), lastModified: null}
           : state.file
       const data =
         !state.data || contents !== state.contents
@@ -94,12 +100,17 @@ type StringGetter = (?ProtocolData) => ?string
 type NumberGetter = (?ProtocolData) => ?number
 type StringSelector = OutputSelector<State, void, ?string>
 type NumberSelector = OutputSelector<State, void, ?number>
+type ProtocolTypeSelector = OutputSelector<State, void, ProtocolType | null>
+type CreatorAppSelector = OutputSelector<State,
+  void,
+  {name: ?string, version: ?string}>
 
 const getName: StringGetter = getter('metadata.protocol-name')
 const getAuthor: StringGetter = getter('metadata.author')
 const getDesc: StringGetter = getter('metadata.description')
 const getCreated: NumberGetter = getter('metadata.created')
 const getLastModified: NumberGetter = getter('metadata.last-modified')
+const getSource: NumberGetter = getter('metadata.source')
 const getAppName: StringGetter = getter('designer-application.application-name')
 const getAppVersion: StringGetter = getter(
   'designer-application.application-version'
@@ -136,11 +147,26 @@ export const getProtocolDescription: StringSelector = createSelector(
   data => getDesc(data)
 )
 
+export const getProtocolSource: StringSelector = createSelector(
+  getProtocolData,
+  data => getSource(data)
+)
+
 export const getProtocolLastUpdated: NumberSelector = createSelector(
   getProtocolFile,
   getProtocolData,
   (file, data) =>
     getLastModified(data) || getCreated(data) || (file && file.lastModified)
+)
+
+export const getProtocolType: ProtocolTypeSelector = createSelector(
+  getProtocolFile,
+  fileToType
+)
+
+export const getProtocolCreatorApp: CreatorAppSelector = createSelector(
+  getProtocolData,
+  data => ({name: getAppName(data), version: getAppVersion(data)})
 )
 
 const METHOD_OT_API = 'Opentrons API'

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -4,7 +4,7 @@
 // import {getter} from '@thi.ng/paths'
 import createLogger from '../logger'
 
-import type {ProtocolFile, ProtocolData} from './types'
+import type {ProtocolFile, ProtocolData, ProtocolType} from './types'
 
 const log = createLogger(__filename)
 
@@ -25,7 +25,7 @@ export function parseProtocolData (
   contents: string,
   // optional Python protocol metadata
   metadata: ?$PropertyType<ProtocolData, 'metadata'>
-): ?ProtocolData {
+): ProtocolData | null {
   if (fileIsJson(file)) {
     try {
       return JSON.parse(contents)
@@ -41,9 +41,15 @@ export function parseProtocolData (
   return null
 }
 
-export function filenameToType (name: string): ?string {
+export function filenameToMimeType (name: string): string | null {
   if (name.endsWith('.json')) return MIME_TYPE_JSON
   if (name.endsWith('.py')) return MIME_TYPE_PYTHON
+  return null
+}
+
+export function fileToType (file: ProtocolFile): ProtocolType | null {
+  if (file.type === MIME_TYPE_JSON) return 'json'
+  if (file.type === MIME_TYPE_PYTHON) return 'python'
   return null
 }
 

--- a/app/src/protocol/types.js
+++ b/app/src/protocol/types.js
@@ -29,3 +29,5 @@ export type ProtocolState = {
   contents: ?string,
   data: ?ProtocolData,
 }
+
+export type ProtocolType = 'json' | 'python'

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -153,7 +153,8 @@ export default function client (dispatch) {
       .create(name, contents)
       .then(apiSession => {
         remote.session_manager.session = apiSession
-        handleApiSession(apiSession)
+        // state change will trigger a session notification, which will
+        // dispatch a successful sessionResponse
       })
       .catch(error => dispatch(actions.sessionResponse(error)))
   }


### PR DESCRIPTION
## overview

This PR wires up protocol data to protocol upload and run control events. Closes #2615 and closes #2618; see those tickets for acceptance criteria.

## changelog

- feat(app): Configure analytics to send Python and JSON protocol info 

## review requests

Required event data in tickets above.

- In dev mode, check console log for "Trackable event"
- In prod mode, check that the branch build goes all the way to mixpanel 
