### PR TITLE
fix(protocol-designer): fix inner mix inside moveLiquid form

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -55,6 +55,10 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware,
   },
+  'aspirate_mix_times': {
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers, defaultTo(1)),
+    castValue: Number,
+  },
   'aspirate_mix_volume': {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
@@ -66,6 +70,10 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   'dispense_labware': {
     getErrors: composeErrors(requiredField),
     hydrate: hydrateLabware,
+  },
+  'dispense_mix_times': {
+    maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers, defaultTo(1)),
+    castValue: Number,
   },
   'dispense_mix_volume': {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
@@ -99,6 +107,7 @@ const stepFieldHelperMap: {[StepFieldName]: StepFieldHelpers} = {
   'times': {
     getErrors: composeErrors(requiredField),
     maskValue: composeMaskers(maskToNumber, onlyPositiveNumbers, onlyIntegers, defaultTo(0)),
+    castValue: Number,
   },
   'volume': {
     getErrors: composeErrors(requiredField, nonZero),

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -28,8 +28,8 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
     console.warn('the specified labware definition could not be located')
   }
 
-  const volume = Number(hydratedFormData.volume) || 0
-  const times = Number(hydratedFormData.times) || 0
+  const volume = hydratedFormData.volume
+  const times = hydratedFormData.times
 
   const aspirateFlowRateUlSec = hydratedFormData['aspirate_flowRate']
   const dispenseFlowRateUlSec = hydratedFormData['dispense_flowRate']


### PR DESCRIPTION
## overview

Closes #3048

Also move `Number` casting from `mixFormToArgs` to the field casters

## changelog


## review requests

Mixing in moveLiquid form should fully work - you need to inspect the JSON to see because mixes are hidden in substeps

Should not break Mix form