### PR TITLE
build(protocol-designer): Remove most images from bundle

### DIFF
--- a/webpack-config/lib/rules.js
+++ b/webpack-config/lib/rules.js
@@ -92,6 +92,8 @@ module.exports = {
   },
 
   // common image formats (url loader)
+  // TODO(mc, 2019-03-06): add a sensible limit or replace with file-loader
+  //  (which means no image inlining) if we can get the app to behave
   images: {
     test: /\.(?:ico|gif|png|jpg|jpeg|webp|svg)$/,
     use: 'url-loader',


### PR DESCRIPTION
## overview

As discussed in RL, this PR is an easy win to reduce bundle the PD bundle size by removing almost all of the inlined images from the bundle

## changelog

Before:
- bundle.b66b2dd51e3c2263caa4.js (4.73 MB, 2.49 MB gzip)
- 1.bundle.ac84872f8541429b5f78.js (21.1 KB, 6.33 KB gzip)

After:

- bundle.6395c9ecd30c90719dea.js (1.91 MB, 458.11 KB gzip)
- 1.bundle.ac84872f8541429b5f78.js (21.1 KB, 6.33 KB gzip)

## review requests

Make sure all the images still work and load and stuff

### follow-ups

We've got some additional low-hanging fruit in terms of bundle size reduction:

- typeform/embed (192 KB, candidate for dynamic import)
- moment (217 KB, prime candidate for replacement)
- opentrons/shared-data (384 KB, candidate for dynamic import)
- See `make -C protocol-designer ANALYZER=1` for more details