### PR TITLE
feat(protocol-designer): point to staging or prod resources accordingly

### DIFF
--- a/protocol-designer/src/components/modals/GateModal/SignUpForm.js
+++ b/protocol-designer/src/components/modals/GateModal/SignUpForm.js
@@ -2,10 +2,14 @@
 
 import * as React from 'react'
 import {makeWidget} from '@typeform/embed'
+import {isProduction} from '../../../networking/opentronsWebApi'
 import styles from '../modal.css'
 
 // TODO: BC: 2019-03-05 this should be an env var fallback to staging after the initial prod deploy
-const SIGNUP_TYPEFORM_URL = 'https://opentrons-ux.typeform.com/to/kr4Bdf'
+
+const STAGING_TYPEFORM_URL = 'https://opentrons-ux.typeform.com/to/Td95E9'
+const PROD_TYPEFORM_URL = 'https://opentrons-ux.typeform.com/to/kr4Bdf'
+const SIGNUP_TYPEFORM_URL = isProduction ? PROD_TYPEFORM_URL : STAGING_TYPEFORM_URL
 
 class SignUpForm extends React.Component<{}> {
   embedElement: React.ElementRef<*>

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -8,6 +8,7 @@
   "beta": "beta",
   "networking": {
     "generic_verification_failure": "Something went wrong with your unique link. Fill out the form below to have a new one sent to your email. Please contact the Opentrons Support team if you require further help.",
-    "unauthorized_verification_failure": "This unique link has expired and is no longer valid, to have a new link sent to your email, fill out the form below."
+    "unauthorized_verification_failure": "This unique link has expired and is no longer valid, to have a new link sent to your email, fill out the form below.",
+    "validation_server_failure": "There was a problem communicating with the Opentrons validation server. Please make sure you are still connected to the internet and try again. If this problem persists, please contact Opentrons support."
   }
 }

--- a/protocol-designer/src/networking/opentronsWebApi.js
+++ b/protocol-designer/src/networking/opentronsWebApi.js
@@ -13,8 +13,10 @@ export type GateStage = 'loading' |
 
 type GateState = {gateStage: GateStage, errorMessage: ?string}
 
-const OPENTRONS_API_BASE_URL = process.env.OT_WEB_API_BASE_URL || 'https://staging.web-api.opentrons.com'
-const PROTOCOL_DESIGNER_URL = process.env.OT_PD_BASE_URL || 'https://staging.designer.opentrons.com'
+export const isProduction = global.location.host === 'designer.opentrons.com'
+
+let OPENTRONS_API_BASE_URL = isProduction ? 'https://web-api.opentrons.com' : 'https://staging.web-api.opentrons.com'
+let PROTOCOL_DESIGNER_URL = isProduction ? 'https://designer.opentrons.com' : 'https://staging.designer.opentrons.com'
 
 const VERIFY_EMAIL_PATH = '/users/verify-email'
 const CONFIRM_EMAIL_PATH = '/users/confirm-email'

--- a/protocol-designer/src/networking/opentronsWebApi.js
+++ b/protocol-designer/src/networking/opentronsWebApi.js
@@ -16,7 +16,7 @@ type GateState = {gateStage: GateStage, errorMessage: ?string}
 export const isProduction = global.location.host === 'designer.opentrons.com'
 
 let OPENTRONS_API_BASE_URL = isProduction ? 'https://web-api.opentrons.com' : 'https://staging.web-api.opentrons.com'
-let PROTOCOL_DESIGNER_URL = isProduction ? 'https://designer.opentrons.com' : 'https://staging.designer.opentrons.com'
+let PROTOCOL_DESIGNER_URL = global.location.href
 
 const VERIFY_EMAIL_PATH = '/users/verify-email'
 const CONFIRM_EMAIL_PATH = '/users/confirm-email'
@@ -63,7 +63,7 @@ export const getGateStage = (hasOptedIntoAnalytics: boolean | null): Promise<Gat
       if (response.ok) { // valid identity token, write new cookie
         writeIdentityCookie(body)
         gateStage = getStageFromIdentityCookie(token, hasOptedIntoAnalytics)
-        global.location.replace(PROTOCOL_DESIGNER_URL)
+        global.location.replace(PROTOCOL_DESIGNER_URL) // redirect to clean token qs param from url
       } else {
         const {status, statusText} = response
         errorMessage = i18n.t('application.networking.unauthorized_verification_failure')

--- a/protocol-designer/src/networking/opentronsWebApi.js
+++ b/protocol-designer/src/networking/opentronsWebApi.js
@@ -15,8 +15,8 @@ type GateState = {gateStage: GateStage, errorMessage: ?string}
 
 export const isProduction = global.location.host === 'designer.opentrons.com'
 
-let OPENTRONS_API_BASE_URL = isProduction ? 'https://web-api.opentrons.com' : 'https://staging.web-api.opentrons.com'
-let PROTOCOL_DESIGNER_URL = global.location.href
+const OPENTRONS_API_BASE_URL = isProduction ? 'https://web-api.opentrons.com' : 'https://staging.web-api.opentrons.com'
+const PROTOCOL_DESIGNER_URL = global.location.href
 
 const VERIFY_EMAIL_PATH = '/users/verify-email'
 const CONFIRM_EMAIL_PATH = '/users/confirm-email'

--- a/protocol-designer/src/networking/opentronsWebApi.js
+++ b/protocol-designer/src/networking/opentronsWebApi.js
@@ -16,7 +16,7 @@ type GateState = {gateStage: GateStage, errorMessage: ?string}
 export const isProduction = global.location.host === 'designer.opentrons.com'
 
 const OPENTRONS_API_BASE_URL = isProduction ? 'https://web-api.opentrons.com' : 'https://staging.web-api.opentrons.com'
-const PROTOCOL_DESIGNER_URL = global.location.href
+const PROTOCOL_DESIGNER_VERIFY_URL = isProduction ? global.location.origin : 'https://staging.designer.opentrons.com'
 
 const VERIFY_EMAIL_PATH = '/users/verify-email'
 const CONFIRM_EMAIL_PATH = '/users/confirm-email'
@@ -63,7 +63,7 @@ export const getGateStage = (hasOptedIntoAnalytics: boolean | null): Promise<Gat
       if (response.ok) { // valid identity token, write new cookie
         writeIdentityCookie(body)
         gateStage = getStageFromIdentityCookie(token, hasOptedIntoAnalytics)
-        global.location.replace(PROTOCOL_DESIGNER_URL) // redirect to clean token qs param from url
+        global.location.replace(global.location.origin) // redirect to clean token qs param from url
       } else {
         const {status, statusText} = response
         errorMessage = i18n.t('application.networking.unauthorized_verification_failure')
@@ -83,7 +83,7 @@ export const getGateStage = (hasOptedIntoAnalytics: boolean | null): Promise<Gat
     const confirmEmailBody = {
       name,
       email,
-      verifyUrl: PROTOCOL_DESIGNER_URL,
+      verifyUrl: PROTOCOL_DESIGNER_VERIFY_URL,
       templateName: 'verify-email-pd',
     }
     return fetch(
@@ -94,13 +94,17 @@ export const getGateStage = (hasOptedIntoAnalytics: boolean | null): Promise<Gat
         gateStage = 'promptCheckEmail'
       } else {
         console.error('Failed to confirm identity and send user email.')
-        errorMessage = i18n.t('application.networking.generic_verification_failure')
+        errorMessage = i18n.t('application.networking.validation_server_failure')
         gateStage = 'failedIdentityVerification'
+
+        const {status, statusText} = response
+        const specificAddendum = (body && body.message) || `${status} ${statusText}`
+        errorMessage = `${errorMessage}  (Error Message: ${specificAddendum})`
       }
       return {gateStage, errorMessage}
     }).catch(error => {
       gateStage = 'failedIdentityVerification'
-      errorMessage = error || i18n.t('application.networking.generic_verification_failure')
+      errorMessage = error || i18n.t('application.networking.validation_server_failure')
       return {gateStage, errorMessage}
     }))
   } else { // No identity token


### PR DESCRIPTION
Switch all staging urls out for production urls

Closes #3180

## changelog

After this PR is merged all non-production builds of PD will point to: 

 - staging typeform
 - staging web api
 - reflexive `location.href` for redirects

and all deployed production builds will point to:

 - production typeform
 - production web api
 - reflexive `location.href` for redirects