### PR TITLE
feat(api): add udev rule for thermocycler board

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -46,7 +46,8 @@ ot_py_sources := $(filter %.py,$(shell $(SHX) find src/opentrons/))
 ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 # And the arbitrary stuff in resources
 ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
-ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
+modules_configs := $(filter %.rules,$(shell $(SHX) find src/opentrons/config/modules))
+ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources) $(modules_configs)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target

--- a/api/src/opentrons/config/modules/95-opentrons-modules.rules
+++ b/api/src/opentrons/config/modules/95-opentrons-modules.rules
@@ -1,3 +1,6 @@
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee93", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_tempdeck"
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee90", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_magdeck"
 KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ee5a", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_bootloader"
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="ed8c", ATTRS{idVendor}=="04d8", SYMLINK+="modules/tty%n_thermocycler"
+# adafruit feather m0 board for dev:
+KERNEL=="ttyACM[0-9]*", SUBSYSTEMS=="usb", ATTRS{idProduct}=="800b", ATTRS{idVendor}=="239a", SYMLINK+="modules/tty%n_thermocycler"

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -91,9 +91,9 @@ class TCPoller(threading.Thread):
         self._halt_write_fd = open(self._halt_path, 'wb', buffering=0)
 
         self._poller = select.poll()
-        self._poller.register(self._send_read_file, eventmask=select.POLLIN)
-        self._poller.register(self._halt_read_file, eventmask=select.POLLIN)
-        self._poller.register(self._connection, eventmask=select.POLLIN)
+        self._poller.register(self._send_read_file, select.POLLIN)
+        self._poller.register(self._halt_read_file, select.POLLIN)
+        self._poller.register(self._connection, select.POLLIN)
 
         serial_thread_name = 'tc_serial_poller_{}'.format(hash(self))
         super().__init__(target=self._serial_poller, name=serial_thread_name)


### PR DESCRIPTION
Addresses #3144

## overview

This PR enables the robot to discover a connected thermocycler module

## changelog

- Added udev rule for the thermocycler boards- These rules make use of the VID and PID of the product to create a symlink to the usb port with the appropriate name. The PID that we use for our modules are sublicensed from Microchip (since we use uC from Microchip). The udev file in this PR includes one rule for the actual board that *will be* the 'Opentrons Thermocycler Module' (PID provided by Microchip for Thermocycler), and a temporary one for the dummy adafruit boards we'll be using for dev
- Added the rules file in Makefile sources so changes made to it are included in the wheel
- Made correction to poll register call (seems like `register()` doesn't use `eventmask` as kwarg)

## review requests

Please check for any code issues and test on your robots
