### PR TITLE
feat(app): Add pipette config modal behind feature flag

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigMessage.js
+++ b/app/src/components/ConfigurePipette/ConfigMessage.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react'
+
+// TODO (ka 2019-2-12): Style this component
+export default function ConfigMessage () {
+  return (
+    <React.Fragment>
+      <h3>WARNING:</h3>
+      <p>
+        These are advanced settings. Please do not attempt to adjust without
+        assitance from an Opentrons support team member, as doing so may affect
+        the lifespan of your pipette.
+      </p>
+      <p>
+        Note that these settings will not override any pipette settings
+        pre-defined in protocols.
+      </p>
+    </React.Fragment>
+  )
+}

--- a/app/src/components/ConfigurePipette/ConfigMessage.js
+++ b/app/src/components/ConfigurePipette/ConfigMessage.js
@@ -1,17 +1,18 @@
 // @flow
 import * as React from 'react'
+import styles from './styles.css'
 
-// TODO (ka 2019-2-12): Style this component
+// TODO (ka 2019-2-12): Add intercom onClick to assitance text
 export default function ConfigMessage () {
   return (
     <React.Fragment>
-      <h3>WARNING:</h3>
-      <p>
+      <h3 className={styles.warning_title}>Warning:</h3>
+      <p className={styles.warning_text}>
         These are advanced settings. Please do not attempt to adjust without
         assitance from an Opentrons support team member, as doing so may affect
         the lifespan of your pipette.
       </p>
-      <p>
+      <p className={styles.warning_text}>
         Note that these settings will not override any pipette settings
         pre-defined in protocols.
       </p>

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -1,0 +1,62 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {Link} from 'react-router-dom'
+import {makeGetRobotPipettes} from '../../http-api-client'
+
+import {getPipetteModelSpecs} from '@opentrons/shared-data'
+
+import {AlertModal} from '@opentrons/components'
+import ConfigMessage from './ConfigMessage'
+
+import type {State} from '../../types'
+import type {Mount} from '../../robot'
+import type {Robot} from '../../discovery'
+import type {PipettesResponse} from '../../http-api-client'
+
+type OP = {
+  robot: Robot,
+  mount: Mount,
+  parentUrl: string,
+}
+
+type SP = {
+  pipettes: ?PipettesResponse,
+}
+
+type Props = SP & OP
+
+export default connect(makeMapStateToProps)(ConfigurePipette)
+
+function ConfigurePipette (props: Props) {
+  const {parentUrl, mount, pipettes} = props
+  // TODO (ka 2019-2-12): This logic is used to get display name in slightly
+  // different ways in several different files.
+  const pipetteModel = pipettes && pipettes[mount].model
+  const pipetteConfig = pipetteModel && getPipetteModelSpecs(pipetteModel)
+  const displayName = pipetteConfig ? pipetteConfig.displayName : ''
+
+  const TITLE = `Pipette Settings: ${displayName}`
+
+  return (
+    <AlertModal
+      heading={TITLE}
+      alertOverlay
+      buttons={[{children: 'cancel', Component: Link, to: parentUrl}]}
+    >
+      <ConfigMessage />
+    </AlertModal>
+  )
+}
+
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
+  const getRobotPipettes = makeGetRobotPipettes()
+
+  return (state, ownProps) => {
+    const pipettesCall = getRobotPipettes(state, ownProps.robot)
+
+    return {
+      pipettes: pipettesCall && pipettesCall.response,
+    }
+  }
+}

--- a/app/src/components/ConfigurePipette/styles.css
+++ b/app/src/components/ConfigurePipette/styles.css
@@ -1,0 +1,12 @@
+@import '@opentrons/components';
+
+.warning_title {
+  @apply --font-body-2-dark;
+
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.warning_text {
+  @apply --font-body-1-dark;
+}

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -2,8 +2,13 @@
 // attached pipettes container card
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {getIn} from '@thi.ng/paths'
 
-import {makeGetRobotPipettes, fetchPipettes, clearMoveResponse} from '../../http-api-client'
+import {
+  makeGetRobotPipettes,
+  fetchPipettes,
+  clearMoveResponse,
+} from '../../http-api-client'
 import InstrumentInfo from './InstrumentInfo'
 import {CardContentFlex} from '../layout'
 import {RefreshCard} from '@opentrons/components'
@@ -11,13 +16,14 @@ import {RefreshCard} from '@opentrons/components'
 import type {State} from '../../types'
 import type {Robot} from '../../discovery'
 import type {Pipette} from '../../http-api-client'
-
+import {getConfig} from '../../config'
 type OP = Robot
 
 type SP = {
   inProgress: boolean,
   left: ?Pipette,
   right: ?Pipette,
+  __featureEnabled: boolean,
 }
 
 type DP = {
@@ -26,6 +32,8 @@ type DP = {
 }
 
 type Props = OP & SP & DP
+
+const __FEATURE_FLAG = 'devInternal.newPipetteConfig'
 
 const TITLE = 'Pipettes'
 
@@ -43,8 +51,20 @@ function AttachedPipettesCard (props: Props) {
       refreshing={props.inProgress}
     >
       <CardContentFlex>
-        <InstrumentInfo mount='left' name={props.name} {...props.left} onClick={props.clearMove} />
-        <InstrumentInfo mount='right' name={props.name} {...props.right} onClick={props.clearMove} />
+        <InstrumentInfo
+          mount="left"
+          name={props.name}
+          {...props.left}
+          onChangeClick={props.clearMove}
+          __enableConfig={props.__featureEnabled}
+        />
+        <InstrumentInfo
+          mount="right"
+          name={props.name}
+          {...props.right}
+          onChangeClick={props.clearMove}
+          __enableConfig={props.__featureEnabled}
+        />
       </CardContentFlex>
     </RefreshCard>
   )
@@ -57,7 +77,12 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const {inProgress, response} = getRobotPipettes(state, ownProps)
     const {left, right} = response || {left: null, right: null}
 
-    return {inProgress, left, right}
+    return {
+      inProgress,
+      left,
+      right,
+      __featureEnabled: !!getIn(getConfig(state), __FEATURE_FLAG),
+    }
   }
 }
 

--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -35,7 +35,7 @@ export default function PipetteInfo (props: Props) {
   const channels = channelsMatch && channelsMatch[1]
   const direction = props.model ? 'change' : 'attach'
 
-  const changeUrl = `/robots/${name}/instruments/pipettes/${mount}`
+  const changeUrl = `/robots/${name}/instruments/pipettes/change/${mount}`
   const configUrl = `/robots/${name}/instruments/pipettes/config/${mount}`
 
   const className = cx(styles.pipette_card, {

--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -16,7 +16,8 @@ type Props = {
   mount: Mount,
   model: ?string,
   name: string,
-  onClick: () => mixed,
+  onChangeClick: () => mixed,
+  __enableConfig: boolean,
 }
 
 // TODO(mc, 2018-03-30): volume and channels should come from the API
@@ -28,15 +29,14 @@ const LABEL_BY_MOUNT = {
 }
 
 export default function PipetteInfo (props: Props) {
-  const {mount, model, name, onClick} = props
+  const {mount, model, name, onChangeClick} = props
   const label = LABEL_BY_MOUNT[mount]
   const channelsMatch = model && model.match(RE_CHANNELS)
   const channels = channelsMatch && channelsMatch[1]
-  const direction = props.model
-    ? 'change'
-    : 'attach'
+  const direction = props.model ? 'change' : 'attach'
 
-  const url = `/robots/${name}/instruments/pipettes/${mount}`
+  const changeUrl = `/robots/${name}/instruments/pipettes/${mount}`
+  const configUrl = `/robots/${name}/instruments/pipettes/config/${mount}`
 
   const className = cx(styles.pipette_card, {
     [styles.right]: props.mount === 'right',
@@ -48,9 +48,17 @@ export default function PipetteInfo (props: Props) {
         label={label}
         value={(model || 'None').split('_').join(' ')}
       />
-      <OutlineButton Component={Link} to={url} onClick={onClick}>
-        {direction}
-      </OutlineButton>
+
+      <div className={styles.button_group}>
+        <OutlineButton Component={Link} to={changeUrl} onClick={onChangeClick}>
+          {direction}
+        </OutlineButton>
+        {props.__enableConfig && model && (
+          <OutlineButton Component={Link} to={configUrl}>
+            settings
+          </OutlineButton>
+        )}
+      </div>
       <div className={styles.image}>
         {channels && (
           <InstrumentDiagram

--- a/app/src/components/InstrumentSettings/styles.css
+++ b/app/src/components/InstrumentSettings/styles.css
@@ -5,15 +5,9 @@
   display: flex;
   position: relative;
   flex-direction: row;
-  align-items: center;
+  align-items: top;
   justify-content: space-between;
-  height: 4rem;
-  padding-top: 1rem;
   width: 49.5%;
-
-  & > a {
-    width: 8rem;
-  }
 }
 
 .pipette_diagram {
@@ -30,7 +24,6 @@
 .image {
   height: 8rem;
   width: 2.25rem;
-  margin-top: -3rem;
   border: 1px solid var(--c-light-gray);
 }
 
@@ -45,5 +38,15 @@
 
   & > a {
     order: 3;
+  }
+}
+
+.button_group {
+  max-width: 9rem;
+  text-align: right;
+
+  & > a {
+    width: 8rem;
+    margin-bottom: 1rem;
   }
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -60,6 +60,11 @@ export type Config = {
   discovery: {
     candidates: string | Array<string>,
   },
+
+  // internal development flags
+  devInternal?: {
+    newPipetteConfig?: boolean,
+  },
 }
 
 type UpdateConfigAction = {|

--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -31,8 +31,7 @@ export default function InstrumentSettingsPage (props: Props) {
       </Page>
       <Switch>
         <Route
-          exact
-          path={`${path}/pipettes`}
+          path={`${path}/pipettes/change`}
           render={props => (
             <ChangePipette {...props} robot={robot} parentUrl={url} />
           )}

--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -4,9 +4,11 @@ import {Switch, Route} from 'react-router'
 
 import InstrumentSettings from '../../components/InstrumentSettings'
 import ChangePipette from '../../components/ChangePipette'
+import ConfigurePipette from '../../components/ConfigurePipette'
 import Page from '../../components/Page'
 
 import type {Match} from 'react-router'
+import type {Mount} from '../../robot'
 import type {Robot} from '../../discovery'
 
 type Props = {
@@ -14,13 +16,16 @@ type Props = {
   match: Match,
 }
 
+// used to guarantee mount param in route is left or right
+const RE_MOUNT = '(left|right)'
+
 export default function InstrumentSettingsPage (props: Props) {
   const {
     robot,
     match: {path, url},
   } = props
   const titleBarProps = {title: robot.displayName}
-
+  const mount: Mount = (props.match.params.mount: any)
   return (
     <React.Fragment>
       <Page titleBarProps={titleBarProps}>
@@ -28,9 +33,16 @@ export default function InstrumentSettingsPage (props: Props) {
       </Page>
       <Switch>
         <Route
+          exact
           path={`${path}/pipettes`}
           render={props => (
             <ChangePipette {...props} robot={robot} parentUrl={url} />
+          )}
+        />
+        <Route
+          path={`${path}/pipettes/config/:mount${RE_MOUNT}`}
+          render={props => (
+            <ConfigurePipette mount={mount} robot={robot} parentUrl={url} />
           )}
         />
       </Switch>

--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -8,7 +8,6 @@ import ConfigurePipette from '../../components/ConfigurePipette'
 import Page from '../../components/Page'
 
 import type {Match} from 'react-router'
-import type {Mount} from '../../robot'
 import type {Robot} from '../../discovery'
 
 type Props = {
@@ -25,7 +24,6 @@ export default function InstrumentSettingsPage (props: Props) {
     match: {path, url},
   } = props
   const titleBarProps = {title: robot.displayName}
-  const mount: Mount = (props.match.params.mount: any)
   return (
     <React.Fragment>
       <Page titleBarProps={titleBarProps}>
@@ -42,7 +40,11 @@ export default function InstrumentSettingsPage (props: Props) {
         <Route
           path={`${path}/pipettes/config/:mount${RE_MOUNT}`}
           render={props => (
-            <ConfigurePipette mount={mount} robot={robot} parentUrl={url} />
+            <ConfigurePipette
+              mount={(props.match.params.mount: any)}
+              robot={robot}
+              parentUrl={url}
+            />
           )}
         />
       </Switch>


### PR DESCRIPTION
## overview

This PR closes #2940 by adding a config button that opens a start modal for pipette config. 

Form to be implemented in #2941.
## changelog

- feat(app): Add pipette config modal behind feature flag

## review requests

Did some final type checking work today without a robot, so please double check that this works on a robot in the office. Calling this a WIP until I can confirm changes work as expected myself.

Run app without feature flag. Go to instruments settings page.
- [ ] config button does not render
- [ ] styles not affected (there was a little bit of alignment that changed, but that was to match the designs)

Run app with pipette config flag
`make -C app dev OT_APP_DEV_INTERNAL__NEW_PIPETTE_CONFIG=1`
- [ ] Config button renders under [change] button for attached/detected pipettes
- [ ] Config button does not render for empty pipette mounts
- [ ] Clicking config opens starter modal
- [ ] Modal title renders attached pipettes correct display name
- [ ] Clicking cancel button closes modal and returns to instrument settings 

## TODO 
- change from feat(app) to refactor since it is behind a feature flag
In next PR:
- Convert alert modal to scrollable alert modal