### PR TITLE
fix(labware-library): Take cornerOffsetFromSlot into account with render

### DIFF
--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -48,16 +48,16 @@ The generator has the following functions:
 
 To build a _regular_ labware, the `options` object should have the following shape:
 
-| field        | type                      | required | description                                     |
-| ------------ | ------------------------- | -------- | ----------------------------------------------- |
-| `metadata`   | [Metadata](#Metadata)     | yes      | Information about the labware                   |
-| `parameters` | [Parameters](#Parameters) | yes      | Parameters that affect labware functionality    |
-| `dimensions` | [Dimensions](#Dimensions) | yes      | Overall dimensions of the labware               |
-| `offset`     | [Offset](#Offset)         | yes      | Distance from slot's top-left corner to well A1 |
-| `grid`       | [Grid](#Grid)             | yes      | Number of rows and columns of wells             |
-| `spacing`    | [Spacing](#Spacing)       | yes      | Distance between rows and columns               |
-| `well`       | [Well](#Well)             | yes      | Well parameters                                 |
-| `brand`      | [Brand](#Brand)           | no       | Labware manufacturer ("generic" if omitted)     |
+| field        | type                      | required | description                                        |
+| ------------ | ------------------------- | -------- | -------------------------------------------------- |
+| `metadata`   | [Metadata](#Metadata)     | yes      | Information about the labware                      |
+| `parameters` | [Parameters](#Parameters) | yes      | Parameters that affect labware functionality       |
+| `dimensions` | [Dimensions](#Dimensions) | yes      | Overall dimensions of the labware                  |
+| `offset`     | [Offset](#Offset)         | yes      | Distance from labware's top-left corner to well A1 |
+| `grid`       | [Grid](#Grid)             | yes      | Number of rows and columns of wells                |
+| `spacing`    | [Spacing](#Spacing)       | yes      | Distance between rows and columns                  |
+| `well`       | [Well](#Well)             | yes      | Well parameters                                    |
+| `brand`      | [Brand](#Brand)           | no       | Labware manufacturer ("generic" if omitted)        |
 
 This example generates [generic_96_wellplate_380_ul.json][]:
 
@@ -100,17 +100,17 @@ const labware = sharedData.createRegularLabware(options)
 
 To build an _irregular_ labware, the `options` object should have the following shape:
 
-| field        | type                           | required | description                                                      |
-| ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
-| `metadata`   | [Metadata](#Metadata)          | yes      | Information about the labware                                    |
-| `parameters` | [Parameters](#Parameters)      | yes      | Parameters that affect labware functionality                     |
-| `dimensions` | [Dimensions](#Dimensions)      | yes      | Overall dimensions of the labware                                |
-| `offset`     | Array<[Offset](#Offset) >      | yes      | Distances from slot's top-left corner to first well of each grid |
-| `grid`       | Array<[Grid](#Grid)>           | yes      | Number of rows and columns per grid                              |
-| `spacing`    | Array<[Spacing](#Spacing)>     | yes      | Distance between rows and columns per grid                       |
-| `well`       | Array<[Well](#Well)>           | yes      | Well parameters per grid                                         |
-| `gridStart`  | Array<[GridStart](#GridStart)> | yes      | Well naming scheme per grid                                      |
-| `brand`      | [Brand](#Brand)                | no       | Labware manufacturer ("generic" if omitted)                      |
+| field        | type                           | required | description                                                         |
+| ------------ | ------------------------------ | -------- | ------------------------------------------------------------------- |
+| `metadata`   | [Metadata](#Metadata)          | yes      | Information about the labware                                       |
+| `parameters` | [Parameters](#Parameters)      | yes      | Parameters that affect labware functionality                        |
+| `dimensions` | [Dimensions](#Dimensions)      | yes      | Overall dimensions of the labware                                   |
+| `offset`     | Array<[Offset](#Offset) >      | yes      | Distances from labware's top-left corner to first well of each grid |
+| `grid`       | Array<[Grid](#Grid)>           | yes      | Number of rows and columns per grid                                 |
+| `spacing`    | Array<[Spacing](#Spacing)>     | yes      | Distance between rows and columns per grid                          |
+| `well`       | Array<[Well](#Well)>           | yes      | Well parameters per grid                                            |
+| `gridStart`  | Array<[GridStart](#GridStart)> | yes      | Well naming scheme per grid                                         |
+| `brand`      | [Brand](#Brand)                | no       | Labware manufacturer ("generic" if omitted)                         |
 
 This example generates [opentrons_6x15_ml_4x50_ml_tuberack.json][]
 

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -66,6 +66,10 @@ function Well (props: LabwareWellRenderProps) {
   const {well, parameters, cornerOffsetFromSlot} = props
   const {shape, diameter, width, length} = well
   const {isTiprack} = parameters
+
+  // TODO(mc, 2019-04-04): cornerOffsetFromSlot is added to x and y because
+  //   labware render is currently in slot coordinate system; revisit this
+  //   decision when deck component refactor is in progress
   const x = well.x + cornerOffsetFromSlot.x
   const y = well.y + cornerOffsetFromSlot.y
 

--- a/labware-library/src/components/LabwareRender/index.js
+++ b/labware-library/src/components/LabwareRender/index.js
@@ -63,9 +63,11 @@ export default function LabwareRender (props: LabwareRenderProps) {
 }
 
 function Well (props: LabwareWellRenderProps) {
-  const {well, parameters} = props
-  const {x, y, shape, diameter, width, length} = well
+  const {well, parameters, cornerOffsetFromSlot} = props
+  const {shape, diameter, width, length} = well
   const {isTiprack} = parameters
+  const x = well.x + cornerOffsetFromSlot.x
+  const y = well.y + cornerOffsetFromSlot.y
 
   if (shape === 'circular' && diameter) {
     const radius = diameter / 2

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -145,7 +145,7 @@
     "cornerOffsetFromSlot": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Distance from bottom-left corner of slot to bottom-left corner of labware",
+      "description": "Distance from left-front-bottom corner of slot to left-front-bottom corner of labware",
       "required": ["x", "y", "z"],
       "properties": {
         "x": {"type": "number"},
@@ -191,15 +191,15 @@
           "properties": {
             "depth": {"$ref": "#/definitions/positiveNumber"},
             "x": {
-              "description": "X location of well in reference to bottom-left of labware",
+              "description": "X location of center-top of well in reference to left-front-bottom of labware",
               "$ref": "#/definitions/positiveNumber"
             },
             "y": {
-              "description": "Y location of well in reference to bottom-left of labware",
+              "description": "Y location of center-top of well in reference to left-front-bottom of labware",
               "$ref": "#/definitions/positiveNumber"
             },
             "z": {
-              "description": "Z location of well in reference to bottom-left of labware",
+              "description": "Z location of center-top of well in reference to left-front-bottom of labware",
               "$ref": "#/definitions/positiveNumber"
             },
             "totalLiquidVolume": {

--- a/shared-data/labware-json-schema/labware-schema.json
+++ b/shared-data/labware-json-schema/labware-schema.json
@@ -145,7 +145,7 @@
     "cornerOffsetFromSlot": {
       "type": "object",
       "additionalProperties": false,
-      "description": "XYZ values from top left corner of slot to well A1",
+      "description": "Distance from bottom-left corner of slot to bottom-left corner of labware",
       "required": ["x", "y", "z"],
       "properties": {
         "x": {"type": "number"},
@@ -191,12 +191,21 @@
           "properties": {
             "depth": {"$ref": "#/definitions/positiveNumber"},
             "x": {
-              "description": "XYZ calculated from bottom-left corner of slot to top-center of the well",
+              "description": "X location of well in reference to bottom-left of labware",
               "$ref": "#/definitions/positiveNumber"
             },
-            "y": {"$ref": "#/definitions/positiveNumber"},
-            "z": {"$ref": "#/definitions/positiveNumber"},
-            "totalLiquidVolume": {"$ref": "#/definitions/positiveNumber"},
+            "y": {
+              "description": "Y location of well in reference to bottom-left of labware",
+              "$ref": "#/definitions/positiveNumber"
+            },
+            "z": {
+              "description": "Z location of well in reference to bottom-left of labware",
+              "$ref": "#/definitions/positiveNumber"
+            },
+            "totalLiquidVolume": {
+              "description": "Total well, tube, or tip volume in microliters",
+              "$ref": "#/definitions/positiveNumber"
+            },
             "width": {"$ref": "#/definitions/positiveNumber"},
             "length": {"$ref": "#/definitions/positiveNumber"},
             "diameter": {"$ref": "#/definitions/positiveNumber"},


### PR DESCRIPTION
## overview

Bug report + fix. This PR fixes the new labware library render not taking `cornerOffsetFromSlot` into account. It also makes some changes to the docs and schema descriptions to make the different origins more clear

## changelog

- fix(labware-library): Take cornerOffsetFromSlot into account with render

## review requests

None of the renders are really changed, but please check code for correctness
