### PR TITLE
perf(protocol-designer): fix selectors used by allSubsteps selector

### DIFF
--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -60,16 +60,19 @@ export const getLabwareTypesById: Selector<LabwareTypeById> = createSelector(
 )
 
 export const getPipetteEntities: Selector<PipetteEntities> = createSelector(
-  rootSelector,
-  (state) => addSpecsToPipetteInvariantProps(state.pipetteInvariantProperties)
+  state => rootSelector(state).pipetteInvariantProperties,
+  (pipetteInvariantProperties) =>
+    addSpecsToPipetteInvariantProps(pipetteInvariantProperties)
 )
 
+export const getInitialDeckSetupStepForm = (state: BaseState) =>
+  rootSelector(state).savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+
 export const getInitialDeckSetup: Selector<InitialDeckSetup> = createSelector(
-  rootSelector,
+  getInitialDeckSetupStepForm,
   getLabwareEntities,
   getPipetteEntities,
-  (state, labwareInvariantProperties, pipetteInvariantProperties) => {
-    const initialSetupStep = state.savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+  (initialSetupStep, labwareInvariantProperties, pipetteInvariantProperties) => {
     assert(
       initialSetupStep && initialSetupStep.stepType === 'manualIntervention',
       'expected initial deck setup step to be "manualIntervention" step')


### PR DESCRIPTION
## overview

* `getInitialDeckSetup` was getting rerun because it had state as one of its dependencies
* `getPipetteEntities` was getting rerun every time anything in `state.stepForms` changed,

Those 2 selectors are dependencies of `allSubsteps`, an expensive selector. Now `allSubsteps` should no longer run with changes to unsavedForm -- actions dispatched when opening, editing, and closing a step form would call `allSubsteps`. Now you should see that `allSubsteps` is only called when you save the form, not open/cancel/make transient edits.

## changelog

* fix selectors used by allSubsteps selector

## review requests

One noticeable change is that if you have a large protocol with many steps, and type a message in a Pause form for example, there should no longer be significant lag when typing (on `edge`, there can be several of seconds of lag after you type a sentence!)

Also opening/canceling a form should be much more responsive, there's maybe almost a second of lag in `edge`

Slack me for an example long protocol if you don't have one!