### PR TITLE
fix(docs): Fix typo and clarify intro in docs, deploy on edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,7 @@ jobs:
           local-dir: api/docs/dist
           github-token: $GITHUB_TOKEN
           on:
-            all_branches: true
-            tags: true
+            branch: edge
             repo: Opentrons/opentrons
 
         # push to real pypi on tag

--- a/api/docs/source/index.rst
+++ b/api/docs/source/index.rst
@@ -2,9 +2,9 @@
 Opentrons API
 ===============
 
-The Opentrons API is a simple framework designed to make writing automated biology lab protocols easy.
+The Opentrons API is a simple Python framework designed to make writing automated biology lab protocols easy.
 
-We’ve designed it in a way we hope is accessible to anyone with basic computer and wetlab skills. As a bench scientist, you should be able to code your automated protocols in a way that reads like a lab notebook.
+We’ve designed it in a way we hope is accessible to anyone with basic Python and wetlab skills. As a bench scientist, you should be able to code your automated protocols in a way that reads like a lab notebook.
 
 
 **********************

--- a/api/docs/source/writing.rst
+++ b/api/docs/source/writing.rst
@@ -85,7 +85,7 @@ You must make sure that you install the `opentrons` package for whichever kernel
 .. code-block:: python
 
    import sys
-   !{sys.executable} -m pip install numpy
+   !{sys.executable} -m pip install opentrons
 
 
 Simulating


### PR DESCRIPTION
In addition to fixing a typo and clarifying some wording in the intro para, this
commit changes back to deploying docs on edge. We should, however, be careful
about exactly what we change in docs, to keep them in sync with the currently
deployed version.
