### PR TITLE
build(babel): Add optional chaining proposal to babel config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -20,5 +20,6 @@ shared-data/definitions2/.*
 [options]
 module.name_mapper.extension='css' -> '@opentrons/components/interfaces/CSSModule.js'
 merge_timeout=300
+esproposal.optional_chaining=enable
 
 [strict]

--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -100,14 +100,11 @@ function AdvancedSettingsCard (props: Props) {
 
 function mapStateToProps (state: State): SP {
   const config = getConfig(state)
-  const __ffShowManualIp = config.devInternal
-    ? !!config.devInternal.manualIp
-    : false
 
   return {
     devToolsOn: config.devtools,
     channel: config.update.channel,
-    __ffShowManualIp: __ffShowManualIp,
+    __ffShowManualIp: Boolean(config.devInternal?.manualIp),
   }
 }
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,7 @@ module.exports = {
   plugins: [
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-optional-chaining',
   ],
   presets: ['@babel/preset-flow', '@babel/preset-react', PRESET_ENV_NO_MODULES],
   overrides: [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-flow": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,6 +328,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
+"@babel/plugin-proposal-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz#ae454f4c21c6c2ce8cb2397dc332ae8b420c5441"
+  integrity sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
@@ -369,6 +377,13 @@
 "@babel/plugin-syntax-optional-catch-binding@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
+  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
## overview

As discussed on Slack, this PR adds [@babel/plugin-proposal-optional-chaining](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) to our Babel plugin chain. This enables the following syntax:

```js
// before
const foo = bar && bar.baz && bar.baz.qux

// after
const foo = bar?.baz?.qux
```

Flow is able to type this syntax correctly.

## changelog

- Add optional chaining proposal to babel config

Note: we also discussed adding [@babel/plugin-proposal-do-expressions](https://babeljs.io/docs/en/babel-plugin-proposal-do-expressions), but Flow does not support this plugin at a syntax level, so we can't move forward (facebook/flow#560).

## review requests

I've made one example change in source to demonstrate the kinds of benefits we could see. A couple things to repeat based on our discussions on Slack and in real life:

- This syntax is easy to overuse. We should be careful and purposeful when we use it, and add comments if anything about it's usage isn't obvious
- The optional function syntax in this proposal is pretty ugly and a little hard to mentally parse
    - The technical reasoning behind the syntax decisions seems sound, but I still think we should probably avoid using it for function calls
