### PR TITLE
feat(app): Add robot pipettes, versions, FFs to mixpanel and intercom

### DIFF
--- a/app/src/analytics/README.md
+++ b/app/src/analytics/README.md
@@ -12,7 +12,7 @@ import {analyticsMiddleware} from './path/to/analytics'
 // add the middleware to the store
 const middleware = applyMiddleware(
   // ...
-  analyticsMiddleware
+  analyticsMiddleware,
   // ...
 )
 
@@ -117,6 +117,7 @@ Some payload fields are [hashed][] for user anonymity while preserving our abili
 
 ### protocol data sent
 
+- Protocol type (Python or JSON)
 - Application Name (e.g. "Opentrons Protocol Designer")
 - Application Version
 - Protocol `metadata.source`

--- a/app/src/analytics/README.md
+++ b/app/src/analytics/README.md
@@ -12,7 +12,7 @@ import {analyticsMiddleware} from './path/to/analytics'
 // add the middleware to the store
 const middleware = applyMiddleware(
   // ...
-  analyticsMiddleware,
+  analyticsMiddleware
   // ...
 )
 
@@ -25,7 +25,7 @@ const store = createStore(reducer, middleware)
 For a given Redux action, add a `case` to the `action.type` switch in [`app/src/analytics/make-event.js`](./make-event.js). `makeEvent` will be passed the full state and the action. Any new case should return either `null` or an object `{name: string, properties: {}}`
 
 ```js
-export default function makeEvent (
+export default function makeEvent(
   action: Action,
   nextState: State,
   prevState: State
@@ -44,16 +44,72 @@ export default function makeEvent (
 
 ## events
 
-| name                     | redux action                   | payload                                 |
-| ------------------------ | ------------------------------ | --------------------------------------- |
-| `robotConnect`           | `robot:CONNECT_RESPONSE`       | success, method, error                  |
-| `protocolUploadRequest`  | `protocol:UPLOAD`              | protocol data                           |
-| `protocolUploadResponse` | `robot:SESSION_RESPONSE/ERROR` | protocol data, success, error           |
-| `runStart`               | `robot:RUN`                    | protocol data                           |
-| `runFinish`              | `robot:RUN_RESPONSE`           | protocol data, success, error, run time |
-| `runPause`               | `robot:PAUSE`                  | protocol, run time data                 |
-| `runResume`              | `robot:RESUME`                 | protocol, run time data                 |
-| `runCancel`              | `robot:CANCEL`                 | protocol, run time data                 |
+### event names and payloads
+
+#### robotConnect
+
+- Redux action: `robot:CONNECT_RESPONSE`
+- Payload:
+  - success: boolean
+  - method: 'usb' | 'wifi'
+  - error: string
+
+#### protocolUploadRequest
+
+- Redux action: `protocol:UPLOAD`
+- Payload:
+  - ...protocol data (see below)
+  - ...robot data (see below)
+
+#### protocolUploadResponse
+
+- Redux action:
+  - `robot:SESSION_RESPONSE`
+  - `robot:SESSION_ERROR`
+- Payload:
+  - ...protocol data (see below)
+  - ...robot data (see below)
+  - success: boolean
+  - error: string
+
+#### runStart
+
+- Redux action: `robot:RUN`
+- Payload:
+
+  - ...protocol data (see below)
+  - ...robot data (see below)
+
+#### runFinish
+
+- Redux action: `robot:RUN_RESPONSE`
+- Payload:
+  - ...protocol data (see below)
+  - ...robot data (see below)
+  - success: boolean
+  - error: string
+  - runTime: number
+
+#### runPause
+
+- Redux action: `robot:PAUSE`
+- Payload:
+  - ...protocol data (see below)
+  - runTime: number
+
+#### runResume
+
+- Redux action: `robot:RESUME`
+- Payload:
+  - ...protocol data (see below)
+  - runTime: number
+
+#### runCancel
+
+- Redux action: `robot:CANCEL`
+- Payload:
+  - ...protocol data (see below)
+  - runTime: number
 
 ### hashing
 
@@ -61,12 +117,22 @@ Some payload fields are [hashed][] for user anonymity while preserving our abili
 
 ### protocol data sent
 
-- Protocol type (Python or JSON)
 - Application Name (e.g. "Opentrons Protocol Designer")
 - Application Version
 - Protocol `metadata.source`
 - Protocol `metadata.protocolName`
 - Protocol `metadata.author` (hashed for anonymity)
 - Protocol `metadata.protocolText` (hashed for anonymity)
+
+### robot data sent
+
+- Pipette models
+  - `robotLeftPipette: string`
+  - `robotRightPipette: string`
+- Software versions
+  - `robotApiServerVersion: string`
+  - `robotSmoothieVersion: string`
+- Feature flags
+  - `robotFF_someFeatureFlagId: boolean`
 
 [hashed]: https://en.wikipedia.org/wiki/Hash_function

--- a/app/src/analytics/index.js
+++ b/app/src/analytics/index.js
@@ -12,6 +12,8 @@ import type {State, Action, ThunkAction, Middleware} from '../types'
 import type {Config} from '../config'
 import type {AnalyticsEvent} from './types'
 
+export * from './selectors'
+
 type AnalyticsConfig = $PropertyType<Config, 'analytics'>
 
 const log = createLogger(__filename)

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -3,7 +3,7 @@
 import createLogger from '../logger'
 import {selectors as robotSelectors} from '../robot'
 import {getConnectedRobot} from '../discovery'
-import {getProtocolAnalyticsData} from './selectors'
+import {getProtocolAnalyticsData, getRobotAnalyticsData} from './selectors'
 
 import type {State, Action} from '../types'
 import type {AnalyticsEvent} from './types'
@@ -37,7 +37,10 @@ export default function makeEvent (
     case 'protocol:UPLOAD': {
       return getProtocolAnalyticsData(nextState).then(data => ({
         name: 'protocolUploadRequest',
-        properties: data,
+        properties: {
+          ...data,
+          ...getRobotAnalyticsData(nextState),
+        },
       }))
     }
 
@@ -52,6 +55,7 @@ export default function makeEvent (
         name: 'protocolUploadResponse',
         properties: {
           ...data,
+          ...getRobotAnalyticsData(nextState),
           success: actionType === 'robot:SESSION_RESPONSE',
           error: (actionPayload.error && actionPayload.error.message) || '',
         },
@@ -62,7 +66,10 @@ export default function makeEvent (
     case 'robot:RUN': {
       return getProtocolAnalyticsData(nextState).then(data => ({
         name: 'runStart',
-        properties: data,
+        properties: {
+          ...data,
+          ...getRobotAnalyticsData(nextState),
+        },
       }))
     }
 
@@ -77,7 +84,13 @@ export default function makeEvent (
 
       return getProtocolAnalyticsData(nextState).then(data => ({
         name: 'runFinish',
-        properties: {...data, runTime, success, error},
+        properties: {
+          ...data,
+          ...getRobotAnalyticsData(nextState),
+          runTime,
+          success,
+          error,
+        },
       }))
     }
 

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -10,6 +10,17 @@ export type ProtocolAnalyticsData = {
   protocolText: string,
 }
 
+export type RobotAnalyticsData = {
+  robotApiServerVersion: string,
+  robotSmoothieVersion: string,
+  robotLeftPipette: string,
+  robotRightPipette: string,
+
+  // feaure flags
+  // e.g. robotFF_settingName
+  [ffName: string]: boolean,
+}
+
 export type AnalyticsEvent = {|
   name: string,
   properties: {},

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -55,6 +55,8 @@ export type Action =
   | ServerAction
   | SettingsAction
 
+export {getRobotApiState} from './reducer'
+
 export {
   startDeckCalibration,
   deckCalibrationCommand,

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -10,6 +10,7 @@ import type {OutputSelector} from 'reselect'
 import type {State, ThunkPromiseAction} from '../types'
 import type {BaseRobot, RobotService} from '../robot'
 import type {ApiCall, ApiRequestError} from './types'
+import type {RobotApiState} from './reducer'
 import type {ApiAction} from './actions'
 import type {MotorAxis} from './motors'
 
@@ -44,7 +45,7 @@ export function fetchPipettes (
   let path = PIPETTES
   if (refresh) path += '?refresh=true'
 
-  return (dispatch) => {
+  return dispatch => {
     dispatch(apiRequest(robot, path, null))
 
     return client(robot, 'GET', path)
@@ -57,10 +58,16 @@ export function fetchPipettes (
 }
 
 export const makeGetRobotPipettes = () => {
-  const selector: OutputSelector<State, BaseRobot, RobotPipettes> = createSelector(
-    getRobotApiState,
-    (state) => state[PIPETTES] || {inProgress: false}
-  )
+  const selector: OutputSelector<State,
+    BaseRobot,
+    RobotPipettes> = createSelector(
+      getRobotApiState,
+      getPipettesRequest
+    )
 
   return selector
+}
+
+export function getPipettesRequest (state: RobotApiState): RobotPipettes {
+  return state[PIPETTES] || {inProgress: false}
 }

--- a/app/src/http-api-client/reducer.js
+++ b/app/src/http-api-client/reducer.js
@@ -15,7 +15,7 @@ import type {ResetState} from './reset'
 import type {SettingsState} from './settings'
 import type {NetworkingState} from './networking'
 
-type RobotApiState = {|
+export type RobotApiState = {|
   ...HealthState,
   ...PipettesState,
   ...ModulesState,
@@ -34,7 +34,10 @@ export default function apiReducer (
   switch (action.type) {
     case 'api:REQUEST': {
       const {request} = action.payload
-      const {name, path, stateByName, stateByPath} = getUpdateInfo(state, action)
+      const {name, path, stateByName, stateByPath} = getUpdateInfo(
+        state,
+        action
+      )
 
       return {
         ...state,
@@ -47,7 +50,10 @@ export default function apiReducer (
 
     case 'api:SUCCESS': {
       const {response} = action.payload
-      const {name, path, stateByName, stateByPath} = getUpdateInfo(state, action)
+      const {name, path, stateByName, stateByPath} = getUpdateInfo(
+        state,
+        action
+      )
 
       return {
         ...state,
@@ -60,7 +66,10 @@ export default function apiReducer (
 
     case 'api:FAILURE': {
       const {error} = action.payload
-      const {name, path, stateByName, stateByPath} = getUpdateInfo(state, action)
+      const {name, path, stateByName, stateByPath} = getUpdateInfo(
+        state,
+        action
+      )
       if (!stateByPath || !stateByPath.inProgress) return state
 
       return {
@@ -73,13 +82,21 @@ export default function apiReducer (
     }
 
     case 'api:CLEAR_RESPONSE': {
-      const {name, path, stateByName, stateByPath} = getUpdateInfo(state, action)
+      const {name, path, stateByName, stateByPath} = getUpdateInfo(
+        state,
+        action
+      )
 
       return {
         ...state,
         [name]: {
           ...stateByName,
-          [path]: {...stateByPath, response: null, inProgress: false, error: null},
+          [path]: {
+            ...stateByPath,
+            response: null,
+            inProgress: false,
+            error: null,
+          },
         },
       }
     }
@@ -113,7 +130,10 @@ export function getRobotApiState (
 }
 
 function getUpdateInfo (state: ApiState, action: *): * {
-  const {path, robot: {name}} = action.payload
+  const {
+    path,
+    robot: {name},
+  } = action.payload
   const stateByName = state[name] || {}
   // $FlowFixMe: type RobotApiState properly
   const stateByPath = stateByName[path] || {}

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -10,6 +10,7 @@ import type {State} from '../types'
 import type {BaseRobot} from '../robot'
 import type {ApiCall} from './types'
 import type {ApiAction, RequestMaker} from './actions'
+import type {RobotApiState} from './reducer'
 
 type Id = string
 
@@ -62,7 +63,7 @@ export function makeGetRobotSettings () {
   return selector
 }
 
-function getSettingsRequest (state: SettingsState): RobotSettingsCall {
+export function getSettingsRequest (state: RobotApiState): RobotSettingsCall {
   let requestState = state[SETTINGS] || {inProgress: false}
 
   // guard against an older version of GET /settings


### PR DESCRIPTION
## overview

This PR adds data about the connected robot to certain analytics events as well as the user's Intercom support profile:

- API version
- Smoothie version
- Left pipette model (already present in Intercom profile)
- Right pipette model (already present in Intercom profile)
- Robot feature flag settings

It submits this data to Intercom any time that data may change, and to MixPanel on:

- Protocol upload request
- Protocol upload success or error
- Run start
- Run finish

Closes #3009, closes #3010

## changelog

- feat(app): Add robot pipettes, versions, FFs to mixpanel and intercom

## review requests

Without any environment variables set, you will see debug logs for the Mixpanel event (`debug: Trackable event`) and for the Intercom event (`debug: Intercom update`).

If you test with the production app, you should see these events go all the way to Mixpanel and Intercom. Make sure you're opted into analytics, and you can get your Mixpanel and Intercom user IDs from the app's config file (see app-shell README for config file location) under the `analytics` and `support` keys, respectively.
