### PR TITLE
fix(api): simulate needs to set loglevel

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -53,9 +53,11 @@ class CommandScraper:
         self._logger = logger
         self._broker = broker
         self._queue = queue.Queue()  # type: ignore
+        level = getattr(logging, level.upper(), logging.WARNING)
+        self._logger.setLevel(level)
         logger.addHandler(
             AccumulatingHandler(
-                getattr(logging, level.upper(), logging.WARNING),
+                level,
                 self._queue))
         self._depth = 0
         self._commands: List[Mapping[str, Mapping[str, Any]]] = []


### PR DESCRIPTION
Since simulate doesn’t run opentrons.main, it needs to configure the opentrons
domain logger to set whatever log level the user asks for (otherwise it will be
at the default of WARNING)

To test, run a simulation with `--log-level=info` and check that any info messages in the code (you might have to add some) are captured properly.