### PR TITLE
fix(protocol-designer): persist migration version to file

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -4,7 +4,7 @@ import mapValues from 'lodash/mapValues'
 import {getFlowRateDefaultsAllPipettes} from '@opentrons/shared-data'
 import {getFileMetadata} from './fileFields'
 import {getInitialRobotState, getRobotStateTimeline} from './commands'
-import {MOST_RECENT_MIGRATION_VERSION} from '../../load-file/migration'
+import {LATEST_MIGRATION_VERSION} from '../../load-file/migration'
 import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepFormSelectors} from '../../step-forms'
@@ -108,7 +108,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
       'designer-application': {
         'application-name': 'opentrons/protocol-designer',
         'application-version': applicationVersion,
-        migrationVersion: MOST_RECENT_MIGRATION_VERSION,
+        migrationVersion: LATEST_MIGRATION_VERSION,
         _internalAppBuildDate,
         data: {
           pipetteTiprackAssignments: mapValues(

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -4,6 +4,7 @@ import mapValues from 'lodash/mapValues'
 import {getFlowRateDefaultsAllPipettes} from '@opentrons/shared-data'
 import {getFileMetadata} from './fileFields'
 import {getInitialRobotState, getRobotStateTimeline} from './commands'
+import {MOST_RECENT_MIGRATION_VERSION} from '../../load-file/migration'
 import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepFormSelectors} from '../../step-forms'
@@ -107,6 +108,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
       'designer-application': {
         'application-name': 'opentrons/protocol-designer',
         'application-version': applicationVersion,
+        migrationVersion: MOST_RECENT_MIGRATION_VERSION,
         _internalAppBuildDate,
         data: {
           pipetteTiprackAssignments: mapValues(

--- a/protocol-designer/src/load-file/migration/__tests__/migrationV1.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/migrationV1.test.js
@@ -11,7 +11,7 @@ import {
   MIX_DEPRECATED_FIELD_NAMES,
   replaceTCDStepsWithMoveLiquidStep,
   updateMigrationVersion,
-  default as wholeMigration,
+  migrateFile,
 } from '../migrationV1.js'
 
 describe('renameOrderedSteps', () => {
@@ -296,17 +296,17 @@ describe('updateMigrationVersion', () => {
 
 describe('version gated migration', () => {
   test('migration occurs when migrationVersion not present in file', () => {
-    const migratedFile = wholeMigration(oldProtocol)
+    const migratedFile = migrateFile(oldProtocol)
     expect(oldProtocol).not.toEqual(migratedFile)
   })
   test('migration does not occur when migrationVersion is 1', () => {
     const stubbedNewFile = {'designer-application': {migrationVersion: 1}}
-    const migratedFile = wholeMigration(stubbedNewFile)
+    const migratedFile = migrateFile(stubbedNewFile)
     expect(migratedFile).toEqual(stubbedNewFile)
   })
   test('migration does not occur when migrationVersion is past 1', () => {
     const stubbedNewFile = {'designer-application': {migrationVersion: 45}}
-    const migratedFile = wholeMigration(stubbedNewFile)
+    const migratedFile = migrateFile(stubbedNewFile)
     expect(migratedFile).toEqual(stubbedNewFile)
   })
 })

--- a/protocol-designer/src/load-file/migration/__tests__/migrationV1.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/migrationV1.test.js
@@ -11,7 +11,6 @@ import {
   MIX_DEPRECATED_FIELD_NAMES,
   replaceTCDStepsWithMoveLiquidStep,
   updateMigrationVersion,
-  migrateFile,
 } from '../migrationV1.js'
 
 describe('renameOrderedSteps', () => {
@@ -291,22 +290,5 @@ describe('updateMigrationVersion', () => {
   const migratedFile = updateMigrationVersion(oldProtocol)
   test('update migrationVersion', () => {
     expect(migratedFile['designer-application'].migrationVersion).toEqual(1)
-  })
-})
-
-describe('version gated migration', () => {
-  test('migration occurs when migrationVersion not present in file', () => {
-    const migratedFile = migrateFile(oldProtocol)
-    expect(oldProtocol).not.toEqual(migratedFile)
-  })
-  test('migration does not occur when migrationVersion is 1', () => {
-    const stubbedNewFile = {'designer-application': {migrationVersion: 1}}
-    const migratedFile = migrateFile(stubbedNewFile)
-    expect(migratedFile).toEqual(stubbedNewFile)
-  })
-  test('migration does not occur when migrationVersion is past 1', () => {
-    const stubbedNewFile = {'designer-application': {migrationVersion: 45}}
-    const migratedFile = migrateFile(stubbedNewFile)
-    expect(migratedFile).toEqual(stubbedNewFile)
   })
 })

--- a/protocol-designer/src/load-file/migration/index.js
+++ b/protocol-designer/src/load-file/migration/index.js
@@ -1,13 +1,17 @@
 // @flow
-
 import flow from 'lodash/flow'
+import max from 'lodash/max'
 import type {ProtocolFile} from '../../file-types'
-import migrationV1 from './migrationV1'
+import {default as migrationV1} from './migrationV1'
+
+const allMigrations = [
+  migrationV1,
+]
+
+export const MOST_RECENT_MIGRATION_VERSION = max(allMigrations.map(m => m.version))
 
 const masterMigration = (file: any): ProtocolFile => (
-  flow([
-    migrationV1,
-  ])(file)
+  flow(allMigrations.map(migration => migration.migrateFile))(file)
 )
 
 export default masterMigration

--- a/protocol-designer/src/load-file/migration/index.js
+++ b/protocol-designer/src/load-file/migration/index.js
@@ -1,6 +1,8 @@
 // @flow
 import flow from 'lodash/flow'
 import max from 'lodash/max'
+import sortBy from 'lodash/sortBy'
+import findIndex from 'lodash/findIndex'
 import type {ProtocolFile} from '../../file-types'
 import {default as migrationV1} from './migrationV1'
 
@@ -8,10 +10,17 @@ const allMigrations = [
   migrationV1,
 ]
 
-export const MOST_RECENT_MIGRATION_VERSION = max(allMigrations.map(m => m.version))
+export const LATEST_MIGRATION_VERSION = max(allMigrations.map(m => m.version))
 
-const masterMigration = (file: any): ProtocolFile => (
-  flow(allMigrations.map(migration => migration.migrateFile))(file)
-)
+const masterMigration = (file: any): ProtocolFile => {
+  const sortedMigrations = sortBy(allMigrations, m => m.version)
+
+  const designerApplication = file.designerApplication || file['designer-application']
+
+  const {migrationVersion} = designerApplication
+  const migrationsToRun = sortedMigrations.slice(findIndex(sortedMigrations, m => m.version === migrationVersion) + 1)
+
+  return flow(migrationsToRun.map(migration => migration.migrateFile))(file)
+}
 
 export default masterMigration

--- a/protocol-designer/src/load-file/migration/migrationV1.js
+++ b/protocol-designer/src/load-file/migration/migrationV1.js
@@ -9,7 +9,7 @@ import type {PipetteEntities} from '../../step-forms'
 import type {FormPatch} from '../../steplist/actions'
 import type {ProtocolFile, FileLabware, FilePipette} from '../../file-types'
 
-export const PRESENT_MIGRATION_VERSION = 1
+const MIGRATION_VERSION = 1
 
 // NOTE: these constants are copied here because
 // the default-values key did not exist for most protocols
@@ -238,28 +238,20 @@ export function updateMigrationVersion (fileData: ProtocolFile): ProtocolFile {
     ...fileData,
     'designer-application': {
       ...fileData['designer-application'],
-      migrationVersion: PRESENT_MIGRATION_VERSION,
+      migrationVersion: MIGRATION_VERSION,
     },
   }
 }
 
-export function migrateFile (fileData: any): ProtocolFile {
-  const {migrationVersion} = fileData['designer-application']
-  if (migrationVersion && migrationVersion >= PRESENT_MIGRATION_VERSION) {
-    return fileData
-  } else {
-    const migratedFile = flow([
-      renameOrderedSteps,
-      addInitialDeckSetupStep,
-      updateStepFormKeys,
-      replaceTCDStepsWithMoveLiquidStep,
-      updateMigrationVersion,
-    ])(fileData)
-    return migratedFile
-  }
-}
+const migrateFile = (fileData: ProtocolFile) => flow([
+  renameOrderedSteps,
+  addInitialDeckSetupStep,
+  updateStepFormKeys,
+  replaceTCDStepsWithMoveLiquidStep,
+  updateMigrationVersion,
+])(fileData)
 
 export default {
-  version: PRESENT_MIGRATION_VERSION,
+  version: MIGRATION_VERSION,
   migrateFile,
 }

--- a/protocol-designer/src/load-file/migration/migrationV1.js
+++ b/protocol-designer/src/load-file/migration/migrationV1.js
@@ -9,7 +9,7 @@ import type {PipetteEntities} from '../../step-forms'
 import type {FormPatch} from '../../steplist/actions'
 import type {ProtocolFile, FileLabware, FilePipette} from '../../file-types'
 
-const PRESENT_MIGRATION_VERSION = 1
+export const PRESENT_MIGRATION_VERSION = 1
 
 // NOTE: these constants are copied here because
 // the default-values key did not exist for most protocols
@@ -243,7 +243,7 @@ export function updateMigrationVersion (fileData: ProtocolFile): ProtocolFile {
   }
 }
 
-export default function migrateFile (fileData: any): ProtocolFile {
+export function migrateFile (fileData: any): ProtocolFile {
   const {migrationVersion} = fileData['designer-application']
   if (migrationVersion && migrationVersion >= PRESENT_MIGRATION_VERSION) {
     return fileData
@@ -257,4 +257,9 @@ export default function migrateFile (fileData: any): ProtocolFile {
     ])(fileData)
     return migratedFile
   }
+}
+
+export default {
+  version: PRESENT_MIGRATION_VERSION,
+  migrateFile,
 }


### PR DESCRIPTION
Migration version is now persisted on file export

Closes #3047

## review requests

- you should be able to import an old protocol, have it migrate successfully, and export it.  The migrationVersion key should be set to 1 in the new json file