### PR TITLE
feat(protocol-designer): hide GateModal in dev by default

### DIFF
--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -57,6 +57,10 @@ Used for analytics segmentation. In Travis CI, this is fed by `$TRAVIS_COMMIT`.
 
 Used for FullStory. Should be provided in the Travis build.
 
+### `OT_PD_SHOW_GATE`
+
+If truthy, uses the `GateModal` component in development. The `GateModal` component is always used in production.
+
 [chrome]: https://www.google.com/chrome/
 [json-schema]: https://json-schema.org/
 [ot-2]: https://opentrons.com/ot-2

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -19,12 +19,14 @@ const SelectorDebugger = process.env.NODE_ENV === 'development'
   ? require('../containers/SelectorDebugger').default
   : () => null
 
+const showGateModal = process.env.NODE_ENV === 'production' || process.env.OT_PD_SHOW_GATE
+
 function ProtocolEditor () {
   return (
     <div>
       <SelectorDebugger />
       <TopPortalRoot />
-      <GateModal />
+      {showGateModal ? <GateModal /> : null}
       <div className={styles.wrapper}>
         <ConnectedNav />
         <ConnectedSidebar />


### PR DESCRIPTION
## overview

Closes #3189

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

* The branch build on PD sandbox should show the GateModal (you may have to clear your cookies to see it)
* `make dev` should not show the GateModal
* `OT_PD_SHOW_GATE=1 make dev` should show the GateModal (as before, you can't get past it unless you serve it on something other than localhost)