### PR TITLE
fix(api): Remove module load regression in V2

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -104,8 +104,8 @@ class Thermocycler(mod_abc.AbstractModule):
 
     def __init__(self,
                  port,
-                 interrupt_callback = None,
-                 simulating = False,
+                 interrupt_callback=None,
+                 simulating=False,
                  loop: asyncio.AbstractEventLoop = None) -> None:
         self._interrupt_cb = interrupt_callback
         if simulating:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -104,8 +104,8 @@ class Thermocycler(mod_abc.AbstractModule):
 
     def __init__(self,
                  port,
-                 interrupt_callback,
-                 simulating,
+                 interrupt_callback = None,
+                 simulating = False,
                  loop: asyncio.AbstractEventLoop = None) -> None:
         self._interrupt_cb = interrupt_callback
         if simulating:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -256,7 +256,8 @@ class ProtocolContext(CommandPublisher):
             geometry = load_module(
                 geo_mod_name, self._deck_layout.position_for(location))
         except KeyError:
-            print(f'Unsupported Module: {module_name}')
+            self._log.error(f'Unsupported Module: {module_name}')
+            raise ValueError(f'Unsupported Module: {module_name}')
         hc_mod_instance = None
         hw = self._hw_manager.hardware._api._backend
         mod_class = {

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -16,6 +16,15 @@ def test_load_module(loop):
     assert isinstance(mod, papi.TemperatureModuleContext)
 
 
+def test_incorrect_module_error(loop):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    ctx.home()
+    with pytest.raises(ValueError):
+        assert ctx.load_module('the cool module', 1)
+
+
 def test_load_simulating_module(loop):
     # Check that a known module will not throw an error if
     # in simulation mode

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -16,6 +16,15 @@ def test_load_module(loop):
     assert isinstance(mod, papi.TemperatureModuleContext)
 
 
+def test_load_simulating_module(loop):
+    # Check that a known module will not throw an error if
+    # in simulation mode
+    ctx = papi.ProtocolContext(loop)
+    ctx.home()
+    mod = ctx.load_module('tempdeck', 1)
+    assert isinstance(mod, papi.TemperatureModuleContext)
+
+
 def test_tempdeck(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [


### PR DESCRIPTION
## overview

Closes #3261 . There was a regression introduced in V2 of the API where a protocol with modules would automatically return an error if those modules were not found. This breaks what the Run App is expecting because this page no longer shows
![Screen Shot 2019-04-01 at 3 57 16 PM](https://user-images.githubusercontent.com/31892318/55355631-e082b200-5496-11e9-9fa1-9c7a24179f6e.png)

## changelog
- Check if a protocol is being simulated and if it is return a simulating module
- Only have a key error if user incorrectly spells a module name

## review requests
Please run this protocol on a robot without modules attached and check that it correctly shows missing modules. Attach modules and check that the modules do not show as missing in the app.
```
def run(ctx):
    tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_300_ul', '1')
    pip = ctx.load_instrument('p300_single', mount='left', tip_racks=[tiprack1])
    td = ctx.load_module('tempdeck', 3)
    md = ctx.load_module('magdeck', 6)
    td.set_temperature(30)
    td.wait_for_temp()
    td.deactivate()
    md.engage(height=10) # without a labware
    md.disengage()
    md.load_labware_by_name('biorad_96_wellPlate_pcr_200_uL')
    md.engage()
    md.disengage()
    td.load_labware_by_name('generic_96_wellPlate_380_uL')
    
    pip.transfer(50, md.labware.wells(), td.labware.wells())

```
