### PR TITLE
refactor: Render pipette config form fields from data

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -9,14 +9,30 @@ import ConfigFormGroup, {FormColumn, ConfigInput} from './ConfigFormGroup'
 
 import type {Pipette} from '../../http-api-client'
 
-type FieldName = 'top' | 'bottom' | 'blowout' | 'droptip'
+// TODO (ka 2-19-2019):
+// defaultAspirateFlowRate, defaultDispenseFlowRate and tipLength
+// do not have the same data shape as other fields
+type FieldName =
+  | 'top'
+  | 'bottom'
+  | 'blowout'
+  | 'dropTip'
+  | 'pickUpCurrent'
+  | 'plungerCurrent'
+  | 'dropTipCurrent'
+  | 'dropTipSpeed'
+  | 'pickUpDistance'
+  | 'tipLength'
+  | 'defaultAspirateFlowRate'
+  | 'defaultDispenseFlowRate'
 
-export type FieldProps = {
+type FieldProps = {
   value: ?number,
   default: number,
-  min: number,
-  max: number,
-  units: string,
+  min?: number,
+  max?: number,
+  units?: string,
+  type?: string,
 }
 
 type ConfigFields = {[FieldName]: FieldProps}
@@ -50,7 +66,6 @@ export default class ConfigForm extends React.Component<Props> {
   render () {
     const {fields} = OPTIONS
     const initialValues = mapValues(fields, f => {
-      // const _value =
       return f.value !== f.default ? f.value.toString() : null
     })
     const plungerFields = getFieldsByKey(PLUNGER_KEYS, fields)
@@ -68,16 +83,18 @@ export default class ConfigForm extends React.Component<Props> {
                 <ConfigFormGroup groupLabel="Plunger Positions">
                   {plungerFields.map(f => {
                     const value = this.getFieldValue(f.name, values)
+                    const _default = f.default.toString()
+                    const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
-                        key={f.name}
-                        name={f.name}
-                        label={f.displayName}
-                        units={f.units}
+                        key={name}
+                        name={name}
+                        label={displayName}
+                        units={units}
                         value={value}
-                        placeholder={f.default}
-                        min={f.min}
-                        max={f.max}
+                        placeholder={_default}
+                        min={min}
+                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -87,16 +104,18 @@ export default class ConfigForm extends React.Component<Props> {
                 <ConfigFormGroup groupLabel="Power / Force">
                   {powerFields.map(f => {
                     const value = this.getFieldValue(f.name, values)
+                    const _default = f.default.toString()
+                    const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
-                        key={f.name}
-                        name={f.name}
-                        label={f.displayName}
-                        units={f.units}
+                        key={name}
+                        name={name}
+                        label={displayName}
+                        units={units}
                         value={value}
-                        placeholder={f.default}
-                        min={f.min}
-                        max={f.max}
+                        placeholder={_default}
+                        min={min}
+                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -108,16 +127,18 @@ export default class ConfigForm extends React.Component<Props> {
                 <ConfigFormGroup groupLabel="Tip Pickup / Drop ">
                   {tipFields.map(f => {
                     const value = this.getFieldValue(f.name, values)
+                    const _default = f.default.toString()
+                    const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
-                        key={f.name}
-                        name={f.name}
-                        label={f.displayName}
-                        units={f.units}
+                        key={name}
+                        name={name}
+                        label={displayName}
+                        units={units}
                         value={value}
-                        placeholder={f.default}
-                        min={f.min}
-                        max={f.max}
+                        placeholder={_default}
+                        min={min}
+                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -133,7 +154,7 @@ export default class ConfigForm extends React.Component<Props> {
   }
 }
 
-function getFieldsByKey (keys: Array<string>, fields: any) {
+function getFieldsByKey (keys: Array<FieldName>, fields: ConfigFields) {
   return keys.map(k => {
     const field = fields[k]
     const displayName = startCase(k)
@@ -164,7 +185,6 @@ const OPTIONS = {
       max: 19.5,
       units: 'mm',
       type: 'float',
-      displayName: 'Top Plunger Position',
       default: 19.5,
     },
     bottom: {
@@ -173,7 +193,6 @@ const OPTIONS = {
       max: 19,
       units: 'mm',
       type: 'float',
-      displayName: 'Bottom Plunger Position',
       default: 2,
     },
     blowout: {
@@ -182,7 +201,6 @@ const OPTIONS = {
       max: 10,
       units: 'mm',
       type: 'float',
-      displayName: 'Blow Out Plunger Position',
       default: 0.5,
     },
     dropTip: {
@@ -191,7 +209,6 @@ const OPTIONS = {
       max: 2,
       units: 'mm',
       type: 'float',
-      displayName: 'Drop Tip Plunger Position',
       default: -5,
     },
     pickUpCurrent: {
@@ -200,7 +217,6 @@ const OPTIONS = {
       max: 1.2,
       units: 'A',
       type: 'float',
-      displayName: 'Pick Up Current',
       default: 0.6,
     },
     pickUpDistance: {
@@ -209,7 +225,6 @@ const OPTIONS = {
       max: 30,
       units: 'mm',
       type: 'float',
-      displayName: 'Pick Up Distance',
       default: 10,
     },
     plungerCurrent: {
@@ -218,7 +233,6 @@ const OPTIONS = {
       max: 0.5,
       units: 'A',
       type: 'float',
-      displayName: 'Plunger Current',
       default: 0.5,
     },
     dropTipCurrent: {
@@ -227,7 +241,6 @@ const OPTIONS = {
       max: 0.8,
       units: 'A',
       type: 'float',
-      displayName: 'Drop Tip Current',
       default: 0.5,
     },
     dropTipSpeed: {
@@ -236,14 +249,12 @@ const OPTIONS = {
       max: 30,
       units: 'mm/sec',
       type: 'float',
-      displayName: 'Drop Tip Speed',
       default: 5,
     },
     tipLength: {
       value: 51.7,
       units: 'mm',
       type: 'float',
-      displayName: 'Tip Length',
       default: 51.7,
     },
     defaultAspirateFlowRate: {

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import {Formik} from 'formik'
 import startCase from 'lodash/startCase'
 import get from 'lodash/get'
+import mapValues from 'lodash/mapValues'
 
 import ConfigFormGroup, {FormColumn, ConfigInput} from './ConfigFormGroup'
 
@@ -48,12 +49,17 @@ export default class ConfigForm extends React.Component<Props> {
 
   render () {
     const {fields} = OPTIONS
+    const initialValues = mapValues(fields, f => {
+      // const _value =
+      return f.value !== f.default ? f.value.toString() : null
+    })
     const plungerFields = getFieldsByKey(PLUNGER_KEYS, fields)
     const powerFields = getFieldsByKey(POWER_KEYS, fields)
     const tipFields = getFieldsByKey(TIP_KEYS, fields)
     console.log(plungerFields)
     return (
       <Formik
+        initialValues={initialValues}
         render={formProps => {
           const {values, handleChange} = formProps
           return (
@@ -144,13 +150,12 @@ const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
 const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
 const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 
-// GET /settings/pipettes/?id='P50MV1318110626'
+// GET /settings/pipettes/P50MV1318060102
 
 const OPTIONS = {
   info: {
-    name: null,
-    model: null,
-    id: 'P50MV1318110626',
+    name: 'p50_multi',
+    model: 'p50_multi_v1.3',
   },
   fields: {
     top: {
@@ -163,7 +168,7 @@ const OPTIONS = {
       default: 19.5,
     },
     bottom: {
-      value: 2,
+      value: 0,
       min: -2,
       max: 19,
       units: 'mm',
@@ -243,10 +248,14 @@ const OPTIONS = {
     },
     defaultAspirateFlowRate: {
       value: 25,
+      min: 0.001,
+      max: 100,
       default: 25,
     },
     defaultDispenseFlowRate: {
       value: 50,
+      min: 0.001,
+      max: 100,
       default: 50,
     },
   },

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -22,14 +22,15 @@ type ConfigFields = {[FieldName]: FieldProps}
 
 type PipetteConfigOptions = {
   info: {
-    name: string,
-    model: string,
+    name: ?string,
+    model: ?string,
+    id: ?string,
   },
   fields: ConfigFields,
 }
 
 type OP = {
-  pipette: ?Pipette,
+  pipette: Pipette,
 }
 
 type SP = {
@@ -48,6 +49,8 @@ export default class ConfigForm extends React.Component<Props> {
   render () {
     const {fields} = OPTIONS
     const plungerFields = getFieldsByKey(PLUNGER_KEYS, fields)
+    const powerFields = getFieldsByKey(POWER_KEYS, fields)
+    const tipFields = getFieldsByKey(TIP_KEYS, fields)
     console.log(plungerFields)
     return (
       <Formik
@@ -58,6 +61,46 @@ export default class ConfigForm extends React.Component<Props> {
               <FormColumn>
                 <ConfigFormGroup groupLabel="Plunger Positions">
                   {plungerFields.map(f => {
+                    const value = this.getFieldValue(f.name, values)
+                    return (
+                      <ConfigInput
+                        key={f.name}
+                        name={f.name}
+                        label={f.displayName}
+                        units={f.units}
+                        value={value}
+                        placeholder={f.default}
+                        min={f.min}
+                        max={f.max}
+                        onChange={handleChange}
+                        error={null}
+                      />
+                    )
+                  })}
+                </ConfigFormGroup>
+                <ConfigFormGroup groupLabel="Power / Force">
+                  {powerFields.map(f => {
+                    const value = this.getFieldValue(f.name, values)
+                    return (
+                      <ConfigInput
+                        key={f.name}
+                        name={f.name}
+                        label={f.displayName}
+                        units={f.units}
+                        value={value}
+                        placeholder={f.default}
+                        min={f.min}
+                        max={f.max}
+                        onChange={handleChange}
+                        error={null}
+                      />
+                    )
+                  })}
+                </ConfigFormGroup>
+              </FormColumn>
+              <FormColumn>
+                <ConfigFormGroup groupLabel="Tip Pickup / Drop ">
+                  {tipFields.map(f => {
                     const value = this.getFieldValue(f.name, values)
                     return (
                       <ConfigInput
@@ -97,42 +140,114 @@ function getFieldsByKey (keys: Array<string>, fields: any) {
   })
 }
 
-const PLUNGER_KEYS = ['top', 'bottom', 'blowOut', 'dropTip']
+const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
+const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
+const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 
-// TODO (ka 2019-2-14): Replace with API response
+// GET /settings/pipettes/?id='P50MV1318110626'
+
 const OPTIONS = {
   info: {
-    name: 'P50 Single',
-    model: '1234567',
+    name: null,
+    model: null,
+    id: 'P50MV1318110626',
   },
   fields: {
     top: {
-      value: null,
-      default: 10,
-      min: 1,
-      max: 15,
+      value: 19.5,
+      min: 5,
+      max: 19.5,
       units: 'mm',
+      type: 'float',
+      displayName: 'Top Plunger Position',
+      default: 19.5,
     },
     bottom: {
-      value: null,
-      default: 9,
-      min: 1,
-      max: 15,
+      value: 2,
+      min: -2,
+      max: 19,
       units: 'mm',
+      type: 'float',
+      displayName: 'Bottom Plunger Position',
+      default: 2,
     },
-    blowOut: {
-      value: null,
-      default: 8,
-      min: 1,
-      max: 15,
+    blowout: {
+      value: 0.5,
+      min: -4,
+      max: 10,
       units: 'mm',
+      type: 'float',
+      displayName: 'Blow Out Plunger Position',
+      default: 0.5,
     },
     dropTip: {
-      value: null,
-      default: 7,
-      min: 1,
-      max: 15,
+      value: -5,
+      min: -6,
+      max: 2,
       units: 'mm',
+      type: 'float',
+      displayName: 'Drop Tip Plunger Position',
+      default: -5,
+    },
+    pickUpCurrent: {
+      value: 0.6,
+      min: 0.05,
+      max: 1.2,
+      units: 'A',
+      type: 'float',
+      displayName: 'Pick Up Current',
+      default: 0.6,
+    },
+    pickUpDistance: {
+      value: 10,
+      min: 1,
+      max: 30,
+      units: 'mm',
+      type: 'float',
+      displayName: 'Pick Up Distance',
+      default: 10,
+    },
+    plungerCurrent: {
+      value: 0.5,
+      min: 0.1,
+      max: 0.5,
+      units: 'A',
+      type: 'float',
+      displayName: 'Plunger Current',
+      default: 0.5,
+    },
+    dropTipCurrent: {
+      value: 0.5,
+      min: 0.1,
+      max: 0.8,
+      units: 'A',
+      type: 'float',
+      displayName: 'Drop Tip Current',
+      default: 0.5,
+    },
+    dropTipSpeed: {
+      value: 5,
+      min: 0.001,
+      max: 30,
+      units: 'mm/sec',
+      type: 'float',
+      displayName: 'Drop Tip Speed',
+      default: 5,
+    },
+    tipLength: {
+      value: 51.7,
+      units: 'mm',
+      type: 'float',
+      displayName: 'Tip Length',
+      default: 51.7,
+    },
+    defaultAspirateFlowRate: {
+      value: 25,
+      default: 25,
+    },
+    defaultDispenseFlowRate: {
+      value: 50,
+      default: 50,
     },
   },
 }

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -2,30 +2,15 @@
 import * as React from 'react'
 import {Formik} from 'formik'
 import startCase from 'lodash/startCase'
-import get from 'lodash/get'
+
 import mapValues from 'lodash/mapValues'
 
-import ConfigFormGroup, {FormColumn, ConfigInput} from './ConfigFormGroup'
+import ConfigFormGroup, {FormColumn} from './ConfigFormGroup'
 
 import type {Pipette} from '../../http-api-client'
 
 // TODO (ka 2-19-2019):
 // Move to settings.js when no longer mock data based
-// defaultAspirateFlowRate, defaultDispenseFlowRate and tipLength
-// do not have the same data shape as other fields
-type FieldName =
-  | 'top'
-  | 'bottom'
-  | 'blowout'
-  | 'dropTip'
-  | 'pickUpCurrent'
-  | 'plungerCurrent'
-  | 'dropTipCurrent'
-  | 'dropTipSpeed'
-  | 'pickUpDistance'
-  | 'tipLength'
-  | 'defaultAspirateFlowRate'
-  | 'defaultDispenseFlowRate'
 
 type FieldProps = {
   value: ?number,
@@ -36,7 +21,12 @@ type FieldProps = {
   type?: string,
 }
 
-type ConfigFields = {[FieldName]: FieldProps}
+export type DisplayFieldProps = FieldProps & {
+  name: string,
+  displayName: string,
+}
+
+type ConfigFields = {[string]: FieldProps}
 
 type PipetteConfigOptions = {
   info: {
@@ -57,19 +47,15 @@ type SP = {
 
 type Props = SP & OP
 
-type FormValues = {[string]: ?(string | {[string]: string})}
-
 const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
 const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
 const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 
 export default class ConfigForm extends React.Component<Props> {
-  getFieldValue (name: string, values: FormValues): ?string {
-    return get(values, name)
-  }
-
-  // TODO (ka 2-19-2019): type this
-  getFieldsByKey (keys: Array<FieldName>, fields: ConfigFields): any {
+  getFieldsByKey (
+    keys: Array<string>,
+    fields: ConfigFields
+  ): Array<DisplayFieldProps> {
     return keys.map(k => {
       const field = fields[k]
       const displayName = startCase(k)
@@ -98,59 +84,30 @@ export default class ConfigForm extends React.Component<Props> {
           return (
             <form>
               <FormColumn>
-                <ConfigFormGroup groupLabel="Plunger Positions">
-                  {plungerFields.map(f => {
-                    const value = this.getFieldValue(f.name, values)
-                    const _default = f.default.toString()
-                    const {name, displayName, units, min, max} = f
-                    return (
-                      <ConfigInput
-                        {...{name, units, value, min, max}}
-                        key={name}
-                        label={displayName}
-                        placeholder={_default}
-                        onChange={handleChange}
-                        error={null}
-                      />
-                    )
-                  })}
-                </ConfigFormGroup>
-                <ConfigFormGroup groupLabel="Power / Force">
-                  {powerFields.map(f => {
-                    const value = this.getFieldValue(f.name, values)
-                    const _default = f.default.toString()
-                    const {name, displayName, units, min, max} = f
-                    return (
-                      <ConfigInput
-                        {...{name, units, value, min, max}}
-                        key={name}
-                        label={displayName}
-                        placeholder={_default}
-                        onChange={handleChange}
-                        error={null}
-                      />
-                    )
-                  })}
-                </ConfigFormGroup>
+                <ConfigFormGroup
+                  groupLabel="Plunger Positions"
+                  values={values}
+                  formFields={plungerFields}
+                  onChange={handleChange}
+                  error={null}
+                />
+
+                <ConfigFormGroup
+                  groupLabel="Power / Force"
+                  values={values}
+                  formFields={powerFields}
+                  onChange={handleChange}
+                  error={null}
+                />
               </FormColumn>
               <FormColumn>
-                <ConfigFormGroup groupLabel="Tip Pickup / Drop ">
-                  {tipFields.map(f => {
-                    const value = this.getFieldValue(f.name, values)
-                    const _default = f.default.toString()
-                    const {name, displayName, units, min, max} = f
-                    return (
-                      <ConfigInput
-                        {...{name, units, value, min, max}}
-                        key={name}
-                        label={displayName}
-                        placeholder={_default}
-                        onChange={handleChange}
-                        error={null}
-                      />
-                    )
-                  })}
-                </ConfigFormGroup>
+                <ConfigFormGroup
+                  groupLabel="Tip Pickup / Drop "
+                  values={values}
+                  formFields={tipFields}
+                  onChange={handleChange}
+                  error={null}
+                />
               </FormColumn>
             </form>
           )

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -10,6 +10,7 @@ import ConfigFormGroup, {FormColumn, ConfigInput} from './ConfigFormGroup'
 import type {Pipette} from '../../http-api-client'
 
 // TODO (ka 2-19-2019):
+// Move to settings.js when no longer mock data based
 // defaultAspirateFlowRate, defaultDispenseFlowRate and tipLength
 // do not have the same data shape as other fields
 type FieldName =
@@ -58,9 +59,27 @@ type Props = SP & OP
 
 type FormValues = {[string]: ?(string | {[string]: string})}
 
+const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
+const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
+const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
+
 export default class ConfigForm extends React.Component<Props> {
   getFieldValue (name: string, values: FormValues): ?string {
     return get(values, name)
+  }
+
+  // TODO (ka 2-19-2019): type this
+  getFieldsByKey (keys: Array<FieldName>, fields: ConfigFields): any {
+    return keys.map(k => {
+      const field = fields[k]
+      const displayName = startCase(k)
+      const name = k
+      return {
+        ...field,
+        name,
+        displayName,
+      }
+    })
   }
 
   render () {
@@ -68,10 +87,9 @@ export default class ConfigForm extends React.Component<Props> {
     const initialValues = mapValues(fields, f => {
       return f.value !== f.default ? f.value.toString() : null
     })
-    const plungerFields = getFieldsByKey(PLUNGER_KEYS, fields)
-    const powerFields = getFieldsByKey(POWER_KEYS, fields)
-    const tipFields = getFieldsByKey(TIP_KEYS, fields)
-    console.log(plungerFields)
+    const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
+    const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
+    const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
     return (
       <Formik
         initialValues={initialValues}
@@ -87,14 +105,10 @@ export default class ConfigForm extends React.Component<Props> {
                     const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
+                        {...{name, units, value, min, max}}
                         key={name}
-                        name={name}
                         label={displayName}
-                        units={units}
-                        value={value}
                         placeholder={_default}
-                        min={min}
-                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -108,14 +122,10 @@ export default class ConfigForm extends React.Component<Props> {
                     const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
+                        {...{name, units, value, min, max}}
                         key={name}
-                        name={name}
                         label={displayName}
-                        units={units}
-                        value={value}
                         placeholder={_default}
-                        min={min}
-                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -131,14 +141,10 @@ export default class ConfigForm extends React.Component<Props> {
                     const {name, displayName, units, min, max} = f
                     return (
                       <ConfigInput
+                        {...{name, units, value, min, max}}
                         key={name}
-                        name={name}
                         label={displayName}
-                        units={units}
-                        value={value}
                         placeholder={_default}
-                        min={min}
-                        max={max}
                         onChange={handleChange}
                         error={null}
                       />
@@ -154,25 +160,7 @@ export default class ConfigForm extends React.Component<Props> {
   }
 }
 
-function getFieldsByKey (keys: Array<FieldName>, fields: ConfigFields) {
-  return keys.map(k => {
-    const field = fields[k]
-    const displayName = startCase(k)
-    const name = k
-    return {
-      ...field,
-      name,
-      displayName,
-    }
-  })
-}
-
-const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
-const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
-const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
-
 // GET /settings/pipettes/P50MV1318060102
-
 const OPTIONS = {
   info: {
     name: 'p50_multi',

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -1,0 +1,138 @@
+// @flow
+import * as React from 'react'
+import {Formik} from 'formik'
+import startCase from 'lodash/startCase'
+import get from 'lodash/get'
+
+import ConfigFormGroup, {FormColumn, ConfigInput} from './ConfigFormGroup'
+
+import type {Pipette} from '../../http-api-client'
+
+type FieldName = 'top' | 'bottom' | 'blowout' | 'droptip'
+
+export type FieldProps = {
+  value: ?number,
+  default: number,
+  min: number,
+  max: number,
+  units: string,
+}
+
+type ConfigFields = {[FieldName]: FieldProps}
+
+type PipetteConfigOptions = {
+  info: {
+    name: string,
+    model: string,
+  },
+  fields: ConfigFields,
+}
+
+type OP = {
+  pipette: ?Pipette,
+}
+
+type SP = {
+  options?: PipetteConfigOptions,
+}
+
+type Props = SP & OP
+
+type FormValues = {[string]: ?(string | {[string]: string})}
+
+export default class ConfigForm extends React.Component<Props> {
+  getFieldValue (name: string, values: FormValues): ?string {
+    return get(values, name)
+  }
+
+  render () {
+    const {fields} = OPTIONS
+    const plungerFields = getFieldsByKey(PLUNGER_KEYS, fields)
+    console.log(plungerFields)
+    return (
+      <Formik
+        render={formProps => {
+          const {values, handleChange} = formProps
+          return (
+            <form>
+              <FormColumn>
+                <ConfigFormGroup groupLabel="Plunger Positions">
+                  {plungerFields.map(f => {
+                    const value = this.getFieldValue(f.name, values)
+                    return (
+                      <ConfigInput
+                        key={f.name}
+                        name={f.name}
+                        label={f.displayName}
+                        units={f.units}
+                        value={value}
+                        placeholder={f.default}
+                        min={f.min}
+                        max={f.max}
+                        onChange={handleChange}
+                        error={null}
+                      />
+                    )
+                  })}
+                </ConfigFormGroup>
+              </FormColumn>
+            </form>
+          )
+        }}
+      />
+    )
+  }
+}
+
+function getFieldsByKey (keys: Array<string>, fields: any) {
+  return keys.map(k => {
+    const field = fields[k]
+    const displayName = startCase(k)
+    const name = k
+    return {
+      ...field,
+      name,
+      displayName,
+    }
+  })
+}
+
+const PLUNGER_KEYS = ['top', 'bottom', 'blowOut', 'dropTip']
+
+// TODO (ka 2019-2-14): Replace with API response
+const OPTIONS = {
+  info: {
+    name: 'P50 Single',
+    model: '1234567',
+  },
+  fields: {
+    top: {
+      value: null,
+      default: 10,
+      min: 1,
+      max: 15,
+      units: 'mm',
+    },
+    bottom: {
+      value: null,
+      default: 9,
+      min: 1,
+      max: 15,
+      units: 'mm',
+    },
+    blowOut: {
+      value: null,
+      default: 8,
+      min: 1,
+      max: 15,
+      units: 'mm',
+    },
+    dropTip: {
+      value: null,
+      default: 7,
+      min: 1,
+      max: 15,
+      units: 'mm',
+    },
+  },
+}

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -11,7 +11,11 @@ type FormGroupProps = {
 }
 
 export default function ConfigFormGroup (props: FormGroupProps) {
-  return <FormGroup label={props.groupLabel}>{props.children}</FormGroup>
+  return (
+    <FormGroup label={props.groupLabel} className={styles.form_group}>
+      {props.children}
+    </FormGroup>
+  )
 }
 
 type FormColProps = {

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -1,0 +1,85 @@
+// @flow
+import * as React from 'react'
+
+import {FormGroup, InputField} from '@opentrons/components'
+
+import styles from './styles.css'
+
+type FormGroupProps = {
+  groupLabel: string,
+  children: React.Node,
+}
+
+export default function ConfigFormGroup (props: FormGroupProps) {
+  return <FormGroup label={props.groupLabel}>{props.children}</FormGroup>
+}
+
+type FormColProps = {
+  children: React.Node,
+  className?: string,
+}
+export function FormColumn (props: FormColProps) {
+  return <div className={styles.form_column}>{props.children}</div>
+}
+
+type FormRowProps = {
+  label: string,
+  labelFor: string,
+  children: React.Node,
+}
+
+const FIELD_ID_PREFIX = '__PipetteConfig__'
+const makeId = (name: *): string => `${FIELD_ID_PREFIX}.${name}`
+
+export function ConfigFormRow (props: FormRowProps) {
+  const {labelFor, label} = props
+  return (
+    <div className={styles.form_row}>
+      <label label={label} htmlFor={labelFor} className={styles.form_label}>
+        {props.label}
+      </label>
+      <div className={styles.form_input}>{props.children}</div>
+    </div>
+  )
+}
+
+type ConfigInputProps = {
+  name: string,
+  label: string,
+  value: ?string,
+  error: ?string,
+  className?: string,
+  placeholder: string,
+  units: string,
+  onChange: (event: *) => mixed,
+}
+
+export function ConfigInput (props: ConfigInputProps) {
+  const {
+    name,
+    label,
+    value,
+    placeholder,
+    units,
+    error,
+    className,
+    onChange,
+  } = props
+  const id = makeId(name)
+  return (
+    <ConfigFormRow label={label} labelFor={id}>
+      <InputField
+        {...{
+          id,
+          name,
+          value,
+          placeholder,
+          units,
+          error,
+          className,
+          onChange,
+        }}
+      />
+    </ConfigFormRow>
+  )
+}

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -1,29 +1,54 @@
 // @flow
 import * as React from 'react'
-
+import get from 'lodash/get'
 import {FormGroup, InputField} from '@opentrons/components'
 
 import styles from './styles.css'
 
-type FormGroupProps = {
-  groupLabel: string,
-  children: React.Node,
-}
-
-export default function ConfigFormGroup (props: FormGroupProps) {
-  return (
-    <FormGroup label={props.groupLabel} className={styles.form_group}>
-      {props.children}
-    </FormGroup>
-  )
-}
+import type {DisplayFieldProps} from './ConfigForm'
 
 type FormColProps = {
   children: React.Node,
   className?: string,
 }
+
 export function FormColumn (props: FormColProps) {
   return <div className={styles.form_column}>{props.children}</div>
+}
+
+type FormValues = {[string]: ?(string | {[string]: string})}
+
+type FormGroupProps = {
+  groupLabel: string,
+  values: FormValues,
+  formFields: Array<DisplayFieldProps>,
+  onChange: (event: *) => mixed,
+  error: ?string,
+}
+
+function getFieldValue (name: string, values: FormValues): ?string {
+  return get(values, name)
+}
+
+export default function ConfigFormGroup (props: FormGroupProps) {
+  const {groupLabel, values, formFields, onChange, error} = props
+  return (
+    <FormGroup label={groupLabel} className={styles.form_group}>
+      {formFields.map(f => {
+        const value = getFieldValue(f.name, values)
+        const _default = f.default.toString()
+        const {name, displayName, units, min, max} = f
+        return (
+          <ConfigInput
+            key={name}
+            label={displayName}
+            placeholder={_default}
+            {...{name, units, value, min, max, onChange, error}}
+          />
+        )
+      })}
+    </FormGroup>
+  )
 }
 
 type FormRowProps = {

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import get from 'lodash/get'
 import {FormGroup, InputField} from '@opentrons/components'
 
 import styles from './styles.css'
@@ -16,7 +15,7 @@ export function FormColumn (props: FormColProps) {
   return <div className={styles.form_column}>{props.children}</div>
 }
 
-type FormValues = {[string]: ?(string | {[string]: string})}
+type FormValues = {[string]: ?string}
 
 type FormGroupProps = {
   groupLabel: string,
@@ -27,7 +26,7 @@ type FormGroupProps = {
 }
 
 function getFieldValue (name: string, values: FormValues): ?string {
-  return get(values, name)
+  return values[name]
 }
 
 export default function ConfigFormGroup (props: FormGroupProps) {

--- a/app/src/components/ConfigurePipette/ConfigMessage.js
+++ b/app/src/components/ConfigurePipette/ConfigMessage.js
@@ -2,14 +2,14 @@
 import * as React from 'react'
 import styles from './styles.css'
 
-// TODO (ka 2019-2-12): Add intercom onClick to assitance text
+// TODO (ka 2019-2-12): Add intercom onClick to assistance text
 export default function ConfigMessage () {
   return (
     <div className={styles.config_message}>
       <h3 className={styles.warning_title}>Warning:</h3>
       <p className={styles.warning_text}>
         These are advanced settings. Please do not attempt to adjust without
-        <span> assitance</span> from an Opentrons support team member, as doing
+        <span> assistance</span> from an Opentrons support team member, as doing
         so may affect the lifespan of your pipette.
       </p>
       <p className={styles.warning_text}>

--- a/app/src/components/ConfigurePipette/ConfigMessage.js
+++ b/app/src/components/ConfigurePipette/ConfigMessage.js
@@ -5,17 +5,17 @@ import styles from './styles.css'
 // TODO (ka 2019-2-12): Add intercom onClick to assitance text
 export default function ConfigMessage () {
   return (
-    <React.Fragment>
+    <div className={styles.config_message}>
       <h3 className={styles.warning_title}>Warning:</h3>
       <p className={styles.warning_text}>
         These are advanced settings. Please do not attempt to adjust without
-        assitance from an Opentrons support team member, as doing so may affect
-        the lifespan of your pipette.
+        <span> assitance</span> from an Opentrons support team member, as doing
+        so may affect the lifespan of your pipette.
       </p>
       <p className={styles.warning_text}>
         Note that these settings will not override any pipette settings
         pre-defined in protocols.
       </p>
-    </React.Fragment>
+    </div>
   )
 }

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -6,8 +6,9 @@ import {makeGetRobotPipettes} from '../../http-api-client'
 
 import {getPipetteModelSpecs} from '@opentrons/shared-data'
 
-import {AlertModal} from '@opentrons/components'
+import {ScrollableAlertModal} from '../modals'
 import ConfigMessage from './ConfigMessage'
+import ConfigForm from './ConfigForm'
 
 import type {State} from '../../types'
 import type {Mount} from '../../robot'
@@ -32,20 +33,22 @@ function ConfigurePipette (props: Props) {
   const {parentUrl, mount, pipettes} = props
   // TODO (ka 2019-2-12): This logic is used to get display name in slightly
   // different ways in several different files.
-  const pipetteModel = pipettes && pipettes[mount].model
+  const pipette = pipettes && pipettes[mount]
+  const pipetteModel = pipette && pipette.model
   const pipetteConfig = pipetteModel && getPipetteModelSpecs(pipetteModel)
   const displayName = pipetteConfig ? pipetteConfig.displayName : ''
 
   const TITLE = `Pipette Settings: ${displayName}`
 
   return (
-    <AlertModal
+    <ScrollableAlertModal
       heading={TITLE}
       alertOverlay
       buttons={[{children: 'cancel', Component: Link, to: parentUrl}]}
     >
       <ConfigMessage />
-    </AlertModal>
+      {pipette && <ConfigForm pipette={pipette} />}
+    </ScrollableAlertModal>
   )
 }
 

--- a/app/src/components/ConfigurePipette/styles.css
+++ b/app/src/components/ConfigurePipette/styles.css
@@ -1,12 +1,39 @@
 @import '@opentrons/components';
 
+.config_message {
+  margin-bottom: 1rem;
+}
+
 .warning_title {
   @apply --font-body-2-dark;
 
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   text-transform: uppercase;
 }
 
 .warning_text {
+  @apply --font-body-1-dark;
+
+  margin-bottom: 0.5rem;
+}
+
+.form_column {
+  width: 50%;
+  display: inline-block;
+}
+
+.form_row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0.25rem 0;
+}
+
+.form_label,
+.form_input {
+  flex: 1 1 50%;
+}
+
+.form_label {
   @apply --font-body-1-dark;
 }

--- a/app/src/components/ConfigurePipette/styles.css
+++ b/app/src/components/ConfigurePipette/styles.css
@@ -20,6 +20,12 @@
 .form_column {
   width: 50%;
   display: inline-block;
+  vertical-align: top;
+  padding: 1rem 2rem 1rem 0;
+}
+
+.form_group {
+  margin-bottom: 2rem;
 }
 
 .form_row {


### PR DESCRIPTION
## overview

This PR closes #2941 by rendering a Pipette Config Form using on mock data. I'm cutting this PR off before wiring before it gets too big.

Mock data is copy/pasted from a postman response from #3070 .

## changelog

- refactor: Render pipette config form fields from data

## review requests

```
make -C app dev OT_APP_DEV_INTERNAL__NEW_PIPETTE_CONFIG=1
```
This PR does:
- [ ] Render pipette config modal
- [ ] Render pipette display name in title
- [ ] Render labeled/grouped form fields from hard coded data
- [ ] Render default as placeholder text when current value matches default
- [ ] Render value as editable text when value != default
- [ ] Clearing an edits field shows default text as placeholder

This PR _does not_ (will be addressed in new ticket #3091 )
- Render bottom button bar with reset and save buttons
- Implement any api calls
- Add any data to 'settings/pipettes' in api state
- Validate any form fields

Questions:
Standard review. Suggestions appreciated.

