### PR TITLE
fix(protocol-designer): fix well order modal height

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellOrder/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrder/WellOrderModal.js
@@ -20,6 +20,7 @@ import type {WellOrderOption} from '../../../../form-types'
 
 import WellOrderViz from './WellOrderViz'
 import styles from './WellOrderInput.css'
+import stepEditStyles from '../../StepEditForm.css'
 
 const DEFAULT_FIRST: WellOrderOption = 't2b'
 const DEFAULT_SECOND: WellOrderOption = 'l2r'
@@ -108,7 +109,7 @@ class WellOrderModal extends React.Component<Props, State> {
               <div className={styles.field_row}>
                 <DropdownField
                   value={firstValue}
-                  className={styles.well_order_dropdown}
+                  className={cx(stepEditStyles.medium_field, styles.well_order_dropdown)}
                   onChange={this.makeOnChange('first')}
                   options={
                     WELL_ORDER_VALUES.map((value) => ({
@@ -119,7 +120,7 @@ class WellOrderModal extends React.Component<Props, State> {
                 <span className={styles.field_spacer}>{i18n.t('modal.well_order.then')}</span>
                 <DropdownField
                   value={secondValue}
-                  className={styles.well_order_dropdown}
+                  className={cx(stepEditStyles.medium_field, styles.well_order_dropdown)}
                   onChange={this.makeOnChange('second')}
                   options={
                     WELL_ORDER_VALUES.map((value) => ({

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -48,7 +48,7 @@ class MixForm extends React.Component<Props, State> {
 
         <div className={styles.form_row}>
           <div className={styles.start_group}>
-            <FormGroup label='Labware:' className={styles.labware_field}>
+            <FormGroup label='Labware:'>
               <LabwareField name="labware" {...focusHandlers} />
             </FormGroup>
             <WellSelectionField name="wells" labwareFieldName="labware" pipetteFieldName="pipette" {...focusHandlers} />

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/SourceDestFields.js
@@ -42,7 +42,7 @@ class SourceDestFields extends React.Component<Props, State> {
     return (
       <div className={styles.form_row}>
         <div className={styles.start_group}>
-          <FormGroup label={labwareLabel} className={styles.labware_field}>
+          <FormGroup label={labwareLabel}>
             <LabwareField name={addFieldNamePrefix('labware')} {...focusHandlers} />
           </FormGroup>
           <WellSelectionField


### PR DESCRIPTION
## overview

:upside_down_face: 

## changelog

* remove reference to non-existent `.labware_field class`

## review requests

Well Order modal should look like the rest of the dropdowns