### PR TITLE
feat(api): add z margin override

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1231,11 +1231,17 @@ class InstrumentContext(CommandPublisher):
     def delay(self):
         return self._ctx.delay()
 
-    def move_to(self, location: types.Location) -> 'InstrumentContext':
+    def move_to(self, location: types.Location, z_safety: float = None) -> 'InstrumentContext':
         """ Move the instrument.
 
         :param location: The location to move to.
         :type location: :py:class:`.types.Location`
+        :param z_safety: An optional height to retract the pipette to before
+                         moving. If not specified, it will be generated based
+                         on the labware from which and to which the pipette is
+                         moving; if it is 0, the pipette will move directly;
+                         and if it is non-zero, the pipette will rise to the
+                         z_safety point before moving in x and y.
         """
         if self._ctx.location_cache:
             from_lw = self._ctx.location_cache.labware
@@ -1249,7 +1255,9 @@ class InstrumentContext(CommandPublisher):
             self._hw_manager.hardware.gantry_position(
                 self._mount, critical_point=cp_override),
             from_lw)
-        moves = geometry.plan_moves(from_loc, location, self._ctx.deck)
+
+        moves = geometry.plan_moves(from_loc, location, self._ctx.deck,
+                                    z_margin_override=z_safety)
         self._log.debug("move_to: {}->{} via:\n\t{}"
                         .format(from_loc, location, moves))
         try:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1231,7 +1231,8 @@ class InstrumentContext(CommandPublisher):
     def delay(self):
         return self._ctx.delay()
 
-    def move_to(self, location: types.Location, z_safety: float = None) -> 'InstrumentContext':
+    def move_to(self, location: types.Location, z_safety: float = None
+                ) -> 'InstrumentContext':
         """ Move the instrument.
 
         :param location: The location to move to.

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -20,8 +20,10 @@ def plan_moves(
         to_loc: types.Location,
         deck: 'Deck',
         well_z_margin: float = 5.0,
-        lw_z_margin: float = 20.0) -> List[Tuple[types.Point,
-                                                 Optional[CriticalPoint]]]:
+        lw_z_margin: float = 20.0,
+        z_margin_override: float = None)\
+        -> List[Tuple[types.Point,
+                      Optional[CriticalPoint]]]:
     """ Plan moves between one :py:class:`.Location` and another.
 
     Each :py:class:`.Location` instance might or might not have a specific
@@ -65,7 +67,7 @@ def plan_moves(
 
     if to_lw and to_lw == from_lw:
         # Two valid labwares. We’ll either raise to clear a well or go direct
-        if to_well and to_well == from_well:
+        if z_margin_override == 0.0 or (to_well and to_well == from_well):
             # If we’re going direct, we can assume we’re already in the correct
             # cp so we can use the override without prep
             return [(to_point, dest_cp_override)]
@@ -78,6 +80,7 @@ def plan_moves(
                 from_safety = from_well.top().point.z + well_z_margin
             else:
                 from_safety = from_lw.highest_z + well_z_margin
+
             safe = max_many(
                 to_point.z,
                 from_point.z,
@@ -89,6 +92,8 @@ def plan_moves(
                         from_point.z,
                         deck.highest_z + lw_z_margin)
 
+    if z_margin_override is not None:
+        safe = z_margin_override
     # We should use the origin’s cp for the first move since it should
     # move only in z and the destination’s cp subsequently
     return [(from_point._replace(z=safe), origin_cp_override),

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -92,7 +92,7 @@ def plan_moves(
                         from_point.z,
                         deck.highest_z + lw_z_margin)
 
-    if z_margin_override is not None:
+    if z_margin_override is not None and z_margin_override >= 0.0:
         safe = z_margin_override
     # We should use the origin’s cp for the first move since it should
     # move only in z and the destination’s cp subsequently

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -63,7 +63,8 @@ def test_location_cache(loop, monkeypatch, load_my_labware):
 
     def fake_plan_move(from_loc, to_loc, deck,
                        well_z_margin=None,
-                       lw_z_margin=None):
+                       lw_z_margin=None,
+                       z_margin_override=None):
         nonlocal test_args
         test_args = (from_loc, to_loc, deck, well_z_margin, lw_z_margin)
         return [(Point(0, 1, 10), None),

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -49,18 +49,19 @@ def test_highest_z():
     assert deck.highest_z == mod.highest_z
 
 
-def check_arc_basic(arc, from_loc, to_loc):
+def check_arc_basic(arc, from_loc, to_loc, use_z_margin_override=False):
     """ Check the tests that should always be true for different-well moves
     - we should always go only up, then only xy, then only down
     - we should have three moves
     """
     assert len(arc) == 3
     assert arc[0][0]._replace(z=0) == from_loc.point._replace(z=0)
-    assert arc[0][0].z >= from_loc.point.z
     assert arc[0][0].z == arc[1][0].z
     assert arc[1][0]._replace(z=0) == to_loc.point._replace(z=0)
-    assert arc[1][0].z >= to_loc.point.z
     assert arc[2][0] == to_loc.point
+    if not use_z_margin_override:
+        assert arc[0][0].z >= from_loc.point.z
+        assert arc[1][0].z >= to_loc.point.z
 
 
 def test_direct_movs():
@@ -146,6 +147,52 @@ def test_arc_tall_point():
     from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
                               7.0, 15.0)
     check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom())
+
+
+def test_arc_lower_z_margin_override():
+    deck = Deck()
+    lw1 = labware.load(labware_name, deck.position_for(1))
+    tall_z = 100
+    z_margin_override = 42
+    old_top = lw1.wells()[0].top()
+    tall_point = old_top.point._replace(z=tall_z)
+    tall_top = old_top._replace(point=tall_point)
+    to_tall = plan_moves(
+        lw1.wells()[2].top(), tall_top, deck, 7.0, 15.0, z_margin_override)
+    check_arc_basic(to_tall, lw1.wells()[2].top(), tall_top, True)
+    assert to_tall[0][0].z == z_margin_override
+
+    from_tall = plan_moves(
+        tall_top, lw1.wells()[3].top(), deck, 7.0, 15.0, z_margin_override)
+    check_arc_basic(from_tall, tall_top, lw1.wells()[3].top(), True)
+    assert from_tall[0][0].z == z_margin_override
+
+    no_well = tall_top._replace(labware=lw1)
+    from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
+                              7.0, 15.0)
+    check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom(), True)
+
+
+def test_arc_zero_z_margin_override():
+    deck = Deck()
+    lw1 = labware.load(labware_name, deck.position_for(1))
+    tall_z = 100
+    z_margin_override = 0
+    old_top = lw1.wells()[0].top()
+    tall_point = old_top.point._replace(z=tall_z)
+    tall_top = old_top._replace(point=tall_point)
+    to_tall = plan_moves(
+        lw1.wells()[2].top(), tall_top, deck, 7.0, 15.0, z_margin_override)
+    assert to_tall == [(tall_top.point, None)]
+
+    from_tall = plan_moves(
+        tall_top, lw1.wells()[3].top(), deck, 7.0, 15.0, z_margin_override)
+    assert from_tall == [(lw1.wells()[3].top().point, None)]
+
+    no_well = tall_top._replace(labware=lw1)
+    from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
+                              7.0, 15.0, z_margin_override)
+    assert from_tall_lw == [(lw1.wells()[4].bottom().point, None)]
 
 
 def test_direct_cp():


### PR DESCRIPTION
## overview

Credit to Seth for writing most of this :tophat:

Allows `InstrumentContext.move_to` command to take argument `z_safety`, which allows an API consumer to force the arc height, or to force direct path if `z_safety=0` is specified. 

The default, `z_safety=None`, preserves the current behavior (which is: arc height is determined by to and from labware, arc height is not applied when moving within a Location but is only used when moving from one Location to another)

Motivation: user may want deeper control over pipette movements, especially for **colony picking**

## changelog

* add `z_margin_override` to `InstrumentContext.move_to` command

## review requests

- [ ] Code review (especially the new tests)
- [ ] Test on robot
