### PR TITLE
perf(protocol-designer): optimize substep components to render less often

### DIFF
--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.js
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.js
@@ -8,7 +8,11 @@ import SubstepRow from './SubstepRow'
 import styles from './StepItem.css'
 import {formatVolume} from './utils'
 
-import type {StepItemSourceDestRow, WellIngredientNames} from '../../steplist/types'
+import type {
+  StepItemSourceDestRow,
+  SubstepIdentifier,
+  WellIngredientNames,
+} from '../../steplist/types'
 
 const DEFAULT_COLLAPSED_STATE = true
 
@@ -16,15 +20,16 @@ type MultiChannelSubstepProps = {|
   rowGroup: Array<StepItemSourceDestRow>,
   ingredNames: WellIngredientNames,
   highlighted?: boolean,
-  onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
-  onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed,
+  stepId: string,
+  substepIndex: number,
+  selectSubstep: SubstepIdentifier => mixed,
 |}
 
 type MultiChannelSubstepState = {
   collapsed: boolean,
 }
 
-export default class MultiChannelSubstep extends React.Component<MultiChannelSubstepProps, MultiChannelSubstepState> {
+export default class MultiChannelSubstep extends React.PureComponent<MultiChannelSubstepProps, MultiChannelSubstepState> {
   state = {collapsed: DEFAULT_COLLAPSED_STATE}
 
   handleToggleCollapsed = () => {
@@ -32,7 +37,7 @@ export default class MultiChannelSubstep extends React.Component<MultiChannelSub
   }
 
   render () {
-    const {rowGroup, highlighted} = this.props
+    const {rowGroup, highlighted, stepId, selectSubstep, substepIndex} = this.props
     const {collapsed} = this.state
 
     // NOTE: need verbose null check for flow to be happy
@@ -44,8 +49,8 @@ export default class MultiChannelSubstep extends React.Component<MultiChannelSub
     const destWellRange = `${firstChannelDest ? firstChannelDest.well : ''}:${lastChannelDest ? lastChannelDest.well : ''}`
     return (
       <ol
-        onMouseEnter={this.props.onMouseEnter}
-        onMouseLeave={this.props.onMouseLeave}
+        onMouseEnter={() => selectSubstep({stepId, substepIndex})}
+        onMouseLeave={() => selectSubstep(null)}
         className={cx({[styles.highlighted]: highlighted})} >
 
         {/* Header row */}
@@ -71,6 +76,8 @@ export default class MultiChannelSubstep extends React.Component<MultiChannelSub
               ingredNames={this.props.ingredNames}
               source={row.source}
               dest={row.dest}
+              stepId={stepId}
+              substepIndex={substepIndex}
             />
           )
         }

--- a/protocol-designer/src/components/steplist/SourceDestSubstep.js
+++ b/protocol-designer/src/components/steplist/SourceDestSubstep.js
@@ -19,12 +19,12 @@ export type StepSubItemProps = {|
 type SourceDestSubstepProps = {|
   ...StepSubItemProps,
   ingredNames: WellIngredientNames,
-  onSelectSubstep: SubstepIdentifier => mixed,
+  selectSubstep: SubstepIdentifier => mixed,
   hoveredSubstep: ?SubstepIdentifier,
 |}
 
 export default function SourceDestSubstep (props: SourceDestSubstepProps) {
-  const {substeps, onSelectSubstep, hoveredSubstep} = props
+  const {substeps, selectSubstep, hoveredSubstep} = props
   if (substeps.multichannel) {
     // multi-channel row item (collapsible)
     return <li>
@@ -32,12 +32,10 @@ export default function SourceDestSubstep (props: SourceDestSubstepProps) {
         <MultiChannelSubstep
           key={groupKey}
           rowGroup={rowGroup}
-          onMouseEnter={() => onSelectSubstep({
-            stepId: substeps.parentStepId,
-            substepIndex: groupKey,
-          })}
+          stepId={substeps.parentStepId}
+          substepIndex={groupKey}
+          selectSubstep={selectSubstep}
           ingredNames={props.ingredNames}
-          onMouseLeave={() => onSelectSubstep(null)}
           highlighted={!!hoveredSubstep &&
             hoveredSubstep.stepId === substeps.parentStepId &&
             hoveredSubstep.substepIndex === groupKey
@@ -59,8 +57,9 @@ export default function SourceDestSubstep (props: SourceDestSubstepProps) {
           substepIndex === hoveredSubstep.substepIndex,
         }
       )}
-      onMouseEnter={() => onSelectSubstep({stepId: substeps.parentStepId, substepIndex})}
-      onMouseLeave={() => onSelectSubstep(null)}
+      selectSubstep={selectSubstep}
+      stepId={substeps.parentStepId}
+      substepIndex={substepIndex}
       ingredNames={props.ingredNames}
       volume={row.volume}
       source={row.source}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -8,11 +8,11 @@ import AspirateDispenseHeader from './AspirateDispenseHeader'
 import MixHeader from './MixHeader'
 import PauseStepItems from './PauseStepItems'
 import StepDescription from '../StepDescription'
-import {stepIconsByType, type StepIdType} from '../../form-types'
+import {stepIconsByType} from '../../form-types'
+import type {FormData, StepIdType, StepType} from '../../form-types'
 import type {Labware} from '../../labware-ingred/types'
 import type {
   SubstepIdentifier,
-  StepItemData,
   SubstepItemData,
   WellIngredientNames,
 } from '../../steplist/types'
@@ -20,8 +20,11 @@ import type {
 type StepItemProps = {
   stepId: StepIdType,
   stepNumber: number,
-  step: ?StepItemData,
+  stepType: StepType,
+  title: string,
+  description: ?string,
   substeps: ?SubstepItemData,
+  rawForm: ?FormData,
 
   collapsed?: boolean,
   error?: ?boolean,
@@ -30,69 +33,76 @@ type StepItemProps = {
   hoveredSubstep: ?SubstepIdentifier,
   ingredNames: WellIngredientNames,
 
-  getLabware: (labwareId: ?string) => ?Labware,
+  labwareById: {[labwareId: string]: ?Labware},
   handleSubstepHover: SubstepIdentifier => mixed,
-  onStepClick?: (event?: SyntheticEvent<>) => mixed,
+  selectStep: (stepId: StepIdType) => mixed,
   onStepContextMenu?: (event?: SyntheticEvent<>) => mixed,
-  onStepItemCollapseToggle?: (event?: SyntheticEvent<>) => mixed,
-  onStepHover?: (event?: SyntheticEvent<>) => mixed,
+  toggleStepCollapsed: (stepId: StepIdType) => mixed,
+  hoverStep: (stepId: StepIdType) => mixed,
   onStepMouseLeave?: (event?: SyntheticEvent<>) => mixed,
 }
 
-function StepItem (props: StepItemProps) {
-  const {
-    step,
-    stepNumber,
+class StepItem extends React.PureComponent<StepItemProps> {
+  render () {
+    const {
+      stepType,
+      title,
+      description,
+      stepId,
+      stepNumber,
 
-    collapsed,
-    error,
-    selected,
-    hovered,
+      collapsed,
+      error,
+      selected,
+      hovered,
 
-    onStepMouseLeave,
-    onStepClick,
-    onStepContextMenu,
-    onStepItemCollapseToggle,
-    onStepHover,
-  } = props
+      onStepMouseLeave,
+      selectStep,
+      onStepContextMenu,
+      toggleStepCollapsed,
+      hoverStep,
+    } = this.props
 
-  const iconName = step && stepIconsByType[step.stepType]
-  const title = step && step.title
-  const Description = <StepDescription description={step && step.description} />
+    const iconName = stepIconsByType[stepType]
+    const Description = <StepDescription description={description} />
 
-  return (
-    <PDTitledList
-      description={Description}
-      iconName={error ? 'alert-circle' : iconName}
-      iconProps={{className: error ? styles.error_icon : ''}}
-      title={title ? `${stepNumber}. ${title}` : ''}
-      onClick={onStepClick}
-      onContextMenu={onStepContextMenu}
-      onMouseEnter={onStepHover}
-      onMouseLeave={onStepMouseLeave}
-      onCollapseToggle={onStepItemCollapseToggle}
-      {...{selected, collapsed, hovered}}
-    >
-      {getStepItemContents(props)}
-    </PDTitledList>
-  )
+    return (
+      <PDTitledList
+        description={Description}
+        iconName={error ? 'alert-circle' : iconName}
+        iconProps={{className: error ? styles.error_icon : ''}}
+        title={title ? `${stepNumber}. ${title}` : ''}
+        onClick={() => selectStep(stepId)}
+        onContextMenu={onStepContextMenu}
+        onMouseEnter={() => hoverStep(stepId)}
+        onMouseLeave={onStepMouseLeave}
+        onCollapseToggle={() => toggleStepCollapsed(stepId)}
+        {...{selected, collapsed, hovered}}
+      >
+        {getStepItemContents(this.props)}
+      </PDTitledList>
+    )
+  }
 }
 
 function getStepItemContents (stepItemProps: StepItemProps) {
   const {
-    step,
+    rawForm,
+    stepType,
     substeps,
-    getLabware,
+    labwareById,
     hoveredSubstep,
     handleSubstepHover,
     ingredNames,
   } = stepItemProps
 
-  const formData = step && step.formData
-
-  if (!step) {
+  if (!rawForm) {
     return null
   }
+
+  const getLabware = (labwareId: ?string) =>
+    labwareId != null ? labwareById[labwareId] : null
+
   // pause substep component uses the delay args directly
   if (substeps && substeps.commandCreatorFnName === 'delay') {
     return <PauseStepItems pauseArgs={substeps} />
@@ -102,15 +112,13 @@ function getStepItemContents (stepItemProps: StepItemProps) {
 
   // headers
   if (
-    formData && (
-      formData.stepType === 'transfer' ||
-      formData.stepType === 'consolidate' ||
-      formData.stepType === 'distribute' ||
-      formData.stepType === 'moveLiquid'
-    )
+    stepType === 'transfer' ||
+    stepType === 'consolidate' ||
+    stepType === 'distribute' ||
+    stepType === 'moveLiquid'
   ) {
-    const sourceLabware = getLabware(formData['aspirate_labware'])
-    const destLabware = getLabware(formData['dispense_labware'])
+    const sourceLabware = getLabware(rawForm['aspirate_labware'])
+    const destLabware = getLabware(rawForm['dispense_labware'])
 
     result.push(
       <AspirateDispenseHeader
@@ -120,12 +128,12 @@ function getStepItemContents (stepItemProps: StepItemProps) {
     )
   }
 
-  if (formData && formData.stepType === 'mix') {
+  if (stepType === 'mix') {
     result.push(
       <MixHeader key='mix-header'
-        volume={formData.volume}
-        times={formData.times}
-        labware={getLabware(formData.labware)}
+        volume={rawForm.volume}
+        times={rawForm.times}
+        labware={getLabware(rawForm.labware)}
       />
     )
   }
@@ -146,7 +154,7 @@ function getStepItemContents (stepItemProps: StepItemProps) {
         ingredNames={ingredNames}
         substeps={substeps}
         hoveredSubstep={hoveredSubstep}
-        onSelectSubstep={handleSubstepHover}
+        selectSubstep={handleSubstepHover}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -34,12 +34,12 @@ type StepItemProps = {
   ingredNames: WellIngredientNames,
 
   labwareById: {[labwareId: string]: ?Labware},
-  handleSubstepHover: SubstepIdentifier => mixed,
+  highlightSubstep: SubstepIdentifier => mixed,
   selectStep: (stepId: StepIdType) => mixed,
   onStepContextMenu?: (event?: SyntheticEvent<>) => mixed,
   toggleStepCollapsed: (stepId: StepIdType) => mixed,
-  hoverStep: (stepId: StepIdType) => mixed,
-  onStepMouseLeave?: (event?: SyntheticEvent<>) => mixed,
+  highlightStep: (stepId: StepIdType) => mixed,
+  unhighlightStep?: (event?: SyntheticEvent<>) => mixed,
 }
 
 class StepItem extends React.PureComponent<StepItemProps> {
@@ -56,11 +56,11 @@ class StepItem extends React.PureComponent<StepItemProps> {
       selected,
       hovered,
 
-      onStepMouseLeave,
+      unhighlightStep,
       selectStep,
       onStepContextMenu,
       toggleStepCollapsed,
-      hoverStep,
+      highlightStep,
     } = this.props
 
     const iconName = stepIconsByType[stepType]
@@ -74,8 +74,8 @@ class StepItem extends React.PureComponent<StepItemProps> {
         title={title ? `${stepNumber}. ${title}` : ''}
         onClick={() => selectStep(stepId)}
         onContextMenu={onStepContextMenu}
-        onMouseEnter={() => hoverStep(stepId)}
-        onMouseLeave={onStepMouseLeave}
+        onMouseEnter={() => highlightStep(stepId)}
+        onMouseLeave={unhighlightStep}
         onCollapseToggle={() => toggleStepCollapsed(stepId)}
         {...{selected, collapsed, hovered}}
       >
@@ -92,7 +92,7 @@ function getStepItemContents (stepItemProps: StepItemProps) {
     substeps,
     labwareById,
     hoveredSubstep,
-    handleSubstepHover,
+    highlightSubstep,
     ingredNames,
   } = stepItemProps
 
@@ -154,7 +154,7 @@ function getStepItemContents (stepItemProps: StepItemProps) {
         ingredNames={ingredNames}
         substeps={substeps}
         hoveredSubstep={hoveredSubstep}
-        selectSubstep={handleSubstepHover}
+        selectSubstep={highlightSubstep}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -1,12 +1,18 @@
 // @flow
 import * as React from 'react'
 import map from 'lodash/map'
+import noop from 'lodash/noop'
 import reduce from 'lodash/reduce'
 import omitBy from 'lodash/omitBy'
 
 import {HoverTooltip, swatchColors} from '@opentrons/components'
 import type {LocationLiquidState} from '../../step-generation'
-import type {SubstepWellData, WellIngredientVolumeData, WellIngredientNames} from '../../steplist/types'
+import type {
+  SubstepIdentifier,
+  SubstepWellData,
+  WellIngredientVolumeData,
+  WellIngredientNames,
+} from '../../steplist/types'
 import IngredPill from './IngredPill'
 import {PDListItem} from '../lists'
 import styles from './StepItem.css'
@@ -19,8 +25,9 @@ type SubstepRowProps = {|
   dest?: SubstepWellData,
   ingredNames: WellIngredientNames,
   className?: string,
-  onMouseEnter?: (e: SyntheticMouseEvent<*>) => mixed,
-  onMouseLeave?: (e: SyntheticMouseEvent<*>) => mixed,
+  stepId: string,
+  substepIndex: number,
+  selectSubstep?: SubstepIdentifier => mixed,
 |}
 
 type PillTooltipContentsProps = {
@@ -68,15 +75,16 @@ export const PillTooltipContents = (props: PillTooltipContentsProps) => {
   )
 }
 
-export default function SubstepRow (props: SubstepRowProps) {
+function SubstepRow (props: SubstepRowProps) {
   const compactedSourcePreIngreds = props.source ? omitBy(props.source.preIngreds, ingred => ingred.volume <= 0) : {}
   const compactedDestPreIngreds = props.dest ? omitBy(props.dest.preIngreds, ingred => ingred.volume <= 0) : {}
+  const selectSubstep = props.selectSubstep || noop
   return (
     <PDListItem
       border
       className={props.className}
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}>
+      onMouseEnter={() => selectSubstep({stepId: props.stepId, substepIndex: props.substepIndex})}
+      onMouseLeave={() => selectSubstep(null)}>
       <HoverTooltip
         portal={Portal}
         tooltipComponent={(
@@ -113,3 +121,6 @@ export default function SubstepRow (props: SubstepRowProps) {
     </PDListItem>
   )
 }
+
+// TODO: Ian 2019-02-04 need to update Flow defs for React.memo $FlowFixMe
+export default React.memo(SubstepRow)

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -76,12 +76,11 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
 
 function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
   return {
-    handleSubstepHover: (payload: SubstepIdentifier) => dispatch(stepsActions.hoverOnSubstep(payload)),
-
+    highlightSubstep: (payload: SubstepIdentifier) => dispatch(stepsActions.hoverOnSubstep(payload)),
     selectStep: (stepId) => dispatch(stepsActions.selectStep(stepId)),
     toggleStepCollapsed: (stepId) => dispatch(stepsActions.toggleStepCollapsed(stepId)),
-    hoverStep: (stepId) => dispatch(stepsActions.hoverOnStep(stepId)),
-    onStepMouseLeave: (stepId) => dispatch(stepsActions.hoverOnStep(null)),
+    highlightStep: (stepId) => dispatch(stepsActions.hoverOnStep(stepId)),
+    unhighlightStep: (stepId) => dispatch(stepsActions.hoverOnStep(null)),
   }
 }
 

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -21,14 +21,17 @@ type OP = {
 }
 
 type SP = {|
-  step: $PropertyType<Props, 'step'>,
+  stepType: $PropertyType<Props, 'stepType'>,
+  title: $PropertyType<Props, 'title'>,
+  description: $PropertyType<Props, 'description'>,
+  rawForm: $PropertyType<Props, 'rawForm'>,
   substeps: $PropertyType<Props, 'substeps'>,
   collapsed: $PropertyType<Props, 'collapsed'>,
   error: $PropertyType<Props, 'error'>,
   selected: $PropertyType<Props, 'selected'>,
   hovered: $PropertyType<Props, 'hovered'>,
   hoveredSubstep: $PropertyType<Props, 'hoveredSubstep'>,
-  getLabware: $PropertyType<Props, 'getLabware'>,
+  labwareById: $PropertyType<Props, 'labwareById'>,
   ingredNames: $PropertyType<Props, 'ingredNames'>,
 |}
 
@@ -45,15 +48,17 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const argsAndErrorsByStepId = stepFormSelectors.getArgsAndErrorsByStepId(state)
   const formAndFieldErrors = argsAndErrorsByStepId[stepId] && argsAndErrorsByStepId[stepId].errors
   const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
-  const warnings = (typeof stepId === 'number') // TODO: Ian 2018-07-13 remove when stepId always number
-    ? dismissSelectors.getTimelineWarningsPerStep(state)[stepId]
-    : []
+  const warnings = dismissSelectors.getTimelineWarningsPerStep(state)[stepId]
   const hasWarnings = warnings && warnings.length > 0
 
   const showErrorState = hasError || hasWarnings
+  const step = allSteps[stepId]
 
   return {
-    step: allSteps[stepId],
+    stepType: step.stepType,
+    title: step.title,
+    description: step.description,
+    rawForm: step.formData,
     substeps: substepSelectors.allSubsteps(state)[stepId],
     hoveredSubstep,
     collapsed,
@@ -64,21 +69,19 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // user is not hovering on substep.
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
-    getLabware: (labwareId: ?string) => labwareId ? stepFormSelectors.getLabwareById(state)[labwareId] : null,
+    labwareById: stepFormSelectors.getLabwareById(state),
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }
 }
 
-function mapDispatchToProps (dispatch: ThunkDispatch<*>, ownProps: OP): DP {
-  const {stepId} = ownProps
-
+function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
   return {
     handleSubstepHover: (payload: SubstepIdentifier) => dispatch(stepsActions.hoverOnSubstep(payload)),
 
-    onStepClick: () => dispatch(stepsActions.selectStep(stepId)),
-    onStepItemCollapseToggle: () => dispatch(stepsActions.toggleStepCollapsed(stepId)),
-    onStepHover: () => dispatch(stepsActions.hoverOnStep(stepId)),
-    onStepMouseLeave: () => dispatch(stepsActions.hoverOnStep(null)),
+    selectStep: (stepId) => dispatch(stepsActions.selectStep(stepId)),
+    toggleStepCollapsed: (stepId) => dispatch(stepsActions.toggleStepCollapsed(stepId)),
+    hoverStep: (stepId) => dispatch(stepsActions.hoverOnStep(stepId)),
+    onStepMouseLeave: (stepId) => dispatch(stepsActions.hoverOnStep(null)),
   }
 }
 


### PR DESCRIPTION
## overview

With many steps and/or many substeps, PD performance becomes awful. This PR minimizes the re-rendering of StepItem and SourceDestSubstep and related, so that it becomes managable to have a step with 999 substeps, or to have a many steps with several substeps each.

There is still sub-optimal re-rendering when opening/cancelling a step form that shouldn't need to happen, but I can't track that down. I think it's due to the structure of PD's highest-level render components that do the layout, like the whole step list is re-rendered when step form visibility changes?? A problem for another day.

## changelog

Detailed in PR comments

## review requests

If you enable "paint flashing" in Chrome's Rendering dev tools you can see when things are re-rendering.

- When moving mouse over substeps, only the de-selected and newly-selected substeps should re-render (please test both single-channel and 8-channel style substeps). On edge, every substep would re-render when you changed the hovered substep.
- Same as above, but for steps (can be collapsed) -- on edge, every step in the list would re-render when you change the hovered step.
- Same but for selected - only the deselected and the newly-selected step should change.
- **DANGER ZONE:** nothing should get cached wrong. Changing upstream steps so the downstream wells have a different liquid type/quantity should always cascade the change down, downstream steps should immediately update. This includes the nested 8-channel substeps. Also, deleting or re-ordering steps shouldn't de-sync the select/highlight behavior to point to a wrong stepId!
