### PR TITLE
feat(api): Allow advanced settings to be null (unset)

### DIFF
--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -8,7 +8,7 @@ def get_setting_with_env_overload(setting_name):
     if env_name in os.environ:
         return os.environ[env_name].lower() in ('1', 'true', 'on')
     else:
-        return advs.get_adv_setting(setting_name)
+        return advs.get_adv_setting(setting_name) is True
 
 
 def short_fixed_trash():

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union, Tuple, Sequence
 from opentrons import types, hardware_control as hc, commands as cmds
 from opentrons.commands import CommandPublisher
 import opentrons.config.robot_configs as rc
-from opentrons.config import advanced_settings
+from opentrons.config import feature_flags as fflags
 from opentrons.hardware_control import adapters, modules
 from opentrons.hardware_control.types import CriticalPoint
 
@@ -109,10 +109,12 @@ class ProtocolContext(CommandPublisher):
         self._commands: List[str] = []
         self._unsubscribe_commands = None
         self.clear_commands()
-        if advanced_settings.get_adv_setting('shortFixedTrash'):
+
+        if fflags.short_fixed_trash():
             trash_name = 'opentrons_1_trash_0.85_L'
         else:
             trash_name = 'opentrons_1_trash_1.1_L'
+
         self.load_labware_by_name(
             trash_name, '12')
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,0 +1,78 @@
+from opentrons.config.advanced_settings import _migrate
+
+
+def test_migrates_empty_object():
+    settings, version = _migrate({})
+
+    assert(version == 1)
+    assert(settings == {
+      'shortFixedTrash': None,
+      'splitLabwareDefinitions': None,
+      'calibrateToBottom': None,
+      'deckCalibrationDots': None,
+      'disableHomeOnBoot': None,
+      'useProtocolApi2': None,
+      'useOldAspirationFunctions': None,
+    })
+
+
+def test_migrates_versionless_new_config():
+    settings, version = _migrate({
+      'shortFixedTrash': True,
+      'splitLabwareDefinitions': False,
+      'calibrateToBottom': True,
+      'deckCalibrationDots': False,
+      'disableHomeOnBoot': True,
+      'useProtocolApi2': False,
+      'useOldAspirationFunctions': True,
+    })
+
+    assert(version == 1)
+    assert(settings == {
+      'shortFixedTrash': True,
+      'splitLabwareDefinitions': None,
+      'calibrateToBottom': True,
+      'deckCalibrationDots': None,
+      'disableHomeOnBoot': True,
+      'useProtocolApi2': None,
+      'useOldAspirationFunctions': True,
+    })
+
+
+def test_migrates_versionless_old_config():
+    settings, version = _migrate({
+      'short-fixed-trash': False,
+      'split-labware-def': True,
+      'calibrate-to-bottom': False,
+      'dots-deck-type': True,
+      'disable-home-on-boot': False,
+    })
+
+    assert(version == 1)
+    assert(settings == {
+      'shortFixedTrash': None,
+      'splitLabwareDefinitions': True,
+      'calibrateToBottom': None,
+      'deckCalibrationDots': True,
+      'disableHomeOnBoot': None,
+      'useProtocolApi2': None,
+      'useOldAspirationFunctions': None,
+    })
+
+
+def test_ignores_invalid_keys():
+    settings, version = _migrate({
+      'foo-bar': True,
+      'bazQux': True
+    })
+
+    assert(version == 1)
+    assert(settings == {
+      'shortFixedTrash': None,
+      'splitLabwareDefinitions': None,
+      'calibrateToBottom': None,
+      'deckCalibrationDots': None,
+      'disableHomeOnBoot': None,
+      'useProtocolApi2': None,
+      'useOldAspirationFunctions': None,
+    })


### PR DESCRIPTION
## overview

This is a first pass at tri-stating the advanced settings. See #3026 for background, but the TL;DR version is we want to be able to store the concept of "a user has set this value to _something_" in addition to the actual setting.

Closes #3026

## changelog

- Adjusted types as necessary to make `bool`s optional
- Added very simple migration functionality
    - Defined two versions of the configuration: unversioned (0) and 1
    - Going from 0 to 1 will:
        - Convert "old" keys to new keys
        - Convert `False` values to `None` (Safer to assume a given "off" value is "unset" than deliberately turned off)

## review requests

The migration routine I used is the simplest one that I'm familiar with: you put a version in with the data and you compare that version to a list of migrator functions you have. I didn't bother with any of the following:

- Putting migrations in their own directory
    - Common in sql-ish migrations, seems like overkill here
- Downward migrations
    - See above

I'm really curious what y'all think of the migration stuff. Also please check out my very basic unit tests and let me know what more you'd like to see.