### PR TITLE
perf(protocol-designer): avoid selector recomputation in step forms

### DIFF
--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -42,25 +42,25 @@ type DP = $Diff<$Diff<Props, SP>, OP>
 
 const makeMapStateToProps = () => {
   const getArgsAndErrors = stepFormSelectors.makeGetArgsAndErrors()
+  const getStep = stepFormSelectors.makeGetStep()
 
   return (state: BaseState, ownProps: OP): SP => {
     const {stepId} = ownProps
 
     const argsAndErrors = getArgsAndErrors(state, stepId)
+    const step = getStep(state, stepId)
 
-    const allSteps = stepFormSelectors.getAllSteps(state)
+    const formAndFieldErrors = argsAndErrors[stepId] && argsAndErrors[stepId].errors
+    const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
+
+    const hasWarnings = dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||
+      dismissSelectors.getHasFormLevelWarningsPerStep(state)[stepId]
+
+    const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
 
     const hoveredSubstep = stepsSelectors.getHoveredSubstep(state)
     const hoveredStep = stepsSelectors.getHoveredStepId(state)
     const selected = stepsSelectors.getSelectedStepId(state) === stepId
-    const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
-
-    const formAndFieldErrors = argsAndErrors[stepId] && argsAndErrors[stepId].errors
-    const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
-    const hasWarnings = dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||
-      dismissSelectors.getHasFormLevelWarningsPerStep(state)[stepId]
-
-    const step = allSteps[stepId]
 
     return {
       stepType: step.stepType,

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -41,14 +41,14 @@ type SP = {|
 type DP = $Diff<$Diff<Props, SP>, OP>
 
 const makeMapStateToProps = () => {
-  const getArgsAndErrors = stepFormSelectors.makeGetArgsAndErrors()
-  const getStep = stepFormSelectors.makeGetStep()
+  const getArgsAndErrors = stepFormSelectors.makeGetArgsAndErrorsWithId()
+  const getStep = stepFormSelectors.makeGetStepWithId()
 
   return (state: BaseState, ownProps: OP): SP => {
     const {stepId} = ownProps
 
-    const argsAndErrors = getArgsAndErrors(state, stepId)
-    const step = getStep(state, stepId)
+    const argsAndErrors = getArgsAndErrors(state, {stepId})
+    const step = getStep(state, {stepId})
 
     const formAndFieldErrors = argsAndErrors[stepId] && argsAndErrors[stepId].errors
     const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -40,41 +40,45 @@ type SP = {|
 
 type DP = $Diff<$Diff<Props, SP>, OP>
 
-function mapStateToProps (state: BaseState, ownProps: OP): SP {
-  const {stepId} = ownProps
-  const allSteps = stepFormSelectors.getAllSteps(state)
+const makeMapStateToProps = () => {
+  const getArgsAndErrors = stepFormSelectors.makeGetArgsAndErrors()
 
-  const hoveredSubstep = stepsSelectors.getHoveredSubstep(state)
-  const hoveredStep = stepsSelectors.getHoveredStepId(state)
-  const selected = stepsSelectors.getSelectedStepId(state) === stepId
-  const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
-  const argsAndErrorsByStepId = stepFormSelectors.getArgsAndErrorsByStepId(state)
-  const formAndFieldErrors = argsAndErrorsByStepId[stepId] && argsAndErrorsByStepId[stepId].errors
-  const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
-  const hasWarnings = dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||
-    dismissSelectors.getHasFormLevelWarningsPerStep(state)[stepId]
+  return (state: BaseState, ownProps: OP): SP => {
+    const {stepId} = ownProps
+    const allSteps = stepFormSelectors.getAllSteps(state)
 
-  const step = allSteps[stepId]
+    const hoveredSubstep = stepsSelectors.getHoveredSubstep(state)
+    const hoveredStep = stepsSelectors.getHoveredStepId(state)
+    const selected = stepsSelectors.getSelectedStepId(state) === stepId
+    const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
+    const argsAndErrorsByStepId = getArgsAndErrors(state, stepId)
+    const formAndFieldErrors = argsAndErrorsByStepId[stepId] && argsAndErrorsByStepId[stepId].errors
+    const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
+    const hasWarnings = dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||
+      dismissSelectors.getHasFormLevelWarningsPerStep(state)[stepId]
 
-  return {
-    stepType: step.stepType,
-    title: step.title,
-    description: step.description,
-    rawForm: step.formData,
-    substeps: substepSelectors.allSubsteps(state)[stepId],
-    hoveredSubstep,
-    collapsed,
-    selected,
-    error: hasError,
-    warning: hasWarnings,
+    const step = allSteps[stepId]
 
-    // no double-highlighting: whole step is only "hovered" when
-    // user is not hovering on substep.
-    hovered: (hoveredStep === stepId) && !hoveredSubstep,
+    return {
+      stepType: step.stepType,
+      title: step.title,
+      description: step.description,
+      rawForm: step.formData,
+      substeps: substepSelectors.allSubsteps(state)[stepId],
+      hoveredSubstep,
+      collapsed,
+      selected,
+      error: hasError,
+      warning: hasWarnings,
 
-    labwareNicknamesById: uiLabwareSelectors.getLabwareNicknamesById(state),
-    labwareTypesById: stepFormSelectors.getLabwareTypesById(state),
-    ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
+      // no double-highlighting: whole step is only "hovered" when
+      // user is not hovering on substep.
+      hovered: (hoveredStep === stepId) && !hoveredSubstep,
+
+      labwareNicknamesById: uiLabwareSelectors.getLabwareNicknamesById(state),
+      labwareTypesById: stepFormSelectors.getLabwareTypesById(state),
+      ingredNames: labwareIngredSelectors.getLiquidNamesById(state),
+    }
   }
 }
 
@@ -88,4 +92,4 @@ function mapDispatchToProps (dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(StepItem)
+export default connect(makeMapStateToProps, mapDispatchToProps)(StepItem)

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -45,14 +45,17 @@ const makeMapStateToProps = () => {
 
   return (state: BaseState, ownProps: OP): SP => {
     const {stepId} = ownProps
+
+    const argsAndErrors = getArgsAndErrors(state, stepId)
+
     const allSteps = stepFormSelectors.getAllSteps(state)
 
     const hoveredSubstep = stepsSelectors.getHoveredSubstep(state)
     const hoveredStep = stepsSelectors.getHoveredStepId(state)
     const selected = stepsSelectors.getSelectedStepId(state) === stepId
     const collapsed = stepsSelectors.getCollapsedSteps(state)[stepId]
-    const argsAndErrorsByStepId = getArgsAndErrors(state, stepId)
-    const formAndFieldErrors = argsAndErrorsByStepId[stepId] && argsAndErrorsByStepId[stepId].errors
+
+    const formAndFieldErrors = argsAndErrors[stepId] && argsAndErrors[stepId].errors
     const hasError = fileDataSelectors.getErrorStepId(state) === stepId || !isEmpty(formAndFieldErrors)
     const hasWarnings = dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||
       dismissSelectors.getHasFormLevelWarningsPerStep(state)[stepId]

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -239,20 +239,19 @@ export const getUnsavedFormErrors: Selector<?StepFormAndFieldErrors> = createSel
 )
 
 // TODO: Brian&Ian 2019-04-02 this is TEMPORARY, should be removed once legacySteps reducer is removed
-const getLegacyStep = (state: BaseState, stepId: StepIdType) => {
-  return state.stepForms.legacySteps[stepId]
+const getLegacyStepWithId = (state: BaseState, props: {stepId: StepIdType}) => {
+  return state.stepForms.legacySteps[props.stepId]
 }
 
-const getStepForm = (state: BaseState, stepId: StepIdType) => {
-  return state.stepForms.savedStepForms[stepId]
+const getStepFormWithId = (state: BaseState, props: {stepId: StepIdType}) => {
+  return state.stepForms.savedStepForms[props.stepId]
 }
 
-export const makeGetArgsAndErrors = () => {
+export const makeGetArgsAndErrorsWithId = () => {
   return createSelector(
-    getStepForm,
+    getStepFormWithId,
     getHydrationContext,
     (stepForm, contextualState) => {
-      console.log('DOING THE WORK args and errors', stepForm && stepForm.id)
       const hydratedForm = _getHydratedForm(stepForm, contextualState)
       const errors = _getFormAndFieldErrorsFromHydratedForm(hydratedForm)
       return isEmpty(errors) ? {stepArgs: stepFormToArgs(hydratedForm)} : {errors, stepArgs: null}
@@ -262,12 +261,11 @@ export const makeGetArgsAndErrors = () => {
 
 // TODO: Brian&Ian 2019-04-02 this is TEMPORARY, should be removed once legacySteps reducer is removed
 // only need it because stepType should exist evergreen outside of legacySteps but doesn't yet
-export const makeGetStep = () => {
+export const makeGetStepWithId = () => {
   return createSelector(
-    getStepForm,
-    getLegacyStep,
+    getStepFormWithId,
+    getLegacyStepWithId,
     (stepForm, legacyStep) => {
-      console.log('DOING THE GET STEP ', stepForm && stepForm.id)
       return ({
         ...legacyStep,
         formData: stepForm,

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -51,6 +51,7 @@ export const getLabwareEntities: Selector<LabwareEntities> = createSelector(
   (state) => state.labwareInvariantProperties
 )
 
+
 export const getLabwareTypesById: Selector<LabwareTypeById> = createSelector(
   getLabwareEntities,
   (labwareEntities) => mapValues(
@@ -237,6 +238,23 @@ export const getUnsavedFormErrors: Selector<?StepFormAndFieldErrors> = createSel
     return errors
   }
 )
+
+const getStepForm = (state: State, stepId: string) => {
+  return state.stepForms.savedStepForms[stepId]
+}
+
+export const makeGetArgsAndErrors = () => {
+  return createSelector(
+    getStepForm,
+    getHydrationContext,
+    (stepForm, contextualState) => {
+      console.log('DOING THE WORK', stepForm && stepForm.id)
+      const hydratedForm = _getHydratedForm(stepForm, contextualState)
+      const errors = _getFormAndFieldErrorsFromHydratedForm(hydratedForm)
+      return isEmpty(errors) ? {stepArgs: stepFormToArgs(hydratedForm)} : {errors, stepArgs: null}
+    }
+  )
+}
 
 export const getArgsAndErrorsByStepId: Selector<{[StepIdType]: StepArgsAndErrors}> = createSelector(
   getOrderedSavedForms,


### PR DESCRIPTION
There are a connected properties in our step item components that are become taxing to calculate as
the length of a protocol grows. By memoizing the result of those calculations for each step item
instance, we can avoid needlessly recalculating the same properties for unrelated step items when
specific changes (e.g. updating the unsaved form) occur.