### PR TITLE
fix(app): render correct image for vial and tube racks

### DIFF
--- a/app/src/components/CalibrateLabware/instructions-data.js
+++ b/app/src/components/CalibrateLabware/instructions-data.js
@@ -244,7 +244,7 @@ function getTypeKey (props: LabwareCalibrationProps) {
     typeKey = 'tiprack'
   } else if (type.includes('trough')) {
     typeKey = 'trough'
-  } else if (type.includes('tube-rack')) {
+  } else if (type.includes('tube') || type.includes('vial')) {
     typeKey = 'tuberack'
   } else if (type.includes('384')) {
     typeKey = 'plate384'


### PR DESCRIPTION
## overview

This PR updates the logic that renders calibration images for tube and vial racks so it renders the same images for labware definition named `tube-rack`, `tuberack` or `vial-rack`.

Closes #3294 

## changelog
- `tube-rack` is now replaced by `tube` and `vial`

## review requests
Please test this protocol in the app on V1 to make sure the calibration screen for all three plates shows the image of a tube rack but not a 96 well plate.

```
from opentrons import labware, instruments

tiprack1 = labware.load('tiprack-10ul', '1')

plate1 = labware.load('opentrons-tuberack-2ml-eppendorf', '2')
plate2 = labware.load('opentrons-tuberack-15_50ml', '3')
plate3 = labware.load('small_vial_rack_16x45', '4')

pip = instruments.P10_Single(mount='left', tip_racks=[tiprack1])

pip.transfer(50, plate1.wells(0), plate2.wells(0))
pip.transfer(50, plate1.wells(0), plate3.wells(0))
```
