### PR TITLE
fix(protocol-designer): fix flex step path-changing interaction

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -13,18 +13,30 @@ beforeEach(() => {
   )
 })
 
-describe('no-op cases should pass through the patch unchanged (same identity)', () => {
+describe('no-op cases should pass through the patch unchanged', () => {
+  const minimalBaseForm = {
+    blah: 'blaaah',
+    // NOTE: without these fields below, `path` gets added to the result
+    path: 'single',
+    aspirate_wells: ['A1'],
+    dispense_wells: ['B1'],
+  }
+
   test('empty patch', () => {
     const patch = {}
-    expect(handleFormHelper(patch, {blah: 'blaaah'})).toBe(patch)
+    expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
   test('patch with unhandled field', () => {
     const patch = {fooField: 123}
-    expect(handleFormHelper(patch, {blah: 'blaaah'})).toBe(patch)
+    expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
   })
 })
 
 describe('path should update...', () => {
+  test('if there is no path in base form', () => {
+    const patch = {}
+    expect(handleFormHelper(patch, {blah: 'blaaah'})).toEqual({path: 'single'})
+  })
   describe('if path is multi and volume*2 exceeds pipette/tip capacity', () => {
     const multiPaths = ['multiAspirate', 'multiDispense']
     multiPaths.forEach(path => {
@@ -65,6 +77,8 @@ describe('disposal volume should update...', () => {
   beforeEach(() => {
     form = {
       path: 'multiDispense',
+      aspirate_wells: ['A1'],
+      dispense_wells: ['B2', 'B3'],
       volume: '2',
       pipette: 'pipetteId',
       disposalVolume_checkbox: true,


### PR DESCRIPTION
Closes #3082 and closes #3083

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Transitioning between any of the 3 paths, and transitioning where the well ratio is N:M (where `N != M` eg 2:4), shouldn't make any weird side-effects like those found in the issues this PR addresses. The non-universal changeTip settings (perSource/perDest) should reset to `always` when made invalid, and the path should reset to `single` when well ratio is N:M.
