### PR TITLE
ci(protocol-designer): build to NEW BUCKET, add .commit file to PD builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,9 @@ jobs:
       deploy:
         - # deploy protocol designer to S3
           <<: *deploy_s3
-          # TODO(mc, 2018-03-26): why is this region not default?
-          region: us-west-2
+          dot_match: true
           local-dir: protocol-designer/dist
-          bucket: opentrons-protocol-designer
+          bucket: opentrons-protocol-designer-builds
           upload-dir: $TRAVIS_BRANCH
         - # deploy components library to S3
           <<: *deploy_s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ jobs:
       deploy:
         - # deploy protocol designer to S3
           <<: *deploy_s3
+          region: us-east-2
           dot_match: true
           local-dir: protocol-designer/dist
           bucket: opentrons-protocol-designer-builds

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -25,7 +25,8 @@ clean:
 .PHONY: build
 build: export NODE_ENV := production
 build:
-	webpack --profile
+	webpack --profile && \
+	git rev-parse HEAD > dist/.commit
 
 # development
 #####################################################################

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -25,7 +25,7 @@ clean:
 .PHONY: build
 build: export NODE_ENV := production
 build:
-	webpack --profile && \
+	webpack --profile
 	git rev-parse HEAD > dist/.commit
 
 # development


### PR DESCRIPTION
## overview

For auditability/provenance, we'll add this `.commit` file in PD build directories.

Also, I just made a new bucket `opentrons-protocol-designer-builds` in `us-east-2 (Ohio)`, and Travis will now send PD branch builds there instead of the old one (`opentrons-protocol-designer`).

## changelog

* `make -C protocol-designer build` updates the .commit file
* travis upload to `opentrons-protocol-designer-builds` bucket

## review requests

- Code review
- Make sure the S3 bucket for this branch build has a `.commit` file with the correct hash
- Should work OK on Windows so that `make build` isn't broken for Windows developers (however, this will not work _perfectly_ on windows b/c it appears that `>` in Windows will add a Windows line ending to the end of the file :angry: however the build should always happen in Travis on unix so that difference should never affect the `.commit` files in S3`