### PR TITLE
feat(protocol-designer): add change tip and reasons for disabled path

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -157,9 +157,17 @@
   padding: 0.5rem;
 }
 
+.path_tooltip_image.disabled {
+  opacity: 0.5;
+}
+
 .path_tooltip_title {
   font-size: var(--fs-header);
   text-align: center;
+}
+
+.path_tooltip_title.disabled {
+  opacity: 0.5;
 }
 
 .path_tooltip_subtitle {

--- a/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
@@ -78,7 +78,7 @@ const PathButton = (buttonProps: ButtonProps) => {
 
 const getSubtitle = (path: PathOption, disabledPathMap: ?{[PathOption]: string}) => {
   const reasonForDisabled = disabledPathMap && disabledPathMap[path]
-  return reasonForDisabled || i18n.t(`form.step_edit_form.field.path.subtitle.${path}`)
+  return reasonForDisabled || ''
 }
 const PathField = (props: PathFieldProps) => {
   return (

--- a/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
@@ -92,7 +92,7 @@ const PathField = (props: PathFieldProps) => {
                 key={option.name}
                 selected={option.name === value}
                 path={option.name}
-                disabled={props.disabledPathMap && Object.keys(props.disabledPathMap).includes(option.name)}
+                disabled={props.disabledPathMap && props.disabledPathMap.hasOwnProperty(option.name)}
                 subtitle={getSubtitle(option.name, props.disabledPathMap)}
                 onClick={() => updateValue(option.name)}>
                 <img src={option.image} className={styles.path_image} />

--- a/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/Path.js
@@ -34,30 +34,28 @@ const ALL_PATH_OPTIONS = [
 
 type PathFieldProps = {
   focusHandlers: FocusHandlers,
-  disabledPaths: ?Set<PathOption>,
+  disabledPathMap: ?{[PathOption]: string},
 }
 
 type ButtonProps = {
   children?: React.Node,
   disabled?: ?boolean,
   selected?: boolean,
+  subtitle: string,
   onClick?: (e: SyntheticMouseEvent<*>) => mixed,
   path: PathOption,
 }
 
 const PathButton = (buttonProps: ButtonProps) => {
-  const {disabled, children, path, selected, onClick} = buttonProps
+  const {disabled, children, path, selected, onClick, subtitle} = buttonProps
 
   const tooltip = (
     <div>
-      <div className={styles.path_tooltip_title}>
+      <div className={cx(styles.path_tooltip_title, {[styles.disabled]: disabled})}>
         {i18n.t(`form.step_edit_form.field.path.title.${path}`)}
       </div>
-      <img className={styles.path_tooltip_image} src={PATH_ANIMATION_IMAGES[path]} />
-      <div className={styles.path_tooltip_subtitle}>{i18n.t(disabled
-        ? `form.step_edit_form.field.path.not_compatible`
-        : `form.step_edit_form.field.path.subtitle.${path}`)}
-      </div>
+      <img className={cx(styles.path_tooltip_image, {[styles.disabled]: disabled})} src={PATH_ANIMATION_IMAGES[path]} />
+      <div className={styles.path_tooltip_subtitle}>{subtitle}</div>
     </div>
   )
 
@@ -78,25 +76,32 @@ const PathButton = (buttonProps: ButtonProps) => {
   )
 }
 
-const PathField = (props: PathFieldProps) => (
-  <FormGroup label='Path:'>
-    <StepField
-      name="path"
-      render={({value, updateValue}) => (
-        <ul className={styles.path_options}>
-          {ALL_PATH_OPTIONS.map(option => (
-            <PathButton
-              key={option.name}
-              selected={option.name === value}
-              path={option.name}
-              disabled={props.disabledPaths && props.disabledPaths.has(option.name)}
-              onClick={() => updateValue(option.name)}>
-              <img src={option.image} className={styles.path_image} />
-            </PathButton>
-          ))}
-        </ul>
-      )} />
-  </FormGroup>
-)
+const getSubtitle = (path: PathOption, disabledPathMap: ?{[PathOption]: string}) => {
+  const reasonForDisabled = disabledPathMap && disabledPathMap[path]
+  return reasonForDisabled || i18n.t(`form.step_edit_form.field.path.subtitle.${path}`)
+}
+const PathField = (props: PathFieldProps) => {
+  return (
+    <FormGroup label='Path:'>
+      <StepField
+        name="path"
+        render={({value, updateValue}) => (
+          <ul className={styles.path_options}>
+            {ALL_PATH_OPTIONS.map(option => (
+              <PathButton
+                key={option.name}
+                selected={option.name === value}
+                path={option.name}
+                disabled={props.disabledPathMap && Object.keys(props.disabledPathMap).includes(option.name)}
+                subtitle={getSubtitle(option.name, props.disabledPathMap)}
+                onClick={() => updateValue(option.name)}>
+                <img src={option.image} className={styles.path_image} />
+              </PathButton>
+            ))}
+          </ul>
+        )} />
+    </FormGroup>
+  )
+}
 
 export default PathField

--- a/protocol-designer/src/components/StepEditForm/fields/Path/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/index.js
@@ -27,30 +27,30 @@ function getDisabledPathMap (
 
   // changeTip is lowest priority disable reasoning
   if (changeTip === 'perDest') {
-    disabledPathMap = {...disabledPathMap, multiDispense: i18n.t('form.step_edit_form.field.path.incompatible_with_per_dest')}
+    disabledPathMap = {...disabledPathMap, multiDispense: i18n.t('form.step_edit_form.field.path.subtitle.incompatible_with_per_dest')}
   } else if (changeTip === 'perSource') {
-    disabledPathMap = {...disabledPathMap, multiAspirate: i18n.t('form.step_edit_form.field.path.incompatible_with_per_source')}
+    disabledPathMap = {...disabledPathMap, multiAspirate: i18n.t('form.step_edit_form.field.path.subtitle.incompatible_with_per_source')}
   }
 
   // transfer volume overwrites change tip disable reasoning
   if (!withinCapacityForMultiPath) {
     disabledPathMap = {
       ...disabledPathMap,
-      multiAspirate: i18n.t('form.step_edit_form.field.path.volume_too_high'),
-      multiDispense: i18n.t('form.step_edit_form.field.path.volume_too_high'),
+      multiAspirate: i18n.t('form.step_edit_form.field.path.subtitle.volume_too_high'),
+      multiDispense: i18n.t('form.step_edit_form.field.path.subtitle.volume_too_high'),
     }
   }
 
   // wellRatio overwrites all other disable reasoning
   if (wellRatio === '1:many') {
-    disabledPathMap = {...disabledPathMap, multiAspirate: i18n.t('form.step_edit_form.field.path.only_many_to_1')}
+    disabledPathMap = {...disabledPathMap, multiAspirate: i18n.t('form.step_edit_form.field.path.subtitle.only_many_to_1')}
   } else if (wellRatio === 'many:1') {
-    disabledPathMap = {...disabledPathMap, multiDispense: i18n.t('form.step_edit_form.field.path.only_1_to_many')}
+    disabledPathMap = {...disabledPathMap, multiDispense: i18n.t('form.step_edit_form.field.path.subtitle.only_1_to_many')}
   } else {
     disabledPathMap = {
       ...disabledPathMap,
-      multiAspirate: i18n.t('form.step_edit_form.field.path.only_many_to_1'),
-      multiDispense: i18n.t('form.step_edit_form.field.path.only_1_to_many'),
+      multiAspirate: i18n.t('form.step_edit_form.field.path.subtitle.only_many_to_1'),
+      multiDispense: i18n.t('form.step_edit_form.field.path.subtitle.only_1_to_many'),
     }
   }
 

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -28,8 +28,8 @@
         "option": {
           "always": "Always",
           "once": "Once",
-          "perSource": "Per Source",
-          "perDest": "Per Destination",
+          "perSource": "Per Source Well",
+          "perDest": "Per Destination Well",
           "never": "Never"
         },
         "option_tooltip": {
@@ -65,15 +65,12 @@
           "multiDispense": "Multi-Dispense"
         },
         "subtitle": {
-          "single": "Speed: slower",
-          "multiAspirate": "Speed: faster",
-          "multiDispense": "Speed: faster"
-        },
-        "only_1_to_many": "Only compatible with 1-to-Many well ratios",
-        "only_many_to_1": "Only compatible with Many-to-1 well ratios",
-        "volume_too_high": "Transfer Volume too high",
-        "incompatible_with_per_dest": "Incompatible with \"Per Destination\" Change Tip setting",
-        "incompatible_with_per_source": "Incompatible with \"Per Source\" Change Tip setting"
+          "only_1_to_many": "Only compatible with 1-to-Many well ratios",
+          "only_many_to_1": "Only compatible with Many-to-1 well ratios",
+          "volume_too_high": "Transfer Volume too high",
+          "incompatible_with_per_dest": "Incompatible with \"Per Destination Well\" Change Tip setting",
+          "incompatible_with_per_source": "Incompatible with \"Per Source Well\" Change Tip setting"
+        }
       }
     },
     "section": {

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -69,7 +69,11 @@
           "multiAspirate": "Speed: faster",
           "multiDispense": "Speed: faster"
         },
-        "not_compatible": "Not compatible with current step settings"
+        "only_1_to_many": "Only compatible with 1-to-Many well ratios",
+        "only_many_to_1": "Only compatible with Many-to-1 well ratios",
+        "volume_too_high": "Transfer Volume too high",
+        "incompatible_with_per_dest": "Incompatible with \"Per Destination\" Change Tip setting",
+        "incompatible_with_per_source": "Incompatible with \"Per Source\" Change Tip setting"
       }
     },
     "section": {


### PR DESCRIPTION
Previously we gave generic reasons to explain why a given Path option had been disabled. As we have
nailed down the interactions of the MoveLiquid form a little more, it became clear that explaining
the reason for disabling was a big UX win. Now when a path option is disabled, the tooltip has a
different visual treatment, as well as a custom explanation of why it has been disabled. Also fixed
a bug preventing the path options from being disabled by incompatible changeTip options.

Closes #3137

## Review Requests 
- [ ] make sure that paths are still disabled as expected before
- [ ] make sure that paths are now disabled when incompatible changeTip options are selected
- [ ] make sure that the tooltip subtitle is as expected for the highest priority disabling factor:
     The priority order is as follows: 
        1. incompatible Well Ratio will always be displayed over other disabling factors
        2. excessive transfer volume will be displayed over Change Tip, but not over Well Ratio
        3. incompatible Change Tip selection will only be displayed if neither of the above are already disabling an option  


