### PR TITLE
fix(protocol-designer): fix drop tip offset and change tip field bugs

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
@@ -17,11 +17,11 @@ import type {StepFieldName, TipOffsetFields} from '../../../../form-types'
 function getLabwareFieldForPositioningField (fieldName: TipOffsetFields): StepFieldName {
   const fieldMap: {[TipOffsetFields]: StepFieldName} = {
     aspirate_mmFromBottom: 'aspirate_labware',
-    aspirate_touchTipMmFromBottom: 'aspirate_labware',
+    aspirate_touchTip_mmFromBottom: 'aspirate_labware',
     dispense_mmFromBottom: 'dispense_labware',
-    dispense_touchTipMmFromBottom: 'dispense_labware',
+    dispense_touchTip_mmFromBottom: 'dispense_labware',
     mix_mmFromBottom: 'labware',
-    mix_touchTipMmFromBottom: 'labware',
+    mix_touchTip_mmFromBottom: 'labware',
   }
   return fieldMap[fieldName]
 }

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -88,7 +88,7 @@ class MixForm extends React.Component<Props, State> {
               {this.state.collapsed !== true &&
                 <FormGroup label="Dispense Options">
                   <CheckboxRowField name={'mix_touchTip_checkbox'} label="Touch tip">
-                    <TipPositionField className={cx(styles.small_field, styles.orphan_field)} fieldName={'mix_touchTipMmFromBottom'} />
+                    <TipPositionField className={cx(styles.small_field, styles.orphan_field)} fieldName={'mix_touchTip_mmFromBottom'} />
                   </CheckboxRowField>
 
                   <CheckboxRowField name='blowout_checkbox' label='Blow out'>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/SourceDestFields.js
@@ -77,7 +77,7 @@ class SourceDestFields extends React.Component<Props, State> {
                   </React.Fragment>
                 }
                 <CheckboxRowField name={addFieldNamePrefix('touchTip_checkbox')} label="Touch tip">
-                  <TipPositionField fieldName={addFieldNamePrefix('touchTipMmFromBottom')} />
+                  <TipPositionField fieldName={addFieldNamePrefix('touchTip_mmFromBottom')} />
                 </CheckboxRowField>
                 <CheckboxRowField name={addFieldNamePrefix('mix_checkbox')} label='Mix'>
                   <TextField

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -15,7 +15,7 @@ export type StepFieldName = any
 // | 'aspirate_mix_times'
 // | 'aspirate_mix_volume'
 // | 'aspirate_touchTip_checkbox'
-// | 'aspirate_touchTipMmFromBottom'
+// | 'aspirate_touchTip_mmFromBottom'
 // | 'aspirate_mmFromBottom'
 // | 'aspirate_wellOrder_first'
 // | 'aspirate_wellOrder_second'
@@ -30,7 +30,7 @@ export type StepFieldName = any
 // | 'dispense_mix_checkbox'
 // | 'dispense_mix_times'
 // | 'dispense_mix_volume'
-// | 'dispense_touchTipMmFromBottom'
+// | 'dispense_touchTip_mmFromBottom'
 // | 'dispense_mmFromBottom'
 // | 'dispense_wellOrder_first'
 // | 'dispense_wellOrder_second'
@@ -40,7 +40,7 @@ export type StepFieldName = any
 // | 'labware'
 // | 'labwareLocationUpdate'
 // | 'mix_mmFromBottom'
-// | 'mix_touchTipMmFromBottom'
+// | 'mix_touchTip_mmFromBottom'
 // | 'path'
 // | 'pauseForAmountOfTime'
 // | 'pauseHour'
@@ -197,18 +197,19 @@ export type HydratedMoveLiquidFormDataLegacy = {
 }
 
 // fields used in TipPositionInput
-export type TipOffsetFields = 'aspirate_mmFromBottom'
+export type TipOffsetFields =
+  | 'aspirate_mmFromBottom'
   | 'dispense_mmFromBottom'
   | 'mix_mmFromBottom'
-  | 'aspirate_touchTipMmFromBottom'
-  | 'dispense_touchTipMmFromBottom'
-  | 'mix_touchTipMmFromBottom'
+  | 'aspirate_touchTip_mmFromBottom'
+  | 'dispense_touchTip_mmFromBottom'
+  | 'mix_touchTip_mmFromBottom'
 
 export function getIsTouchTipField (fieldName: string): boolean {
   const touchTipFields = [
-    'aspirate_touchTipMmFromBottom',
-    'dispense_touchTipMmFromBottom',
-    'mix_touchTipMmFromBottom',
+    'aspirate_touchTip_mmFromBottom',
+    'dispense_touchTip_mmFromBottom',
+    'mix_touchTip_mmFromBottom',
   ]
   return touchTipFields.includes(fieldName)
 }

--- a/protocol-designer/src/load-file/migration/1_1_0.js
+++ b/protocol-designer/src/load-file/migration/1_1_0.js
@@ -130,6 +130,8 @@ export const TCD_DEPRECATED_FIELD_NAMES = [
   'offsetFromBottomMm',
   'dispense_touchTip',
   'aspirate_touchTip',
+  'aspirate_touchTipMmFromBottom',
+  'dispense_touchTipMmFromBottom',
 ]
 export const MIX_DEPRECATED_FIELD_NAMES = [
   'step-name',
@@ -142,6 +144,7 @@ export const MIX_DEPRECATED_FIELD_NAMES = [
   'dispense_blowout_labware',
   'dispense_blowout_location',
   'touchTip',
+  'mix_touchTipMmFromBottom',
 ]
 export function updateStepFormKeys (fileData: ProtocolFile): ProtocolFile {
   const savedStepForms = fileData['designer-application'].data.savedStepForms
@@ -161,6 +164,8 @@ export function updateStepFormKeys (fileData: ProtocolFile): ProtocolFile {
         disposalVolume_checkbox: formData['aspirate_disposalVol_checkbox'],
         disposalVolume_volume: formData['aspirate_disposalVol_volume'],
         preWetTip: formData['aspirate_preWetTip'],
+        aspirate_touchTip_mmFromBottom: formData['aspirate_touchTipMmFromBottom'],
+        dispense_touchTip_mmFromBottom: formData['dispense_touchTipMmFromBottom'],
       }
 
       return {
@@ -178,6 +183,7 @@ export function updateStepFormKeys (fileData: ProtocolFile): ProtocolFile {
         mix_touchTip_checkbox: formData['touchTip'],
         blowout_checkbox: formData['dispense_blowout_checkbox'],
         blowout_location: formData['dispense_blowout_location'] || formData['dispense_blowout_labware'],
+        mix_touchTip_mmFromBottom: formData['mix_touchTipMmFromBottom'],
       }
       return {
         ...omitBy(updatedFields, isUndefined),

--- a/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.js
+++ b/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.js
@@ -96,7 +96,9 @@ describe('updateStepFormKeys', () => {
               'aspirate_changeTip': 'always',
               'aspirate_preWetTip': true,
               'aspirate_touchTip': true,
+              'aspirate_touchTipMmFromBottom': 20,
               'dispense_touchTip': true,
+              'dispense_touchTipMmFromBottom': 22,
               'dispense_blowout_checkbox': true,
               'dispense_blowout_labware': 'trashId',
               'dispense_blowout_location': 'trashId',
@@ -118,7 +120,9 @@ describe('updateStepFormKeys', () => {
               'aspirate_changeTip': 'always',
               'aspirate_preWetTip': true,
               'aspirate_touchTip': true,
+              'aspirate_touchTipMmFromBottom': 20,
               'dispense_touchTip': true,
+              'dispense_touchTipMmFromBottom': 22,
               'dispense_blowout_checkbox': true,
               'dispense_blowout_labware': 'trashId',
               'dispense_blowout_location': 'trashId',
@@ -140,7 +144,9 @@ describe('updateStepFormKeys', () => {
               'aspirate_changeTip': 'always',
               'aspirate_preWetTip': true,
               'aspirate_touchTip': true,
+              'aspirate_touchTipMmFromBottom': 20,
               'dispense_touchTip': true,
+              'dispense_touchTipMmFromBottom': 22,
               'dispense_blowout_checkbox': true,
               'dispense_blowout_labware': 'trashId',
               'dispense_blowout_location': 'trashId',
@@ -171,10 +177,12 @@ describe('updateStepFormKeys', () => {
       const oldFields = stubbedTCDStepsFile['designer-application'].data.savedStepForms['1']
       const addedFields = {
         aspirate_touchTip_checkbox: oldFields['aspirate_touchTip'],
+        aspirate_touchTip_mmFromBottom: oldFields['aspirate_touchTipMmFromBottom'],
         blowout_checkbox: oldFields['dispense_blowout_checkbox'],
         blowout_location: oldFields['dispense_blowout_location'],
         changeTip: oldFields['aspirate_changeTip'],
         dispense_touchTip_checkbox: oldFields['dispense_touchTip'],
+        dispense_touchTip_mmFromBottom: oldFields['dispense_touchTipMmFromBottom'],
         disposalVolume_checkbox: oldFields['aspirate_disposalVol_checkbox'],
         disposalVolume_volume: oldFields['aspirate_disposalVol_volume'],
         preWetTip: oldFields['aspirate_preWetTip'],
@@ -186,6 +194,7 @@ describe('updateStepFormKeys', () => {
           expect(stepForm[fieldName]).toEqual(undefined)
         })
         each(migratedFile['designer-application'].data.savedStepForms, stepForm => {
+          console.log({fieldName, addedFields, stepForm})
           expect(stepForm[fieldName]).toEqual(addedFields[fieldName])
         })
       })
@@ -215,6 +224,7 @@ describe('updateStepFormKeys', () => {
               'aspirate_wellOrder_first': 'l2r',
               'aspirate_wellOrder_second': 't2b',
               'touchTip': true,
+              'mix_touchTipMmFromBottom': 24,
             },
           },
         },
@@ -241,6 +251,7 @@ describe('updateStepFormKeys', () => {
         mix_wellOrder_first: oldFields['aspirate_wellOrder_first'],
         mix_wellOrder_second: oldFields['aspirate_wellOrder_second'],
         mix_touchTip_checkbox: oldFields['touchTip'],
+        mix_touchTip_mmFromBottom: oldFields['mix_touchTipMmFromBottom'],
         blowout_checkbox: oldFields['dispense_blowout_checkbox'],
         blowout_location: oldFields['dispense_blowout_location'],
       }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -8,9 +8,9 @@
       "aspirate_mmFromBottom": "Change from where in the well the robot aspirates",
       "dispense_mmFromBottom": "Change from where in the well the robot dispenses",
       "mix_mmFromBottom": "Change from where in the well the robot aspirates and dispenses during the mix",
-      "aspirate_touchTipMmFromBottom": "Change from where in the well the robot performs touch tip",
-      "dispense_touchTipMmFromBottom": "Change from where in the well the robot performs touch tip",
-      "mix_touchTipMmFromBottom": "Change from where in the well the robot performs touch tip"
+      "aspirate_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
+      "dispense_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
+      "mix_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip"
     },
     "field_label": "Distance from bottom of well"
   },

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -127,13 +127,13 @@ const updatePatchOnLabwareChange = (patch: FormPatch, rawForm: FormData): FormPa
       ? getDefaultFields(
         'aspirate_wells',
         'aspirate_mmFromBottom',
-        'aspirate_touchTipMmFromBottom')
+        'aspirate_touchTip_mmFromBottom')
       : {}),
     ...(destLabwareChanged
       ? getDefaultFields(
         'dispense_wells',
         'dispense_mmFromBottom',
-        'dispense_touchTipMmFromBottom')
+        'dispense_touchTip_mmFromBottom')
       : {}),
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -1,5 +1,5 @@
 // @flow
-
+import assert from 'assert'
 import { getLabware } from '@opentrons/shared-data'
 import intersection from 'lodash/intersection'
 import type { FormData } from '../../../form-types'
@@ -12,8 +12,8 @@ type MixStepArgs = MixArgs
 // TODO: BC 2018-10-30 move getting labwareDef into hydration layer upstream
 const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const {labware, pipette} = hydratedFormData
-  const touchTip = !!hydratedFormData['touchTip']
-  const touchTipMmFromBottom = hydratedFormData['mix_touchTipMmFromBottom']
+  const touchTip = Boolean(hydratedFormData['mix_touchTip_checkbox'])
+  const touchTipMmFromBottom = hydratedFormData['mix_touchTip_mmFromBottom']
 
   let wells = hydratedFormData.wells || []
   const orderFirst = hydratedFormData.mix_wellOrder_first
@@ -40,7 +40,9 @@ const mixFormToArgs = (hydratedFormData: FormData): MixStepArgs => {
   const dispenseOffsetFromBottomMm = hydratedFormData['mix_mmFromBottom']
 
   // It's radiobutton, so one should always be selected.
-  const changeTip = hydratedFormData['aspirate_changeTip'] || DEFAULT_CHANGE_TIP_OPTION
+  // One changeTip option should always be selected.
+  assert(hydratedFormData['changeTip'], 'mixFormToArgs expected non-falsey changeTip option')
+  const changeTip = hydratedFormData['changeTip'] || DEFAULT_CHANGE_TIP_OPTION
 
   const blowoutLocation = hydratedFormData['blowout_checkbox'] ? hydratedFormData['blowout_location'] : null
 


### PR DESCRIPTION
## overview

Closes #3122 and closes #3123 - both are field name inconsistency issues

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- [ ] Make sure you can do changeTip never and changeTip always (which means "for each well") in the Mix form.

- [ ] Make sure touch tip offset fields work correctly _de novo_ (aspirate + dispense in moveLiquid form, plus the one in the mix form)
- [ ] Make sure the same 3 touch tip offset fields migrate correctly from pre-flex PD (eg production)

I tested a pre-flex do-it-all protocol and make sure the touch tip offset and change tip fields migrate and save correctly. I used http://www.jsondiff.com/ and the grandfathered protocol re-exported thru production PD (because for some reason it's missing commands for steps in the Google Drive version!)