### PR TITLE
fix(shared-data): Fix diameter of generic 96 flat

### DIFF
--- a/shared-data/definitions2/generic_96_wellPlate_380_uL.json
+++ b/shared-data/definitions2/generic_96_wellPlate_380_uL.json
@@ -156,7 +156,7 @@
         "H1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 11.24,
@@ -165,7 +165,7 @@
         "G1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 20.24,
@@ -174,7 +174,7 @@
         "F1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 29.24,
@@ -183,7 +183,7 @@
         "E1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 38.24,
@@ -192,7 +192,7 @@
         "D1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 47.24,
@@ -201,7 +201,7 @@
         "C1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 56.24,
@@ -210,7 +210,7 @@
         "B1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 65.24,
@@ -219,7 +219,7 @@
         "A1": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 14.38,
             "y": 74.24,
@@ -228,7 +228,7 @@
         "H2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 11.24,
@@ -237,7 +237,7 @@
         "G2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 20.24,
@@ -246,7 +246,7 @@
         "F2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 29.24,
@@ -255,7 +255,7 @@
         "E2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 38.24,
@@ -264,7 +264,7 @@
         "D2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 47.24,
@@ -273,7 +273,7 @@
         "C2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 56.24,
@@ -282,7 +282,7 @@
         "B2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 65.24,
@@ -291,7 +291,7 @@
         "A2": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 23.38,
             "y": 74.24,
@@ -300,7 +300,7 @@
         "H3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 11.24,
@@ -309,7 +309,7 @@
         "G3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 20.24,
@@ -318,7 +318,7 @@
         "F3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 29.24,
@@ -327,7 +327,7 @@
         "E3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 38.24,
@@ -336,7 +336,7 @@
         "D3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 47.24,
@@ -345,7 +345,7 @@
         "C3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 56.24,
@@ -354,7 +354,7 @@
         "B3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 65.24,
@@ -363,7 +363,7 @@
         "A3": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 32.38,
             "y": 74.24,
@@ -372,7 +372,7 @@
         "H4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 11.24,
@@ -381,7 +381,7 @@
         "G4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 20.24,
@@ -390,7 +390,7 @@
         "F4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 29.24,
@@ -399,7 +399,7 @@
         "E4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 38.24,
@@ -408,7 +408,7 @@
         "D4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 47.24,
@@ -417,7 +417,7 @@
         "C4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 56.24,
@@ -426,7 +426,7 @@
         "B4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 65.24,
@@ -435,7 +435,7 @@
         "A4": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 41.38,
             "y": 74.24,
@@ -444,7 +444,7 @@
         "H5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 11.24,
@@ -453,7 +453,7 @@
         "G5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 20.24,
@@ -462,7 +462,7 @@
         "F5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 29.24,
@@ -471,7 +471,7 @@
         "E5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 38.24,
@@ -480,7 +480,7 @@
         "D5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 47.24,
@@ -489,7 +489,7 @@
         "C5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 56.24,
@@ -498,7 +498,7 @@
         "B5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 65.24,
@@ -507,7 +507,7 @@
         "A5": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 50.38,
             "y": 74.24,
@@ -516,7 +516,7 @@
         "H6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 11.24,
@@ -525,7 +525,7 @@
         "G6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 20.24,
@@ -534,7 +534,7 @@
         "F6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 29.24,
@@ -543,7 +543,7 @@
         "E6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 38.24,
@@ -552,7 +552,7 @@
         "D6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 47.24,
@@ -561,7 +561,7 @@
         "C6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 56.24,
@@ -570,7 +570,7 @@
         "B6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 65.24,
@@ -579,7 +579,7 @@
         "A6": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 59.38,
             "y": 74.24,
@@ -588,7 +588,7 @@
         "H7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 11.24,
@@ -597,7 +597,7 @@
         "G7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 20.24,
@@ -606,7 +606,7 @@
         "F7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 29.24,
@@ -615,7 +615,7 @@
         "E7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 38.24,
@@ -624,7 +624,7 @@
         "D7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 47.24,
@@ -633,7 +633,7 @@
         "C7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 56.24,
@@ -642,7 +642,7 @@
         "B7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 65.24,
@@ -651,7 +651,7 @@
         "A7": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 68.38,
             "y": 74.24,
@@ -660,7 +660,7 @@
         "H8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 11.24,
@@ -669,7 +669,7 @@
         "G8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 20.24,
@@ -678,7 +678,7 @@
         "F8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 29.24,
@@ -687,7 +687,7 @@
         "E8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 38.24,
@@ -696,7 +696,7 @@
         "D8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 47.24,
@@ -705,7 +705,7 @@
         "C8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 56.24,
@@ -714,7 +714,7 @@
         "B8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 65.24,
@@ -723,7 +723,7 @@
         "A8": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 77.38,
             "y": 74.24,
@@ -732,7 +732,7 @@
         "H9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 11.24,
@@ -741,7 +741,7 @@
         "G9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 20.24,
@@ -750,7 +750,7 @@
         "F9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 29.24,
@@ -759,7 +759,7 @@
         "E9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 38.24,
@@ -768,7 +768,7 @@
         "D9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 47.24,
@@ -777,7 +777,7 @@
         "C9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 56.24,
@@ -786,7 +786,7 @@
         "B9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 65.24,
@@ -795,7 +795,7 @@
         "A9": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 86.38,
             "y": 74.24,
@@ -804,7 +804,7 @@
         "H10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 11.24,
@@ -813,7 +813,7 @@
         "G10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 20.24,
@@ -822,7 +822,7 @@
         "F10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 29.24,
@@ -831,7 +831,7 @@
         "E10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 38.24,
@@ -840,7 +840,7 @@
         "D10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 47.24,
@@ -849,7 +849,7 @@
         "C10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 56.24,
@@ -858,7 +858,7 @@
         "B10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 65.24,
@@ -867,7 +867,7 @@
         "A10": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 95.38,
             "y": 74.24,
@@ -876,7 +876,7 @@
         "H11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 11.24,
@@ -885,7 +885,7 @@
         "G11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 20.24,
@@ -894,7 +894,7 @@
         "F11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 29.24,
@@ -903,7 +903,7 @@
         "E11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 38.24,
@@ -912,7 +912,7 @@
         "D11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 47.24,
@@ -921,7 +921,7 @@
         "C11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 56.24,
@@ -930,7 +930,7 @@
         "B11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 65.24,
@@ -939,7 +939,7 @@
         "A11": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 104.38,
             "y": 74.24,
@@ -948,7 +948,7 @@
         "H12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 11.24,
@@ -957,7 +957,7 @@
         "G12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 20.24,
@@ -966,7 +966,7 @@
         "F12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 29.24,
@@ -975,7 +975,7 @@
         "E12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 38.24,
@@ -984,7 +984,7 @@
         "D12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 47.24,
@@ -993,7 +993,7 @@
         "C12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 56.24,
@@ -1002,7 +1002,7 @@
         "B12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 65.24,
@@ -1011,7 +1011,7 @@
         "A12": {
             "depth": 10.54,
             "shape": "circular",
-            "diameter": 10,
+            "diameter": 6.4,
             "totalLiquidVolume": 380,
             "x": 113.38,
             "y": 74.24,


### PR DESCRIPTION
## overview

@sfoster1 noticed that the diameter of the generic 96 flat was very off. Unfortunately the ANSI standard mechanical drawings do not actually recommend a diameter -- and this seems to be one of the largely varying parameters on well plates.

## changelog
- Change diameter from 10 -> 6.4 (note this value was pulled from older definition of 96 flat)

## review requests
- I suppose we should test touch tip on a random 96 flat lying around?