### PR TITLE
fix(api): Do not change the wifi keys dir and ensure it is created

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -123,10 +123,16 @@ CONFIG_ELEMENTS = (
                   ' an absolute path, it will be used directly. If it is a '
                   'relative path it will be relative to log_dir'
                   'The location of the file to save serial logs to'),
+    # Unlike other config elements, the wifi keys dir is still in
+    # /data/user_storage/opentrons_data because these paths are fed directly to
+    # NetworkManager and stored in connections files there. To change this
+    # directory, we would have to modify those connections files, presumably on
+    # boot, which is a level of complexity that makes it worth having an
+    # annoying path.
     ConfigElement('wifi_keys_dir',
                   'Wifi Keys Dir',
-                  Path('network_keys'),
-                  ConfigElementType.FILE,
+                  Path('user_storage/opentrons_data/network_keys'),
+                  ConfigElementType.DIR,
                   'The directory in which to save any key material for wifi'
                   ' auth. Not relevant outside of a robot.'),
     ConfigElement('hardware_controller_lockfile',


### PR DESCRIPTION
This fixes two bugs:

- Because the wifi keys dir was incorrectly specified as a file in the
  configelements, it would not be created on boot if it did not exist
- Because the absolute paths of key material are stored in NetworkManager
  connection files, we cannot simply move the wifi keys dir in an update without
  rewriting the config files on first boot. That’s a lot of complexity and
  avoiding it is worth keeping an annoying path around.

## Testing

This PR is about both ensuring the config and ensuring the migration of the config. We need to make sure that if the robot was previously connected to a network that required key material, it remains connected after an update and a hard reboot (during a soft reboot, since NetworkManager lives in the base OS, the keys will remain in memory and you won't notice changes). We also need to make sure that if for whatever reason the directory doesn't exist, it gets created.

So:

- On 3.6.5, connect to a wifi network that requires key material
- Remote in and delete
 - /data/config.json, /data/network_keys
- Update to 3.7, click restart, then once the robot's back up, hard restart (as in interrupt power)
- [ ] Check that the robot remains connected to the network
- [ ] Check that the keys it used are still selectable in the wifi config pane (or /keys in postman)
- [ ] Check that you can still upload keys
- ssh into the robot and rm -rf /data/user_storage/opentrons_data/network_keys
- Hard restart the robot
- Note that the robot is no longer connected to the network that required key material
- [ ] Check that you can still upload keys in the wifi config pane
- [ ] Just to make sure, connect to that wireless network

Keys and passwords to the test network:
network is linksys-ttls-mschapv2
security is wpa-eap, ttls/mschapv2
username science
password biology
[keys.zip](https://github.com/Opentrons/opentrons/files/2895428/keys.zip)
privkey password is "whatever"