### PR TITLE
build(api): Include API clean and uninstall in top level make uninstall task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ usb_host = $(shell yarn run -s discovery find -i 169.254 fd00 -c "[fd00:0:cafe:f
 
 # install all project dependencies
 .PHONY: install
-install: install-py install-js
+install: install-js install-py
 
 .PHONY: install-py
 install-py:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install: install-py install-js
 .PHONY: install-py
 install-py:
 	$(OT_PYTHON) -m pip install pipenv==2018.10.9
-	$(MAKE) -C $(API_DIR) install
+	$(MAKE) -C $(API_DIR) clean install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 
 # front-end dependecies handled by yarn

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install: install-js install-py
 .PHONY: install-py
 install-py:
 	$(OT_PYTHON) -m pip install pipenv==2018.10.9
-	$(MAKE) -C $(API_DIR) clean install
+	$(MAKE) -C $(API_DIR) install
 	$(MAKE) -C $(UPDATE_SERVER_DIR) install
 
 # front-end dependecies handled by yarn
@@ -49,6 +49,7 @@ install-js:
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile
 .PHONY: uninstall
 uninstall:
+	$(MAKE) -C $(API_DIR) clean uninstall
 	shx rm -rf '**/node_modules'
 
 # install flow typed definitions for all JS projects that use flow

--- a/api/Makefile
+++ b/api/Makefile
@@ -53,7 +53,7 @@ ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
 clean_cmd = shx rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc'
 
 .PHONY: all
-all: lint test
+all: clean wheel
 
 .PHONY: install
 install:
@@ -62,6 +62,9 @@ install:
 .PHONY: clean
 clean:
 	$(clean_cmd)
+
+.PHONY: uninstall
+uninstall:
 	pipenv --rm
 
 $(wheel_pattern): setup.py $(ot_sources)
@@ -71,7 +74,6 @@ $(wheel_pattern): setup.py $(ot_sources)
 	$(python)	-m twine check $@
 	shx ls dist
 
-.PHONY: wheel
 wheel: $(wheel_file)
 
 .PHONY: test


### PR DESCRIPTION
## overview

Include API clean and uninstall in top level make uninstall task: in order to ensure that API install handles changes in directory structure correctly. This required removing pipenv uninstall from clean into its own task. Also modified the API all task per request from @mcous. This PR is pulling double-duty as a ticket.

## changelog

- Add API `clean` and `uninstall` to top level `make uninstall` task
- Revise other make tasks accordingly 

## review requests

Tested locally on OSX, review if change is desirable
