### PR TITLE
fix(api): Avoid resource contention on smoothie serial during boot

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -4,7 +4,9 @@ import json
 HERE = os.path.abspath(os.path.dirname(__file__))
 from opentrons import config  # noqa(E402)
 from opentrons.data_storage import database_migration  # noqa(E402)
-if not config.feature_flags.split_labware_definitions()\
+
+if os.environ.get('OT_UPDATE_SERVER') != 'true'\
+   and not config.feature_flags.split_labware_definitions()\
    and not config.feature_flags.use_protocol_api_v2():
     database_migration.check_version_and_perform_necessary_migrations()
 


### PR DESCRIPTION
Starting the update server backgrounded and then immediately moving on to
the api server can cause boot failures due to resource contention on the
smoothie’s serial port, since the update server tries to talk to the
smoothie to get its firmware version. To fix this, we need to make the
update server actually close out the smoothie connection so we can hook
in some synch logic, but barring that we
- set a magic env var in the update server so that when it imports the
  api wheel, the api wheel knows to not do some long-lasting tasks at
  import time, which lessons the time we need to-
- sleep in between the update server and api server starting. Sorry.
