### PR TITLE
chore(protocol-designer): add reselect-tools support

### DIFF
--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -38,12 +38,13 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1",
+    "reselect": "4.0.0",
     "uuid": "^3.3.2",
     "yup": "^0.26.6"
   },
   "devDependencies": {
     "flow-bin": "^0.82.0",
-    "flow-typed": "^2.5.1"
+    "flow-typed": "^2.5.1",
+    "reselect-tools": "^0.0.7"
   }
 }

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -4,6 +4,8 @@ import thunk from 'redux-thunk'
 import {makePersistSubscriber, rehydratePersistedAction} from './persist'
 import {fileUploadMessage} from './load-file/actions'
 
+const ReselectTools = process.env.NODE_ENV === 'development' ? require('reselect-tools') : undefined
+
 function getRootReducer () {
   const rootReducer: any = combineReducers({
     analytics: require('./analytics').rootReducer,
@@ -52,6 +54,9 @@ export default function configureStore () {
     /* preloadedState, */
     composeEnhancers(applyMiddleware(thunk))
   )
+
+  // give reselect tools access to state if in dev env
+  if (ReselectTools) ReselectTools.getStateWith(() => store.getState())
 
   // initial rehydration, and persistence subscriber
   store.dispatch(rehydratePersistedAction())

--- a/protocol-designer/src/step-forms/index.js
+++ b/protocol-designer/src/step-forms/index.js
@@ -1,4 +1,5 @@
 // @flow
+import {registerSelectors} from 'reselect-tools'
 import rootReducer from './reducers'
 import type {RootState} from './reducers'
 import * as selectors from './selectors'
@@ -9,6 +10,9 @@ export * from './types'
 export type {
   RootState,
 }
+
+registerSelectors(selectors)
+
 export {
   rootReducer,
   actions,

--- a/protocol-designer/src/step-forms/index.js
+++ b/protocol-designer/src/step-forms/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {registerSelectors} from 'reselect-tools'
+import {registerSelectors} from '../utils'
 import rootReducer from './reducers'
 import type {RootState} from './reducers'
 import * as selectors from './selectors'

--- a/protocol-designer/src/utils/index.js
+++ b/protocol-designer/src/utils/index.js
@@ -3,7 +3,7 @@ import uuidv1 from 'uuid/v1'
 import type {BoundingRect, GenericRect} from '../collision-types'
 import type {Wells} from '../labware-ingred/types'
 
-export const registerSelectors = (process.env.NODE_ENV === 'development') ? require('reselect-tools').registerSelectors : (a) => {}
+export const registerSelectors = (process.env.NODE_ENV === 'development') ? require('reselect-tools').registerSelectors : (a: any) => {}
 
 export type FormConnector<F> = (accessor: $Keys<F>) =>
   // $FlowFixMe: Missing type annotation for `$Values`

--- a/protocol-designer/src/utils/index.js
+++ b/protocol-designer/src/utils/index.js
@@ -3,6 +3,8 @@ import uuidv1 from 'uuid/v1'
 import type {BoundingRect, GenericRect} from '../collision-types'
 import type {Wells} from '../labware-ingred/types'
 
+export const registerSelectors = (process.env.NODE_ENV === 'development') ? require('reselect-tools').registerSelectors : (a) => {}
+
 export type FormConnector<F> = (accessor: $Keys<F>) =>
   // $FlowFixMe: Missing type annotation for `$Values`
   {onChange: (e: SyntheticInputEvent<*>) => mixed, value: $Values<F>}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12176,6 +12176,18 @@ requires-port@1.0.x, requires-port@1.x.x, requires-port@^1.0.0, requires-port@~1
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect-tools@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/reselect-tools/-/reselect-tools-0.0.7.tgz#bff19df422ebebd1a7c322262db94a554f6b44ed"
+  integrity sha512-+RGguS8ph21y04l6YwQwL+VfJ/c0qyZKCkhCd5ZwbNJ/lklsJml3CIim+uaG/t+7jYZQcwDW4bk5+VzTeuzwtw==
+  dependencies:
+    reselect "4.0.0"
+
+reselect@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"


### PR DESCRIPTION
In order to audit the performance and dependency trees of our selectors, let's use reselect-tools to
visualize them.

