### PR TITLE
fix(api): Correctly format acceleration from settings as dict

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import json
 import logging
 import os
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple, Union
 
 from opentrons.config import get_config_index, feature_flags as fflags
 
@@ -42,7 +42,7 @@ Y_CURRENT_LOW = 0.3
 Y_CURRENT_HIGH = 1.25
 
 
-HIGH_CURRENT = {
+HIGH_CURRENT: Dict[str, float] = {
     'X': X_CURRENT_HIGH,
     'Y': Y_CURRENT_HIGH,
     'Z': MOUNT_CURRENT_HIGH,
@@ -51,7 +51,7 @@ HIGH_CURRENT = {
     'C': PLUNGER_CURRENT_HIGH
 }
 
-LOW_CURRENT = {
+LOW_CURRENT: Dict[str, float] = {
     'X': X_CURRENT_LOW,
     'Y': Y_CURRENT_LOW,
     'Z': MOUNT_CURRENT_LOW,
@@ -60,7 +60,7 @@ LOW_CURRENT = {
     'C': PLUNGER_CURRENT_LOW
 }
 
-DEFAULT_CURRENT = {
+DEFAULT_CURRENT: Dict[str, float] = {
     'X': HIGH_CURRENT['X'],
     'Y': HIGH_CURRENT['Y'],
     'Z': HIGH_CURRENT['Z'],
@@ -76,7 +76,7 @@ A_MAX_SPEED = 125
 B_MAX_SPEED = 40
 C_MAX_SPEED = 40
 
-DEFAULT_MAX_SPEEDS = {
+DEFAULT_MAX_SPEEDS: Dict[str, float] = {
     'X': X_MAX_SPEED,
     'Y': Y_MAX_SPEED,
     'Z': Z_MAX_SPEED,
@@ -88,7 +88,7 @@ DEFAULT_MAX_SPEEDS = {
 DEFAULT_CURRENT_STRING = ' '.join(
     ['{}{}'.format(key, value) for key, value in DEFAULT_CURRENT.items()])
 
-DEFAULT_DECK_CALIBRATION = [
+DEFAULT_DECK_CALIBRATION: List[List[float]] = [
     [1.00, 0.00, 0.00,  0.00],
     [0.00, 1.00, 0.00,  0.00],
     [0.00, 0.00, 1.00,  0.00],
@@ -101,7 +101,7 @@ A_ACCELERATION = 1500
 B_ACCELERATION = 200
 C_ACCELERATION = 200
 
-DEFAULT_ACCELERATION = {
+DEFAULT_ACCELERATION: Dict[str, float] = {
     'X': X_ACCELERATION,
     'Y': Y_ACCELERATION,
     'Z': Z_ACCELERATION,
@@ -232,13 +232,20 @@ def _build_tip_probe(tip_probe_settings: dict) -> tip_probe_config:
     )
 
 
+def _build_acceleration(from_conf: Union[Dict, str, None]) -> Dict[str, float]:
+    if not from_conf or isinstance(from_conf, str):
+        return DEFAULT_ACCELERATION
+    else:
+        return from_conf
+
+
 def _build_config(deck_cal: List[List[float]],
                   robot_settings: Dict[str, Any]) -> robot_config:
     cfg = robot_config(
         name=robot_settings.get('name', 'Ada Lovelace'),
         version=int(robot_settings.get('version', ROBOT_CONFIG_VERSION)),
         steps_per_mm=robot_settings.get('steps_per_mm', DEFAULT_STEPS_PER_MM),
-        acceleration=robot_settings.get('acceleration', DEFAULT_ACCELERATION),
+        acceleration=_build_acceleration(robot_settings.get('acceleration')),
         gantry_calibration=deck_cal or DEFAULT_DECK_CALIBRATION,
         instrument_offset=build_fallback_instrument_offset(robot_settings),
         tip_length=robot_settings.get('tip_length', DEFAULT_TIP_LENGTH_DICT),

--- a/api/tests/opentrons/hardware_control/test_robots_config.py
+++ b/api/tests/opentrons/hardware_control/test_robots_config.py
@@ -14,7 +14,7 @@ dummy_settings = {
     'name': 'Andy',
     'version': 42,
     'steps_per_mm': 'steps_rulz',
-    'acceleration': 'acceleration_rulz',
+    'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
     'instrument_offset': {
         'left': {
             'single': [1, 2, 3],


### PR DESCRIPTION
The system was previously expecting acceleration config to be a dict, but on robots that already had saved robotSettings.json it would be a string. Make sure to coerce it into the right type.