### PR TITLE
feat(protocol-designer): hook up flexible step to handleFormChange and gen commands!

### DIFF
--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -4,20 +4,20 @@ import type {PauseFormData} from '../../step-generation'
 import {PDListItem} from '../lists'
 
 type Props = {
-  substeps: PauseFormData,
+  pauseArgs: PauseFormData,
 }
 
 export default function PauseStepItems (props: Props) {
-  const {substeps} = props
-  if (substeps.wait === true) {
+  const {pauseArgs} = props
+  if (pauseArgs.wait === true) {
     // Show message if waiting indefinitely
-    return <PDListItem>{substeps.message}</PDListItem>
+    return <PDListItem>{pauseArgs.message}</PDListItem>
   }
-  if (!substeps.meta) {
+  if (!pauseArgs.meta) {
     // No message or time, show nothing
     return null
   }
-  const {hours, minutes, seconds} = substeps.meta
+  const {hours, minutes, seconds} = pauseArgs.meta
   return <PDListItem>
     <span>{hours} hr</span>
     <span>{minutes} m</span>

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -132,10 +132,10 @@ function getStepItemContents (stepItemProps: StepItemProps) {
 
   if (
     substeps && (
-      substeps.stepType === 'transfer' ||
-      substeps.stepType === 'consolidate' ||
-      substeps.stepType === 'distribute' ||
-      substeps.stepType === 'mix'
+      substeps.commandCreatorFnName === 'transfer' ||
+      substeps.commandCreatorFnName === 'consolidate' ||
+      substeps.commandCreatorFnName === 'distribute' ||
+      substeps.commandCreatorFnName === 'mix'
     )
   ) {
     result.push(

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -91,20 +91,20 @@ function getStepItemContents (stepItemProps: StepItemProps) {
   if (!step) {
     return null
   }
-
-  if (substeps && substeps.stepType === 'pause') {
-    return <PauseStepItems {...{substeps}} />
+  // pause substep component uses the delay args directly
+  if (substeps && substeps.commandCreatorFnName === 'delay') {
+    return <PauseStepItems pauseArgs={substeps} />
   }
 
   const result = []
 
   // headers
-
   if (
     formData && (
       formData.stepType === 'transfer' ||
       formData.stepType === 'consolidate' ||
-      formData.stepType === 'distribute'
+      formData.stepType === 'distribute' ||
+      formData.stepType === 'moveLiquid'
     )
   ) {
     const sourceLabware = getLabware(formData['aspirate_labware'])
@@ -129,12 +129,12 @@ function getStepItemContents (stepItemProps: StepItemProps) {
   }
 
   // non-header substeps
-
   if (
     substeps && (
       substeps.commandCreatorFnName === 'transfer' ||
       substeps.commandCreatorFnName === 'consolidate' ||
       substeps.commandCreatorFnName === 'distribute' ||
+      substeps.commandCreatorFnName === 'moveLiquid' ||
       substeps.commandCreatorFnName === 'mix'
     )
   ) {

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -69,7 +69,7 @@ const distribute = (data: DistributeFormData): CompoundCommandCreator => (prevRo
       const transferData: TransferFormData = {
         ...(data: TransferLikeFormDataFields),
         changeTip,
-        stepType: 'transfer',
+        commandCreatorFnName: 'transfer',
         sourceWells: [data.sourceWell],
         destWells: [destWell],
         mixBeforeAspirate: data.mixBeforeAspirate,

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -23,7 +23,7 @@ let blowoutSingleToSourceA1
 
 beforeEach(() => {
   mixinArgs = {
-    stepType: 'distribute',
+    commandCreatorFnName: 'distribute',
     name: 'distribute test',
     description: 'test blah blah',
 

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
   })
 
   mixinArgs = {
-    stepType: 'mix',
+    commandCreatorFnName: 'mix',
     name: 'mix test',
     description: 'test blah blah',
 

--- a/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/transfer.test.js
@@ -16,7 +16,7 @@ let robotInitialState
 
 beforeEach(() => {
   transferArgs = {
-    stepType: 'transfer',
+    commandCreatorFnName: 'transfer',
     name: 'Transfer Test',
     description: 'test blah blah',
     pipette: 'p300SingleId',

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -55,7 +55,7 @@ export type TransferLikeFormDataFields = {
 }
 
 export type ConsolidateFormData = {
-  stepType: 'consolidate',
+  commandCreatorFnName: 'consolidate',
 
   sourceWells: Array<string>,
   destWell: string,
@@ -70,7 +70,7 @@ export type ConsolidateFormData = {
 } & TransferLikeFormDataFields
 
 export type TransferFormData = {
-  stepType: 'transfer',
+  commandCreatorFnName: 'transfer',
 
   sourceWells: Array<string>,
   destWells: Array<string>,
@@ -85,7 +85,7 @@ export type TransferFormData = {
 } & TransferLikeFormDataFields
 
 export type DistributeFormData = {
-  stepType: 'distribute',
+  commandCreatorFnName: 'distribute',
 
   sourceWell: string,
   destWells: Array<string>,
@@ -101,8 +101,8 @@ export type DistributeFormData = {
 } & TransferLikeFormDataFields
 
 export type MixFormData = {
-  ...SharedFormDataFields,
-  stepType: 'mix',
+  ...$Exact<SharedFormDataFields>,
+  commandCreatorFnName: 'mix',
   labware: string,
   pipette: string,
   wells: Array<string>,
@@ -127,9 +127,9 @@ export type MixFormData = {
   dispenseFlowRateUlSec?: ?number,
 }
 
-export type PauseFormData = {|
-  ...SharedFormDataFields,
-  stepType: 'pause',
+export type PauseFormData = {
+  ...$Exact<SharedFormDataFields>,
+  commandCreatorFnName: 'delay',
   message?: string,
   wait: number | true,
   meta: ?{
@@ -137,7 +137,7 @@ export type PauseFormData = {|
     minutes?: number,
     seconds?: number,
   },
-|}
+}
 
 export type CommandCreatorData =
   | ConsolidateFormData

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -171,7 +171,7 @@ const updatePatchOnPipetteChannelChange = (
   return {...patch, ...update}
 }
 
-export default function handleFormChangeMoveLiquid (
+export default function dependentFieldsUpdateMoveLiquid (
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
   pipetteEntities: PipetteEntities,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -2,7 +2,7 @@
 import assert from 'assert'
 import uniq from 'lodash/uniq'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
-
+import handleFormChangeMoveLiquid from './handleFormChangeMoveLiquid'
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {FormData} from '../../../form-types'
 import type {StepFieldName} from '../../fieldLevel'
@@ -40,13 +40,21 @@ function getChannels (pipetteId: string, pipetteEntities: PipetteEntities): Pipe
 
 function handleFormChange (
   patch: FormPatch,
-  baseForm: ?FormData,
+  rawForm: ?FormData,
   pipetteEntities: PipetteEntities,
   labwareEntities: LabwareEntities
 ): FormPatch {
   // pass thru, unchanged
-  if (baseForm == null) { return patch }
+  if (rawForm == null) { return patch }
 
+  if (rawForm.stepType === 'moveLiquid') {
+    // TODO IMMEDIATELY rename handleFormChangeMoveLiquid to processPatchMoveLiquid or something?
+    const d = handleFormChangeMoveLiquid(patch, rawForm, pipetteEntities, labwareEntities)
+    return {...patch, ...d}
+  }
+
+  // everything below is legacy: remove in #2916
+  const baseForm = rawForm
   let updateOverrides = getChangeLabwareEffects(patch)
 
   if (baseForm.pipette && patch.pipette) {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -2,7 +2,7 @@
 import assert from 'assert'
 import uniq from 'lodash/uniq'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
-import handleFormChangeMoveLiquid from './handleFormChangeMoveLiquid'
+import dependentFieldsUpdateMoveLiquid from './dependentFieldsUpdateMoveLiquid'
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {FormData} from '../../../form-types'
 import type {StepFieldName} from '../../fieldLevel'
@@ -48,9 +48,8 @@ function handleFormChange (
   if (rawForm == null) { return patch }
 
   if (rawForm.stepType === 'moveLiquid') {
-    // TODO IMMEDIATELY rename handleFormChangeMoveLiquid to processPatchMoveLiquid or something?
-    const d = handleFormChangeMoveLiquid(patch, rawForm, pipetteEntities, labwareEntities)
-    return {...patch, ...d}
+    const dependentFieldsPatch = dependentFieldsUpdateMoveLiquid(patch, rawForm, pipetteEntities, labwareEntities)
+    return {...patch, ...dependentFieldsPatch}
   }
 
   // everything below is legacy: remove in #2916

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -1,5 +1,5 @@
 // @flow
-import handleFormChangeMoveLiquid from '../handleFormChangeMoveLiquid'
+import dependentFieldsUpdateMoveLiquid from '../dependentFieldsUpdateMoveLiquid'
 
 let pipetteEntities
 let labwareEntities
@@ -8,7 +8,7 @@ let handleFormHelper
 beforeEach(() => {
   pipetteEntities = {pipetteId: {name: 'p10_single', tiprackModel: 'tiprack-10ul'}}
   labwareEntities = {}
-  handleFormHelper = (patch, baseForm) => handleFormChangeMoveLiquid(
+  handleFormHelper = (patch, baseForm) => dependentFieldsUpdateMoveLiquid(
     patch, baseForm, pipetteEntities, labwareEntities
   )
 })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -1,5 +1,4 @@
 // @flow
-import assert from 'assert'
 import uniq from 'lodash/uniq'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
 
@@ -35,11 +34,10 @@ export function getAllWellsFromPrimaryWells (
   return uniq(allWells)
 }
 
-export function getChannels (pipetteId: string, pipetteEntities: PipetteEntities): PipetteChannels {
+export function getChannels (pipetteId: string, pipetteEntities: PipetteEntities): ?PipetteChannels {
   const pipette: ?* = pipetteEntities[pipetteId]
   if (!pipette) {
-    assert(false, `${pipetteId} not found in pipettes, cannot handleFormChange properly`)
-    return 1
+    return null
   }
   return pipette.spec.channels
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -5,6 +5,7 @@ import type {CommandCreatorData} from '../../../step-generation'
 import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import transferLikeFormToArgs from './transferLikeFormToArgs'
+import moveLiquidFormToArgs from './moveLiquidFormToArgs'
 
 // NOTE: this acts as an adapter for the PD defined data shape of the step forms
 // to create arguments that the step generation service is expecting
@@ -12,17 +13,21 @@ import transferLikeFormToArgs from './transferLikeFormToArgs'
 
 type StepArgs = CommandCreatorData | null
 
-const stepFormToArgs = (formData: FormData): StepArgs => {
-  switch (formData.stepType) {
+// TODO: Ian 2019-01-29 use hydrated form type
+const stepFormToArgs = (hydratedForm: FormData): StepArgs => {
+  switch (hydratedForm.stepType) {
+    case 'moveLiquid':
+      return moveLiquidFormToArgs({...hydratedForm, fields: hydratedForm}) // TODO: Ian 2019-01-29 nest all fields under `fields` (in #2917 ?)
     case 'transfer':
     case 'consolidate':
     case 'distribute':
-      return transferLikeFormToArgs(formData)
+      return transferLikeFormToArgs(hydratedForm)
     case 'pause':
-      return pauseFormToArgs(formData)
+      return pauseFormToArgs(hydratedForm)
     case 'mix':
-      return mixFormToArgs(formData)
+      return mixFormToArgs(hydratedForm)
     default:
+      console.warn(`stepFormToArgs not implemented for ${hydratedForm.stepType}`)
       return null
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -45,7 +45,7 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const blowoutLocation = hydratedFormData['dispense_blowout_checkbox'] ? hydratedFormData['dispense_blowout_location'] : null
 
   return {
-    stepType: 'mix',
+    commandCreatorFnName: 'mix',
     name: `Mix ${hydratedFormData.id}`, // TODO real name for steps
     description: 'description would be here 2018-03-01', // TODO get from form
     labware: labware.id,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -149,7 +149,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
     case 'single': {
       const transferStepArguments: TransferFormData = {
         ...commonFields,
-        stepType: 'transfer', // TODO: Ian 2019-01-15 remove stepType from FormData types
+        commandCreatorFnName: 'transfer',
         blowoutLocation,
         sourceWells,
         destWells,
@@ -160,7 +160,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
     case 'multiAspirate': {
       const consolidateStepArguments: ConsolidateFormData = {
         ...commonFields,
-        stepType: 'consolidate', // TODO: Ian 2019-01-15 remove stepType from FormData types
+        commandCreatorFnName: 'consolidate',
         blowoutLocation,
         mixFirstAspirate: mixBeforeAspirate,
         sourceWells,
@@ -171,7 +171,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
     case 'multiDispense': {
       const distributeStepArguments: DistributeFormData = {
         ...commonFields,
-        stepType: 'distribute', // TODO: Ian 2019-01-15 remove stepType from FormData types
+        commandCreatorFnName: 'distribute',
         disposalVolume,
         // TODO: Ian 2019-01-15 these args have TODOs to get renamed, let's do it after deleting Distribute step
         disposalLabware: blowoutLabware,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -14,7 +14,7 @@ const pauseFormToArgs = (formData: FormData): PauseStepArgs => {
   const message = formData['pauseMessage'] || ''
 
   return {
-    stepType: 'pause',
+    commandCreatorFnName: 'delay',
     name: `Pause ${formData.id}`, // TODO real name for steps
     description: 'description would be here 2018-03-01', // TODO get from form
     wait: (formData['pauseForAmountOfTime'] === 'false') ? true : totalSeconds,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -146,7 +146,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
       const transferStepArguments: TransferFormData = {
         ...commonFields,
         blowoutLocation,
-        stepType: 'transfer',
+        commandCreatorFnName: 'transfer',
         sourceWells,
         destWells,
         mixBeforeAspirate,
@@ -161,7 +161,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
         mixFirstAspirate,
         sourceWells,
         destWell: destWells[0],
-        stepType: 'consolidate',
+        commandCreatorFnName: 'consolidate',
         name: `Consolidate ${hydratedFormData.id}`, // TODO Ian 2018-04-03 real name for steps
       }
       return consolidateStepArguments
@@ -175,7 +175,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
         mixBeforeAspirate,
         sourceWell: sourceWells[0],
         destWells,
-        stepType: 'distribute',
+        commandCreatorFnName: 'distribute',
         name: `Distribute ${hydratedFormData.id}`, // TODO Ian 2018-04-03 real name for steps
       }
       return distributeStepArguments

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -71,13 +71,13 @@ function transferLikeSubsteps (args: {
   }
 
   // if false, show aspirate vol instead
-  const showDispenseVol = stepArgs.stepType === 'distribute'
+  const showDispenseVol = stepArgs.commandCreatorFnName === 'distribute'
 
   let substepCommandCreators
 
   // Call appropriate command creator with the validateForm fields.
   // Disable any mix args so those aspirate/dispenses don't show up in substeps
-  if (stepArgs.stepType === 'transfer') {
+  if (stepArgs.commandCreatorFnName === 'transfer') {
     const commandCallArgs = {
       ...stepArgs,
       mixBeforeAspirate: null,
@@ -86,7 +86,7 @@ function transferLikeSubsteps (args: {
     }
 
     substepCommandCreators = transfer(commandCallArgs)(robotState)
-  } else if (stepArgs.stepType === 'distribute') {
+  } else if (stepArgs.commandCreatorFnName === 'distribute') {
     const commandCallArgs = {
       ...stepArgs,
       mixBeforeAspirate: null,
@@ -94,7 +94,7 @@ function transferLikeSubsteps (args: {
     }
 
     substepCommandCreators = distribute(commandCallArgs)(robotState)
-  } else if (stepArgs.stepType === 'consolidate') {
+  } else if (stepArgs.commandCreatorFnName === 'consolidate') {
     const commandCallArgs = {
       ...stepArgs,
       mixFirstAspirate: null,
@@ -103,11 +103,11 @@ function transferLikeSubsteps (args: {
     }
 
     substepCommandCreators = consolidate(commandCallArgs)(robotState)
-  } else if (stepArgs.stepType === 'mix') {
+  } else if (stepArgs.commandCreatorFnName === 'mix') {
     substepCommandCreators = mix(stepArgs)(robotState)
   } else {
     // TODO Ian 2018-05-21 Use assert here. Should be unreachable
-    console.warn(`transferLikeSubsteps got unsupported stepType "${stepArgs.stepType}"`)
+    console.warn(`transferLikeSubsteps got unsupported stepType "${stepArgs.commandCreatorFnName}"`)
     return null
   }
 
@@ -144,7 +144,7 @@ function transferLikeSubsteps (args: {
           return {
             activeTips,
             source,
-            dest: stepArgs.stepType === 'mix' ? source : dest, // NOTE: since source and dest are same for mix, we're showing source on both sides. Otherwise dest would show the intermediate volume state
+            dest: stepArgs.commandCreatorFnName === 'mix' ? source : dest, // NOTE: since source and dest are same for mix, we're showing source on both sides. Otherwise dest would show the intermediate volume state
             volume: showDispenseVol ? nextMultiRow.volume : currentMultiRow.volume,
           }
         })
@@ -168,7 +168,7 @@ function transferLikeSubsteps (args: {
     )
     return {
       multichannel: true,
-      stepType: stepArgs.stepType,
+      stepType: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
       multiRows: mergedMultiRows,
     }
@@ -219,7 +219,7 @@ function transferLikeSubsteps (args: {
 
     return {
       multichannel: false,
-      stepType: stepArgs.stepType,
+      stepType: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
       rows: mergedRows,
     }
@@ -248,17 +248,17 @@ export function generateSubsteps (
 
   const {stepArgs} = stepArgsAndErrors
 
-  if (stepArgs.stepType === 'pause') {
+  if (stepArgs.commandCreatorFnName === 'pause') {
     // just returns formData
     const formData: PauseFormData = stepArgs
     return formData
   }
 
   if (
-    stepArgs.stepType === 'consolidate' ||
-    stepArgs.stepType === 'distribute' ||
-    stepArgs.stepType === 'transfer' ||
-    stepArgs.stepType === 'mix'
+    stepArgs.commandCreatorFnName === 'consolidate' ||
+    stepArgs.commandCreatorFnName === 'distribute' ||
+    stepArgs.commandCreatorFnName === 'transfer' ||
+    stepArgs.commandCreatorFnName === 'mix'
   ) {
     return transferLikeSubsteps({
       stepArgs,
@@ -269,6 +269,6 @@ export function generateSubsteps (
     })
   }
 
-  console.warn('allSubsteps doesn\'t support step type: ', stepArgs.stepType, stepId)
+  console.warn('allSubsteps doesn\'t support commandCreatorFnName: ', stepArgs.commandCreatorFnName, stepId)
   return null
 }

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -168,7 +168,7 @@ function transferLikeSubsteps (args: {
     )
     return {
       multichannel: true,
-      stepType: stepArgs.commandCreatorFnName,
+      commandCreatorFnName: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
       multiRows: mergedMultiRows,
     }
@@ -219,7 +219,7 @@ function transferLikeSubsteps (args: {
 
     return {
       multichannel: false,
-      stepType: stepArgs.commandCreatorFnName,
+      commandCreatorFnName: stepArgs.commandCreatorFnName,
       parentStepId: stepId,
       rows: mergedRows,
     }
@@ -248,7 +248,7 @@ export function generateSubsteps (
 
   const {stepArgs} = stepArgsAndErrors
 
-  if (stepArgs.commandCreatorFnName === 'pause') {
+  if (stepArgs.commandCreatorFnName === 'delay') {
     // just returns formData
     const formData: PauseFormData = stepArgs
     return formData

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -5,7 +5,6 @@ import type {
   StepIdType,
   StepFieldName,
   StepType,
-  TransferLikeStepType,
 } from '../form-types'
 import type {LabwareEntities, PipetteEntities} from '../step-forms'
 import type {FormError} from './formLevel/errors'
@@ -59,16 +58,24 @@ export type StepItemSourceDestRow = {
   channelId?: number,
 }
 
+// NOTE: delay is NOT a source-dest-style command creator, this type exists
+// mostly to tell flow that :/
+type SourceDestCommandCreatorName =
+  | 'transfer'
+  | 'distribute'
+  | 'consolidate'
+  | 'mix'
+
 export type SourceDestSubstepItemSingleChannel = {|
   multichannel: false,
-  stepType: TransferLikeStepType | 'mix',
+  commandCreatorFnName: SourceDestCommandCreatorName,
   parentStepId: StepIdType,
   rows: Array<StepItemSourceDestRow>,
 |}
 
 export type SourceDestSubstepItemMultiChannel = {|
   multichannel: true,
-  stepType: TransferLikeStepType | 'mix',
+  commandCreatorFnName: SourceDestCommandCreatorName,
   parentStepId: StepIdType,
   volume?: ?number, // uniform volume for all steps
   multiRows: Array<Array<StepItemSourceDestRow>>, // Array of arrays.
@@ -79,7 +86,7 @@ export type SourceDestSubstepItem = SourceDestSubstepItemSingleChannel | SourceD
 
 export type SubstepItemData =
   | SourceDestSubstepItem
-  | PauseFormData // Pause substep uses same data as processed form
+  | PauseFormData // Pause substep uses same data as delay args
 
 export type StepItemData = {
   id: StepIdType,

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -137,7 +137,7 @@ export const getTipsForCurrentStep: GetTipSelector = createSelector(
         const {substepIndex} = hoveredSubstepIdentifier
         const substepsForStep = allSubsteps[hoveredSubstepIdentifier.stepId]
 
-        if (substepsForStep && substepsForStep.stepType !== 'pause') {
+        if (substepsForStep && substepsForStep.commandCreatorFnName !== 'delay') {
           if (substepsForStep.multichannel) {
             const hoveredSubstepData = substepsForStep.multiRows[substepIndex][0] // just use first multi row
 

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -86,7 +86,7 @@ const getHoveredStepLabware: Selector<Array<string>> = createSelector(
     }
 
     // step types that have no labware that gets highlighted
-    if (!(stepArgs.commandCreatorFnName === 'pause')) {
+    if (!(stepArgs.commandCreatorFnName === 'delay')) {
       // TODO Ian 2018-05-08 use assert here
       console.warn(`getHoveredStepLabware does not support step type "${stepArgs.commandCreatorFnName}"`)
     }

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -62,33 +62,33 @@ const getHoveredStepLabware: Selector<Array<string>> = createSelector(
       return blank
     }
 
-    const stepForm = allStepArgsAndErrors[hoveredStep].stepArgs
+    const stepArgs = allStepArgsAndErrors[hoveredStep].stepArgs
 
-    if (!stepForm) {
+    if (!stepArgs) {
       return blank
     }
 
     if (
-      stepForm.stepType === 'consolidate' ||
-      stepForm.stepType === 'distribute' ||
-      stepForm.stepType === 'transfer'
+      stepArgs.commandCreatorFnName === 'consolidate' ||
+      stepArgs.commandCreatorFnName === 'distribute' ||
+      stepArgs.commandCreatorFnName === 'transfer'
     ) {
       // source and dest labware
-      const src = stepForm.sourceLabware
-      const dest = stepForm.destLabware
+      const src = stepArgs.sourceLabware
+      const dest = stepArgs.destLabware
 
       return [src, dest]
     }
 
-    if (stepForm.stepType === 'mix') {
+    if (stepArgs.commandCreatorFnName === 'mix') {
       // only 1 labware
-      return [stepForm.labware]
+      return [stepArgs.labware]
     }
 
     // step types that have no labware that gets highlighted
-    if (!(stepForm.stepType === 'pause')) {
+    if (!(stepArgs.commandCreatorFnName === 'pause')) {
       // TODO Ian 2018-05-08 use assert here
-      console.warn(`getHoveredStepLabware does not support step type "${stepForm.stepType}"`)
+      console.warn(`getHoveredStepLabware does not support step type "${stepArgs.commandCreatorFnName}"`)
     }
 
     return blank


### PR DESCRIPTION
## overview

Closes #2922

- hook up new step to handleFormChange, so dependent fields should change properly
- refactor how args get used to call command creator fns. Once it's args, `stepType` is replaced with the appropriate `commandCreatorFnName` (eg moveLiquid goes to transfer, consolidate, or distribute; pause goes to delay)

## changelog

above

## review requests

- Code review
- Should basically work. Exceptions:

    - No substeps will show for the new form yet.

    - Known bug: saving a flex step form with a disposal volume will blow up b/c of AssertionError in distribute. I want to do a follow-up when we go into distribute and make sure everything works with the new args + remove old transfer-fallback functionality

- Pause / Mix substeps should work correctly, there is a change I broke them with the commandCreatorFnName refactor