### PR TITLE
fix(api): add target temp verification to set_temperature

### DIFF
--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -209,14 +209,7 @@ class TempDeck:
                 '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
         except (TempDeckError, SerialException, SerialNoResponse) as e:
             return str(e)
-        # Wait until new target temperature is registered by the module
-        retries = 3
-        while self.target != celsius:
-            sleep(0.25)
-            retries -= 1
-            if retries < 0:
-                log.warning('Target temperature could not be verified')
-                break
+        self._temperature.update({'target': celsius})
         return ''
 
     def update_temperature(self, default=None) -> str:

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -203,12 +203,20 @@ class TempDeck:
 
     def set_temperature(self, celsius) -> str:
         self.run_flag.wait()
+        celsius = round(float(celsius), GCODE_ROUNDING_PRECISION)
         try:
-            celsius = round(float(celsius), GCODE_ROUNDING_PRECISION)
             self._send_command(
                 '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
         except (TempDeckError, SerialException, SerialNoResponse) as e:
             return str(e)
+        # Wait until new target temperature is registered by the module
+        retries = 3
+        while self.target != celsius:
+            sleep(0.25)
+            retries -= 1
+            if retries < 0:
+                log.warning('Target temperature could not be verified')
+                break
         return ''
 
     def update_temperature(self, default=None) -> str:


### PR DESCRIPTION
Closes #3218

## overview

This PR provides a temporary solution to the problem mentioned in #3218 . 

## changelog
- Force temperature cache update after setting new temperature in `_driver.set_temperature()`

## todo
- Fix this cache <-> device status out of sync problem with the solution built for thermocycler

## review requests

Please test this protocol on a robot and verify that robot pauses during each of the three `wait_for_temp`s. 
Also verify through robot log that the three `prints` responded with a 'target' of the newly set temperature (this is to make sure `wait_for_temp` isn't waiting because of an unstable state of the tempdeck which results in the 'status' changing momentarily) 
```
from opentrons import robot, labware, instruments
from opentrons import modules

def run_custom_protocol():

	tiprack = labware.load('tiprack-1000ul', 3)
	pipette = instruments.P1000_Single(
		mount='right',
		tip_racks=[tiprack])

	dye_container = labware.load('trough-12row', '2')
	dye = dye_container.wells('A1')

	td = modules.load('tempdeck', '4')
	output = labware.load('96-flat','4', share=True)

	target_temperature1 = 30
	target_temperature2 = 35
	target_temperature3 = 40

	td.set_temperature(target_temperature1)
	if not robot.is_simulating():
		print("target: {}".format(td.target))
		print("status: {}".format(td.status))
	td.wait_for_temp()
	# Should begin only after tempdeck has reached temp1
	pipette.distribute(
        50,
        dye,
        output.wells('A1'),
        new_tip='once')

	td.set_temperature(target_temperature2)
	if not robot.is_simulating():
		print("target: {}".format(td.target))
		print("status: {}".format(td.status))
	td.wait_for_temp()
	# Should begin only after tempdeck has reached temp2
	pipette.distribute(
        50,
        dye,
        output.wells('A1'),
        new_tip='once')

	td.set_temperature(target_temperature3)
	if not robot.is_simulating():
		print("target: {}".format(td.target))
		print("status: {}".format(td.status))
	td.wait_for_temp()
	# Should begin only after tempdeck has reached temp3
	pipette.distribute(
        50,
        dye,
        output.wells('A1'),
        new_tip='once')
	
	td.deactivate()

run_custom_protocol()
```