### PR TITLE
ci(protocol-designer): make deploy bucket env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
           region: us-east-2
           dot_match: true
           local-dir: protocol-designer/dist
-          bucket: opentrons-protocol-designer-builds
+          bucket: $OT_PD_DEPLOY_BUCKET
           upload-dir: $TRAVIS_BRANCH
         - # deploy components library to S3
           <<: *deploy_s3


### PR DESCRIPTION
In order to make viewing branch builds artifacts easier, let's move them to an easier location that is stored in a travis env var.