### PR TITLE
fix(protocol-designer): prevent disallowed path + blowout location combos

### DIFF
--- a/components/src/forms/DropdownField.js
+++ b/components/src/forms/DropdownField.js
@@ -11,6 +11,8 @@ export type DropdownOption = {
   disabled?: boolean,
 }
 
+export type Options = Array<DropdownOption>
+
 // TODO(mc, 2018-02-22): disabled prop
 type Props = {
   /** change handler */
@@ -26,7 +28,7 @@ type Props = {
   /** name of field in form */
   name?: string,
   /** Array of {name, value} data */
-  options: Array<DropdownOption>,
+  options: Options,
   /** classes to apply */
   className?: string,
   /** optional caption. hidden when `error` is given */

--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.js
@@ -14,7 +14,7 @@ import {
 import i18n from '../../localization'
 import styles from './LiquidPlacementForm.css'
 import formStyles from '../forms/forms.css'
-import type {Options} from '../../types'
+import type {Options} from '@opentrons/components'
 
 export type ValidFormValues = {
   selectedLiquidId: string,

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
@@ -1,21 +1,16 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {DropdownField, type DropdownOption} from '@opentrons/components'
+import {DropdownField, type Options} from '@opentrons/components'
 import cx from 'classnames'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 import {selectors as uiLabwareSelectors} from '../../../ui/labware'
-import type {StepFieldName} from '../../../steplist/fieldLevel'
-import {
-  SOURCE_WELL_BLOWOUT_DESTINATION,
-  DEST_WELL_BLOWOUT_DESTINATION,
-} from '../../../step-generation/utils'
-import type {BaseState} from '../../../types'
-import type {FocusHandlers} from '../types'
+import {getBlowoutLocationOptionsForForm} from '../utils'
 import FieldConnector from './FieldConnector'
 import styles from '../StepEditForm.css'
-
-type Options = Array<DropdownOption>
+import type {StepFieldName} from '../../../steplist/fieldLevel'
+import type {BaseState} from '../../../types'
+import type {FocusHandlers} from '../types'
 
 // TODO: 2019-01-24 i18n for these options
 
@@ -26,17 +21,8 @@ type BlowoutLocationDropdownOP = {
 type BlowoutLocationDropdownSP = {options: Options}
 const BlowoutLocationDropdownSTP = (state: BaseState, ownProps: BlowoutLocationDropdownOP): BlowoutLocationDropdownSP => {
   const unsavedForm = stepFormSelectors.getUnsavedForm(state)
-  const {stepType, path} = unsavedForm || {}
-
-  let options = uiLabwareSelectors.getDisposalLabwareOptions(state)
-  if (stepType === 'mix') {
-    options = [...options, {name: 'Destination Well', value: DEST_WELL_BLOWOUT_DESTINATION}]
-  } else if (stepType === 'moveLiquid') {
-    options = [...options, {name: 'Destination Well', value: DEST_WELL_BLOWOUT_DESTINATION}]
-    if (path === 'single') {
-      options = [...options, {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION}]
-    }
-  }
+  const disposalLabwareOptions = uiLabwareSelectors.getDisposalLabwareOptions(state)
+  const options = getBlowoutLocationOptionsForForm(disposalLabwareOptions, unsavedForm)
 
   return {options}
 }

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -1,13 +1,13 @@
 // @flow
 import * as React from 'react'
-import {FormGroup, CheckboxField, type DropdownOption, DropdownField} from '@opentrons/components'
+import {FormGroup, CheckboxField, DropdownField, type Options} from '@opentrons/components'
 import {connect} from 'react-redux'
 import cx from 'classnames'
 
 import {getMaxDisposalVolumeForMultidispense} from '../../../steplist/formLevel/handleFormChange/utils'
-import {SOURCE_WELL_BLOWOUT_DESTINATION} from '../../../step-generation/utils'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 import {selectors as uiLabwareSelectors} from '../../../ui/labware'
+import {getBlowoutLocationOptionsForForm} from '../utils'
 
 import FieldConnector from './FieldConnector'
 import TextField from './Text'
@@ -17,7 +17,7 @@ import type {FocusHandlers} from '../types'
 import styles from '../StepEditForm.css'
 
 type SP = {
-  disposalDestinationOptions: Array<DropdownOption>,
+  disposalDestinationOptions: Options,
   maxDisposalVolume: ?number,
 }
 
@@ -91,12 +91,13 @@ const DisposalVolumeField = (props: Props) => (
 )
 
 const mapSTP = (state: BaseState): SP => {
+  const rawForm = stepFormSelectors.getUnsavedForm(state)
   return {
-    maxDisposalVolume: getMaxDisposalVolumeForMultidispense(stepFormSelectors.getUnsavedForm(state), stepFormSelectors.getPipetteEntities(state)),
-    disposalDestinationOptions: [
-      ...uiLabwareSelectors.getDisposalLabwareOptions(state),
-      {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION},
-    ],
+    maxDisposalVolume: getMaxDisposalVolumeForMultidispense(rawForm, stepFormSelectors.getPipetteEntities(state)),
+    disposalDestinationOptions: getBlowoutLocationOptionsForForm(
+      uiLabwareSelectors.getDisposalLabwareOptions(state),
+      rawForm
+    ),
   }
 }
 

--- a/protocol-designer/src/components/StepEditForm/fields/Labware.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Labware.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {DropdownField, type DropdownOption} from '@opentrons/components'
+import {DropdownField, type Options} from '@opentrons/components'
 import cx from 'classnames'
 import {selectors as uiLabwareSelectors} from '../../../ui/labware'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
@@ -9,8 +9,6 @@ import type {BaseState} from '../../../types'
 import type {FocusHandlers} from '../types'
 import styles from '../StepEditForm.css'
 import StepField from './FieldConnector'
-
-type Options = Array<DropdownOption>
 
 type LabwareFieldOP = {name: StepFieldName, className?: string} & FocusHandlers
 type LabwareFieldSP = {labwareOptions: Options}

--- a/protocol-designer/src/components/StepEditForm/fields/Pipette.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Pipette.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux'
 import {
   FormGroup,
   DropdownField,
-  type DropdownOption,
+  type Options,
 } from '@opentrons/components'
 import {selectors as stepFormSelectors} from '../../../step-forms'
 import type {StepFieldName} from '../../../steplist/fieldLevel'
@@ -13,8 +13,6 @@ import type {StepType} from '../../../form-types'
 import styles from '../StepEditForm.css'
 import type {FocusHandlers} from '../types'
 import StepField from './FieldConnector'
-
-type Options = Array<DropdownOption>
 
 type PipetteFieldOP = {name: StepFieldName, stepType?: StepType} & FocusHandlers
 type PipetteFieldSP = {pipetteOptions: Options}

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -20,6 +20,7 @@ export function getBlowoutLocationOptionsForForm (
     return disposalLabwareOptions
   }
   const {stepType} = rawForm
+  // TODO: Ian 2019-02-21 use i18n for names
   const destOption = {name: 'Destination Well', value: DEST_WELL_BLOWOUT_DESTINATION}
   const sourceOption = {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION}
 

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -1,8 +1,50 @@
 // @flow
+import assert from 'assert'
 import * as React from 'react'
 import difference from 'lodash/difference'
 import i18n from '../../localization'
+import {
+  SOURCE_WELL_BLOWOUT_DESTINATION,
+  DEST_WELL_BLOWOUT_DESTINATION,
+} from '../../step-generation/utils'
 import styles from './StepEditForm.css'
+import type {Options} from '@opentrons/components'
+import type {FormData} from '../../form-types'
+
+export function getBlowoutLocationOptionsForForm (
+  disposalLabwareOptions: Options,
+  rawForm: ?FormData,
+): Options {
+  if (!rawForm) {
+    assert(rawForm, `getBlowoutLocationOptionsForForm expected a form`)
+    return disposalLabwareOptions
+  }
+  const {stepType} = rawForm
+  const destOption = {name: 'Destination Well', value: DEST_WELL_BLOWOUT_DESTINATION}
+  const sourceOption = {name: 'Source Well', value: SOURCE_WELL_BLOWOUT_DESTINATION}
+
+  if (stepType === 'mix') {
+    return [...disposalLabwareOptions, destOption]
+  } else if (stepType === 'moveLiquid') {
+    const path = rawForm.path
+    switch (path) {
+      case 'single': {
+        return [...disposalLabwareOptions, sourceOption, destOption]
+      }
+      case 'multiDispense': {
+        return [...disposalLabwareOptions, sourceOption, {...destOption, disabled: true}]
+      }
+      case 'multiAspirate': {
+        return [...disposalLabwareOptions, {...sourceOption, disabled: true}, destOption]
+      }
+      default: {
+        assert(false, `getBlowoutLocationOptionsForForm got unexpected path for moveLiquid step: ${path}`)
+        return disposalLabwareOptions
+      }
+    }
+  }
+  return disposalLabwareOptions
+}
 
 export function getVisibleAlerts<Field, Alert: {dependentFields: Array<Field>}> (args: {
   focusedField: ?Field,

--- a/protocol-designer/src/labware-ingred/selectors.js
+++ b/protocol-designer/src/labware-ingred/selectors.js
@@ -5,6 +5,7 @@ import mapValues from 'lodash/mapValues'
 import max from 'lodash/max'
 import reduce from 'lodash/reduce'
 
+import type {Options} from '@opentrons/components'
 import type {
   RootState,
   DrillDownLabwareId,
@@ -17,7 +18,7 @@ import type {
   LiquidGroup,
   OrderedLiquids,
 } from './types'
-import type {BaseState, Options, Selector} from './../types'
+import type {BaseState, Selector} from './../types'
 
 // TODO: Ian 2019-02-15 no RootSlice, use BaseState
 type RootSlice = {labwareIngred: RootState}

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -37,6 +37,9 @@ export default function getDefaultsForStepType (stepType: StepType): {[StepField
         aspirate_wells: [],
         aspirate_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
         aspirate_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        aspirate_mix_checkbox: false,
+        aspirate_mix_times: null,
+        aspirate_mix_volume: null,
         aspirate_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         aspirate_touchTip_checkbox: false,
 
@@ -44,8 +47,14 @@ export default function getDefaultsForStepType (stepType: StepType): {[StepField
         dispense_wells: [],
         dispense_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
         dispense_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        dispense_mix_checkbox: false,
+        dispense_mix_times: null,
+        dispense_mix_volume: null,
         dispense_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
         dispense_touchTip_checkbox: false,
+
+        disposalVolume_checkbox: false,
+        disposalVolume_volume: null,
 
         blowout_checkbox: false,
         blowout_location: FIXED_TRASH_ID,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -1,5 +1,12 @@
 // @flow
-import dependentFieldsUpdateMoveLiquid from '../dependentFieldsUpdateMoveLiquid'
+import dependentFieldsUpdateMoveLiquid, {
+  updatePatchBlowoutFields,
+} from '../dependentFieldsUpdateMoveLiquid'
+
+import {
+  SOURCE_WELL_BLOWOUT_DESTINATION,
+  DEST_WELL_BLOWOUT_DESTINATION,
+} from '../../../../step-generation'
 
 let pipetteEntities
 let labwareEntities
@@ -171,6 +178,36 @@ describe('disposal volume should update...', () => {
         aspirate_mix_checkbox: false,
         aspirate_mix_times: null,
         aspirate_mix_volume: null,
+      })
+    })
+  })
+
+  describe('blowout location should reset via updatePatchBlowoutFields...', () => {
+    const resetBlowoutLocation = {
+      blowout_location: 'trashId',
+    }
+
+    const testCases = [
+      {prevPath: 'single', nextPath: 'multiAspirate', incompatible: SOURCE_WELL_BLOWOUT_DESTINATION},
+      {prevPath: 'single', nextPath: 'multiDispense', incompatible: DEST_WELL_BLOWOUT_DESTINATION},
+    ]
+
+    testCases.forEach(({prevPath, nextPath, incompatible}) => {
+      const patch = {path: nextPath}
+      test(`when changing path ${prevPath} → ${nextPath}, arbitrary labware still allowed`, () => {
+        const result = updatePatchBlowoutFields(patch, {
+          path: prevPath,
+          blowout_location: 'someKindaTrashLabwareIdHere',
+        })
+        expect(result).toEqual(patch)
+      })
+
+      test(`when changing path ${prevPath} → ${nextPath}, ${incompatible} reset to trashId`, () => {
+        const result = updatePatchBlowoutFields(patch, {
+          path: prevPath,
+          blowout_location: incompatible,
+        })
+        expect(result).toEqual({...patch, ...resetBlowoutLocation})
       })
     })
   })

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -39,5 +39,3 @@ export type VolumeJson = {
     [wellName: string]: JsonWellData,
   },
 }
-
-export type Options = Array<{value: string, name: string, disabled?: boolean}>

--- a/protocol-designer/src/ui/labware/selectors.js
+++ b/protocol-designer/src/ui/labware/selectors.js
@@ -9,7 +9,8 @@ import {selectors as labwareIngredSelectors} from '../../labware-ingred/selector
 import {labwareToDisplayName} from '../../labware-ingred/utils'
 import {DISPOSAL_LABWARE_TYPES} from '../../constants'
 
-import type {Selector, Options} from '../../types'
+import type {Options} from '@opentrons/components'
+import type {Selector} from '../../types'
 import type {LabwareEntity} from '../../step-forms'
 
 export const getLabwareNicknamesById: Selector<{[labwareId: string]: string}> = createSelector(


### PR DESCRIPTION
## overview
    
Closes #3104

## changelog

* add missing fields to getDefaultsForStepType moveLiquid form
* in dependentFieldsUpdateMoveLiquid, use defaults from getDefaultsForStepType
* clean up dependentFieldsUpdateMoveLiquid
* add tests for new updatePatchBlowoutFields fn

## review requests

The behavior below should now be enforced - getting to the NO's should be impossible (PD will reset your blowout location to be default trash)

### Permitted blowout locations by path type

| path |  trash labware | source well | dest well |
|---------------|--------|--------|------|
| single        | yes    | yes    | yes  |
| multiDispense | yes    | yes    | NO  |
| multiAspirate | yes    |  NO | yes  |