### PR TITLE
feat(app): Enable pipette config modal and form

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -113,7 +113,7 @@ export default class ConfigForm extends React.Component<Props> {
           set(errors, name, `number required`)
         } else if (
           typeof min === 'number' &&
-          max &&
+          typeof max === 'number' &&
           (parsed < min || value > max)
         ) {
           set(errors, name, `Min ${min} / Max ${max}`)

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -98,9 +98,7 @@ export default class ConfigForm extends React.Component<Props> {
 
   validate = (values: FormValues) => {
     const errors = {}
-    const fields = this.props.showHiddenFields
-      ? this.props.pipetteConfig.fields
-      : this.getVisibleFields()
+    const fields = this.getVisibleFields()
     const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
 
     // validate all visible fields with min and max

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -137,14 +137,14 @@ export default class ConfigForm extends React.Component<Props> {
   render () {
     const {parentUrl} = this.props
     const fields = this.getVisibleFields()
-    const HIDDEN_KEYS = this.getUnknownKeys()
+    const UNKNOWN_KEYS = this.getUnknownKeys()
     const initialValues = mapValues(fields, f => {
       return f.value !== f.default ? f.value.toString() : ''
     })
     const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
     const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
     const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
-    const devFields = this.getFieldsByKey(HIDDEN_KEYS, fields)
+    const devFields = this.getFieldsByKey(UNKNOWN_KEYS, fields)
 
     return (
       <Formik

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
-
 import {
   makeGetRobotPipettes,
   makeGetRobotPipetteConfigs,
@@ -11,6 +10,7 @@ import {
   makeGetPipetteRequestById,
 } from '../../http-api-client'
 import {chainActions} from '../../util'
+import {getConfig} from '../../config'
 
 import {getPipetteModelSpecs} from '@opentrons/shared-data'
 
@@ -39,6 +39,7 @@ type SP = {|
   pipette: ?Pipette,
   pipetteConfig: ?PipetteConfigResponse,
   configError: ?ApiRequestError,
+  __featureEnabled: boolean,
 |}
 
 type DP = {|
@@ -72,6 +73,7 @@ function ConfigurePipette (props: Props) {
           pipetteConfig={pipetteConfig}
           parentUrl={parentUrl}
           updateConfig={updateConfig}
+          showHiddenFields={props.__featureEnabled}
         />
       )}
     </ScrollableAlertModal>
@@ -93,10 +95,12 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
       pipette && configResponse && configResponse[pipette.id]
     const configSetConfigCall =
       pipette && getPipetteRequestById(state, ownProps.robot, pipette.id)
+    const devInternal = getConfig(state).devInternal
     return {
       pipette,
       pipetteConfig,
       configError: configSetConfigCall && configSetConfigCall.error,
+      __featureEnabled: !!devInternal && !!devInternal.allPipetteConfig,
     }
   }
 }

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -2,7 +2,6 @@
 // attached pipettes container card
 import * as React from 'react'
 import {connect} from 'react-redux'
-import {getIn} from '@thi.ng/paths'
 
 import {
   makeGetRobotPipettes,
@@ -20,7 +19,6 @@ import {Card, IntervalWrapper} from '@opentrons/components'
 import type {State} from '../../types'
 import type {Robot} from '../../discovery'
 import type {Pipette} from '../../http-api-client'
-import {getConfig} from '../../config'
 
 type OP = Robot
 
@@ -29,7 +27,6 @@ type SP = {
   left: ?Pipette,
   right: ?Pipette,
   showSettings: boolean,
-  __featureEnabled: boolean,
 }
 
 type DP = {
@@ -38,8 +35,6 @@ type DP = {
 }
 
 type Props = OP & SP & DP
-
-const __FEATURE_FLAG = 'devInternal.newPipetteConfig'
 
 const TITLE = 'Pipettes'
 
@@ -59,7 +54,6 @@ function AttachedPipettesCard (props: Props) {
             {...props.left}
             onChangeClick={props.clearMove}
             showSettings={props.showSettings}
-            __enableConfig={props.__featureEnabled}
           />
           <InstrumentInfo
             mount="right"
@@ -67,7 +61,6 @@ function AttachedPipettesCard (props: Props) {
             {...props.right}
             onChangeClick={props.clearMove}
             showSettings={props.showSettings}
-            __enableConfig={props.__featureEnabled}
           />
         </CardContentFlex>
       </Card>
@@ -88,7 +81,6 @@ function makeMapStateToProps (): (state: State, ownProps: OP) => SP {
       left,
       right,
       showSettings: !!configCall.response,
-      __featureEnabled: !!getIn(getConfig(state), __FEATURE_FLAG),
     }
   }
 }

--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -18,7 +18,6 @@ type Props = {
   name: string,
   onChangeClick: () => mixed,
   showSettings: boolean,
-  __enableConfig: boolean,
 }
 
 // TODO(mc, 2018-03-30): volume and channels should come from the API
@@ -54,7 +53,7 @@ export default function PipetteInfo (props: Props) {
         <OutlineButton Component={Link} to={changeUrl} onClick={onChangeClick}>
           {direction}
         </OutlineButton>
-        {props.__enableConfig && model && showSettings && (
+        {model && showSettings && (
           <OutlineButton Component={Link} to={configUrl}>
             settings
           </OutlineButton>

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -64,7 +64,7 @@ export type Config = {
 
   // internal development flags
   devInternal?: {
-    newPipetteConfig?: boolean,
+    allPipetteConfig?: boolean,
     manualIp?: boolean,
   },
 }


### PR DESCRIPTION
## overview
This PR removes feature flag and enables pipette config for up to date robots (robots which return a response from /settings/pipettes)

This PR also renders validates and submits hidden fields when new feature flag `--internalDev.allPipetteConfig` is true.

closes #3112



## changelog
- feat(app): Enable pipette config modal and form
- feat(app): Render hidden config fields behind new feat flag

## review requests

*note: I gave a build to support so I will hold off on merging this until they give me feedback on functionality*

`make -C app dev` 
- [x] pipette config settings button renders for robots with up to date software (returns data from pipette config endpoint)
- [x] pipette config settings button does not render for mounts with no pipette, or for robots without the latest robot software
- [x] [settings] button opens modal with config form for the correct pipette
- [x] validation works as expected
- [x] form submit works as expected
- [x] reset all works as expected
- [x] clearing a value resets to placeholder/default
- [x] non default saved values (returned from robot) render as editable text
- [x] [save] is disabled when validation errors exist
- [x] [save] button submits form and closes modal
- [x] reopening modal renders updated pipette config values

`make -C app dev OT_APP_DEV_INTERNAL__ALL_PIPETTE_CONFIG=1`
- [x] all default settings listed above work as expected
- [x] hidden fields render
- [x] hidden fields validate as expected
- [x] hidden fields update config on submit
