### PR TITLE
refactor(app): Add FF'd non-functional manual IP entry modal

### DIFF
--- a/app/src/components/AppSettings/AddManualIp/index.js
+++ b/app/src/components/AppSettings/AddManualIp/index.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react'
+import {Link} from 'react-router-dom'
+
+import {AlertModal} from '@opentrons/components'
+import {Portal} from '../../portal'
+
+export type AddManualIpProps = {
+  backUrl: string,
+}
+
+export default function AddManualIp (props: AddManualIpProps) {
+  return (
+    <Portal>
+      <AlertModal
+        alertOverlay
+        iconName="wifi"
+        heading="Manually Add Robot Network Addresses"
+        buttons={[{Component: Link, to: props.backUrl, children: 'Done'}]}
+      >
+        <p>
+          Enter an IP address or hostname to connect to your robot if automatic
+          discovery is not working. For this feature to work reliably, you (or
+          your network administrator) should assign a static IP address to your
+          robot.
+        </p>
+      </AlertModal>
+    </Portal>
+  )
+}

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -64,6 +64,7 @@ export type Config = {
   // internal development flags
   devInternal?: {
     newPipetteConfig?: boolean,
+    manualIp?: boolean,
   },
 }
 


### PR DESCRIPTION
## overview

Closes #2740. See ticket for acceptance criteria

![2019-02-13 16 23 43](https://user-images.githubusercontent.com/2963448/52744877-c60a7d00-2fab-11e9-809a-500d3aed8f81.gif)

## changelog

- Added non-functional manual IP address entry modal behind development feature flag

## review requests

```shell
make -C app dev OT_APP_DEV_INTERNAL__MANUAL_IP=1
```
