### PR TITLE
fix(api): cache modules in singleton for apiV1 protocols

### DIFF
--- a/api/docs/source/modules.rst
+++ b/api/docs/source/modules.rst
@@ -47,9 +47,7 @@ be done like the following:
     from opentrons import modules, robot
 
     robot.connect()
-    for module in robot.modules:
-            module.disconnect()
-    robot.modules = modules.discover_and_connect()
+    robot.discover_modules()
 
     module = modules.load('Module Name', slot)
     ... etc

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -83,7 +83,6 @@ class Controller:
         self.config = config or opentrons.config.robot_configs.load()
         self._smoothie_driver = driver_3_0.SmoothieDriver_3_0_0(
             config=self.config)
-        self._attached_modules = {}
         self._cached_fw_version: Optional[str] = None
 
     def move(self, target_position: Dict[str, float],

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -99,8 +99,7 @@ def discover() -> List[Tuple[str, Any]]:
                 log.warning("Unexpected module connected: {} on {}"
                             .format(name, port))
                 continue
-            absolute_port = '/dev/modules/{}'.format(port)
-            discovered_modules.append((absolute_port, name))
+            discovered_modules.append((port, name))
     log.info('Discovered modules: {}'.format(discovered_modules))
 
     # for module in discovered_modules:

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -60,9 +60,10 @@ def load(name, slot):
             # support for multiple instances of one module type this
             # accessor would then load the correct disambiguated module
             # instance via the module's serial
+            module_instances = _mod_robot.attached_modules.values()
             matching_modules = [
-                module for module in _mod_robot.modules if isinstance(
-                    module, SUPPORTED_MODULES.get(name)
+                mod for mod in module_instances if isinstance(
+                    mod, SUPPORTED_MODULES.get(name)
                 )
             ]
             if matching_modules:

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -102,12 +102,6 @@ def discover() -> List[Tuple[str, Any]]:
             discovered_modules.append((port, name))
     log.info('Discovered modules: {}'.format(discovered_modules))
 
-    # for module in discovered_modules:
-    #     try:
-    #         module.connect()
-    #     except AttributeError:
-    #         log.exception('Failed to connect module')
-
     return discovered_modules
 
 

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1046,7 +1046,7 @@ class Robot(CommandPublisher):
         for mod in gone:
             self._attached_modules.pop(mod)
         for mod in new:
-            module_class = modules.SUPPORTED_MODULES.get(discovered[mod][1])
+            module_class = modules.SUPPORTED_MODULES[discovered[mod][1]]
             absolute_port = '/dev/modules/{}'.format(discovered[mod][0])
             self._attached_modules[mod]\
                 = module_class(port=absolute_port, broker=self.broker)

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1032,6 +1032,10 @@ class Robot(CommandPublisher):
     async def disengage_axes(self, axes):
         self._driver.disengage_axis(''.join(axes))
 
+    @property
+    def attached_modules(self):
+        return self._attached_modules
+
     def discover_modules(self):
         discovered = {port + model: (port, model)
                       for port, model in modules.discover()}

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import logging
 from functools import lru_cache
+from typing import Dict, Any
 
 from numpy import add, subtract
 
@@ -105,7 +106,7 @@ class Robot(CommandPublisher):
         super().__init__(broker)
         self.config = config or load()
         self._driver = driver_3_0.SmoothieDriver_3_0_0(config=self.config)
-        self.modules = []
+        self._attached_modules: Dict[str, Any] = {}  # key is port + model
         self.fw_version = self._driver.get_fw_version()
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
@@ -1032,6 +1033,21 @@ class Robot(CommandPublisher):
         self._driver.disengage_axis(''.join(axes))
 
     def discover_modules(self):
-        for module in self.modules:
-            module.disconnect()
-        self.modules = modules.discover_and_connect()
+        discovered = {port + model: (port, model)
+                      for port, model in modules.discover()}
+        these = set(discovered.keys())
+        known = set(self._attached_modules.keys())
+        new = these - known
+        gone = known - these
+        for mod in gone:
+            self._attached_modules.pop(mod)
+        for mod in new:
+            module_class = modules.SUPPORTED_MODULES.get(discovered[mod][1])
+            absolute_port = '/dev/modules/{}'.format(discovered[mod][0])
+            self._attached_modules[mod]\
+                = module_class(port=absolute_port, broker=self.broker)
+
+            try:
+                self._attached_modules[mod].connect()
+            except AttributeError:
+                log.exception('Failed to connect module')

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -121,7 +121,7 @@ async def get_attached_modules(request):
         ]
     else:
         hw.discover_modules()
-        hw_mods = hw.modules
+        hw_mods = hw.modules.values()
         module_data = [
             {
                 'name': mod.name(),
@@ -150,7 +150,7 @@ async def get_module_data(request):
     if ff.use_protocol_api_v2():
         hw_mods = await hw.discover_modules()
     else:
-        hw_mods = hw.modules
+        hw_mods = hw.modules.values()
 
     for module in hw_mods:
         is_serial_match = module.device_info.get('serial') == requested_serial

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -121,7 +121,7 @@ async def get_attached_modules(request):
         ]
     else:
         hw.discover_modules()
-        hw_mods = hw.modules.values()
+        hw_mods = hw.attached_modules.values()
         module_data = [
             {
                 'name': mod.name(),
@@ -150,7 +150,7 @@ async def get_module_data(request):
     if ff.use_protocol_api_v2():
         hw_mods = await hw.discover_modules()
     else:
-        hw_mods = hw.modules.values()
+        hw_mods = hw.attached_modules.values()
 
     for module in hw_mods:
         is_serial_match = module.device_info.get('serial') == requested_serial

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -66,7 +66,7 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
         hw.connect()
 
     hw.discover_modules()
-    hw_mods = hw.modules.values()
+    hw_mods = hw.attached_modules.values()
 
     res = {}
     for module in hw_mods:

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -64,11 +64,12 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
     # ensure there is a reference to the port
     if not hw.is_connected():
         hw.connect()
-    for module in hw.modules:
-        module.disconnect()
-    hw.modules = modules.discover_and_connect()
+
+    hw.discover_modules()
+    hw_mods = hw.modules.values()
+
     res = {}
-    for module in hw.modules:
+    for module in hw_mods:
         if module.device_info.get('serial') == serialnum:
             log.info("Module with serial {} found".format(serialnum))
             bootloader_port = await modules.enter_bootloader(module)

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -70,7 +70,7 @@ def test_run_magdeck_connected(
     monkeypatch.setattr(serial_communication, 'write_and_return', mock_write)
     magdeck = modules.MagDeck(port='/dev/modules/tty1_magdeck')
     magdeck.connect()
-    robot.modules = [magdeck]
+    robot._attached_modules = {'tty1_magdeckmagdeck': magdeck}
     modules.load('magdeck', '4')
     assert connected
 
@@ -94,7 +94,7 @@ def test_run_tempdeck_connected(
     monkeypatch.setattr(serial_communication, 'write_and_return', mock_write)
     tempdeck = modules.TempDeck(port='/dev/modules/tty1_tempdeck')
     tempdeck.connect()
-    robot.modules = [tempdeck]
+    robot._attached_modules = {'tty1_tempdecktempdeck': tempdeck}
     modules.load('tempdeck', '5')
     assert connected
     tempdeck.disconnect()  # Necessary to kill the thread started by connect()

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -108,13 +108,11 @@ async def test_get_modules_v2(
 @pytest.mark.api1_only
 async def test_get_modules_v1(
         virtual_smoothie_env, loop, async_client, monkeypatch):
-    test_module = legacy_modules.MagDeck(port="/dev/modules/tty1_magdeck")
 
-    def stub_discover_modules():
-        return [test_module]
+    def stub_discover():
+        return [('tty1_magdeck', 'magdeck')]
 
-    monkeypatch.setattr(legacy_modules,
-                        "discover_and_connect", stub_discover_modules)
+    monkeypatch.setattr(legacy_modules, "discover", stub_discover)
     await check_modules_response(async_client)
 
 

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -112,7 +112,11 @@ def dummy_attached_modules():
 
 
 async def test_update_module_firmware(
-        dummy_attached_modules, virtual_smoothie_env, loop, test_client, monkeypatch):
+        dummy_attached_modules,
+        virtual_smoothie_env,
+        loop,
+        test_client,
+        monkeypatch):
 
     app = init(loop)
     client = await loop.create_task(test_client(app))
@@ -156,7 +160,11 @@ async def test_update_module_firmware(
 
 
 async def test_fail_update_module_firmware(
-        dummy_attached_modules, virtual_smoothie_env, loop, test_client, monkeypatch):
+        dummy_attached_modules,
+        virtual_smoothie_env,
+        loop,
+        test_client,
+        monkeypatch):
     app = init(loop)
     client = await loop.create_task(test_client(app))
     serial_num = 'mdYYYYMMDD123'


### PR DESCRIPTION
## overview

Every sequential call to GET /modules was disconnecting and reconnecting all of the modules which
causes interruptions during runs. This introduces a similar caching layer as is implemented in
apiV2. Modules are not disconnected and reconnected if they were there before and are still there.

Closes #3205

## changelog

- modules are now stored in the robot singleton as a Dict[str, Any], like APIv2 hardware control, as opposed to a list of Module class instances
- we now only connect "new" modules on discover, which should prevent inadvertently decapitating modules during runs by looking for new ones.

## review requests

- [ ] Run a Tempdeck protocol and visit the "pipettes & modules" page for that robot during the run. The tempdeck should still be connected and continue functioning.
- [ ] Ensure that Tempdeck still behaves as it should during protocols run from Jupyter Notebook
