### PR TITLE
fix(protocol-designer): clear inner mix fields when new path does not support them

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -290,6 +290,28 @@ function updatePatchOnWellRatioChange (patch: FormPatch, rawForm: FormData) {
   }
 }
 
+function updatePatchMixFields (patch: FormPatch, rawForm: FormData): FormPatch {
+  if (patch.path) {
+    if (patch.path === 'multiAspirate') {
+      return {
+        ...patch,
+        aspirate_mix_checkbox: false,
+        aspirate_mix_times: null,
+        aspirate_mix_volume: null,
+      }
+    }
+    if (patch.path === 'multiDispense') {
+      return {
+        ...patch,
+        dispense_mix_checkbox: false,
+        dispense_mix_times: null,
+        dispense_mix_volume: null,
+      }
+    }
+  }
+  return patch
+}
+
 export default function dependentFieldsUpdateMoveLiquid (
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
@@ -305,5 +327,6 @@ export default function dependentFieldsUpdateMoveLiquid (
     chainPatch => updatePatchPathField(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
     chainPatch => clampDisposalVolume(chainPatch, rawForm, pipetteEntities),
+    chainPatch => updatePatchMixFields(chainPatch, rawForm),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -112,13 +112,16 @@ describe('disposal volume should update...', () => {
 
   describe('when volume is raised so that disposal vol must be exactly zero, clear/zero disposal volume fields', () => {
     const volume = '5' // 5 + 5 = 10 which is P10 capacity ==> max disposal volume is zero
-    test('when form is newly changed to multiDispense: clear the fields', () => {
+    test('when form is newly changed to multiDispense: clear the disposal vol + dispense_mix_* fields', () => {
       const patch = {path: 'multiDispense'}
       const result = handleFormHelper(patch, {...form, path: 'single', volume})
       expect(result).toEqual({
         ...patch,
         disposalVolume_volume: null,
         disposalVolume_checkbox: false,
+        dispense_mix_checkbox: false,
+        dispense_mix_times: null,
+        dispense_mix_volume: null,
       })
     })
 
@@ -146,5 +149,29 @@ describe('disposal volume should update...', () => {
   test('when disposal volume is a negative number, set to zero', () => {
     const result = handleFormHelper({disposalVolume_volume: '-2'}, form)
     expect(result).toEqual({disposalVolume_volume: '0'})
+  })
+
+  describe('mix fields should clear...', () => {
+    // NOTE: path --> multiDispense handled in "when form is newly changed to multiDispense" test above
+
+    test('when path is changed to multiAspirate, clear aspirate mix fields', () => {
+      const form = {
+        path: 'single',
+        aspirate_wells: ['A1', 'A2'],
+        dispense_wells: ['B1'],
+        volume: 3,
+        pipette: 'pipetteId',
+        aspirate_mix_checkbox: true,
+        aspirate_mix_times: 2,
+        aspirate_mix_volume: 1,
+      }
+      const result = handleFormHelper({path: 'multiAspirate'}, form)
+      expect(result).toEqual({
+        path: 'multiAspirate',
+        aspirate_mix_checkbox: false,
+        aspirate_mix_times: null,
+        aspirate_mix_volume: null,
+      })
+    })
   })
 })


### PR DESCRIPTION
## overview

Closes #3098

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- [ ] Going from any path to multiDispense should clear the "dispense" section mix, because you can't mix between dispenses then

- [ ] Going from any path to multiAspirate should clear the "aspirate" section mix fields, because you can't mix between aspirates then

- [ ] Mixes do not get cleared when you select an invalid well ratio, or move from any path to "single" path