### PR TITLE
refactor(api): Add Thermocycler stub to hardware_control

### DIFF
--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple
 from .mod_abc import AbstractModule
 # Must import tempdeck and magdeck (and other modules going forward) so they
 # actually create the subclasses
-from . import update, tempdeck, magdeck # noqa(W0611)
+from . import update, tempdeck, magdeck, thermocycler  # noqa(W0611)
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -1,0 +1,75 @@
+from . import mod_abc
+
+
+class SimulatingDriver:
+    def __init__(self):
+        self._port = None
+
+    @property
+    def status(self):
+        return '???'
+
+    def connect(self, port):
+        self._port = port
+
+    def disengage(self):
+        pass
+
+
+class Thermocycler(mod_abc.AbstractModule):
+    """
+    Under development. API subject to change without a version bump
+    """
+    @classmethod
+    def build(cls, port, simulating=False):
+        """Build and connect to a Thermocycler
+        """
+        mod = cls(port, simulating)
+        return mod
+
+    @classmethod
+    def name(cls):
+        return 'thermocycler'
+
+    @classmethod
+    def display_name(cls):
+        return 'Thermocycler'
+
+    def __init__(self, port, simulating):
+        if simulating:
+            self._driver = SimulatingDriver()
+        else:
+            # self._driver = ThermocyclerDriver()
+            self._driver = None
+        self._port = port
+        self._device_info = None
+        self._poller = None
+
+    def disengage(self):
+        self._driver.disengage()
+
+    @property
+    def status(self):
+        return self._driver.status
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    @property
+    def live_data(self):
+        return {
+            'status': self.status,
+            'data': {}
+        }
+
+    @property
+    def is_simulated(self):
+        return isinstance(self._driver, SimulatingDriver)
+
+    @property
+    def port(self):
+        return self._port
+
+    async def prep_for_update(self):
+        pass

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1599,20 +1599,3 @@ class MagneticModuleContext(ModuleContext):
     def status(self):
         """ The status of the module. either 'engaged' or 'disengaged' """
         return self._module.status
-
-
-class ThermocyclerContext(ModuleContext):
-    """ An object representing a connected Temperature Module.
-
-        It should not be instantiated directly; instead, it should be
-        created through :py:meth:`.ProtocolContext.load_module`.
-        """
-
-    def __init__(self,
-                 ctx: ProtocolContext,
-                 hw_module: modules.thermocycler.Thermocycler,
-                 geometry: ModuleGeometry,
-                 loop: asyncio.AbstractEventLoop) -> None:
-        self._module = hw_module
-        self._loop = loop
-        super().__init__(ctx, geometry)

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1599,3 +1599,20 @@ class MagneticModuleContext(ModuleContext):
     def status(self):
         """ The status of the module. either 'engaged' or 'disengaged' """
         return self._module.status
+
+
+class ThermocyclerContext(ModuleContext):
+    """ An object representing a connected Temperature Module.
+
+        It should not be instantiated directly; instead, it should be
+        created through :py:meth:`.ProtocolContext.load_module`.
+        """
+
+    def __init__(self,
+                 ctx: ProtocolContext,
+                 hw_module: modules.thermocycler.Thermocycler,
+                 geometry: ModuleGeometry,
+                 loop: asyncio.AbstractEventLoop) -> None:
+        self._module = hw_module
+        self._loop = loop
+        super().__init__(ctx, geometry)


### PR DESCRIPTION
## overview

Adds the minimal stub of Thermocycler to the hardware_control module. Prep work for #2992 

## review requests

Should be able to:

```
$ make local-shell
(api)bash-3.2$ python
>>> from opentrons.hardware_control import modules
>>> t = modules.thermocycler.Thermocycler(None, True)
```