### PR TITLE
fix(api): cli deck cal pipette control and tests

### DIFF
--- a/api/README.rst
+++ b/api/README.rst
@@ -100,3 +100,30 @@ Configuration
 -------------
 
 The module has a lot of configuration, some of which is only relevant when running on an actual robot, but some of which could be useful during simulation. When the module is first imported, it will try and write configuration files in ``~/.opentrons/config.json`` (``C:\Users\%USERNAME%\.opentrons\config.json`` on Windows). This contains mostly paths to other configuration files and directories, most of which will be in that folder. The location can be changed by setting the environment variable ``OT_API_CONFIG_DIR`` to another path. Inividual settings in the config file can be overridden by setting environment variables named like ``OT_API_${UPPERCASED_VAR_NAME}`` (for instance, to override the ``serial_log_file`` config element you could set the environment variable ``OT_API_SERIAL_LOG_FILE`` to a different path).
+
+
+Using the Deck Calibration Tool
+-------------------------------
+
+You can run this tool from the command line of the robot by using `ssh` to access the terminal.
+To run the tool either type `calibrate` or `python -m opentrons.deck_calibration.dc_main`
+
+Instructions:
+    - Robot must be set up with two 300ul or 50ul single-channel pipettes
+      installed on the right-hand and left-hand mount.
+    - Put a GEB 300ul tip onto the pipette.
+    - Use the arrow keys to jog the robot over slot 5 in an open space that
+      is not an engraving or a hole.
+    - Use the 'q' and 'a' keys to jog the pipette up and down respectively
+      until the tip is just touching the deck surface, then press 'z'. This
+      will save the 'Z' height.
+    - Press '1' to automatically go to the expected location of the first
+      calibration point. Jog the robot until the tip is actually at
+      the point, then press 'enter'.
+    - Repeat with '2' and '3'.
+    - After calibrating all three points, press the space bar to save the
+      configuration.
+    - Optionally, press 4,5,6 or 7 to validate the new configuration.
+    - Press 'p' to perform tip probe. Press the space bar to save again.
+    - Press 'm' to perform mount calibration. Press the space bar to save again.
+    - Press 'esc' to exit the program.

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -318,6 +318,8 @@ class CLITool:
             0,
             l_pipette)
 
+        self._current_mount = r_pipette
+
     def validate(
             self,
             point: Tuple[float, float, float],
@@ -451,15 +453,14 @@ def main():
     A CLI application for performing factory calibration of an Opentrons robot
 
     Instructions:
-        - Robot must be set up with a 300ul single-channel pipette installed on
-          the right-hand mount.
+        - Robot must be set up with two 300ul or 50ul single-channel pipettes
+          installed on the right-hand and left-hand mount.
         - Put a GEB 300ul tip onto the pipette.
-        - Use the arrow keys to jog the robot over an open area of the deck
-          (the base deck surface, not over a ridge or numeral engraving). You
-          can use the '-' and '=' keys to decrease or increase the amount of
-          distance moved with each jog action.
+        - Use the arrow keys to jog the robot over slot 5 in an open space that
+          is not an engraving or a hole.
         - Use the 'q' and 'a' keys to jog the pipette up and down respectively
-          until the tip is just touching the deck surface, then press 'z'.
+          until the tip is just touching the deck surface, then press 'z'. This
+          will save the 'Z' height.
         - Press '1' to automatically go to the expected location of the first
           calibration point. Jog the robot until the tip is actually at
           the point, then press 'enter'.
@@ -467,7 +468,8 @@ def main():
         - After calibrating all three points, press the space bar to save the
           configuration.
         - Optionally, press 4,5,6 or 7 to validate the new configuration.
-        - Press 'p' to perform tip probe.
+        - Press 'p' to perform tip probe. Press the space bar to save again.
+        - Press 'm' to perform mount calibration.
         - Press 'esc' to exit the program.
     """
     prompt = input(

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -103,7 +103,7 @@ class CLITool:
         self._expected_points = {
             key: (vX, vY, tip_length)
             for key, (vX, vY) in point_set.items()}
-        self._actual_points = {
+        self.actual_points = {
             1: (0, 0),
             2: (0, 0),
             3: (0, 0)}
@@ -245,11 +245,11 @@ class CLITool:
             msg = self.save_mount_offset()
         else:
             pos = self._position()[:-1]
-            self._actual_points[self._current_point] = pos
+            self.actual_points[self._current_point] = pos
             log.debug("Saving {} for point {}".format(
                 pos, self._current_point))
             msg = 'saved #{}: {}'.format(
-                self._current_point, self._actual_points[self._current_point])
+                self._current_point, self.actual_points[self._current_point])
         return msg
 
     def save_mount_offset(self) -> str:
@@ -281,7 +281,7 @@ class CLITool:
         """
         expected = [self._expected_points[p][:2] for p in [1, 2, 3]]
         log.debug("save_transform expected: {}".format(expected))
-        actual = [self._actual_points[p][:2] for p in [1, 2, 3]]
+        actual = [self.actual_points[p][:2] for p in [1, 2, 3]]
         log.debug("save_transform actual: {}".format(actual))
         # Generate a 2 dimensional transform matrix from the two matricies
         flat_matrix = solve(expected, actual)
@@ -289,6 +289,7 @@ class CLITool:
         current_z = self.calibration_matrix[2][3]
         # Add the z component to form the 3 dimensional transform
         self.calibration_matrix = add_z(flat_matrix, current_z)
+
         gantry_calibration = list(
                 map(lambda i: list(i), self.calibration_matrix))
         log.debug("save_transform calibration_matrix: {}".format(
@@ -386,7 +387,7 @@ class CLITool:
 
     def _update_text_box(self, msg):
         expected = [self._expected_points[p] for p in [1, 2, 3]]
-        actual = [self._actual_points[p] for p in [1, 2, 3]]
+        actual = [self.actual_points[p] for p in [1, 2, 3]]
         points = '\n'.join([
             # Highlight point being calibrated
             # Display actual and expected coordinates

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -54,8 +54,10 @@ class CLITool:
     def __init__(self, point_set, tip_length, loop=None):
         # URWID user interface objects
         if not loop:
-            loop = urwid.main_loop.AsyncioEventLoop(
-                loop=asyncio.get_event_loop())
+            loop = asyncio.get_event_loop()
+        loop = urwid.main_loop.AsyncioEventLoop(
+            loop=loop)
+
         controls = '\n'.join([
             'arrow keys: move the gantry',
             'q/a:        move the pipette up/down',
@@ -160,6 +162,14 @@ class CLITool:
     @calibration_matrix.setter
     def calibration_matrix(self, calibration):
         self._calibration_matrix = calibration
+
+    @property
+    def actual_points(self):
+        return self._actual_points
+
+    @actual_points.setter
+    def actual_points(self, points):
+        self._actual_points = points
 
     def current_step(self):
         return self._steps[self._steps_index]
@@ -400,7 +410,6 @@ class CLITool:
 def probe(tip_length: float, hardware) -> str:
     if not feature_flags.use_protocol_api_v2():
         hardware.reset()
-
         pipette = instruments.P300_Single(mount='right')   # type: ignore
         probe_center = tuple(probe_instrument(
             pipette, robot, tip_length=tip_length))

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -2,6 +2,7 @@ import pytest
 from opentrons.config import (CONFIG,
                               robot_configs,
                               advanced_settings as advs)
+from opentrons.deck_calibration import dc_main
 
 # TODO (Laura 02252019): CLI tool is extremely frail. Need to add tests for
 # the different funcs called on it that are not shared with
@@ -77,3 +78,17 @@ async def test_new_deck_points():
     assert expected_points2['1'] == (12.13, 9.0)
     assert expected_points2['2'] == (380.87, 9.0)
     assert expected_points2['3'] == (12.13, 258.0)
+
+def test_tip_probe(mock_config, async_server):
+    hardware = async_server['com.opentrons.hardware']
+    tip_length = 51.7  # p300/p50 tip length
+    output = dc_main.probe(tip_length, hardware)
+    assert output == 'Tip probe'
+
+
+def test_validate_points():
+    return None
+
+
+def test_mount_offset():
+    return None

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -1,13 +1,14 @@
 import pytest
+import numpy as np
+
 from opentrons.config import (CONFIG,
                               robot_configs,
                               advanced_settings as advs)
 from opentrons.deck_calibration import dc_main
+from opentrons.deck_calibration.dc_main import get_calibration_points
+from opentrons.deck_calibration.endpoints import expected_points
 
-# TODO (Laura 02252019): CLI tool is extremely frail. Need to add tests for
-# the different funcs called on it that are not shared with
-# deck calibration endpoints.
-# List -> validate func, check calibration matrix, check mount offset func etc
+
 @pytest.fixture
 def mock_config():
     test_config = robot_configs.load()
@@ -53,8 +54,7 @@ def test_save_and_clear_config(mock_config, async_server):
 async def test_new_deck_points():
     # Checks that the correct deck calibration points are being used
     # if feature_flag is set (or not)
-    from opentrons.deck_calibration.dc_main import get_calibration_points
-    from opentrons.deck_calibration.endpoints import expected_points
+
     advs.set_adv_setting('deckCalibrationDots', True)
     calibration_points = get_calibration_points()
     expected_points1 = expected_points()
@@ -79,16 +79,86 @@ async def test_new_deck_points():
     assert expected_points2['2'] == (380.87, 9.0)
     assert expected_points2['3'] == (12.13, 258.0)
 
+
+@pytest.mark.api1_only
+def test_move_output(mock_config, loop, async_server, monkeypatch):
+    # Check that the robot moves to the correct locations
+    # TODO: Make tests for both APIs
+    hardware = async_server['com.opentrons.hardware']
+
+    monkeypatch.setattr(
+        dc_main.CLITool, 'hardware', hardware)
+    tip_length = 51.7
+    tool = dc_main.CLITool(
+        point_set=get_calibration_points(), tip_length=tip_length, loop=loop)
+
+    assert tool.hardware is hardware
+    # Move to all three calibration points
+    expected_pts = tool._expected_points
+    for pt in range(3):
+        point = pt + 1
+        tool.validate(expected_pts[point], point, tool._current_mount)
+        assert np.isclose(
+            tool._position(), expected_pts[point]).all()
+
+
 def test_tip_probe(mock_config, async_server):
+    # Test that tip probe returns successfully
     hardware = async_server['com.opentrons.hardware']
     tip_length = 51.7  # p300/p50 tip length
     output = dc_main.probe(tip_length, hardware)
     assert output == 'Tip probe'
 
 
-def test_validate_points():
-    return None
+@pytest.mark.api1_only
+def test_mount_offset(loop, monkeypatch, async_server):
+    # Check that mount offset gives the expected output when position is
+    # slightly changed
+    hardware = async_server['com.opentrons.hardware']
+
+    def fake_position(something):
+        return [11.13, 8, 51.7]
+
+    monkeypatch.setattr(
+        dc_main.CLITool, 'hardware', hardware)
+
+    tip_length = 51.7
+    tool = dc_main.CLITool(
+        point_set=get_calibration_points(), tip_length=tip_length, loop=loop)
+
+    monkeypatch.setattr(
+        dc_main.CLITool, '_position', fake_position)
+    expected_offset = (1.0, 1.0, 0.0)
+
+    tool.save_mount_offset()
+    assert expected_offset == tool.hardware.config.mount_offset
 
 
-def test_mount_offset():
-    return None
+@pytest.mark.api1_only
+def test_gantry_matrix_output(mock_config, loop, async_server, monkeypatch):
+    # Check that the robot moves to the correct locations
+    # TODO: Make tests for both APIs
+    hardware = async_server['com.opentrons.hardware']
+
+    monkeypatch.setattr(
+        dc_main.CLITool, 'hardware', hardware)
+    tip_length = 51.7
+    tool = dc_main.CLITool(
+        point_set=get_calibration_points(), tip_length=tip_length, loop=loop)
+
+    expected = np.array([
+        [1.00, 0.00, 0.00,  -4.00],
+        [0.00, 1.00, 0.00,  0.50],
+        [0.00, 0.00, 1.00,  -25.65],
+        [0.00, 0.00, 0.00,  1.00]])
+
+    actual_points = {
+        1: (12.13, 9.5),
+        2: (380.87, 9.5),
+        3: (12.13, 348.5)}
+    monkeypatch.setattr(
+        dc_main.CLITool, 'actual_points', actual_points)
+
+    tool.save_z_value()
+    tool.save_transform()
+    assert np.isclose(expected, tool.hardware.config.gantry_calibration).all()

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -1,5 +1,5 @@
 import pytest
-import copy
+import sys
 import numpy as np
 
 from opentrons.config import (CONFIG,
@@ -13,11 +13,10 @@ from opentrons.deck_calibration.endpoints import expected_points
 @pytest.fixture
 def mock_config():
     test_config = robot_configs.load()
-    old_config = copy.deepcopy(test_config)
     new_config = test_config._replace(name='new-value1')
     robot_configs.save_robot_settings(new_config)
     yield new_config
-    robot_configs.save_robot_settings(old_config)
+    robot_configs.save_robot_settings(test_config)
 
 
 @pytest.mark.api1_only
@@ -82,6 +81,8 @@ async def test_new_deck_points():
     assert expected_points2['3'] == (12.13, 258.0)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Incompatible with Windows")
 @pytest.mark.api1_only
 def test_move_output(mock_config, loop, async_server, monkeypatch):
     # Check that the robot moves to the correct locations
@@ -112,6 +113,8 @@ def test_tip_probe(mock_config, async_server):
     assert output == 'Tip probe'
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Incompatible with Windows")
 @pytest.mark.api1_only
 def test_mount_offset(mock_config, loop, monkeypatch, async_server):
     # Check that mount offset gives the expected output when position is
@@ -140,6 +143,8 @@ def test_mount_offset(mock_config, loop, monkeypatch, async_server):
     hardware.reset()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Incompatible with Windows")
 @pytest.mark.api1_only
 def test_gantry_matrix_output(mock_config, loop, async_server, monkeypatch):
     # Check that the robot moves to the correct locations


### PR DESCRIPTION
## overview
_sigh_. Closes #3133 and fixes bug introduced in 3.7.0.

After mount calibration, you could not re-verify points as the mount would be set to the left and never to be re-set to the right.

## changelog
- Add better instructions for CLI within the py file as well as in the README of top level api.
- Add actual tests on the CLI code to catch bugs a little better

## review requests
Test on robot, how do tests look 😢 
