### PR TITLE
fix(app): Fix modules not populating the modules card

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -58,7 +58,7 @@ class Module:
         self.id = id(module)
         if isinstance(module, labware.ModuleGeometry):
             self.name = module.load_name
-            self.slow = module.parent
+            self.slot = module.parent
         else:
             self.name = module.get_name()
             self.slot = module.parent.get_name()

--- a/app/src/components/InstrumentSettings/ModulesCardContents.js
+++ b/app/src/components/InstrumentSettings/ModulesCardContents.js
@@ -3,14 +3,20 @@ import * as React from 'react'
 import type {Module} from '../../http-api-client'
 import ModuleItem, {NoModulesMessage} from '../ModuleItem'
 
+import filter from 'lodash/filter'
+
 type Props = {
   modules: ?Array<Module>,
   showThermo: boolean,
 }
 
 export default function ModulesCardContents (props: Props) {
-  const {modules} = props
-  if (!modules || !modules[0]) return <NoModulesMessage />
+  const {showThermo} = props
+  const modules = filter(props.modules, m => {
+    return showThermo || m.name !== 'thermocycler'
+  })
+
+  if (modules.length === 0) return <NoModulesMessage />
 
   return (
     <React.Fragment>

--- a/app/src/components/InstrumentSettings/ModulesCardContents.js
+++ b/app/src/components/InstrumentSettings/ModulesCardContents.js
@@ -9,8 +9,8 @@ type Props = {
 }
 
 export default function ModulesCardContents (props: Props) {
-  const {modules, showThermo} = props
-  if (!modules || !modules[0] || !showThermo) return <NoModulesMessage />
+  const {modules} = props
+  if (!modules || !modules[0]) return <NoModulesMessage />
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## overview

Logic was introduced into edge which made the modules (temperature + magnetic) not populate the modules card in the app even though the endpoint was returning correctly formatted data. We will need to do another alpha release once this is merged.

## changelog
- Remove logic checking for thermocycler flag
- Fix a typo in models.py

## review requests

Please test this branch on your robot
