### PR TITLE
feat(protocol-designer): update title and add beta tag

### DIFF
--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -43,6 +43,15 @@ function TitleWithIcon (props: TitleWithIconProps) {
   )
 }
 
+type TitleWithBetaTagProps = {text?: ?string}
+
+const TitleWithBetaTag = (props: TitleWithBetaTagProps) => (
+  <div className={styles.title_wrapper}>
+    <div className={styles.icon_inline_text}>{props.text}</div>
+    <div className={styles.beta_tag}>{i18n.t('application.beta')}</div>
+  </div>
+)
+
 function mapStateToProps (state: BaseState): SP {
   const selectedLabwareId = labwareIngredSelectors.getSelectedLabwareId(state)
   const _page = selectors.getCurrentPage(state)
@@ -59,13 +68,18 @@ function mapStateToProps (state: BaseState): SP {
 
   switch (_page) {
     case 'liquids':
-    case 'file-splash':
     case 'file-detail':
+      return {
+        _page,
+        title: i18n.t([`nav.title.${_page}`, fileName]),
+        subtitle: i18n.t([`nav.subtitle.${_page}`, '']),
+      }
+    case 'file-splash':
     case 'settings-features':
     case 'settings-app':
       return {
         _page,
-        title: i18n.t([`nav.title.${_page}`, fileName]),
+        title: <TitleWithBetaTag text={i18n.t([`nav.title.${_page}`, fileName])} />,
         subtitle: i18n.t([`nav.subtitle.${_page}`, '']),
       }
     case 'steplist':

--- a/protocol-designer/src/containers/TitleBar.css
+++ b/protocol-designer/src/containers/TitleBar.css
@@ -1,3 +1,5 @@
+@import '@opentrons/components';
+
 .icon {
   vertical-align: middle;
   height: 1.25rem;
@@ -13,4 +15,20 @@
   position: sticky;
   top: 0;
   z-index: 101;
+}
+
+.title_wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.beta_tag {
+  font-size: 1rem;
+  font-weight: 500;
+  margin-left: 0.75rem;
+  padding: 0.4rem 0.5rem;
+  color: var(--c-font-light);
+  background-color: var(--c-med-gray);
+  letter-spacing: 0.5px;
+  border-radius: 0.3125rem;
 }

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -3,5 +3,6 @@
     "mix": "mix",
     "moveLiquid": "transfer",
     "pause": "pause"
-  }
+  },
+  "beta": "beta"
 }

--- a/protocol-designer/src/localization/en/nav.json
+++ b/protocol-designer/src/localization/en/nav.json
@@ -16,9 +16,9 @@
     "__end__": "Final Deck State"
   },
   "title": {
-    "settings-features": "Opentrons Beta",
-    "settings-app": "Opentrons Beta",
-    "file-splash": "Opentrons Beta"
+    "settings-features": "Protocol Designer",
+    "settings-app": "Protocol Designer",
+    "file-splash": "Protocol Designer"
   },
   "subtitle": {
     "file-detail": "File Details",


### PR DESCRIPTION
Closes #3127

*Changelog*
- changes the title from "Opentrons Beta" to "Protocol Designer [BETA]"
- gives the Beta tag a separate style