### PR TITLE
fix(shared-data): Ensure all volumes are µL; remove displayLengthUnits

### DIFF
--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -66,8 +66,7 @@ const options = {
   metadata: {
     displayName: 'ANSI 96 Standard Microplate',
     displayCategory: 'wellPlate',
-    displayVolumeUnits: 'uL',
-    displayLengthUnits: 'mm',
+    displayVolumeUnits: 'µL',
     tags: ['flat', 'microplate', 'SBS', 'ANSI', 'generic'],
   },
   parameters: {
@@ -121,7 +120,6 @@ const options = {
     displayName: 'Opentrons 6x15mL 4x50mL tube rack',
     displayCategory: 'tubeRack',
     displayVolumeUnits: 'mL',
-    displayLengthUnits: 'mm',
     tags: ['opentrons', 'modular', 'tuberack', '15', 'mL', '50'],
   },
   parameters: {
@@ -197,7 +195,10 @@ Fields:
   - `trough`
   - `trash`
   - `other`
-- `displayVolumeUnits` is the units scale to use in the labware load name and app display rather than the default of `µL`
+- `displayVolumeUnits` is the units scale to use in the labware load name and app display; defaults to `µL` and must be one of:
+  - `µL`
+  - `mL`
+  - `L`
 - `tags` is a list of generic words that a user may search for to find the labware
 
 #### Parameters

--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -138,8 +138,18 @@ const options = {
   grid: [{row: 3, column: 2}, {row: 2, column: 2}],
   spacing: [{row: 25, column: 25}, {row: 35, column: 35}],
   well: [
-    {totalLiquidVolume: 15, diameter: 14.5, shape: 'circular', depth: 117.98},
-    {totalLiquidVolume: 50, diameter: 26.45, shape: 'circular', depth: 113.85},
+    {
+      totalLiquidVolume: 15000,
+      diameter: 14.5,
+      shape: 'circular',
+      depth: 117.98,
+    },
+    {
+      totalLiquidVolume: 50000,
+      diameter: 26.45,
+      shape: 'circular',
+      depth: 113.85,
+    },
   ],
   gridStart: [
     {rowStart: 'A', colStart: '1', rowStride: 1, colStride: 1},
@@ -255,6 +265,8 @@ Fields:
 | diameter          | number | no       | Diameter of the well in **mm**; required if `shape: 'circular'`           |
 | length            | number | no       | Length (x-axis) of the well in **mm**; required if `shape: 'rectangular'` |
 | width             | number | no       | Width (y-axis) of the well in **mm**; required if `shape: 'rectangular'`  |
+
+**`totalLiquidVolume` must be specified in µL**. The generator will convert the value in µL to `metadata.displayVolumeUnits` for the `loadName`.
 
 Note: The full well schema includes `x`, `y`, and `z` fields, but they should not be set by the user. The generator functions will calculate well positions.
 

--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import uniqWith from 'lodash/uniqWith'
 
+import {getDisplayVolume} from '@opentrons/shared-data'
 import {Icon} from '@opentrons/components'
 import styles from './styles.css'
 
@@ -202,7 +203,8 @@ function WellProperties (props: LabwareCardProps) {
             <div className={styles.well_volume}>
               <p className={styles.top_label}>{EN_MAX_VOLUME}</p>
               <p className={styles.value}>
-                {w.totalLiquidVolume} {displayVolumeUnits}
+                {getDisplayVolume(w.totalLiquidVolume, displayVolumeUnits, 2)}{' '}
+                {displayVolumeUnits}
               </p>
             </div>
           </div>

--- a/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
+++ b/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
@@ -215,7 +215,7 @@ exports[`LabwareList component renders 1`] = `
             >
               380
                
-              uL
+              µL
             </p>
           </div>
         </div>
@@ -463,7 +463,7 @@ exports[`LabwareList component renders 1`] = `
             >
               300
                
-              uL
+              µL
             </p>
           </div>
         </div>

--- a/shared-data/definitions2/biorad_96_wellplate_pcr_200_ul.json
+++ b/shared-data/definitions2/biorad_96_wellplate_pcr_200_ul.json
@@ -126,8 +126,7 @@
   "metadata": {
     "displayName": "Bio-Rad HardShell 96-Well PCR Plate",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "uL",
-    "displayLengthUnits": "mm",
+    "displayVolumeUnits": "µL",
     "tags": [
       "flat",
       "plate",

--- a/shared-data/definitions2/corning_12_wellplate_6.9_ml.json
+++ b/shared-data/definitions2/corning_12_wellplate_6.9_ml.json
@@ -26,7 +26,6 @@
     "metadata": {
         "displayName": "Corning 12 Well Plate",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "wellPlate",
         "tags": [
             "SBS",
@@ -57,7 +56,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 24.94,
             "y": 16.79,
             "z": 2.49
@@ -66,7 +65,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 24.94,
             "y": 42.8,
             "z": 2.49
@@ -75,7 +74,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 24.94,
             "y": 68.81,
             "z": 2.49
@@ -84,7 +83,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 60.95,
             "y": 16.79,
             "z": 2.49
@@ -93,7 +92,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 60.95,
             "y": 42.8,
             "z": 2.49
@@ -102,7 +101,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 60.95,
             "y": 68.81,
             "z": 2.49
@@ -111,7 +110,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 96.96,
             "y": 16.79,
             "z": 2.49
@@ -120,7 +119,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 96.96,
             "y": 42.8,
             "z": 2.49
@@ -129,7 +128,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 96.96,
             "y": 68.81,
             "z": 2.49
@@ -138,7 +137,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 132.97,
             "y": 16.79,
             "z": 2.49
@@ -147,7 +146,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 132.97,
             "y": 42.8,
             "z": 2.49
@@ -156,7 +155,7 @@
             "shape": "circular",
             "depth": 17.53,
             "diameter": 22.73,
-            "totalLiquidVolume": 6.9,
+            "totalLiquidVolume": 6900,
             "x": 132.97,
             "y": 68.81,
             "z": 2.49

--- a/shared-data/definitions2/corning_24_wellplate_3.4_ml.json
+++ b/shared-data/definitions2/corning_24_wellplate_3.4_ml.json
@@ -42,7 +42,6 @@
     "metadata": {
         "displayName": "Corning 24 Well Plate",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "wellPlate",
         "tags": [
             "SBS",
@@ -73,7 +72,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 17.48,
             "y": 19.3,
             "z": 2.87
@@ -82,7 +81,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 17.48,
             "y": 38.6,
             "z": 2.87
@@ -91,7 +90,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 17.48,
             "y": 57.9,
             "z": 2.87
@@ -100,7 +99,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 17.48,
             "y": 77.2,
             "z": 2.87
@@ -109,7 +108,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 36.78,
             "y": 19.3,
             "z": 2.87
@@ -118,7 +117,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 36.78,
             "y": 38.6,
             "z": 2.87
@@ -127,7 +126,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 36.78,
             "y": 57.9,
             "z": 2.87
@@ -136,7 +135,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 36.78,
             "y": 77.2,
             "z": 2.87
@@ -145,7 +144,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 56.08,
             "y": 19.3,
             "z": 2.87
@@ -154,7 +153,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 56.08,
             "y": 38.6,
             "z": 2.87
@@ -163,7 +162,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 56.08,
             "y": 57.9,
             "z": 2.87
@@ -172,7 +171,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 56.08,
             "y": 77.2,
             "z": 2.87
@@ -181,7 +180,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 75.38,
             "y": 19.3,
             "z": 2.87
@@ -190,7 +189,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 75.38,
             "y": 38.6,
             "z": 2.87
@@ -199,7 +198,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 75.38,
             "y": 57.9,
             "z": 2.87
@@ -208,7 +207,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 75.38,
             "y": 77.2,
             "z": 2.87
@@ -217,7 +216,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 94.68,
             "y": 19.3,
             "z": 2.87
@@ -226,7 +225,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 94.68,
             "y": 38.6,
             "z": 2.87
@@ -235,7 +234,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 94.68,
             "y": 57.9,
             "z": 2.87
@@ -244,7 +243,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 94.68,
             "y": 77.2,
             "z": 2.87
@@ -253,7 +252,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 113.98,
             "y": 19.3,
             "z": 2.87
@@ -262,7 +261,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 113.98,
             "y": 38.6,
             "z": 2.87
@@ -271,7 +270,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 113.98,
             "y": 57.9,
             "z": 2.87
@@ -280,7 +279,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 16.26,
-            "totalLiquidVolume": 3.4,
+            "totalLiquidVolume": 3400,
             "x": 113.98,
             "y": 77.2,
             "z": 2.87

--- a/shared-data/definitions2/corning_384_wellplate_112_ul.json
+++ b/shared-data/definitions2/corning_384_wellplate_112_ul.json
@@ -437,8 +437,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Corning 384 Well Plate",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "wellPlate",
         "tags": [
             "SBS",

--- a/shared-data/definitions2/corning_48_wellplate_1.6_ml.json
+++ b/shared-data/definitions2/corning_48_wellplate_1.6_ml.json
@@ -70,7 +70,6 @@
     "metadata": {
         "displayName": "Corning 48 Well Plate",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "wellPlate",
         "tags": [
             "SBS",
@@ -101,7 +100,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 10.08,
             "z": 2.62
@@ -110,7 +109,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 23.16,
             "z": 2.62
@@ -119,7 +118,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 36.24,
             "z": 2.62
@@ -128,7 +127,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 49.32,
             "z": 2.62
@@ -137,7 +136,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 62.4,
             "z": 2.62
@@ -146,7 +145,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 18.16,
             "y": 75.48,
             "z": 2.62
@@ -155,7 +154,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 10.08,
             "z": 2.62
@@ -164,7 +163,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 23.16,
             "z": 2.62
@@ -173,7 +172,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 36.24,
             "z": 2.62
@@ -182,7 +181,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 49.32,
             "z": 2.62
@@ -191,7 +190,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 62.4,
             "z": 2.62
@@ -200,7 +199,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 31.24,
             "y": 75.48,
             "z": 2.62
@@ -209,7 +208,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 10.08,
             "z": 2.62
@@ -218,7 +217,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 23.16,
             "z": 2.62
@@ -227,7 +226,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 36.24,
             "z": 2.62
@@ -236,7 +235,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 49.32,
             "z": 2.62
@@ -245,7 +244,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 62.4,
             "z": 2.62
@@ -254,7 +253,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 44.32,
             "y": 75.48,
             "z": 2.62
@@ -263,7 +262,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 10.08,
             "z": 2.62
@@ -272,7 +271,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 23.16,
             "z": 2.62
@@ -281,7 +280,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 36.24,
             "z": 2.62
@@ -290,7 +289,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 49.32,
             "z": 2.62
@@ -299,7 +298,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 62.4,
             "z": 2.62
@@ -308,7 +307,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 57.4,
             "y": 75.48,
             "z": 2.62
@@ -317,7 +316,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 10.08,
             "z": 2.62
@@ -326,7 +325,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 23.16,
             "z": 2.62
@@ -335,7 +334,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 36.24,
             "z": 2.62
@@ -344,7 +343,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 49.32,
             "z": 2.62
@@ -353,7 +352,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 62.4,
             "z": 2.62
@@ -362,7 +361,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 70.48,
             "y": 75.48,
             "z": 2.62
@@ -371,7 +370,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 10.08,
             "z": 2.62
@@ -380,7 +379,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 23.16,
             "z": 2.62
@@ -389,7 +388,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 36.24,
             "z": 2.62
@@ -398,7 +397,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 49.32,
             "z": 2.62
@@ -407,7 +406,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 62.4,
             "z": 2.62
@@ -416,7 +415,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 83.56,
             "y": 75.48,
             "z": 2.62
@@ -425,7 +424,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 10.08,
             "z": 2.62
@@ -434,7 +433,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 23.16,
             "z": 2.62
@@ -443,7 +442,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 36.24,
             "z": 2.62
@@ -452,7 +451,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 49.32,
             "z": 2.62
@@ -461,7 +460,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 62.4,
             "z": 2.62
@@ -470,7 +469,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 96.64,
             "y": 75.48,
             "z": 2.62
@@ -479,7 +478,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 10.08,
             "z": 2.62
@@ -488,7 +487,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 23.16,
             "z": 2.62
@@ -497,7 +496,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 36.24,
             "z": 2.62
@@ -506,7 +505,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 49.32,
             "z": 2.62
@@ -515,7 +514,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 62.4,
             "z": 2.62
@@ -524,7 +523,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 11.56,
-            "totalLiquidVolume": 1.6,
+            "totalLiquidVolume": 1600,
             "x": 109.72,
             "y": 75.48,
             "z": 2.62

--- a/shared-data/definitions2/corning_6_wellplate_16.8_ml.json
+++ b/shared-data/definitions2/corning_6_wellplate_16.8_ml.json
@@ -18,7 +18,6 @@
     "metadata": {
         "displayName": "Corning 6 Well Plate",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "wellPlate",
         "tags": [
             "SBS",
@@ -49,7 +48,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 24.76,
             "y": 23.16,
             "z": 2.87
@@ -58,7 +57,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 24.76,
             "y": 62.28,
             "z": 2.87
@@ -67,7 +66,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 63.88,
             "y": 23.16,
             "z": 2.87
@@ -76,7 +75,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 63.88,
             "y": 62.28,
             "z": 2.87
@@ -85,7 +84,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 103,
             "y": 23.16,
             "z": 2.87
@@ -94,7 +93,7 @@
             "shape": "circular",
             "depth": 17.4,
             "diameter": 35.43,
-            "totalLiquidVolume": 16.8,
+            "totalLiquidVolume": 16800,
             "x": 103,
             "y": 62.28,
             "z": 2.87

--- a/shared-data/definitions2/eppendorf_96_tiprack_1000_ul.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_1000_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "epT.I.P.S. 50-1000 uL tiprack",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tipRack",
         "tags": [
             "SBS",

--- a/shared-data/definitions2/eppendorf_96_tiprack_10_ul.json
+++ b/shared-data/definitions2/eppendorf_96_tiprack_10_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "epT.I.P.S. 0.1-10 uL tiprack",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tipRack",
         "tags": [
             "SBS",

--- a/shared-data/definitions2/generic_96_wellplate_380_ul.json
+++ b/shared-data/definitions2/generic_96_wellplate_380_ul.json
@@ -126,8 +126,7 @@
     "metadata": {
         "displayName": "ANSI 96 Standard Microplate",
         "displayCategory": "wellPlate",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "tags": [
             "flat",
             "microplate",

--- a/shared-data/definitions2/opentrons_15_tuberack_15_ml_falcon.json
+++ b/shared-data/definitions2/opentrons_15_tuberack_15_ml_falcon.json
@@ -29,7 +29,6 @@
     "otId": "01b7cd80-e8f3-11e8-b93b-5f6727dde048",
     "deprecated": false,
     "metadata": {
-        "displayLengthUnits": "mm",
         "displayVolumeUnits": "mL",
         "displayCategory": "tubeRack",
         "displayName": "Opentrons 15 mL tuberack",
@@ -62,7 +61,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 10.5,
             "y": 14.38,
             "z": 5.78
@@ -71,7 +70,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 10.5,
             "y": 39.38,
             "z": 5.78
@@ -80,7 +79,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 10.5,
             "y": 64.38,
             "z": 5.78
@@ -89,7 +88,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 35.5,
             "y": 14.38,
             "z": 5.78
@@ -98,7 +97,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 35.5,
             "y": 39.38,
             "z": 5.78
@@ -107,7 +106,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 35.5,
             "y": 64.38,
             "z": 5.78
@@ -116,7 +115,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 60.5,
             "y": 14.38,
             "z": 5.78
@@ -125,7 +124,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 60.5,
             "y": 39.38,
             "z": 5.78
@@ -134,7 +133,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 60.5,
             "y": 64.38,
             "z": 5.78
@@ -143,7 +142,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 85.5,
             "y": 14.38,
             "z": 5.78
@@ -152,7 +151,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 85.5,
             "y": 39.38,
             "z": 5.78
@@ -161,7 +160,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 85.5,
             "y": 64.38,
             "z": 5.78
@@ -170,7 +169,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 110.5,
             "y": 14.38,
             "z": 5.78
@@ -179,7 +178,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 110.5,
             "y": 39.38,
             "z": 5.78
@@ -188,7 +187,7 @@
             "depth": 117.98,
             "diameter": 14.5,
             "shape": "circular",
-            "totalLiquidVolume": 15,
+            "totalLiquidVolume": 15000,
             "x": 110.5,
             "y": 64.38,
             "z": 5.78

--- a/shared-data/definitions2/opentrons_1_trash_0.85_l.json
+++ b/shared-data/definitions2/opentrons_1_trash_0.85_l.json
@@ -9,7 +9,6 @@
     "metadata": {
         "displayCategory": "trash",
         "displayVolumeUnits": "L",
-        "displayLengthUnits": "mm",
         "displayName": "Short Fixed Trash",
         "tags": [
             "trash",
@@ -39,7 +38,7 @@
             "shape": "rectangular",
             "length": 165.67,
             "width": 107.11,
-            "totalLiquidVolume": 0.85,
+            "totalLiquidVolume": 850000,
             "depth": 53,
             "x": 82.84,
             "y": 53.56,

--- a/shared-data/definitions2/opentrons_1_trash_1.1_l.json
+++ b/shared-data/definitions2/opentrons_1_trash_1.1_l.json
@@ -9,7 +9,6 @@
     "metadata": {
         "displayCategory": "trash",
         "displayVolumeUnits": "L",
-        "displayLengthUnits": "mm",
         "displayName": "Tall Fixed Trash",
         "tags": [
             "trash",
@@ -39,7 +38,7 @@
             "shape": "rectangular",
             "length": 165.67,
             "width": 107.11,
-            "totalLiquidVolume": 1.1,
+            "totalLiquidVolume": 1100000,
             "depth": 77,
             "x": 82.84,
             "y": 53.56,

--- a/shared-data/definitions2/opentrons_24_aluminum_tuberack_2_ml.json
+++ b/shared-data/definitions2/opentrons_24_aluminum_tuberack_2_ml.json
@@ -42,7 +42,6 @@
     "metadata": {
         "displayName": "Aluminum 2mL block",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "tubeRack"
     },
     "cornerOffsetFromSlot": {
@@ -66,7 +65,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 20.75,
             "y": 16.88,
             "z": 6.7
@@ -75,7 +74,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 20.75,
             "y": 34.13,
             "z": 6.7
@@ -84,7 +83,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 20.75,
             "y": 51.38,
             "z": 6.7
@@ -93,7 +92,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 20.75,
             "y": 68.63,
             "z": 6.7
@@ -102,7 +101,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38,
             "y": 16.88,
             "z": 6.7
@@ -111,7 +110,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38,
             "y": 34.13,
             "z": 6.7
@@ -120,7 +119,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38,
             "y": 51.38,
             "z": 6.7
@@ -129,7 +128,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38,
             "y": 68.63,
             "z": 6.7
@@ -138,7 +137,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 55.25,
             "y": 16.88,
             "z": 6.7
@@ -147,7 +146,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 55.25,
             "y": 34.13,
             "z": 6.7
@@ -156,7 +155,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 55.25,
             "y": 51.38,
             "z": 6.7
@@ -165,7 +164,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 55.25,
             "y": 68.63,
             "z": 6.7
@@ -174,7 +173,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 72.5,
             "y": 16.88,
             "z": 6.7
@@ -183,7 +182,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 72.5,
             "y": 34.13,
             "z": 6.7
@@ -192,7 +191,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 72.5,
             "y": 51.38,
             "z": 6.7
@@ -201,7 +200,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 72.5,
             "y": 68.63,
             "z": 6.7
@@ -210,7 +209,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 89.75,
             "y": 16.88,
             "z": 6.7
@@ -219,7 +218,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 89.75,
             "y": 34.13,
             "z": 6.7
@@ -228,7 +227,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 89.75,
             "y": 51.38,
             "z": 6.7
@@ -237,7 +236,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 89.75,
             "y": 68.63,
             "z": 6.7
@@ -246,7 +245,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 107,
             "y": 16.88,
             "z": 6.7
@@ -255,7 +254,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 107,
             "y": 34.13,
             "z": 6.7
@@ -264,7 +263,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 107,
             "y": 51.38,
             "z": 6.7
@@ -273,7 +272,7 @@
             "shape": "circular",
             "depth": 42,
             "diameter": 8.5,
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 107,
             "y": 68.63,
             "z": 6.7

--- a/shared-data/definitions2/opentrons_24_tuberack_1.5_ml_eppendorf.json
+++ b/shared-data/definitions2/opentrons_24_tuberack_1.5_ml_eppendorf.json
@@ -49,7 +49,6 @@
         ],
         "displayName": "Opentrons snapcap 1.5mL tuberack",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "tubeRack"
     },
     "cornerOffsetFromSlot": {
@@ -73,7 +72,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 18.21,
             "y": 17.59,
             "z": 42.05
@@ -82,7 +81,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 18.21,
             "y": 36.87,
             "z": 42.05
@@ -91,7 +90,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 18.21,
             "y": 56.15,
             "z": 42.05
@@ -100,7 +99,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 18.21,
             "y": 75.43,
             "z": 42.05
@@ -109,7 +108,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 38.1,
             "y": 17.59,
             "z": 42.05
@@ -118,7 +117,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 38.1,
             "y": 36.87,
             "z": 42.05
@@ -127,7 +126,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 38.1,
             "y": 56.15,
             "z": 42.05
@@ -136,7 +135,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 38.1,
             "y": 75.43,
             "z": 42.05
@@ -145,7 +144,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 57.99,
             "y": 17.59,
             "z": 42.05
@@ -154,7 +153,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 57.99,
             "y": 36.87,
             "z": 42.05
@@ -163,7 +162,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 57.99,
             "y": 56.15,
             "z": 42.05
@@ -172,7 +171,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 57.99,
             "y": 75.43,
             "z": 42.05
@@ -181,7 +180,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 77.88,
             "y": 17.59,
             "z": 42.05
@@ -190,7 +189,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 77.88,
             "y": 36.87,
             "z": 42.05
@@ -199,7 +198,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 77.88,
             "y": 56.15,
             "z": 42.05
@@ -208,7 +207,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 77.88,
             "y": 75.43,
             "z": 42.05
@@ -217,7 +216,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 97.77,
             "y": 17.59,
             "z": 42.05
@@ -226,7 +225,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 97.77,
             "y": 36.87,
             "z": 42.05
@@ -235,7 +234,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 97.77,
             "y": 56.15,
             "z": 42.05
@@ -244,7 +243,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 97.77,
             "y": 75.43,
             "z": 42.05
@@ -253,7 +252,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 117.66,
             "y": 17.59,
             "z": 42.05
@@ -262,7 +261,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 117.66,
             "y": 36.87,
             "z": 42.05
@@ -271,7 +270,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 117.66,
             "y": 56.15,
             "z": 42.05
@@ -280,7 +279,7 @@
             "depth": 37.8,
             "diameter": 8.7,
             "shape": "circular",
-            "totalLiquidVolume": 1.5,
+            "totalLiquidVolume": 1500,
             "x": 117.66,
             "y": 75.43,
             "z": 42.05

--- a/shared-data/definitions2/opentrons_24_tuberack_2_ml_eppendorf.json
+++ b/shared-data/definitions2/opentrons_24_tuberack_2_ml_eppendorf.json
@@ -40,7 +40,6 @@
     "otId": "b28e5eb0-e8f0-11e8-b93b-5f6727dde048",
     "deprecated": false,
     "metadata": {
-        "displayLengthUnits": "mm",
         "displayVolumeUnits": "mL",
         "displayCategory": "tubeRack",
         "displayName": "Opentrons snapcap 2mL tuberack",
@@ -74,7 +73,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 18.21,
               "y": 17.59,
               "z": 41.27
@@ -83,7 +82,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 18.21,
               "y": 36.87,
               "z": 41.27
@@ -92,7 +91,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 18.21,
               "y": 56.15,
               "z": 41.27
@@ -101,7 +100,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 18.21,
               "y": 75.43,
               "z": 41.27
@@ -110,7 +109,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 38.1,
               "y": 17.59,
               "z": 41.27
@@ -119,7 +118,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 38.1,
               "y": 36.87,
               "z": 41.27
@@ -128,7 +127,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 38.1,
               "y": 56.15,
               "z": 41.27
@@ -137,7 +136,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 38.1,
               "y": 75.43,
               "z": 41.27
@@ -146,7 +145,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 57.99,
               "y": 17.59,
               "z": 41.27
@@ -155,7 +154,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 57.99,
               "y": 36.87,
               "z": 41.27
@@ -164,7 +163,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 57.99,
               "y": 56.15,
               "z": 41.27
@@ -173,7 +172,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 57.99,
               "y": 75.43,
               "z": 41.27
@@ -182,7 +181,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 77.88,
               "y": 17.59,
               "z": 41.27
@@ -191,7 +190,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 77.88,
               "y": 36.87,
               "z": 41.27
@@ -200,7 +199,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 77.88,
               "y": 56.15,
               "z": 41.27
@@ -209,7 +208,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 77.88,
               "y": 75.43,
               "z": 41.27
@@ -218,7 +217,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 97.77,
               "y": 17.59,
               "z": 41.27
@@ -227,7 +226,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 97.77,
               "y": 36.87,
               "z": 41.27
@@ -236,7 +235,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 97.77,
               "y": 56.15,
               "z": 41.27
@@ -245,7 +244,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 97.77,
               "y": 75.43,
               "z": 41.27
@@ -254,7 +253,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 117.66,
               "y": 17.59,
               "z": 41.27
@@ -263,7 +262,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 117.66,
               "y": 36.87,
               "z": 41.27
@@ -272,7 +271,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 117.66,
               "y": 56.15,
               "z": 41.27
@@ -281,7 +280,7 @@
               "depth": 38.58,
               "diameter": 9.9,
               "shape": "circular",
-              "totalLiquidVolume": 2,
+              "totalLiquidVolume": 2000,
               "x": 117.66,
               "y": 75.43,
               "z": 41.27

--- a/shared-data/definitions2/opentrons_24_tuberack_2_ml_screwcap.json
+++ b/shared-data/definitions2/opentrons_24_tuberack_2_ml_screwcap.json
@@ -40,7 +40,6 @@
     "otId": "e8c55910-e8f1-11e8-b93b-5f6727dde048",
     "deprecated": false,
     "metadata": {
-        "displayLengthUnits": "mm",
         "displayVolumeUnits": "mL",
         "displayCategory": "tubeRack",
         "displayName": "Opentrons screwcap 2mL tuberack",
@@ -74,7 +73,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 18.21,
             "y": 17.59,
             "z": 42
@@ -83,7 +82,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 18.21,
             "y": 36.87,
             "z": 42
@@ -92,7 +91,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 18.21,
             "y": 56.15,
             "z": 42
@@ -101,7 +100,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 18.21,
             "y": 75.43,
             "z": 42
@@ -110,7 +109,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38.1,
             "y": 17.59,
             "z": 42
@@ -119,7 +118,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38.1,
             "y": 36.87,
             "z": 42
@@ -128,7 +127,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38.1,
             "y": 56.15,
             "z": 42
@@ -137,7 +136,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 38.1,
             "y": 75.43,
             "z": 42
@@ -146,7 +145,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 57.99,
             "y": 17.59,
             "z": 42
@@ -155,7 +154,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 57.99,
             "y": 36.87,
             "z": 42
@@ -164,7 +163,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 57.99,
             "y": 56.15,
             "z": 42
@@ -173,7 +172,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 57.99,
             "y": 75.43,
             "z": 42
@@ -182,7 +181,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 77.88,
             "y": 17.59,
             "z": 42
@@ -191,7 +190,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 77.88,
             "y": 36.87,
             "z": 42
@@ -200,7 +199,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 77.88,
             "y": 56.15,
             "z": 42
@@ -209,7 +208,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 77.88,
             "y": 75.43,
             "z": 42
@@ -218,7 +217,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 97.77,
             "y": 17.59,
             "z": 42
@@ -227,7 +226,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 97.77,
             "y": 36.87,
             "z": 42
@@ -236,7 +235,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 97.77,
             "y": 56.15,
             "z": 42
@@ -245,7 +244,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 97.77,
             "y": 75.43,
             "z": 42
@@ -254,7 +253,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 117.66,
             "y": 17.59,
             "z": 42
@@ -263,7 +262,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 117.66,
             "y": 36.87,
             "z": 42
@@ -272,7 +271,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 117.66,
             "y": 56.15,
             "z": 42
@@ -281,7 +280,7 @@
             "depth": 42,
             "diameter": 8.5,
             "shape": "circular",
-            "totalLiquidVolume": 2,
+            "totalLiquidVolume": 2000,
             "x": 117.66,
             "y": 75.43,
             "z": 42

--- a/shared-data/definitions2/opentrons_6_tuberack_50_ml_falcon.json
+++ b/shared-data/definitions2/opentrons_6_tuberack_50_ml_falcon.json
@@ -16,7 +16,6 @@
     "otId": "14807fb0-e8f4-11e8-b93b-5f6727dde048",
     "deprecated": false,
     "metadata": {
-        "displayLengthUnits": "mm",
         "displayVolumeUnits": "mL",
         "displayCategory": "tubeRack",
         "displayName": "Opentrons 50 mL tuberack",
@@ -49,7 +48,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 33,
             "y": 21.88,
             "z": 6.04
@@ -58,7 +57,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 33,
             "y": 56.88,
             "z": 6.04
@@ -67,7 +66,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 68,
             "y": 21.88,
             "z": 6.04
@@ -76,7 +75,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 68,
             "y": 56.88,
             "z": 6.04
@@ -85,7 +84,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 103,
             "y": 21.88,
             "z": 6.04
@@ -94,7 +93,7 @@
             "depth": 113.85,
             "diameter": 26.45,
             "shape": "circular",
-            "totalLiquidVolume": 50,
+            "totalLiquidVolume": 50000,
             "x": 103,
             "y": 56.88,
             "z": 6.04

--- a/shared-data/definitions2/opentrons_6x15_ml_4x50_ml_tuberack.json
+++ b/shared-data/definitions2/opentrons_6x15_ml_4x50_ml_tuberack.json
@@ -25,7 +25,6 @@
         "displayName": "Opentrons 6x15mL 4x50mL tube rack",
         "displayCategory": "tubeRack",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "tags": [
             "opentrons",
             "modular",
@@ -53,7 +52,7 @@
     },
     "wells": {
           "A1": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -62,7 +61,7 @@
               "z": 5.78
           },
           "B1": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -71,7 +70,7 @@
               "z": 5.78
           },
           "C1": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -80,7 +79,7 @@
               "z": 5.78
           },
           "A2": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -89,7 +88,7 @@
               "z": 5.78
           },
           "B2": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -98,7 +97,7 @@
               "z": 5.78
           },
           "C2": {
-              "totalLiquidVolume": 15,
+              "totalLiquidVolume": 15000,
               "diameter": 14.5,
               "shape": "circular",
               "depth": 117.98,
@@ -107,7 +106,7 @@
               "z": 5.78
           },
           "A3": {
-              "totalLiquidVolume": 50,
+              "totalLiquidVolume": 50000,
               "diameter": 26.45,
               "shape": "circular",
               "depth": 113.85,
@@ -116,7 +115,7 @@
               "z": 5.95
           },
           "B3": {
-              "totalLiquidVolume": 50,
+              "totalLiquidVolume": 50000,
               "diameter": 26.45,
               "shape": "circular",
               "depth": 113.85,
@@ -125,7 +124,7 @@
               "z": 5.95
           },
           "A4": {
-              "totalLiquidVolume": 50,
+              "totalLiquidVolume": 50000,
               "diameter": 26.45,
               "shape": "circular",
               "depth": 113.85,
@@ -134,7 +133,7 @@
               "z": 5.95
           },
           "B4": {
-              "totalLiquidVolume": 50,
+              "totalLiquidVolume": 50000,
               "diameter": 26.45,
               "shape": "circular",
               "depth": 113.85,

--- a/shared-data/definitions2/opentrons_96_aluminum_biorad_wellplate_200_ul.json
+++ b/shared-data/definitions2/opentrons_96_aluminum_biorad_wellplate_200_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Aluminum Bio-Rad PCR plate 200uL",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "wellPlate"
     },
     "cornerOffsetFromSlot": {

--- a/shared-data/definitions2/opentrons_96_aluminum_tuberack_200_ul.json
+++ b/shared-data/definitions2/opentrons_96_aluminum_tuberack_200_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Aluminum PCR block 200uL",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tubeRack"
     },
     "cornerOffsetFromSlot": {

--- a/shared-data/definitions2/opentrons_96_tiprack_1000_ul.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_1000_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons GEB 1000uL Tiprack",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tipRack",
         "tags": [
             "GEB",

--- a/shared-data/definitions2/opentrons_96_tiprack_10_ul.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_10_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons GEB 10uL Tiprack",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tipRack",
         "tags": [
             "GEB",

--- a/shared-data/definitions2/opentrons_96_tiprack_300_ul.json
+++ b/shared-data/definitions2/opentrons_96_tiprack_300_ul.json
@@ -125,8 +125,7 @@
     "deprecated": false,
     "metadata": {
         "displayName": "Opentrons GEB 300uL Tiprack",
-        "displayVolumeUnits": "uL",
-        "displayLengthUnits": "mm",
+        "displayVolumeUnits": "µL",
         "displayCategory": "tipRack",
         "tags": [
             "GEB",

--- a/shared-data/definitions2/usa_scientific_12_trough_22_ml.json
+++ b/shared-data/definitions2/usa_scientific_12_trough_22_ml.json
@@ -42,7 +42,6 @@
     "metadata": {
         "displayName": "12 Channel Trough",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "displayCategory": "trough"
     },
     "cornerOffsetFromSlot": {
@@ -68,7 +67,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 13.94,
             "y": 42.9,
             "z": 2.29
@@ -78,7 +77,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 23.03,
             "y": 42.9,
             "z": 2.29
@@ -88,7 +87,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 32.12,
             "y": 42.9,
             "z": 2.29
@@ -98,7 +97,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 41.21,
             "y": 42.9,
             "z": 2.29
@@ -108,7 +107,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 50.3,
             "y": 42.9,
             "z": 2.29
@@ -118,7 +117,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 59.39,
             "y": 42.9,
             "z": 2.29
@@ -128,7 +127,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 68.48,
             "y": 42.9,
             "z": 2.29
@@ -138,7 +137,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 77.57,
             "y": 42.9,
             "z": 2.29
@@ -148,7 +147,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 86.66,
             "y": 42.9,
             "z": 2.29
@@ -158,7 +157,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 95.75,
             "y": 42.9,
             "z": 2.29
@@ -168,7 +167,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 104.84,
             "y": 42.9,
             "z": 2.29
@@ -178,7 +177,7 @@
             "depth": 42.16,
             "length": 8.33,
             "width": 71.88,
-            "totalLiquidVolume": 22,
+            "totalLiquidVolume": 22000,
             "x": 113.93,
             "y": 42.9,
             "z": 2.29

--- a/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
+++ b/shared-data/js/__tests__/fixtures/irregularLabwareExample1.json
@@ -82,7 +82,6 @@
         "displayName": "Fake Irregular Container",
         "displayCategory": "tubeRack",
         "displayVolumeUnits": "mL",
-        "displayLengthUnits": "mm",
         "tags": [
             "fake",
             "opentrons"
@@ -112,7 +111,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 10,
             "y": 30,
             "z": 58.94
@@ -121,7 +120,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 10,
             "y": 25,
             "z": 58.94
@@ -130,7 +129,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 10,
             "y": 20,
             "z": 58.94
@@ -139,7 +138,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 10,
             "y": 15,
             "z": 58.94
@@ -148,7 +147,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 10,
             "y": 10,
             "z": 58.94
@@ -157,7 +156,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 20,
             "y": 30,
             "z": 58.94
@@ -166,7 +165,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 20,
             "y": 25,
             "z": 58.94
@@ -175,7 +174,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 20,
             "y": 20,
             "z": 58.94
@@ -184,7 +183,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 20,
             "y": 15,
             "z": 58.94
@@ -193,7 +192,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 20,
             "y": 10,
             "z": 58.94
@@ -202,7 +201,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 30,
             "y": 30,
             "z": 58.94
@@ -211,7 +210,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 30,
             "y": 25,
             "z": 58.94
@@ -220,7 +219,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 30,
             "y": 20,
             "z": 58.94
@@ -229,7 +228,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 30,
             "y": 15,
             "z": 58.94
@@ -238,7 +237,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 30,
             "y": 10,
             "z": 58.94
@@ -247,7 +246,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 40,
             "y": 30,
             "z": 58.94
@@ -256,7 +255,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 40,
             "y": 25,
             "z": 58.94
@@ -265,7 +264,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 40,
             "y": 20,
             "z": 58.94
@@ -274,7 +273,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 40,
             "y": 15,
             "z": 58.94
@@ -283,7 +282,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 40,
             "y": 10,
             "z": 58.94
@@ -292,7 +291,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 50,
             "y": 30,
             "z": 58.94
@@ -301,7 +300,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 50,
             "y": 25,
             "z": 58.94
@@ -310,7 +309,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 50,
             "y": 20,
             "z": 58.94
@@ -319,7 +318,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 50,
             "y": 15,
             "z": 58.94
@@ -328,7 +327,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 50,
             "y": 10,
             "z": 58.94
@@ -337,7 +336,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 60,
             "y": 30,
             "z": 58.94
@@ -346,7 +345,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 60,
             "y": 25,
             "z": 58.94
@@ -355,7 +354,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 60,
             "y": 20,
             "z": 58.94
@@ -364,7 +363,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 60,
             "y": 15,
             "z": 58.94
@@ -373,7 +372,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 60,
             "y": 10,
             "z": 58.94
@@ -382,7 +381,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 70,
             "y": 30,
             "z": 58.94
@@ -391,7 +390,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 70,
             "y": 25,
             "z": 58.94
@@ -400,7 +399,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 70,
             "y": 20,
             "z": 58.94
@@ -409,7 +408,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 70,
             "y": 15,
             "z": 58.94
@@ -418,7 +417,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 70,
             "y": 10,
             "z": 58.94
@@ -427,7 +426,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 80,
             "y": 30,
             "z": 58.94
@@ -436,7 +435,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 80,
             "y": 25,
             "z": 58.94
@@ -445,7 +444,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 80,
             "y": 20,
             "z": 58.94
@@ -454,7 +453,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 80,
             "y": 15,
             "z": 58.94
@@ -463,7 +462,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 80,
             "y": 10,
             "z": 58.94
@@ -472,7 +471,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 90,
             "y": 30,
             "z": 58.94
@@ -481,7 +480,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 90,
             "y": 25,
             "z": 58.94
@@ -490,7 +489,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 90,
             "y": 20,
             "z": 58.94
@@ -499,7 +498,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 90,
             "y": 15,
             "z": 58.94
@@ -508,7 +507,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 90,
             "y": 10,
             "z": 58.94
@@ -517,7 +516,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 100,
             "y": 30,
             "z": 58.94
@@ -526,7 +525,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 100,
             "y": 25,
             "z": 58.94
@@ -535,7 +534,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 100,
             "y": 20,
             "z": 58.94
@@ -544,7 +543,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 100,
             "y": 15,
             "z": 58.94
@@ -553,7 +552,7 @@
             "depth": 10.54,
             "shape": "circular",
             "diameter": 10,
-            "totalLiquidVolume": 3,
+            "totalLiquidVolume": 3000,
             "x": 100,
             "y": 10,
             "z": 58.94
@@ -562,7 +561,7 @@
             "depth": 20.54,
             "shape": "circular",
             "diameter": 15,
-            "totalLiquidVolume": 10,
+            "totalLiquidVolume": 10000,
             "x": 15,
             "y": 15,
             "z": 48.94
@@ -571,7 +570,7 @@
             "depth": 20.54,
             "shape": "circular",
             "diameter": 15,
-            "totalLiquidVolume": 10,
+            "totalLiquidVolume": 10000,
             "x": 25,
             "y": 15,
             "z": 48.94
@@ -580,7 +579,7 @@
             "depth": 20.54,
             "shape": "circular",
             "diameter": 15,
-            "totalLiquidVolume": 10,
+            "totalLiquidVolume": 10000,
             "x": 35,
             "y": 15,
             "z": 48.94
@@ -589,7 +588,7 @@
             "depth": 20.54,
             "shape": "circular",
             "diameter": 15,
-            "totalLiquidVolume": 10,
+            "totalLiquidVolume": 10000,
             "x": 45,
             "y": 15,
             "z": 48.94
@@ -598,7 +597,7 @@
             "depth": 20.54,
             "shape": "circular",
             "diameter": 15,
-            "totalLiquidVolume": 10,
+            "totalLiquidVolume": 10000,
             "x": 55,
             "y": 15,
             "z": 48.94

--- a/shared-data/js/__tests__/fixtures/labwareExample.json
+++ b/shared-data/js/__tests__/fixtures/labwareExample.json
@@ -4,8 +4,7 @@
   "metadata": {
     "displayName": "fake labware",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "uL",
-    "displayLengthUnits": "mm"
+    "displayVolumeUnits": "µL"
   },
   "brand": {
     "brandId": ["t40u9sernisofsea"],

--- a/shared-data/js/__tests__/fixtures/labwareExample2.json
+++ b/shared-data/js/__tests__/fixtures/labwareExample2.json
@@ -4,8 +4,7 @@
   "metadata": {
     "displayName": "fake labware 2",
     "displayCategory": "wellPlate",
-    "displayVolumeUnits": "uL",
-    "displayLengthUnits": "mm"
+    "displayVolumeUnits": "mL"
   },
   "brand": {
     "brand": "generic"
@@ -13,7 +12,7 @@
   "parameters": {
     "format": "irregular",
     "isTiprack": false,
-    "loadName": "generic_6_wellplate_100_ul",
+    "loadName": "generic_6_wellplate_1_ml",
     "isMagneticModuleCompatible": false
   },
   "cornerOffsetFromSlot": {
@@ -30,7 +29,7 @@
   "wells": {
     "A1": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 10,
       "y": 28,
@@ -39,7 +38,7 @@
     },
     "B1": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 10,
       "y": 19,
@@ -48,7 +47,7 @@
     },
     "C1": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 10,
       "y": 10,
@@ -57,7 +56,7 @@
     },
     "A2": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 19,
       "y": 28,
@@ -66,7 +65,7 @@
     },
     "B2": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 19,
       "y": 19,
@@ -75,7 +74,7 @@
     },
     "C2": {
       "depth": 40,
-      "totalLiquidVolume": 100,
+      "totalLiquidVolume": 1000,
       "diameter": 30,
       "x": 19,
       "y": 10,

--- a/shared-data/js/helpers/__tests__/volume.test.js
+++ b/shared-data/js/helpers/__tests__/volume.test.js
@@ -1,0 +1,90 @@
+// volume helpers tests
+
+import * as helpers from '..'
+
+describe('volume helpers', () => {
+  const SPECS = [
+    {
+      name: 'getDisplayVolume outputs µL string by default',
+      func: helpers.getDisplayVolume,
+      input: [380],
+      expected: '380',
+    },
+    {
+      name: 'getDisplayVolume converts to mL',
+      func: helpers.getDisplayVolume,
+      input: [4200, 'mL'],
+      expected: '4.2',
+    },
+    {
+      name: 'getDisplayVolume converts to L',
+      func: helpers.getDisplayVolume,
+      input: [800000, 'L'],
+      expected: '0.8',
+    },
+    {
+      name: 'getDisplayVolume can round to fixed digits',
+      func: helpers.getDisplayVolume,
+      input: [123456789, 'L', 3],
+      expected: '123.457',
+    },
+    {
+      name: 'getAsciiVolumeUnits converts µL to uL',
+      func: helpers.getAsciiVolumeUnits,
+      input: ['µL'],
+      expected: 'uL',
+    },
+    {
+      name: 'getAsciiVolumeUnits leaves mL alone',
+      func: helpers.getAsciiVolumeUnits,
+      input: ['mL'],
+      expected: 'mL',
+    },
+    {
+      name: 'getAsciiVolumeUnits leaves L alone',
+      func: helpers.getAsciiVolumeUnits,
+      input: ['L'],
+      expected: 'L',
+    },
+    {
+      name: 'ensureVolumeUnits converts undefined to µL',
+      func: helpers.ensureVolumeUnits,
+      input: [undefined],
+      expected: 'µL',
+    },
+    {
+      name: 'ensureVolumeUnits converts uL to µL',
+      func: helpers.ensureVolumeUnits,
+      input: ['uL'],
+      expected: 'µL',
+    },
+    {
+      name: 'ensureVolumeUnits leaves mL alone',
+      func: helpers.ensureVolumeUnits,
+      input: ['mL'],
+      expected: 'mL',
+    },
+    {
+      name: 'ensureVolumeUnits leaves L alone',
+      func: helpers.ensureVolumeUnits,
+      input: ['L'],
+      expected: 'L',
+    },
+    {
+      name: 'ensureVolumeUnits converts ml to mL',
+      func: helpers.ensureVolumeUnits,
+      input: ['ml'],
+      expected: 'mL',
+    },
+    {
+      name: 'ensureVolumeUnits leaves l to L',
+      func: helpers.ensureVolumeUnits,
+      input: ['l'],
+      expected: 'L',
+    },
+  ]
+
+  SPECS.forEach(s => {
+    test(s.name, () => expect(s.func(...s.input)).toEqual(s.expected))
+  })
+})

--- a/shared-data/js/helpers/index.js
+++ b/shared-data/js/helpers/index.js
@@ -1,9 +1,10 @@
 // @flow
 
-import canPipetteUseLabware from './canPipetteUseLabware'
-import computeWellAccess from './computeWellAccess'
-import getWellTotalVolume from './getWellTotalVolume'
-import wellIsRect from './wellIsRect'
+export {default as canPipetteUseLabware} from './canPipetteUseLabware'
+export {default as computeWellAccess} from './computeWellAccess'
+export {default as getWellTotalVolume} from './getWellTotalVolume'
+export {default as wellIsRect} from './wellIsRect'
+export * from './volume'
 
 export const intToAlphabetLetter = (i: number, lowerCase: boolean = false) =>
   String.fromCharCode((lowerCase ? 96 : 65) + i)
@@ -59,11 +60,4 @@ export function splitWellsOnColumn (sortedArray: Array<string>): Array<Array<str
       return [...acc.slice(0, -1), [...lastColumn[0], curr]]
     }
   }, [])
-}
-
-export {
-  canPipetteUseLabware,
-  computeWellAccess,
-  getWellTotalVolume,
-  wellIsRect,
 }

--- a/shared-data/js/helpers/volume.js
+++ b/shared-data/js/helpers/volume.js
@@ -1,0 +1,31 @@
+// @flow
+// utilities for working with volumes in µL
+import round from 'lodash/round'
+import type {LabwareVolumeUnits} from '../types'
+
+const SCALE_BY_UNITS = {
+  µL: 1,
+  mL: 1000,
+  L: 1000000,
+}
+
+export function getDisplayVolume (
+  volumeInMicroliters: number,
+  displayUnits?: LabwareVolumeUnits = 'µL',
+  digits?: number
+): string {
+  const volume = volumeInMicroliters / SCALE_BY_UNITS[displayUnits]
+
+  return `${typeof digits === 'number' ? round(volume, digits) : volume}`
+}
+
+export function getAsciiVolumeUnits (displayUnits: LabwareVolumeUnits) {
+  if (displayUnits === 'µL') return 'uL'
+  return displayUnits
+}
+
+export function ensureVolumeUnits (maybeUnits: ?string): LabwareVolumeUnits {
+  if (maybeUnits === 'mL' || maybeUnits === 'ml') return 'mL'
+  if (maybeUnits === 'L' || maybeUnits === 'l') return 'L'
+  return 'µL'
+}

--- a/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
@@ -103,7 +103,6 @@ describe('test createIrregularLabware function', () => {
         displayName: 'Fake Irregular Container',
         displayCategory: 'tubeRack',
         displayVolumeUnits: 'mL',
-        displayLengthUnits: 'mm',
         tags: ['fake', 'opentrons'],
       },
       parameters: {
@@ -121,13 +120,13 @@ describe('test createIrregularLabware function', () => {
           depth: 10.54,
           shape: 'circular',
           diameter: 10,
-          totalLiquidVolume: 3,
+          totalLiquidVolume: 3000,
         },
         {
           depth: 20.54,
           shape: 'circular',
           diameter: 15,
-          totalLiquidVolume: 10,
+          totalLiquidVolume: 10000,
         },
       ],
       offset: [{x: 10, y: 10, z: 69.48}, {x: 15, y: 15, z: 69.48}],
@@ -165,12 +164,23 @@ describe('test createIrregularLabware function', () => {
           totalLiquidVolume: 2000,
         },
       ],
-      // TODO Ian 2018-11-08: add test with mL, expect displayVol = vol/1000 (would fail right now)
-      units: 'uL',
+      units: 'µL',
       displayCategory: 'wellPlate',
       brand: 'some brand',
     })
 
     expect(loadName).toEqual('somebrand_6x400_ul_4x2000_ul_wellplate')
+  })
+
+  test('labware loadName generated correctly for multi-grid labware in other units', () => {
+    const loadName = _generateIrregularLoadName({
+      grid: [{row: 3, column: 2}],
+      well: [{depth: 20, shape: 'circular', totalLiquidVolume: 4000}],
+      units: 'mL',
+      displayCategory: 'wellPlate',
+      brand: 'some brand',
+    })
+
+    expect(loadName).toEqual('somebrand_6x4_ml_wellplate')
   })
 })

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -41,11 +41,14 @@ export type LabwareDisplayCategory =
   | 'wellPlate'
   | 'other'
 
+export type LabwareWellShape = 'rectangular' | 'circular'
+
+export type LabwareVolumeUnits = 'µL' | 'mL' | 'L'
+
 export type LabwareMetadata = {|
   displayName: string,
   displayCategory: LabwareDisplayCategory,
-  displayVolumeUnits: string,
-  displayLengthUnits?: string,
+  displayVolumeUnits: LabwareVolumeUnits,
   tags?: Array<string>,
 |}
 
@@ -79,7 +82,7 @@ export type LabwareBrand = {|
 
 export type LabwareWellProperties = {|
   depth: number,
-  shape: string,
+  shape: LabwareWellShape,
   totalLiquidVolume: number,
   diameter?: number,
   length?: number,

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "description": "Properties used for search and display",
       "additionalProperties": false,
-      "required": ["displayName", "displayCategory"],
+      "required": ["displayName", "displayCategory", "displayVolumeUnits"],
       "properties": {
         "displayName": {
           "description": "Easy to remember name of labware",
@@ -50,11 +50,10 @@
             "other"
           ]
         },
-        "displayLengthUnits": {
-          "type": "string"
-        },
         "displayVolumeUnits": {
-          "type": "string"
+          "description": "Volume units for display",
+          "type": "string",
+          "enum": ["µL", "mL", "L"]
         },
         "tags": {
           "type": "array",


### PR DESCRIPTION
## overview

This PR updates `definitions2` and the labware definition generators to make two changes discussed in #3240.

## changelog

- `well.totalLiquidVolume` is now _always_ specified as a number in µL
    - Before, it was a number specified in whatever units were in `metadata.displayVolumeUnits`
    - This coupled functionality with displayMetadata, which was bad
- `metadata.displayLengthVolume` was removed because `mm` will always be the display 

The schema was also updated to _only_ allow the following values for `displayVolumeUnits`:

- µL
- mL
- L

"µL" was selected over "uL" because the former is SI, while the later is only "officially" allowed in certain contexts. The generators were updated to handle the following inputs for `displayVolumeUnits`:

- User inputs nothing > definition set to `µL`
- User inputs `ul` or `uL` > set to `µL`
- User inputs `ml` > set to `mL`
- User inputs `l` > set to `L`
- User inputs `µL`, `mL`, or `L` > value used as input

To ensure ease of use and consistent compatibility, `loadName` is populated according to:

- `µL` > `ul`
- `mL` > `ml`
- `L` > `l`

## review requests

`totalLiquidVolume`, `displayVolumeUnits`, and the removed `displayLengthUnits` were all only used in the front end, if at all. Please check the following projects:

- [ ] Labware designer
- [ ] Labware library - <http://sandbox.labware.opentrons.com/shared-data-consistent-units>
