### PR TITLE
fix(components): do not convert humanized labware type decimal to space

### DIFF
--- a/components/src/utils.js
+++ b/components/src/utils.js
@@ -1,12 +1,13 @@
 // @flow
-import startCase from 'lodash/startCase'
 import {
   swatchColors,
   MIXED_WELL_COLOR,
   AIR,
 } from '@opentrons/components'
 
-export const humanizeLabwareType = startCase
+export const humanizeLabwareType = (labwareType: string): string => {
+  return labwareType.replace(/-|_/g, ' ')
+}
 
 export const wellNameSplit = (wellName: string): [string, string] => {
   // Eg B9 => ['B', '9']


### PR DESCRIPTION
## overview

Closes #2766 

Now labware like `tube-rack-.75-ml` will display as "tube rack .75ml" not "Tube Rack 75 Ml" (type case is handled by CSS for labware names in all cases I can see). In addition to hyphens, underscores are also converted to spaces to future-proof for `definitions2/` naming style (although maybe that's n/a, since they have an actual `displayName`)

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- [ ] Any weird labware name exceptions I'm missing?
- [ ] PD ok?
- [ ] Run App ok?