### PR TITLE
feat(protocol-designer): fallback in migV1 to path=single if path is falsy

### DIFF
--- a/protocol-designer/src/load-file/migration/migrationV1.js
+++ b/protocol-designer/src/load-file/migration/migrationV1.js
@@ -8,6 +8,7 @@ import {getPipetteCapacity} from '../../pipettes/pipetteData'
 import type {PipetteEntities} from '../../step-forms'
 import type {FormPatch} from '../../steplist/actions'
 import type {ProtocolFile, FileLabware, FilePipette} from '../../file-types'
+import type {FormData} from '../../form-types'
 
 const MIGRATION_VERSION = 1
 
@@ -31,8 +32,12 @@ export const initialDeckSetupStepForm = {
 function _updatePatchPathField (patch: FormPatch, rawForm: FormData, pipetteEntities: PipetteEntities) {
   const appliedPatch = {...rawForm, ...patch}
   const {path, changeTip} = appliedPatch
-  // pass-thru: incomplete form
-  if (!path) return patch
+
+  if (!path) {
+    console.warn(`No path for form: ${String(rawForm.id)}. Falling back to "single" path`)
+    // sanity check - fall back to 'single' if no path specified
+    return {...patch, path: 'single'}
+  }
 
   const numericVolume = Number(appliedPatch.volume) || 0
   const pipetteCapacity = getPipetteCapacity(pipetteEntities[appliedPatch.pipette])


### PR DESCRIPTION
# overview

In #3087 `dependentFieldsUpdateMoveLiquid` was updated to have this behavior and @b-cooper suggested to do it in the migV1 fn too, but I forgot! So I'm doing it here

# review requests

Still a good idea?