### PR TITLE
feat(protocol-designer): auto-select well of single well labware

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
@@ -98,7 +98,7 @@ const updatePatchOnPipetteChange = (
   return patch
 }
 
-export default function dependentFieldsUpdateMoveLiquid (
+export default function dependentFieldsUpdateMix (
   originalPatch: FormPatch,
   rawForm: FormData, // raw = NOT hydrated
   pipetteEntities: PipetteEntities,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
@@ -1,0 +1,114 @@
+// @flow
+import pick from 'lodash/pick'
+import {
+  chainPatchUpdaters,
+  fieldHasChanged,
+  getChannels,
+  getDefaultWells,
+  getAllWellsFromPrimaryWells,
+} from './utils'
+import getDefaultsForStepType from '../getDefaultsForStepType'
+import type {FormData, StepFieldName} from '../../../form-types'
+import type {FormPatch} from '../../actions/types'
+import type {LabwareEntities, PipetteEntities} from '../../../step-forms/types'
+
+// TODO: Ian 2019-02-21 import this from a more central place - see #2926
+const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
+  pick(getDefaultsForStepType('mix'), fields)
+
+const updatePatchOnLabwareChange = (
+  patch: FormPatch,
+  rawForm: FormData,
+  labwareEntities: LabwareEntities,
+  pipetteEntities: PipetteEntities
+): FormPatch => {
+  const labwareChanged = fieldHasChanged(rawForm, patch, 'labware')
+
+  if (!labwareChanged) return patch
+
+  const appliedPatch = {...rawForm, ...patch}
+  const pipetteId = appliedPatch.pipette
+
+  return labwareChanged
+    ? {
+      ...getDefaultFields(
+        'mix_mmFromBottom',
+        'mix_touchTip_mmFromBottom'),
+      wells: getDefaultWells({
+        labwareId: appliedPatch.labware, pipetteId, labwareEntities, pipetteEntities}),
+    }
+    : {}
+}
+
+// NOTE: this is similar to fn in moveLiquid dependentFieldsUpdate,
+// if it's used more consider making a util
+const updatePatchOnPipetteChannelChange = (
+  patch: FormPatch,
+  rawForm: FormData,
+  labwareEntities: LabwareEntities,
+  pipetteEntities: PipetteEntities
+) => {
+  if (patch.pipette === undefined) return patch
+  let update = {}
+
+  const prevChannels = getChannels(rawForm.pipette, pipetteEntities)
+  const nextChannels = typeof patch.pipette === 'string'
+    ? getChannels(patch.pipette, pipetteEntities)
+    : null
+
+  const appliedPatch = {...rawForm, ...patch}
+  const singleToMulti = prevChannels === 1 && nextChannels === 8
+  const multiToSingle = prevChannels === 8 && nextChannels === 1
+
+  if (patch.pipette === null || singleToMulti) {
+    // reset all well selection
+    const pipetteId = appliedPatch.pipette
+    update = {
+      wells: getDefaultWells({
+        labwareId: appliedPatch.labware, pipetteId, labwareEntities, pipetteEntities}),
+    }
+  } else if (multiToSingle) {
+    // multi-channel to single-channel: convert primary wells to all wells
+    const labwareId = appliedPatch.labware
+    const labwareType = labwareId && labwareEntities[labwareId] && labwareEntities[labwareId].type
+
+    update = {
+      wells: getAllWellsFromPrimaryWells(appliedPatch.wells, labwareType),
+    }
+  }
+  return {...patch, ...update}
+}
+
+const updatePatchOnPipetteChange = (
+  patch: FormPatch,
+  rawForm: FormData,
+  pipetteEntities: PipetteEntities
+) => {
+  // when pipette ID is changed (to another ID, or to null),
+  // set any flow rates to null
+  if (fieldHasChanged(rawForm, patch, 'pipette')) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'aspirate_flowRate',
+        'dispense_flowRate',
+      ),
+    }
+  }
+
+  return patch
+}
+
+export default function dependentFieldsUpdateMoveLiquid (
+  originalPatch: FormPatch,
+  rawForm: FormData, // raw = NOT hydrated
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities
+): FormPatch {
+  // sequentially modify parts of the patch until it's fully updated
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnLabwareChange(chainPatch, rawForm, labwareEntities, pipetteEntities),
+    chainPatch => updatePatchOnPipetteChannelChange(chainPatch, rawForm, labwareEntities, pipetteEntities),
+    chainPatch => updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.js
@@ -29,15 +29,14 @@ const updatePatchOnLabwareChange = (
   const appliedPatch = {...rawForm, ...patch}
   const pipetteId = appliedPatch.pipette
 
-  return labwareChanged
-    ? {
-      ...getDefaultFields(
-        'mix_mmFromBottom',
-        'mix_touchTip_mmFromBottom'),
-      wells: getDefaultWells({
-        labwareId: appliedPatch.labware, pipetteId, labwareEntities, pipetteEntities}),
-    }
-    : {}
+  return {
+    ...patch,
+    ...getDefaultFields(
+      'mix_mmFromBottom',
+      'mix_touchTip_mmFromBottom'),
+    wells: getDefaultWells({
+      labwareId: appliedPatch.labware, pipetteId, labwareEntities, pipetteEntities}),
+  }
 }
 
 // NOTE: this is similar to fn in moveLiquid dependentFieldsUpdate,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -7,6 +7,7 @@ import {getPipetteNameSpecs} from '@opentrons/shared-data'
 import makeConditionalPatchUpdater from './makeConditionalPatchUpdater'
 import {
   chainPatchUpdaters,
+  fieldHasChanged,
   getChannels,
   getDefaultWells,
   getAllWellsFromPrimaryWells,
@@ -23,16 +24,6 @@ import {
 import type {FormData, StepFieldName} from '../../../form-types'
 import type {FormPatch} from '../../actions/types'
 import type {LabwareEntities, PipetteEntities} from '../../../step-forms/types'
-
-function _fieldHasChanged (
-  rawForm: FormData,
-  patch: FormPatch,
-  fieldName: StepFieldName
-): boolean {
-  return Boolean(
-    patch[fieldName] !== undefined &&
-    patch[fieldName] !== rawForm[fieldName])
-}
 
 // TODO: Ian 2019-02-21 import this from a more central place - see #2926
 const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
@@ -121,8 +112,8 @@ const updatePatchOnLabwareChange = (
   labwareEntities: LabwareEntities,
   pipetteEntities: PipetteEntities
 ): FormPatch => {
-  const sourceLabwareChanged = _fieldHasChanged(rawForm, patch, 'aspirate_labware')
-  const destLabwareChanged = _fieldHasChanged(rawForm, patch, 'dispense_labware')
+  const sourceLabwareChanged = fieldHasChanged(rawForm, patch, 'aspirate_labware')
+  const destLabwareChanged = fieldHasChanged(rawForm, patch, 'dispense_labware')
 
   if (!sourceLabwareChanged && !destLabwareChanged) return patch
 
@@ -162,7 +153,7 @@ const updatePatchOnPipetteChange = (
 ) => {
   // when pipette ID is changed (to another ID, or to null),
   // set any flow rates, mix volumes, air gaps, or disposal volumes to null
-  if (_fieldHasChanged(rawForm, patch, 'pipette')) {
+  if (fieldHasChanged(rawForm, patch, 'pipette')) {
     return {
       ...patch,
       ...getDefaultFields(
@@ -363,7 +354,7 @@ function updatePatchMixFields (patch: FormPatch, rawForm: FormData): FormPatch {
 export function updatePatchBlowoutFields (patch: FormPatch, rawForm: FormData): FormPatch {
   const appliedPatch = {...rawForm, ...patch}
 
-  if (_fieldHasChanged(rawForm, patch, 'path')) {
+  if (fieldHasChanged(rawForm, patch, 'path')) {
     const {path, blowout_location} = appliedPatch
     // reset blowout_location when path changes to avoid invalid location for path
     // or reset whenever checkbox is toggled

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -1,5 +1,6 @@
 // @flow
 import dependentFieldsUpdateMoveLiquid from './dependentFieldsUpdateMoveLiquid'
+import dependentFieldsUpdateMix from './dependentFieldsUpdateMix'
 import type {FormData} from '../../../form-types'
 import type {FormPatch} from '../../actions/types'
 import type {LabwareEntities, PipetteEntities} from '../../../step-forms/types'
@@ -14,6 +15,10 @@ function handleFormChange (
 
   if (rawForm.stepType === 'moveLiquid') {
     const dependentFieldsPatch = dependentFieldsUpdateMoveLiquid(patch, rawForm, pipetteEntities, labwareEntities)
+    return {...patch, ...dependentFieldsPatch}
+  }
+  if (rawForm.stepType === 'mix') {
+    const dependentFieldsPatch = dependentFieldsUpdateMix(patch, rawForm, pipetteEntities, labwareEntities)
     return {...patch, ...dependentFieldsPatch}
   }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
@@ -1,0 +1,86 @@
+// @flow
+import dependentFieldsUpdateMix from '../dependentFieldsUpdateMix'
+import {DEFAULT_MM_FROM_BOTTOM_DISPENSE} from '../../../../constants'
+let pipetteEntities
+let labwareEntities
+let handleFormHelper
+
+beforeEach(() => {
+  pipetteEntities = {
+    pipetteId: {name: 'p10_single', tiprackModel: 'tiprack-10ul', spec: {channels: 1}},
+    pipetteMultiId: {name: 'p10_multi', tiprackModel: 'tiprack-10ul', spec: {channels: 8}},
+  }
+  labwareEntities = {trashId: {type: 'trash-box'}, plateId: {type: '96-flat'}}
+  handleFormHelper = (patch, baseForm) => dependentFieldsUpdateMix(
+    patch, baseForm, pipetteEntities, labwareEntities
+  )
+})
+
+describe('no-op cases should pass through the patch unchanged', () => {
+  const minimalBaseForm = {
+    blah: 'blaaah',
+  }
+
+  test('empty patch', () => {
+    const patch = {}
+    expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
+  })
+  test('patch with unhandled field', () => {
+    const patch = {fooField: 123}
+    expect(handleFormHelper(patch, minimalBaseForm)).toBe(patch)
+  })
+})
+
+describe('well selection should update', () => {
+  let form
+  beforeEach(() => {
+    form = {
+      labware: 'plateId',
+      wells: ['A1', 'B1'],
+      volume: '2',
+      pipette: 'pipetteId',
+    }
+  })
+
+  test('pipette cleared', () => {
+    const patch = {pipette: null}
+    expect(handleFormHelper(patch, form)).toEqual({...patch, wells: []})
+  })
+
+  test('pipette single -> multi', () => {
+    const patch = {pipette: 'pipetteMultiId'}
+    expect(handleFormHelper(patch, form)).toEqual({...patch, wells: []})
+  })
+
+  test('pipette multi -> single', () => {
+    const multiChForm = {
+      ...form,
+      pipette: 'pipetteMultiId',
+      wells: ['A10'],
+    }
+    const patch = {pipette: 'pipetteId'}
+    expect(handleFormHelper(patch, multiChForm)).toEqual({
+      ...patch,
+      wells: ['A10', 'B10', 'C10', 'D10', 'E10', 'F10', 'G10', 'H10'],
+    })
+  })
+
+  test('select single-well labware', () => {
+    const patch = {labware: 'trashId'}
+    expect(handleFormHelper(patch, form)).toEqual({
+      ...patch,
+      wells: ['A1'],
+      mix_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+    })
+  })
+
+  test('select labware with multiple wells', () => {
+    const trashLabwareForm = {...form, labware: 'trashId'}
+    const patch = {labware: 'plateId'}
+    expect(handleFormHelper(patch, trashLabwareForm)).toEqual({
+      ...patch,
+      wells: [],
+      mix_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -7,7 +7,7 @@ import {getPipetteCapacity} from '../../../pipettes/pipetteData'
 import {getWellSetForMultichannel} from '../../../well-selection/utils'
 import type {PipetteChannels} from '@opentrons/shared-data'
 import type {FormPatch} from '../../actions/types'
-import type {FormData} from '../../../form-types'
+import type {FormData, StepFieldName} from '../../../form-types'
 import type {LabwareEntities, PipetteEntities} from '../../../step-forms'
 
 export function chainPatchUpdaters (initialPatch: FormPatch, fns: Array<(FormPatch => FormPatch)>): FormPatch {
@@ -113,4 +113,14 @@ export function getDefaultWells (args: GetDefaultWellsArgs): Array<string> {
   }
 
   return []
+}
+
+export function fieldHasChanged (
+  rawForm: FormData,
+  patch: FormPatch,
+  fieldName: StepFieldName
+): boolean {
+  return Boolean(
+    patch[fieldName] !== undefined &&
+    patch[fieldName] !== rawForm[fieldName])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -80,7 +80,6 @@ export function volumeInCapacityForMulti (
   )
 }
 
-// TODO IMMEDIATELY: use in Mix form
 type GetDefaultWellsArgs = {
   labwareId: ?string,
   pipetteId: ?string,


### PR DESCRIPTION
## overview

Adds auto-selection of wells for single-well labware (right now in PD that's just fixed-trash and trash-box) - closes #3146 

Should skip auto-selection if there's a single-well labware that is not multi-channel compatible.

While extending this to Mix form, I realized Mix form was pretty broken. Changing pipette channels did not update well selection, I think we saw some bugs from this earlier but didn't trace them down to Mix form so couldn't replicated. Also tip positioning fields didn't reset when pipette was changed. This PR should make Mix form fields reset correctly.

## changelog

* add `dependentFieldsUpdateMix`
* new `getDefaultWells` util used to update wells and auto-select well of single-well labware

## review requests

- Code review
- In both moveLiquid and Mix forms, single-well labware's well should be auto-selected when that labware is selected (unless there is no pipette, then it should NOT). Make sure this works when changing pipette single-to-multi and multi-to-single.
- All fields in Mix form should update properly if related fields change, mirroring the behavior of moveLiquid form
