### PR TITLE
refactor(app): Add form submission to pipette config form

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigErrorBanner.js
+++ b/app/src/components/ConfigurePipette/ConfigErrorBanner.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react'
+import {AlertItem} from '@opentrons/components'
+import styles from './styles.css'
+type Props = {
+  message: ?string,
+}
+type State = {dismissed: boolean}
+
+const TITLE = 'Error updating pipette settings'
+export default class ConfigBanner extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+    this.state = {dismissed: false}
+  }
+
+  render () {
+    const {message} = this.props
+    const isVisible = message && !this.state.dismissed
+    if (!isVisible) return null
+
+    return (
+      <AlertItem
+        type="warning"
+        onCloseClick={() => this.setState({dismissed: true})}
+        title={TITLE}
+      >
+        <p className={styles.config_submit_error}>
+          Some of the pipette config settings submitted were not valid.
+        </p>
+        <p className={styles.config_submit_error}>
+          <strong>ERROR: {message}</strong>
+        </p>
+        <p className={styles.config_submit_error}>Please contact support.</p>
+      </AlertItem>
+    )
+  }
+}

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -15,7 +15,7 @@ export function FormColumn (props: FormColProps) {
   return <div className={styles.form_column}>{props.children}</div>
 }
 
-type FormValues = {[string]: ?string}
+export type FormValues = {[string]: ?string}
 
 type FormGroupProps = {
   groupLabel: string,

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -29,23 +29,24 @@ import type {
   ApiRequestError,
 } from '../../http-api-client'
 
-type OP = {
+type OP = {|
   robot: Robot,
   mount: Mount,
   parentUrl: string,
-}
+|}
 
-type SP = {
+type SP = {|
   pipette: ?Pipette,
   pipetteConfig: ?PipetteConfigResponse,
   configError: ?ApiRequestError,
-}
+|}
 
-type DP = {
+type DP = {|
   updateConfig: (id: string, PipetteConfigRequest) => mixed,
-}
+|}
 
-type Props = SP & OP & DP
+// type Props = SP & OP & DP
+type Props = {...$Exact<OP>, ...$Exact<SP>, ...$Exact<DP>}
 
 export default connect(
   makeMapStateToProps,

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -1,21 +1,33 @@
 // @flow
 import * as React from 'react'
 import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+
 import {
   makeGetRobotPipettes,
   makeGetRobotPipetteConfigs,
+  fetchPipetteConfigs,
+  setPipetteConfigs,
+  makeGetPipetteRequestById,
 } from '../../http-api-client'
+import {chainActions} from '../../util'
 
 import {getPipetteModelSpecs} from '@opentrons/shared-data'
 
 import {ScrollableAlertModal} from '../modals'
 import ConfigMessage from './ConfigMessage'
 import ConfigForm from './ConfigForm'
+import ConfigErrorBanner from './ConfigErrorBanner'
 
 import type {State} from '../../types'
 import type {Mount} from '../../robot'
 import type {Robot} from '../../discovery'
-import type {Pipette, PipetteConfigResponse} from '../../http-api-client'
+import type {
+  Pipette,
+  PipetteConfigRequest,
+  PipetteConfigResponse,
+  ApiRequestError,
+} from '../../http-api-client'
 
 type OP = {
   robot: Robot,
@@ -26,14 +38,22 @@ type OP = {
 type SP = {
   pipette: ?Pipette,
   pipetteConfig: ?PipetteConfigResponse,
+  configError: ?ApiRequestError,
 }
 
-type Props = SP & OP
+type DP = {
+  updateConfig: (id: string, PipetteConfigRequest) => mixed,
+}
 
-export default connect(makeMapStateToProps)(ConfigurePipette)
+type Props = SP & OP & DP
+
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(ConfigurePipette)
 
 function ConfigurePipette (props: Props) {
-  const {parentUrl, pipette, pipetteConfig} = props
+  const {parentUrl, pipette, pipetteConfig, updateConfig, configError} = props
   // TODO (ka 2019-2-12): This logic is used to get display name in slightly
   // different ways in several different files.
   const pipetteModel = pipette && pipette.model
@@ -41,15 +61,16 @@ function ConfigurePipette (props: Props) {
   const displayName = pipetteSpec ? pipetteSpec.displayName : ''
 
   const TITLE = `Pipette Settings: ${displayName}`
-
   return (
     <ScrollableAlertModal heading={TITLE} alertOverlay>
+      {configError && <ConfigErrorBanner message={configError.message} />}
       <ConfigMessage />
       {pipette && pipetteConfig && (
         <ConfigForm
           pipette={pipette}
           pipetteConfig={pipetteConfig}
           parentUrl={parentUrl}
+          updateConfig={updateConfig}
         />
       )}
     </ScrollableAlertModal>
@@ -59,6 +80,7 @@ function ConfigurePipette (props: Props) {
 function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
   const getRobotPipettes = makeGetRobotPipettes()
   const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
+  const getPipetteRequestById = makeGetPipetteRequestById()
   return (state, ownProps) => {
     const pipettesCall = getRobotPipettes(state, ownProps.robot)
     const pipettes = pipettesCall && pipettesCall.response
@@ -68,10 +90,26 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
     const configResponse = configCall.response
     const pipetteConfig =
       pipette && configResponse && configResponse[pipette.id]
-
+    const configSetConfigCall =
+      pipette && getPipetteRequestById(state, ownProps.robot, pipette.id)
     return {
       pipette,
       pipetteConfig,
+      configError: configSetConfigCall && configSetConfigCall.error,
     }
+  }
+}
+
+function mapDispatchToProps (dispatch: Dispatch, ownProps: OP): DP {
+  const {robot, parentUrl} = ownProps
+  return {
+    updateConfig: (id, params) =>
+      dispatch(
+        chainActions(
+          setPipetteConfigs(robot, id, params),
+          fetchPipetteConfigs(robot),
+          push(parentUrl)
+        )
+      ),
   }
 }

--- a/app/src/components/ConfigurePipette/styles.css
+++ b/app/src/components/ConfigurePipette/styles.css
@@ -56,3 +56,10 @@
 .reset_message {
   @apply --font-body-1-dark;
 }
+
+.config_submit_error {
+  font-size: var(--fs-body-1);
+  color: var(--c-warning-dark);
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}

--- a/app/src/http-api-client/client.js
+++ b/app/src/http-api-client/client.js
@@ -5,7 +5,7 @@ import type {Error} from '../types'
 import type {RobotService} from '../robot'
 import type {ApiRequestError} from './types'
 
-export type Method = 'GET' | 'POST'
+export type Method = 'GET' | 'POST' | 'PATCH'
 
 // TODO(mc, 2018-04-30): deprecate importing this type from client
 export type {ApiRequestError}
@@ -59,11 +59,15 @@ export default function client<T, U> (
 }
 
 function jsonFromResponse<T> (response: Response): Promise<T> {
-  return response.json()
+  return response
+    .json()
     .then(
-      (body) => response.ok
-        ? (body: T)
-        : Promise.reject(ResponseError(response, (body: ?{message: ?string}))),
+      body =>
+        response.ok
+          ? (body: T)
+          : Promise.reject(
+            ResponseError(response, (body: ?{message: ?string}))
+          ),
       fetchErrorFromError
     )
 }


### PR DESCRIPTION
## overview
This PR wires up `PATCH` settings/pipettes/{id} to pipette config form.

closes #2943

![2019-03-06 15 46 38](https://user-images.githubusercontent.com/3430313/53912654-68f06d00-4027-11e9-9dbe-658b43a03090.gif)


## changelog

- refactor(app): Add form submission to pipette config form
## review requests

`make -C app dev OT_APP_DEV_INTERNAL__NEW_PIPETTE_CONFIG=1`

This PR:
- DOES NOT perform form validation
- DOES render an error from api if you enter a field that is incorrect/out of min/max range (this is precautionary measure, but due to soon to be implemented form validation a user should never see this)

Please test on a robot with valid and invalid fields.

