### PR TITLE
chore(repo): Configure semantic PR plugin for squash-merging only

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# always validate the PR title, and ignore the commits
+# https://github.com/probot/semantic-pull-requests
+titleOnly: true


### PR DESCRIPTION
## overview

The default configuration of the Semantic Pull Request plugin gives a ✅ if there is _either_ a semantic commit in the PR title or in any of the commits that make up the PR. This is bad for us, because we _always_ squash merge, so only the title matters. We want the semantic PR check to fail if the title is non-semantic, regardless if any of the commits are.

This config change ensures that we only pass if the title is correct

## changelog

- chore(repo): Configure semantic PR plugin for squash-merging only

## review requests

Check against documentation:
https://github.com/probot/semantic-pull-requests#configuration
