### PR TITLE
fix(protocol-designer): fix FormAlerts warning dismissal

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -1,13 +1,14 @@
 // @flow
+import assert from 'assert'
 import * as React from 'react'
-import type {Dispatch} from 'redux'
 import {connect} from 'react-redux'
 import {AlertItem} from '@opentrons/components'
 import {actions as dismissActions, selectors as dismissSelectors} from '../../dismiss'
 import {getVisibleAlerts} from './utils'
-import type {StepIdType} from '../../form-types'
 import {selectors as stepsSelectors} from '../../ui/steps'
 import {selectors as stepFormSelectors} from '../../step-forms'
+import type {Dispatch} from 'redux'
+import type {StepIdType} from '../../form-types'
 import type {StepFieldName} from '../../steplist/fieldLevel'
 import type {FormError, FormWarning} from '../../steplist/formLevel'
 import type {BaseState} from '../../types'
@@ -87,13 +88,8 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
 
 const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
   dismissWarning: (warning, stepId) => {
-    if (typeof stepId === 'string') {
-      // TODO: Ian 2018-07-13 remove this conditional once stepIds are always numbers
-      console.warn(`Tried to dismiss form-level warning for "special" stepId ${stepId}`)
-      return
-    }
     if (stepId == null) {
-      console.warn('Tried to dismiss form-level warning with no stepId.')
+      assert(false, 'Tried to dismiss form-level warning with no stepId.')
       return
     }
     dispatch(dismissActions.dismissFormWarning({warning, stepId}))


### PR DESCRIPTION
## overview

Closes #3092

## changelog

* remove old assertion expecting stepId to be number

## review requests

The bug was: in a never-saved "pristine" form: enter a volume below pipette minimum (eg 1 for a P300), get the "volume below pipette min" form-level warning. Before this PR, clicking the "X" to dismiss that warning did nothing (except do `console.warn` in the console). This PR should make it so the warning is dismissed when you click the X.