### PR TITLE
fix(protocol-designer): fix mixFormToArgs changeTip

### DIFF
--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -1,5 +1,5 @@
 // @flow
-
+import assert from 'assert'
 import { getLabware } from '@opentrons/shared-data'
 import intersection from 'lodash/intersection'
 import type { FormData } from '../../../form-types'
@@ -39,8 +39,9 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const aspirateOffsetFromBottomMm = hydratedFormData['mix_mmFromBottom']
   const dispenseOffsetFromBottomMm = hydratedFormData['mix_mmFromBottom']
 
-  // It's radiobutton, so one should always be selected.
-  const changeTip = hydratedFormData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
+  // One changeTip option should always be selected.
+  assert(hydratedFormData['changeTip'], 'mixFormToArgs expected non-falsey changeTip option')
+  const changeTip = hydratedFormData['changeTip'] || DEFAULT_CHANGE_TIP_OPTION
 
   const blowoutLocation = hydratedFormData['blowout_checkbox'] ? hydratedFormData['blowout_location'] : null
 


### PR DESCRIPTION
## overview

Closes #3122

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Mix form `changeTip` should be fixed for (before it would always default to `once`)