### PR TITLE
fix(protocol-designer): fix svg deck overlay issues for Firefox compat

### DIFF
--- a/protocol-designer/src/components/labware/BrowseLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareOverlay.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import styles from './labware.css'
 
 import ClickableText from './ClickableText'
+import OverlayPanel from './OverlayPanel'
 
 type Props = {
   drillDown: () => mixed,
@@ -13,7 +14,7 @@ type Props = {
 function BrowseLabwareOverlay (props: Props) {
   return (
     <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
-      <rect className={styles.overlay_panel} />
+      <OverlayPanel />
       <ClickableText
         onClick={props.drillDown}
         iconName='water' y='40%' text='View Liquids' />

--- a/protocol-designer/src/components/labware/ClickableText.js
+++ b/protocol-designer/src/components/labware/ClickableText.js
@@ -28,9 +28,11 @@ export default function ClickableText (props: Props) {
       />
 
       <g className={styles.clickable_text}>
-        <text x='0' y={props.y}>{props.text}</text>
+        <text x='0' y={props.y} className={styles.clickable_text_text}>
+          {props.text}
+        </text>
         {props.iconName && (
-          <g className={styles.icon}>
+          <g className={styles.clickable_text_icon}>
             <Icon name={props.iconName} y={props.y} height={height} />
           </g>
         )}

--- a/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
+++ b/protocol-designer/src/components/labware/DisabledSelectSlotOverlay.js
@@ -2,10 +2,11 @@
 import React from 'react'
 import cx from 'classnames'
 import styles from './labware.css'
+import OverlayPanel from './OverlayPanel'
 
 const DisabledSelectSlotOverlay = () => (
   <g className={cx(styles.slot_overlay, styles.disabled)}>
-    <rect className={styles.overlay_panel} />
+    <OverlayPanel />
     <g className={styles.clickable_text}>
       <text x="-7%" y="40%">Drag to New Slot</text>
     </g>

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -19,6 +19,7 @@ import type {StepIdType} from '../../form-types'
 import HighlightableLabware from '../../containers/HighlightableLabware'
 import ClickableText from './ClickableText'
 import NameThisLabwareOverlay from './NameThisLabwareOverlay'
+import OverlayPanel from './OverlayPanel'
 import DisabledSelectSlotOverlay from './DisabledSelectSlotOverlay'
 import BrowseLabwareOverlay from './BrowseLabwareOverlay'
 import {type TerminalItemId, START_TERMINAL_ITEM_ID, END_TERMINAL_ITEM_ID} from '../../steplist'
@@ -141,7 +142,7 @@ function LabwareDeckSlotOverlay ({
 }) {
   return (
     <g className={cx(styles.slot_overlay, styles.appear_on_mouseover)}>
-      <rect className={styles.overlay_panel} />
+      <OverlayPanel />
       {canAddIngreds &&
         <ClickableText
           onClick={editLiquids}
@@ -188,7 +189,7 @@ function SlotWithLabware (props: SlotWithLabwareProps) {
 
 const EmptyDestinationSlotOverlay = () => (
   <g className={cx(styles.slot_overlay)}>
-    <rect className={styles.overlay_panel} />
+    <OverlayPanel />
     <g className={styles.clickable_text}>
       <text x='0' y='40%'>Place Here</text>
     </g>
@@ -202,7 +203,7 @@ function EmptyDeckSlotOverlay (props: EmptyDeckSlotOverlayProps) {
   const {addLabware} = props
   return (
     <g className={cx(styles.slot_overlay, styles.appear_on_mouseover, styles.add_labware)}>
-      <rect className={styles.overlay_panel} />
+      <OverlayPanel />
       <ClickableText onClick={addLabware}
         iconName='plus' y='40%' text='Add Labware' />
     </g>

--- a/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
+++ b/protocol-designer/src/components/labware/NameThisLabwareOverlay.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import ClickableText from './ClickableText'
+import OverlayPanel from './OverlayPanel'
 import styles from './labware.css'
 import ForeignDiv from '../../components/ForeignDiv'
 import i18n from '../../localization'
@@ -54,7 +55,7 @@ export default class NameThisLabwareOverlay extends React.Component<Props, State
       <ClickOutside onClickOutside={this.onSubmit}>
         {({ref}) => (
           <g className={styles.slot_overlay} ref={ref}>
-            <rect className={styles.overlay_panel} />
+            <OverlayPanel />
             <g transform='translate(5, 0)'>
               <ForeignDiv x='0' y='15%' width='92%'>
                 <input

--- a/protocol-designer/src/components/labware/OverlayPanel.js
+++ b/protocol-designer/src/components/labware/OverlayPanel.js
@@ -1,0 +1,9 @@
+// @flow
+import * as React from 'react'
+import styles from './labware.css'
+
+const OverlayPanel = () => (
+  <rect className={styles.overlay_panel} x="0" y="0" width="100%" height="100%" />
+)
+
+export default OverlayPanel

--- a/protocol-designer/src/components/labware/labware.css
+++ b/protocol-designer/src/components/labware/labware.css
@@ -17,11 +17,6 @@
   fill: var(--c-light-gray);
 }
 
-.overlay_panel {
-  width: 100%;
-  height: 100%;
-}
-
 .slot_overlay.disabled .overlay_panel {
   opacity: 0.9;
 }
@@ -52,11 +47,14 @@
   cursor: pointer;
   transform: translate(20%, 0);
   text-transform: uppercase;
-  dominant-baseline: text-before-edge;
+}
 
-  & .icon {
-    transform: translate(-60%, 0);
-  }
+.clickable_text_text {
+  dominant-baseline: text-before-edge;
+}
+
+.clickable_text_icon {
+  transform: translate(-60%, 0);
 }
 
 .clickable_area {

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -75,11 +75,10 @@ class DeckSetup extends React.Component<Props> {
           {this.props.drilledDown && <BrowseLabwareModal />}
           <ClickOutside onClickOutside={this.props.handleClickOutside}>
             {({ref}) => (
-              <div ref={ref}>
+              <div ref={ref} className={styles.deck_wrapper}>
                 <Deck
                   DragPreviewLayer={DragPreviewLayer}
-                  LabwareComponent={LabwareContainer}
-                  className={styles.deck} />
+                  LabwareComponent={LabwareContainer} />
               </div>
             )}
           </ClickOutside>

--- a/protocol-designer/src/containers/Deck.css
+++ b/protocol-designer/src/containers/Deck.css
@@ -1,6 +1,6 @@
 @import '@opentrons/components';
 
-.deck {
+.deck_wrapper {
   padding: 1rem;
   max-width: 100%;
   width: 100vh;


### PR DESCRIPTION
## overview

Chrome & Firefox handle some SVG stuff differently, so the Firefox deck overlays were not showing up on hover, and the text was offset at a weird place. This should make deck overlays look pretty much the same in Firefox as they were in Chrome.

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

https://s3-us-west-2.amazonaws.com/opentrons-protocol-designer/pd_fix-firefox-deck-overlays/index.html

PD in Chrome should look and act the same as before - please make sure there's no regression with Deck interactivity.

I've tested only on Linux versions of Firefox + Chrome. Please test deck UI:

- [x] Mac Firefox
- [x] Mac Chrome
- [ ] Windows Firefox
- [ ] Windows Chrome
