### PR TITLE
refactor(protocol-designer): cleanup handful of small form-related cruft

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -70,11 +70,12 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
     alerts: dismissSelectors.getFormWarningsForSelectedStep(state),
   })
 
-  const errors = stepFormSelectors.getFormLevelErrors(state)
+  const unsavedFormErrors = stepFormSelectors.getUnsavedFormErrors(state)
+  const formLevelErrors = (unsavedFormErrors && unsavedFormErrors.form) || []
   const filteredErrors = getVisibleAlerts({
     focusedField,
     dirtyFields,
-    alerts: errors,
+    alerts: formLevelErrors,
   })
 
   return {

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -41,7 +41,8 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const hoveredStep = stepsSelectors.getHoveredStepId(state)
   const selected = stepsSelectors.getSelectedStepId(state) === stepId
   const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
-  const formAndFieldErrors = stepFormSelectors.getFormAndFieldErrorsByStepId(state)[stepId]
+  const argsAndErrorsByStepId = stepFormSelectors.getArgsAndErrorsByStepId(state)
+  const formAndFieldErrors = argsAndErrorsByStepId[stepId] && argsAndErrorsByStepId[stepId].errors
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
   const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
     ? dismissSelectors.getTimelineWarningsPerStep(state)[stepId]

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,9 +1,8 @@
 // @flow
 import * as React from 'react'
 import {getWellTotalVolume} from '@opentrons/shared-data'
-import type {StepFieldName} from '../../form-types'
 import KnowledgeBaseLink from '../../components/KnowledgeBaseLink'
-
+import type {FormError} from './errors'
 /*******************
 ** Warning Messages **
 ********************/
@@ -14,10 +13,8 @@ export type FormWarningType =
   | 'BELOW_MIN_DISPOSAL_VOLUME'
 
 export type FormWarning = {
+  ...$Exact<FormError>,
   type: FormWarningType,
-  title: string,
-  body?: React.Node,
-  dependentFields: Array<StepFieldName>,
 }
 // TODO: Ian 2018-12-06 use i18n for title/body text
 const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -137,7 +137,7 @@ const getSelectedStep = createSelector(
 
 // TODO: BC: 2018-10-26 remove this when we decide to not block save
 export const getCurrentFormCanBeSaved: Selector<boolean> = createSelector(
-  stepFormSelectors.getHydratedUnsavedFormErrors,
+  stepFormSelectors.getUnsavedFormErrors,
   (formErrors) => {
     return Boolean(formErrors && isEmpty(formErrors))
   }


### PR DESCRIPTION
## overview

Miscellaneous cleanup for form-related code, shouldn't affect any functionality 

## changelog

* remove duplicate form hydration code via `_getHydratedForm` helper
* remove `getFormLevelErrors` selector - it's the same as `getUnsavedFormErrors(state).form`
* rename for clarity: getHydratedUnsavedFormErrors -> getUnsavedFormErrors (since the errors aren't hydrated)
* remove NO_SAVED_FORM_ERROR, it's a leftover and is no longer used anywhere
* consolidate FormError + FormWarning type def (no change from flow perspective)

## review requests

- code review: any accidental functionality changes? Are renamed names actually clearer?
- quick pass to make sure nothing broke around forms & form warning / errors