### PR TITLE
refactor(components): Standardize form field font styles

### DIFF
--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -1,5 +1,19 @@
 @import '../index.css';
 
+:root {
+  --font-form-default: {
+    font-size: var(--fs-body-1);
+    font-weight: var(--fw-regular);
+    color: var(--c-font-dark);
+  }
+
+  --font-form-caption: {
+    font-size: var(--fs-caption);
+    font-weight: var(--fw-semibold);
+    color: var(--c-med-gray);
+  }
+}
+
 .accessibly_hidden {
   position: absolute;
   overflow: hidden;
@@ -12,7 +26,7 @@
 }
 
 .form_field {
-  @apply --font-body-2-dark;
+  @apply --font-form-default;
 
   display: flex;
   align-items: center;
@@ -29,7 +43,7 @@
 }
 
 .form_group_label {
-  @apply --font-body-1-dark;
+  @apply --font-form-default;
 
   font-weight: var(--fw-semibold);
   margin-bottom: 0.15rem;
@@ -40,7 +54,7 @@
   display: block;
   width: 1.25rem;
   min-width: 1.25rem;
-  color: var(--c-dark-gray);
+  color: var(--c-font-dark);
 
   &:not(.checkbox_disabled):hover {
     cursor: pointer;
@@ -68,14 +82,14 @@
   padding: 0.25rem 0.25rem 0.25rem 0.5rem;
 
   & input {
+    @apply --font-form-default;
+
     background-color: inherit;
     border-radius: inherit;
     border: none;
     flex: 1 1 auto;
-    color: var(--c-dark-gray);
     width: 100%;
     height: 1rem;
-    font-size: var(--fs-body-1);
 
     /* TODO: Ian 2018-09-14 Firefox has 1px padding on input element,
     * but I can't figure out how to fix it in Firefox without breaking it in Chrome.
@@ -99,20 +113,20 @@
   }
 
   & .suffix {
+    @apply --font-form-default;
+
+    font-weight: var(--fw-semibold);
     display: inline-block;
     flex: 1 0;
-    font-weight: var(--fw-semibold);
     text-align: right;
     align-self: center;
-    color: var(--c-dark-gray);
   }
 }
 
 .input_caption {
-  font-size: var(--fs-caption);
-  font-weight: var(--fw-semibold);
+  @apply --font-form-caption;
+
   line-height: 1.2;
-  color: var(--c-med-gray);
 
   & .right {
     float: right;
@@ -145,15 +159,14 @@
   position: relative;
 
   & select {
+    @apply --font-form-default;
+
     border: 0;
     padding: 0.25rem 0.5rem;
     outline: none;
     height: 1.5rem;
     border-radius: 3px;
-    color: var(--c-dark-gray);
-    background-color: var(--c-light-gray);
     font-family: inherit;
-    font-size: inherit;
     width: 100%;
     appearance: none;
     overflow: hidden;

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -31,19 +31,16 @@
 }
 
 .large_field {
-  font-size: var(--fs-body-1);
   width: 14rem;
   margin-right: 0.5rem;
 }
 
 .medium_field {
-  font-size: var(--fs-body-1);
   width: 12em;
   margin-right: 0.5rem;
 }
 
 .small_field {
-  font-size: var(--fs-body-1);
   width: 5rem;
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
## overview

This PR addresses the fact that due to a lack of a specified font size within the form field suffix area, style one offs were arising in both PD and RA. This PR standardizes form font styles and pulls a few as root styles and removes PD one off for unit/suffix styling.

## changelog

- refactor(components): Standardize form field font styles

## review requests

- [ ] Form fonts in PD still render as desired (step edit form)
- [ ] Form fonts in RA still render as desired (pipette config, jog units, wifi modal)

Made the decision to make a `:root` style for default and caption fonts rather than using `@apply --font-body-dark` this way if the form font size, color, or weights change, we can change it here in the form stylesheet instead of higher up in atomic font styles. Does this seem sane? Will call this out in a code comment.

