### PR TITLE
fix(api): Relax numpy version constraints for wheel

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -106,7 +106,7 @@ PACKAGES = find_packages(where='src')
 INSTALL_REQUIRES = [
     'pyserial==3.2.1',
     'aiohttp==2.3.8',
-    'numpy==1.12.1',
+    'numpy>=1.12.1',
     'urwid==1.3.1']
 
 


### PR DESCRIPTION
The strict constraint on numpy makes it very hard to install on windows, since
this is a version that requires msvc to compile lapack dependencies; it also
conflicts with most jupyter installations which have transitive dependencies
from e.g. astropy that require different versions.
