### PR TITLE
fix(protocol-designer): warn window.alert on unload

### DIFF
--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -4,24 +4,11 @@ import { Provider } from 'react-redux'
 import { AppContainer } from 'react-hot-loader'
 
 import configureStore from './configureStore'
-import i18n from './localization'
 import App from './components/App'
-import {selectors as loadFileSelectors} from './load-file'
-import {selectors as analyticsSelectors} from './analytics'
-import {initializeAnalytics} from './analytics/integrations'
+import initialize from './initialize'
 const store = configureStore()
 
-if (process.env.NODE_ENV === 'production') {
-  window.onbeforeunload = (e) => {
-    // NOTE: the custom text will be ignored in modern browsers
-    return loadFileSelectors.hasUnsavedChanges(store.getState()) ? i18n.t('alert.window.confirm_leave') : undefined
-  }
-
-  // Initialize analytics if user has already opted in
-  if (analyticsSelectors.getHasOptedIn(store.getState())) {
-    initializeAnalytics()
-  }
-}
+initialize(store)
 
 const render = (Component) => {
   ReactDOM.render(

--- a/protocol-designer/src/initialize.js
+++ b/protocol-designer/src/initialize.js
@@ -1,0 +1,22 @@
+// @flow
+
+import i18n from './localization'
+import {selectors as loadFileSelectors} from './load-file'
+import {selectors as analyticsSelectors} from './analytics'
+import {initializeAnalytics} from './analytics/integrations'
+
+const initialize = (store: Object) => {
+  if (process.env.NODE_ENV === 'production') {
+    window.onbeforeunload = (e) => {
+      // NOTE: the custom text will be ignored in modern browsers
+      return loadFileSelectors.getHasUnsavedChanges(store.getState()) ? i18n.t('alert.window.confirm_leave') : undefined
+    }
+
+    // Initialize analytics if user has already opted in
+    if (analyticsSelectors.getHasOptedIn(store.getState())) {
+      initializeAnalytics()
+    }
+  }
+}
+
+export default initialize


### PR DESCRIPTION
*Overview* 

We would like to warn users that they are about to lose their protocol if they refresh or close
their browser tab. A regression occured because of updated selector naming conventions, and it
wasn't caught due src/index.js being ignored by flow. This branch moves that initialization logic
into a separate file that is interpretted by flow.

*Changelog*
- update name of selector used to determine if there are unsaved changes ('hasUnsavedChanges' --> 'getHasUnsavedChanges')
- move initialization from `src/index.js` into a new file `src/initialize.js` and add flow annotation
 