### PR TITLE
fix(shared-data): fix case of 'brand' text

### DIFF
--- a/shared-data/definitions2/corning_12_wellplate_6.9_ml.json
+++ b/shared-data/definitions2/corning_12_wellplate_6.9_ml.json
@@ -163,7 +163,7 @@
         }
     },
     "brand": {
-        "brand": "corning",
+        "brand": "Corning",
         "brandId": [
             "3336",
             "3512",

--- a/shared-data/definitions2/corning_24_wellplate_3.4_ml.json
+++ b/shared-data/definitions2/corning_24_wellplate_3.4_ml.json
@@ -287,7 +287,7 @@
         }
     },
     "brand": {
-        "brand": "corning",
+        "brand": "Corning",
         "brandId": [
             "3337",
             "3524",

--- a/shared-data/definitions2/corning_384_wellplate_112_ul.json
+++ b/shared-data/definitions2/corning_384_wellplate_112_ul.json
@@ -3923,7 +3923,7 @@
         }
     },
     "brand": {
-        "brand": "corning",
+        "brand": "Corning",
         "brandId": [
             "3640",
             "3662",

--- a/shared-data/definitions2/corning_48_wellplate_1.6_ml.json
+++ b/shared-data/definitions2/corning_48_wellplate_1.6_ml.json
@@ -531,7 +531,7 @@
         }
     },
     "brand": {
-        "brand": "corning",
+        "brand": "Corning",
         "brandId": [
             "3548"
         ]

--- a/shared-data/definitions2/corning_6_wellplate_16.8_ml.json
+++ b/shared-data/definitions2/corning_6_wellplate_16.8_ml.json
@@ -101,7 +101,7 @@
         }
     },
     "brand": {
-        "brand": "corning",
+        "brand": "Corning",
         "brandId": [
             "3335",
             "3506",

--- a/shared-data/definitions2/eppendorf_96_tiprack_1000_ul.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_1000_ul.json
@@ -1020,7 +1020,7 @@
         }
     },
     "brand": {
-        "brand": "eppendorf",
+        "brand": "Eppendorf",
         "brandId": [
             "022491105"
         ]

--- a/shared-data/definitions2/eppendorf_96_tiprack_10_ul.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_10_ul.json
@@ -1020,7 +1020,7 @@
         }
     },
     "brand": {
-        "brand": "eppendorf",
+        "brand": "Eppendorf",
         "brandId": [
             "022491300"
         ]


### PR DESCRIPTION
## overview

'brand' copy needs to be capitalized appropriately for correct renders in Labware Library and other projects. Noted in #3249

## changelog

* correct capitalization in labware defs

## review requests

:baby_chick: 