### PR TITLE
feat(protocol-designer): show tooltips on disabled fields in Transfer form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/FieldConnector.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FieldConnector.js
@@ -43,7 +43,7 @@ const FieldConnector = (props: StepFieldProps) => {
   const errors = getFieldErrors(name, value)
   const errorToShow = (showErrors && errors.length > 0) ? errors.join(', ') : null
 
-  const tooltipComponent = props.tooltipComponent || getTooltipForField(stepType, name)
+  const tooltipComponent = props.tooltipComponent || getTooltipForField(stepType, name, disabled)
 
   if (!tooltipComponent) return render({value, updateValue, errorToShow, disabled})
 

--- a/protocol-designer/src/components/StepEditForm/fields/Volume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Volume.js
@@ -12,7 +12,7 @@ import styles from '../StepEditForm.css'
 type Props = {stepType: StepType, focusHandlers: FocusHandlers, label: string}
 const Volume = (props: Props) => (
   <HoverTooltip
-    tooltipComponent={getTooltipForField(props.stepType, 'volume')}
+    tooltipComponent={getTooltipForField(props.stepType, 'volume', false)}
     placement='top-start'>
     {(hoverTooltipHandlers) =>
       <FormGroup

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -59,7 +59,10 @@ export function getVisibleAlerts<Field, Alert: {dependentFields: Array<Field>}> 
   )
 }
 
-export function getTooltipForField (stepType: ?string, name: string): ?React.Node {
+// NOTE: some field components get their tooltips directly from i18n, and do not use `getTooltipForField`.
+// TODO: Ian 2019-03-29 implement tooltip-content-getting in a more organized way
+// once we have more comprehensive requirements about tooltips
+export function getTooltipForField (stepType: ?string, name: string, disabled: boolean): ?React.Node {
   if (!stepType) {
     console.error(`expected stepType for form, cannot getTooltipText for ${name}`)
     return null
@@ -70,10 +73,22 @@ export function getTooltipForField (stepType: ?string, name: string): ?React.Nod
     ? name.split('_').slice(1).join('_')
     : name
 
+  // NOTE: this is a temporary solution until we want to be able to choose from
+  // multiple tooltips for the same field depending on form state.
+  // As-is, this will only let us show two tooltips for any given field per step type:
+  // non-disabled tooltip copy, and disabled tooltip copy.
+  const disabledKeys = disabled
+    ? [
+      `tooltip.step_fields.${stepType}.disabled.${name}`,
+      `tooltip.step_fields.${stepType}.disabled.$generic`,
+    ]
+    : []
+
   // specificity cascade for names.
   // first level: "disabled" wins out if disabled arg is true
   // second level: prefix. "aspirate_foo" wins over "foo"
   const text: string = i18n.t([
+    ...disabledKeys,
     `tooltip.step_fields.defaults.${name}`,
     `tooltip.step_fields.defaults.${nameWithoutPrefix}`,
     '',

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -30,6 +30,12 @@
       "mix_touchTip_checkbox": "Touch tip to each side of the well after mixing",
 
       "volume": "Volume to dispense in each well"
+    },
+    "moveLiquid": {
+      "disabled": {
+        "$generic": "Incompatible with current path",
+        "blowout_checkbox": "Redundant with disposal volume"
+      }
     }
   }
 }


### PR DESCRIPTION
## overview

Closes #3259

## changelog


## review requests

- Should apply only to Transfer form (aka moveLiquid in code)
- Disabled advanced settings should show "Incompatible with current path" tooltip (conveniently the ones that are disabled for reasons do not use `getTooltipForField`), when they are disabled due to the path (and not due to missing labware / pipette selection)
- Blowout advanced setting tooltip should say "Redundant with disposal volume" when & only when it is disabled due to Disposal Volume being checked in a multi dispense