### PR TITLE
PD: fix missing disp vol warning

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -147,6 +147,11 @@
   list-style: none;
 }
 
+.tooltip {
+  line-height: 1rem;
+  max-width: 18rem;
+}
+
 .path_tooltip_image {
   padding: 0.5rem;
 }

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -26,7 +26,7 @@ const DisposalVolumeField = (props: Props) => (
   <FormGroup label='Multi-Dispense Options:'>
     <FieldConnector
       name="disposalVolume_checkbox"
-      render={({value, updateValue}) => {
+      render={({value, updateValue, hoverTooltipHandlers}) => {
         const {maxDisposalVolume} = props
         const volumeBoundsCaption = maxDisposalVolume != null
           ? `max ${maxDisposalVolume} μL`
@@ -45,7 +45,7 @@ const DisposalVolumeField = (props: Props) => (
 
         return (
           <React.Fragment>
-            <div className={cx(
+            <div {...hoverTooltipHandlers} className={cx(
               styles.checkbox_row,
               styles.multi_dispense_options,
               {[styles.captioned_field]: volumeBoundsCaption}
@@ -64,13 +64,13 @@ const DisposalVolumeField = (props: Props) => (
             {
               value
                 ? (
-                  <div className={styles.checkbox_row}>
-                    <div className={styles.sub_select_label}>Blowout</div>
-                    <FieldConnector
-                      name="blowout_location"
-                      focusedField={props.focusHandlers.focusedField}
-                      dirtyFields={props.focusHandlers.dirtyFields}
-                      render={({value, updateValue}) => (
+                  <FieldConnector
+                    name="blowout_location"
+                    focusedField={props.focusHandlers.focusedField}
+                    dirtyFields={props.focusHandlers.dirtyFields}
+                    render={({value, updateValue, hoverTooltipHandlers}) => (
+                      <div {...hoverTooltipHandlers} className={styles.checkbox_row} >
+                        <div className={styles.sub_select_label}>Blowout</div>
                         <DropdownField
                           className={cx(styles.medium_field, styles.orphan_field)}
                           options={props.disposalDestinationOptions}
@@ -78,8 +78,8 @@ const DisposalVolumeField = (props: Props) => (
                           onFocus={() => { props.focusHandlers.onFieldFocus('blowout_location') }}
                           value={value ? String(value) : null}
                           onChange={(e: SyntheticEvent<HTMLSelectElement>) => { updateValue(e.currentTarget.value) } } />
-                      )} />
-                  </div>
+                      </div>
+                    )} />
                 )
                 : null
             }

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -1,6 +1,8 @@
 // @flow
+import * as React from 'react'
 import difference from 'lodash/difference'
 import i18n from '../../localization'
+import styles from './StepEditForm.css'
 
 export function getVisibleAlerts<Field, Alert: {dependentFields: Array<Field>}> (args: {
   focusedField: ?Field,
@@ -14,7 +16,7 @@ export function getVisibleAlerts<Field, Alert: {dependentFields: Array<Field>}> 
   )
 }
 
-export function getTooltipForField (stepType: ?string, name: string): ?string {
+export function getTooltipForField (stepType: ?string, name: string): ?React.Node {
   if (!stepType) {
     console.error(`expected stepType for form, cannot getTooltipText for ${name}`)
     return null
@@ -36,5 +38,5 @@ export function getTooltipForField (stepType: ?string, name: string): ?string {
     '',
   ])
 
-  return text || null
+  return text ? (<div className={styles.tooltip}>{text}</div>) : null
 }

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -26,7 +26,7 @@ export function getTooltipForField (stepType: ?string, name: string): ?string {
     : name
 
   // specificity cascade for names.
-  // first level: try getting from step_fields.transfer, fallback to step_fields.default
+  // first level: try getting from step_fields.moveLiquid, fallback to step_fields.default
   // second level: prefix. "aspirate_foo" wins over "foo"
   const text: string = i18n.t([
     `tooltip.step_fields.${stepType}.${name}`,

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -9,8 +9,6 @@ export type StepFieldName = any
 // | 'aspirate_airGap_checkbox'
 // | 'aspirate_airGap_volume'
 // | 'aspirate_changeTip'
-// | 'aspirate_disposalVol_checkbox'
-// | 'aspirate_disposalVol_volume'
 // | 'aspirate_flowRate'
 // | 'aspirate_labware'
 // | 'aspirate_mix_checkbox'
@@ -37,6 +35,8 @@ export type StepFieldName = any
 // | 'dispense_wellOrder_first'
 // | 'dispense_wellOrder_second'
 // | 'dispense_wells'
+// | 'disposalVolume_checkbox',
+// | 'disposalVolume_volume',
 // | 'labware'
 // | 'labwareLocationUpdate'
 // | 'mix_mmFromBottom'
@@ -64,6 +64,8 @@ export type StepFieldName = any
 // | 'dispense_blowout_checkbox'
 // | 'dispense_blowout_location'
 // | 'dispense_touchTip'
+// | 'aspirate_disposalVol_checkbox'
+// | 'aspirate_disposalVol_volume'
 
 // TODO Ian 2019-01-16 factor out to some constants.js ? See #2926
 export const stepIconsByType: {[string]: IconName} = {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -21,7 +21,7 @@
       "dispense_tipPosition": "Where in the well the pipette dispenses to",
 
       "blowout_checkbox": "Where to dispose of remaining volume in tip",
-      "disposalVol_checkbox": "Aspirate extra volume that is disposed of after a distribute is complete. We recommend a disposal volume of at least the pipette's minimum.",
+      "disposalVolume_checkbox": "Aspirate extra volume that is disposed of after a multi-dispense is complete. We recommend a disposal volume of at least the pipette's minimum.",
 
       "changeTip": "Choose when the robot picks up fresh tips",
       "preWetTip": "Pre-wet pipette tip by aspirating and dispensing 2/3 of the tip's max volume",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -26,13 +26,9 @@
       "changeTip": "Choose when the robot picks up fresh tips",
       "preWetTip": "Pre-wet pipette tip by aspirating and dispensing 2/3 of the tip's max volume",
       "tipPosition": "Distance from the bottom of the well",
-      "touchTip": "Touch tip to 4 sides of the well",
+      "touchTip_checkbox": "Touch tip to 4 sides of the well",
 
       "volume": "Volume to dispense in each well"
-    },
-
-    "consolidate": {
-      "volume": "Volume to aspirate from each well"
     }
   }
 }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -21,6 +21,7 @@
       "dispense_tipPosition": "Where in the well the pipette dispenses to",
 
       "blowout_checkbox": "Where to dispose of remaining volume in tip",
+      "blowout_location": "Where to dispose of remaining volume in tip",
       "disposalVolume_checkbox": "Aspirate extra volume that is disposed of after a multi-dispense is complete. We recommend a disposal volume of at least the pipette's minimum.",
 
       "changeTip": "Choose when the robot picks up fresh tips",

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -147,8 +147,12 @@ const updatePatchDisposalVolumeFields = (
 ) => {
   const appliedPatch = {...rawForm, ...patch}
 
-  if (patch.path && patch.path !== 'multiDispense' && rawForm.path === 'multiDispense') {
-    // clear disposal volume whenever path was changed from multiDispense
+  const pathChangedFromMultiDispense = patch.path &&
+    patch.path !== 'multiDispense' &&
+    rawForm.path === 'multiDispense'
+  if (pathChangedFromMultiDispense || patch.disposalVolume_checkbox === false) {
+    // clear disposal volume whenever path is changed from multiDispense
+    // or whenever disposalVolume_checkbox is cleared
     return {
       ...patch,
       ...clearedDisposalVolumeFields,
@@ -157,7 +161,8 @@ const updatePatchDisposalVolumeFields = (
 
   const shouldReinitializeDisposalVolume = (
     (patch.path === 'multiDispense' && rawForm.path !== 'multiDispense') ||
-    (patch.pipette && patch.pipette !== rawForm.pipette)
+    (patch.pipette && patch.pipette !== rawForm.pipette) ||
+    patch.disposalVolume_checkbox
   )
   if (shouldReinitializeDisposalVolume) {
     const pipetteEntity = pipetteEntities[appliedPatch.pipette]

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -37,7 +37,7 @@ const FORM_WARNINGS: {[FormWarningType]: FormWarning} = {
         Read more <KnowledgeBaseLink to='distribute'>here</KnowledgeBaseLink>.
       </React.Fragment>
     ),
-    dependentFields: ['disposalVol_volume', 'pipette'],
+    dependentFields: ['disposalVolume_volume', 'pipette', 'path'],
   },
 }
 export type WarningChecker = (mixed) => ?FormWarning
@@ -66,11 +66,11 @@ export const maxDispenseWellVolume = (fields: HydratedFormData): ?FormWarning =>
 }
 
 export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
-  const {disposalVol_checkbox, disposalVol_volume, pipette} = fields
-  if (!(pipette && pipette.spec)) return null
-  const isUnselected = !disposalVol_checkbox || !disposalVol_volume
+  const {disposalVolume_checkbox, disposalVolume_volume, pipette, path} = fields
+  if (!(pipette && pipette.spec) || path !== 'multiDispense') return null
+  const isUnselected = !disposalVolume_checkbox || !disposalVolume_volume
   if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
-  const isBelowMin = disposalVol_volume < (pipette.spec.minVolume)
+  const isBelowMin = disposalVolume_volume < (pipette.spec.minVolume)
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
 }
 


### PR DESCRIPTION
## overview

Closes #3093, and also fixes the "touch tip" tooltip and the "blowout" tooltip

## changelog

* `getTooltipForField` returns a div with new `.tooltip` class to style all StepEditForm tooltips
* pass `hoverTooltipHandlers` down correctly, to fix disposal volume + blowout fields
* clear `disposalVolume_volume` when checkbox is unchecked, and re-initialize the volume when the checkbox is checked

## review requests

- Disposal volume below pipette minimum should generate dismissable disposal volume warning
- When path is not multiDispense, you should never get disposal volume warning
- Disposal volume tooltip should show correctly
- Fixes the "touch tip" tooltip (it did not appear before).
- Fixes blowout tooltip (for special multiDispense-only blowout field in the bottom right)