### PR TITLE
fix(protocol-designer): fix bug where 'default-values' shape did not conform to JSON schema

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -1,7 +1,7 @@
 // @flow
 import {createSelector} from 'reselect'
 import mapValues from 'lodash/mapValues'
-import {getPropertyAllPipettes} from '@opentrons/shared-data'
+import {getFlowRateDefaultsAllPipettes} from '@opentrons/shared-data'
 import {getFileMetadata} from './fileFields'
 import {getInitialRobotState, getRobotStateTimeline} from './commands'
 import {selectors as dismissSelectors} from '../../dismiss'
@@ -25,9 +25,9 @@ const applicationVersion = process.env.OT_PD_VERSION || 'unknown version'
 // when we look at saved protocols (without requiring us to trace thru git logs)
 const _internalAppBuildDate = process.env.OT_PD_BUILD_DATE
 
-const executionDefaults = {
-  'aspirate-flow-rate': getPropertyAllPipettes('defaultAspirateFlowRate'),
-  'dispense-flow-rate': getPropertyAllPipettes('defaultDispenseFlowRate'),
+const executionDefaults: $PropertyType<ProtocolFile, 'default-values'> = {
+  'aspirate-flow-rate': getFlowRateDefaultsAllPipettes('defaultAspirateFlowRate'),
+  'dispense-flow-rate': getFlowRateDefaultsAllPipettes('defaultDispenseFlowRate'),
   'aspirate-mm-from-bottom': DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
   'dispense-mm-from-bottom': DEFAULT_MM_FROM_BOTTOM_DISPENSE,
   'touch-tip-mm-from-top': DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP,

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -62,6 +62,9 @@ export type ProtocolFile = {
   'default-values': {
     'aspirate-flow-rate': FlowRateForPipettes,
     'dispense-flow-rate': FlowRateForPipettes,
+    'aspirate-mm-from-bottom': number,
+    'dispense-mm-from-bottom': number,
+    'touch-tip-mm-from-top'?: number, // TODO: Ian 2019-02-12 make required in protocol schema breaking change
   },
 
   'designer-application': {

--- a/shared-data/js/pipettes.js
+++ b/shared-data/js/pipettes.js
@@ -1,5 +1,5 @@
 // @flow
-import mapValues from 'lodash/mapValues'
+import reduce from 'lodash/reduce'
 import pipetteNameSpecs from '../robot-data/pipetteNameSpecs.json'
 import pipetteModelSpecs from '../robot-data/pipetteModelSpecs.json'
 
@@ -44,9 +44,7 @@ const ALL_PIPETTES: Array<PipetteNameSpecs> = ALL_PIPETTE_NAMES
 
 // use a name like 'p10_single' to get specs true for all models under that name
 export function getPipetteNameSpecs (name: string): ?PipetteNameSpecs {
-  console.log(name)
   const config = pipetteNameSpecs[name]
-
   return config && {...config, name}
 }
 
@@ -115,6 +113,9 @@ function comparePipettes (sortBy: Array<SortableProps>) {
   }
 }
 
-export function getPropertyAllPipettes (propertyName: $Keys<PipetteNameSpecs>) {
-  return mapValues(pipetteNameSpecs, config => config[propertyName])
+export function getFlowRateDefaultsAllPipettes (flowRateName: 'defaultAspirateFlowRate' | 'defaultDispenseFlowRate'): {[pipetteName: string]: number} {
+  return reduce(pipetteNameSpecs, (acc, spec: PipetteNameSpecs, pipetteName: string) => ({
+    ...acc,
+    [pipetteName]: spec[flowRateName].value,
+  }), {})
 }


### PR DESCRIPTION
## overview

The change to shape of PipetteNameSpecs caused PD to export invalid protocols that do not run because of `default-values` flow-rate shape change in #2999

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

On `edge`, protocols will fail to upload in Run App with error `TypeError: unsupported operand type(s) for /: 'dict' and 'float'`. They will also fail JSON schema validation (eg http://jsonschemavalidator.net/)

With this PR, protocols should upload correctly and pass JSON schema validation

Should not affect Run App