### PR TITLE
feat(api): add pipette config endpoint

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -3,7 +3,7 @@ import logging
 import json
 import re
 from collections import namedtuple
-from typing import Any, Dict, List, Union, Tuple, Sequence
+from typing import Any, Dict, List, Union, Tuple, Sequence, Optional
 import pkgutil
 
 from opentrons.config import feature_flags as ff, CONFIG
@@ -197,7 +197,8 @@ def piecewise_volume_conversion(
     return i[1]*ul + i[2]
 
 
-def save_overrides(pipette_id: str, overrides: Dict[str, Any], model: str):
+def save_overrides(
+        pipette_id: str, overrides: Dict[str, Any], model: Optional[str]):
     override_dir = CONFIG['pipette_config_overrides_dir']
     try:
         existing = load_overrides(pipette_id)

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -343,7 +343,6 @@ def _load_json(filename) -> dict:
 
 
 def _save_json(data, filename):
-    # print("Saving json file at {}".format(filename))
     try:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         with open(filename, 'w') as file:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -369,7 +369,7 @@ class API(HardwareAPILike):
         if instr:
             await self.home([Axis.of_plunger(mount)])
             await self._move_plunger(mount,
-                                     instr.config.plunger_positions['bottom'])
+                                     instr.config.bottom)
 
     @_log_call
     async def home(self, axes: List[Axis] = None):
@@ -868,7 +868,7 @@ class API(HardwareAPILike):
     def _plunger_position(self, instr: Pipette, ul: float,
                           action: str) -> float:
         mm = ul / instr.ul_per_mm(ul, action)
-        position = mm + instr.config.plunger_positions['bottom']
+        position = mm + instr.config.bottom
         return round(position, 6)
 
     @_log_call
@@ -886,7 +886,7 @@ class API(HardwareAPILike):
                                          this_pipette.config.plunger_current)
         try:
             await self._move_plunger(
-                mount, this_pipette.config.plunger_positions['blow_out'])
+                mount, this_pipette.config.blow_out)
         except Exception:
             self._log.exception('Blow out failed')
             raise
@@ -912,7 +912,7 @@ class API(HardwareAPILike):
         self._backend.set_active_current(plunger_ax,
                                          instr.config.plunger_current)
         await self._move_plunger(
-            mount, instr.config.plunger_positions['bottom'])
+            mount, instr.config.bottom)
 
         # Press the nozzle into the tip <presses> number of times,
         # moving further by <increment> mm after each press
@@ -955,8 +955,8 @@ class API(HardwareAPILike):
         assert instr.has_tip, 'Cannot drop tip without a tip attached'
         self._log.info("Dropping tip off from {}".format(instr.name))
         plunger_ax = Axis.of_plunger(mount)
-        droptip = instr.config.plunger_positions['drop_tip']
-        bottom = instr.config.plunger_positions['bottom']
+        droptip = instr.config.drop_tip
+        bottom = instr.config.bottom
         self._backend.set_active_current(plunger_ax,
                                          instr.config.plunger_current)
         await self._move_plunger(mount, bottom)
@@ -1016,7 +1016,11 @@ class API(HardwareAPILike):
             raise top_types.PipetteNotAttachedError(
                 "No pipette attached to {} mount".format(mount.name))
 
-        pos_dict: Dict = instr.config.plunger_positions
+        pos_dict: Dict = {
+            'top': instr.config.top,
+            'bottom': instr.config.bottom,
+            'blow_out': instr.config.blow_out,
+            'drop_tip': instr.config.drop_tip}
         if top is not None:
             pos_dict['top'] = top
         if bottom is not None:
@@ -1025,7 +1029,8 @@ class API(HardwareAPILike):
             pos_dict['blow_out'] = blow_out
         if bottom is not None:
             pos_dict['drop_tip'] = drop_tip
-        instr.update_config_item('plunger_positions', pos_dict)
+        for key in pos_dict.keys():
+            instr.update_config_item(key, pos_dict[key])
 
     @_log_call
     def set_flow_rate(self, mount, aspirate=None, dispense=None):

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -5,7 +5,7 @@ from threading import Event
 from typing import Dict, Optional, List, Tuple
 from contextlib import contextmanager
 from opentrons import types
-from opentrons.config.pipette_config import configs
+from opentrons.config.pipette_config import config_models
 from . import modules
 
 
@@ -14,7 +14,7 @@ MODULE_LOG = logging.getLogger(__name__)
 
 def find_config(prefix: str) -> str:
     """ Find the most recent config matching `prefix` """
-    matches = [conf for conf in configs if conf.startswith(prefix)]
+    matches = [conf for conf in config_models if conf.startswith(prefix)]
     if not matches:
         raise KeyError('No match found for prefix {}'.format(prefix))
     if prefix in matches:

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -195,7 +195,11 @@ class InstrumentsWrapper(object):
             config = config._replace(min_volume=min_volume)
         if max_volume is not None:
             config = config._replace(max_volume=max_volume)
-
+        plunger_positions = {
+            'top': config.top,
+            'bottom': config.bottom,
+            'blow_out': config.blow_out,
+            'drop_tip': config.drop_tip}
         p = self.Pipette(
             model_offset=config.model_offset,
             mount=mount,
@@ -210,7 +214,7 @@ class InstrumentsWrapper(object):
             plunger_current=config.plunger_current,
             drop_tip_current=config.drop_tip_current,
             drop_tip_speed=config.drop_tip_speed,
-            plunger_positions=config.plunger_positions.copy(),
+            plunger_positions=plunger_positions,
             ul_per_mm=config.ul_per_mm,
             pick_up_current=config.pick_up_current,
             pick_up_distance=config.pick_up_distance,

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -849,8 +849,10 @@ class Robot(CommandPublisher):
                 'id': self.model_by_mount['left']['id']
             }
         left_model = left_data.get('model')
+
         if left_model:
-            tip_length = pipette_config.load(left_model).tip_length
+            tip_length = pipette_config.load(
+                left_model, left_data['id']).tip_length
             left_data.update({'tip_length': tip_length})
 
         right_data = {
@@ -861,7 +863,8 @@ class Robot(CommandPublisher):
             }
         right_model = right_data.get('model')
         if right_model:
-            tip_length = pipette_config.load(right_model).tip_length
+            tip_length = pipette_config.load(
+                right_model, right_data['id']).tip_length
             right_data.update({'tip_length': tip_length})
         return {
             'left': left_data,

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -8,7 +8,7 @@ import importlib.util
 from typing import Any, List
 
 import opentrons.hardware_control as hc
-from opentrons.config.pipette_config import configs
+from opentrons.config.pipette_config import config_models
 from opentrons.types import Mount
 from .labware import Labware
 from .contexts import ProtocolContext, InstrumentContext
@@ -140,7 +140,7 @@ class AddInstrumentCtors(type):
     def __new__(cls, name, bases, namespace, **kwds):
         """ Add the pipette initializer functions to the class. """
         res = type.__new__(cls, name, bases, namespace)
-        for config in configs:
+        for config in config_models:
             # Split the long name with the version
             comps = config.split('_')
             # To get the name without the version

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -253,9 +253,9 @@ def _validate_move_data(data):
         error = True
     if target == 'pipette':
         model = data.get('model')
-        if model not in pipette_config.configs:
+        if model not in pipette_config.config_models:
             message = "Model '{}' not recognized, must be one " \
-                      "of {}".format(model, pipette_config.configs)
+                      "of {}".format(model, pipette_config.config_models)
             error = True
     else:
         model = None

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -170,10 +170,6 @@ async def modify_pipette_settings(request: web.Request) -> web.Response:
     """
     Expects a dictionary with mutable configs in a flattened shape such as:
     {
-    'info': {
-        'name': ..,
-        'model': ..
-    }
     'fields': {
             'pickUpCurrent': {'value': some_value},
             'dropTipSpeed': {'value': some_value}
@@ -184,9 +180,10 @@ async def modify_pipette_settings(request: web.Request) -> web.Response:
     }
     """
     pipette_id = request.match_info['id']
+    whole_config = pc.load_config_dict(pipette_id)
     config_match = pc.list_mutable_configs(pipette_id)
     data = await request.json()
-    if not data.get('fields') or not data.get('info'):
+    if not data.get('fields'):
         return web.json_response(status=400)
 
     for key, value in data['fields'].items():
@@ -197,5 +194,5 @@ async def modify_pipette_settings(request: web.Request) -> web.Response:
                 return web.json_response(
                     {'message': '{} out of range with {}'.format(key, value)},
                     status=412)
-    pc.save_overrides(pipette_id, data['fields'], data['info']['model'])
+    pc.save_overrides(pipette_id, data['fields'], whole_config.get('model'))
     return web.json_response(status=204)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from opentrons.config import (advanced_settings as advs,
                               robot_configs as rc,
                               feature_flags as ff,
+                              pipette_config as pc,
                               IS_ROBOT)
 from opentrons.data_storage import database as db
 from opentrons.protocol_api import labware
@@ -132,3 +133,69 @@ async def available_resets(request: web.Request) -> web.Response:
     """ Indicate what parts of the user configuration are available for reset.
     """
     return web.json_response({'options': _settings_reset_options}, status=200)
+
+
+async def pipette_settings(request: web.Request) -> web.Response:
+    res = {}
+    for id in pc.known_pipettes():
+        whole_config = pc.load_config_dict(id)
+        res[id] = {
+            'info': {
+                'name': whole_config.get('name'),
+                'model': whole_config.get('model')
+            },
+            'fields': pc.list_mutable_configs(pipette_id=id)
+        }
+    return web.json_response(res, status=200)
+
+
+async def pipette_settings_id(request: web.Request) -> web.Response:
+    pipette_id = request.match_info['id']
+    if pipette_id not in pc.known_pipettes():
+        return web.json_response(
+            {'message': '{} is not a valid pipette id'.format(pipette_id)},
+            status=404)
+    whole_config = pc.load_config_dict(pipette_id)
+    res = {
+        'info': {
+            'name': whole_config.get('name'),
+            'model': whole_config.get('model')
+        },
+        'fields': pc.list_mutable_configs(pipette_id)
+        }
+    return web.json_response(res, status=200)
+
+
+async def modify_pipette_settings(request: web.Request) -> web.Response:
+    """
+    Expects a dictionary with mutable configs in a flattened shape such as:
+    {
+    'info': {
+        'name': ..,
+        'model': ..
+    }
+    'fields': {
+            'pickUpCurrent': {'value': some_value},
+            'dropTipSpeed': {'value': some_value}
+    }
+    If a value needs to be reset, simply type in the body formatted as above:
+        'configKey': null
+
+    }
+    """
+    pipette_id = request.match_info['id']
+    config_match = pc.list_mutable_configs(pipette_id)
+    data = await request.json()
+    if not data.get('fields') or not data.get('info'):
+        return web.json_response(status=400)
+
+    for key, value in data['fields'].items():
+        if value:
+            config = value['value']
+            default = config_match[key]
+            if config < default['min'] or config > default['max']:
+                return web.json_response(
+                    {'message': '{} out of range with {}'.format(key, value)},
+                    status=412)
+    pc.save_overrides(pipette_id, data['fields'], data['info']['model'])
+    return web.json_response(status=204)

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -78,3 +78,11 @@ class HTTPServer(object):
             '/settings/reset', settings.reset)
         self.app.router.add_get(
             '/settings/reset/options', settings.available_resets)
+        self.app.router.add_get(
+            '/settings/pipettes', settings.pipette_settings
+        )
+        self.app.router.add_get(
+            '/settings/pipettes/{id}', settings.pipette_settings_id)
+        self.app.router.add_patch(
+            '/settings/pipettes/{id}/fields', settings.modify_pipette_settings
+        )

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -84,5 +84,5 @@ class HTTPServer(object):
         self.app.router.add_get(
             '/settings/pipettes/{id}', settings.pipette_settings_id)
         self.app.router.add_patch(
-            '/settings/pipettes/{id}/fields', settings.modify_pipette_settings
+            '/settings/pipettes/{id}', settings.modify_pipette_settings
         )

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -12,7 +12,7 @@ defs = json.loads(
 
 
 @pytest.mark.parametrize('pipette_model',
-                         [c for c in pipette_config.configs if not
+                         [c for c in pipette_config.config_models if not
                           (c.startswith('p1000')
                            or c.startswith('p300_multi'))])
 def test_versioned_aspiration(pipette_model, monkeypatch):
@@ -42,7 +42,7 @@ def test_versioned_aspiration(pipette_model, monkeypatch):
 
 # TODO: make sure the mm of movement for max volume aspirate and max volume
 # TODO: dispense agree
-@pytest.mark.parametrize('pipette_model', pipette_config.configs)
+@pytest.mark.parametrize('pipette_model', pipette_config.config_models)
 def test_ul_per_mm_continuous(pipette_model):
     """
     For each model of pipette, for each boundary between pieces of the
@@ -85,9 +85,6 @@ def test_override_load():
     new_id = '0djaisoa921jas'
     new_pconf = pipette_config.load('p300_multi_v1.4', new_id)
 
-    # We shouldn’t write a new file for a nonexistent id
-    assert not (cdir/f'{new_id}.json').is_file()
-
     assert new_pconf != pconf
 
     unspecced = pipette_config.load('p300_multi_v1.4')
@@ -98,17 +95,42 @@ def test_override_save():
     cdir = CONFIG['pipette_config_overrides_dir']
 
     overrides = {
-        'pickUpCurrent': {"value": 1231.213},
-        'dropTipSpeed': {"value": 121}
+        'pickUpCurrent': {
+            "value": 1231.213},
+        'dropTipSpeed': {
+            "value": 121}
     }
 
     new_id = 'aoa2109j09cj2a'
+    model = 'p300_multi_v1'
 
-    pipette_config.save_overrides(new_id, overrides)
+    pipette_config.save_overrides(new_id, overrides, model)
 
     assert (cdir/f'{new_id}.json').is_file()
 
     loaded = pipette_config.load_overrides(new_id)
 
-    assert loaded['pickUpCurrent'] == overrides['pickUpCurrent']
-    assert loaded['dropTipSpeed'] == overrides['dropTipSpeed']
+    assert loaded['pickUpCurrent']['value'] == \
+        overrides['pickUpCurrent']['value']
+    assert loaded['dropTipSpeed']['value'] == \
+        overrides['dropTipSpeed']['value']
+
+
+def test_mutable_configs_only(monkeypatch):
+    # Test that only set mutable configs are populated in this dictionary
+
+    monkeypatch.setattr(
+        pipette_config, 'mutable_configs', ['tipLength', 'plungerCurrent'])
+
+    new_id = 'aoa2109j09cj2a'
+    model = 'p300_multi_v1'
+
+    pipette_config.save_overrides(new_id, {}, model)
+
+    config = pipette_config.list_mutable_configs(new_id)
+    # instead of dealing with unordered lists, convert to set and check whether
+    # these lists have a difference between them
+    difference = set(list(config.keys())) - \
+        set(pipette_config.mutable_configs)
+    # ensure empty
+    assert bool(difference) is False

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -24,7 +24,7 @@ def test_tip_tracking():
 
 
 def test_critical_points():
-    for config in pipette_config.configs:
+    for config in pipette_config.config_models:
         loaded = pipette_config.load(config)
         pip = pipette.Pipette(config,
                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
@@ -47,7 +47,7 @@ def test_critical_points():
 
 
 def test_volume_tracking():
-    for config in pipette_config.configs:
+    for config in pipette_config.config_models:
         loaded = pipette_config.load(config)
         pip = pipette.Pipette(config,
                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
@@ -73,25 +73,10 @@ def test_volume_tracking():
 
 
 def test_config_update():
-    for config in pipette_config.configs:
+    for config in pipette_config.config_models:
         pip = pipette.Pipette(config,
                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                               'testID')
-        sample_plunger_pos = {'top': {"value": 19.5,
-                                      "edit": True,
-                                      "min": 0,
-                                      "max": 5},
-                              'bottom': {"value": 2,
-                                         "edit": True,
-                                         "min": 0,
-                                         "max": 5},
-                              'blowOut': {"value": -1,
-                                          "edit": True,
-                                          "min": -6,
-                                          "max": 5},
-                              'dropTip': {"value": -4.5,
-                                          "edit": True,
-                                          "min": -6,
-                                          "max": 5}}
-        pip.update_config_item('plunger_positions', sample_plunger_pos)
-        assert pip.config.plunger_positions == sample_plunger_pos
+        sample_plunger_pos = {'top': 19.5}
+        pip.update_config_item('top', sample_plunger_pos.get('top'))
+        assert pip.config.top == sample_plunger_pos.get('top')

--- a/api/tests/opentrons/hardware_control/test_tip_probe.py
+++ b/api/tests/opentrons/hardware_control/test_tip_probe.py
@@ -35,7 +35,7 @@ async def test_input_checks(hardware_api, monkeypatch):
 
 
 @pytest.mark.parametrize('mount', [Mount.RIGHT, Mount.LEFT])
-@pytest.mark.parametrize('pipette_model', pipette_config.configs)
+@pytest.mark.parametrize('pipette_model', pipette_config.config_models)
 async def test_moves_to_hotspot(hardware_api, monkeypatch,
                                 mount, pipette_model):
     move_calls = []
@@ -103,7 +103,7 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
 
 
 @pytest.mark.parametrize('mount', [Mount.RIGHT, Mount.LEFT])
-@pytest.mark.parametrize('pipette_model', pipette_config.configs)
+@pytest.mark.parametrize('pipette_model', pipette_config.config_models)
 async def test_update_instrument_offset(hardware_api, mount, pipette_model):
     await hardware_api.cache_instruments({mount: pipette_model})
     p = Point(1, 2, 3)

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -67,7 +67,7 @@ def test_all_pipette_models_can_transfer():
 
 def test_pipette_models_reach_max_volume():
 
-    for model in pipette_config.configs:
+    for model in pipette_config.config_models:
         config = pipette_config.load(model)
         robot.reset()
         pipette = instruments._create_pipette_from_config(

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -8,7 +8,7 @@ from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, adapters
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
-from opentrons.config.pipette_config import configs
+from opentrons.config.pipette_config import config_models
 from opentrons.protocol_api import transfers as tf
 
 import pytest
@@ -27,7 +27,7 @@ def load_my_labware(monkeypatch):
 
 def test_load_instrument(loop):
     ctx = papi.ProtocolContext(loop=loop)
-    for config in configs:
+    for config in config_models:
         loaded = ctx.load_instrument(config, Mount.LEFT, replace=True)
         assert loaded.name == config
         prefix = config.split('_v')[0]

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -8,7 +8,8 @@ import pytest
 
 from opentrons.server import init
 from opentrons.data_storage import database as db
-from opentrons import config
+from opentrons.config import pipette_config
+from opentrons import config, types
 
 
 def validate_response_body(body):
@@ -163,3 +164,182 @@ async def test_reset_v2(virtual_smoothie_env, loop, async_client):
 
     # precondition
     await execute_reset_tests_v2(async_client)
+
+
+async def test_receive_pipette_settings(
+        async_server, loop, async_client):
+
+    test_model = 'p300_multi_v1'
+    test_id = 'abc123'
+    test_id2 = 'abcd123'
+    hw = async_server['com.opentrons.hardware']
+
+    if async_server['api_version'] == 1:
+        hw.model_by_mount = {'left': {'model': test_model, 'id': test_id},
+                             'right': {'model': test_model, 'id': test_id2}}
+        hw.get_attached_pipettes()
+    else:
+        hw._backend._attached_instruments = {
+            types.Mount.RIGHT: {'model': test_model, 'id': test_id},
+            types.Mount.LEFT: {'model': test_model, 'id': test_id2}
+        }
+
+        await hw.cache_instruments()
+
+    resp = await async_client.get('/settings/pipettes')
+    body = await resp.json()
+    assert test_id in body
+    assert body[test_id]['fields'] == pipette_config.list_mutable_configs(
+        pipette_id=test_id)
+
+
+async def test_receive_pipette_settings_one_pipette(
+        async_server, loop, async_client):
+    # This will check that sending a known pipette id works,
+    # and sending an unknown one does not
+    test_model = 'p300_multi_v1'
+    test_id = 'abc123'
+    test_id2 = 'abcd123'
+
+    hw = async_server['com.opentrons.hardware']
+    if async_server['api_version'] == 1:
+        hw.model_by_mount = {'left': {'model': test_model, 'id': test_id},
+                             'right': {'model': test_model, 'id': test_id2}}
+        hw.get_attached_pipettes()
+    else:
+        hw._backend._attached_instruments = {
+            types.Mount.RIGHT: {'model': test_model, 'id': test_id},
+            types.Mount.LEFT: {'model': test_model, 'id': test_id2}}
+        await hw.cache_instruments()
+    resp = await async_client.get('/settings/pipettes/{}'.format(test_id))
+    body = await resp.json()
+    assert body['fields'] == pipette_config.list_mutable_configs(
+        pipette_id=test_id)
+
+    # Non-existent pipette id and get 404
+    resp = await async_client.get(
+        '/settings/pipettes/{}'.format('wannabepipette'))
+    assert resp.status == 404
+
+
+async def test_modify_pipette_settings(async_server, loop, async_client):
+    # This test will check that setting modified pipette configs
+    # works as expected
+
+    test_model = 'p300_multi_v1'
+    test_id = 'abc123'
+    test_id2 = 'abcd123'
+
+    changes = {
+        'info': {
+            'model': test_model,
+            'id': test_id},
+        'fields': {
+            'pickUpCurrent': {'value': 1}
+            }
+        }
+
+    hw = async_server['com.opentrons.hardware']
+    if async_server['api_version'] == 1:
+        hw.model_by_mount = {'left': {'model': test_model, 'id': test_id},
+                             'right': {'model': test_model, 'id': test_id2}}
+        hw.get_attached_pipettes()
+    else:
+        hw._backend._attached_instruments = {
+            types.Mount.RIGHT: {'model': test_model, 'id': test_id},
+            types.Mount.LEFT: {'model': test_model, 'id': test_id2}}
+        await hw.cache_instruments()
+
+    # Check data has not been changed yet
+    resp = await async_client.get('/settings/pipettes/{}'.format(test_id))
+    body = await resp.json()
+    assert body['fields']['pickUpCurrent'] == \
+        pipette_config.list_mutable_configs(
+            pipette_id=test_id)['pickUpCurrent']
+
+    # Check that data is changed and matches the changes specified
+    resp = await async_client.patch(
+        '/settings/pipettes/{}/fields'.format(test_id),
+        json=changes)
+    assert resp.status == 204
+    check = await async_client.get('/settings/pipettes/{}'.format(test_id))
+    body = await check.json()
+    assert body['fields']['pickUpCurrent']['value'] == \
+        changes['fields']['pickUpCurrent']['value']
+
+    # Check that None reverts a setting to default
+    changes2 = {
+        'info': {
+            'model': test_model,
+            'id': test_id
+            },
+        'fields': {
+            'pickUpCurrent': None
+            }
+            }
+    resp = await async_client.patch(
+        '/settings/pipettes/{}/fields'.format(test_id),
+        json=changes2)
+    assert resp.status == 204
+    check = await async_client.get('/settings/pipettes/{}'.format(test_id))
+    body = await check.json()
+    assert body['fields']['pickUpCurrent']['value'] == \
+        pipette_config.list_mutable_configs(
+            pipette_id=test_id)['pickUpCurrent']['default']
+
+
+async def test_incorrect_modify_pipette_settings(
+        async_server, loop, async_client):
+
+    test_model = 'p300_multi_v1'
+    test_id = 'abc123'
+    test_id2 = 'abcd123'
+
+    bad_changes1 = {
+        'info': {
+            'model': test_model,
+            'id': test_id},
+        }
+
+    bad_changes2 = {
+        'fields': {
+            'pickUpCurrent': {'value': 1}
+            }
+        }
+
+    out_of_range = {
+            'info': {
+                'model': test_model,
+                'id': test_id},
+            'fields': {
+                'pickUpCurrent': {'value': 1000}
+                }
+            }
+    hw = async_server['com.opentrons.hardware']
+    if async_server['api_version'] == 1:
+        hw.model_by_mount = {'left': {'model': test_model, 'id': test_id},
+                             'right': {'model': test_model, 'id': test_id2}}
+        hw.get_attached_pipettes()
+    else:
+        hw._backend._attached_instruments = {
+            types.Mount.RIGHT: {'model': test_model, 'id': test_id},
+            types.Mount.LEFT: {'model': test_model, 'id': test_id2}}
+        await hw.cache_instruments()
+
+    # check no fields fails
+    resp = await async_client.patch(
+        '/settings/pipettes/{}/fields'.format(test_id),
+        json=bad_changes1)
+    assert resp.status == 400
+
+    # check no info fails
+    resp = await async_client.patch(
+        '/settings/pipettes/{}/fields'.format(test_id),
+        json=bad_changes2)
+    assert resp.status == 400
+
+    # check over max fails
+    resp = await async_client.patch(
+        '/settings/pipettes/{}/fields'.format(test_id),
+        json=out_of_range)
+    assert resp.status == 412

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -297,20 +297,11 @@ async def test_incorrect_modify_pipette_settings(
 
     bad_changes1 = {
         'info': {
-            'model': test_model,
-            'id': test_id},
-        }
-
-    bad_changes2 = {
-        'fields': {
             'pickUpCurrent': {'value': 1}
             }
         }
 
     out_of_range = {
-            'info': {
-                'model': test_model,
-                'id': test_id},
             'fields': {
                 'pickUpCurrent': {'value': 1000}
                 }
@@ -330,12 +321,6 @@ async def test_incorrect_modify_pipette_settings(
     resp = await async_client.patch(
         '/settings/pipettes/{}/fields'.format(test_id),
         json=bad_changes1)
-    assert resp.status == 400
-
-    # check no info fails
-    resp = await async_client.patch(
-        '/settings/pipettes/{}/fields'.format(test_id),
-        json=bad_changes2)
     assert resp.status == 400
 
     # check over max fails

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -2,22 +2,51 @@
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_multi_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -1,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -31,43 +60,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.4,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -1,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -143,22 +165,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_multi_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -2.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -5.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -172,43 +223,34 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.4,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -2.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 0.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -5.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -284,22 +326,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_multi_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -1,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -313,43 +384,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.4,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -1,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -425,22 +489,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_single_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -1,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -454,43 +547,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -1,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -571,22 +657,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_single_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -2.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -6,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -600,43 +715,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -2.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 0.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -6,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -717,22 +825,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p10_single_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -5.2,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 10,
@@ -746,43 +883,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.4,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -5.2,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 33,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -863,22 +993,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_multi_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2.5,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -3.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -892,43 +1051,34 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 2,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -3.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -994,22 +1144,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_multi_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -1023,43 +1202,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1125,22 +1297,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_multi_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -1154,43 +1355,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1256,22 +1450,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_single_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2.01,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -1285,43 +1508,34 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 2,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2.01,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1387,22 +1601,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_single_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -6,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -1416,43 +1659,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -6,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1518,22 +1754,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p50_single_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 50,
@@ -1547,43 +1812,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1649,22 +1907,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_multi_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 3,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 3.5,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -2,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 300,
@@ -1678,43 +1965,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 3,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 3.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -2,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1744,22 +2024,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_multi_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 1.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 3.5,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -3.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 300,
@@ -1773,43 +2082,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 1.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 3.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -3.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1839,22 +2141,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_multi_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 1.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 3.5,
+  },
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 8-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -3.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm",
     "value": 5,
   },
   "maxVolume": 300,
@@ -1868,43 +2199,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.6,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 1.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 3.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -3.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -1934,22 +2258,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_single_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 1.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 300,
@@ -1963,43 +2316,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 1.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2085,22 +2431,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_single_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": -1.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 1.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -5.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 300,
@@ -2114,43 +2489,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": -1.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 1.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -5.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2236,22 +2604,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p300_single_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 3,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4.5,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 300,
@@ -2265,43 +2662,36 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 10,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.3,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 3,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4.5,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2387,22 +2777,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p1000_single_v1 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 1,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 3,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 500,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 1000,
   },
   "displayName": "P1000 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -2.2,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 1000,
@@ -2416,45 +2835,38 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 15,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 1,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 3,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -2.2,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 76.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2504,22 +2916,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p1000_single_v1.3 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 500,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 1000,
   },
   "displayName": "P1000 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.7,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 1000,
@@ -2533,45 +2974,38 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 15,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 76.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2621,22 +3055,51 @@ Object {
 
 exports[`pipette data accessors getPipetteModelSpecs model p1000_single_v1.4 snapshot 1`] = `
 Object {
+  "blowout": Object {
+    "max": 10,
+    "min": -4,
+    "type": "float",
+    "units": "mm",
+    "value": 0.5,
+  },
+  "bottom": Object {
+    "max": 19,
+    "min": -2,
+    "type": "float",
+    "units": "mm",
+    "value": 2.5,
+  },
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 500,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 1000,
   },
   "displayName": "P1000 Single-Channel",
+  "dropTip": Object {
+    "max": 2,
+    "min": -6,
+    "type": "float",
+    "units": "mm",
+    "value": -4,
+  },
   "dropTipCurrent": Object {
     "max": 0.8,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.7,
   },
   "dropTipSpeed": Object {
     "max": 30,
     "min": 0.001,
+    "type": "float",
+    "units": "mm/sec",
     "value": 5,
   },
   "maxVolume": 1000,
@@ -2650,45 +3113,38 @@ Object {
   "pickUpCurrent": Object {
     "max": 1.2,
     "min": 0.05,
+    "type": "float",
+    "units": "amps",
     "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,
     "min": 1,
+    "type": "float",
+    "units": "mm",
     "value": 15,
   },
   "plungerCurrent": Object {
     "max": 0.5,
     "min": 0.1,
+    "type": "float",
+    "units": "amps",
     "value": 0.5,
-  },
-  "plungerPositions": Object {
-    "blowOut": Object {
-      "max": 10,
-      "min": -4,
-      "value": 0.5,
-    },
-    "bottom": Object {
-      "max": 19,
-      "min": -2,
-      "value": 2.5,
-    },
-    "dropTip": Object {
-      "max": 2,
-      "min": -6,
-      "value": -4,
-    },
-    "top": Object {
-      "max": 19.5,
-      "min": 5,
-      "value": 19.5,
-    },
   },
   "quirks": Array [
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "type": "float",
+    "units": "mm",
     "value": 76.7,
+  },
+  "top": Object {
+    "max": 19.5,
+    "min": 5,
+    "type": "float",
+    "units": "mm",
+    "value": 19.5,
   },
   "ulPerMm": Array [
     Object {
@@ -2740,9 +3196,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p10_multi snapshot 1`] 
 Object {
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 8-Channel",
@@ -2756,9 +3216,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p10_single snapshot 1`]
 Object {
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 5,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 50,
+    "min": 0.001,
     "value": 10,
   },
   "displayName": "P10 Single-Channel",
@@ -2772,9 +3236,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p50_multi snapshot 1`] 
 Object {
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 8-Channel",
@@ -2788,9 +3256,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p50_single snapshot 1`]
 Object {
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 25,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 100,
+    "min": 0.001,
     "value": 50,
   },
   "displayName": "P50 Single-Channel",
@@ -2804,9 +3276,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p300_multi snapshot 1`]
 Object {
   "channels": 8,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 8-Channel",
@@ -2820,9 +3296,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p300_single snapshot 1`
 Object {
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 150,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 600,
+    "min": 0.001,
     "value": 300,
   },
   "displayName": "P300 Single-Channel",
@@ -2836,9 +3316,13 @@ exports[`pipette data accessors getPipetteNameSpecs name p1000_single snapshot 1
 Object {
   "channels": 1,
   "defaultAspirateFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 500,
   },
   "defaultDispenseFlowRate": Object {
+    "max": 2000,
+    "min": 50,
     "value": 1000,
   },
   "displayName": "P1000 Single-Channel",

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -80,6 +80,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 33,
@@ -243,6 +245,10 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
+    "type": "float",
+    "units": "mm",
     "value": 33,
   },
   "top": Object {
@@ -404,6 +410,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 33,
@@ -567,6 +575,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 33,
@@ -735,6 +745,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 33,
@@ -903,6 +915,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 33,
@@ -1071,6 +1085,10 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
   },
   "top": Object {
@@ -1222,6 +1240,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -1375,6 +1395,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -1528,6 +1550,10 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
+    "type": "float",
+    "units": "mm",
     "value": 51.7,
   },
   "top": Object {
@@ -1679,6 +1705,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -1832,6 +1860,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -1985,6 +2015,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2102,6 +2134,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2219,6 +2253,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2336,6 +2372,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2509,6 +2547,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2682,6 +2722,8 @@ Object {
   },
   "quirks": Array [],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 51.7,
@@ -2857,6 +2899,8 @@ Object {
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 76.7,
@@ -2996,6 +3040,8 @@ Object {
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 76.7,
@@ -3135,6 +3181,8 @@ Object {
     "needs-pickup-shake",
   ],
   "tipLength": Object {
+    "max": 100,
+    "min": 0,
     "type": "float",
     "units": "mm",
     "value": 76.7,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -95,7 +95,9 @@
       "tipLength": {
         "value": 33,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p10_single_v1.3": {
@@ -195,7 +197,9 @@
       "tipLength": {
         "value": 33,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p10_single_v1.4": {
@@ -294,7 +298,10 @@
       "tipLength": {
         "value": 33,
         "units": "mm",
-        "type": "float"}
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
     },
     "p10_multi_v1": {
       "name": "p10_multi",
@@ -391,7 +398,9 @@
       "tipLength": {
         "value": 33,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p10_multi_v1.3": {
@@ -486,7 +495,13 @@
         "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
     },
     "p10_multi_v1.4": {
       "name": "p10_multi",
@@ -583,7 +598,9 @@
       "tipLength": {
         "value": 33,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p50_single_v1": {
@@ -676,7 +693,13 @@
         "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
     },
     "p50_single_v1.3": {
       "name": "p50_single",
@@ -771,7 +794,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p50_single_v1.4": {
@@ -867,7 +892,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p50_multi_v1": {
@@ -960,7 +987,13 @@
         "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
     },
     "p50_multi_v1.3": {
       "name": "p50_multi",
@@ -1055,7 +1088,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p50_multi_v1.4": {
@@ -1151,7 +1186,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_single_v1": {
@@ -1251,7 +1288,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_single_v1.3": {
@@ -1351,7 +1390,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_single_v1.4": {
@@ -1451,7 +1492,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_multi_v1": {
@@ -1535,7 +1578,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_multi_v1.3": {
@@ -1619,7 +1664,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p300_multi_v1.4": {
@@ -1703,7 +1750,9 @@
       "tipLength": {
         "value": 51.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p1000_single_v1": {
@@ -1791,7 +1840,9 @@
       "tipLength": {
         "value": 76.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p1000_single_v1.3": {
@@ -1879,7 +1930,9 @@
       "tipLength": {
         "value": 76.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     },
     "p1000_single_v1.4": {
@@ -1967,7 +2020,9 @@
       "tipLength": {
         "value": 76.7,
         "units": "mm",
-        "type": "float"
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
     }
   },

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -2,53 +2,70 @@
   "config": {
     "p10_single_v1": {
       "name": "p10_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -1,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "type": "float",
+        "units": "mm"
+      },
+      "blowout": {
+        "value": -1,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30},
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
+      },
       "ulPerMm": [{
         "aspirate": [
           [1.8263, -0.0958, 1.088],
@@ -75,41 +92,55 @@
         }
       ],
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p10_single_v1.3": {
       "name": "p10_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 0.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -2.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -6,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 0.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -2.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -6,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
       "ulPerMm": [
@@ -141,55 +172,75 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
 
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p10_single_v1.4": {
       "name": "p10_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -5.2,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5.2,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.4,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
       "ulPerMm": [
@@ -221,54 +272,73 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float"}
     },
     "p10_multi_v1": {
       "name": "p10_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -1,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -1,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.4,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -299,54 +369,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p10_multi_v1.3": {
       "name": "p10_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 0.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -2.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -5.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 0.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -2.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.4,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -377,54 +467,70 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
       "tipLength": {"value": 33}
     },
     "p10_multi_v1.4": {
       "name": "p10_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -1,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -1,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.4,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -455,54 +561,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 33}
+      "tipLength": {
+        "value": 33,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p50_single_v1": {
       "name": "p50_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2.01,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 2,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2.01,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 2,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "ulPerMm": [
@@ -531,70 +657,92 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
       "tipLength": {"value": 51.7}
     },
     "p50_single_v1.3": {
       "name": "p50_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -6,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -6,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "ulPerMm": [
         {
@@ -620,41 +768,55 @@
         }
       ],
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p50_single_v1.4": {
       "name": "p50_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "ulPerMm": [
@@ -683,54 +845,74 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p50_multi_v1": {
       "name": "p50_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 2,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -3.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 2,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -3.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -759,54 +941,70 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
       "tipLength": {"value": 51.7}
     },
     "p50_multi_v1.3": {
       "name": "p50_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -835,54 +1033,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p50_multi_v1.4": {
       "name": "p50_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -911,54 +1129,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_single_v1": {
       "name": "p300_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 1.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 1.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "ulPerMm": [
@@ -991,54 +1229,74 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_single_v1.3": {
       "name": "p300_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 1.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": -1.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -5.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 1.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -1.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "ulPerMm": [
@@ -1071,54 +1329,74 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_single_v1.4": {
       "name": "p300_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 3,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 3,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
       "ulPerMm": [
@@ -1151,54 +1429,74 @@
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_multi_v1": {
       "name": "p300_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 3.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 3,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -2,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 3.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 3,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -2,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -1215,54 +1513,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_multi_v1.3": {
       "name": "p300_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 3.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 1.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -3.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 3.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 1.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -3.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -1279,54 +1597,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p300_multi_v1.4": {
       "name": "p300_multi",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 3.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 1.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -3.5,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 3.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 1.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -3.5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.6,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 10,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
       "ulPerMm": [
@@ -1343,54 +1681,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "quirks": [],
-      "tipLength": {"value": 51.7}
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p1000_single_v1": {
       "name": "p1000_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 3,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 1,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -2.2,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 3,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 1,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -2.2,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 15,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
       "ulPerMm": [
@@ -1411,54 +1769,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": ["needs-pickup-shake"],
-      "tipLength": {"value": 76.7}
+      "tipLength": {
+        "value": 76.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p1000_single_v1.3": {
       "name": "p1000_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 15,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
       "ulPerMm": [
@@ -1479,54 +1857,74 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.7,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": ["needs-pickup-shake"],
-      "tipLength": {"value": 76.7}
+      "tipLength": {
+        "value": 76.7,
+        "units": "mm",
+        "type": "float"
+      }
     },
     "p1000_single_v1.4": {
       "name": "p1000_single",
-      "plungerPositions": {
-        "top": {
-          "value": 19.5,
-          "min": 5,
-          "max": 19.5
-        },
-        "bottom": {
-          "value": 2.5,
-          "min": -2,
-          "max": 19.0
-        },
-        "blowOut": {
-          "value": 0.5,
-          "min": -4,
-          "max": 10
-        },
-        "dropTip": {
-          "value": -4,
-          "min": -6,
-          "max": 2
-        }
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2.5,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -4,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
       },
       "pickUpCurrent": {
         "value": 0.1,
         "min": 0.05,
-        "max": 1.2
+        "max": 1.2,
+        "units": "amps",
+        "type": "float"
       },
       "pickUpDistance": {
         "value": 15,
         "min": 1,
-        "max": 30
+        "max": 30,
+        "units": "mm",
+        "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
       "ulPerMm": [
@@ -1547,22 +1945,32 @@
       "plungerCurrent": {
         "value": 0.5,
         "min": 0.1,
-        "max": 0.5
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipCurrent": {
         "value": 0.7,
         "min": 0.1,
-        "max": 0.8
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
       },
       "dropTipSpeed": {
         "value": 5,
         "min": 0.001,
-        "max": 30
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
       },
       "quirks": ["needs-pickup-shake"],
-      "tipLength": {"value": 76.7}
+      "tipLength": {
+        "value": 76.7,
+        "units": "mm",
+        "type": "float"
+      }
     }
   },
-  "mutableConfigs": ["top", "bottom", "blowOut", "dropTip", "pickUpCurrent", "pickUpDistance", "plungerCurrent", "dropTipCurrent", "dropTipSpeed", "tipLength", "defaultAspirateFlowRate", "defaultDispenseFlowRate"]
+  "mutableConfigs": ["top", "bottom", "blowout", "dropTip", "pickUpCurrent", "pickUpDistance", "plungerCurrent", "dropTipCurrent", "dropTipSpeed", "tipLength", "defaultAspirateFlowRate", "defaultDispenseFlowRate"]
 
 }

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -4,53 +4,109 @@
     "minVolume": 1,
     "maxVolume": 10,
     "channels": 1,
-    "defaultAspirateFlowRate": {"value": 5},
-    "defaultDispenseFlowRate": {"value": 10}
+    "defaultAspirateFlowRate": {
+      "value": 5,
+      "min": 0.001,
+      "max": 50
+    },
+    "defaultDispenseFlowRate": {
+      "value": 10,
+      "min": 0.001,
+      "max": 50
+    }
   },
   "p10_multi": {
     "displayName": "P10 8-Channel",
     "minVolume": 1,
     "maxVolume": 10,
-    "defaultAspirateFlowRate": {"value": 5},
-    "defaultDispenseFlowRate": {"value": 10},
+    "defaultAspirateFlowRate": {
+      "value": 5,
+      "min": 0.001,
+      "max": 50
+    },
+    "defaultDispenseFlowRate": {
+      "value": 10,
+      "min": 0.001,
+      "max": 50
+    },
     "channels": 8
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
-    "defaultAspirateFlowRate": {"value": 25},
-    "defaultDispenseFlowRate": {"value": 50},
+    "defaultAspirateFlowRate": {
+      "value": 25,
+      "min": 0.001,
+      "max": 100
+    },
+    "defaultDispenseFlowRate": {
+      "value": 50,
+      "min": 0.001,
+      "max": 100
+    },
     "channels": 1,
     "minVolume": 5,
     "maxVolume": 50
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
-    "defaultAspirateFlowRate": {"value": 25},
-    "defaultDispenseFlowRate": {"value": 50},
+    "defaultAspirateFlowRate": {
+      "value": 25,
+      "min": 0.001,
+      "max": 100
+    },
+    "defaultDispenseFlowRate": {
+      "value": 50,
+      "min": 0.001,
+      "max": 100
+    },
     "channels": 8,
     "minVolume": 5,
     "maxVolume": 50
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
-    "defaultAspirateFlowRate": {"value": 150},
-    "defaultDispenseFlowRate": {"value": 300},
+    "defaultAspirateFlowRate": {
+      "value": 150,
+      "min": 0.001,
+      "max": 600
+    },
+    "defaultDispenseFlowRate": {
+      "value": 300,
+      "min": 0.001,
+      "max": 600
+    },
     "channels": 1,
     "minVolume": 30,
     "maxVolume": 300
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
-    "defaultAspirateFlowRate": {"value": 150},
-    "defaultDispenseFlowRate": {"value": 300},
+    "defaultAspirateFlowRate": {
+      "value": 150,
+      "min": 0.001,
+      "max": 600
+    },
+    "defaultDispenseFlowRate": {
+      "value": 300,
+      "min": 0.001,
+      "max": 600
+    },
     "channels": 8,
     "minVolume": 30,
     "maxVolume": 300
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
-    "defaultAspirateFlowRate": {"value": 500},
-    "defaultDispenseFlowRate": {"value": 1000},
+    "defaultAspirateFlowRate": {
+      "value": 500,
+      "min": 50,
+      "max": 2000
+    },
+    "defaultDispenseFlowRate": {
+      "value": 1000,
+      "min": 50,
+      "max": 2000
+    },
     "channels": 1,
     "minVolume": 100,
     "maxVolume": 1000

--- a/shared-data/robot-data/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/robot-data/schemas/pipetteModelSpecsSchema.json
@@ -40,7 +40,10 @@
      "properties": {
        "value": {"type": ["number", "array"]},
        "min": {"type": "number"},
-       "max": {"type": "number"}
+       "max": {"type": "number"},
+       "units": {"type": "string"},
+       "type": {"type": "string"},
+       "displayName": {"type": "string"}
     }
   }
   },
@@ -57,7 +60,10 @@
         ".*": {
           "required": [
             "name",
-            "plungerPositions",
+            "top",
+            "bottom",
+            "blowout",
+            "dropTip",
             "pickUpCurrent",
             "pickUpDistance",
             "modelOffset",
@@ -74,17 +80,10 @@
               "description": "reference to name of this version, should match a key in pipetteNameSpecs.json",
               "type": "string"
             },
-            "plungerPositions": {
-              "type": "object",
-              "required": ["top", "bottom", "blowOut", "dropTip"],
-              "additionalProperties": false,
-              "properties": {
-                "top": {"$ref": "#/definitions/editConfigurations"},
-                "bottom": {"$ref": "#/definitions/editConfigurations"},
-                "blowOut": {"$ref": "#/definitions/editConfigurations"},
-                "dropTip": {"$ref": "#/definitions/editConfigurations"}
-              }
-            },
+            "top": {"$ref": "#/definitions/editConfigurations"},
+            "bottom": {"$ref": "#/definitions/editConfigurations"},
+            "blowout": {"$ref": "#/definitions/editConfigurations"},
+            "dropTip": {"$ref": "#/definitions/editConfigurations"},
             "pickUpCurrent": {"$ref": "#/definitions/editConfigurations"},
             "pickUpDistance": {"$ref": "#/definitions/editConfigurations"},
             "modelOffset": {"$ref": "#/definitions/xyzArray"},

--- a/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/robot-data/schemas/pipetteNameSpecsSchema.json
@@ -28,8 +28,15 @@
       "additionalProperties": false,
       "properties": {
         "channels": {"$ref": "#/definitions/channels"},
-        "defaultAspirateFlowRate": {"value": {"$ref": "#/definitions/positiveNumber"}},
-        "defaultDispenseFlowRate": {"value": {"$ref": "#/definitions/positiveNumber"}},
+        "defaultAspirateFlowRate": {
+          "value": {"$ref": "#/definitions/positiveNumber"},
+          "min": {"$ref": "#/definitions/positiveNumber"},
+          "max": {"$ref": "#/definitions/positiveNumber"}},
+        "defaultDispenseFlowRate": {
+          "value": {"$ref": "#/definitions/positiveNumber"},
+          "min": {"$ref": "#/definitions/positiveNumber"},
+          "max": {"$ref": "#/definitions/positiveNumber"}
+        },
         "displayName": {"type": "string"},
         "maxVolume": {"$ref": "#/definitions/positiveNumber"},
         "minVolume": {"$ref": "#/definitions/positiveNumber"}


### PR DESCRIPTION
## overview

Accidentally merged this PR during a release. See merged PR and revert here. There is a slight modification to the PATCH endpoint in that it no longer relies on an info field sent by the user.

## changelog
- Add functions to pipette_config to allow for easier access/shape of data
- Change plunger positions to top level keys instead of nested
- Add three endpoints to get all configs, get a particular config and modify the config

## How-To on Testing
Endpoints are the following:
GET request to ```/settings/pipettes``` returns all pipette configs saved on that robot (will populate for any pipette that has been attached on your robot)
GET request to ```/settings/pipettes/{id}``` returns one pipette config for a known id on the robot (ids can be found from first GET request)
PATCH request to ```/settings/pipettes/{id}/fields``` to modify a config. The shape of this should be:

```
    'fields': {
            'pickUpCurrent': {'value': some_value},
            'dropTipSpeed': {'value': some_value}
    }
    If a value needs to be reset, simply type in the body formatted as above:
        'configKey': null
    }
```

## review requests
@mcous I need help with commit messaging whenever you get the chance.
@Kadee80 does this patch endpoint still seem reasonable to you?
@IanLondon implementation of PATCH look ok?