### PR TITLE
ci(travis): Match ^v for tag stuff instead of testing presence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,8 @@ jobs:
           script: make -C api deploy pypi_username=${PYPI_USER} pypi_password=${PYPI_PASSWORD}
           on:
             all_branches: true
-            tags: true
+            condition: $TRAVIS_TAG =~ ^v
             repo: Opentrons/opentrons
-            branch: edge
 
         # push to test pypi on pr
         - provider: script
@@ -131,23 +130,21 @@ jobs:
       name: 'Build/deploy Opentrons App for POSIX (unsigned dev builds)'
       os: linux
       script: make -C app-shell dist-posix
-      if: tag IS blank AND NOT branch =~ ^(edge|release_.+)$
+      if: (NOT tag =~ ^v) AND (NOT branch =~ ^(edge|release_.+)$)
 
     - # build the Opentrons App for Linux (tagged / edge / RC builds)
       <<: *app_stage_build
       name: 'Build/deploy Opentrons App for Linux'
       os: linux
       script: make -C app-shell dist-linux
-      if: tag IS present OR branch =~ ^(edge|release_.+)$
+      if: tag =~ ^v OR branch =~ ^(edge|release_.+)$
 
     - # build the Opentrons App for macOS (tagged / edge / RC builds)
       <<: *app_stage_build
       name: 'Build/deploy Opentrons App for macOS'
       os: osx
       script: make -C app-shell dist-osx
-      if: tag IS present OR branch =~ ^(edge|release_.+)$
-
-
+      if: tag =~ ^v OR branch =~ ^(edge|release_.+)$
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,10 @@ jobs:
       name: 'Build/deploy Opentrons App for POSIX (unsigned dev builds)'
       os: linux
       script: make -C app-shell dist-posix
-      if: (NOT tag =~ ^v) AND (NOT branch =~ ^(edge|release_.+)$)
+      # TODO(mc, 2019-03-07): app-shell makefile still looks for presense of
+      # tag rather than correct tag format. For now, skip app builds entirely if
+      # tag is present but does not match ^v
+      if: tag IS blank AND (NOT branch =~ ^(edge|release_.+)$)
 
     - # build the Opentrons App for Linux (tagged / edge / RC builds)
       <<: *app_stage_build

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -31,6 +31,8 @@ update_files := "dist/@(alpha|beta|latest)*.@(yml|json)"
 publish_dir := dist/publish
 
 # TODO(mc, 2018-03-27): move all this to some sort of envfile
+# TODO(mc, 2018-03-07): tag logic here is too naive since PD will tag its
+#   releases independently. See TODO in .travis.yml and revisit this logic
 # build id suffix to add to artifacts
 # if no build number -> dev
 # if tagged build (branch == tag) -> b$(BUILD_NUMBER)


### PR DESCRIPTION
## overview

This change allows PD to tag its independent releases without triggering app/API stuff if the tags
are scoped (e.g. git tag -a protocol-designer@1.2.3)

