### PR TITLE
refactor(app): Connect pipette config form to api endpoint

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -1,48 +1,37 @@
 // @flow
 import * as React from 'react'
+import {connect} from 'react-redux'
+import {Link} from 'react-router-dom'
 import {Formik} from 'formik'
 import startCase from 'lodash/startCase'
-
 import mapValues from 'lodash/mapValues'
 
+import {makeGetRobotPipetteConfigs} from '../../http-api-client'
+import {BottomButtonBar} from '../modals'
 import ConfigFormGroup, {FormColumn} from './ConfigFormGroup'
 
-import type {Pipette} from '../../http-api-client'
+import type {State} from '../../types'
+import type {Robot} from '../../discovery'
+import type {
+  Pipette,
+  Field,
+  PipetteConfigResponse,
+  PipetteConfigFields,
+} from '../../http-api-client'
 
-// TODO (ka 2-19-2019):
-// Move to settings.js when no longer mock data based
-
-type FieldProps = {
-  value: ?number,
-  default: number,
-  min?: number,
-  max?: number,
-  units?: string,
-  type?: string,
-}
-
-export type DisplayFieldProps = FieldProps & {
+export type DisplayFieldProps = Field & {
   name: string,
   displayName: string,
 }
 
-type ConfigFields = {[string]: FieldProps}
-
-type PipetteConfigOptions = {
-  info: {
-    name: ?string,
-    model: ?string,
-    id: ?string,
-  },
-  fields: ConfigFields,
-}
-
 type OP = {
+  robot: Robot,
   pipette: Pipette,
+  parentUrl: string,
 }
 
 type SP = {
-  options?: PipetteConfigOptions,
+  pipetteConfig: ?PipetteConfigResponse,
 }
 
 type Props = SP & OP
@@ -51,10 +40,10 @@ const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
 const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
 const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 
-export default class ConfigForm extends React.Component<Props> {
+class ConfigForm extends React.Component<Props> {
   getFieldsByKey (
     keys: Array<string>,
-    fields: ConfigFields
+    fields: PipetteConfigFields
   ): Array<DisplayFieldProps> {
     return keys.map(k => {
       const field = fields[k]
@@ -69,150 +58,83 @@ export default class ConfigForm extends React.Component<Props> {
   }
 
   render () {
-    const {fields} = OPTIONS
-    const initialValues = mapValues(fields, f => {
-      return f.value !== f.default ? f.value.toString() : null
-    })
-    const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
-    const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
-    const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
-    return (
-      <Formik
-        initialValues={initialValues}
-        render={formProps => {
-          const {values, handleChange} = formProps
-          return (
-            <form>
-              <FormColumn>
-                <ConfigFormGroup
-                  groupLabel="Plunger Positions"
-                  values={values}
-                  formFields={plungerFields}
-                  onChange={handleChange}
-                  error={null}
-                />
+    const {pipetteConfig, parentUrl} = this.props
 
-                <ConfigFormGroup
-                  groupLabel="Power / Force"
-                  values={values}
-                  formFields={powerFields}
-                  onChange={handleChange}
-                  error={null}
+    if (!pipetteConfig) {
+      return null
+    } else {
+      const {fields} = pipetteConfig
+      const initialValues = mapValues(fields, f => {
+        return f.value !== f.default ? f.value.toString() : null
+      })
+      const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
+      const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
+      const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
+      return (
+        <Formik
+          initialValues={initialValues}
+          render={formProps => {
+            const {values, handleChange} = formProps
+            return (
+              <form>
+                <FormColumn>
+                  <ConfigFormGroup
+                    groupLabel="Plunger Positions"
+                    values={values}
+                    formFields={plungerFields}
+                    onChange={handleChange}
+                    error={null}
+                  />
+
+                  <ConfigFormGroup
+                    groupLabel="Power / Force"
+                    values={values}
+                    formFields={powerFields}
+                    onChange={handleChange}
+                    error={null}
+                  />
+                </FormColumn>
+                <FormColumn>
+                  <ConfigFormGroup
+                    groupLabel="Tip Pickup / Drop "
+                    values={values}
+                    formFields={tipFields}
+                    onChange={handleChange}
+                    error={null}
+                  />
+                </FormColumn>
+                <BottomButtonBar
+                  buttons={[
+                    {children: 'cancel', Component: Link, to: parentUrl},
+                  ]}
                 />
-              </FormColumn>
-              <FormColumn>
-                <ConfigFormGroup
-                  groupLabel="Tip Pickup / Drop "
-                  values={values}
-                  formFields={tipFields}
-                  onChange={handleChange}
-                  error={null}
-                />
-              </FormColumn>
-            </form>
-          )
-        }}
-      />
-    )
+              </form>
+            )
+          }}
+        />
+      )
+    }
   }
 }
 
-// GET /settings/pipettes/P50MV1318060102
-const OPTIONS = {
-  info: {
-    name: 'p50_multi',
-    model: 'p50_multi_v1.3',
-  },
-  fields: {
-    top: {
-      value: 19.5,
-      min: 5,
-      max: 19.5,
-      units: 'mm',
-      type: 'float',
-      default: 19.5,
-    },
-    bottom: {
-      value: 0,
-      min: -2,
-      max: 19,
-      units: 'mm',
-      type: 'float',
-      default: 2,
-    },
-    blowout: {
-      value: 0.5,
-      min: -4,
-      max: 10,
-      units: 'mm',
-      type: 'float',
-      default: 0.5,
-    },
-    dropTip: {
-      value: -5,
-      min: -6,
-      max: 2,
-      units: 'mm',
-      type: 'float',
-      default: -5,
-    },
-    pickUpCurrent: {
-      value: 0.6,
-      min: 0.05,
-      max: 1.2,
-      units: 'A',
-      type: 'float',
-      default: 0.6,
-    },
-    pickUpDistance: {
-      value: 10,
-      min: 1,
-      max: 30,
-      units: 'mm',
-      type: 'float',
-      default: 10,
-    },
-    plungerCurrent: {
-      value: 0.5,
-      min: 0.1,
-      max: 0.5,
-      units: 'A',
-      type: 'float',
-      default: 0.5,
-    },
-    dropTipCurrent: {
-      value: 0.5,
-      min: 0.1,
-      max: 0.8,
-      units: 'A',
-      type: 'float',
-      default: 0.5,
-    },
-    dropTipSpeed: {
-      value: 5,
-      min: 0.001,
-      max: 30,
-      units: 'mm/sec',
-      type: 'float',
-      default: 5,
-    },
-    tipLength: {
-      value: 51.7,
-      units: 'mm',
-      type: 'float',
-      default: 51.7,
-    },
-    defaultAspirateFlowRate: {
-      value: 25,
-      min: 0.001,
-      max: 100,
-      default: 25,
-    },
-    defaultDispenseFlowRate: {
-      value: 50,
-      min: 0.001,
-      max: 100,
-      default: 50,
-    },
-  },
+export default connect(
+  makeMapStateToProps,
+  null
+)(ConfigForm)
+
+function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
+  const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
+
+  return (state, ownProps) => {
+    const {
+      robot,
+      pipette: {id},
+    } = ownProps
+    const configCall = getRobotPipetteConfigs(state, robot)
+    const configResponse = configCall.response
+    const pipetteConfig = configResponse && configResponse[id]
+    return {
+      pipetteConfig: pipetteConfig,
+    }
+  }
 }

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -6,24 +6,20 @@ import {Formik} from 'formik'
 import startCase from 'lodash/startCase'
 import mapValues from 'lodash/mapValues'
 
-import {
-  makeGetRobotPipetteConfigs,
-  fetchPipetteConfigs,
-} from '../../http-api-client'
-import {IntervalWrapper} from '@opentrons/components'
-import {BottomButtonBar} from '../modals'
+import {makeGetRobotPipetteConfigs} from '../../http-api-client'
+import FormButtonBar from './FormButtonBar'
 import ConfigFormGroup, {FormColumn} from './ConfigFormGroup'
 
 import type {State} from '../../types'
 import type {Robot} from '../../discovery'
 import type {
   Pipette,
-  Field,
+  PipetteSettingsField,
   PipetteConfigResponse,
   PipetteConfigFields,
 } from '../../http-api-client'
 
-export type DisplayFieldProps = Field & {
+export type DisplayFieldProps = PipetteSettingsField & {
   name: string,
   displayName: string,
 }
@@ -38,11 +34,7 @@ type SP = {
   pipetteConfig: ?PipetteConfigResponse,
 }
 
-type DP = {
-  fetchPipetteConfigs: () => mixed,
-}
-
-type Props = SP & OP & DP
+type Props = SP & OP
 
 const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
 const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
@@ -66,7 +58,7 @@ class ConfigForm extends React.Component<Props> {
   }
 
   render () {
-    const {pipetteConfig, parentUrl, fetchPipetteConfigs} = this.props
+    const {pipetteConfig, parentUrl} = this.props
 
     if (!pipetteConfig) {
       return null
@@ -80,49 +72,49 @@ class ConfigForm extends React.Component<Props> {
       const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
 
       return (
-        <IntervalWrapper interval={5000} refresh={fetchPipetteConfigs}>
-          <Formik
-            initialValues={initialValues}
-            render={formProps => {
-              const {values, handleChange} = formProps
-              return (
-                <form>
-                  <FormColumn>
-                    <ConfigFormGroup
-                      groupLabel="Plunger Positions"
-                      values={values}
-                      formFields={plungerFields}
-                      onChange={handleChange}
-                      error={null}
-                    />
-
-                    <ConfigFormGroup
-                      groupLabel="Power / Force"
-                      values={values}
-                      formFields={powerFields}
-                      onChange={handleChange}
-                      error={null}
-                    />
-                  </FormColumn>
-                  <FormColumn>
-                    <ConfigFormGroup
-                      groupLabel="Tip Pickup / Drop "
-                      values={values}
-                      formFields={tipFields}
-                      onChange={handleChange}
-                      error={null}
-                    />
-                  </FormColumn>
-                  <BottomButtonBar
-                    buttons={[
-                      {children: 'cancel', Component: Link, to: parentUrl},
-                    ]}
+        <Formik
+          initialValues={initialValues}
+          render={formProps => {
+            const {values, handleChange, handleReset} = formProps
+            return (
+              <form>
+                <FormColumn>
+                  <ConfigFormGroup
+                    groupLabel="Plunger Positions"
+                    values={values}
+                    formFields={plungerFields}
+                    onChange={handleChange}
+                    error={null}
                   />
-                </form>
-              )
-            }}
-          />
-        </IntervalWrapper>
+
+                  <ConfigFormGroup
+                    groupLabel="Power / Force"
+                    values={values}
+                    formFields={powerFields}
+                    onChange={handleChange}
+                    error={null}
+                  />
+                </FormColumn>
+                <FormColumn>
+                  <ConfigFormGroup
+                    groupLabel="Tip Pickup / Drop "
+                    values={values}
+                    formFields={tipFields}
+                    onChange={handleChange}
+                    error={null}
+                  />
+                </FormColumn>
+                <FormButtonBar
+                  buttons={[
+                    {children: 'reset all', onClick: handleReset},
+                    {children: 'cancel', Component: Link, to: parentUrl},
+                    {children: 'save', type: 'submit', disabled: true},
+                  ]}
+                />
+              </form>
+            )
+          }}
+        />
       )
     }
   }
@@ -130,7 +122,7 @@ class ConfigForm extends React.Component<Props> {
 
 export default connect(
   makeMapStateToProps,
-  mapDispatchToProps
+  null
 )(ConfigForm)
 
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
@@ -147,11 +139,5 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     return {
       pipetteConfig: pipetteConfig,
     }
-  }
-}
-
-function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
-  return {
-    fetchPipetteConfigs: () => dispatch(fetchPipetteConfigs(ownProps.robot)),
   }
 }

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -1,17 +1,12 @@
 // @flow
 import * as React from 'react'
-import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
 import {Formik} from 'formik'
 import startCase from 'lodash/startCase'
 import mapValues from 'lodash/mapValues'
-
-import {makeGetRobotPipetteConfigs} from '../../http-api-client'
 import FormButtonBar from './FormButtonBar'
 import ConfigFormGroup, {FormColumn} from './ConfigFormGroup'
 
-import type {State} from '../../types'
-import type {Robot} from '../../discovery'
 import type {
   Pipette,
   PipetteSettingsField,
@@ -24,23 +19,17 @@ export type DisplayFieldProps = PipetteSettingsField & {
   displayName: string,
 }
 
-type OP = {
-  robot: Robot,
-  pipette: Pipette,
+type Props = {
   parentUrl: string,
+  pipette: Pipette,
+  pipetteConfig: PipetteConfigResponse,
 }
-
-type SP = {
-  pipetteConfig: ?PipetteConfigResponse,
-}
-
-type Props = SP & OP
 
 const PLUNGER_KEYS = ['top', 'bottom', 'blowout', 'dropTip']
 const POWER_KEYS = ['plungerCurrent', 'pickUpCurrent', 'dropTipCurrent']
 const TIP_KEYS = ['dropTipSpeed', 'pickUpDistance']
 
-class ConfigForm extends React.Component<Props> {
+export default class ConfigForm extends React.Component<Props> {
   getFieldsByKey (
     keys: Array<string>,
     fields: PipetteConfigFields
@@ -59,85 +48,58 @@ class ConfigForm extends React.Component<Props> {
 
   render () {
     const {pipetteConfig, parentUrl} = this.props
+    const {fields} = pipetteConfig
+    const initialValues = mapValues(fields, f => {
+      return f.value !== f.default ? f.value.toString() : null
+    })
+    const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
+    const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
+    const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
 
-    if (!pipetteConfig) {
-      return null
-    } else {
-      const {fields} = pipetteConfig
-      const initialValues = mapValues(fields, f => {
-        return f.value !== f.default ? f.value.toString() : null
-      })
-      const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
-      const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
-      const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
-
-      return (
-        <Formik
-          initialValues={initialValues}
-          render={formProps => {
-            const {values, handleChange, handleReset} = formProps
-            return (
-              <form>
-                <FormColumn>
-                  <ConfigFormGroup
-                    groupLabel="Plunger Positions"
-                    values={values}
-                    formFields={plungerFields}
-                    onChange={handleChange}
-                    error={null}
-                  />
-
-                  <ConfigFormGroup
-                    groupLabel="Power / Force"
-                    values={values}
-                    formFields={powerFields}
-                    onChange={handleChange}
-                    error={null}
-                  />
-                </FormColumn>
-                <FormColumn>
-                  <ConfigFormGroup
-                    groupLabel="Tip Pickup / Drop "
-                    values={values}
-                    formFields={tipFields}
-                    onChange={handleChange}
-                    error={null}
-                  />
-                </FormColumn>
-                <FormButtonBar
-                  buttons={[
-                    {children: 'reset all', onClick: handleReset},
-                    {children: 'cancel', Component: Link, to: parentUrl},
-                    {children: 'save', type: 'submit', disabled: true},
-                  ]}
+    return (
+      <Formik
+        initialValues={initialValues}
+        render={formProps => {
+          const {values, handleChange, handleReset} = formProps
+          return (
+            <form>
+              <FormColumn>
+                <ConfigFormGroup
+                  groupLabel="Plunger Positions"
+                  values={values}
+                  formFields={plungerFields}
+                  onChange={handleChange}
+                  error={null}
                 />
-              </form>
-            )
-          }}
-        />
-      )
-    }
-  }
-}
 
-export default connect(
-  makeMapStateToProps,
-  null
-)(ConfigForm)
-
-function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
-  const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
-
-  return (state, ownProps) => {
-    const {
-      robot,
-      pipette: {id},
-    } = ownProps
-    const configCall = getRobotPipetteConfigs(state, robot)
-    const configResponse = configCall.response
-    const pipetteConfig = configResponse && configResponse[id]
-    return {
-      pipetteConfig: pipetteConfig,
-    }
+                <ConfigFormGroup
+                  groupLabel="Power / Force"
+                  values={values}
+                  formFields={powerFields}
+                  onChange={handleChange}
+                  error={null}
+                />
+              </FormColumn>
+              <FormColumn>
+                <ConfigFormGroup
+                  groupLabel="Tip Pickup / Drop "
+                  values={values}
+                  formFields={tipFields}
+                  onChange={handleChange}
+                  error={null}
+                />
+              </FormColumn>
+              <FormButtonBar
+                buttons={[
+                  {children: 'reset all', onClick: handleReset},
+                  {children: 'cancel', Component: Link, to: parentUrl},
+                  {children: 'save', type: 'submit'},
+                ]}
+              />
+            </form>
+          )
+        }}
+      />
+    )
   }
 }

--- a/app/src/components/ConfigurePipette/FormButtonBar.js
+++ b/app/src/components/ConfigurePipette/FormButtonBar.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from 'react'
+
+import {BottomButtonBar} from '../modals'
+
+import styles from './styles.css'
+
+import type {ButtonProps} from '@opentrons/components'
+
+type Props = {
+  buttons: Array<?ButtonProps>,
+}
+
+export default function FormButtonBar (props: Props) {
+  const className = styles.form_button
+  const buttons = props.buttons.map(button => {
+    return {
+      ...button,
+      className,
+    }
+  })
+
+  return (
+    <React.Fragment>
+      <p className={styles.reset_message}>
+        * To reset an individual setting, simply clear the field.
+      </p>
+      <BottomButtonBar buttons={buttons} />
+    </React.Fragment>
+  )
+}

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {Link} from 'react-router-dom'
 import {makeGetRobotPipettes} from '../../http-api-client'
 
 import {getPipetteModelSpecs} from '@opentrons/shared-data'
@@ -30,7 +29,7 @@ type Props = SP & OP
 export default connect(makeMapStateToProps)(ConfigurePipette)
 
 function ConfigurePipette (props: Props) {
-  const {parentUrl, mount, pipettes} = props
+  const {parentUrl, mount, pipettes, robot} = props
   // TODO (ka 2019-2-12): This logic is used to get display name in slightly
   // different ways in several different files.
   const pipette = pipettes && pipettes[mount]
@@ -41,13 +40,11 @@ function ConfigurePipette (props: Props) {
   const TITLE = `Pipette Settings: ${displayName}`
 
   return (
-    <ScrollableAlertModal
-      heading={TITLE}
-      alertOverlay
-      buttons={[{children: 'cancel', Component: Link, to: parentUrl}]}
-    >
+    <ScrollableAlertModal heading={TITLE} alertOverlay>
       <ConfigMessage />
-      {pipette && <ConfigForm pipette={pipette} />}
+      {pipette && (
+        <ConfigForm pipette={pipette} robot={robot} parentUrl={parentUrl} />
+      )}
     </ScrollableAlertModal>
   )
 }

--- a/app/src/components/ConfigurePipette/styles.css
+++ b/app/src/components/ConfigurePipette/styles.css
@@ -43,3 +43,16 @@
 .form_label {
   @apply --font-body-1-dark;
 }
+
+.form_button {
+  min-width: 7rem;
+
+  &:first-child {
+    float: left;
+    min-width: 8rem;
+  }
+}
+
+.reset_message {
+  @apply --font-body-1-dark;
+}

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -15,7 +15,7 @@ import {chainActions} from '../../util'
 
 import InstrumentInfo from './InstrumentInfo'
 import {CardContentFlex} from '../layout'
-import {RefreshCard} from '@opentrons/components'
+import {Card, IntervalWrapper} from '@opentrons/components'
 
 import type {State} from '../../types'
 import type {Robot} from '../../discovery'
@@ -50,31 +50,28 @@ export default connect(
 
 function AttachedPipettesCard (props: Props) {
   return (
-    <RefreshCard
-      title={TITLE}
-      watch={props.name}
-      refresh={props.fetchPipettes}
-      refreshing={props.inProgress}
-    >
-      <CardContentFlex>
-        <InstrumentInfo
-          mount="left"
-          name={props.name}
-          {...props.left}
-          onChangeClick={props.clearMove}
-          showSettings={props.showSettings}
-          __enableConfig={props.__featureEnabled}
-        />
-        <InstrumentInfo
-          mount="right"
-          name={props.name}
-          {...props.right}
-          onChangeClick={props.clearMove}
-          showSettings={props.showSettings}
-          __enableConfig={props.__featureEnabled}
-        />
-      </CardContentFlex>
-    </RefreshCard>
+    <IntervalWrapper interval={5000} refresh={props.fetchPipettes}>
+      <Card title={TITLE}>
+        <CardContentFlex>
+          <InstrumentInfo
+            mount="left"
+            name={props.name}
+            {...props.left}
+            onChangeClick={props.clearMove}
+            showSettings={props.showSettings}
+            __enableConfig={props.__featureEnabled}
+          />
+          <InstrumentInfo
+            mount="right"
+            name={props.name}
+            {...props.right}
+            onChangeClick={props.clearMove}
+            showSettings={props.showSettings}
+            __enableConfig={props.__featureEnabled}
+          />
+        </CardContentFlex>
+      </Card>
+    </IntervalWrapper>
   )
 }
 

--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -17,6 +17,7 @@ type Props = {
   model: ?string,
   name: string,
   onChangeClick: () => mixed,
+  showSettings: boolean,
   __enableConfig: boolean,
 }
 
@@ -29,17 +30,17 @@ const LABEL_BY_MOUNT = {
 }
 
 export default function PipetteInfo (props: Props) {
-  const {mount, model, name, onChangeClick} = props
+  const {mount, model, name, onChangeClick, showSettings} = props
   const label = LABEL_BY_MOUNT[mount]
   const channelsMatch = model && model.match(RE_CHANNELS)
   const channels = channelsMatch && channelsMatch[1]
-  const direction = props.model ? 'change' : 'attach'
+  const direction = model ? 'change' : 'attach'
 
   const changeUrl = `/robots/${name}/instruments/pipettes/change/${mount}`
   const configUrl = `/robots/${name}/instruments/pipettes/config/${mount}`
 
   const className = cx(styles.pipette_card, {
-    [styles.right]: props.mount === 'right',
+    [styles.right]: mount === 'right',
   })
 
   return (
@@ -53,7 +54,7 @@ export default function PipetteInfo (props: Props) {
         <OutlineButton Component={Link} to={changeUrl} onClick={onChangeClick}>
           {direction}
         </OutlineButton>
-        {props.__enableConfig && model && (
+        {props.__enableConfig && model && showSettings && (
           <OutlineButton Component={Link} to={configUrl}>
             settings
           </OutlineButton>

--- a/app/src/http-api-client/__tests__/settings.test.js
+++ b/app/src/http-api-client/__tests__/settings.test.js
@@ -3,7 +3,13 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 
 import client from '../client'
-import {fetchSettings, setSettings, makeGetRobotSettings} from '..'
+import {
+  fetchSettings,
+  setSettings,
+  makeGetRobotSettings,
+  fetchPipetteConfigs,
+  makeGetRobotPipetteConfigs,
+} from '..'
 
 jest.mock('../client')
 
@@ -34,9 +40,11 @@ describe('/settings', () => {
     test('calls GET /settings', () => {
       client.__setMockResponse(response)
 
-      return store.dispatch(fetchSettings(robot))
+      return store
+        .dispatch(fetchSettings(robot))
         .then(() =>
-          expect(client).toHaveBeenCalledWith(robot, 'GET', 'settings', null))
+          expect(client).toHaveBeenCalledWith(robot, 'GET', 'settings', null)
+        )
     })
 
     test('dispatches api:REQUEST and api:SUCCESS', () => {
@@ -48,7 +56,8 @@ describe('/settings', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(fetchSettings(robot))
+      return store
+        .dispatch(fetchSettings(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -62,7 +71,8 @@ describe('/settings', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(fetchSettings(robot))
+      return store
+        .dispatch(fetchSettings(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
@@ -78,9 +88,16 @@ describe('/settings', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(setSettings(robot, request))
+      return store
+        .dispatch(setSettings(robot, request))
         .then(() =>
-          expect(client).toHaveBeenCalledWith(robot, 'POST', 'settings', request))
+          expect(client).toHaveBeenCalledWith(
+            robot,
+            'POST',
+            'settings',
+            request
+          )
+        )
     })
 
     test('dispatches api:REQUEST and api:SUCCESS', () => {
@@ -92,7 +109,8 @@ describe('/settings', () => {
 
       client.__setMockResponse(response)
 
-      return store.dispatch(setSettings(robot, request))
+      return store
+        .dispatch(setSettings(robot, request))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
 
@@ -106,7 +124,74 @@ describe('/settings', () => {
 
       client.__setMockError(error)
 
-      return store.dispatch(setSettings(robot, request))
+      return store
+        .dispatch(setSettings(robot, request))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+  })
+
+  describe('fetchPipetteConfig action creator', () => {
+    const path = 'settings/pipettes'
+    const response = {
+      P300S20180206A02: {
+        info: {
+          name: 'p300_single',
+          model: 'p300_single_v1',
+        },
+        fields: {
+          top: {
+            value: 19,
+            min: 5,
+            max: 19.5,
+            units: 'mm',
+            type: 'float',
+            default: 19.5,
+          },
+        },
+      },
+    }
+
+    test('calls GET /settings/pipettes', () => {
+      client.__setMockResponse(response)
+
+      return store
+        .dispatch(fetchPipetteConfigs(robot))
+        .then(() =>
+          expect(client).toHaveBeenCalledWith(
+            robot,
+            'GET',
+            'settings/pipettes',
+            null
+          )
+        )
+    })
+
+    test('dispatches api:REQUEST and api:SUCCESS', () => {
+      const request = null
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:SUCCESS', payload: {robot, response, path}},
+      ]
+
+      client.__setMockResponse(response)
+
+      return store
+        .dispatch(fetchPipetteConfigs(robot))
+        .then(() => expect(store.getActions()).toEqual(expectedActions))
+    })
+
+    test('dispatches api:REQUEST and api:FAILURE', () => {
+      const request = null
+      const error = {name: 'ResponseError', status: 500, message: ''}
+      const expectedActions = [
+        {type: 'api:REQUEST', payload: {robot, request, path}},
+        {type: 'api:FAILURE', payload: {robot, error, path}},
+      ]
+
+      client.__setMockError(error)
+
+      return store
+        .dispatch(fetchPipetteConfigs(robot))
         .then(() => expect(store.getActions()).toEqual(expectedActions))
     })
   })
@@ -115,14 +200,14 @@ describe('/settings', () => {
     beforeEach(() => {
       state.api.api[NAME] = {
         settings: {inProgress: true},
+        'settings/pipettes': {inProgress: true},
       }
     })
 
     test('makeGetRobotSettings', () => {
       const getSettings = makeGetRobotSettings()
 
-      expect(getSettings(state, robot))
-        .toEqual(state.api.api[NAME].settings)
+      expect(getSettings(state, robot)).toEqual(state.api.api[NAME].settings)
 
       expect(getSettings(state, {name: 'foo'})).toEqual({inProgress: false})
     })
@@ -135,6 +220,18 @@ describe('/settings', () => {
       expect(getSettings(state, robot)).toEqual({
         ...state.api.api[NAME].settings,
         response: {settings: []},
+      })
+    })
+
+    test('makeGetRobotPipetteConfigs', () => {
+      const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
+
+      expect(getRobotPipetteConfigs(state, robot)).toEqual(
+        state.api.api[NAME]['settings/pipettes']
+      )
+
+      expect(getRobotPipetteConfigs(state, {name: 'foo'})).toEqual({
+        inProgress: false,
       })
     })
   })

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -19,6 +19,7 @@ export type Pipette = {
   model: ?string,
   mount_axis: MotorAxis,
   plunger_axis: MotorAxis,
+  id: string,
 }
 
 export type PipettesResponse = {

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -24,6 +24,25 @@ export type Setting = {
   value: Value,
 }
 
+export type Field = {
+  value: ?number,
+  default: number,
+  min?: number,
+  max?: number,
+  units?: string,
+  type?: string,
+}
+
+export type PipetteConfigFields = {[string]: Field}
+
+export type PipetteConfigResponse = {
+  info: {
+    name: ?string,
+    model: ?string,
+  },
+  fields: PipetteConfigFields,
+}
+
 type SettingsRequest = ?{id: Id, value: Value}
 
 type SettingsResponse = {settings: Array<Setting>}
@@ -32,10 +51,17 @@ export type SettingsAction = ApiAction<'settings',
   SettingsRequest,
   SettingsResponse>
 
+// TODO type this based on SetConfigRequest when implemented
+type PipetteConfigRequest = ?{id: string}
+
 export type RobotSettingsCall = ApiCall<SettingsRequest, SettingsResponse>
+
+export type PipetteConfigCall = ApiCall<PipetteConfigRequest,
+  PipetteConfigResponse>
 
 export type SettingsState = {|
   settings?: RobotSettingsCall,
+  'settings/pipettes'?: PipetteConfigCall,
 |}
 
 const SETTINGS: 'settings' = 'settings'
@@ -50,6 +76,15 @@ export const fetchSettings: SettingsRequestMaker = buildRequestMaker(
 export const setSettings: SettingsRequestMaker = buildRequestMaker(
   'POST',
   SETTINGS
+)
+
+const PIPETTE_SETTINGS: 'settings/pipettes' = 'settings/pipettes'
+
+type PipetteConfigRequestMaker = RequestMaker<PipetteConfigRequest>
+
+export const fetchPipetteConfigs: PipetteConfigRequestMaker = buildRequestMaker(
+  'GET',
+  PIPETTE_SETTINGS
 )
 
 export function makeGetRobotSettings () {
@@ -72,4 +107,22 @@ export function getSettingsRequest (state: RobotApiState): RobotSettingsCall {
   }
 
   return requestState
+}
+
+export function makeGetRobotPipetteConfigs () {
+  const selector: OutputSelector<State,
+    BaseRobot,
+    PipetteConfigCall> = createSelector(
+      getRobotApiState,
+      getRobotPipetteConfigs
+    )
+
+  return selector
+}
+
+export function getRobotPipetteConfigs (
+  state: RobotApiState,
+  id: string
+): PipetteConfigCall {
+  return state[PIPETTE_SETTINGS] || {inProgress: false}
 }

--- a/app/src/http-api-client/settings.js
+++ b/app/src/http-api-client/settings.js
@@ -24,7 +24,7 @@ export type Setting = {
   value: Value,
 }
 
-export type Field = {
+export type PipetteSettingsField = {
   value: ?number,
   default: number,
   min?: number,
@@ -33,7 +33,7 @@ export type Field = {
   type?: string,
 }
 
-export type PipetteConfigFields = {[string]: Field}
+export type PipetteConfigFields = {[string]: PipetteSettingsField}
 
 export type PipetteConfigResponse = {
   info: {


### PR DESCRIPTION
## overview
This PR connects the pipette config form to the `settings/pipettes` endpoint and populates the form with actual pipette config data.

closes #3091
![2019-03-04 15 54 02](https://user-images.githubusercontent.com/3430313/53762321-d076b300-3e95-11e9-94cc-3d721c79ebfd.gif)



## changelog
- refactor(app): Connect pipette config form to api endpoint
- refactor(app): Move button bar from ScrollableAlertModal to ConfigForm component (for future reset button work)

## review requests
Standard review. Can be tested on Sunset.

`make -C app dev OT_APP_DEV_INTERNAL__NEW_PIPETTE_CONFIG=1`