### PR TITLE
fix(api): Correctly migrate probe center settings

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -216,6 +216,16 @@ def _build_z_clearance(z_clearance: dict) -> tip_probe_z_clearance:
     )
 
 
+def _tip_probe_settings_with_migration(full_settings):
+    new_tp = full_settings.get('tip_probe', {})
+    old_tp = full_settings.get('probe_center', {})
+    if old_tp:
+        new_tp['center'] = old_tp
+    elif 'center' not in new_tp:
+        new_tp['center'] = _default_probe_center()
+    return new_tp
+
+
 def _build_tip_probe(tip_probe_settings: dict) -> tip_probe_config:
     return tip_probe_config(
         bounce_distance=tip_probe_settings.get('bounce_distance',
@@ -226,7 +236,7 @@ def _build_tip_probe(tip_probe_settings: dict) -> tip_probe_config:
                                                 TIP_PROBE_SWITCH_CLEARANCE),
         z_clearance=_build_z_clearance(tip_probe_settings.get('z_clearance',
                                                               {})),
-        center=_default_probe_center(),
+        center=tip_probe_settings.get('center', _default_probe_center()),
         dimensions=tip_probe_settings.get('dimensions',
                                           _default_probe_dimensions())
     )
@@ -257,7 +267,8 @@ def _build_config(deck_cal: List[List[float]],
         default_max_speed=robot_settings.get(
             'default_max_speed', DEFAULT_MAX_SPEEDS),
         log_level=robot_settings.get('log_level', DEFAULT_LOG_LEVEL),
-        tip_probe=_build_tip_probe(robot_settings.get('tip_probe', {}))
+        tip_probe=_build_tip_probe(
+            _tip_probe_settings_with_migration(robot_settings))
     )
     return cfg
 

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -285,10 +285,10 @@ def _config_to_save(
 
 def load(deck_cal_file=None):
     deck_cal_file = deck_cal_file or CONFIG['deck_calibration_file']
-    log.info("Loading deck calibration from {}".format(deck_cal_file))
+    log.debug("Loading deck calibration from {}".format(deck_cal_file))
     deck_cal = _load_json(deck_cal_file).get('gantry_calibration', {})
     settings_file = CONFIG['robot_settings_file']
-    log.info("Loading robot settings from {}".format(settings_file))
+    log.debug("Loading robot settings from {}".format(settings_file))
     robot_settings = _load_json(settings_file) or {}
     return _build_config(deck_cal, robot_settings)
 


### PR DESCRIPTION
https://github.com/Opentrons/opentrons/commit/3264cff558fb7f5961f915c5870e0cbe1709c61d
introduced a new format for tip probe config data that overwrote the output of
the CLI deck calibration tip probe.

The tip probe during CLI deck calibration is different from other contexts
because it actually changes the location of the probe center in config. We were
no longer loading that change.

This commit properly migrates the probe_center config field when updating from
3.6.5, and properly loads it on more recent versions.

In addition, when updating from 3.6.5 or prior it will migrate the most recent robot settings backup if it can't find a normal robotSettings.json file. This allows affected users to downgrade (to reestablish the old settings index) then reupgrade.

## Testing

- Put a robot on 3.6.5 ( [mac](https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.5-mac-b13330.zip) [windows](https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.5-win-b9177.exe) [linux](https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.6.5-linux-b13330.AppImage) )
- Run CLI deck calibration, or hand-modify the `probe_center` field of robotSettings.json
- Update to this branch
- Check that `'tip_probe'/'center'` in `/data/robot_settings.json` contains the same value that robotSettings.json did before the update
- Go and modify the latest backup robot settings config in the old directory (e.g. `/mnt/usbdrive/robotSettings-1555xxxyyyzzz.json`)
- Downgrade to 3.6.5
- Install this branch
- Check that the changes in that most recent backup were migrated
