### PR TITLE
fix(api): Do not cache instruments when simulating

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -40,7 +40,6 @@ class InstrumentsWrapper(object):
         return inst.Pipette(self.robot, *args, **kwargs)
 
     def _pipette_details(self, mount, name_or_model):
-        self.robot.cache_instrument_models()
         pipette_model_version = self.retrieve_version_number(
             mount, name_or_model)
         attached = self.robot.get_attached_pipettes()


### PR DESCRIPTION
It’s nice to try and make the instrument data always consistent, but the point
of having a separate cache method is to run it when you’re _not_ simulating to
preserve data for when you _are_. If you cache when simulating, you overwrite
your stored instruments with nothing and get incorrect model values.

Test: 
- Upload a protocol to a robot with pipettes attached and make sure the models displayed in the protocol config screen match the models in the pipette info page.