### PR TITLE
feat(api): Load and save per-pipette-id config overrides

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -214,5 +214,5 @@ def load_overrides(pipette_id: str) -> Dict[str, Any]:
     try:
         return json.load(fi)
     except json.JSONDecodeError as e:
-        log.warning(f'pipette override for {pipette_id} is corrupt')
+        log.warning(f'pipette override for {pipette_id} is corrupt: {e}')
         return {}

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -131,14 +131,10 @@ def get_pipettes(hardware):
         left = attached_pipettes.get('left')
         right = attached_pipettes.get('right')
         if left['model'] in pipette_config.configs:
-            pip_config = pipette_config.load(left['model'])
-            left_pipette = instruments._create_pipette_from_config(
-                mount='left', config=pip_config, name=left['model'])
-
+            left_pipette = instruments.pipette_by_name('left', left['model'])
         if right['model'] in pipette_config.configs:
-            pip_config = pipette_config.load(right['model'])
-            right_pipette = instruments._create_pipette_from_config(
-                mount='right', config=pip_config, name=right['model'])
+            right_pipette = instruments.pipette_by_name(
+                'right', right['model'])
     else:
         attached_pipettes = hardware.attached_instruments
         left_pipette = attached_pipettes.get(Mount.LEFT)

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -21,7 +21,7 @@ class Pipette:
                  model: str,
                  inst_offset_config: Dict[str, Tuple[float, float, float]],
                  pipette_id: str = None) -> None:
-        self._config = pipette_config.load(model)
+        self._config = pipette_config.load(model, pipette_id)
         self._name = model
         self._current_volume = 0.0
         self._current_tip_length = 0.0

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -39,6 +39,19 @@ class InstrumentsWrapper(object):
         """
         return inst.Pipette(self.robot, *args, **kwargs)
 
+    def _pipette_details(self, mount, name_or_model):
+        self.robot.cache_instrument_models()
+        pipette_model_version = self.retrieve_version_number(
+            mount, name_or_model)
+        attached = self.robot.get_attached_pipettes()
+        if attached[mount]['model'] == pipette_model_version\
+           and attached[mount]['id']\
+           and attached[mount]['id'] != 'uncommissioned':
+            pip_id = attached[mount]['id']
+        else:
+            pip_id = None
+        return (pipette_model_version, pip_id)
+
     def P10_Single(
             self,
             mount,
@@ -48,21 +61,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p10_single')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p10_single',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P10_Multi(
             self,
@@ -73,21 +75,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p10_multi')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p10_multi',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P50_Single(
             self,
@@ -98,21 +89,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p50_single')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p50_single',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P50_Multi(
             self,
@@ -123,21 +103,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p50_multi')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p50_multi',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P300_Single(
             self,
@@ -148,21 +117,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p300_single')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p300_single',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P300_Multi(
             self,
@@ -173,21 +131,10 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p300_multi')
-        config = pipette_config.load(pipette_model_version)
-
-        return self._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_model_version,
-            trash_container=trash_container,
-            tip_racks=tip_racks,
-            aspirate_flow_rate=aspirate_flow_rate,
-            dispense_flow_rate=dispense_flow_rate,
-            min_volume=min_volume,
-            max_volume=max_volume)
+        return self.pipette_by_name(mount, 'p300_multi',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
     def P1000_Single(
             self,
@@ -198,10 +145,24 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
+        return self.pipette_by_name(mount, 'p1000_single',
+                                    trash_container, tip_racks,
+                                    aspirate_flow_rate, dispense_flow_rate,
+                                    min_volume, max_volume)
 
-        pipette_model_version = self.retrieve_version_number(
-            mount, 'p1000_single')
-        config = pipette_config.load(pipette_model_version)
+    def pipette_by_name(
+            self,
+            mount,
+            name_or_model,
+            trash_container='',
+            tip_racks=[],
+            aspirate_flow_rate=None,
+            dispense_flow_rate=None,
+            min_volume=None,
+            max_volume=None):
+        pipette_model_version, pip_id = self._pipette_details(
+            mount, name_or_model)
+        config = pipette_config.load(pipette_model_version, pip_id)
 
         return self._create_pipette_from_config(
             config=config,
@@ -260,6 +221,9 @@ class InstrumentsWrapper(object):
         return p
 
     def retrieve_version_number(self, mount, expected_model_substring):
+        if pipette_config.HAS_MODEL_RE.match(expected_model_substring):
+            return expected_model_substring
+
         attached_model = robot.get_attached_pipettes()[mount]['model']
 
         if attached_model and expected_model_substring in attached_model:

--- a/api/src/opentrons/protocols/__init__.py
+++ b/api/src/opentrons/protocols/__init__.py
@@ -1,7 +1,6 @@
 import time
 from itertools import chain
 from opentrons import instruments, labware, robot
-from opentrons.config import pipette_config
 
 
 def _sleep(seconds):
@@ -23,15 +22,7 @@ def load_pipettes(protocol_data):
         name = props.get('name')
         if not name:
             name = model.split('_v')[0]
-
-        pipette_name_version = instruments.retrieve_version_number(
-            mount, name)
-        config = pipette_config.load(pipette_name_version)
-
-        pipette = instruments._create_pipette_from_config(
-            config=config,
-            mount=mount,
-            name=pipette_name_version)
+        pipette = instruments.pipette_by_name(mount, name)
 
         pipettes_by_id[pipette_id] = pipette
 


### PR DESCRIPTION
These are saved in CONFIG[’pipette_config_overrides_dir], by default
${OT_API_CONFIG_DIR}/pipettes. They are named {pipette_id}.json. They should
contain a structure suitable for updating into a loaded pipette config dict
after the name and model configs are merged.

These overrides are applied whenever pipette configs are loaded, if a pipette id
is known.

Closes #2936
