### PR TITLE
PD HOTFIX RELEASE: resolve bug where PD failed to save correct labware slots

### DIFF
--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -2,7 +2,7 @@
 import {connect} from 'react-redux'
 import assert from 'assert'
 import LabwareDetailsCard from './LabwareDetailsCard'
-import {selectors as labwareIngredSelectors} from '../../../labware-ingred/reducers'
+import {selectors as stepFormSelectors} from '../../../step-forms'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import type {ElementProps} from 'react'
 import type {Dispatch} from 'redux'
@@ -17,7 +17,7 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const labwareData = labwareIngredSelectors.getSelectedLabware(state)
+  const labwareData = stepFormSelectors.getSelectedLabware(state)
   assert(labwareData, 'Expected labware data to exist in connected labware details card')
 
   const props = (labwareData)

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -1,12 +1,11 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import type {Dispatch} from 'redux'
 import LabwareSelectionModal from './LabwareSelectionModal'
 import {closeLabwareSelector, createContainer} from '../../labware-ingred/actions'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepFormSelectors} from '../../step-forms'
-import type {BaseState} from '../../types'
+import type {BaseState, ThunkDispatch} from '../../types'
 
 type Props = React.ElementProps<typeof LabwareSelectionModal>
 
@@ -22,7 +21,7 @@ function mapStateToProps (state: BaseState): SP {
   }
 }
 
-function mergeProps (stateProps: SP, dispatchProps: {dispatch: Dispatch<*>}): Props {
+function mergeProps (stateProps: SP, dispatchProps: {dispatch: ThunkDispatch<*>}): Props {
   const dispatch = dispatchProps.dispatch
 
   return {

--- a/protocol-designer/src/components/LiquidPlacementForm/index.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/index.js
@@ -6,7 +6,7 @@ import {
   removeWellsContents,
   setWellContents,
 } from '../../labware-ingred/actions'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 import * as wellContentsSelectors from '../../top-selectors/well-contents'
 import wellSelectionSelectors from '../../well-selection/selectors'
 import {deselectAllWells} from '../../well-selection/actions'

--- a/protocol-designer/src/components/LiquidPlacementModal.js
+++ b/protocol-designer/src/components/LiquidPlacementModal.js
@@ -13,7 +13,8 @@ import LiquidPlacementForm from '../components/LiquidPlacementForm'
 import SingleLabwareWrapper from '../components/SingleLabware'
 import WellSelectionInstructions from './WellSelectionInstructions'
 
-import {selectors} from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../step-forms'
 import * as wellContentsSelectors from '../top-selectors/well-contents'
 import wellSelectionSelectors from '../well-selection/selectors'
 import {
@@ -75,7 +76,7 @@ class LiquidPlacementModal extends React.Component<Props, State> {
 const mapStateToProps = (state: BaseState): SP => {
   const containerId = selectors.getSelectedLabwareId(state)
   const selectedWells = wellSelectionSelectors.getSelectedWells(state)
-  if (containerId === null) {
+  if (containerId == null) {
     console.error('LiquidPlacementModal: No labware is selected, and no labwareId was given to LiquidPlacementModal')
     return {
       selectedWells: {},
@@ -85,7 +86,7 @@ const mapStateToProps = (state: BaseState): SP => {
     }
   }
 
-  const labware = selectors.getLabwareById(state)[containerId]
+  const labware = stepFormSelectors.getLabwareById(state)[containerId]
   let wellContents: ContentsByWell = {}
 
   // selection for deck setup: shows initial state of liquids

--- a/protocol-designer/src/components/LiquidsPage/index.js
+++ b/protocol-designer/src/components/LiquidsPage/index.js
@@ -6,7 +6,7 @@ import assert from 'assert'
 import LiquidEditForm from './LiquidEditForm'
 import LiquidsPageInfo from './LiquidsPageInfo'
 import * as labwareIngredActions from '../../labware-ingred/actions'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 
 import type {LiquidGroup} from '../../labware-ingred/types'
 import type {BaseState, ThunkDispatch} from '../../types'

--- a/protocol-designer/src/components/LiquidsSidebar/index.js
+++ b/protocol-designer/src/components/LiquidsSidebar/index.js
@@ -10,7 +10,7 @@ import {
 import {PDTitledList} from '../lists'
 import listButtonStyles from '../listButtons.css'
 
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 import type {OrderedLiquids} from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
 import type {BaseState} from '../../types'

--- a/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
+++ b/protocol-designer/src/components/StepEditForm/TipPositionInput/index.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {HoverTooltip, FormGroup, InputField} from '@opentrons/components'
 import { getLabware } from '@opentrons/shared-data'
-import {selectors as labwareIngredsSelectors} from '../../../labware-ingred/reducers'
 import i18n from '../../../localization'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 import stepFormStyles from '../StepEditForm.css'
@@ -99,7 +98,7 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
 
   let wellHeightMM = null
   if (formData && formData[labwareFieldName]) {
-    const labwareById = labwareIngredsSelectors.getLabwareById(state)
+    const labwareById = stepFormSelectors.getLabwareById(state)
     const labware = labwareById[formData[labwareFieldName]]
     const labwareDef = labware && labware.type && getLabware(labware.type)
     if (labwareDef) {

--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
@@ -11,7 +11,7 @@ import type {PipetteNameSpecs} from '@opentrons/shared-data'
 import type {BaseState, ThunkDispatch} from '../../../types'
 
 import * as wellContentsSelectors from '../../../top-selectors/well-contents'
-import {selectors} from '../../../labware-ingred/reducers'
+import {selectors} from '../../../labware-ingred/selectors'
 import type {Wells, ContentsByWell} from '../../../labware-ingred/types'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 import {selectors as stepsSelectors} from '../../../ui/steps'
@@ -114,7 +114,7 @@ class WellSelectionModal extends React.Component<Props, State> {
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {pipetteId, labwareId} = ownProps
 
-  const allLabware = selectors.getLabwareById(state)
+  const allLabware = stepFormSelectors.getLabwareById(state)
   const labware = labwareId && allLabware && allLabware[labwareId]
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
 

--- a/protocol-designer/src/components/StepEditForm/formFields.js
+++ b/protocol-designer/src/components/StepEditForm/formFields.js
@@ -11,7 +11,6 @@ import {
 } from '@opentrons/components'
 import i18n from '../../localization'
 import {selectors as stepFormSelectors} from '../../step-forms'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
 import {hydrateField} from '../../steplist/fieldLevel'
 import type {StepFieldName} from '../../steplist/fieldLevel'
 import {
@@ -131,7 +130,7 @@ type BlowoutLocationDropdownOP = {
 } & FocusHandlers
 type BlowoutLocationDropdownSP = {options: Options}
 const BlowoutLocationDropdownSTP = (state: BaseState, ownProps: BlowoutLocationDropdownOP): BlowoutLocationDropdownSP => {
-  let options = labwareIngredSelectors.disposalLabwareOptions(state)
+  let options = stepFormSelectors.getDisposalLabwareOptions(state)
   if (ownProps.includeDestWell) {
     options = [
       ...options,
@@ -168,7 +167,7 @@ export const BlowoutLocationDropdown = connect(BlowoutLocationDropdownSTP)((prop
 type LabwareDropdownOP = {name: StepFieldName, className?: string} & FocusHandlers
 type LabwareDropdownSP = {labwareOptions: Options}
 const LabwareDropdownSTP = (state: BaseState): LabwareDropdownSP => ({
-  labwareOptions: labwareIngredSelectors.labwareOptions(state),
+  labwareOptions: stepFormSelectors.getLabwareOptions(state),
 })
 export const LabwareDropdown = connect(LabwareDropdownSTP)((props: LabwareDropdownOP & LabwareDropdownSP) => {
   const {labwareOptions, name, className, focusedField, dirtyFields, onFieldBlur, onFieldFocus} = props

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.js
@@ -17,7 +17,8 @@ import type {BaseState, ThunkDispatch} from '../../types'
 import i18n from '../../localization'
 
 import * as wellContentsSelectors from '../../top-selectors/well-contents'
-import {selectors} from '../../labware-ingred/reducers'
+import {selectors} from '../../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../../step-forms'
 import * as labwareIngredsActions from '../../labware-ingred/actions'
 import type {ContentsByWell} from '../../labware-ingred/types'
 import type {WellIngredientNames} from '../../steplist/types'
@@ -91,7 +92,7 @@ class BrowseLabwareModal extends React.Component<Props> {
 
 function mapStateToProps (state: BaseState): SP {
   const labwareId = selectors.getDrillDownLabwareId(state)
-  const allLabware = selectors.getLabwareById(state)
+  const allLabware = stepFormSelectors.getLabwareById(state)
   const labware = labwareId && allLabware ? allLabware[labwareId] : null
   const allWellContents = wellContentsSelectors.getLastValidWellContents(state)
   const wellContents = labwareId && allWellContents ? allWellContents[labwareId] : {}

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -1,7 +1,6 @@
 // @flow
 import type {ElementProps} from 'react'
 import {connect} from 'react-redux'
-import type {Dispatch} from 'redux'
 import mapValues from 'lodash/mapValues'
 import uniq from 'lodash/uniq'
 import {INITIAL_DECK_SETUP_STEP_ID} from '../../../constants'
@@ -13,7 +12,7 @@ import * as labwareIngredActions from '../../../labware-ingred/actions'
 import {actions as stepFormActions} from '../../../step-forms'
 import {actions as steplistActions} from '../../../steplist'
 import FilePipettesModal from '../FilePipettesModal'
-import type {BaseState} from '../../../types'
+import type {BaseState, ThunkDispatch} from '../../../types'
 import type {PipetteOnDeck} from '../../../step-forms'
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(FilePipettesModal)
@@ -40,7 +39,7 @@ function mapStateToProps (state: BaseState): SP {
   }
 }
 
-function mapDispatchToProps (dispatch: Dispatch<*>): DP {
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
   return {
     onCancel: () => dispatch(navigationActions.toggleNewProtocolModal(false)),
     _createNewProtocol: ({newProtocolFields, pipettes}) => {

--- a/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
+++ b/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
@@ -6,7 +6,7 @@ import {PDListItem} from '../lists'
 import {START_TERMINAL_TITLE} from '../../constants'
 import type {BaseState} from '../../types'
 import {START_TERMINAL_ITEM_ID} from '../../steplist'
-import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
+import {selectors as stepFormSelectors} from '../../step-forms'
 
 type Props = {
   showHint: boolean,
@@ -29,7 +29,7 @@ function StartingDeckStateTerminalItem (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   // since default-trash counts as 1, labwareCount <= 1 means "user did not add labware"
-  const noLabware = Object.keys(labwareIngredsSelectors.getLabwareById(state)).length <= 1
+  const noLabware = Object.keys(stepFormSelectors.getLabwareById(state)).length <= 1
   return {showHint: noLabware}
 }
 

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -42,6 +42,9 @@ export function getAllWellsForLabware (labwareType: string): Array<string> {
   return Object.keys(labware.wells)
 }
 
+// Labware types that are allowed to act as disposal labware
+export const DISPOSAL_LABWARE_TYPES = ['trash-box', 'fixed-trash']
+
 export const FIXED_TRASH_ID: 'trashId' = 'trashId'
 
 export const START_TERMINAL_TITLE = 'STARTING DECK STATE'

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -16,9 +16,10 @@ import LabwareSelectionModal from '../components/LabwareSelectionModal'
 import StepEditForm from '../components/StepEditForm'
 import TimelineAlerts from '../components/alerts/TimelineAlerts'
 
-import {selectors} from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/selectors'
 import * as labwareIngredActions from '../labware-ingred/actions'
 import {START_TERMINAL_ITEM_ID, type TerminalItemId} from '../steplist'
+import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors} from '../ui/steps'
 
 import type {BaseState, ThunkDispatch} from '../types'
@@ -40,7 +41,7 @@ type Props = {
 
 const mapStateToProps = (state: BaseState): StateProps => ({
   selectedTerminalItemId: stepsSelectors.getSelectedTerminalItemId(state),
-  ingredSelectionMode: Boolean(selectors.getSelectedLabware(state)),
+  ingredSelectionMode: Boolean(stepFormSelectors.getSelectedLabware(state)),
   drilledDown: !!selectors.getDrillDownLabwareId(state),
 })
 

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors} from '../navigation'
+import {selectors as stepFormSelectors} from '../step-forms'
 
 import ConnectedStepList from './ConnectedStepList'
 import IngredientsList from './IngredientsList'
@@ -36,7 +36,7 @@ function Sidebar (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   const page = selectors.getCurrentPage(state)
-  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedLabware(state)
+  const liquidPlacementMode = Boolean(stepFormSelectors.getSelectedLabware(state))
 
   return {
     page,

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -10,7 +10,7 @@ import {selectors as dismissSelectors} from '../dismiss'
 import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import {selectors as fileDataSelectors} from '../file-data'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
 import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 why is importing StepItem from index.js not working?
 
 type Props = React.ElementProps<typeof StepItem>
@@ -62,7 +62,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // user is not hovering on substep.
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
-    getLabware: (labwareId: ?string) => labwareId ? labwareIngredSelectors.getLabwareById(state)[labwareId] : null,
+    getLabware: (labwareId: ?string) => labwareId ? stepFormSelectors.getLabwareById(state)[labwareId] : null,
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -7,7 +7,8 @@ import {TitleBar, Icon, humanizeLabwareType, type IconName} from '@opentrons/com
 import styles from './TitleBar.css'
 import i18n from '../localization'
 import {START_TERMINAL_TITLE, END_TERMINAL_TITLE} from '../constants'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import {END_TERMINAL_ITEM_ID, START_TERMINAL_ITEM_ID} from '../steplist'
 import {selectors as fileDataSelectors} from '../file-data'
@@ -42,15 +43,16 @@ function TitleWithIcon (props: TitleWithIconProps) {
 }
 
 function mapStateToProps (state: BaseState): SP {
+  const selectedLabware = stepFormSelectors.getSelectedLabware(state)
   const _page = selectors.getCurrentPage(state)
   const fileName = fileDataSelectors.protocolName(state)
   const selectedStep = stepsSelectors.getSelectedStep(state)
   const selectedTerminalId = stepsSelectors.getSelectedTerminalItemId(state)
-  const labware = labwareIngredSelectors.getSelectedLabware(state)
-  const labwareNames = labwareIngredSelectors.getLabwareNicknamesById(state)
+  const labware = selectedLabware
+  const labwareNames = stepFormSelectors.getLabwareNicknamesById(state)
   const labwareNickname = labware && labware.id && labwareNames[labware.id]
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
-  const liquidPlacementMode = !!labwareIngredSelectors.getSelectedLabware(state)
+  const liquidPlacementMode = Boolean(selectedLabware)
   const wellSelectionLabwareKey = stepsSelectors.getWellSelectionLabwareKey(state)
 
   switch (_page) {
@@ -86,7 +88,7 @@ function mapStateToProps (state: BaseState): SP {
         subtitle = END_TERMINAL_TITLE
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
-          const drilledDownLabware = labwareIngredSelectors.getLabwareById(state)[drilledDownLabwareId]
+          const drilledDownLabware = stepFormSelectors.getLabwareById(state)[drilledDownLabwareId]
           title = drilledDownLabware && drilledDownLabware.nickname
           subtitle = drilledDownLabware && humanizeLabwareType(drilledDownLabware.type)
         }

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -6,7 +6,7 @@ import noop from 'lodash/noop'
 
 import HighlightableLabware from '../components/HighlightableLabware'
 
-import {selectors} from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/selectors'
 import {
   START_TERMINAL_ITEM_ID,
   END_TERMINAL_ITEM_ID,
@@ -33,7 +33,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const selectedContainerId = selectors.getSelectedLabwareId(state)
   const containerId = ownProps.containerId || selectedContainerId
 
-  if (containerId === null) {
+  if (containerId == null) {
     console.error('HighlightableLabware: No container is selected, and no containerId was given to Connected HighlightableLabware')
     return {
       containerId: '',
@@ -42,7 +42,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     }
   }
 
-  const labware = selectors.getLabwareById(state)[containerId]
+  const labware = stepFormSelectors.getLabwareById(state)[containerId]
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
   const wellSelectionModeForLabware = selectedContainerId === containerId
   let wellContents: ContentsByWell = {}

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {selectors} from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../step-forms'
 import * as wellSelectionSelectors from '../top-selectors/well-contents'
 import {removeWellsContents} from '../labware-ingred/actions'
 import type {Dispatch} from 'redux'
@@ -18,7 +19,7 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const container = selectors.getSelectedLabware(state)
+  const container = stepFormSelectors.getSelectedLabware(state)
   const _labwareId = container && container.id
 
   return {

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -3,7 +3,8 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 
 import {getLabware, getIsTiprack} from '@opentrons/shared-data'
-import {selectors} from '../labware-ingred/reducers'
+import {selectors} from '../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../step-forms'
 import {
   openIngredientSelector,
   deleteContainer,
@@ -47,14 +48,14 @@ type SP = $Diff<Props, {...DP, ...MP}>
 
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {slot} = ownProps
-  const container = selectors.containersBySlot(state)[ownProps.slot]
-  const labwareNames = selectors.getLabwareNicknamesById(state)
+  const container = stepFormSelectors.getContainersBySlot(state)[ownProps.slot]
+  const labwareNames = stepFormSelectors.getLabwareNicknamesById(state)
 
   const containerType = container && container.type
   const containerId = container && container.id
   const containerName = containerId && labwareNames[containerId]
 
-  const selectedContainer = selectors.getSelectedLabware(state)
+  const selectedContainer = stepFormSelectors.getSelectedLabware(state)
   const isSelectedSlot = !!(selectedContainer && selectedContainer.slot === slot)
 
   const selectedTerminalItem = stepsSelectors.getSelectedTerminalItemId(state)

--- a/protocol-designer/src/containers/SelectorDebugger.js
+++ b/protocol-designer/src/containers/SelectorDebugger.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import mapValues from 'lodash/mapValues'
 
-import {selectors as labwareIngred} from '../labware-ingred/reducers'
+import {selectors as labwareIngred} from '../labware-ingred/selectors'
 import {selectors as fileDataSelectors} from '../file-data'
 import {selectors as stepSelectors} from '../ui/steps'
 import type {BaseState} from '../types'

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -11,7 +11,7 @@ import type {BaseState, Selector} from '../../types'
 import {getAllWellsForLabware} from '../../constants'
 import * as StepGeneration from '../../step-generation'
 import {selectors as stepFormSelectors} from '../../step-forms'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 import type {StepIdType} from '../../form-types'
 import type {LabwareOnDeck, PipetteOnDeck} from '../../step-forms'
 
@@ -24,7 +24,7 @@ const all96Tips = reduce(
 // NOTE this just adds missing well keys to the labware-ingred 'deck setup' liquid state
 export const getLabwareLiquidState: Selector<StepGeneration.LabwareLiquidState> = createSelector(
   labwareIngredSelectors.getLiquidsByLabwareId,
-  labwareIngredSelectors.getLabwareById,
+  stepFormSelectors.getLabwareById,
   (ingredLocations, allLabware) => {
     const allLabwareIds: Array<string> = Object.keys(allLabware)
     return allLabwareIds.reduce((

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -5,7 +5,7 @@ import {getPropertyAllPipettes} from '@opentrons/shared-data'
 import {getFileMetadata} from './fileFields'
 import {getInitialRobotState, getRobotStateTimeline} from './commands'
 import {selectors as dismissSelectors} from '../../dismiss'
-import {selectors as ingredSelectors} from '../../labware-ingred/reducers'
+import {selectors as ingredSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepFormSelectors} from '../../step-forms'
 import {
   DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
@@ -43,7 +43,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   stepFormSelectors.getSavedStepForms,
   stepFormSelectors.getOrderedStepIds,
   stepFormSelectors.getPipetteEntities,
-  ingredSelectors.getLabwareNicknamesById,
+  stepFormSelectors.getLabwareNicknamesById,
   (
     fileMetadata,
     initialRobotState,

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.js
@@ -1,4 +1,5 @@
-import {selectors} from '../reducers'
+// @flow
+import {selectors} from '../selectors'
 
 // FIXTURES
 

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -2,11 +2,10 @@
 import {createAction} from 'redux-actions'
 import type {Dispatch} from 'redux'
 
-import {selectors} from './reducers'
-import {uuid} from '../utils'
-import type {GetState} from '../types'
-import type {IngredInputs} from './types'
+import {selectors} from '../selectors'
 import type {DeckSlot} from '@opentrons/components'
+import type {GetState} from '../../types'
+import type {IngredInputs} from '../types'
 
 type IngredInputsExact = $Exact<IngredInputs>
 
@@ -48,26 +47,19 @@ export const drillUpFromLabware = createAction(
 
 // ==== Create/delete/modify labware =====
 
-type CreateContainerArgs = {
+export type CreateContainerArgs = {|
   slot?: DeckSlot,
   containerType: string,
-}
+|}
 
 export type CreateContainerAction = {
   type: 'CREATE_CONTAINER',
   payload: {
-    ...$Exact<CreateContainerArgs>,
+    ...CreateContainerArgs,
     id: string,
+    disambiguationNumber: number,
   },
 }
-
-export const createContainer = createAction(
-  'CREATE_CONTAINER',
-  (args: CreateContainerArgs) => ({
-    id: `${uuid()}:${args.containerType}`,
-    ...args,
-  })
-)
 
 export type DeleteContainerAction = {
   type: 'DELETE_CONTAINER',
@@ -107,6 +99,8 @@ export type SwapSlotContentsAction = {
   },
 }
 
+// TODO: Ian 2019-01-24 later, this should work on stepId or a range of steps.
+// We could follow the pattern of SubstituteStepFormPipettesAction.
 export const swapSlotContents = (sourceSlot: DeckSlot, destSlot: DeckSlot): SwapSlotContentsAction => ({
   type: 'SWAP_SLOT_CONTENTS',
   payload: {sourceSlot, destSlot},
@@ -117,15 +111,9 @@ export type DuplicateLabwareAction = {
   payload: {
     templateLabwareId: string,
     duplicateLabwareId: string,
+    duplicateDisambiguationNumber: number,
   },
 }
-export const duplicateLabware = (templateLabwareId: string): DuplicateLabwareAction => ({
-  type: 'DUPLICATE_LABWARE',
-  payload: {
-    templateLabwareId,
-    duplicateLabwareId: uuid(),
-  },
-})
 
 export type RemoveWellsContents = {
   type: 'REMOVE_WELLS_CONTENTS',

--- a/protocol-designer/src/labware-ingred/actions/index.js
+++ b/protocol-designer/src/labware-ingred/actions/index.js
@@ -1,0 +1,3 @@
+// @flow
+export * from './actions'
+export * from './thunks'

--- a/protocol-designer/src/labware-ingred/actions/thunks.js
+++ b/protocol-designer/src/labware-ingred/actions/thunks.js
@@ -1,0 +1,57 @@
+// @flow
+import assert from 'assert'
+import {uuid} from '../../utils'
+import {selectors as labwareIngredsSelectors} from '../selectors'
+import {selectors as stepFormSelectors} from '../../step-forms'
+import type {
+  CreateContainerArgs,
+  CreateContainerAction,
+  DuplicateLabwareAction,
+} from './actions'
+import type {BaseState, GetState, ThunkDispatch} from '../../types'
+
+function getNextDisambiguationNumber (state: BaseState, newLabwareType: string): number {
+  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+  const labwareNamesMap = labwareIngredsSelectors.getLabwareNameInfo(state)
+  const allIds = Object.keys(labwareEntities)
+  const sameTypeLabware = allIds.filter(labwareId =>
+    labwareEntities[labwareId] &&
+    labwareEntities[labwareId].type === newLabwareType)
+  const disambigNumbers = sameTypeLabware.map(labwareId =>
+    (labwareNamesMap[labwareId] &&
+    labwareNamesMap[labwareId].disambiguationNumber) || 0)
+
+  return disambigNumbers.length > 0
+    ? Math.max(...disambigNumbers) + 1
+    : 1
+}
+
+export const createContainer = (args: CreateContainerArgs) =>
+  (dispatch: ThunkDispatch<CreateContainerAction>, getState: GetState) => {
+    const disambiguationNumber = getNextDisambiguationNumber(getState(), args.containerType)
+
+    dispatch({
+      type: 'CREATE_CONTAINER',
+      payload: {
+        ...args,
+        id: `${uuid()}:${args.containerType}`,
+        disambiguationNumber,
+      },
+    })
+  }
+
+export const duplicateLabware = (templateLabwareId: string) =>
+  (dispatch: ThunkDispatch<DuplicateLabwareAction>, getState: GetState) => {
+    const state = getState()
+    const templateLabwareEntity = stepFormSelectors.getLabwareEntities(state)[templateLabwareId]
+    assert(templateLabwareEntity, `no entity for labware ${templateLabwareId}, cannot run duplicateLabware thunk`)
+    if (!templateLabwareEntity) return
+    dispatch({
+      type: 'DUPLICATE_LABWARE',
+      payload: {
+        duplicateDisambiguationNumber: getNextDisambiguationNumber(state, templateLabwareEntity.type),
+        templateLabwareId,
+        duplicateLabwareId: uuid(),
+      },
+    })
+  }

--- a/protocol-designer/src/labware-ingred/selectors.js
+++ b/protocol-designer/src/labware-ingred/selectors.js
@@ -1,0 +1,151 @@
+// @flow
+import {createSelector} from 'reselect'
+import forEach from 'lodash/forEach'
+import mapValues from 'lodash/mapValues'
+import max from 'lodash/max'
+import reduce from 'lodash/reduce'
+
+import type {
+  RootState,
+  DrillDownLabwareId,
+  SelectedContainerId,
+  SelectedLiquidGroupState,
+} from './reducers'
+import type {
+  AllIngredGroupFields,
+  IngredInputs,
+  LiquidGroup,
+  OrderedLiquids,
+} from './types'
+import type {BaseState, Options} from './../types'
+
+type Selector<T> = (RootSlice) => T
+type RootSlice = {labwareIngred: RootState}
+
+const rootSelector = (state: RootSlice): RootState => state.labwareIngred
+
+const getLabwareNameInfo = createSelector(
+  rootSelector,
+  s => s.containers
+)
+
+const getLiquidGroupsById = (state: RootSlice) => rootSelector(state).ingredients
+const getLiquidsByLabwareId = (state: RootSlice) => rootSelector(state).ingredLocations
+
+const getNextLiquidGroupId: Selector<string> = createSelector(
+  getLiquidGroupsById,
+  (ingredGroups) => ((max(Object.keys(ingredGroups).map(id => parseInt(id))) + 1) || 0).toString()
+)
+
+const getLiquidNamesById: Selector<{[ingredId: string]: string}> = createSelector(
+  getLiquidGroupsById,
+  ingredGroups => mapValues(ingredGroups, (ingred: LiquidGroup) => ingred.name)
+)
+
+const getLiquidSelectionOptions: Selector<Options> = createSelector(
+  getLiquidGroupsById,
+  (liquidGroupsById) => {
+    return Object.keys(liquidGroupsById).map(id => ({
+      // NOTE: if these fallbacks are used, it's a bug
+      name: (liquidGroupsById[id])
+        ? liquidGroupsById[id].name || `(Unnamed Liquid: ${String(id)})`
+        : 'Missing Liquid',
+      value: id,
+    }))
+  }
+)
+
+// false or selected slot to add labware to, eg 'A2'
+const selectedAddLabwareSlot = (state: BaseState) => rootSelector(state).modeLabwareSelection
+
+const getSavedLabware = (state: BaseState) => rootSelector(state).savedLabware
+
+const getSelectedLabwareId: Selector<SelectedContainerId> = createSelector(
+  rootSelector,
+  rootState => rootState.selectedContainerId
+)
+
+const getSelectedLiquidGroupState: Selector<SelectedLiquidGroupState> = createSelector(
+  rootSelector,
+  rootState => rootState.selectedLiquidGroup
+)
+
+const getDrillDownLabwareId: Selector<DrillDownLabwareId> = createSelector(
+  rootSelector,
+  rootState => rootState.drillDownLabwareId
+)
+
+// TODO Ian 2018-07-06 consolidate into types.js
+type IngredGroupFields = {
+  [ingredGroupId: string]: {
+    groupId: string,
+    ...$Exact<IngredInputs>,
+  },
+}
+const allIngredientGroupFields: Selector<AllIngredGroupFields> = createSelector(
+  getLiquidGroupsById,
+  (ingreds) => reduce(
+    ingreds,
+    (acc: IngredGroupFields, ingredGroup: IngredGroupFields, ingredGroupId: string) => ({
+      ...acc,
+      [ingredGroupId]: ingredGroup,
+    }), {})
+)
+
+const allIngredientNamesIds: BaseState => OrderedLiquids = createSelector(
+  getLiquidGroupsById,
+  ingreds => Object.keys(ingreds).map(ingredId =>
+    ({ingredientId: ingredId, name: ingreds[ingredId].name}))
+)
+
+const getLabwareSelectionMode: Selector<boolean> = createSelector(
+  rootSelector,
+  (rootState) => {
+    return rootState.modeLabwareSelection !== false
+  }
+)
+
+const getLiquidGroupsOnDeck: Selector<Array<string>> = createSelector(
+  getLiquidsByLabwareId,
+  (ingredLocationsByLabware) => {
+    let liquidGroups: Set<string> = new Set()
+    forEach(ingredLocationsByLabware, (byWell: $Values<typeof ingredLocationsByLabware>) =>
+      forEach(byWell, (groupContents: $Values<typeof byWell>) => {
+        forEach(groupContents, (contents: $Values<typeof groupContents>, groupId: $Keys<typeof groupContents>) => {
+          if (contents.volume > 0) {
+            liquidGroups.add(groupId)
+          }
+        })
+      })
+    )
+    return [...liquidGroups]
+  }
+)
+
+const getDeckHasLiquid: Selector<boolean> = createSelector(
+  getLiquidGroupsOnDeck,
+  (liquidGroups) => liquidGroups.length > 0
+)
+
+// TODO: prune selectors
+export const selectors = {
+  rootSelector,
+
+  getLiquidGroupsById,
+  getLiquidsByLabwareId,
+  getLiquidNamesById,
+  getLabwareSelectionMode,
+  getLabwareNameInfo,
+  getLiquidSelectionOptions,
+  getLiquidGroupsOnDeck,
+  getNextLiquidGroupId,
+  getSavedLabware,
+  getSelectedLabwareId,
+  getSelectedLiquidGroupState,
+  getDrillDownLabwareId,
+
+  allIngredientGroupFields,
+  allIngredientNamesIds,
+  selectedAddLabwareSlot,
+  getDeckHasLiquid,
+}

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -4,12 +4,16 @@ import type {LabwareData, LocationLiquidState} from '../step-generation'
 
 //  ===== LABWARE ===========
 
-// NOTE: In labware-ingred, labware objects have a `disambiguationNumber` field
-// so that UI can render "96 Flat (2)"
+// TODO: Ian 2019-01-24 deprecate this type, use LabwareEntity or DisplayLabware instead
 export type Labware = {|
   ...LabwareData,
   id: string,
   nickname?: string,
+  disambiguationNumber: number,
+|}
+
+export type DisplayLabware = {|
+  nickname: ?string,
   disambiguationNumber: number,
 |}
 

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -10,9 +10,10 @@ import reduce from 'lodash/reduce'
 
 import {sortedSlotnames, type DeckSlot} from '@opentrons/components'
 import {
-  getIdsInRange,
-  pipetteModelToName,
   addSpecsToPipetteInvariantProps,
+  getIdsInRange,
+  getLabwareIdInSlot,
+  pipetteModelToName,
 } from '../utils'
 import {
   INITIAL_DECK_SETUP_STEP_ID,
@@ -30,6 +31,7 @@ import type {
   CreateContainerAction,
   DeleteContainerAction,
   DuplicateLabwareAction,
+  SwapSlotContentsAction,
 } from '../../labware-ingred/actions'
 import type {FormData, StepIdType} from '../../form-types'
 import type {FileLabware, FilePipette} from '../../file-types'
@@ -143,6 +145,7 @@ type SavedStepFormsActions =
   | DuplicateStepAction
   | ChangeSavedStepFormAction
   | DuplicateLabwareAction
+  | SwapSlotContentsAction
 
 export const savedStepForms = (
   rootState: RootState,
@@ -189,6 +192,28 @@ export const savedStepForms = (
           },
         },
       }
+    }
+    case 'SWAP_SLOT_CONTENTS': {
+      const {sourceSlot, destSlot} = action.payload
+      return mapValues(savedStepForms, (savedForm: FormData) => {
+        if (savedForm.stepType === 'manualIntervention') {
+          // swap labware slots from all manualIntervention steps
+          const sourceLabwareId = getLabwareIdInSlot(
+            savedForm.labwareLocationUpdate, sourceSlot)
+          const destLabwareId = getLabwareIdInSlot(
+            savedForm.labwareLocationUpdate, destSlot)
+
+          return {
+            ...savedForm,
+            labwareLocationUpdate: {
+              ...savedForm.labwareLocationUpdate,
+              ...(sourceLabwareId ? {[sourceLabwareId]: destSlot} : {}),
+              ...(destLabwareId ? {[destLabwareId]: sourceSlot} : {}),
+            },
+          }
+        }
+        return savedForm
+      })
     }
     case 'DELETE_CONTAINER': {
       const labwareIdToDelete = action.payload.containerId

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -6,8 +6,8 @@ import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import some from 'lodash/some'
 import {createSelector} from 'reselect'
-import {getPipetteNameSpecs, getLabware} from '@opentrons/shared-data'
-import {INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
+import {getIsTiprack, getPipetteNameSpecs, getLabware} from '@opentrons/shared-data'
+import {DISPOSAL_LABWARE_TYPES, INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
 import {
   generateNewForm,
   getFormWarnings,
@@ -19,6 +19,7 @@ import {
   getFieldErrors,
 } from '../../steplist/fieldLevel'
 import {addSpecsToPipetteInvariantProps} from '../utils'
+import {labwareToDisplayName} from '../../labware-ingred/utils'
 
 import type {ElementProps} from 'react'
 import type {
@@ -48,8 +49,9 @@ import type {
   FormPipettesByMount,
 } from '../types'
 import type {RootState} from '../reducers'
-import type {BaseState, Selector} from '../../types'
+import type {BaseState, Selector, Options} from '../../types'
 import type {FormData, StepIdType, StepType} from '../../form-types'
+import type {Labware, LabwareTypeById} from '../../labware-ingred/types'
 
 // TODO: BC 2018-10-30 after separation of getStepArgs and getStepErrors
 // , move the NO_SAVED_FORM_ERROR into a separate wrapping selector
@@ -89,6 +91,106 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
       }),
     }
   }
+)
+
+// TODO: Ian 2019-01-24 this selector needs info from the labware atoms's
+// `containers` reducer as well as stepForms,
+// so it probably doesn't belong in step-forms/...
+// Also, the `Labware` type should probably be deprecated later on
+// $FlowFixMe I think it's a flow bug?
+export const getLabwareById: Selector<{[labwareId: string]: ?Labware}> = createSelector(
+  getInitialDeckSetup,
+  state => state.labwareIngred.containers, // HACK to avoid circular dependency
+  (initialDeckSetup, displayLabwareById) => mapValues(
+    initialDeckSetup.labware,
+    (l: LabwareOnDeck, id: string): ?Labware => {
+      const displayLabware = displayLabwareById[id]
+      return displayLabware
+        ? {
+          nickname: displayLabware.nickname,
+          disambiguationNumber: displayLabware.disambiguationNumber,
+          id,
+          type: l.type,
+          slot: l.slot,
+        }
+        : null
+    })
+)
+
+export const getLabwareNicknamesById: Selector<{[labwareId: string]: string}> = createSelector(
+  getLabwareById,
+  (labwareById) => mapValues(
+    labwareById,
+    labwareToDisplayName,
+  )
+)
+
+/** Returns options for disposal (e.g. fixed trash and trash box) */
+export const getDisposalLabwareOptions: Selector<Options> = createSelector(
+  getLabwareById,
+  getLabwareNicknamesById,
+  (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
+    if (!labware.type || !DISPOSAL_LABWARE_TYPES.includes(labware.type)) {
+      return acc
+    }
+    return [
+      ...acc,
+      {
+        name: names[labwareId],
+        value: labwareId,
+      },
+    ]
+  }, [])
+)
+
+/** Returns options for dropdowns, excluding tiprack labware */
+export const getLabwareOptions: Selector<Options> = createSelector(
+  getLabwareById,
+  getLabwareNicknamesById,
+  (labwareById, names) => reduce(labwareById, (acc: Options, labware: Labware, labwareId): Options => {
+    const isTiprack = getIsTiprack(labware.type)
+    if (!labware.type || isTiprack) {
+      return acc
+    }
+    return [
+      ...acc,
+      {
+        name: names[labwareId],
+        value: labwareId,
+      },
+    ]
+  }, [])
+)
+
+export const getLabwareTypes: Selector<LabwareTypeById> = createSelector(
+  getLabwareById,
+  (labwareById) => mapValues(
+    labwareById,
+    (labware: Labware) => labware.type
+  )
+)
+
+// TODO: Ian 2019-01-24 this selector needs info from the labware atoms's
+// `containers` reducer as well as stepForms,
+// so it probably doesn't belong in step-forms/...
+export const getSelectedLabware: Selector<?Labware> = createSelector(
+  state => state.labwareIngred.selectedContainerId, // HACK to avoid circular dependency
+  getLabwareById,
+  (selectedLabwareId, labware) =>
+    (selectedLabwareId && labware[selectedLabwareId]) || null
+)
+
+type ContainersBySlot = {[DeckSlot]: {...Labware, containerId: string}}
+export const getContainersBySlot: Selector<ContainersBySlot> = createSelector(
+  getLabwareById,
+  containers => reduce(
+    containers,
+    (acc: ContainersBySlot, containerObj: Labware, containerId: string) => ({
+      ...acc,
+      // NOTE: containerId added in so you still have a reference
+      [containerObj.slot]: {...containerObj, containerId},
+    }),
+    {})
 )
 
 export const getPermittedTipracks: Selector<Array<string>> = createSelector(

--- a/protocol-designer/src/step-forms/utils.js
+++ b/protocol-designer/src/step-forms/utils.js
@@ -2,6 +2,7 @@
 import assert from 'assert'
 import reduce from 'lodash/reduce'
 import {getPipetteNameSpecs} from '@opentrons/shared-data'
+import type {DeckSlot} from '@opentrons/components'
 import type {PipetteInvariantState} from './reducers'
 import type {PipetteEntity, PipetteEntities} from './types'
 
@@ -18,6 +19,17 @@ export function getIdsInRange<T: string | number> (orderedIds: Array<T>, startId
   assert(endIdx !== -1, `end step "${String(endId)}" does not exist in orderedStepIds`)
   assert(endIdx >= startIdx, `expected end index to be greater than or equal to start index, got "${startIdx}", "${endIdx}"`)
   return orderedIds.slice(startIdx, endIdx + 1)
+}
+
+export function getLabwareIdInSlot (
+  labwareIdToSlot: {[labwareId: string]: DeckSlot},
+  slot: DeckSlot
+): ?string {
+  const labwareIdsForSourceSlot = Object.entries(labwareIdToSlot)
+    .filter(([id, labwareSlot]) => labwareSlot === slot)
+    .map(([id, labwareSlot]) => id)
+  assert(labwareIdsForSourceSlot.length < 2, `multiple labware in slot ${slot}, expected none or one`)
+  return labwareIdsForSourceSlot[0]
 }
 
 // helper to add the 'spec' key to pipette entities safely

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -1,6 +1,6 @@
 // @flow
 import {uuid} from '../../utils'
-import {selectors as labwareIngredsSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredsSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepsSelectors, actions as stepsActions} from '../../ui/steps'
 import {actions as tutorialActions} from '../../tutorial'
 import type {StepType, StepIdType} from '../../form-types'

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -1,7 +1,6 @@
 // @flow
 import {createSelector} from 'reselect'
 
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as fileDataSelectors} from '../file-data'
 
@@ -17,7 +16,7 @@ type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
   stepFormSelectors.getInitialDeckSetup,
-  labwareIngredSelectors.getLabwareTypes,
+  stepFormSelectors.getLabwareTypes,
   stepFormSelectors.getOrderedStepIds,
   fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.getInitialRobotState,

--- a/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
@@ -4,7 +4,8 @@ import {createSelector} from 'reselect'
 import reduce from 'lodash/reduce'
 
 import {getLabware, type WellDefinition} from '@opentrons/shared-data'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as stepFormSelectors} from '../../step-forms'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
 import wellSelectionSelectors from '../../well-selection/selectors'
 
 import type {Selector} from '../../types'
@@ -55,9 +56,9 @@ const _getWellContents = (
 }
 
 const getWellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
-  labwareIngredSelectors.getLabwareById,
+  stepFormSelectors.getLabwareById,
   labwareIngredSelectors.getLiquidsByLabwareId,
-  labwareIngredSelectors.getSelectedLabware,
+  stepFormSelectors.getSelectedLabware,
   wellSelectionSelectors.getSelectedWells,
   wellSelectionSelectors.getHighlightedWells,
   (labwareById, liquidsByLabware, selectedLabware, selectedWells, highlightedWells) => {

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -9,7 +9,8 @@ import omitBy from 'lodash/omitBy'
 
 import * as StepGeneration from '../../step-generation'
 import {selectors as fileDataSelectors} from '../../file-data'
-import {selectors as labwareIngredSelectors} from '../../labware-ingred/reducers'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
+import {selectors as stepFormSelectors} from '../../step-forms'
 import wellSelectionSelectors from '../../well-selection/selectors'
 import {getAllWellsForLabware, getMaxVolumes} from '../../constants'
 
@@ -111,7 +112,7 @@ export const getLastValidWellContents: Selector<WellContentsByLabware> = createS
 
 export const getSelectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
-  labwareIngredSelectors.getSelectedLabware,
+  stepFormSelectors.getSelectedLabware,
   (selectedWells, selectedContainer) => {
     const selectedWellNames = Object.keys(selectedWells)
     const selectedContainerType = selectedContainer && selectedContainer.type

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -4,7 +4,6 @@ import selectors from './selectors'
 import {changeFormInput} from '../steplist/actions'
 
 import {selectors as stepFormSelectors} from '../step-forms'
-import {selectors as labwareIngredSelectors} from '../labware-ingred/reducers'
 
 import type {ThunkDispatch, GetState} from '../types'
 import type {StepFieldName} from '../form-types'
@@ -71,7 +70,7 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
       stepFormSelectors.getPipetteEntities(state)[payload.pipetteId]
     ) || null
 
-    const labware = labwareIngredSelectors.getLabwareById(state)
+    const labware = stepFormSelectors.getLabwareById(state)
     // TODO type this action, make an underline fn action creator
 
     dispatch({


### PR DESCRIPTION
Includes fix in #2966, no other changes. This is our first hotfix release (I think?)

PD should now save labware to the correct slots, even after moving labware.

QA Requests:
- Make sure everything touching labware still works, especially around moving/duplicating/swapping labware, naming labware, seeing labware names (including in protocols loaded from a file), & disambiguation number behavior.