### PR TITLE
feat(api): Add fake data for thermocycler endpoint

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1072,10 +1072,23 @@ class API(HardwareAPILike):
         for mod in gone:
             self._attached_modules.pop(mod)
         for mod in new:
-            self._attached_modules[mod]\
-                = self._backend.build_module(discovered[mod][0],
-                                             discovered[mod][1],
-                                             self.pause_with_message)
+            print("MODULES INFO HARDWARE")
+            print(discovered[mod])
+            if 'thermocycler' in discovered[mod][1]:
+                self._attached_modules[mod] = {
+                    'name': discovered[mod][1],
+                    'displayName': discovered[mod][1],
+                    'port': discovered[mod][0],
+                    'serial': 'TCFAKE',
+                    'model': 'thermocycler_v1',
+                    'fwVersion': 'v1',
+                    'status': 'connected',
+                    'data': {}}
+            else:
+                self._attached_modules[mod]\
+                    = self._backend.build_module(discovered[mod][0],
+                                                 discovered[mod][1],
+                                                 self.pause_with_message)
         return list(self._attached_modules.values())
 
     @_log_call

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -107,6 +107,7 @@ async def get_attached_modules(request):
     hw = hw_from_req(request)
     if ff.use_protocol_api_v2():
         hw_mods = await hw.discover_modules()
+        print(hw_mods)
         module_data = [
             {
                 'name': mod.name(),
@@ -117,8 +118,9 @@ async def get_attached_modules(request):
                 'fwVersion': mod.device_info.get('version'),
                 **mod.live_data
             }
-            for mod in hw_mods
+            if not isinstance(mod, dict) else mod for mod in hw_mods
         ]
+        print(module_data)
     else:
         hw.discover_modules()
         hw_mods = hw.modules

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -123,6 +123,7 @@ async def check_modules_response(async_client):
                    'displayName', 'status', 'data'])
     resp = await async_client.get('/modules')
     body = await resp.json()
+    print(body)
     assert resp.status == 200
     assert 'modules' in body
     assert len(body['modules']) == 1


### PR DESCRIPTION
## overview

This is a quick add-in to unblock Katie from frontend work for the thermocycler. This should _not_ be merged and this PR will be closed once status is actually implemented.

## changelog

- Add fake data when a fake TC module is discovered. Data is formatted as:
```
                self._attached_modules[mod] = {
                    'name': discovered[mod][1],
                    'displayName': discovered[mod][1],
                    'port': discovered[mod][0],
                    'serial': 'TCFAKE',
                    'model': 'thermocycler_v1',
                    'fwVersion': 'v1',
                    'status': 'connected',
                    'data': {}}
```

## review requests

@Kadee80 need anything else?
