### PR TITLE
feat(protocol-designer): update pause form design

### DIFF
--- a/components/src/forms/SelectField.css
+++ b/components/src/forms/SelectField.css
@@ -23,7 +23,7 @@
   border: none;
   padding: 0.25rem 0;
   outline: none;
-  border-radius: 3px;
+  border-radius: var(--bd-radius-form-field);
   height: 1.75rem;
   box-shadow: none;
 
@@ -37,7 +37,7 @@
   @apply --font-body-1-dark;
 
   background-color: var(--c-white);
-  border-radius: 3px;
+  border-radius: var(--bd-radius-form-field);
 }
 
 .select_group {

--- a/components/src/forms/forms.css
+++ b/components/src/forms/forms.css
@@ -83,7 +83,7 @@
   display: flex;
   flex: 1 1;
   background-color: var(--c-light-gray);
-  border-radius: 3px;
+  border-radius: var(--bd-radius-form-field);
   padding: 0.25rem 0.25rem 0.25rem 0.5rem;
 
   & input {
@@ -174,7 +174,7 @@
     padding: 0.25rem 0.5rem;
     outline: none;
     height: 1.5rem;
-    border-radius: 3px;
+    border-radius: var(--bd-radius-form-field);
     font-family: inherit;
     width: 100%;
     appearance: none;

--- a/components/src/styles/borders.css
+++ b/components/src/styles/borders.css
@@ -3,6 +3,7 @@
 :root {
   /* borders */
   --bd-radius-default: 2px;
+  --bd-radius-form-field: 3px;
   --bd-radius-pill: 12px;
   --bd-width-default: 1px;
   --bd-light: var(--bd-width-default) solid var(--c-light-gray);

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -41,6 +41,28 @@
   width: 5.75rem;
 }
 
+.full_width_field {
+  width: 100%;
+}
+
+/* TODO: Ian 2019-03-25 make this a component library input? */
+.textarea_field {
+  background-color: var(--c-light-gray);
+  border-radius: var(--bd-radius-form-field);
+  padding: 0.25rem 0.25rem 0.25rem 0.5rem;
+  height: 100%;
+  width: 100%;
+
+  /* resets */
+  border: none;
+  overflow: auto;
+  outline: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  resize: none;
+}
+
 .orphan_field {
   margin: 0;
 }

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -47,6 +47,7 @@
 
 /* TODO: Ian 2019-03-25 make this a component library input? */
 .textarea_field {
+  font-size: var(--fs-body-1);
   background-color: var(--c-light-gray);
   border-radius: var(--bd-radius-form-field);
   padding: 0.25rem 0.25rem 0.25rem 0.5rem;

--- a/protocol-designer/src/components/StepEditForm/fields/ConditionalOnField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ConditionalOnField.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {selectors as stepFormSelectors} from '../../../step-forms'
+
+import type {BaseState} from '../../../types'
+import type {StepFieldName} from '../../../form-types'
+
+type SP = {
+  value: mixed,
+}
+
+type OP = {
+  name: StepFieldName,
+  condition: (value: mixed) => boolean,
+  children: React.Node,
+}
+
+type Props = SP & OP
+
+function ConditionalOnField (props: Props) {
+  return props.condition(props.value)
+    ? props.children
+    : null
+}
+
+function STP (state: BaseState, ownProps: OP): SP {
+  const formData = stepFormSelectors.getUnsavedForm(state)
+  return {
+    value: formData ? formData[ownProps.name] : null,
+  }
+}
+
+export default connect(STP)(ConditionalOnField)

--- a/protocol-designer/src/components/StepEditForm/fields/Text.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Text.js
@@ -5,7 +5,10 @@ import type {StepFieldName} from '../../../steplist/fieldLevel'
 import type {FocusHandlers} from '../types'
 import StepField from './FieldConnector'
 
-type TextFieldProps = {name: StepFieldName} & FocusHandlers
+type TextFieldProps = {
+  className?: string,
+  name: StepFieldName,
+} & FocusHandlers
 const TextField = (props: TextFieldProps & React.ElementProps<typeof InputField>) => {
   const {name, focusedField, dirtyFields, onFieldFocus, onFieldBlur, ...inputProps} = props
   return (

--- a/protocol-designer/src/components/StepEditForm/fields/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/index.js
@@ -8,6 +8,7 @@ export {default as TextField} from './Text'
 
 /* Specialized Fields */
 
+export {default as ConditionalOnField} from './ConditionalOnField'
 export {default as WellSelectionField} from './WellSelection'
 export {default as WellOrderField} from './WellOrder'
 export {default as TipPositionField} from './TipPosition'

--- a/protocol-designer/src/components/StepEditForm/forms/Pause.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Pause.js
@@ -12,6 +12,14 @@ import type {FocusHandlers} from '../types'
 type PauseFormProps = {focusHandlers: FocusHandlers}
 function PauseForm (props: PauseFormProps): React.Element<'div'> {
   const {focusHandlers} = props
+
+  // time fields blur together
+  const blurAllTimeUnitFields = () => {
+    ['pauseHour', 'pauseMinute', 'pauseSecond'].forEach(timeUnitFieldName =>
+      props.focusHandlers.onFieldBlur(timeUnitFieldName)
+    )
+  }
+
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -25,23 +33,27 @@ function PauseForm (props: PauseFormProps): React.Element<'div'> {
           <div className={styles.checkbox_row}>
             <RadioGroupField
               name="pauseForAmountOfTime"
-              options={[{name: 'Pause until told to resume', value: 'false'}]}
+              options={[{
+                name: i18n.t('form.step_edit_form.field.pauseForAmountOfTime.options.false'),
+                value: 'false'}]}
               {...focusHandlers} />
           </div>
           <div className={styles.checkbox_row}>
             <RadioGroupField
               name="pauseForAmountOfTime"
-              options={[{name: 'Delay for an amount of time', value: 'true'}]}
+              options={[{
+                name: i18n.t('form.step_edit_form.field.pauseForAmountOfTime.options.true'),
+                value: 'true'}]}
               {...focusHandlers} />
           </div>
           <ConditionalOnField name={'pauseForAmountOfTime'} condition={(val) => val === 'true'}>
             <div className={styles.form_row}>
-              <TextField {...focusHandlers} className={styles.small_field}
-                units="hr" name="pauseHour" />
-              <TextField {...focusHandlers} className={styles.small_field}
-                units="m" name="pauseMinute" />
-              <TextField {...focusHandlers} className={styles.small_field}
-                units="s" name="pauseSecond" />
+              <TextField {...focusHandlers} onFieldBlur={blurAllTimeUnitFields} className={styles.small_field}
+                units={i18n.t('application.units.hours')} name="pauseHour" />
+              <TextField {...focusHandlers} onFieldBlur={blurAllTimeUnitFields} className={styles.small_field}
+                units={i18n.t('application.units.minutes')} name="pauseMinute" />
+              <TextField {...focusHandlers} onFieldBlur={blurAllTimeUnitFields} className={styles.small_field}
+                units={i18n.t('application.units.seconds')} name="pauseSecond" />
             </div>
           </ConditionalOnField>
         </div>
@@ -49,7 +61,9 @@ function PauseForm (props: PauseFormProps): React.Element<'div'> {
           <div className={styles.form_row}>
             {/* TODO: Ian 2019-03-25 consider making this a component eg `TextAreaField.js` if used anywhere else */}
             <StepField {...focusHandlers} name='pauseMessage' render={({value, updateValue}) => (
-              <FormGroup label='Message to display' className={styles.full_width_field}>
+              <FormGroup
+                className={styles.full_width_field}
+                label={i18n.t('form.step_edit_form.field.pauseMessage.label')}>
                 <textarea
                   className={styles.textarea_field}
                   value={value}

--- a/protocol-designer/src/components/StepEditForm/forms/Pause.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Pause.js
@@ -1,40 +1,63 @@
 // @flow
 import * as React from 'react'
 import {FormGroup} from '@opentrons/components'
+import i18n from '../../../localization'
 
-import formStyles from '../../forms/forms.css'
+import {ConditionalOnField, TextField, RadioGroupField} from '../fields'
+import StepField from '../fields/FieldConnector'
+import styles from '../StepEditForm.css'
 
-import {TextField, RadioGroupField} from '../fields'
 import type {FocusHandlers} from '../types'
 
 type PauseFormProps = {focusHandlers: FocusHandlers}
 function PauseForm (props: PauseFormProps): React.Element<'div'> {
   const {focusHandlers} = props
   return (
-    <div className={formStyles.row_wrapper}>
-      <div className={formStyles.column_1_2}>
-        <RadioGroupField
-          name="pauseForAmountOfTime"
-          options={[{name: 'Pause for an amount of time', value: 'true'}]}
-          {...focusHandlers} />
-        <FormGroup className={formStyles.stacked_row}>
-          <TextField units="hr" name="pauseHour" {...focusHandlers} />
-        </FormGroup>
-        <FormGroup className={formStyles.stacked_row}>
-          <TextField units="m" name="pauseMinute" {...focusHandlers} />
-        </FormGroup>
-        <FormGroup className={formStyles.stacked_row}>
-          <TextField units="s" name="pauseSecond" {...focusHandlers} />
-        </FormGroup>
+    <div className={styles.form_wrapper}>
+      <div className={styles.section_header}>
+        <span className={styles.section_header_text}>
+          {i18n.t('application.stepType.pause')}
+        </span>
       </div>
-      <div className={formStyles.column_1_2}>
-        <RadioGroupField
-          name="pauseForAmountOfTime"
-          options={[{name: 'Pause until told to resume', value: 'false'}]}
-          {...focusHandlers} />
-        <FormGroup label='Message to display'>
-          <TextField name="pauseMessage" {...focusHandlers} />
-        </FormGroup>
+
+      <div className={styles.section_wrapper}>
+        <div className={styles.section_column}>
+          <div className={styles.checkbox_row}>
+            <RadioGroupField
+              name="pauseForAmountOfTime"
+              options={[{name: 'Pause until told to resume', value: 'false'}]}
+              {...focusHandlers} />
+          </div>
+          <div className={styles.checkbox_row}>
+            <RadioGroupField
+              name="pauseForAmountOfTime"
+              options={[{name: 'Delay for an amount of time', value: 'true'}]}
+              {...focusHandlers} />
+          </div>
+          <ConditionalOnField name={'pauseForAmountOfTime'} condition={(val) => val === 'true'}>
+            <div className={styles.form_row}>
+              <TextField {...focusHandlers} className={styles.small_field}
+                units="hr" name="pauseHour" />
+              <TextField {...focusHandlers} className={styles.small_field}
+                units="m" name="pauseMinute" />
+              <TextField {...focusHandlers} className={styles.small_field}
+                units="s" name="pauseSecond" />
+            </div>
+          </ConditionalOnField>
+        </div>
+        <div className={styles.section_column}>
+          <div className={styles.form_row}>
+            {/* TODO: Ian 2019-03-25 consider making this a component eg `TextAreaField.js` if used anywhere else */}
+            <StepField {...focusHandlers} name='pauseMessage' render={({value, updateValue}) => (
+              <FormGroup label='Message to display' className={styles.full_width_field}>
+                <textarea
+                  className={styles.textarea_field}
+                  value={value}
+                  onChange={(e: SyntheticInputEvent<*>) => updateValue(e.currentTarget.value)} />
+              </FormGroup>)
+            }/>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/protocol-designer/src/components/steplist/PauseStepItems.js
+++ b/protocol-designer/src/components/steplist/PauseStepItems.js
@@ -9,20 +9,22 @@ type Props = {
 
 export default function PauseStepItems (props: Props) {
   const {pauseArgs} = props
-  if (pauseArgs.wait === true) {
-    // Show message if waiting indefinitely
-    return <PDListItem>{pauseArgs.message}</PDListItem>
-  }
   if (!pauseArgs.meta) {
     // No message or time, show nothing
     return null
   }
+  const {message, wait} = pauseArgs
   const {hours, minutes, seconds} = pauseArgs.meta
-  return <PDListItem>
-    <span>{hours} hr</span>
-    <span>{minutes} m</span>
-    <span>{seconds} s</span>
-    <span/>
-    <span/>
-  </PDListItem>
+  return (
+    <React.Fragment>
+      {message && <PDListItem>{message}</PDListItem>}
+      {wait !== true && <PDListItem>
+        <span>{hours} hr</span>
+        <span>{minutes} m</span>
+        <span>{seconds} s</span>
+        <span/>
+        <span/>
+      </PDListItem>}
+    </React.Fragment>
+  )
 }

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -48,7 +48,7 @@ export const drillUpFromLabware = createAction(
 // ==== Create/delete/modify labware =====
 
 export type CreateContainerArgs = {|
-  slot?: DeckSlot,
+  slot?: DeckSlot, // NOTE: if slot is omitted, next available slot will be used.
   containerType: string,
 |}
 

--- a/protocol-designer/src/labware-ingred/actions/thunks.js
+++ b/protocol-designer/src/labware-ingred/actions/thunks.js
@@ -29,16 +29,25 @@ function getNextDisambiguationNumber (state: BaseState, newLabwareType: string):
 
 export const createContainer = (args: CreateContainerArgs) =>
   (dispatch: ThunkDispatch<CreateContainerAction>, getState: GetState) => {
-    const disambiguationNumber = getNextDisambiguationNumber(getState(), args.containerType)
+    const state = getState()
+    const disambiguationNumber = getNextDisambiguationNumber(state, args.containerType)
+    const initialSetupStep = stepFormSelectors.getSavedStepForms(state)[INITIAL_DECK_SETUP_STEP_ID]
+    const labwareLocations = (initialSetupStep && initialSetupStep.labwareLocationUpdate) || {}
 
-    dispatch({
-      type: 'CREATE_CONTAINER',
-      payload: {
-        ...args,
-        id: `${uuid()}:${args.containerType}`,
-        disambiguationNumber,
-      },
-    })
+    const slot = args.slot || getNextAvailableSlot(labwareLocations)
+    if (slot) {
+      dispatch({
+        type: 'CREATE_CONTAINER',
+        payload: {
+          ...args,
+          id: `${uuid()}:${args.containerType}`,
+          disambiguationNumber,
+          slot,
+        },
+      })
+    } else {
+      console.warn('no slots available, cannot create labware')
+    }
   }
 
 export const duplicateLabware = (templateLabwareId: string) =>

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -7,7 +7,10 @@
   "units": {
     "microliter": "μL",
     "microliterPerSec": "μL/s",
-    "times": "x"
+    "times": "x",
+    "seconds": "s",
+    "minutes": "m",
+    "hours": "h"
   },
   "version": "Protocol Designer Version",
   "beta": "beta",

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -72,6 +72,13 @@
       "step_name": {"label": "Step Name"},
       "step_notes": {"label": "Step Notes"},
       "mix": {"label": "mix"},
+      "pauseForAmountOfTime": {
+        "options": {
+          "false": "Pause until told to resume",
+          "true": "Delay for an amount of time"
+        }
+      },
+      "pauseMessage": {"label": "message to display"},
       "path": {
         "title": {
           "single": "Single Transfers",

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -40,7 +40,7 @@ const FORM_ERRORS: {[FormErrorKey]: FormError} = {
   },
   TIME_PARAM_REQUIRED: {
     title: 'Must include hours, minutes, or seconds',
-    dependentFields: ['pauseForAmountOfTime'],
+    dependentFields: ['pauseForAmountOfTime', 'pauseHour', 'pauseMinute', 'pauseSecond'],
   },
   WELL_RATIO_MOVE_LIQUID: {
     title: 'Well selection must be 1 to many, many to 1, or N to N',

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -60,6 +60,14 @@ export default function getDefaultsForStepType (stepType: StepType): {[StepField
         blowout_location: FIXED_TRASH_ID,
         preWetTip: false,
       }
+    case 'pause':
+      return {
+        pauseForAmountOfTime: null,
+        pauseHour: null,
+        pauseMinute: null,
+        pauseSecond: null,
+        pauseMessage: '',
+      }
     default:
       return {}
   }

--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
@@ -8,6 +8,7 @@ function _getDisabledFields (rawForm: FormData): Set<string> {
   switch (rawForm.stepType) {
     case 'moveLiquid': return getDisabledFieldsMoveLiquidForm(rawForm)
     case 'mix': return getDisabledFieldsMixForm(rawForm)
+    case 'pause': return new Set() // nothing to disable
     default: {
       console.warn(`disabled fields for step type ${rawForm.stepType} not yet implemented!`)
       return new Set()


### PR DESCRIPTION
## overview

Closes #3142

## changelog

- new design for pause form
- update substep design to show message even for timed pause

## review requests

- [ ] Component library changes don't affect Run App
- [ ] Pause form and pause substeps match design in #3142 
- [ ] Pause form should only show error "hour minutes seconds is required" when those fields have been blurred
- [ ] Creating new protocol and adding labware should work fine (fixing reversion I missed reviewing #3255)