### PR TITLE
fix(protocol-designer): fix mix form disabled fields

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMixForm.js
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/getDisabledFieldsMixForm.js
@@ -3,13 +3,13 @@ import type {FormData} from '../../../form-types'
 
 // NOTE: expects that '_checkbox' fields are implemented so that
 // when checkbox is disabled, its dependent fields are hidden
-export default function getDisabledFieldsMoveLiquidForm (
+export default function getDisabledFieldsMixForm (
   rawForm: FormData // TODO IMMEDIATELY use raw form type instead of FormData
 ): Set<string> {
   const disabled = new Set()
 
   if (!rawForm.pipette || !rawForm['labware']) {
-    disabled.add('touchTip') // TODO: BC 2019-1-29 this is actually touchTip_checkbox
+    disabled.add('mix_touchTip_checkbox')
     disabled.add('mix_mmFromBottom')
     disabled.add('wells')
   }


### PR DESCRIPTION
## overview

Closes #3049

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Mix fields should be disabled correctly. Specifically, touch tip and tip position fields should be disabled unless both pipette and labware are selected.