### PR TITLE
PD Fixups: Remove old `Labware` flow type

### DIFF
--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import assert from 'assert'
 import LabwareDetailsCard from './LabwareDetailsCard'
 import {selectors as stepFormSelectors} from '../../../step-forms'
+import {selectors as uiLabwareSelectors} from '../../../ui/labware'
 import {selectors as labwareIngredSelectors} from '../../../labware-ingred/selectors'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import type {ElementProps} from 'react'
@@ -18,7 +19,7 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId?: string}
 
 function mapStateToProps (state: BaseState): SP {
-  const labwareNicknamesById = stepFormSelectors.getLabwareNicknamesById(state)
+  const labwareNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
   const labwareId = labwareIngredSelectors.getSelectedLabwareId(state)
   const labwareType = labwareId && stepFormSelectors.getLabwareTypesById(state)[labwareId]
 

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import assert from 'assert'
 import LabwareDetailsCard from './LabwareDetailsCard'
 import {selectors as stepFormSelectors} from '../../../step-forms'
+import {selectors as labwareIngredSelectors} from '../../../labware-ingred/selectors'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import type {ElementProps} from 'react'
 import type {Dispatch} from 'redux'
@@ -17,13 +18,15 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const labwareData = stepFormSelectors.getSelectedLabware(state)
-  assert(labwareData, 'Expected labware data to exist in connected labware details card')
+  const labwareId = labwareIngredSelectors.getSelectedLabwareId(state)
+  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+  const labwareNicknamesById = stepFormSelectors.getLabwareNicknamesById(state)
+  assert(labwareId, 'Expected labware id to exist in connected labware details card')
 
-  const props = (labwareData)
+  const props = (labwareId)
     ? {
-      labwareType: labwareData.type,
-      nickname: labwareData.nickname || 'Unnamed Labware',
+      labwareType: labwareEntities[labwareId] && labwareEntities[labwareId].type,
+      nickname: labwareNicknamesById[labwareId] || 'Unnamed Labware',
     }
     : {
       labwareType: '?',
@@ -32,7 +35,7 @@ function mapStateToProps (state: BaseState): SP {
 
   return {
     ...props,
-    _labwareId: labwareData && labwareData.id,
+    _labwareId: labwareId,
   }
 }
 

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -15,26 +15,24 @@ type DP = {
   renameLabware: $PropertyType<Props, 'renameLabware'>,
 }
 
-type SP = $Diff<Props, DP> & {_labwareId: ?string}
+type SP = $Diff<Props, DP> & {_labwareId?: string}
 
 function mapStateToProps (state: BaseState): SP {
-  const labwareId = labwareIngredSelectors.getSelectedLabwareId(state)
-  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
   const labwareNicknamesById = stepFormSelectors.getLabwareNicknamesById(state)
-  assert(labwareId, 'Expected labware id to exist in connected labware details card')
+  const labwareId = labwareIngredSelectors.getSelectedLabwareId(state)
+  const labwareType = labwareId && stepFormSelectors.getLabwareTypesById(state)[labwareId]
 
-  const props = (labwareId)
-    ? {
-      labwareType: labwareEntities[labwareId] && labwareEntities[labwareId].type,
-      nickname: labwareNicknamesById[labwareId] || 'Unnamed Labware',
-    }
-    : {
+  assert(labwareId && labwareType, 'Expected labware id & type to exist in connected labware details card')
+  if (!labwareId || !labwareType) {
+    return {
       labwareType: '?',
       nickname: '?',
     }
+  }
 
   return {
-    ...props,
+    labwareType: labwareType,
+    nickname: labwareNicknamesById[labwareId] || 'Unnamed Labware',
     _labwareId: labwareId,
   }
 }

--- a/protocol-designer/src/components/LiquidPlacementModal.js
+++ b/protocol-designer/src/components/LiquidPlacementModal.js
@@ -87,7 +87,7 @@ const mapStateToProps = (state: BaseState): SP => {
     }
   }
 
-  const labware = stepFormSelectors.getLabwareEntities(state)[labwareId]
+  const labwareType = stepFormSelectors.getLabwareTypesById(state)[labwareId]
   let wellContents: ContentsByWell = {}
 
   // selection for deck setup: shows initial state of liquids
@@ -96,7 +96,7 @@ const mapStateToProps = (state: BaseState): SP => {
   return {
     selectedWells,
     wellContents,
-    containerType: labware ? labware.type : 'missing labware',
+    containerType: labwareType || 'missing labware',
     liquidNamesById: selectors.getLiquidNamesById(state),
   }
 }

--- a/protocol-designer/src/components/LiquidPlacementModal.js
+++ b/protocol-designer/src/components/LiquidPlacementModal.js
@@ -1,4 +1,5 @@
 // @flow
+import assert from 'assert'
 import * as React from 'react'
 import {connect} from 'react-redux'
 import type {Dispatch} from 'redux'
@@ -74,10 +75,10 @@ class LiquidPlacementModal extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state: BaseState): SP => {
-  const containerId = selectors.getSelectedLabwareId(state)
+  const labwareId = selectors.getSelectedLabwareId(state)
   const selectedWells = wellSelectionSelectors.getSelectedWells(state)
-  if (containerId == null) {
-    console.error('LiquidPlacementModal: No labware is selected, and no labwareId was given to LiquidPlacementModal')
+  if (labwareId == null) {
+    assert(false, 'LiquidPlacementModal: No labware is selected, and no labwareId was given to LiquidPlacementModal')
     return {
       selectedWells: {},
       wellContents: {},
@@ -86,11 +87,11 @@ const mapStateToProps = (state: BaseState): SP => {
     }
   }
 
-  const labware = stepFormSelectors.getLabwareById(state)[containerId]
+  const labware = stepFormSelectors.getLabwareEntities(state)[labwareId]
   let wellContents: ContentsByWell = {}
 
   // selection for deck setup: shows initial state of liquids
-  wellContents = wellContentsSelectors.getWellContentsAllLabware(state)[containerId]
+  wellContents = wellContentsSelectors.getWellContentsAllLabware(state)[labwareId]
 
   return {
     selectedWells,

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -1,6 +1,7 @@
 @import '@opentrons/components';
 
 .form_row {
+  margin-top: 1.5rem;
   min-height: 2.25rem;
   display: flex;
   flex-direction: row;
@@ -52,7 +53,7 @@
 }
 
 .checkbox_row {
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
   height: 1.5rem;
   display: flex;
   flex-direction: row;

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import {DropdownField, type DropdownOption} from '@opentrons/components'
 import cx from 'classnames'
 import {selectors as stepFormSelectors} from '../../../step-forms'
+import {selectors as uiLabwareSelectors} from '../../../ui/labware'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
 import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
@@ -27,7 +28,7 @@ const BlowoutLocationDropdownSTP = (state: BaseState, ownProps: BlowoutLocationD
   const unsavedForm = stepFormSelectors.getUnsavedForm(state)
   const {stepType, path} = unsavedForm || {}
 
-  let options = stepFormSelectors.getDisposalLabwareOptions(state)
+  let options = uiLabwareSelectors.getDisposalLabwareOptions(state)
   if (stepType === 'mix') {
     options = [...options, {name: 'Destination Well', value: DEST_WELL_BLOWOUT_DESTINATION}]
   } else if (stepType === 'moveLiquid') {

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -7,6 +7,7 @@ import cx from 'classnames'
 import {getMaxDisposalVolumeForMultidispense} from '../../../steplist/formLevel/handleFormChange/utils'
 import {SOURCE_WELL_BLOWOUT_DESTINATION} from '../../../step-generation/utils'
 import {selectors as stepFormSelectors} from '../../../step-forms'
+import {selectors as uiLabwareSelectors} from '../../../ui/labware'
 
 import FieldConnector from './FieldConnector'
 import TextField from './Text'
@@ -93,7 +94,7 @@ const mapSTP = (state: BaseState): SP => {
   return {
     maxDisposalVolume: getMaxDisposalVolumeForMultidispense(stepFormSelectors.getUnsavedForm(state), stepFormSelectors.getPipetteEntities(state)),
     disposalDestinationOptions: [
-      ...stepFormSelectors.getDisposalLabwareOptions(state),
+      ...uiLabwareSelectors.getDisposalLabwareOptions(state),
       {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION},
     ],
   }

--- a/protocol-designer/src/components/StepEditForm/fields/Labware.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Labware.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {connect} from 'react-redux'
 import {DropdownField, type DropdownOption} from '@opentrons/components'
 import cx from 'classnames'
-import {selectors as stepFormSelectors} from '../../../step-forms'
+import {selectors as uiLabwareSelectors} from '../../../ui/labware'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
 import type {BaseState} from '../../../types'
 import type {FocusHandlers} from '../types'
@@ -15,7 +15,7 @@ type Options = Array<DropdownOption>
 type LabwareFieldOP = {name: StepFieldName, className?: string} & FocusHandlers
 type LabwareFieldSP = {labwareOptions: Options}
 const LabwareFieldSTP = (state: BaseState): LabwareFieldSP => ({
-  labwareOptions: stepFormSelectors.getLabwareOptions(state),
+  labwareOptions: uiLabwareSelectors.getLabwareOptions(state),
 })
 const LabwareField = connect(LabwareFieldSTP)((props: LabwareFieldOP & LabwareFieldSP) => {
   const {labwareOptions, name, className, focusedField, dirtyFields, onFieldBlur, onFieldFocus} = props

--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
@@ -98,9 +98,8 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   let wellHeightMM = null
   const labwareId: ?string = rawForm && rawForm[labwareFieldName]
   if (labwareId != null) {
-    const labwareEntities = stepFormSelectors.getLabwareEntities(state)
-    const labware = labwareEntities[labwareId]
-    const labwareDef = labware && getLabware(labware.type)
+    const labwareType = stepFormSelectors.getLabwareTypesById(state)[labwareId]
+    const labwareDef = labwareType && getLabware(labwareType)
     if (labwareDef) {
       // NOTE: only taking depth of first well in labware def, UI not currently equipped for multiple depths
       const firstWell = labwareDef.wells['A1']

--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
@@ -91,15 +91,16 @@ class TipPositionInput extends React.Component<OP & SP, TipPositionInputState> {
 }
 
 const mapSTP = (state: BaseState, ownProps: OP): SP => {
-  const formData = stepFormSelectors.getUnsavedForm(state)
+  const rawForm = stepFormSelectors.getUnsavedForm(state)
   const {fieldName} = ownProps
   const labwareFieldName = getLabwareFieldForPositioningField(ownProps.fieldName)
 
   let wellHeightMM = null
-  if (formData && formData[labwareFieldName]) {
-    const labwareById = stepFormSelectors.getLabwareById(state)
-    const labware = labwareById[formData[labwareFieldName]]
-    const labwareDef = labware && labware.type && getLabware(labware.type)
+  const labwareId: ?string = rawForm && rawForm[labwareFieldName]
+  if (labwareId != null) {
+    const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+    const labware = labwareEntities[labwareId]
+    const labwareDef = labware && getLabware(labware.type)
     if (labwareDef) {
       // NOTE: only taking depth of first well in labware def, UI not currently equipped for multiple depths
       const firstWell = labwareDef.wells['A1']
@@ -110,9 +111,9 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   }
 
   return {
-    disabled: formData ? getDisabledFields(formData).has(fieldName) : false,
+    disabled: rawForm ? getDisabledFields(rawForm).has(fieldName) : false,
     wellHeightMM,
-    mmFromBottom: formData && formData[fieldName],
+    mmFromBottom: rawForm && rawForm[fieldName],
   }
 }
 

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
@@ -114,8 +114,7 @@ class WellSelectionModal extends React.Component<Props, State> {
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {pipetteId, labwareId} = ownProps
 
-  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
-  const labware = labwareId ? labwareEntities[labwareId] : null
+  const labwareType = labwareId ? stepFormSelectors.getLabwareTypesById(state)[labwareId] : null
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
 
   const stepId = stepsSelectors.getSelectedStepId(state)
@@ -133,7 +132,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     initialSelectedWells: formData ? formData[ownProps.name] : [],
     pipetteSpec: pipette && pipette.spec,
     wellContents: labwareId && allWellContentsForStep ? allWellContentsForStep[labwareId] : {},
-    containerType: labware ? labware.type : 'missing labware',
+    containerType: labwareType || 'missing labware',
     ingredNames,
   }
 }

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
@@ -114,8 +114,8 @@ class WellSelectionModal extends React.Component<Props, State> {
 function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {pipetteId, labwareId} = ownProps
 
-  const allLabware = stepFormSelectors.getLabwareById(state)
-  const labware = labwareId && allLabware && allLabware[labwareId]
+  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+  const labware = labwareId ? labwareEntities[labwareId] : null
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
 
   const stepId = stepsSelectors.getSelectedStepId(state)
@@ -132,7 +132,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   return {
     initialSelectedWells: formData ? formData[ownProps.name] : [],
     pipetteSpec: pipette && pipette.spec,
-    wellContents: labware && allWellContentsForStep ? allWellContentsForStep[labware.id] : {},
+    wellContents: labwareId && allWellContentsForStep ? allWellContentsForStep[labwareId] : {},
     containerType: labware ? labware.type : 'missing labware',
     ingredNames,
   }

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.js
@@ -92,8 +92,7 @@ class BrowseLabwareModal extends React.Component<Props> {
 
 function mapStateToProps (state: BaseState): SP {
   const labwareId = selectors.getDrillDownLabwareId(state)
-  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
-  const labwareType = (labwareId && labwareEntities[labwareId] && labwareEntities[labwareId].type) || 'missing labware'
+  const labwareType = (labwareId && stepFormSelectors.getLabwareTypesById(state)[labwareId]) || 'missing labware'
   const allWellContents = wellContentsSelectors.getLastValidWellContents(state)
   const wellContents = labwareId && allWellContents ? allWellContents[labwareId] : {}
   const ingredNames = selectors.getLiquidNamesById(state)

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.js
@@ -92,15 +92,15 @@ class BrowseLabwareModal extends React.Component<Props> {
 
 function mapStateToProps (state: BaseState): SP {
   const labwareId = selectors.getDrillDownLabwareId(state)
-  const allLabware = stepFormSelectors.getLabwareById(state)
-  const labware = labwareId && allLabware ? allLabware[labwareId] : null
+  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+  const labwareType = (labwareId && labwareEntities[labwareId] && labwareEntities[labwareId].type) || 'missing labware'
   const allWellContents = wellContentsSelectors.getLastValidWellContents(state)
   const wellContents = labwareId && allWellContents ? allWellContents[labwareId] : {}
   const ingredNames = selectors.getLiquidNamesById(state)
   return {
     wellContents,
     ingredNames,
-    labwareType: labware ? labware.type : 'missing labware',
+    labwareType,
   }
 }
 

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
@@ -5,17 +5,22 @@ import {Icon, HoverTooltip} from '@opentrons/components'
 import {PDListItem} from '../lists'
 import styles from './StepItem.css'
 import LabwareTooltipContents from './LabwareTooltipContents'
-import type {Labware} from '../../labware-ingred/types'
-import {labwareToDisplayName} from '../../labware-ingred/utils'
 import {Portal} from './TooltipPortal'
 
 type AspirateDispenseHeaderProps = {
-  sourceLabware: ?Labware,
-  destLabware: ?Labware,
+  sourceLabwareNickname: ?string,
+  sourceLabwareType: ?string,
+  destLabwareNickname: ?string,
+  destLabwareType: ?string,
 }
 
 function AspirateDispenseHeader (props: AspirateDispenseHeaderProps) {
-  const {sourceLabware, destLabware} = props
+  const {
+    sourceLabwareNickname,
+    sourceLabwareType,
+    destLabwareNickname,
+    destLabwareType,
+  } = props
 
   return (
     <React.Fragment>
@@ -28,10 +33,14 @@ function AspirateDispenseHeader (props: AspirateDispenseHeaderProps) {
       <PDListItem className={cx(styles.step_subitem_column_header, styles.emphasized_cell)}>
         <HoverTooltip
           portal={Portal}
-          tooltipComponent={<LabwareTooltipContents labware={sourceLabware} />}>
+          tooltipComponent={(
+            <LabwareTooltipContents
+              labwareNickname={sourceLabwareNickname}
+              labwareType={sourceLabwareType} />
+          )}>
           {(hoverTooltipHandlers) => (
             <span {...hoverTooltipHandlers} className={styles.labware_display_name}>
-              {sourceLabware && labwareToDisplayName(sourceLabware)}
+              {sourceLabwareNickname}
             </span>
           )}
         </HoverTooltip>
@@ -39,10 +48,14 @@ function AspirateDispenseHeader (props: AspirateDispenseHeaderProps) {
         <Icon name='ot-transfer' />
         <HoverTooltip
           portal={Portal}
-          tooltipComponent={<LabwareTooltipContents labware={destLabware} />}>
+          tooltipComponent={(
+            <LabwareTooltipContents
+              labwareNickname={destLabwareNickname}
+              labwareType={destLabwareType} />
+          )}>
           {(hoverTooltipHandlers) => (
             <span {...hoverTooltipHandlers} className={styles.labware_display_name}>
-              {destLabware && labwareToDisplayName(destLabware)}
+              {destLabwareNickname}
             </span>
           )}
         </HoverTooltip>

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.js
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.js
@@ -1,19 +1,20 @@
 // @flow
 import * as React from 'react'
-import type {Labware} from '../../labware-ingred/types'
-import {labwareToDisplayName} from '../../labware-ingred/utils'
 import styles from './StepItem.css'
 
-type LabwareTooltipContentsProps = {labware: ?Labware}
-const LabwareTooltipContents = ({labware}: LabwareTooltipContentsProps) => {
-  const displayName = labware && labwareToDisplayName(labware)
+type LabwareTooltipContentsProps = {
+  labwareNickname: ?string,
+  labwareType: ?string,
+}
+const LabwareTooltipContents = (props: LabwareTooltipContentsProps) => {
+  const {labwareNickname, labwareType} = props
   return (
     <div className={styles.labware_tooltip_contents}>
-      <p className={styles.labware_name}>{displayName}</p>
-      {labware && labware.type !== displayName &&
+      <p className={styles.labware_name}>{labwareNickname}</p>
+      {labwareNickname &&
         <React.Fragment>
           <div className={styles.labware_spacer} />
-          <p>{labware && labware.type}</p>
+          <p>{labwareType}</p>
         </React.Fragment>
       }
     </div>

--- a/protocol-designer/src/components/steplist/MixHeader.js
+++ b/protocol-designer/src/components/steplist/MixHeader.js
@@ -4,26 +4,26 @@ import cx from 'classnames'
 import {HoverTooltip} from '@opentrons/components'
 import {PDListItem} from '../lists'
 import styles from './StepItem.css'
-import type {Labware} from '../../labware-ingred/types'
 import LabwareTooltipContents from './LabwareTooltipContents'
 import {Portal} from './TooltipPortal'
 
 type Props = {
   volume: ?string,
   times: ?string,
-  labware: ?Labware,
+  labwareNickname: ?string,
+  labwareType: ?string,
 }
 
 export default function MixHeader (props: Props) {
-  const {volume, times, labware} = props
+  const {volume, times, labwareNickname, labwareType} = props
   return (
     <PDListItem className={styles.step_subitem}>
       <HoverTooltip
         portal={Portal}
-        tooltipComponent={<LabwareTooltipContents labware={labware} />}>
+        tooltipComponent={<LabwareTooltipContents {...{labwareNickname, labwareType}} />}>
         {(hoverTooltipHandlers) => (
           <span {...hoverTooltipHandlers} className={cx(styles.emphasized_cell, styles.labware_display_name)}>
-            {labware && labware.nickname}
+            {labwareNickname}
           </span>
         )}
       </HoverTooltip>

--- a/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
+++ b/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
@@ -29,7 +29,7 @@ function StartingDeckStateTerminalItem (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   // since default-trash counts as 1, labwareCount <= 1 means "user did not add labware"
-  const noLabware = Object.keys(stepFormSelectors.getLabwareById(state)).length <= 1
+  const noLabware = Object.keys(stepFormSelectors.getLabwareEntities(state)).length <= 1
   return {showHint: noLabware}
 }
 

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -32,7 +32,7 @@ type StepItemProps = {
   hoveredSubstep: ?SubstepIdentifier,
   ingredNames: WellIngredientNames,
 
-  labwareNicknamesById: {[labwareId: string]: ?string},
+  labwareNicknamesById: {[labwareId: string]: string},
   labwareTypesById: {[labwareId: string]: ?string},
   highlightSubstep: SubstepIdentifier => mixed,
   selectStep: (stepId: StepIdType) => mixed,

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -10,7 +10,6 @@ import PauseStepItems from './PauseStepItems'
 import StepDescription from '../StepDescription'
 import {stepIconsByType} from '../../form-types'
 import type {FormData, StepIdType, StepType} from '../../form-types'
-import type {Labware} from '../../labware-ingred/types'
 import type {
   SubstepIdentifier,
   SubstepItemData,
@@ -33,7 +32,8 @@ type StepItemProps = {
   hoveredSubstep: ?SubstepIdentifier,
   ingredNames: WellIngredientNames,
 
-  labwareById: {[labwareId: string]: ?Labware},
+  labwareNicknamesById: {[labwareId: string]: ?string},
+  labwareTypesById: {[labwareId: string]: ?string},
   highlightSubstep: SubstepIdentifier => mixed,
   selectStep: (stepId: StepIdType) => mixed,
   onStepContextMenu?: (event?: SyntheticEvent<>) => mixed,
@@ -90,7 +90,8 @@ function getStepItemContents (stepItemProps: StepItemProps) {
     rawForm,
     stepType,
     substeps,
-    labwareById,
+    labwareNicknamesById,
+    labwareTypesById,
     hoveredSubstep,
     highlightSubstep,
     ingredNames,
@@ -99,9 +100,6 @@ function getStepItemContents (stepItemProps: StepItemProps) {
   if (!rawForm) {
     return null
   }
-
-  const getLabware = (labwareId: ?string) =>
-    labwareId != null ? labwareById[labwareId] : null
 
   // pause substep component uses the delay args directly
   if (substeps && substeps.commandCreatorFnName === 'delay') {
@@ -112,18 +110,26 @@ function getStepItemContents (stepItemProps: StepItemProps) {
 
   // headers
   if (stepType === 'moveLiquid') {
-    const sourceLabware = getLabware(rawForm['aspirate_labware'])
-    const destLabware = getLabware(rawForm['dispense_labware'])
+    const sourceLabwareId = rawForm['aspirate_labware']
+    const destLabwareId = rawForm['dispense_labware']
 
-    result.push(<AspirateDispenseHeader key='moveLiquid-header' {...{sourceLabware, destLabware}} />)
+    result.push(<AspirateDispenseHeader
+      key='moveLiquid-header'
+      sourceLabwareNickname={labwareNicknamesById[sourceLabwareId]}
+      sourceLabwareType={labwareTypesById[sourceLabwareId]}
+      destLabwareNickname={labwareNicknamesById[destLabwareId]}
+      destLabwareType={labwareTypesById[destLabwareId]}
+    />)
   }
 
   if (stepType === 'mix') {
+    const mixLabwareId = rawForm['labware']
     result.push(
       <MixHeader key='mix-header'
         volume={rawForm.volume}
         times={rawForm.times}
-        labware={getLabware(rawForm.labware)}
+        labwareNickname={labwareNicknamesById[mixLabwareId]}
+        labwareType={labwareTypesById[mixLabwareId]}
       />
     )
   }

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -16,10 +16,9 @@ import LabwareSelectionModal from '../components/LabwareSelectionModal'
 import StepEditForm from '../components/StepEditForm'
 import TimelineAlerts from '../components/alerts/TimelineAlerts'
 
-import {selectors} from '../labware-ingred/selectors'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
 import * as labwareIngredActions from '../labware-ingred/actions'
 import {START_TERMINAL_ITEM_ID, type TerminalItemId} from '../steplist'
-import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors} from '../ui/steps'
 
 import type {BaseState, ThunkDispatch} from '../types'
@@ -41,8 +40,8 @@ type Props = {
 
 const mapStateToProps = (state: BaseState): StateProps => ({
   selectedTerminalItemId: stepsSelectors.getSelectedTerminalItemId(state),
-  ingredSelectionMode: Boolean(stepFormSelectors.getSelectedLabware(state)),
-  drilledDown: !!selectors.getDrillDownLabwareId(state),
+  ingredSelectionMode: labwareIngredSelectors.getSelectedLabwareId(state) != null,
+  drilledDown: labwareIngredSelectors.getDrillDownLabwareId(state) != null,
 })
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DispatchProps => ({

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {selectors} from '../navigation'
-import {selectors as stepFormSelectors} from '../step-forms'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
 
 import ConnectedStepList from './ConnectedStepList'
 import IngredientsList from './IngredientsList'
@@ -36,7 +36,7 @@ function Sidebar (props: Props) {
 
 function mapStateToProps (state: BaseState): Props {
   const page = selectors.getCurrentPage(state)
-  const liquidPlacementMode = Boolean(stepFormSelectors.getSelectedLabware(state))
+  const liquidPlacementMode = labwareIngredSelectors.getSelectedLabwareId(state) != null
 
   return {
     page,

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import isEmpty from 'lodash/isEmpty'
-import mapValues from 'lodash/mapValues'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import type {SubstepIdentifier} from '../steplist/types'
@@ -72,8 +71,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
     labwareNicknamesById: stepFormSelectors.getLabwareNicknamesById(state),
-    // TODO IMMEDIATELY: make this a selector, it is widely used. use it in the diff'd other containers
-    labwareTypesById: mapValues(stepFormSelectors.getLabwareEntities(state), l => l.type),
+    labwareTypesById: stepFormSelectors.getLabwareTypesById(state),
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import isEmpty from 'lodash/isEmpty'
+import mapValues from 'lodash/mapValues'
 import type {BaseState, ThunkDispatch} from '../types'
 
 import type {SubstepIdentifier} from '../steplist/types'
@@ -31,7 +32,8 @@ type SP = {|
   selected: $PropertyType<Props, 'selected'>,
   hovered: $PropertyType<Props, 'hovered'>,
   hoveredSubstep: $PropertyType<Props, 'hoveredSubstep'>,
-  labwareById: $PropertyType<Props, 'labwareById'>,
+  labwareNicknamesById: $PropertyType<Props, 'labwareNicknamesById'>,
+  labwareTypesById: $PropertyType<Props, 'labwareTypesById'>,
   ingredNames: $PropertyType<Props, 'ingredNames'>,
 |}
 
@@ -69,7 +71,9 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // user is not hovering on substep.
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
-    labwareById: stepFormSelectors.getLabwareById(state),
+    labwareNicknamesById: stepFormSelectors.getLabwareNicknamesById(state),
+    // TODO IMMEDIATELY: make this a selector, it is widely used. use it in the diff'd other containers
+    labwareTypesById: mapValues(stepFormSelectors.getLabwareEntities(state), l => l.type),
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }
 }

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -11,6 +11,7 @@ import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import {selectors as fileDataSelectors} from '../file-data'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
+import {selectors as uiLabwareSelectors} from '../ui/labware'
 import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 why is importing StepItem from index.js not working?
 
 type Props = React.ElementProps<typeof StepItem>
@@ -70,7 +71,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     // user is not hovering on substep.
     hovered: (hoveredStep === stepId) && !hoveredSubstep,
 
-    labwareNicknamesById: stepFormSelectors.getLabwareNicknamesById(state),
+    labwareNicknamesById: uiLabwareSelectors.getLabwareNicknamesById(state),
     labwareTypesById: stepFormSelectors.getLabwareTypesById(state),
     ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
   }

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -43,17 +43,18 @@ function TitleWithIcon (props: TitleWithIconProps) {
 }
 
 function mapStateToProps (state: BaseState): SP {
-  const selectedLabware = stepFormSelectors.getSelectedLabware(state)
+  const selectedLabwareId = labwareIngredSelectors.getSelectedLabwareId(state)
   const _page = selectors.getCurrentPage(state)
   const fileName = fileDataSelectors.protocolName(state)
   const selectedStep = stepsSelectors.getSelectedStep(state)
   const selectedTerminalId = stepsSelectors.getSelectedTerminalItemId(state)
-  const labware = selectedLabware
   const labwareNames = stepFormSelectors.getLabwareNicknamesById(state)
-  const labwareNickname = labware && labware.id && labwareNames[labware.id]
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
-  const liquidPlacementMode = Boolean(selectedLabware)
   const wellSelectionLabwareKey = stepsSelectors.getWellSelectionLabwareKey(state)
+
+  const labwareNickname = selectedLabwareId != null && labwareNames[selectedLabwareId]
+  const labwareType = selectedLabwareId != null && stepFormSelectors.getLabwareTypes(state)[selectedLabwareId]
+  const liquidPlacementMode = selectedLabwareId != null
 
   switch (_page) {
     case 'liquids':
@@ -74,8 +75,8 @@ function mapStateToProps (state: BaseState): SP {
         return {
           _page,
           _liquidPlacementMode: liquidPlacementMode,
-          title: labwareNickname || null,
-          subtitle: labware && humanizeLabwareType(labware.type),
+          title: labwareNickname,
+          subtitle: labwareType,
           backButtonLabel: 'Deck',
         }
       }
@@ -88,9 +89,10 @@ function mapStateToProps (state: BaseState): SP {
         subtitle = END_TERMINAL_TITLE
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
-          const drilledDownLabware = stepFormSelectors.getLabwareById(state)[drilledDownLabwareId]
-          title = drilledDownLabware && drilledDownLabware.nickname
-          subtitle = drilledDownLabware && humanizeLabwareType(drilledDownLabware.type)
+          const labwareEntity = stepFormSelectors.getLabwareEntities(state)[drilledDownLabwareId]
+          const displayLabware = labwareIngredSelectors.getLabwareNameInfo(state)[drilledDownLabwareId]
+          title = displayLabware && displayLabware.nickname
+          subtitle = labwareEntity && humanizeLabwareType(labwareEntity.type)
         }
       } else if (selectedStep) {
         if (wellSelectionLabwareKey) { // well selection modal

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -53,8 +53,8 @@ function mapStateToProps (state: BaseState): SP {
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
   const wellSelectionLabwareKey = stepsSelectors.getWellSelectionLabwareKey(state)
 
-  const labwareNickname = selectedLabwareId != null && labwareNames[selectedLabwareId]
-  const labwareType = selectedLabwareId != null && stepFormSelectors.getLabwareTypesById(state)[selectedLabwareId]
+  const labwareNickname = selectedLabwareId != null ? labwareNames[selectedLabwareId] : null
+  const labwareType = selectedLabwareId != null ? stepFormSelectors.getLabwareTypesById(state)[selectedLabwareId] : null
   const liquidPlacementMode = selectedLabwareId != null
 
   switch (_page) {

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -53,7 +53,7 @@ function mapStateToProps (state: BaseState): SP {
   const wellSelectionLabwareKey = stepsSelectors.getWellSelectionLabwareKey(state)
 
   const labwareNickname = selectedLabwareId != null && labwareNames[selectedLabwareId]
-  const labwareType = selectedLabwareId != null && stepFormSelectors.getLabwareTypes(state)[selectedLabwareId]
+  const labwareType = selectedLabwareId != null && stepFormSelectors.getLabwareTypesById(state)[selectedLabwareId]
   const liquidPlacementMode = selectedLabwareId != null
 
   switch (_page) {
@@ -89,10 +89,10 @@ function mapStateToProps (state: BaseState): SP {
         subtitle = END_TERMINAL_TITLE
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
-          const labwareEntity = stepFormSelectors.getLabwareEntities(state)[drilledDownLabwareId]
+          const labwareType = stepFormSelectors.getLabwareTypesById(state)[drilledDownLabwareId]
           const displayLabware = labwareIngredSelectors.getLabwareNameInfo(state)[drilledDownLabwareId]
           title = displayLabware && displayLabware.nickname
-          subtitle = labwareEntity && humanizeLabwareType(labwareEntity.type)
+          subtitle = labwareType && humanizeLabwareType(labwareType)
         }
       } else if (selectedStep) {
         if (wellSelectionLabwareKey) { // well selection modal

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -8,6 +8,7 @@ import styles from './TitleBar.css'
 import i18n from '../localization'
 import {START_TERMINAL_TITLE, END_TERMINAL_TITLE} from '../constants'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
+import {selectors as uiLabwareSelectors} from '../ui/labware'
 import {selectors as stepFormSelectors} from '../step-forms'
 import {selectors as stepsSelectors, actions as stepsActions} from '../ui/steps'
 import {END_TERMINAL_ITEM_ID, START_TERMINAL_ITEM_ID} from '../steplist'
@@ -48,7 +49,7 @@ function mapStateToProps (state: BaseState): SP {
   const fileName = fileDataSelectors.protocolName(state)
   const selectedStep = stepsSelectors.getSelectedStep(state)
   const selectedTerminalId = stepsSelectors.getSelectedTerminalItemId(state)
-  const labwareNames = stepFormSelectors.getLabwareNicknamesById(state)
+  const labwareNames = uiLabwareSelectors.getLabwareNicknamesById(state)
   const drilledDownLabwareId = labwareIngredSelectors.getDrillDownLabwareId(state)
   const wellSelectionLabwareKey = stepsSelectors.getWellSelectionLabwareKey(state)
 
@@ -90,8 +91,8 @@ function mapStateToProps (state: BaseState): SP {
         if (drilledDownLabwareId) {
           backButtonLabel = 'Deck'
           const labwareType = stepFormSelectors.getLabwareTypesById(state)[drilledDownLabwareId]
-          const displayLabware = labwareIngredSelectors.getLabwareNameInfo(state)[drilledDownLabwareId]
-          title = displayLabware && displayLabware.nickname
+          const nickname = uiLabwareSelectors.getLabwareNicknamesById(state)[drilledDownLabwareId]
+          title = nickname
           subtitle = labwareType && humanizeLabwareType(labwareType)
         }
       } else if (selectedStep) {

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -42,7 +42,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     }
   }
 
-  const labwareEntity = stepFormSelectors.getLabwareEntities(state)[containerId]
+  const labwareType = stepFormSelectors.getLabwareTypesById(state)[containerId]
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
   const wellSelectionModeForLabware = selectedContainerId === containerId
   let wellContents: ContentsByWell = {}
@@ -113,7 +113,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   return {
     wellContents,
     getTipProps: getTipProps || noop,
-    containerType: labwareEntity ? labwareEntity.type : 'missing labware',
+    containerType: labwareType || 'missing labware',
   }
 }
 

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -42,7 +42,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
     }
   }
 
-  const labware = stepFormSelectors.getLabwareById(state)[containerId]
+  const labwareEntity = stepFormSelectors.getLabwareEntities(state)[containerId]
   const allWellContentsForSteps = wellContentsSelectors.getAllWellContentsForSteps(state)
   const wellSelectionModeForLabware = selectedContainerId === containerId
   let wellContents: ContentsByWell = {}
@@ -113,7 +113,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   return {
     wellContents,
     getTipProps: getTipProps || noop,
-    containerType: labware ? labware.type : 'missing labware',
+    containerType: labwareEntity ? labwareEntity.type : 'missing labware',
   }
 }
 

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {selectors} from '../labware-ingred/selectors'
-import {selectors as stepFormSelectors} from '../step-forms'
+import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
 import * as wellSelectionSelectors from '../top-selectors/well-contents'
 import {removeWellsContents} from '../labware-ingred/actions'
 import type {Dispatch} from 'redux'
@@ -19,15 +18,18 @@ type DP = {
 type SP = $Diff<Props, DP> & {_labwareId: ?string}
 
 function mapStateToProps (state: BaseState): SP {
-  const container = stepFormSelectors.getSelectedLabware(state)
-  const _labwareId = container && container.id
+  const selectedLabwareId = labwareIngredSelectors.getSelectedLabwareId(state)
+  const labwareWellContents = (
+    selectedLabwareId &&
+    labwareIngredSelectors.getLiquidsByLabwareId(state)[selectedLabwareId]
+  ) || {}
 
   return {
-    liquidGroupsById: selectors.getLiquidGroupsById(state),
-    labwareWellContents: (container && selectors.getLiquidsByLabwareId(state)[container.id]) || {},
+    liquidGroupsById: labwareIngredSelectors.getLiquidGroupsById(state),
+    labwareWellContents,
     selectedIngredientGroupId: wellSelectionSelectors.getSelectedWellsCommonIngredId(state),
     selected: false,
-    _labwareId,
+    _labwareId: selectedLabwareId,
   }
 }
 

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import noop from 'lodash/noop'
 import {getLabware, getIsTiprack} from '@opentrons/shared-data'
 import {selectors as labwareIngredSelectors} from '../labware-ingred/selectors'
+import {selectors as uiLabwareSelectors} from '../ui/labware'
 import {selectors as stepFormSelectors} from '../step-forms'
 import {
   openIngredientSelector,
@@ -50,7 +51,7 @@ function mapStateToProps (state: BaseState, ownProps: OP): SP {
   const {slot} = ownProps
   // TODO: Ian 2019-02-14 to enable multiple deck setup steps, this needs to be timeline aware.
   // For multiple deck setup support, pick by slot without using timeline frame index is a HACK.
-  const labwareNames = stepFormSelectors.getLabwareNicknamesById(state)
+  const labwareNames = uiLabwareSelectors.getLabwareNicknamesById(state)
   const initialLabware = stepFormSelectors.getInitialDeckSetup(state).labware
   const selectedLabwareId = labwareIngredSelectors.getSelectedLabwareId(state)
   const selectedTerminalItem = stepsSelectors.getSelectedTerminalItemId(state)

--- a/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
+++ b/protocol-designer/src/file-data/__tests__/commandsSelectors.test.js
@@ -1,25 +1,13 @@
 import {getLabwareLiquidState} from '../selectors'
 
-let labwareState
+let labwareTypesById
 let ingredLocs
 
 beforeEach(() => {
-  labwareState = {
-    'FIXED_TRASH_ID': {
-      type: 'fixed-trash',
-      name: 'Trash',
-      slot: '12',
-    },
-    wellPlateId: {
-      slot: '10',
-      type: '96-flat',
-      name: 'Labware 1',
-    },
-    troughId: {
-      slot: '8',
-      type: 'trough-12row',
-      name: 'Labware 2',
-    },
+  labwareTypesById = {
+    FIXED_TRASH_ID: 'fixed-trash',
+    wellPlateId: '96-flat',
+    troughId: 'trough-12row',
   }
 
   ingredLocs = {
@@ -54,7 +42,7 @@ describe('getLabwareLiquidState', () => {
   test('labware + no ingreds: generate empty well keys', () => {
     const result = getLabwareLiquidState.resultFunc(
       {},
-      labwareState
+      labwareTypesById
     )
 
     hasAllWellKeys(result)
@@ -63,7 +51,7 @@ describe('getLabwareLiquidState', () => {
   test('selects liquids with multiple ingredient groups & multiple labware: generate all well keys', () => {
     const result = getLabwareLiquidState.resultFunc(
       ingredLocs,
-      labwareState
+      labwareTypesById
     )
 
     expect(result).toMatchObject(ingredLocs)

--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -24,14 +24,14 @@ const all96Tips = reduce(
 // NOTE this just adds missing well keys to the labware-ingred 'deck setup' liquid state
 export const getLabwareLiquidState: Selector<StepGeneration.LabwareLiquidState> = createSelector(
   labwareIngredSelectors.getLiquidsByLabwareId,
-  stepFormSelectors.getLabwareById,
-  (ingredLocations, allLabware) => {
-    const allLabwareIds: Array<string> = Object.keys(allLabware)
+  stepFormSelectors.getLabwareTypesById,
+  (ingredLocations, labwareTypes) => {
+    const allLabwareIds: Array<string> = Object.keys(labwareTypes)
     return allLabwareIds.reduce((
       acc: StepGeneration.LabwareLiquidState,
       labwareId
     ): StepGeneration.LabwareLiquidState => {
-      const labwareType = allLabware[labwareId] && allLabware[labwareId].type
+      const labwareType = labwareTypes[labwareId]
       const allWells = labwareType ? getAllWellsForLabware(labwareType) : []
       const liquidStateForLabwareAllWells = allWells.reduce(
         (innerAcc: StepGeneration.SingleLabwareLiquidState, well) => ({

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -7,6 +7,7 @@ import {getInitialRobotState, getRobotStateTimeline} from './commands'
 import {selectors as dismissSelectors} from '../../dismiss'
 import {selectors as ingredSelectors} from '../../labware-ingred/selectors'
 import {selectors as stepFormSelectors} from '../../step-forms'
+import {selectors as uiLabwareSelectors} from '../../ui/labware'
 import {
   DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
   DEFAULT_MM_FROM_BOTTOM_DISPENSE,
@@ -43,7 +44,7 @@ export const createFile: BaseState => ProtocolFile = createSelector(
   stepFormSelectors.getSavedStepForms,
   stepFormSelectors.getOrderedStepIds,
   stepFormSelectors.getPipetteEntities,
-  stepFormSelectors.getLabwareNicknamesById,
+  uiLabwareSelectors.getLabwareNicknamesById,
   (
     fileMetadata,
     initialRobotState,

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -8,12 +8,12 @@ describe('DELETE_CONTAINER action', () => {
       containersInitialState,
       {
         type: 'DELETE_CONTAINER',
-        payload: {containerId: '123'},
+        payload: {labwareId: '123'},
       }
     )).toEqual(containersInitialState)
   })
 
-  test('no-op with nonexistent containerId', () => {
+  test('no-op with nonexistent labwareId', () => {
     expect(containers(
       {
         '1': 'blah',
@@ -21,7 +21,7 @@ describe('DELETE_CONTAINER action', () => {
       },
       {
         type: 'DELETE_CONTAINER',
-        payload: {containerId: '123'},
+        payload: {labwareId: '123'},
       }
     )).toEqual({
       '1': 'blah',
@@ -29,7 +29,7 @@ describe('DELETE_CONTAINER action', () => {
     })
   })
 
-  test('delete given containerId', () => {
+  test('delete given labwareId', () => {
     expect(containers(
       {
         '1': 'blah',
@@ -38,7 +38,7 @@ describe('DELETE_CONTAINER action', () => {
       },
       {
         type: 'DELETE_CONTAINER',
-        payload: {containerId: '123'},
+        payload: {labwareId: '123'},
       }
     )).toEqual({
       '1': 'blah',

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -64,9 +64,7 @@ export type CreateContainerAction = {
 export type DeleteContainerAction = {
   type: 'DELETE_CONTAINER',
   payload: {
-    containerId: string,
-    slot: DeckSlot,
-    containerType: string,
+    labwareId: string,
   },
 }
 export const deleteContainer = createAction(

--- a/protocol-designer/src/labware-ingred/actions/thunks.js
+++ b/protocol-designer/src/labware-ingred/actions/thunks.js
@@ -11,12 +11,11 @@ import type {
 import type {BaseState, GetState, ThunkDispatch} from '../../types'
 
 function getNextDisambiguationNumber (state: BaseState, newLabwareType: string): number {
-  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
+  const labwareTypesById = stepFormSelectors.getLabwareTypesById(state)
   const labwareNamesMap = labwareIngredsSelectors.getLabwareNameInfo(state)
-  const allIds = Object.keys(labwareEntities)
+  const allIds = Object.keys(labwareTypesById)
   const sameTypeLabware = allIds.filter(labwareId =>
-    labwareEntities[labwareId] &&
-    labwareEntities[labwareId].type === newLabwareType)
+    labwareTypesById[labwareId] === newLabwareType)
   const disambigNumbers = sameTypeLabware.map(labwareId =>
     (labwareNamesMap[labwareId] &&
     labwareNamesMap[labwareId].disambiguationNumber) || 0)
@@ -43,15 +42,16 @@ export const createContainer = (args: CreateContainerArgs) =>
 export const duplicateLabware = (templateLabwareId: string) =>
   (dispatch: ThunkDispatch<DuplicateLabwareAction>, getState: GetState) => {
     const state = getState()
-    const templateLabwareEntity = stepFormSelectors.getLabwareEntities(state)[templateLabwareId]
-    assert(templateLabwareEntity, `no entity for labware ${templateLabwareId}, cannot run duplicateLabware thunk`)
-    if (!templateLabwareEntity) return
-    dispatch({
-      type: 'DUPLICATE_LABWARE',
-      payload: {
-        duplicateDisambiguationNumber: getNextDisambiguationNumber(state, templateLabwareEntity.type),
-        templateLabwareId,
-        duplicateLabwareId: uuid(),
-      },
-    })
+    const templateLabwareType = stepFormSelectors.getLabwareTypesById(state)[templateLabwareId]
+    assert(templateLabwareType, `no type for labware ${templateLabwareId}, cannot run duplicateLabware thunk`)
+    if (templateLabwareType) {
+      dispatch({
+        type: 'DUPLICATE_LABWARE',
+        payload: {
+          duplicateDisambiguationNumber: getNextDisambiguationNumber(state, templateLabwareType),
+          templateLabwareId,
+          duplicateLabwareId: uuid(),
+        },
+      })
+    }
   }

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -22,9 +22,6 @@ import type {
   SetWellContentsAction,
 } from '../actions'
 
-// external actions (for types)
-import type {OpenWellSelectionModalAction} from '../../well-selection/actions'
-
 // REDUCERS
 
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
@@ -40,10 +37,6 @@ export type SelectedContainerId = ?string
 const selectedContainerId = handleActions({
   OPEN_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.openIngredientSelector>): SelectedContainerId => action.payload,
   CLOSE_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.closeIngredientSelector>): SelectedContainerId => null,
-  // TODO IMMEDIATELY is this needed? If not, remove the action.
-  OPEN_WELL_SELECTION_MODAL: (state, action: OpenWellSelectionModalAction): SelectedContainerId =>
-    action.payload.labwareId,
-  CLOSE_WELL_SELECTION_MODAL: (): SelectedContainerId => null,
 }, null)
 
 export type DrillDownLabwareId = ?string

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -10,7 +10,7 @@ import {FIXED_TRASH_ID} from '../../constants'
 import {getPDMetadata} from '../../file-types'
 import type {DeckSlot} from '@opentrons/components'
 import type {SingleLabwareLiquidState, LabwareLiquidState} from '../../step-generation'
-import type {LiquidGroupsById, Labware, DisplayLabware} from '../types'
+import type {LiquidGroupsById, DisplayLabware} from '../types'
 import type {LoadFileAction} from '../../load-file'
 import type {
   RemoveWellsContents,
@@ -23,7 +23,7 @@ import type {
 } from '../actions'
 
 // external actions (for types)
-import typeof {openWellSelectionModal} from '../../well-selection/actions'
+import type {OpenWellSelectionModalAction} from '../../well-selection/actions'
 
 // REDUCERS
 
@@ -40,9 +40,8 @@ export type SelectedContainerId = ?string
 const selectedContainerId = handleActions({
   OPEN_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.openIngredientSelector>): SelectedContainerId => action.payload,
   CLOSE_INGREDIENT_SELECTOR: (state, action: ActionType<typeof actions.closeIngredientSelector>): SelectedContainerId => null,
-
-  // $FlowFixMe: Cannot get `action.payload` because property `payload` is missing in function
-  OPEN_WELL_SELECTION_MODAL: (state, action: ActionType<openWellSelectionModal>): SelectedContainerId =>
+  // TODO IMMEDIATELY is this needed? If not, remove the action.
+  OPEN_WELL_SELECTION_MODAL: (state, action: OpenWellSelectionModalAction): SelectedContainerId =>
     action.payload.labwareId,
   CLOSE_WELL_SELECTION_MODAL: (): SelectedContainerId => null,
 }, null)
@@ -89,9 +88,9 @@ export const containers = handleActions({
       },
     }
   },
-  DELETE_CONTAINER: (state: ContainersState, action: ActionType<typeof actions.deleteContainer>) => pickBy(
+  DELETE_CONTAINER: (state: ContainersState, action: ActionType<typeof actions.deleteContainer>): ContainersState => pickBy(
     state,
-    (value: Labware, key: string) => key !== action.payload.containerId
+    (value: DisplayLabware, key: string) => key !== action.payload.labwareId
   ),
   RENAME_LABWARE: (state: ContainersState, action: ActionType<typeof actions.renameLabware>): ContainersState => {
     const {labwareId, name} = action.payload
@@ -142,8 +141,9 @@ type SavedLabwareState = {[labwareId: string]: boolean}
 /** Keeps track of which labware have saved nicknames */
 export const savedLabware = handleActions({
   DELETE_CONTAINER: (state: SavedLabwareState, action: ActionType<typeof actions.deleteContainer>) => ({
+    // TODO IMMEDIATELY should this be omit?
     ...state,
-    [action.payload.containerId]: false,
+    [action.payload.labwareId]: false,
   }),
   RENAME_LABWARE: (state: SavedLabwareState, action: ActionType<typeof actions.renameLabware>) => ({
     ...state,
@@ -222,7 +222,7 @@ export const ingredLocations = handleActions({
     state: LocationsState,
     action: ActionType<typeof actions.deleteContainer>
   ): LocationsState =>
-    omit(state, action.payload.containerId),
+    omit(state, action.payload.labwareId),
   LOAD_FILE: (state: LocationsState, action: LoadFileAction): LocationsState =>
     getPDMetadata(action.payload).ingredLocations,
 }, {})

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -141,7 +141,6 @@ type SavedLabwareState = {[labwareId: string]: boolean}
 /** Keeps track of which labware have saved nicknames */
 export const savedLabware = handleActions({
   DELETE_CONTAINER: (state: SavedLabwareState, action: ActionType<typeof actions.deleteContainer>) => ({
-    // TODO IMMEDIATELY should this be omit?
     ...state,
     [action.payload.labwareId]: false,
   }),

--- a/protocol-designer/src/labware-ingred/selectors.js
+++ b/protocol-designer/src/labware-ingred/selectors.js
@@ -17,14 +17,15 @@ import type {
   LiquidGroup,
   OrderedLiquids,
 } from './types'
-import type {BaseState, Options} from './../types'
+import type {BaseState, Options, Selector} from './../types'
 
-type Selector<T> = (RootSlice) => T
+// TODO: Ian 2019-02-15 no RootSlice, use BaseState
 type RootSlice = {labwareIngred: RootState}
 
 const rootSelector = (state: RootSlice): RootState => state.labwareIngred
 
-const getLabwareNameInfo = createSelector(
+// NOTE: not intended for UI use! Use getLabwareNicknamesById for the string.
+const getLabwareNameInfo: Selector<*> = createSelector(
   rootSelector,
   s => s.containers
 )

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -1,16 +1,8 @@
 // @flow
-import type {LabwareData, LocationLiquidState} from '../step-generation'
+import type {LocationLiquidState} from '../step-generation'
 // TODO Ian 2018-02-19 make these shared in component library, standardize with Run App
 
 //  ===== LABWARE ===========
-
-// TODO: Ian 2019-01-24 deprecate this type, use LabwareEntity or DisplayLabware instead
-export type Labware = {|
-  ...LabwareData,
-  id: string,
-  nickname?: string,
-  disambiguationNumber: number,
-|}
 
 export type DisplayLabware = {|
   nickname: ?string,

--- a/protocol-designer/src/labware-ingred/utils.js
+++ b/protocol-designer/src/labware-ingred/utils.js
@@ -1,7 +1,11 @@
 // @flow
 import {humanizeLabwareType} from '@opentrons/components'
-import type {Labware} from './types'
+import type {DisplayLabware} from './types'
 
-export const labwareToDisplayName = (l: Labware) => (
-  l.nickname || `${humanizeLabwareType(l.type)} (${l.disambiguationNumber})`
+export const labwareToDisplayName = (
+  displayLabware: DisplayLabware,
+  labwareType: string
+) => (
+  displayLabware.nickname ||
+  `${humanizeLabwareType(labwareType)} (${displayLabware.disambiguationNumber})`
 )

--- a/protocol-designer/src/labware-ingred/utils.js
+++ b/protocol-designer/src/labware-ingred/utils.js
@@ -3,9 +3,10 @@ import {humanizeLabwareType} from '@opentrons/components'
 import type {DisplayLabware} from './types'
 
 export const labwareToDisplayName = (
-  displayLabware: DisplayLabware,
+  displayLabware: ?DisplayLabware,
   labwareType: string
-) => (
-  displayLabware.nickname ||
-  `${humanizeLabwareType(labwareType)} (${displayLabware.disambiguationNumber})`
-)
+) => {
+  const disambiguationNumber = displayLabware ? displayLabware.disambiguationNumber : ''
+  return (displayLabware && displayLabware.nickname) ||
+  `${humanizeLabwareType(labwareType)} (${disambiguationNumber})`
+}

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -27,7 +27,6 @@ export const _allReducers = {
 export type RootState = {
   page: Page,
   newProtocolModal: boolean,
-  wellSelectionModal: boolean,
 }
 
 const rootReducer = combineReducers(_allReducers)

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -214,7 +214,7 @@ export const savedStepForms = (
       })
     }
     case 'DELETE_CONTAINER': {
-      const labwareIdToDelete = action.payload.containerId
+      const labwareIdToDelete = action.payload.labwareId
       return mapValues(savedStepForms, (savedForm: FormData) => {
         if (savedForm.stepType === 'manualIntervention') {
           // remove instances of labware from all manualIntervention steps
@@ -364,7 +364,7 @@ export const labwareInvariantProperties = handleActions({
     }
   },
   DELETE_CONTAINER: (state: LabwareEntities, action: DeleteContainerAction): LabwareEntities => {
-    return omit(state, action.payload.containerId)
+    return omit(state, action.payload.labwareId)
   },
   LOAD_FILE: (state: LabwareEntities, action: LoadFileAction): LabwareEntities => {
     const file = action.payload

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -12,16 +12,15 @@ import isEmpty from 'lodash/isEmpty'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import {createSelector} from 'reselect'
-import {getIsTiprack, getPipetteNameSpecs, getLabware} from '@opentrons/shared-data'
+import {getPipetteNameSpecs, getLabware} from '@opentrons/shared-data'
 import i18n from '../../localization'
-import {DISPOSAL_LABWARE_TYPES, INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
+import {INITIAL_DECK_SETUP_STEP_ID} from '../../constants'
 import {generateNewForm, getFormWarnings, getFormErrors, stepFormToArgs} from '../../steplist/formLevel'
 import {hydrateField, getFieldErrors} from '../../steplist/fieldLevel'
 import {addSpecsToPipetteInvariantProps} from '../utils'
-import {labwareToDisplayName} from '../../labware-ingred/utils'
 
 import type {FormWarning} from '../../steplist/formLevel'
-import type {BaseState, Selector, Options} from '../../types'
+import type {BaseState, Selector} from '../../types'
 import type {FormData, StepIdType, StepType} from '../../form-types'
 import type {LabwareTypeById} from '../../labware-ingred/types'
 import type {
@@ -85,54 +84,6 @@ export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
       }),
     }
   }
-)
-
-// $FlowFixMe TODO IMMEDIATELY
-export const getLabwareNicknamesById: Selector<{[labwareId: string]: string}> = createSelector(
-  getLabwareEntities,
-  state => state.labwareIngred.containers, // TODO IMMEDIATELY: move this selector to ui and use real labwareIngred selector
-  (labwareEntities, displayLabware) => mapValues(
-    labwareEntities,
-    (labwareEntity: LabwareEntity, id: string) =>
-      labwareToDisplayName(displayLabware[id], labwareEntity.type),
-  )
-)
-
-// TODO IMMEDIATELY move out to ui or something?
-/** Returns options for disposal (e.g. fixed trash and trash box) */
-export const getDisposalLabwareOptions: Selector<Options> = createSelector(
-  getLabwareEntities,
-  getLabwareNicknamesById,
-  (labwareById, names) => reduce(labwareById, (acc: Options, labware: LabwareEntity, labwareId): Options => {
-    if (!labware.type || !DISPOSAL_LABWARE_TYPES.includes(labware.type)) {
-      return acc
-    }
-    return [
-      ...acc,
-      {
-        name: names[labwareId],
-        value: labwareId,
-      },
-    ]
-  }, [])
-)
-
-// TODO IMMEDIATELY move out to ui or something?
-/** Returns options for dropdowns, excluding tiprack labware */
-export const getLabwareOptions: Selector<Options> = createSelector(
-  getLabwareTypesById,
-  getLabwareNicknamesById,
-  (labwareTypesById, nicknamesById) => reduce(labwareTypesById, (acc: Options, labwareType: string, labwareId): Options => {
-    return getIsTiprack(labwareType)
-      ? acc
-      : [
-        ...acc,
-        {
-          name: nicknamesById[labwareId],
-          value: labwareId,
-        },
-      ]
-  }, [])
 )
 
 export const getPermittedTipracks: Selector<Array<string>> = createSelector(

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -41,3 +41,5 @@ export type LabwareEntities = {
     type: string,
   |},
 }
+
+export type LabwareEntity = $Values<LabwareEntities>

--- a/protocol-designer/src/top-selectors/substeps.js
+++ b/protocol-designer/src/top-selectors/substeps.js
@@ -16,7 +16,7 @@ type AllSubsteps = {[StepIdType]: ?SubstepItemData}
 export const allSubsteps: Selector<AllSubsteps> = createSelector(
   stepFormSelectors.getArgsAndErrorsByStepId,
   stepFormSelectors.getInitialDeckSetup,
-  stepFormSelectors.getLabwareTypes,
+  stepFormSelectors.getLabwareTypesById,
   stepFormSelectors.getOrderedStepIds,
   fileDataSelectors.getRobotStateTimeline,
   fileDataSelectors.getInitialRobotState,

--- a/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
+++ b/protocol-designer/src/top-selectors/well-contents/__tests__/getWellContentsAllLabware.test.js
@@ -1,78 +1,60 @@
 import getWellContentsAllLabware from '../getWellContentsAllLabware'
 
-// FIXTURES
-const baseIngredFields = {
-  groupId: '0',
-  name: 'Some Ingred',
-  description: null,
-  serialize: false,
-}
-
-const containerState = {
-  'FIXED_TRASH_ID': {
-    type: 'trash-box',
-    name: 'Trash',
-    slot: '12',
-  },
-  container1Id: {
-    slot: '10',
-    type: '96-flat',
-    name: 'Labware 1',
-  },
-  container2Id: {
-    slot: '8',
-    type: '96-deep-well',
-    name: 'Labware 2',
-  },
-  container3Id: {
-    slot: '9',
-    type: 'tube-rack-2ml',
-    name: 'Labware 3',
-  },
-}
-
-const ingredsByLabwareXXSingleIngred = {
-  'container1Id': {
-    '0': {
-      ...baseIngredFields,
-      wells: {
-        A1: {volume: 100},
-        B1: {volume: 150},
-      },
-    },
-  },
-  'container2Id': {},
-  'container3Id': {},
-  'FIXED_TRASH_ID': {},
-}
-
-const defaultWellContents = {
-  highlighted: false,
-  selected: false,
-}
-
-const container1MaxVolume = 400
-
 describe('getWellContentsAllLabware', () => {
-  const singleIngredResult = getWellContentsAllLabware.resultFunc(
-    containerState, // all labware
-    ingredsByLabwareXXSingleIngred,
-    {id: 'container1Id'}, // selected labware
-    {A1: 'A1', B1: 'B1'}, // selected
-    {A3: 'A3'} // highlighted
-  )
+  const container1MaxVolume = 400
+  let baseIngredFields
+  let labwareTypesById
+  let ingredsByLabwareXXSingleIngred
+  let defaultWellContents
+  let singleIngredResult
 
-  // TODO: 2nd test case
-  // const twoIngredResult = selectors.getWellContentsAllLabware.resultFunc(
-  //   containerState, // all labware
-  //   ingredsByLabwareXXTwoIngred,
-  //   containerState.container2Id, // selected labware
-  //   {A1: 'A1', B1: 'B1'}, // selected
-  //   {A3: 'A3'} // highlighted
-  // )
+  beforeEach(() => {
+    baseIngredFields = {
+      groupId: '0',
+      name: 'Some Ingred',
+      description: null,
+      serialize: false,
+    }
 
-  test('container has expected number of wells', () => {
+    labwareTypesById = {
+      FIXED_TRASH_ID: 'trash-box',
+      container1Id: '96-flat',
+      container2Id: '96-deep-well',
+      container3Id: 'tube-rack-2ml',
+    }
+
+    ingredsByLabwareXXSingleIngred = {
+      'container1Id': {
+        '0': {
+          ...baseIngredFields,
+          wells: {
+            A1: {volume: 100},
+            B1: {volume: 150},
+          },
+        },
+      },
+      'container2Id': {},
+      'container3Id': {},
+      'FIXED_TRASH_ID': {},
+    }
+
+    defaultWellContents = {
+      highlighted: false,
+      selected: false,
+    }
+
+    singleIngredResult = getWellContentsAllLabware.resultFunc(
+      labwareTypesById, // all labware types
+      ingredsByLabwareXXSingleIngred,
+      'container1Id', // selected labware id
+      {A1: 'A1', B1: 'B1'}, // selected
+      {A3: 'A3'} // highlighted
+    )
+  })
+
+  test('containers have expected number of wells', () => {
     expect(Object.keys(singleIngredResult.container1Id).length).toEqual(96)
+    expect(Object.keys(singleIngredResult.container2Id).length).toEqual(96)
   })
 
   test('selects well contents of all labware (for Plate props)', () => {
@@ -110,5 +92,16 @@ describe('getWellContentsAllLabware', () => {
         },
       },
     })
+  })
+
+  test('no selected wells when labwareId is not selected', () => {
+    const result = getWellContentsAllLabware.resultFunc(
+      labwareTypesById, // all labware types
+      ingredsByLabwareXXSingleIngred,
+      null, // selected labware id
+      {A1: 'A1', B1: 'B1'}, // selected
+      {A3: 'A3'} // highlighted
+    )
+    expect(result.container1Id.A1.selected).toBe(false)
   })
 })

--- a/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
@@ -68,7 +68,6 @@ const getWellContentsAllLabware: Selector<WellContentsByLabware> = createSelecto
     return allLabwareIds.reduce((acc: WellContentsByLabware, labwareId: string) => {
       const liquidsForLabware = liquidsByLabware[labwareId]
       const isSelectedLabware = selectedLabwareId === labwareId
-      console.log({isSelectedLabware, labwareId, selectedLabwareId})
 
       const wellContents = _getWellContents(
         labwareTypesById[labwareId],

--- a/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
+++ b/protocol-designer/src/top-selectors/well-contents/getWellContentsAllLabware.js
@@ -58,15 +58,15 @@ const _getWellContents = (
 const getWellContentsAllLabware: Selector<WellContentsByLabware> = createSelector(
   stepFormSelectors.getLabwareById,
   labwareIngredSelectors.getLiquidsByLabwareId,
-  stepFormSelectors.getSelectedLabware,
+  labwareIngredSelectors.getSelectedLabwareId,
   wellSelectionSelectors.getSelectedWells,
   wellSelectionSelectors.getHighlightedWells,
-  (labwareById, liquidsByLabware, selectedLabware, selectedWells, highlightedWells) => {
+  (labwareById, liquidsByLabware, selectedLabwareId, selectedWells, highlightedWells) => {
     const allLabwareIds: Array<string> = Object.keys(labwareById) // TODO Ian 2018-05-29 weird flow error w/o annotation
 
     return allLabwareIds.reduce((acc: {[labwareId: string]: ContentsByWell | null}, labwareId: string) => {
       const liquidsForLabware = liquidsByLabware[labwareId]
-      const isSelectedLabware = selectedLabware && (selectedLabware.id === labwareId)
+      const isSelectedLabware = selectedLabwareId === labwareId
 
       // Skip labware ids with no liquids
       return {

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -113,7 +113,7 @@ export const getLastValidWellContents: Selector<WellContentsByLabware> = createS
 export const getSelectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
   labwareIngredSelectors.getSelectedLabwareId,
-  stepFormSelectors.getLabwareTypes,
+  stepFormSelectors.getLabwareTypesById,
   (selectedWells, selectedLabwareId, labwareTypes) => {
     const selectedWellNames = Object.keys(selectedWells)
     const selectedLabwareType = selectedLabwareId && labwareTypes[selectedLabwareId]

--- a/protocol-designer/src/top-selectors/well-contents/index.js
+++ b/protocol-designer/src/top-selectors/well-contents/index.js
@@ -112,15 +112,16 @@ export const getLastValidWellContents: Selector<WellContentsByLabware> = createS
 
 export const getSelectedWellsMaxVolume: Selector<number> = createSelector(
   wellSelectionSelectors.getSelectedWells,
-  stepFormSelectors.getSelectedLabware,
-  (selectedWells, selectedContainer) => {
+  labwareIngredSelectors.getSelectedLabwareId,
+  stepFormSelectors.getLabwareTypes,
+  (selectedWells, selectedLabwareId, labwareTypes) => {
     const selectedWellNames = Object.keys(selectedWells)
-    const selectedContainerType = selectedContainer && selectedContainer.type
-    if (!selectedContainerType) {
+    const selectedLabwareType = selectedLabwareId && labwareTypes[selectedLabwareId]
+    if (!selectedLabwareType) {
       console.warn('No container type selected, cannot get max volume')
       return Infinity
     }
-    const maxVolumesByWell = getMaxVolumes(selectedContainerType)
+    const maxVolumesByWell = getMaxVolumes(selectedLabwareType)
     const maxVolumesList = (selectedWellNames.length > 0)
       // when wells are selected, only look at vols of selected wells
       ? Object.values(pick(maxVolumesByWell, selectedWellNames))

--- a/protocol-designer/src/ui/labware/index.js
+++ b/protocol-designer/src/ui/labware/index.js
@@ -1,0 +1,6 @@
+// @flow
+import * as selectors from './selectors'
+
+export {
+  selectors,
+}

--- a/protocol-designer/src/ui/labware/selectors.js
+++ b/protocol-designer/src/ui/labware/selectors.js
@@ -1,0 +1,58 @@
+// @flow
+import {createSelector} from 'reselect'
+import mapValues from 'lodash/mapValues'
+import reduce from 'lodash/reduce'
+
+import {getIsTiprack} from '@opentrons/shared-data'
+import {selectors as stepFormSelectors} from '../../step-forms'
+import {selectors as labwareIngredSelectors} from '../../labware-ingred/selectors'
+import {labwareToDisplayName} from '../../labware-ingred/utils'
+import {DISPOSAL_LABWARE_TYPES} from '../../constants'
+
+import type {Selector, Options} from '../../types'
+import type {LabwareEntity} from '../../step-forms'
+
+export const getLabwareNicknamesById: Selector<{[labwareId: string]: string}> = createSelector(
+  stepFormSelectors.getLabwareEntities,
+  labwareIngredSelectors.getLabwareNameInfo,
+  (labwareEntities, displayLabware): {[labwareId: string]: string} => mapValues(
+    labwareEntities,
+    (labwareEntity: LabwareEntity, id: string) =>
+      labwareToDisplayName(displayLabware[id], labwareEntity.type),
+  )
+)
+
+/** Returns options for dropdowns, excluding tiprack labware */
+export const getLabwareOptions: Selector<Options> = createSelector(
+  stepFormSelectors.getLabwareTypesById,
+  getLabwareNicknamesById,
+  (labwareTypesById, nicknamesById) => reduce(labwareTypesById, (acc: Options, labwareType: string, labwareId): Options => {
+    return getIsTiprack(labwareType)
+      ? acc
+      : [
+        ...acc,
+        {
+          name: nicknamesById[labwareId],
+          value: labwareId,
+        },
+      ]
+  }, [])
+)
+
+/** Returns options for disposal (e.g. fixed trash and trash box) */
+export const getDisposalLabwareOptions: Selector<Options> = createSelector(
+  stepFormSelectors.getLabwareEntities,
+  getLabwareNicknamesById,
+  (labwareById, names) => reduce(labwareById, (acc: Options, labware: LabwareEntity, labwareId): Options => {
+    if (!labware.type || !DISPOSAL_LABWARE_TYPES.includes(labware.type)) {
+      return acc
+    }
+    return [
+      ...acc,
+      {
+        name: names[labwareId],
+        value: labwareId,
+      },
+    ]
+  }, [])
+)

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -1,14 +1,7 @@
 // @flow
 import {createAction} from 'redux-actions'
-import selectors from './selectors'
-import {changeFormInput} from '../steplist/actions'
 
-import {selectors as stepFormSelectors} from '../step-forms'
-
-import type {ThunkDispatch, GetState} from '../types'
-import type {StepFieldName} from '../form-types'
 import type {Wells} from '../labware-ingred/types'
-import type {Channels} from '@opentrons/components'
 
 // ===== Preselect / select wells in plate
 
@@ -33,80 +26,3 @@ export const deselectWells = createAction(
 export const deselectAllWells = createAction(
   'DESELECT_ALL_WELLS'
 )
-
-// Well selection modal
-export type OpenWellSelectionModalPayload = {
-  labwareId: string,
-  pipetteId: string,
-  formFieldAccessor: StepFieldName, // TODO: BC rename this 'name'
-  pipetteChannels?: ?Channels,
-  labwareName?: string,
-}
-export type OpenWellSelectionModalAction = {
-  type: 'OPEN_WELL_SELECTION_MODAL',
-  payload: OpenWellSelectionModalPayload,
-}
-
-function _wellArrayToObj (wells: ?Array<string>): Wells {
-  if (!wells) {
-    return {}
-  }
-  return wells.reduce((acc: Wells, well: string) => ({
-    ...acc,
-    [well]: well,
-  }), {})
-}
-
-export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =>
-  (dispatch: ThunkDispatch<*>, getState: GetState) => {
-    const state = getState()
-    const accessor = payload.formFieldAccessor
-    const formData = stepFormSelectors.getUnsavedForm(state)
-
-    const wells: Wells = (accessor && formData && formData[accessor] &&
-      _wellArrayToObj(formData[accessor])) || {}
-
-    // initially selected wells in form get selected in state before modal opens
-    dispatch(selectWells(wells))
-
-    const pipette = (
-      payload.pipetteId != null &&
-      stepFormSelectors.getPipetteEntities(state)[payload.pipetteId]
-    ) || null
-
-    // const labware = stepFormSelectors.getLabwareById(state)
-    // TODO type this action, make an underline fn action creator
-
-    dispatch({
-      type: 'OPEN_WELL_SELECTION_MODAL',
-      payload: {
-        ...payload,
-        pipetteChannels: pipette && pipette.spec.channels,
-        labwareName: 'TODO IMMEDIATELY labwareName', // labware && labware[payload.labwareId] && labware[payload.labwareId].type,
-      },
-    })
-  }
-
-export const closeWellSelectionModal = (): * => ({
-  type: 'CLOSE_WELL_SELECTION_MODAL',
-  payload: null,
-})
-
-export const saveWellSelectionModal = () =>
-  (dispatch: ThunkDispatch<*>, getState: GetState) => {
-    const state = getState()
-    const wellSelectionModalData = selectors.getWellSelectionModalData(state)
-
-    // this if-else is mostly for Flow
-    if (wellSelectionModalData) {
-      dispatch(changeFormInput({
-        update: {
-          [wellSelectionModalData.formFieldAccessor]: selectors.getSelectedWellNames(state),
-        },
-      }))
-    } else {
-      console.warn('No well selection modal data in state')
-    }
-
-    dispatch(closeWellSelectionModal())
-  }

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -42,6 +42,10 @@ export type OpenWellSelectionModalPayload = {
   pipetteChannels?: ?Channels,
   labwareName?: string,
 }
+export type OpenWellSelectionModalAction = {
+  type: 'OPEN_WELL_SELECTION_MODAL',
+  payload: OpenWellSelectionModalPayload,
+}
 
 function _wellArrayToObj (wells: ?Array<string>): Wells {
   if (!wells) {
@@ -70,7 +74,7 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
       stepFormSelectors.getPipetteEntities(state)[payload.pipetteId]
     ) || null
 
-    const labware = stepFormSelectors.getLabwareById(state)
+    // const labware = stepFormSelectors.getLabwareById(state)
     // TODO type this action, make an underline fn action creator
 
     dispatch({
@@ -78,7 +82,7 @@ export const openWellSelectionModal = (payload: OpenWellSelectionModalPayload) =
       payload: {
         ...payload,
         pipetteChannels: pipette && pipette.spec.channels,
-        labwareName: labware && labware[payload.labwareId] && labware[payload.labwareId].type,
+        labwareName: 'TODO IMMEDIATELY labwareName', // labware && labware[payload.labwareId] && labware[payload.labwareId].type,
       },
     })
   }

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -4,7 +4,6 @@ import {combineReducers} from 'redux'
 import {handleActions} from 'redux-actions'
 
 import type {Wells} from '../labware-ingred/types'
-import type {OpenWellSelectionModalPayload} from './actions'
 
 type WellSelectionAction = {
   payload: Wells, // NOTE: primary wells.
@@ -39,28 +38,17 @@ const selectedWells = handleActions({
   }),
   // Actions that cause "deselect everything" behavior:
   CLOSE_INGREDIENT_SELECTOR: () => selectedWellsInitialState,
-  CLOSE_WELL_SELECTION_MODAL: () => selectedWellsInitialState,
   DESELECT_ALL_WELLS: () => selectedWellsInitialState,
   REMOVE_WELLS_CONTENTS: () => selectedWellsInitialState,
   SET_WELL_CONTENTS: () => selectedWellsInitialState,
 }, selectedWellsInitialState)
 
-// TODO IMMEDIATELY address or ticket this
-// TODO: BC 2018-11-01 unused, remove and all references to the actions
-type WellSelectionModalState = OpenWellSelectionModalPayload | null
-const wellSelectionModal = handleActions({
-  OPEN_WELL_SELECTION_MODAL: (state, action: {payload: OpenWellSelectionModalPayload}) => action.payload,
-  CLOSE_WELL_SELECTION_MODAL: () => null,
-}, null)
-
 export type RootState = {|
   selectedWells: SelectedWellsState,
-  wellSelectionModal: WellSelectionModalState,
 |}
 
 const rootReducer = combineReducers({
   selectedWells,
-  wellSelectionModal,
 })
 
 export default rootReducer

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -45,6 +45,7 @@ const selectedWells = handleActions({
   SET_WELL_CONTENTS: () => selectedWellsInitialState,
 }, selectedWellsInitialState)
 
+// TODO IMMEDIATELY address or ticket this
 // TODO: BC 2018-11-01 unused, remove and all references to the actions
 type WellSelectionModalState = OpenWellSelectionModalPayload | null
 const wellSelectionModal = handleActions({

--- a/protocol-designer/src/well-selection/selectors.js
+++ b/protocol-designer/src/well-selection/selectors.js
@@ -1,60 +1,19 @@
 // @flow
 import {createSelector} from 'reselect'
-import reduce from 'lodash/reduce'
-import {wellSetToWellObj} from './utils'
-import {computeWellAccess, sortWells} from '@opentrons/shared-data'
+import {sortWells} from '@opentrons/shared-data'
 import type {BaseState, Selector} from '../types'
 import type {Wells} from '../labware-ingred/types'
-import type {OpenWellSelectionModalPayload} from './actions'
 
 const rootSelector = (state: BaseState) => state.wellSelection
 
-const getWellSelectionModalData: Selector<?OpenWellSelectionModalPayload> = createSelector(
-  rootSelector,
-  s => s.wellSelectionModal
-)
-
-const getSelectedPrimaryWells: Selector<Wells> = createSelector(
+const getSelectedWells: Selector<Wells> = createSelector(
   rootSelector,
   state => state.selectedWells.selected
 )
 
-const getHighlightedPrimaryWells: Selector<Wells> = createSelector(
+const getHighlightedWells: Selector<Wells> = createSelector(
   rootSelector,
   state => state.selectedWells.highlighted
-)
-
-function _primaryToAllWells (
-  wells: Wells,
-  _wellSelectionModalData: ?OpenWellSelectionModalPayload
-): Wells {
-  const {labwareName = null, pipetteChannels = null} = _wellSelectionModalData || {}
-  if (!labwareName || pipetteChannels !== 8) {
-    // single-channel or ingredient selection
-    return wells
-  }
-
-  if (!labwareName) {
-    console.warn('Expected labwareName from well selection modal data')
-    return {}
-  }
-
-  return reduce(wells, (acc: Wells, well: string): Wells => ({
-    ...acc,
-    ...wellSetToWellObj(computeWellAccess(labwareName, well)),
-  }), {})
-}
-
-const getSelectedWells: Selector<Wells> = createSelector(
-  getSelectedPrimaryWells,
-  getWellSelectionModalData,
-  _primaryToAllWells
-)
-
-const getHighlightedWells: Selector<Wells> = createSelector(
-  getHighlightedPrimaryWells,
-  getWellSelectionModalData,
-  _primaryToAllWells
 )
 
 const getSelectedWellNames: Selector<Array<string>> = createSelector(
@@ -66,5 +25,4 @@ export default {
   getSelectedWellNames,
   getSelectedWells,
   getHighlightedWells,
-  getWellSelectionModalData,
 }


### PR DESCRIPTION
## overview

Backstory for future reference: we're been moving to split labware information into two data types:
- `LabwareEntity` is a responsibility of `step-forms/`. A `LabwareEntity` has a `type` (eg `96-flat`), and that's it for now and the foreseeable future.
- `DisplayLabware` is the responsibility of `labware-ingred/`. (Side note: we plan to eventually move labware-ingred into `ui/` for the ui concerns and `step-forms/` for the ingredient stuff

Closes #3052

## changelog

* remove `Labware` type and all uses. Instead, use `LabwareEntity` or `DisplayLabware`.
* prefer `getLabwareTypesById` to `getLabwareEntities`, unless there's a good reason to get the whole entities map
* move getLabwareNicknamesById, getDisposalLabwareOptions, getLabwareOptions to new `ui/labware/selectors.js`
* refactor StepItem props to take labware nicknames and labware types separately, refactor props of the StepItem child components to take a flat props object of strings, instead of `Labware`

## review requests

There should be no user-facing changes from edge

Things touched to test:
- [ ] Step items (headers and tooltips related to labware names)
- [ ] Well highlighting (via steps & substeps)
- [ ] Labware naming & renaming (including duplication)
- [ ] Well selection modal functionality
- [ ] Final deck state view
- [ ] Title bar shows labware correctly in all the places it should (add liquids modal, final deck state view, ??)
