### PR TITLE
feat(api): Add set_temperature command to API and driver

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -371,6 +371,13 @@ def thermocycler_open():
     )
 
 
+def thermocycler_set_temp():
+    text = "Setting thermocycler temperature"
+    return make_command(
+        name=command_types.THERMOCYCLER_SET_TEMP,
+        payload={'text': text})
+
+
 def thermocycler_close():
     text = "Closing thermocycler lid"
     return make_command(

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1673,6 +1673,51 @@ class ThermocyclerContext(ModuleContext):
         """ Closes the lid"""
         return self._module.close()
 
+    @cmds.publish.both(command=cmds.thermocycler_set_temp)
+    def set_temperature(self,
+                        temp: float,
+                        hold_time: float = None,
+                        ramp_rate: float = None):
+        """ Set the target temperature, in C.
+
+        Valid operational range yet to be determined.
+        :param temp: The target temperature, in degrees C.
+        :param hold_time: The time to hold after reaching temperature. If
+                          ``hold_time`` is not specified, the Thermocycler will
+                          hold this temperature indefinitely (requiring manual
+                          intervention to end the cycle).
+        :param ramp_rate: The target rate of temperature change, in degC/sec.
+                          If ``ramp_rate`` is not specified, it will default to
+                          the maximum ramp rate as defined in the device
+                          configuration.
+        """
+        return self._module.set_temperature(
+            temp=temp, hold_time=hold_time, ramp_rate=ramp_rate)
+
+    def wait_for_temp(self):
+        """ Block until the module reaches its setpoint"""
+        self._loop.run_until_complete(self._module.wait_for_temp())
+
+    @property
+    def temperature(self):
+        """ Current temperature in degrees C"""
+        return self._module.temperature
+
+    @property
+    def target(self):
+        """ Target temperature in degrees C"""
+        return self._module.target
+
+    @property
+    def ramp_rate(self):
+        """ Current ramp rate in degrees C/sec"""
+        return self._module.ramp_rate
+
+    @property
+    def hold_time(self):
+        """ Remaining hold time in sec"""
+        return self._module.hold_time
+
     @cmds.publish.both(command=cmds.thermocycler_deactivate)
     def deactivate(self):
         return self._module.deactivate()

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,3 +1,4 @@
+import asyncio
 from opentrons.hardware_control import modules
 
 
@@ -21,3 +22,30 @@ def test_lid():
 
     temp.open()
     assert temp.lid_status == 'open'
+
+
+def test_sim_state():
+    therm = modules.build('', 'thermocycler', True, lambda x: None)
+    assert therm.temperature is None
+    assert therm.target is None
+    assert therm.status == 'idle'
+    assert therm.live_data['status'] == therm.status
+    assert therm.live_data['data']['currentTemp'] == therm.temperature
+    assert therm.live_data['data']['targetTemp'] == therm.target
+    status = therm.device_info
+    assert status['serial'] == 'dummySerial'
+    assert status['model'] == 'dummyModel'
+    assert status['version'] == 'dummyVersion'
+
+
+async def test_sim_update():
+    therm = modules.build('', 'thermocycler', True, lambda x: None)
+    therm.set_temperature(10, None, 4.0)
+    assert therm.temperature == 10
+    assert therm.target == 10
+    assert therm.status == 'holding at target'
+    await asyncio.wait_for(therm.wait_for_temp(), timeout=0.2)
+    therm.deactivate()
+    assert therm.temperature is None
+    assert therm.target is None
+    assert therm.status == 'idle'


### PR DESCRIPTION
## overview

Adds `set_temperature` command to driver and re-adds it to API (whoops). Closes #2979 

## review requests

- [ ] Able to create a simulating hardware controller with a simulating Thermocycler, and issue `set_temperature` commands
- [ ] Able to simulate a protocol with a Thermocycler module in the API and issue `set_temperature` and `wait_for_temp` commands

hardware control snippet (in api directory: `make local-shell` and then `python`):
```
import opentrons.hardware_control as hc
import opentrons.hardware_control.adapters as adapt

api = hc.API.build_hardware_simulator(attached_modules=['thermocycler'])
synch = adapt.SynchronousAdapter(api)
synch.discover_modules()
synch.attached_modules

synch.attached_modules['mod0thermocycler'].live_data
synch.attached_modules['mod0thermocycler'].set_temperature(4, None, None)
synch.attached_modules['mod0thermocycler'].live_data
synch.attached_modules['mod0thermocycler'].set_temperature(99, 5, 8) # Note time remaining will be 0
synch.attached_modules['mod0thermocycler'].live_data
```

API snippet (run with simulate script):
```
def run(ctx):
    t = ctx.load_module('thermocycler', '10')
    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300_uL', '1')
    p300single = ctx.load_instrument(
        'p300_single',
        Mount.RIGHT,
        tip_racks=[tiprack])
    p300multi = ctx.load_instrument(
        'p300_multi',
        Mount.LEFT,
        tip_racks=[tiprack])
    source = ctx.load_labware_by_name('generic_96_wellPlate_380_uL', '2')
    dest = t.load_labware('generic_96_wellPlate_380_uL')

    t.close()
    t.set_temperature(4, hold_time=1)
    t.wait_for_temp()
    t.set_temperature(99, hold_time=30, ramp_rate=5)
    t.wait_for_temp()
    t.set_temperature(4)
```
