### PR TITLE
fix(shared-data): fix y axis svg value for fixed trash

### DIFF
--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -7,3 +7,6 @@ export const SLOT_WIDTH_MM = 85.48 // along Y axis in robot coordinate system
 // constants for SVG renders of the deck
 export const SLOT_RENDER_WIDTH = SLOT_LENGTH_MM // along X axis in SVG coords
 export const SLOT_RENDER_HEIGHT = SLOT_WIDTH_MM // along Y axis in SVG coords
+
+// taken from definitions2/opentrons_1_trash_1.1_L.json dimensions
+export const FIXED_TRASH_RENDER_HEIGHT = 165.86 // along Y axis in SVG coords

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -1,7 +1,7 @@
 // @flow
 import mapValues from 'lodash/mapValues'
 import definitions from '../build/labware.json'
-import {SLOT_RENDER_HEIGHT} from './constants'
+import {SLOT_RENDER_HEIGHT, FIXED_TRASH_RENDER_HEIGHT} from './constants'
 import type {LabwareDefinition, WellDefinition} from './types'
 
 export default function getLabware (labwareName: string): ?LabwareDefinition {
@@ -12,6 +12,21 @@ export default function getLabware (labwareName: string): ?LabwareDefinition {
 export function getIsTiprack (labwareName: string): boolean {
   const labware = getLabware(labwareName)
   return Boolean(labware && labware.metadata && labware.metadata.isTiprack)
+}
+
+/* Render Helpers */
+
+// NOTE: this doesn't account for the differing footprints of labware
+// the fixed trash render height is the first bandaid to partially
+// mend this, but overall the labware definitions in shared-data are
+// insufficient to render labware at the resolution we'd like to
+// achieve going forward.
+
+// TODO: BC 2019-02-28 The height constants used here should be replaced with the heights
+// in the dimensions field of the corresponding labware in definitions2
+const _getSvgYValueForWell = (labwareName: string, wellDef: WellDefinition) => {
+  const renderHeight = labwareName === 'fixed-trash' ? FIXED_TRASH_RENDER_HEIGHT : SLOT_RENDER_HEIGHT
+  return renderHeight - wellDef.y
 }
 
 /** For display. Flips Y axis to match SVG, applies offset to wells */
@@ -33,7 +48,6 @@ export function getWellDefsForSVG (labwareName: string) {
   return mapValues(wellDefs, (wellDef: WellDefinition) => ({
     ...wellDef,
     x: wellDef.x + xCorrection,
-    // flip y axis to match SVG y axis direction
-    y: SLOT_RENDER_HEIGHT - wellDef.y + yCorrection,
+    y: _getSvgYValueForWell(labwareName, wellDef) + yCorrection,
   }))
 }


### PR DESCRIPTION
NOTE: this only updates a helper for rendering that happens to live in shared-data, it shouldn't effect anything outside of PD rendering. 

The y value being generated by the getWellDefsForSVG was only accounting for labware that fit
precisely in a slot. This adds a temporary fix to allow the fix trash to be rendered closer to
correctly which takes into account the difference in overall dimensions between the fixed trash and
all other labware. This also adds a comment documenting the reasoning and explaining the long term
goal for more robust render specific data for given labware.

*Review Requests*
- [ ] check code and comments
- [ ] select "Trash" as a source or destination and open the well selection modal, you should see the well in the correct location now. 