### PR TITLE
refactor(labware-library): Build out labware gallery functionality

### DIFF
--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -9,6 +9,7 @@ import uniqWith from 'lodash/uniqWith'
 
 import {getDisplayVolume} from '@opentrons/shared-data'
 import {Icon} from '@opentrons/components'
+import Gallery from './LabwareGallery'
 import styles from './styles.css'
 
 import type {
@@ -71,7 +72,7 @@ export default function LabwareCard (props: LabwareCardProps) {
     <li className={styles.card}>
       <TopBar {...props} />
       <Title {...props} />
-      <Gallery />
+      <Gallery {...props} />
       <div className={styles.stats}>
         <PlateDimensions {...props} />
         <Wells {...props} />
@@ -105,26 +106,6 @@ function Title (props: LabwareCardProps) {
         <Icon className={styles.title_icon} name="chevron-right" />
       </h2>
     </a>
-  )
-}
-
-// TODO(mc, 2019-03-22): unsemantic placeholder; fix up and move to own file
-function Gallery () {
-  return (
-    <div className={styles.gallery}>
-      <div className={styles.gallery_main} />
-      <div className={styles.thumbnail_row}>
-        <div className={styles.thumbnail_container}>
-          <div className={styles.thumbnail} />
-        </div>
-        <div className={styles.thumbnail_container}>
-          <div className={styles.thumbnail} />
-        </div>
-        <div className={styles.thumbnail_container}>
-          <div className={styles.thumbnail} />
-        </div>
-      </div>
-    </div>
   )
 }
 

--- a/labware-library/src/components/LabwareList/LabwareGallery.js
+++ b/labware-library/src/components/LabwareList/LabwareGallery.js
@@ -27,10 +27,6 @@ class Gallery extends React.Component<GalleryProps, GalleryState> {
     this.state = {currentImage: 1}
   }
 
-  handleSelectImage = (currentImage: number) => {
-    this.setState({currentImage})
-  }
-
   render () {
     const {definition} = this.props
     const {currentImage} = this.state

--- a/labware-library/src/components/LabwareList/LabwareGallery.js
+++ b/labware-library/src/components/LabwareList/LabwareGallery.js
@@ -20,8 +20,6 @@ type ThumbnailProps = {
 }
 
 class Gallery extends React.Component<GalleryProps, GalleryState> {
-  state: GalleryState
-
   constructor (props: GalleryProps) {
     super(props)
     this.state = {currentImage: 1}

--- a/labware-library/src/components/LabwareList/LabwareGallery.js
+++ b/labware-library/src/components/LabwareList/LabwareGallery.js
@@ -1,0 +1,78 @@
+// @flow
+import * as React from 'react'
+
+import LabwareRender from '../LabwareRender'
+import styles from './styles.css'
+
+import type {LabwareDefinition2 as LabwareDefinition} from '@opentrons/shared-data'
+
+export type GalleryProps = {
+  definition: LabwareDefinition,
+}
+
+export type GalleryState = {
+  currentImage: number,
+}
+
+type ThumbnailProps = {
+  onClick: () => mixed,
+  children: React.Node,
+}
+
+class Gallery extends React.Component<GalleryProps, GalleryState> {
+  state: GalleryState
+
+  constructor (props: GalleryProps) {
+    super(props)
+    this.state = {currentImage: 1}
+  }
+
+  handleSelectImage = (currentImage: number) => {
+    this.setState({currentImage})
+  }
+
+  render () {
+    const {definition} = this.props
+    const {currentImage} = this.state
+
+    // TODO(mc, 2019-03-27): use actual images
+    const images = [
+      <img key="left" src={`https://placekitten.com/480/480`} />,
+      <LabwareRender key="center" definition={definition} />,
+      <img key="right" src={`https://placekitten.com/512/512`} />,
+    ]
+
+    return (
+      <div className={styles.gallery}>
+        <div className={styles.gallery_main}>
+          <div className={styles.image_container}>{images[currentImage]}</div>
+        </div>
+        <div className={styles.thumbnail_row}>
+          {images.map((img, index) => (
+            <Thumbnail
+              key={index}
+              imageId={index}
+              onClick={() => this.setState({currentImage: index})}
+            >
+              {img}
+            </Thumbnail>
+          ))}
+        </div>
+      </div>
+    )
+  }
+}
+
+function Thumbnail (props: ThumbnailProps) {
+  const {onClick, children} = props
+
+  return (
+    <button className={styles.thumbnail_container} onClick={onClick}>
+      <div className={styles.thumbnail}>
+        <div className={styles.image_container}>{children}</div>
+      </div>
+    </button>
+  )
+}
+
+export default Gallery

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -65,17 +65,26 @@
 
 .gallery_main {
   @apply --aspect-4-3;
+}
 
-  background-color: var(--c-blue);
+.image_container {
+  @apply --aspect-item;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .thumbnail_row {
+  display: flex;
+  justify-content: space-around;
   width: 100%;
   margin-top: var(--spacing-5);
 }
 
 .thumbnail_container {
-  display: inline-block;
+  @apply --clickable;
+
   width: calc(var(--size-third) - var(--spacing-5) * 2 / 3);
   margin-right: var(--spacing-5);
 }
@@ -86,8 +95,6 @@
 
 .thumbnail {
   @apply --aspect-1-1;
-
-  background-color: var(--c-blue);
 }
 
 .dimensions {

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -1,0 +1,113 @@
+// @flow
+// render labware definition to SVG
+// TODO(mc, 2019-03-27): Move this component to components library for usage in
+//   app and protocol-designer
+import * as React from 'react'
+import flatMap from 'lodash/flatMap'
+
+import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
+import {LabwareOutline} from '@opentrons/components'
+import styles from './styles.css'
+
+import type {
+  LabwareDefinition2 as LabwareDefinition,
+  LabwareParameters,
+  LabwareOffset,
+  LabwareWell,
+} from '@opentrons/shared-data'
+
+export type LabwareRenderProps = {
+  definition: LabwareDefinition,
+}
+
+export type LabwareWellRenderProps = {
+  well: LabwareWell,
+  parameters: LabwareParameters,
+  cornerOffsetFromSlot: LabwareOffset,
+}
+
+export default function LabwareRender (props: LabwareRenderProps) {
+  const {parameters, ordering, cornerOffsetFromSlot, wells} = props.definition
+
+  // SVG coordinate system is flipped in Y from our definitions
+  const transform = `translate(0,${SLOT_RENDER_HEIGHT}) scale(1,-1)`
+  const viewBox = `0 0 ${SLOT_RENDER_WIDTH} ${SLOT_RENDER_HEIGHT}`
+
+  return (
+    <svg className={styles.labware_render} viewBox={viewBox}>
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1px"
+        transform={transform}
+      >
+        <LabwareOutline />
+        {parameters.isTiprack && <TipRackOutline />}
+        {flatMap(
+          ordering,
+          // all arguments typed to stop Flow from complaining
+          (row: Array<string>, i: number, c: Array<Array<string>>) => {
+            return row.map(wellName => {
+              return (
+                <Well
+                  key={wellName}
+                  well={wells[wellName]}
+                  parameters={parameters}
+                  cornerOffsetFromSlot={cornerOffsetFromSlot}
+                />
+              )
+            })
+          }
+        )}
+      </g>
+    </svg>
+  )
+}
+
+function TipRackOutline () {
+  return (
+    <rect
+      x={8}
+      y={5}
+      width={SLOT_RENDER_WIDTH - 16}
+      height={SLOT_RENDER_HEIGHT - 10}
+      rx="4px"
+      ry="4px"
+    />
+  )
+}
+
+function Well (props: LabwareWellRenderProps) {
+  const {well, parameters, cornerOffsetFromSlot} = props
+  const {shape, diameter, width, length} = well
+  const {isTiprack} = parameters
+
+  const x = well.x + cornerOffsetFromSlot.x
+  const y = well.y + cornerOffsetFromSlot.y
+
+  if (shape === 'circular' && diameter) {
+    // TODO(mc, 2019-03-27): figure out tip rendering; see:
+    //   components/src/deck/Well.js
+    //   components/src/deck/Tip.js
+    return (
+      <>
+        <circle cx={x} cy={y} r={diameter / 2} />
+        {isTiprack && <circle cx={x} cy={y} r={(diameter - 2.5) / 2} />}
+      </>
+    )
+  }
+
+  if (shape === 'rectangular' && length && width) {
+    return (
+      <rect
+        x={x - length / 2}
+        y={y - width / 2}
+        width={length}
+        height={width}
+      />
+    )
+  }
+
+  console.warn('Invalid well', well)
+  return null
+}

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -4,6 +4,7 @@
 //   app and protocol-designer
 import * as React from 'react'
 import flatMap from 'lodash/flatMap'
+import cx from 'classnames'
 
 import {SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT} from '@opentrons/shared-data'
 import {LabwareOutline} from '@opentrons/components'
@@ -28,6 +29,7 @@ export type LabwareWellRenderProps = {
 
 export default function LabwareRender (props: LabwareRenderProps) {
   const {parameters, ordering, cornerOffsetFromSlot, wells} = props.definition
+  const {isTiprack} = parameters
 
   // SVG coordinate system is flipped in Y from our definitions
   const transform = `translate(0,${SLOT_RENDER_HEIGHT}) scale(1,-1)`
@@ -35,14 +37,11 @@ export default function LabwareRender (props: LabwareRenderProps) {
 
   return (
     <svg className={styles.labware_render} viewBox={viewBox}>
-      <g
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1px"
-        transform={transform}
-      >
-        <LabwareOutline />
-        {parameters.isTiprack && <TipRackOutline />}
+      <g className={styles.labware_detail_group}>
+        <LabwareOutline className={cx({[styles.tiprack_outline]: isTiprack})} />
+        {isTiprack && <TipRackOutline />}
+      </g>
+      <g className={styles.well_group} transform={transform}>
         {flatMap(
           ordering,
           // all arguments typed to stop Flow from complaining
@@ -65,16 +64,16 @@ export default function LabwareRender (props: LabwareRenderProps) {
 }
 
 // TODO(mc, 2019-03-28): Need UX guidance on this component
-const TR_OUTLINE_X_OFFSET = 8
-const TR_OUTLINE_Y_OFFSET = 5
+const TIPRACK_OUTLINE_X_OFFSET = 8
+const TIPRACK_OUTLINE_Y_OFFSET = 5
 
 function TipRackOutline () {
   return (
     <rect
-      x={TR_OUTLINE_X_OFFSET}
-      y={TR_OUTLINE_Y_OFFSET}
-      width={SLOT_RENDER_WIDTH - 2 * TR_OUTLINE_X_OFFSET}
-      height={SLOT_RENDER_HEIGHT - 2 * TR_OUTLINE_Y_OFFSET}
+      x={TIPRACK_OUTLINE_X_OFFSET}
+      y={TIPRACK_OUTLINE_Y_OFFSET}
+      width={SLOT_RENDER_WIDTH - 2 * TIPRACK_OUTLINE_X_OFFSET}
+      height={SLOT_RENDER_HEIGHT - 2 * TIPRACK_OUTLINE_Y_OFFSET}
       rx="4px"
       ry="4px"
     />

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -64,13 +64,17 @@ export default function LabwareRender (props: LabwareRenderProps) {
   )
 }
 
+// TODO(mc, 2019-03-28): Need UX guidance on this component
+const TR_OUTLINE_X_OFFSET = 8
+const TR_OUTLINE_Y_OFFSET = 5
+
 function TipRackOutline () {
   return (
     <rect
-      x={8}
-      y={5}
-      width={SLOT_RENDER_WIDTH - 16}
-      height={SLOT_RENDER_HEIGHT - 10}
+      x={TR_OUTLINE_X_OFFSET}
+      y={TR_OUTLINE_Y_OFFSET}
+      width={SLOT_RENDER_WIDTH - 2 * TR_OUTLINE_X_OFFSET}
+      height={SLOT_RENDER_HEIGHT - 2 * TR_OUTLINE_Y_OFFSET}
       rx="4px"
       ry="4px"
     />
@@ -78,12 +82,9 @@ function TipRackOutline () {
 }
 
 function Well (props: LabwareWellRenderProps) {
-  const {well, parameters, cornerOffsetFromSlot} = props
-  const {shape, diameter, width, length} = well
+  const {well, parameters} = props
+  const {x, y, shape, diameter, width, length} = well
   const {isTiprack} = parameters
-
-  const x = well.x + cornerOffsetFromSlot.x
-  const y = well.y + cornerOffsetFromSlot.y
 
   if (shape === 'circular' && diameter) {
     // TODO(mc, 2019-03-27): figure out tip rendering; see:

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -39,7 +39,6 @@ export default function LabwareRender (props: LabwareRenderProps) {
     <svg className={styles.labware_render} viewBox={viewBox}>
       <g className={styles.labware_detail_group}>
         <LabwareOutline className={cx({[styles.tiprack_outline]: isTiprack})} />
-        {isTiprack && <TipRackOutline />}
       </g>
       <g className={styles.well_group} transform={transform}>
         {flatMap(
@@ -63,36 +62,20 @@ export default function LabwareRender (props: LabwareRenderProps) {
   )
 }
 
-// TODO(mc, 2019-03-28): Need UX guidance on this component
-const TIPRACK_OUTLINE_X_OFFSET = 8
-const TIPRACK_OUTLINE_Y_OFFSET = 5
-
-function TipRackOutline () {
-  return (
-    <rect
-      x={TIPRACK_OUTLINE_X_OFFSET}
-      y={TIPRACK_OUTLINE_Y_OFFSET}
-      width={SLOT_RENDER_WIDTH - 2 * TIPRACK_OUTLINE_X_OFFSET}
-      height={SLOT_RENDER_HEIGHT - 2 * TIPRACK_OUTLINE_Y_OFFSET}
-      rx="4px"
-      ry="4px"
-    />
-  )
-}
-
 function Well (props: LabwareWellRenderProps) {
   const {well, parameters} = props
   const {x, y, shape, diameter, width, length} = well
   const {isTiprack} = parameters
 
   if (shape === 'circular' && diameter) {
+    const radius = diameter / 2
     // TODO(mc, 2019-03-27): figure out tip rendering; see:
     //   components/src/deck/Well.js
     //   components/src/deck/Tip.js
     return (
       <>
-        <circle cx={x} cy={y} r={diameter / 2} />
-        {isTiprack && <circle cx={x} cy={y} r={(diameter - 2.5) / 2} />}
+        <circle cx={x} cy={y} r={radius} />
+        {isTiprack && <circle cx={x} cy={y} r={radius - 1} />}
       </>
     )
   }

--- a/labware-library/src/components/LabwareRender/styles.css
+++ b/labware-library/src/components/LabwareRender/styles.css
@@ -1,0 +1,5 @@
+.labware_render {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}

--- a/labware-library/src/components/LabwareRender/styles.css
+++ b/labware-library/src/components/LabwareRender/styles.css
@@ -14,6 +14,7 @@
 
 .tiprack_outline {
   fill: var(--c-plate-bg);
+  stroke: var(--c-charcoal);
 }
 
 .well_group {

--- a/labware-library/src/components/LabwareRender/styles.css
+++ b/labware-library/src/components/LabwareRender/styles.css
@@ -1,5 +1,29 @@
+@import '@opentrons/components';
+
 .labware_render {
   width: 100%;
   height: 100%;
   overflow: visible;
+}
+
+.labware_detail_group {
+  fill: none;
+  stroke: var(--c-black);
+  stroke-width: 1;
+}
+
+.tiprack_outline {
+  fill: var(--c-plate-bg);
+}
+
+.well_group {
+  fill: var(--c-white);
+  stroke: var(--c-black);
+
+  /*
+   * TODO(mc, 2019-03-28): align this value with components library; 0.4 looks
+   *   a little too small on retina at labware library sizes and especially too
+   *   small in the thumbnails
+   */
+  stroke-width: 0.6;
 }

--- a/labware-library/src/styles/reset.css
+++ b/labware-library/src/styles/reset.css
@@ -31,6 +31,7 @@ main {
 /* make images responsive */
 img {
   max-width: 100%;
+  max-height: 100%;
   border-style: none;
 }
 
@@ -43,7 +44,8 @@ h5,
 h6,
 p,
 ul,
-ol {
+ol,
+button {
   margin: 0;
   padding: 0;
 }
@@ -57,4 +59,10 @@ ol {
 /* no underline on links by default */
 a {
   text-decoration: none;
+}
+
+/* no styles on buttons by default */
+button {
+  border: none;
+  background-color: transparent;
 }


### PR DESCRIPTION
## overview
This PR closes #3088 by building out a gallery for the labware card component. Until #3269 is resolved, the gallery displays three images:

- Top-down render of labware from data
- Two placeholder images

Clicking any of the three will display that image in the main gallery view.

## changelog

- refactor(labware-library): Build out labware gallery functionality

## review requests

<http://sandbox.labware.opentrons.com/lablib-gallery>

**Please note**
- We don't have any non-render images (#3269)
- Not all labware definitions are correct, so not all renders are correct (#3271)
- Fixed trash renders don't make sense, but fixed trash labware will not be displayed (#3078)

**Acceptance criteria copied from 3088**
- [ ] Display one main image per labware
- [ ] Allow user to select and view up to 3 different images from a thumbnail library (thumbnail library is static)
- [ ] One image should be an auto-generated top-down render
- ~Gracefully handle more than three images (display 3, don't break)~ N/A pending #3269
- ~Selected thumbnail should be highlighted~ requirement removed
- [ ] Image cropping should be handled in a sane manner
    - Hard to observe with placeholders, but images are styled to be fully contained and centered in their parent
