### PR TITLE
fix(components): Revert addition of "sideEffects": false

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -4,7 +4,6 @@
   "description": "React components library for Opentrons' projects",
   "main": "src/index.js",
   "style": "src/index.css",
-  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Opentrons/opentrons.git"


### PR DESCRIPTION
## overview

Bug report + fix

The addition of `"sideEffects": false` to `components/package.json` enabled tree-shaking of the components library. This, however, caused CSS specificity problems in PD (and probably
elsewhere). The addition needs to be reverted until we can understand why and fix the underlying cause.

Tree-shaking is beneficial for bundle-size reduction, so our longer-term goal should still be to enable tree-shaking of the components library.

## review requests

To verify fix, look at the well selection modal in a step edit form in PD sandbox:

<http://sandbox.designer.opentrons.com/components-fix-tree-shaking>