### PR TITLE
fix(docs): Catch some last api v4 references

### DIFF
--- a/api/docs/source/labware.rst
+++ b/api/docs/source/labware.rst
@@ -25,7 +25,7 @@ If you are interested in using your own labware that is not included in the API,
 
 .. note::
 
-    We are in the process of revising the labware definitions used on the OT2. Documentation for previously existing definitions is left over from OT1, and is incomplete. `Check out this webpage`__ to see a visualization of all the API's legacy built-in labware definitions. For JSON protocols and APIv4 protocols, see the visualizations and descriptions under `Opentrons Labware`_.
+    We are in the process of revising the labware definitions used on the OT2. Documentation for previously existing definitions is left over from OT1, and is incomplete. `Check out this webpage`__ to see a visualization of all the API's legacy built-in labware definitions. For JSON protocols see the visualizations and descriptions under `Opentrons Labware`_.
 
 __ https://andysigler.github.io/ot-api-containerviz/
 

--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -91,7 +91,7 @@ The fields above ("protocolName", "author", "description", and "source") are the
 Run Function
 ^^^^^^^^^^^^
 
-Opentrons API version 4 protocols are structured around a function called ``run(ctx)``. This function must be named exactly ``run`` and must take exactly one mandatory argument (its name doesn’t matter). When the robot runs a protocol, it will call this function, and pass it an object that does two things:
+Opentrons API version 2 protocols are structured around a function called ``run(ctx)``. This function must be named exactly ``run`` and must take exactly one mandatory argument (its name doesn’t matter). When the robot runs a protocol, it will call this function, and pass it an object that does two things:
 
 1) Remember, track, and check the robot’s state
 2) Expose the functions that make the robot act
@@ -125,7 +125,7 @@ More complete documentation on labware methods (such as the ``.wells()`` method)
 This table lists the names of valid labwares that can be loaded with :py:meth:`.ProtocolContext.load_labware_by_name`, along with the name of the legacy labware definition each is equivalent to (if any).
 
 +-------------------------------------------+----------------------------------------+
-| API 4.0 Labware Name                      | API 3.x Labware Name                   |
+| API 2 Labware Name                        | API 1 Labware Name                     |
 +===========================================+========================================+
 | biorad_96_wellPlate_pcr_200_uL            | 96-pcr-flat                            |
 +-------------------------------------------+----------------------------------------+


### PR DESCRIPTION
@pantslakz found some references to api v4 which is properly named api v2.