### PR TITLE
feat(protocol-designer): improve ux behavior of disposal volume

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -63,6 +63,10 @@
   font-size: var(--fs-body-1);
 }
 
+.captioned_field {
+  margin-bottom: 1rem;
+}
+
 .hidden_fields {
   margin: 0 1rem 0 2.5rem;
   min-width: 14.5rem;

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -1,11 +1,10 @@
 // @flow
 import * as React from 'react'
-import round from 'lodash/round'
 import {FormGroup, CheckboxField, type DropdownOption, DropdownField} from '@opentrons/components'
 import {connect} from 'react-redux'
 import cx from 'classnames'
 
-import {getMaxDisposalVolume} from '../../../steplist/formLevel/handleFormChange/utils'
+import {getMaxDisposalVolumeForMultidispense} from '../../../steplist/formLevel/handleFormChange/utils'
 import {SOURCE_WELL_BLOWOUT_DESTINATION} from '../../../step-generation/utils'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 
@@ -23,8 +22,6 @@ type SP = {
 
 type Props = SP & {focusHandlers: FocusHandlers}
 
-const DISPOSAL_VOL_MAX_DIGITS = 2
-
 const DisposalVolumeField = (props: Props) => (
   <FormGroup label='Multi-Dispense Options:'>
     <FieldConnector
@@ -32,7 +29,7 @@ const DisposalVolumeField = (props: Props) => (
       render={({value, updateValue}) => {
         const {maxDisposalVolume} = props
         const volumeBoundsCaption = maxDisposalVolume != null
-          ? `max ${round(maxDisposalVolume, DISPOSAL_VOL_MAX_DIGITS)} μL`
+          ? `max ${maxDisposalVolume} μL`
           : null
 
         const volumeField = (
@@ -94,7 +91,7 @@ const DisposalVolumeField = (props: Props) => (
 
 const mapSTP = (state: BaseState): SP => {
   return {
-    maxDisposalVolume: getMaxDisposalVolume(stepFormSelectors.getUnsavedForm(state), stepFormSelectors.getPipetteEntities(state)),
+    maxDisposalVolume: getMaxDisposalVolumeForMultidispense(stepFormSelectors.getUnsavedForm(state), stepFormSelectors.getPipetteEntities(state)),
     disposalDestinationOptions: [
       ...stepFormSelectors.getDisposalLabwareOptions(state),
       {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION},

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -1,81 +1,105 @@
 // @flow
 import * as React from 'react'
+import round from 'lodash/round'
 import {FormGroup, CheckboxField, type DropdownOption, DropdownField} from '@opentrons/components'
 import {connect} from 'react-redux'
 import cx from 'classnames'
 
+import {getMaxDisposalVolume} from '../../../steplist/formLevel/handleFormChange/utils'
 import {SOURCE_WELL_BLOWOUT_DESTINATION} from '../../../step-generation/utils'
 import {selectors as stepFormSelectors} from '../../../step-forms'
-import type {BaseState} from '../../../types'
-import styles from '../StepEditForm.css'
-import type {FocusHandlers} from '../types'
 
 import FieldConnector from './FieldConnector'
 import TextField from './Text'
 
-type SP = {disposalDestinationOptions: Array<DropdownOption>}
+import type {BaseState} from '../../../types'
+import type {FocusHandlers} from '../types'
+import styles from '../StepEditForm.css'
+
+type SP = {
+  disposalDestinationOptions: Array<DropdownOption>,
+  maxDisposalVolume: ?number,
+}
 
 type Props = SP & {focusHandlers: FocusHandlers}
+
+const DISPOSAL_VOL_MAX_DIGITS = 2
 
 const DisposalVolumeField = (props: Props) => (
   <FormGroup label='Multi-Dispense Options:'>
     <FieldConnector
       name="disposalVolume_checkbox"
-      render={({value, updateValue}) => (
-        <React.Fragment>
-          <div className={cx(styles.checkbox_row, styles.multi_dispense_options)}>
-            <CheckboxField
-              label="Disposal Volume"
-              value={!!value}
-              className={styles.checkbox_field}
-              onChange={(e: SyntheticInputEvent<*>) => updateValue(!value)} />
+      render={({value, updateValue}) => {
+        const {maxDisposalVolume} = props
+        const volumeBoundsCaption = maxDisposalVolume != null
+          ? `max ${round(maxDisposalVolume, DISPOSAL_VOL_MAX_DIGITS)} μL`
+          : null
+
+        const volumeField = (
+          <div>
+            <TextField
+              name="disposalVolume_volume"
+              units="μL"
+              caption={volumeBoundsCaption}
+              className={cx(styles.small_field, styles.orphan_field)}
+              {...props.focusHandlers} />
+          </div>
+        )
+
+        return (
+          <React.Fragment>
+            <div className={cx(
+              styles.checkbox_row,
+              styles.multi_dispense_options,
+              {[styles.captioned_field]: volumeBoundsCaption}
+            )}>
+              <CheckboxField
+                label="Disposal Volume"
+                value={Boolean(value)}
+                className={styles.checkbox_field}
+                onChange={(e: SyntheticInputEvent<*>) => updateValue(!value)} />
+              {
+                value
+                  ? volumeField
+                  : null
+              }
+            </div>
             {
               value
                 ? (
-                  <div>
-                    <TextField
-                      name="disposalVolume_volume"
-                      units="μL"
-                      caption={`between 1 and ${5}`}
-                      className={cx(styles.small_field, styles.orphan_field)}
-                      {...props.focusHandlers} />
+                  <div className={styles.checkbox_row}>
+                    <div className={styles.sub_select_label}>Blowout</div>
+                    <FieldConnector
+                      name="blowout_location"
+                      focusedField={props.focusHandlers.focusedField}
+                      dirtyFields={props.focusHandlers.dirtyFields}
+                      render={({value, updateValue}) => (
+                        <DropdownField
+                          className={cx(styles.medium_field, styles.orphan_field)}
+                          options={props.disposalDestinationOptions}
+                          onBlur={() => { props.focusHandlers.onFieldBlur('blowout_location') }}
+                          onFocus={() => { props.focusHandlers.onFieldFocus('blowout_location') }}
+                          value={value ? String(value) : null}
+                          onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
+                      )} />
                   </div>
                 )
                 : null
             }
-          </div>
-          {
-            value
-              ? (
-                <div className={styles.checkbox_row}>
-                  <div className={styles.sub_select_label}>Blowout</div>
-                  <FieldConnector
-                    name="blowout_location"
-                    focusedField={props.focusHandlers.focusedField}
-                    dirtyFields={props.focusHandlers.dirtyFields}
-                    render={({value, updateValue}) => (
-                      <DropdownField
-                        className={cx(styles.medium_field, styles.orphan_field)}
-                        options={props.disposalDestinationOptions}
-                        onBlur={() => { props.focusHandlers.onFieldBlur('blowout_location') }}
-                        onFocus={() => { props.focusHandlers.onFieldFocus('blowout_location') }}
-                        value={value ? String(value) : null}
-                        onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
-                    )} />
-                </div>
-              )
-              : null
-          }
-        </React.Fragment>
-      )} />
+          </React.Fragment>
+        )
+      }} />
   </FormGroup>
 )
 
-const mapSTP = (state: BaseState): SP => ({
-  disposalDestinationOptions: [
-    ...stepFormSelectors.getDisposalLabwareOptions(state),
-    {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION},
-  ],
-})
+const mapSTP = (state: BaseState): SP => {
+  return {
+    maxDisposalVolume: getMaxDisposalVolume(stepFormSelectors.getUnsavedForm(state), stepFormSelectors.getPipetteEntities(state)),
+    disposalDestinationOptions: [
+      ...stepFormSelectors.getDisposalLabwareOptions(state),
+      {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION},
+    ],
+  }
+}
 
 export default connect(mapSTP)(DisposalVolumeField)

--- a/protocol-designer/src/components/StepEditForm/fields/Path/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/index.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux'
 import Path from './Path'
 import {selectors as stepFormSelectors} from '../../../../step-forms'
 import {getWellRatio} from '../../../../steplist/utils'
-import {getPipetteCapacity} from '../../../../pipettes/pipetteData'
+import {volumeInCapacityForMulti} from '../../../../steplist/formLevel/handleFormChange/utils'
 import type {ElementProps} from 'react'
 import type {PipetteEntities} from '../../../../step-forms'
 import type {FormData, PathOption} from '../../../../form-types'
@@ -16,16 +16,9 @@ function getDisabledPaths (
   rawForm: ?FormData,
   pipetteEntities: PipetteEntities
 ): ?Set<PathOption> {
-  if (!rawForm) return null
+  if (!rawForm || !rawForm.pipette) return null
 
-  // TODO IMMEDIATELY share this fn with dependentFieldsUpdateMoveLiquid
-  const pipetteCapacity = rawForm.pipette && getPipetteCapacity(pipetteEntities[rawForm.pipette])
-  // NOTE: ensuring that disposalVolume_volume will not exceed pipette capacity is responsibility of dependentFieldsUpdateMoveLiquid
-  const withinCapacityForMultiPath = (
-    rawForm.volume > 0 &&
-    pipetteCapacity > 0 &&
-    rawForm.volume * 2 <= pipetteCapacity
-  )
+  const withinCapacityForMultiPath = volumeInCapacityForMulti(rawForm, pipetteEntities)
   const wellRatio = getWellRatio(rawForm.aspirate_wells, rawForm.dispense_wells)
 
   if (withinCapacityForMultiPath) {

--- a/protocol-designer/src/components/StepEditForm/fields/Path/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/index.js
@@ -18,13 +18,12 @@ function getDisabledPaths (
 ): ?Set<PathOption> {
   if (!rawForm) return null
 
-  const disposalVolume = (rawForm.disposalVolume_checkbox && rawForm.disposalVolume_volume) || 0
   const pipetteCapacity = rawForm.pipette && getPipetteCapacity(pipetteEntities[rawForm.pipette])
-  // TODO IMMEDIATELY also apply 2x-well-rule and add disposal volume -- make this a util, and search for other places this happens
+  // NOTE: ensuring that disposalVolume_volume will not exceed pipette capacity is responsibility of dependentFieldsUpdateMoveLiquid
   const withinCapacityForMultiPath = (
     rawForm.volume > 0 &&
     pipetteCapacity > 0 &&
-    rawForm.volume * 2 + disposalVolume <= pipetteCapacity
+    rawForm.volume * 2 <= pipetteCapacity
   )
   const wellRatio = getWellRatio(rawForm.aspirate_wells, rawForm.dispense_wells)
 

--- a/protocol-designer/src/components/StepEditForm/fields/Path/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/index.js
@@ -18,6 +18,7 @@ function getDisabledPaths (
 ): ?Set<PathOption> {
   if (!rawForm) return null
 
+  // TODO IMMEDIATELY share this fn with dependentFieldsUpdateMoveLiquid
   const pipetteCapacity = rawForm.pipette && getPipetteCapacity(pipetteEntities[rawForm.pipette])
   // NOTE: ensuring that disposalVolume_volume will not exceed pipette capacity is responsibility of dependentFieldsUpdateMoveLiquid
   const withinCapacityForMultiPath = (

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -74,19 +74,11 @@ export function updatePatchPathField (patch: FormPatch, rawForm: FormData, pipet
   // pass-thru: incomplete form
   if (!path) return patch
 
-  const numericVolume = Number(appliedPatch.volume) || 0
-  const pipetteCapacity = getPipetteCapacity(pipetteEntities[appliedPatch.pipette])
-  let pipetteCapacityExceeded = numericVolume > pipetteCapacity
-
+  const volumeNum = Number(appliedPatch.volume)
+  let pipetteCapacityExceeded = false
   if (appliedPatch.volume && appliedPatch.pipette && appliedPatch.pipette in pipetteEntities) {
     const pipetteCapacity = getPipetteCapacity(pipetteEntities[appliedPatch.pipette])
-    if (appliedPatch.volume * 2 > pipetteCapacity) {
-      pipetteCapacityExceeded = appliedPatch.volume > pipetteCapacity
-    }
-  }
-
-  if (pipetteCapacityExceeded) {
-    return {...patch, path: 'single'}
+    pipetteCapacityExceeded = (volumeNum * 2) > pipetteCapacity
   }
 
   // changeTip value incompatible with next path value

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -1,22 +1,21 @@
 // @flow
 import assert from 'assert'
 import clamp from 'lodash/clamp'
-import floor from 'lodash/floor'
+import round from 'lodash/round'
 import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import makeConditionalPatchUpdater from './makeConditionalPatchUpdater'
 import {
   chainPatchUpdaters,
   getChannels,
   getAllWellsFromPrimaryWells,
-  getMaxDisposalVolume,
+  getMaxDisposalVolumeForMultidispense,
+  volumeInCapacityForMulti,
+  DISPOSAL_VOL_DIGITS,
 } from './utils'
-import {getPipetteCapacity} from '../../../pipettes/pipetteData'
 import {getWellRatio} from '../../utils'
 import type {FormData} from '../../../form-types'
 import type {FormPatch} from '../../actions/types'
 import type {LabwareEntities, PipetteEntities} from '../../../step-forms/types'
-
-const DISPOSAL_VOL_DIGITS = 2
 
 const wellRatioUpdatesMap = [
   {
@@ -75,11 +74,9 @@ export function updatePatchPathField (patch: FormPatch, rawForm: FormData, pipet
   // pass-thru: incomplete form
   if (!path) return patch
 
-  const volumeNum = Number(appliedPatch.volume)
   let pipetteCapacityExceeded = false
   if (appliedPatch.volume && appliedPatch.pipette && appliedPatch.pipette in pipetteEntities) {
-    const pipetteCapacity = getPipetteCapacity(pipetteEntities[appliedPatch.pipette])
-    pipetteCapacityExceeded = (volumeNum * 2) > pipetteCapacity
+    pipetteCapacityExceeded = !volumeInCapacityForMulti(appliedPatch, pipetteEntities)
   }
 
   // changeTip value incompatible with next path value
@@ -178,6 +175,7 @@ const updatePatchDisposalVolumeFields = (
 }
 
 // clamp disposal volume so it cannot be negative, or exceed the capacity for multiDispense
+// also rounds it to acceptable digits before clamping
 const clampDisposalVolume = (
   patch: FormPatch,
   rawForm: FormData,
@@ -186,18 +184,21 @@ const clampDisposalVolume = (
   const appliedPatch = {...rawForm, ...patch}
   if (appliedPatch.path !== 'multiDispense') return patch
 
-  const maxDisposalVolume = getMaxDisposalVolume(appliedPatch, pipetteEntities)
+  const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(appliedPatch, pipetteEntities)
   if (maxDisposalVolume == null) {
     assert(false, `clampDisposalVolume got null maxDisposalVolume for pipette, something weird happened`)
     return patch
   }
 
-  const nextDisposalVolume = clamp(Number(appliedPatch.disposalVolume_volume), 0, maxDisposalVolume)
+  const nextDisposalVolume = clamp(
+    round(Number(appliedPatch.disposalVolume_volume), DISPOSAL_VOL_DIGITS),
+    0,
+    maxDisposalVolume)
 
   if (nextDisposalVolume > 0) {
     return {
       ...patch,
-      disposalVolume_volume: String(floor(nextDisposalVolume, DISPOSAL_VOL_DIGITS)),
+      disposalVolume_volume: String(nextDisposalVolume),
     }
   }
   // clear out if path is new, or set to zero/null depending on checkbox

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -1,4 +1,5 @@
 // @flow
+import clamp from 'lodash/clamp'
 import floor from 'lodash/floor'
 import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import makeConditionalPatchUpdater from './makeConditionalPatchUpdater'
@@ -156,8 +157,8 @@ const updatePatchDisposalVolumeFields = (
 ) => {
   const appliedPatch = {...rawForm, ...patch}
 
-  if (appliedPatch.path !== 'multiDispense') {
-    // clear disposal volume whenever path is not multiDispense
+  if (patch.path && patch.path !== 'multiDispense' && rawForm.path === 'multiDispense') {
+    // clear disposal volume whenever path was changed from multiDispense
     return {
       ...patch,
       ...clearedDisposalVolumeFields,
@@ -170,11 +171,6 @@ const updatePatchDisposalVolumeFields = (
   )
   if (shouldReinitializeDisposalVolume) {
     const pipetteEntity = pipetteEntities[appliedPatch.pipette]
-    // const pipetteCapacity = getPipetteCapacity(pipetteEntity)
-    // at least 2 well's worth of volume must fit in pipette
-    // const availableVolume = pipetteCapacity - Number(appliedPatch.volume) * 2
-    // const canAddDisposalVolume = availableVolume > 0
-
     const pipetteSpec = getPipetteNameSpecs(pipetteEntity.name)
     const recommendedMinimumDisposalVol = (pipetteSpec && pipetteSpec.minVolume) || 0
 
@@ -198,25 +194,18 @@ const clampDisposalVolume = (
   if (appliedPatch.path !== 'multiDispense') return patch
 
   const maxDisposalVolume = getMaxDisposalVolume(appliedPatch, pipetteEntities)
-  if (
-    maxDisposalVolume != null &&
-    Number(appliedPatch.disposalVolume_volume) > maxDisposalVolume
-  ) {
-    const nextDisposalVolume = Math.max(
-      floor(maxDisposalVolume || 0, DISPOSAL_VOL_DIGITS),
-      0)
+  if (!maxDisposalVolume) return patch
 
-    return nextDisposalVolume
-      ? {
-        ...patch,
-        disposalVolume_volume: String(nextDisposalVolume),
-      }
-      : {
-        ...patch,
-        ...clearedDisposalVolumeFields,
-      }
-  }
-  return patch
+  const nextDisposalVolume = clamp(Number(appliedPatch.disposalVolume_volume), 0, maxDisposalVolume)
+  return nextDisposalVolume > 0
+    ? {
+      ...patch,
+      disposalVolume_volume: String(floor(nextDisposalVolume, DISPOSAL_VOL_DIGITS)),
+    }
+    : {
+      ...patch,
+      ...clearedDisposalVolumeFields,
+    }
 }
 
 const updatePatchOnPipetteChannelChange = (

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -25,13 +25,21 @@ describe('no-op cases should pass through the patch unchanged (same identity)', 
 })
 
 describe('path should update...', () => {
-  describe('if path is multi and volume exceeds pipette/tip capacity', () => {
+  describe('if path is multi and volume*2 exceeds pipette/tip capacity', () => {
     const multiPaths = ['multiAspirate', 'multiDispense']
     multiPaths.forEach(path => {
       test(`path ${path} → single`, () => {
         // volume is updated, existing path was multi
-        const result2 = handleFormHelper({volume: '9999'}, {path, volume: '1', pipette: 'pipetteId'})
-        expect(result2).toMatchObject({path: 'single', volume: '9999'})
+        // NOTE: 6 exceeds multi-well capacity of P10 (cannot fit 2 wells)
+        console.log('test path', path)
+        const result2 = handleFormHelper(
+          {volume: '6'},
+          {
+            path,
+            volume: '1',
+            pipette: 'pipetteId',
+          })
+        expect(result2).toMatchObject({path: 'single', volume: '6'})
       })
     })
   })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -88,6 +88,28 @@ describe('disposal volume should update...', () => {
       disposalVolume_volume: form.disposalVolume_volume})
   })
 
+  describe('when volume is raised so that disposal vol must be exactly zero, clear/zero disposal volume fields', () => {
+    const volume = '5' // 5 + 5 = 10 which is P10 capacity ==> max disposal volume is zero
+    test('when form is newly changed to multiDispense: clear the fields', () => {
+      const patch = {path: 'multiDispense'}
+      const result = handleFormHelper(patch, {...form, path: 'single', volume})
+      expect(result).toEqual({
+        ...patch,
+        disposalVolume_volume: null,
+        disposalVolume_checkbox: false,
+      })
+    })
+
+    test('when form was multiDispense already: set to zero', () => {
+      const patch = {volume}
+      const result = handleFormHelper(patch, form)
+      expect(result).toEqual({
+        ...patch,
+        disposalVolume_volume: '0',
+      })
+    })
+  })
+
   test('when volume is raised past disposal volume, lower disposal volume', () => {
     const result = handleFormHelper({volume: '4.6'}, form)
     expect(result).toEqual({
@@ -100,7 +122,7 @@ describe('disposal volume should update...', () => {
   })
 
   test('when disposal volume is not > zero, clear the disposal volume fields', () => {
-    const expected = {disposalVolume_volume: null, disposalVolume_checkbox: false}
+    const expected = {disposalVolume_volume: '0'}
     const testCases = ['-999', '0', '', null]
     testCases.forEach(dispVol => {
       expect(

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -71,6 +71,17 @@ describe('disposal volume should update...', () => {
       disposalVolume_volume: '1.1',
     }
   })
+
+  describe('should not remove valid decimal', () => {
+    const testCases = ['.', '0.', '.1', '1.', '']
+    testCases.forEach(disposalVolume_volume => {
+      test(`input is ${disposalVolume_volume}`, () => {
+        const result = handleFormHelper({disposalVolume_volume}, form)
+        expect(result.disposalVolume_volume).toBe(disposalVolume_volume)
+      })
+    })
+  })
+
   test('when path is changed: multiDispense → single', () => {
     const result = handleFormHelper({path: 'single'}, form)
     expect(result).toEqual({
@@ -82,9 +93,7 @@ describe('disposal volume should update...', () => {
   test('when volume is raised but disposal vol is still in capacity, do not change (noop case)', () => {
     const patch = {volume: '2.5'}
     const result = handleFormHelper(patch, form)
-    expect(result).toEqual({
-      volume: '2.5',
-      disposalVolume_volume: form.disposalVolume_volume})
+    expect(result).toEqual(patch)
   })
 
   describe('when volume is raised so that disposal vol must be exactly zero, clear/zero disposal volume fields', () => {
@@ -120,13 +129,8 @@ describe('disposal volume should update...', () => {
     expect(result).toEqual({disposalVolume_volume: '6'})
   })
 
-  test('when disposal volume is not > zero, clear the disposal volume fields', () => {
-    const expected = {disposalVolume_volume: '0'}
-    const testCases = ['-999', '0', '', null]
-    testCases.forEach(dispVol => {
-      expect(
-        handleFormHelper({disposalVolume_volume: dispVol}, form)
-      ).toEqual(expected)
-    })
+  test('when disposal volume is a negative number, set to zero', () => {
+    const result = handleFormHelper({disposalVolume_volume: '-2'}, form)
+    expect(result).toEqual({disposalVolume_volume: '0'})
   })
 })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -30,11 +30,8 @@ describe('path should update...', () => {
     multiPaths.forEach(path => {
       test(`path ${path} → single`, () => {
         // volume is updated, existing path was multi
-        const result = handleFormHelper({volume: 9999}, {pipette: 'pipetteId', path})
-        expect(result).toEqual({path: 'single', volume: 9999})
-        // path is updated, existing volume exceeds capacity
-        const result2 = handleFormHelper({path}, {pipette: 'pipetteId', volume: 9999})
-        expect(result2).toEqual({path: 'single'})
+        const result2 = handleFormHelper({volume: '9999'}, {path, volume: '1', pipette: 'pipetteId'})
+        expect(result2).toMatchObject({path: 'single', volume: '9999'})
       })
     })
   })
@@ -49,9 +46,58 @@ describe('path should update...', () => {
     cases.forEach(([changeTip, badPath]) => {
       test(`"${changeTip}" selected: path → single`, () => {
         const patch = {changeTip}
-        const result = handleFormHelper({...patch, path: badPath}, {pipette: 'pipetteId'})
-        expect(result).toEqual({...patch, path: 'single'})
+        const result = handleFormHelper({...patch, path: badPath}, {})
+        expect(result.path).toEqual('single')
       })
+    })
+  })
+})
+
+describe('disposal volume should update...', () => {
+  let form
+  beforeEach(() => {
+    form = {
+      path: 'multiDispense',
+      volume: '2',
+      pipette: 'pipetteId',
+      disposalVolume_checkbox: true,
+      disposalVolume_volume: '1.1',
+    }
+  })
+  test('when path is changed: multiDispense → single', () => {
+    const result = handleFormHelper({path: 'single'}, form)
+    expect(result).toEqual({
+      path: 'single',
+      disposalVolume_checkbox: false,
+      disposalVolume_volume: null})
+  })
+
+  test('when volume is raised but disposal vol is still in capacity, do not change (noop case)', () => {
+    const patch = {volume: '2.5'}
+    const result = handleFormHelper(patch, form)
+    expect(result).toEqual({
+      volume: '2.5',
+      disposalVolume_volume: form.disposalVolume_volume})
+  })
+
+  test('when volume is raised past disposal volume, lower disposal volume', () => {
+    const result = handleFormHelper({volume: '4.6'}, form)
+    expect(result).toEqual({
+      volume: '4.6', disposalVolume_volume: '0.8'})
+  })
+
+  test('clamp excessive disposal volume to max', () => {
+    const result = handleFormHelper({disposalVolume_volume: '9999'}, form)
+    expect(result).toEqual({disposalVolume_volume: '6'})
+  })
+
+  test('when disposal volume is not > zero, clear the disposal volume fields', () => {
+    const expected = {disposalVolume_volume: null, disposalVolume_checkbox: false}
+    const testCases = ['-999', '0', '', null]
+    testCases.forEach(dispVol => {
+      expect(
+        handleFormHelper({disposalVolume_volume: dispVol}, form)
+      ).toEqual(expected)
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -31,7 +31,6 @@ describe('path should update...', () => {
       test(`path ${path} → single`, () => {
         // volume is updated, existing path was multi
         // NOTE: 6 exceeds multi-well capacity of P10 (cannot fit 2 wells)
-        console.log('test path', path)
         const result2 = handleFormHelper(
           {volume: '6'},
           {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -1,9 +1,9 @@
 // @flow
 import assert from 'assert'
+import round from 'lodash/round'
 import uniq from 'lodash/uniq'
 import {getPipetteCapacity} from '../../../pipettes/pipetteData'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
-
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {FormPatch} from '../../actions/types'
 import type {FormData} from '../../../form-types'
@@ -45,12 +45,36 @@ export function getChannels (pipetteId: string, pipetteEntities: PipetteEntities
   return pipette.spec.channels
 }
 
-export function getMaxDisposalVolume (rawForm: ?FormData, pipetteEntities: PipetteEntities): ?number {
+export const DISPOSAL_VOL_DIGITS = 1
+
+export function getMaxDisposalVolumeForMultidispense (rawForm: ?FormData, pipetteEntities: PipetteEntities): ?number {
   // calculate max disposal volume for given volume & pipette. Might be negative!
   if (!rawForm) return null
-  assert(rawForm.path === 'multiDispense', `getMaxDisposalVolume expected multiDispense, got path ${rawForm.path}`)
+  assert(rawForm.path === 'multiDispense', `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${rawForm.path}`)
   const volume = Number(rawForm.volume)
   const pipetteEntity = pipetteEntities[rawForm.pipette]
   const pipetteCapacity = getPipetteCapacity(pipetteEntity)
-  return pipetteCapacity - (volume * 2)
+  return round(pipetteCapacity - (volume * 2), DISPOSAL_VOL_DIGITS)
+}
+
+// Ensures that 2x volume can fit in pipette
+// NOTE: ensuring that disposalVolume_volume will not exceed pipette capacity
+// is responsibility of dependentFieldsUpdateMoveLiquid's clamp fn
+export function volumeInCapacityForMulti (
+  rawForm: FormData,
+  pipetteEntities: PipetteEntities
+): boolean {
+  const volume = Number(rawForm.volume)
+  assert(
+    rawForm.pipette in pipetteEntities,
+    `volumeInCapacityForMulti expected pipette ${rawForm.pipette} to be in pipetteEntities`
+  )
+  const pipetteEntity = pipetteEntities[rawForm.pipette]
+  const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
+
+  return (
+    volume > 0 &&
+    pipetteCapacity > 0 &&
+    volume * 2 <= pipetteCapacity
+  )
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -45,8 +45,8 @@ export function getChannels (pipetteId: string, pipetteEntities: PipetteEntities
   return pipette.spec.channels
 }
 
-export function getMaxDisposalVolume (rawForm: ?FormData, pipetteEntities: PipetteEntities) {
-  // calculate max disposal volume for given volume & pipette
+export function getMaxDisposalVolume (rawForm: ?FormData, pipetteEntities: PipetteEntities): ?number {
+  // calculate max disposal volume for given volume & pipette. Might be negative!
   if (!rawForm) return null
   assert(rawForm.path === 'multiDispense', `getMaxDisposalVolume expected multiDispense, got path ${rawForm.path}`)
   const volume = Number(rawForm.volume)

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -1,10 +1,13 @@
 // @flow
+import assert from 'assert'
 import uniq from 'lodash/uniq'
+import {getPipetteCapacity} from '../../../pipettes/pipetteData'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
 
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {FormPatch} from '../../actions/types'
-import type {PipetteEntities} from '../../../step-forms/types'
+import type {FormData} from '../../../form-types'
+import type {PipetteEntities} from '../../../step-forms'
 
 export function chainPatchUpdaters (initialPatch: FormPatch, fns: Array<(FormPatch => FormPatch)>): FormPatch {
   return fns.reduce((patchAcc: FormPatch, fn) => {
@@ -40,4 +43,14 @@ export function getChannels (pipetteId: string, pipetteEntities: PipetteEntities
     return null
   }
   return pipette.spec.channels
+}
+
+export function getMaxDisposalVolume (rawForm: ?FormData, pipetteEntities: PipetteEntities) {
+  // calculate max disposal volume for given volume & pipette
+  if (!rawForm) return null
+  assert(rawForm.path === 'multiDispense', `getMaxDisposalVolume expected multiDispense, got path ${rawForm.path}`)
+  const volume = Number(rawForm.volume)
+  const pipetteEntity = pipetteEntities[rawForm.pipette]
+  const pipetteCapacity = getPipetteCapacity(pipetteEntity)
+  return pipetteCapacity - (volume * 2)
 }


### PR DESCRIPTION
## overview

Some fancy things are happening:

* When you go from 'single' to 'multiDispense' path, the disposal volume auto-populates. The value is either the recommended disposal volume (equal to pipette's minVolume), or if that's too big, the largest amount that can fit into the pipette with 2 wells' worth of volume (volume x 2).
    * Exception: if the specified volume is exactly half the pipette capacity, that means you get no disposal volume. So the field will not be filled, the checkbox is false.
* If you are already on multiDispense, and you change the volume or the pipette in a way that lowers the disposal volume cap, the disposal volume decrease. The checkbox won't null out. Instead, the disposal volume will be set to zero.
* If 2 wells' worth of volume would exceed pipette/tip capacity, the disposal vol checkbox + number fields are cleared and the path automatically changes to single

Also, when it's visible, the disposal volume number field has a caption that displays the max possible disposal volume given the pipette and step volume. Like `"Max <n>"`

### code notes

New `getMaxDisposalVolumeForMultidispense` util is used by the `DisposalVolume` container to show `Max <n>` (display-only concern), and also by `clampDisposalVolume` in `dependentFieldsUpdateMoveLiquid.js` (form-level data manipulation), so single they use the same logic via that fn, the number you see should always actually be the one used as a max.

Similarly `volumeInCapacityForMulti` is used in the `Path` container for disabling paths that are incompatible, and also used by `updatePatchPatchField` for moving to 'single' from a multiAsp/multiDisp path when the volume is exceeded. So these two concerns should also keep in sync (previous to this PR, multiDispense could get disabled but remain selected because the two places used different logic)

## changelog

* disposal volume behavior as described above
* fix bug with multiDispense path being disabled when it shouldn't
* break out logic into util fns: `getMaxDisposalVolumeForMultidispense` and `volumeInCapacityForMulti`

## review requests

* Stuff in overview works as described
