### PR TITLE
fix(api): Clear globals in simulate script

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -44,7 +44,7 @@ def simulate(protocol_file):
         if isinstance(proto, dict):
             opentrons.protocols.execute_protocol(proto)
         else:
-            exec(proto)
+            exec(proto, {})
 
 
 # Note - this script is also set up as a setuptools entrypoint and thus does


### PR DESCRIPTION
For some reason if you don’t explicitly pass a new context to exec() it won’t
let you access things you imported from lower scopes, so any access to e.g.
labware wouldn’t work in a protocol like:

```
from opentrons import labware, instruments

def run_protocol():
   l = labware.load('96-flat', 2)

run_protocol()
```

would not be able to find the imported `labware` object.
