### PR TITLE
fix(app): Select correct wifi cred file when duplicate name uploaded

### DIFF
--- a/app/src/components/RobotSettings/SelectNetwork/index.js
+++ b/app/src/components/RobotSettings/SelectNetwork/index.js
@@ -156,8 +156,7 @@ class SelectNetwork extends React.Component<Props, SelectNetworkState> {
               />
             </ConnectModal>
           )}
-          {configRequest &&
-            !!(configError || configResponse) && (
+          {configRequest && !!(configError || configResponse) && (
             <WifiConnectModal
               error={configError}
               request={configRequest}


### PR DESCRIPTION
## overview

Bug report + fix.

This PR addresses a un-ticketed TODO in WPA-EAP where if a user uploads a credential file with the same name (but different contents) as a file already on the robot, the client may use the existing file rather than the new one in the `/wifi/configure` http request.

This fix also demonstrates how we've hit the limits of our robot API state metaphors in the app; we should prioritize pulling in a redux library to lean on instead of rolling our own stuff.

## changelog

- fix(app): Select correct wifi cred file when duplicate name uploaded

## review requests

- [ ] WPA-EAP connection works with freshly uploaded files
- [ ] WPA-EAP connection works with existing files selected (not uploaded)
- [ ] WPA-EAP connection works with existing files uploaded and matched
- [ ] WPA-EAP connection works with new creds uploaded with duplicate filenames but different contents
