### PR TITLE
feat(protocol-designer): disabled distribute's fallback to transfer

### DIFF
--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
-import type {PauseFormData} from '../../step-generation'
+import type {DelayArgs} from '../../step-generation'
 import {PDListItem} from '../lists'
 
 type Props = {
-  pauseArgs: PauseFormData,
+  pauseArgs: DelayArgs,
 }
 
 export default function PauseStepItems (props: Props) {

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -127,7 +127,7 @@ export const getInitialRobotState: BaseState => StepGeneration.RobotState = crea
   }
 )
 
-function compoundCommandCreatorFromStepArgs (stepArgs: StepGeneration.CommandCreatorData): ?StepGeneration.CompoundCommandCreator {
+function compoundCommandCreatorFromStepArgs (stepArgs: StepGeneration.CommandCreatorArgs): ?StepGeneration.CompoundCommandCreator {
   switch (stepArgs.commandCreatorFnName) {
     case 'consolidate': return StepGeneration.consolidate(stepArgs)
     case 'delay': {
@@ -148,13 +148,13 @@ export const getRobotStateTimeline: Selector<StepGeneration.Timeline> = createSe
   stepFormSelectors.getOrderedStepIds,
   getInitialRobotState,
   (allStepArgsAndErrors, orderedStepIds, initialRobotState) => {
-    const allStepArgs: Array<StepGeneration.CommandCreatorData | null> = orderedStepIds.map(stepId => {
+    const allStepArgs: Array<StepGeneration.CommandCreatorArgs | null> = orderedStepIds.map(stepId => {
       return (allStepArgsAndErrors[stepId] && allStepArgsAndErrors[stepId].stepArgs) || null
     })
 
     // TODO: Ian 2018-06-14 `takeWhile` isn't inferring the right type
     // $FlowFixMe
-    const continuousStepArgs: Array<StepGeneration.CommandCreatorData> = takeWhile(
+    const continuousStepArgs: Array<StepGeneration.CommandCreatorArgs> = takeWhile(
       allStepArgs,
       stepArgs => stepArgs
     )

--- a/protocol-designer/src/step-generation/commandCreators/atomic/delay.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/delay.js
@@ -1,17 +1,17 @@
 // @flow
-import type {PauseFormData, RobotState, CommandCreator} from '../../types'
+import type {DelayArgs, RobotState, CommandCreator} from '../../types'
 
-const pause = (data: PauseFormData): CommandCreator => (prevRobotState: RobotState) => {
+const delay = (args: DelayArgs): CommandCreator => (prevRobotState: RobotState) => {
   return {
     robotState: prevRobotState,
     commands: [{
       command: 'delay',
       params: {
-        message: data.message,
-        wait: data.wait,
+        message: args.message,
+        wait: args.wait,
       },
     }],
   }
 }
 
-export default pause
+export default delay

--- a/protocol-designer/src/step-generation/commandCreators/compound/mix.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/mix.js
@@ -2,7 +2,7 @@
 import flatMap from 'lodash/flatMap'
 import {repeatArray, blowoutUtil} from '../../utils'
 import * as errorCreators from '../../errorCreators'
-import type {MixFormData, RobotState, CommandCreator, CompoundCommandCreator} from '../../types'
+import type {MixArgs, RobotState, CommandCreator, CompoundCommandCreator} from '../../types'
 import {aspirate, dispense, replaceTip, touchTip} from '../atomic'
 
 /** Helper fn to make mix command creators w/ minimal arguments */
@@ -34,7 +34,7 @@ export function mixUtil (args: {
   ], times)
 }
 
-const mix = (data: MixFormData): CompoundCommandCreator => (prevRobotState: RobotState) => {
+const mix = (data: MixArgs): CompoundCommandCreator => (prevRobotState: RobotState) => {
   /**
     Mix will aspirate and dispense a uniform volume some amount of times from a set of wells
     in a single labware.

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -55,10 +55,14 @@ export function pipetteVolumeExceeded (args: {
   actionName: string,
   volume: string | number,
   maxVolume: string | number,
+  disposalVolume?: string | number,
 }): CommandCreatorError {
-  const {actionName, volume, maxVolume} = args
+  const {actionName, volume, maxVolume, disposalVolume} = args
+  const message = disposalVolume != null
+    ? `Attemped to ${actionName} volume + disposal volume greater than pipette max volume (${volume} + ${disposalVolume} > ${maxVolume})`
+    : `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`
   return {
-    message: `Attempted to ${actionName} volume greater than pipette max volume (${volume} > ${maxVolume})`,
+    message,
     type: 'PIPETTE_VOLUME_EXCEEDED',
   }
 }

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -7,7 +7,7 @@ import {
   compoundCommandCreatorHasErrors,
   commandFixtures as cmd,
 } from './fixtures'
-import type {DistributeFormData} from '../types'
+import type {DistributeArgs} from '../types'
 const distribute = compoundCommandCreatorNoErrors(_distribute)
 const distributeWithErrors = compoundCommandCreatorHasErrors(_distribute)
 
@@ -65,7 +65,7 @@ describe('distribute: minimal example', () => {
   test('single channel; 60uL from A1 -> A2, A3; no tip pickup', () => {
     // TODO Ian 2018-05-03 distributeArgs needs to be typed because the
     // commandCreatorNoErrors wrapper casts the arg type to any :(
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
@@ -85,7 +85,7 @@ describe('distribute: minimal example', () => {
 
 describe('tip handling for multiple distribute chunks', () => {
   test('changeTip: "once"', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -112,7 +112,7 @@ describe('tip handling for multiple distribute chunks', () => {
   })
 
   test('changeTip: "always"', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -142,7 +142,7 @@ describe('tip handling for multiple distribute chunks', () => {
 
   test('changeTip: "never" with carried-over tip', () => {
     // NOTE: this has been used as BASE CASE for the "advanced settings" tests
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -164,7 +164,7 @@ describe('tip handling for multiple distribute chunks', () => {
   })
 
   test('changeTip: "never" should fail with no initial tip', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -185,7 +185,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
   test('mix before aspirate, then aspirate disposal volume', () => {
     // NOTE this also tests "uneven final chunk" eg A6 in [A2 A3 | A4 A5 | A6]
     // which is especially relevant to disposal volume
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5', 'A6'],
@@ -219,7 +219,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
 
   test.skip('pre-wet tip', () => {
     // TODO Ian 2018-05-04 pre-wet volume is TBD.
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -298,7 +298,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
   })
 
   test('touch tip after aspirate', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -324,7 +324,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
   })
 
   test('touch tip after dispense', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -361,7 +361,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
     const disposalLabware = 'sourcePlateId'
     const disposalWell = 'A1'
     const aspirateVol = (volume * 2) + disposalVolume
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3', 'A4', 'A5'],
@@ -405,7 +405,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch', () => {
 
 describe('invalid input + state errors', () => {
   test('invalid pipette ID should throw error', () => {
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
@@ -424,104 +424,39 @@ describe('invalid input + state errors', () => {
 })
 
 describe('distribute volume exceeds pipette max volume', () => {
-  test(`change tip: always`, () => {
-    const changeTip = 'always'
-    const distributeArgs: DistributeFormData = {
-      ...mixinArgs,
-      sourceWell: 'A1',
-      destWells: ['A2', 'A3'],
-      changeTip,
-      volume: 350,
-      disposalVolume: null, // TODO additional test with blowout
-      disposalLabware: null,
-      disposalWell: null,
-    }
-    const result = distribute(distributeArgs)(robotInitialState)
-
-    expect(result.commands).toEqual([
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('A1'),
-
-      cmd.aspirate('A1', 300),
-      dispense('A2', 300),
-
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('B1'),
-
-      cmd.aspirate('A1', 50),
-      dispense('A2', 50),
-
-      // A2 done, move to A3
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('C1'),
-
-      cmd.aspirate('A1', 300),
-      dispense('A3', 300),
-
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('D1'),
-
-      cmd.aspirate('A1', 50),
-      dispense('A3', 50),
-    ])
-  })
-
-  test(`change tip: once`, () => {
+  test(`no disposal volume`, () => {
     const changeTip = 'once'
-    const distributeArgs: DistributeFormData = {
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
       changeTip,
       volume: 350,
-      disposalVolume: null, // TODO additional test with blowout
+      disposalVolume: null,
       disposalLabware: null,
       disposalWell: null,
     }
-    const result = distribute(distributeArgs)(robotInitialState)
+    const result = distributeWithErrors(distributeArgs)(robotInitialState)
 
-    expect(result.commands).toEqual([
-      cmd.dropTip('A1'),
-      cmd.pickUpTip('A1'),
-
-      cmd.aspirate('A1', 300),
-      dispense('A2', 300),
-      cmd.aspirate('A1', 50),
-      dispense('A2', 50),
-
-      // A2 done, move to A3
-      cmd.aspirate('A1', 300),
-      dispense('A3', 300),
-      cmd.aspirate('A1', 50),
-      dispense('A3', 50),
-    ])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].type).toEqual('PIPETTE_VOLUME_EXCEEDED')
   })
 
-  test(`change tip: never`, () => {
-    const changeTip = 'never'
-    const distributeArgs: DistributeFormData = {
+  test(`with disposal volume`, () => {
+    const changeTip = 'once'
+    const distributeArgs: DistributeArgs = {
       ...mixinArgs,
       sourceWell: 'A1',
       destWells: ['A2', 'A3'],
       changeTip,
-      volume: 350,
-      disposalVolume: null, // TODO additional test with blowout
-      disposalLabware: null,
-      disposalWell: null,
+      volume: 250,
+      disposalVolume: 100, // TODO additional test with blowout
+      disposalLabware: 'trashId',
+      disposalWell: 'A1',
     }
-    const result = distribute(distributeArgs)(robotInitialState)
+    const result = distributeWithErrors(distributeArgs)(robotInitialState)
 
-    expect(result.commands).toEqual([
-      cmd.aspirate('A1', 300),
-      dispense('A2', 300),
-      cmd.aspirate('A1', 50),
-      dispense('A2', 50),
-
-      // A2 done, move to A3
-      cmd.aspirate('A1', 300),
-      dispense('A3', 300),
-      cmd.aspirate('A1', 50),
-      dispense('A3', 50),
-    ])
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].type).toEqual('PIPETTE_VOLUME_EXCEEDED')
   })
 })

--- a/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/distribute.test.js
@@ -450,7 +450,7 @@ describe('distribute volume exceeds pipette max volume', () => {
       destWells: ['A2', 'A3'],
       changeTip,
       volume: 250,
-      disposalVolume: 100, // TODO additional test with blowout
+      disposalVolume: 100,
       disposalLabware: 'trashId',
       disposalWell: 'A1',
     }

--- a/protocol-designer/src/step-generation/test-with-flow/mix.test.js
+++ b/protocol-designer/src/step-generation/test-with-flow/mix.test.js
@@ -6,7 +6,7 @@ import {
   compoundCommandCreatorHasErrors,
   commandFixtures as cmd,
 } from './fixtures'
-import type {MixFormData} from '../types'
+import type {MixArgs} from '../types'
 const mix = compoundCommandCreatorNoErrors(_mix)
 const mixWithErrors = compoundCommandCreatorHasErrors(_mix)
 
@@ -38,7 +38,7 @@ beforeEach(() => {
 describe('mix: change tip', () => {
   const volume = 5
   const times = 2
-  const makeArgs = (changeTip): MixFormData => ({
+  const makeArgs = (changeTip): MixArgs => ({
     ...mixinArgs,
     volume,
     times,
@@ -135,7 +135,7 @@ describe('mix: advanced options', () => {
     const DISPENSE_OFFSET = 12
     const ASPIRATE_FLOW_RATE = 3
     const DISPENSE_FLOW_RATE = 6
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...mixinArgs,
       volume,
       times,
@@ -168,7 +168,7 @@ describe('mix: advanced options', () => {
   })
 
   test('touch tip (after each dispense)', () => {
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...mixinArgs,
       volume,
       times,
@@ -211,7 +211,7 @@ describe('mix: advanced options', () => {
   })
 
   test('blowout', () => {
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...mixinArgs,
       volume,
       times,
@@ -250,7 +250,7 @@ describe('mix: advanced options', () => {
   })
 
   test('touch tip after blowout', () => {
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...mixinArgs,
       volume,
       times,
@@ -305,7 +305,7 @@ describe('mix: errors', () => {
     }
   })
   test('invalid labware', () => {
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...errorArgs,
       labware: 'invalidLabwareId',
     }
@@ -317,7 +317,7 @@ describe('mix: errors', () => {
   })
 
   test('invalid pipette', () => {
-    const args: MixFormData = {
+    const args: MixArgs = {
       ...errorArgs,
       pipette: 'invalidPipetteId',
     }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -5,12 +5,12 @@ import type {DeckSlot, Mount} from '@opentrons/components'
 
 export type ChangeTipOptions = 'always' | 'once' | 'never' | 'perDest' | 'perSource'
 
-export type MixArgs = {|
+export type InnerMixArgs = {|
   volume: number,
   times: number,
 |}
 
-export type SharedFormDataFields = {|
+type CommonArgs = {|
   /** Optional user-readable name for this step */
   name: ?string,
   /** Optional user-readable description/notes for this step */
@@ -19,8 +19,8 @@ export type SharedFormDataFields = {|
 
 // ===== Processed form types. Used as args to call command creator fns =====
 
-export type TransferLikeFormDataFields = {
-  ...SharedFormDataFields,
+export type SharedTransferLikeArgs = {
+  ...CommonArgs,
 
   pipette: string, // PipetteId
 
@@ -54,7 +54,7 @@ export type TransferLikeFormDataFields = {
   dispenseOffsetFromBottomMm?: ?number,
 }
 
-export type ConsolidateFormData = {
+export type ConsolidateArgs = {
   commandCreatorFnName: 'consolidate',
 
   sourceWells: Array<string>,
@@ -64,12 +64,12 @@ export type ConsolidateFormData = {
   blowoutLocation: ?string,
 
   /** Mix in first well in chunk */
-  mixFirstAspirate: ?MixArgs,
+  mixFirstAspirate: ?InnerMixArgs,
   /** Mix in destination well after dispense */
-  mixInDestination: ?MixArgs,
-} & TransferLikeFormDataFields
+  mixInDestination: ?InnerMixArgs,
+} & SharedTransferLikeArgs
 
-export type TransferFormData = {
+export type TransferArgs = {
   commandCreatorFnName: 'transfer',
 
   sourceWells: Array<string>,
@@ -79,12 +79,12 @@ export type TransferFormData = {
   blowoutLocation: ?string,
 
   /** Mix in first well in chunk */
-  mixBeforeAspirate: ?MixArgs,
+  mixBeforeAspirate: ?InnerMixArgs,
   /** Mix in destination well after dispense */
-  mixInDestination: ?MixArgs,
-} & TransferLikeFormDataFields
+  mixInDestination: ?InnerMixArgs,
+} & SharedTransferLikeArgs
 
-export type DistributeFormData = {
+export type DistributeArgs = {
   commandCreatorFnName: 'distribute',
 
   sourceWell: string,
@@ -97,11 +97,11 @@ export type DistributeFormData = {
   disposalWell: ?string,
 
   /** Mix in first well in chunk */
-  mixBeforeAspirate: ?MixArgs,
-} & TransferLikeFormDataFields
+  mixBeforeAspirate: ?InnerMixArgs,
+} & SharedTransferLikeArgs
 
-export type MixFormData = {
-  ...$Exact<SharedFormDataFields>,
+export type MixArgs = {
+  ...$Exact<CommonArgs>,
   commandCreatorFnName: 'mix',
   labware: string,
   pipette: string,
@@ -127,8 +127,8 @@ export type MixFormData = {
   dispenseFlowRateUlSec?: ?number,
 }
 
-export type PauseFormData = {
-  ...$Exact<SharedFormDataFields>,
+export type DelayArgs = {
+  ...$Exact<CommonArgs>,
   commandCreatorFnName: 'delay',
   message?: string,
   wait: number | true,
@@ -139,12 +139,12 @@ export type PauseFormData = {
   },
 }
 
-export type CommandCreatorData =
-  | ConsolidateFormData
-  | DistributeFormData
-  | MixFormData
-  | PauseFormData
-  | TransferFormData
+export type CommandCreatorArgs =
+  | ConsolidateArgs
+  | DistributeArgs
+  | MixArgs
+  | DelayArgs
+  | TransferArgs
 
 // TODO: Ian 2019-01-07 with multiple deck setup steps, we might want to
 // separate 'entities' from 'locations' for pipettes/labware, and remove

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -5,13 +5,13 @@ import mixFormToArgs from './mixFormToArgs'
 import pauseFormToArgs from './pauseFormToArgs'
 import moveLiquidFormToArgs from './moveLiquidFormToArgs'
 import type {FormData} from '../../../form-types'
-import type {CommandCreatorData} from '../../../step-generation'
+import type {CommandCreatorArgs} from '../../../step-generation'
 
 // NOTE: this acts as an adapter for the PD defined data shape of the step forms
 // to create arguments that the step generation service is expecting
 // in order to generate command creators
 
-type StepArgs = CommandCreatorData | null
+type StepArgs = CommandCreatorArgs | null
 
 // TODO: Ian 2019-01-29 use hydrated form type
 const stepFormToArgs = (hydratedForm: FormData): StepArgs => {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -3,11 +3,11 @@
 import { getLabware } from '@opentrons/shared-data'
 import intersection from 'lodash/intersection'
 import type { FormData } from '../../../form-types'
-import type { MixFormData } from '../../../step-generation'
+import type { MixArgs } from '../../../step-generation'
 import { DEFAULT_CHANGE_TIP_OPTION } from '../../../constants'
 import { orderWells } from '../../utils'
 
-type MixStepArgs = MixFormData
+type MixStepArgs = MixArgs
 
 // TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -8,10 +8,10 @@ import {getOrderedWells} from '../../utils'
 
 import type {HydratedMoveLiquidFormData} from '../../../form-types'
 import type {
-  ConsolidateFormData,
-  DistributeFormData,
-  TransferFormData,
-  MixArgs,
+  ConsolidateArgs,
+  DistributeArgs,
+  TransferArgs,
+  InnerMixArgs,
 } from '../../../step-generation'
 
 export function getMixData (
@@ -19,7 +19,7 @@ export function getMixData (
   checkboxField: *,
   volumeField: *,
   timesField: *
-): ?MixArgs {
+): ?InnerMixArgs {
   const checkbox = hydratedFormData[checkboxField]
   const volume = hydratedFormData[volumeField]
   const times = hydratedFormData[timesField]
@@ -34,7 +34,7 @@ export function getMixData (
   return null
 }
 
-type MoveLiquidStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
+type MoveLiquidStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
 
 const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): MoveLiquidStepArgs => {
   assert(
@@ -161,7 +161,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
 
   switch (path) {
     case 'single': {
-      const transferStepArguments: TransferFormData = {
+      const transferStepArguments: TransferArgs = {
         ...commonFields,
         commandCreatorFnName: 'transfer',
         blowoutLocation,
@@ -172,7 +172,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
       return transferStepArguments
     }
     case 'multiAspirate': {
-      const consolidateStepArguments: ConsolidateFormData = {
+      const consolidateStepArguments: ConsolidateArgs = {
         ...commonFields,
         commandCreatorFnName: 'consolidate',
         blowoutLocation,
@@ -183,7 +183,7 @@ const moveLiquidFormToArgs = (hydratedFormData: HydratedMoveLiquidFormData): Mov
       return consolidateStepArguments
     }
     case 'multiDispense': {
-      const distributeStepArguments: DistributeFormData = {
+      const distributeStepArguments: DistributeArgs = {
         ...commonFields,
         commandCreatorFnName: 'distribute',
         disposalVolume,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.js
@@ -1,9 +1,9 @@
 // @flow
 
 import type { FormData } from '../../../form-types'
-import type { PauseFormData } from '../../../step-generation'
+import type { DelayArgs } from '../../../step-generation'
 
-type PauseStepArgs = PauseFormData
+type PauseStepArgs = DelayArgs
 
 const pauseFormToArgs = (formData: FormData): PauseStepArgs => {
   const hours = parseFloat(formData['pauseHour']) || 0

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/transferLikeFormToArgs.js
@@ -4,9 +4,9 @@ import { getLabware } from '@opentrons/shared-data'
 import intersection from 'lodash/intersection'
 import type { FormData } from '../../../form-types'
 import type {
-  ConsolidateFormData,
-  DistributeFormData,
-  TransferFormData,
+  ConsolidateArgs,
+  DistributeArgs,
+  TransferArgs,
 } from '../../../step-generation'
 import {SOURCE_WELL_BLOWOUT_DESTINATION} from '../../../step-generation/utils'
 import { DEFAULT_CHANGE_TIP_OPTION } from '../../../constants'
@@ -21,7 +21,7 @@ function getMixData (hydratedFormData, checkboxField, volumeField, timesField) {
     : null
 }
 
-type TransferLikeStepArgs = ConsolidateFormData | DistributeFormData | TransferFormData | null
+type TransferLikeStepArgs = ConsolidateArgs | DistributeArgs | TransferArgs | null
 
 // TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArgs => {
@@ -143,7 +143,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
 
   switch (stepType) {
     case 'transfer': {
-      const transferStepArguments: TransferFormData = {
+      const transferStepArguments: TransferArgs = {
         ...commonFields,
         blowoutLocation,
         commandCreatorFnName: 'transfer',
@@ -155,7 +155,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
       return transferStepArguments
     }
     case 'consolidate': {
-      const consolidateStepArguments: ConsolidateFormData = {
+      const consolidateStepArguments: ConsolidateArgs = {
         ...commonFields,
         blowoutLocation,
         mixFirstAspirate,
@@ -167,7 +167,7 @@ const transferLikeFormToArgs = (hydratedFormData: FormData): TransferLikeStepArg
       return consolidateStepArguments
     }
     case 'distribute': {
-      const distributeStepArguments: DistributeFormData = {
+      const distributeStepArguments: DistributeArgs = {
         ...commonFields,
         disposalVolume,
         disposalLabware,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -30,11 +30,11 @@ import type {StepIdType} from '../form-types'
 import type {RobotState} from '../step-generation'
 
 import type {
-  ConsolidateFormData,
-  DistributeFormData,
-  MixFormData,
-  PauseFormData,
-  TransferFormData,
+  ConsolidateArgs,
+  DistributeArgs,
+  MixArgs,
+  DelayArgs,
+  TransferArgs,
 } from '../step-generation/types'
 import type {PipetteOnDeck} from '../step-forms'
 type AllPipetteData = {[pipetteId: string]: PipetteOnDeck}
@@ -43,7 +43,7 @@ export type GetIngreds = (labware: string, well: string) => Array<NamedIngred>
 type GetLabwareType = (labwareId: string) => ?string
 
 function transferLikeSubsteps (args: {
-  stepArgs: ConsolidateFormData | DistributeFormData | TransferFormData | MixFormData,
+  stepArgs: ConsolidateArgs | DistributeArgs | TransferArgs | MixArgs,
   allPipetteData: AllPipetteData,
   getLabwareType: GetLabwareType,
   robotState: RobotState,
@@ -250,7 +250,7 @@ export function generateSubsteps (
 
   if (stepArgs.commandCreatorFnName === 'delay') {
     // just returns formData
-    const formData: PauseFormData = stepArgs
+    const formData: DelayArgs = stepArgs
     return formData
   }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {PauseFormData, CommandCreatorData} from '../step-generation'
+import type {DelayArgs, CommandCreatorArgs} from '../step-generation'
 import type {
   FormData,
   StepIdType,
@@ -86,7 +86,7 @@ export type SourceDestSubstepItem = SourceDestSubstepItemSingleChannel | SourceD
 
 export type SubstepItemData =
   | SourceDestSubstepItem
-  | PauseFormData // Pause substep uses same data as delay args
+  | DelayArgs // Pause substep uses same data as delay args
 
 export type StepItemData = {
   id: StepIdType,
@@ -105,7 +105,7 @@ export type StepFormAndFieldErrors = {
 
 export type StepArgsAndErrors = {
   errors: StepFormAndFieldErrors,
-  stepArgs: CommandCreatorData | null, // TODO: incompleteData field when this is null?
+  stepArgs: CommandCreatorArgs | null, // TODO: incompleteData field when this is null?
 }
 
 export type StepFormContextualState = {

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -32,7 +32,7 @@ function _wellsForPipette (pipetteChannels: 1 | 8, labwareType: string, wells: A
 }
 
 function _getSelectedWellsForStep (
-  stepArgs: StepGeneration.CommandCreatorData,
+  stepArgs: StepGeneration.CommandCreatorArgs,
   labwareId: string,
   robotState: StepGeneration.RobotState
 ): Array<string> {
@@ -87,7 +87,7 @@ function _getSelectedWellsForStep (
 
 /** Scan through given substep rows to get a list of source/dest wells for the given labware */
 function _getSelectedWellsForSubstep (
-  stepArgs: StepGeneration.CommandCreatorData,
+  stepArgs: StepGeneration.CommandCreatorArgs,
   labwareId: string,
   substeps: ?SubstepItemData,
   substepIndex: number
@@ -126,11 +126,11 @@ function _getSelectedWellsForSubstep (
   }
 
   // source + dest steps
-  // $FlowFixMe: property `sourceLabware` is missing in `MixFormData`
+  // $FlowFixMe: property `sourceLabware` is missing in `MixArgs`
   if (stepArgs.sourceLabware && stepArgs.sourceLabware === labwareId) {
     wells.push(...getWells('source'))
   }
-  // $FlowFixMe: property `destLabware` is missing in `MixFormData`
+  // $FlowFixMe: property `destLabware` is missing in `MixArgs`
   if (stepArgs.destLabware && stepArgs.destLabware === labwareId) {
     wells.push(...getWells('dest'))
   }

--- a/protocol-designer/src/ui/steps/types.js
+++ b/protocol-designer/src/ui/steps/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type {PauseFormData} from '../../step-generation'
+import type {DelayArgs} from '../../step-generation'
 import type {
   StepIdType,
   TransferLikeStepType,
@@ -56,6 +56,6 @@ export type SourceDestSubstepItem = SourceDestSubstepItemSingleChannel | SourceD
 
 export type SubstepItemData =
   | SourceDestSubstepItem
-  | PauseFormData // Pause substep uses same data as processed form
+  | DelayArgs // Pause substep uses same data as processed form
 
 export type SubSteps = {[StepIdType]: ?SubstepItemData}


### PR DESCRIPTION
## overview

Closes #2921

Also, renamed ConsolidateFormData types to ConsolidateArgs for command creator fns, and `data` to `args` inside the command creator fn defs themselves to match

## changelog


## review requests

- code/tests review

Shouldn't change behavior - the UX around what to do when disposal volume + 2*volume exceeds pipette/tip capacity is still TBD and funky, but this PR doesn't actually change any of that