### PR TITLE
fix(api): Fix mistakenly-changed pick up current for p10s1.4

### DIFF
--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -897,7 +897,7 @@ Object {
     "min": 0.05,
     "type": "float",
     "units": "amps",
-    "value": 0.4,
+    "value": 0.1,
   },
   "pickUpDistance": Object {
     "max": 30,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -233,7 +233,7 @@
         "type": "float"
       },
       "pickUpCurrent": {
-        "value": 0.4,
+        "value": 0.1,
         "min": 0.05,
         "max": 1.2,
         "units": "amps",


### PR DESCRIPTION
Looks like this was changed in the schema change, and it shouldn't be.

Changes p10 single v1.4 pick up current from 0.4A back to 0.1A