### PR TITLE
feat(protocol-designer): add 404 redirect page

### DIFF
--- a/protocol-designer/src/error.html
+++ b/protocol-designer/src/error.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <title>404 Redirect</title>
+  <meta charset='utf-8'>
+</head>
+
+<body>
+  <script>
+    var location = window.location
+    var protocol = location.protocol
+    var host = location.host
+
+    window.location.replace(protocol + '//' + host)
+  </script>
+  <noscript>
+    Page not found. If you believe this is an error, please contact Opentrons support.
+  </noscript>
+</body>
+</html>

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -21,6 +21,7 @@ const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')
 const HTML_ENTRY = path.join(__dirname, 'src/index.hbs')
+const ERROR_HTML = path.join(__dirname, 'src/error.html')
 
 const passThruEnvVars = Object.keys(process.env)
   .filter(v => v.startsWith(PROTOCOL_DESIGNER_ENV_VAR_PREFIX))
@@ -79,6 +80,7 @@ module.exports = merge.strategy({'module.rules': 'replace'})(baseConfig, {
     }),
     new HtmlWebpackPlugin({
       title, description, author, template: HTML_ENTRY}),
+    new HtmlWebpackPlugin({filename: 'error.html', inject: false, template: ERROR_HTML}),
     new ScriptExtHtmlWebpackPlugin({defaultAttribute: 'defer'}),
   ],
 })


### PR DESCRIPTION
## overview

Closes #3167

Credit to Mike for the redirect to `host` idea + code

## changelog

* add `error.html` to build

## review requests

* Code review?

NOTE: After this change is deployed, the staging and prod S3 website settings will have to be modified so that errors go to this new `error.html` (otherwise they'll continue to serve `index.html`)