### PR TITLE
refactor(app): Implement temperature module controls behind FF

### DIFF
--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -3,19 +3,23 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 
-import { RefreshCard } from '@opentrons/components'
+import { Card, IntervalWrapper } from '@opentrons/components'
 import { fetchModules, makeGetRobotModules } from '../../http-api-client'
 import ModulesCardContents from './ModulesCardContents'
+import { getConfig } from '../../config'
 
 import type { State, Dispatch } from '../../types'
 import type { Module } from '../../http-api-client'
 import type { Robot } from '../../discovery'
 
-type OP = Robot
+type OP = {
+  robot: Robot,
+}
 
 type SP = {|
   modules: ?Array<Module>,
   refreshing: boolean,
+  __featureEnabled: boolean,
 |}
 
 type DP = {| refresh: () => mixed |}
@@ -31,15 +35,15 @@ export default connect(
 
 function AttachedModulesCard(props: Props) {
   return (
-    <RefreshCard
-      title={TITLE}
-      watch={props.name}
-      refreshing={props.refreshing}
-      refresh={props.refresh}
-      column
-    >
-      <ModulesCardContents modules={props.modules} />
-    </RefreshCard>
+    <IntervalWrapper interval={2000} refresh={props.refresh}>
+      <Card title={TITLE} column>
+        <ModulesCardContents
+          modules={props.modules}
+          robot={props.robot}
+          showControls={props.__featureEnabled}
+        />
+      </Card>
+    </IntervalWrapper>
   )
 }
 
@@ -47,18 +51,20 @@ function makeSTP(): (state: State, ownProps: OP) => SP {
   const getRobotModules = makeGetRobotModules()
 
   return (state, ownProps) => {
-    const modulesCall = getRobotModules(state, ownProps)
+    const modulesCall = getRobotModules(state, ownProps.robot)
     const modulesResponse = modulesCall.response
     const modules = modulesResponse && modulesResponse.modules
+    const devInternal = getConfig(state).devInternal
     return {
       modules: modules,
       refreshing: modulesCall.inProgress,
+      __featureEnabled: !!devInternal && !!devInternal.tempdeckControls,
     }
   }
 }
 
 function DTP(dispatch: Dispatch, ownProps: OP): DP {
   return {
-    refresh: () => dispatch(fetchModules(ownProps)),
+    refresh: () => dispatch(fetchModules(ownProps.robot)),
   }
 }

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -20,7 +20,9 @@ import type { State } from '../../types'
 import type { Robot } from '../../discovery'
 import type { Pipette } from '../../http-api-client'
 
-type OP = Robot
+type OP = {
+  robot: Robot,
+}
 
 type SP = {|
   inProgress: boolean,
@@ -50,14 +52,14 @@ function AttachedPipettesCard(props: Props) {
         <CardContentFlex>
           <InstrumentInfo
             mount="left"
-            name={props.name}
+            name={props.robot.name}
             {...props.left}
             onChangeClick={props.clearMove}
             showSettings={props.showSettings}
           />
           <InstrumentInfo
             mount="right"
-            name={props.name}
+            name={props.robot.name}
             {...props.right}
             onChangeClick={props.clearMove}
             showSettings={props.showSettings}
@@ -73,9 +75,9 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
 
   return (state, ownProps) => {
-    const { inProgress, response } = getRobotPipettes(state, ownProps)
+    const { inProgress, response } = getRobotPipettes(state, ownProps.robot)
     const { left, right } = response || { left: null, right: null }
-    const configCall = getRobotPipetteConfigs(state, ownProps)
+    const configCall = getRobotPipetteConfigs(state, ownProps.robot)
     return {
       inProgress,
       left,
@@ -89,8 +91,11 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   return {
     fetchPipettes: () =>
       dispatch(
-        chainActions(fetchPipettes(ownProps), fetchPipetteConfigs(ownProps))
+        chainActions(
+          fetchPipettes(ownProps.robot),
+          fetchPipetteConfigs(ownProps.robot)
+        )
       ),
-    clearMove: () => dispatch(clearMoveResponse(ownProps)),
+    clearMove: () => dispatch(clearMoveResponse(ownProps.robot)),
   }
 }

--- a/app/src/components/InstrumentSettings/ModulesCardContents.js
+++ b/app/src/components/InstrumentSettings/ModulesCardContents.js
@@ -3,18 +3,27 @@ import * as React from 'react'
 import type { Module } from '../../http-api-client'
 import ModuleItem, { NoModulesMessage } from '../ModuleItem'
 
+import type { Robot } from '../../discovery'
+
 type Props = {
+  robot: Robot,
   modules: ?Array<Module>,
+  showControls: boolean,
 }
 
 export default function ModulesCardContents(props: Props) {
-  const { modules } = props
+  const { modules, robot, showControls } = props
   if (!modules || !modules[0]) return <NoModulesMessage />
 
   return (
     <React.Fragment>
       {modules.map((mod, index) => (
-        <ModuleItem module={mod} key={index} />
+        <ModuleItem
+          module={mod}
+          key={index}
+          robot={robot}
+          showControls={showControls}
+        />
       ))}
     </React.Fragment>
   )

--- a/app/src/components/InstrumentSettings/index.js
+++ b/app/src/components/InstrumentSettings/index.js
@@ -8,16 +8,18 @@ import { CardContainer, CardRow } from '../layout'
 
 import type { Robot } from '../../discovery'
 
-type Props = Robot
+type Props = {
+  robot: Robot,
+}
 
 export default function InstrumentSettings(props: Props) {
   return (
     <CardContainer>
       <CardRow>
-        <AttachedPipettesCard {...props} />
+        <AttachedPipettesCard robot={props.robot} />
       </CardRow>
       <CardRow>
-        <AttachedModulesCard {...props} />
+        <AttachedModulesCard robot={props.robot} />
       </CardRow>
     </CardContainer>
   )

--- a/app/src/components/ModuleControls/ModuleData.js
+++ b/app/src/components/ModuleControls/ModuleData.js
@@ -1,0 +1,27 @@
+// @flow
+import * as React from 'react'
+import {LabeledValue} from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = {
+  currentTemp: ?number,
+  targetTemp: ?number,
+}
+
+export default function ModuleData (props: Props) {
+  const {currentTemp, targetTemp} = props
+  return (
+    <div className={styles.module_data}>
+      <LabeledValue
+        label="Current Temp"
+        value={currentTemp ? `${currentTemp} °C` : 'None'}
+        className={styles.span_50}
+      />
+      <LabeledValue
+        label="Target Temp"
+        value={targetTemp ? `${targetTemp} °C` : 'None'}
+        className={styles.span_50}
+      />
+    </div>
+  )
+}

--- a/app/src/components/ModuleControls/ModuleData.js
+++ b/app/src/components/ModuleControls/ModuleData.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {LabeledValue} from '@opentrons/components'
+import { LabeledValue } from '@opentrons/components'
 import styles from './styles.css'
 
 type Props = {
@@ -8,8 +8,8 @@ type Props = {
   targetTemp: ?number,
 }
 
-export default function ModuleData (props: Props) {
-  const {currentTemp, targetTemp} = props
+export default function ModuleData(props: Props) {
+  const { currentTemp, targetTemp } = props
   return (
     <div className={styles.module_data}>
       <LabeledValue

--- a/app/src/components/ModuleControls/TempField.js
+++ b/app/src/components/ModuleControls/TempField.js
@@ -4,11 +4,11 @@ import styles from './styles.css'
 
 type Props = {
   field: any,
-  inputRef: {current: null | HTMLInputElement},
+  inputRef: { current: null | HTMLInputElement },
 }
 
-export default function TempField (props: Props) {
-  const {field, inputRef} = props
+export default function TempField(props: Props) {
+  const { field, inputRef } = props
   return (
     <div className={styles.target_field}>
       <label className={styles.target_label}>Set Target Temp:</label>

--- a/app/src/components/ModuleControls/TempField.js
+++ b/app/src/components/ModuleControls/TempField.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+type Props = {
+  field: any,
+  inputRef: {current: null | HTMLInputElement},
+}
+
+export default function TempField (props: Props) {
+  const {field, inputRef} = props
+  return (
+    <div className={styles.target_field}>
+      <label className={styles.target_label}>Set Target Temp:</label>
+      <input
+        {...field}
+        type="text"
+        className={styles.target_input}
+        ref={inputRef}
+      />
+    </div>
+  )
+}

--- a/app/src/components/ModuleControls/TemperatureControls.js
+++ b/app/src/components/ModuleControls/TemperatureControls.js
@@ -1,0 +1,67 @@
+// @flow
+import * as React from 'react'
+import {Formik, Form, Field} from 'formik'
+import {OutlineButton} from '@opentrons/components'
+import TempField from './TempField'
+
+import styles from './styles.css'
+
+import type {SetTemperatureRequest} from '../../http-api-client'
+
+type Props = {
+  setTemp: (request: SetTemperatureRequest) => mixed,
+}
+
+export default class TemperatureControls extends React.Component<Props> {
+  inputRef: {current: null | HTMLInputElement}
+  constructor (props: Props) {
+    super(props)
+    this.inputRef = React.createRef()
+  }
+
+  deactivateModule = () => {
+    const request = {
+      command_type: 'deactivate',
+    }
+    this.props.setTemp(request)
+  }
+  render () {
+    return (
+      <Formik
+        initialValues={{target: ''}}
+        onSubmit={(values, actions) => {
+          const target = values.target === '' ? null : Number(values.target)
+          if (!target) {
+            return
+          }
+          const request = {
+            command_type: 'set_temperature',
+            args: [target],
+          }
+          this.props.setTemp(request)
+
+          const $input = this.inputRef.current
+          if ($input) $input.blur()
+
+          actions.resetForm()
+        }}
+        render={formProps => {
+          return (
+            <Form className={styles.temperature_form}>
+              <Field name="target" component={TempField} />
+              <OutlineButton type="submit" className={styles.set_button}>
+                Set target
+              </OutlineButton>
+              <OutlineButton
+                className={styles.set_button}
+                onClick={this.deactivateModule}
+              >
+                Deactivate
+              </OutlineButton>
+            </Form>
+          )
+        }}
+      />
+    )
+  }
+}

--- a/app/src/components/ModuleControls/TemperatureControls.js
+++ b/app/src/components/ModuleControls/TemperatureControls.js
@@ -1,20 +1,20 @@
 // @flow
 import * as React from 'react'
-import {Formik, Form, Field} from 'formik'
-import {OutlineButton} from '@opentrons/components'
+import { Formik, Form, Field } from 'formik'
+import { OutlineButton } from '@opentrons/components'
 import TempField from './TempField'
 
 import styles from './styles.css'
 
-import type {SetTemperatureRequest} from '../../http-api-client'
+import type { SetTemperatureRequest } from '../../http-api-client'
 
 type Props = {
   setTemp: (request: SetTemperatureRequest) => mixed,
 }
 
 export default class TemperatureControls extends React.Component<Props> {
-  inputRef: {current: null | HTMLInputElement}
-  constructor (props: Props) {
+  inputRef: { current: null | HTMLInputElement }
+  constructor(props: Props) {
     super(props)
     this.inputRef = React.createRef()
   }
@@ -25,10 +25,10 @@ export default class TemperatureControls extends React.Component<Props> {
     }
     this.props.setTemp(request)
   }
-  render () {
+  render() {
     return (
       <Formik
-        initialValues={{target: ''}}
+        initialValues={{ target: '' }}
         onSubmit={(values, actions) => {
           const target = values.target === '' ? null : Number(values.target)
           if (!target) {

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {connect} from 'react-redux'
-import {IntervalWrapper} from '@opentrons/components'
+import { connect } from 'react-redux'
+import { IntervalWrapper } from '@opentrons/components'
 import ModuleData from './ModuleData'
 import TemperatureControls from './TemperatureControls'
 
@@ -10,14 +10,14 @@ import {
   fetchModuleData,
   setTargetTemp,
 } from '../../http-api-client'
-import type {State, Dispatch} from '../../types'
+import type { State, Dispatch } from '../../types'
 
 import type {
   Module,
   FetchTemperatureDataResponse,
   SetTemperatureRequest,
 } from '../../http-api-client'
-import type {Robot} from '../../discovery'
+import type { Robot } from '../../discovery'
 
 const POLL_MODULE_INTERVAL_MS = 2000
 
@@ -35,15 +35,15 @@ type DP = {|
   setTargetTemp: (request: SetTemperatureRequest) => mixed,
 |}
 
-type Props = {...$Exact<OP>, ...SP, ...DP}
+type Props = { ...OP, ...SP, ...DP }
 
 export default connect(
   makeSTP,
   mapDTP
 )(ModuleControls)
 
-function ModuleControls (props: Props) {
-  const {moduleData, fetchModuleData} = props
+function ModuleControls(props: Props) {
+  const { moduleData, fetchModuleData } = props
 
   const currentTemp =
     moduleData && moduleData.data && moduleData.data.currentTemp
@@ -61,7 +61,7 @@ function ModuleControls (props: Props) {
   )
 }
 
-function makeSTP (): (state: State, ownProps: OP) => SP {
+function makeSTP(): (state: State, ownProps: OP) => SP {
   const getRobotModuleData = makeGetRobotModuleData()
   return (state, ownProps) => {
     const _serial = ownProps.module.serial
@@ -74,8 +74,8 @@ function makeSTP (): (state: State, ownProps: OP) => SP {
   }
 }
 
-function mapDTP (dispatch: Dispatch, ownProps: OP): DP {
-  const {robot} = ownProps
+function mapDTP(dispatch: Dispatch, ownProps: OP): DP {
+  const { robot } = ownProps
   const serial = ownProps.module.serial
   return {
     fetchModuleData: () => dispatch(fetchModuleData(robot, serial)),

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -1,0 +1,84 @@
+// @flow
+import * as React from 'react'
+import {connect} from 'react-redux'
+import {IntervalWrapper} from '@opentrons/components'
+import ModuleData from './ModuleData'
+import TemperatureControls from './TemperatureControls'
+
+import {
+  makeGetRobotModuleData,
+  fetchModuleData,
+  setTargetTemp,
+} from '../../http-api-client'
+import type {State, Dispatch} from '../../types'
+
+import type {
+  Module,
+  FetchTemperatureDataResponse,
+  SetTemperatureRequest,
+} from '../../http-api-client'
+import type {Robot} from '../../discovery'
+
+const POLL_MODULE_INTERVAL_MS = 2000
+
+type OP = {|
+  robot: Robot,
+  module: Module,
+|}
+
+type SP = {|
+  moduleData: ?FetchTemperatureDataResponse,
+|}
+
+type DP = {|
+  fetchModuleData: () => mixed,
+  setTargetTemp: (request: SetTemperatureRequest) => mixed,
+|}
+
+type Props = {...$Exact<OP>, ...SP, ...DP}
+
+export default connect(
+  makeSTP,
+  mapDTP
+)(ModuleControls)
+
+function ModuleControls (props: Props) {
+  const {moduleData, fetchModuleData} = props
+
+  const currentTemp =
+    moduleData && moduleData.data && moduleData.data.currentTemp
+  const targetTemp = moduleData && moduleData.data && moduleData.data.targetTemp
+
+  return (
+    <IntervalWrapper
+      refresh={fetchModuleData}
+      interval={POLL_MODULE_INTERVAL_MS}
+    >
+      <ModuleData currentTemp={currentTemp} targetTemp={targetTemp} />
+
+      <TemperatureControls setTemp={props.setTargetTemp} />
+    </IntervalWrapper>
+  )
+}
+
+function makeSTP (): (state: State, ownProps: OP) => SP {
+  const getRobotModuleData = makeGetRobotModuleData()
+  return (state, ownProps) => {
+    const _serial = ownProps.module.serial
+    const _robot = ownProps.robot
+    const moduleDataCall = _robot && getRobotModuleData(state, _robot, _serial)
+    const moduleData = moduleDataCall && moduleDataCall.response
+    return {
+      moduleData,
+    }
+  }
+}
+
+function mapDTP (dispatch: Dispatch, ownProps: OP): DP {
+  const {robot} = ownProps
+  const serial = ownProps.module.serial
+  return {
+    fetchModuleData: () => dispatch(fetchModuleData(robot, serial)),
+    setTargetTemp: request => dispatch(setTargetTemp(robot, serial, request)),
+  }
+}

--- a/app/src/components/ModuleControls/styles.css
+++ b/app/src/components/ModuleControls/styles.css
@@ -1,0 +1,63 @@
+@import '@opentrons/components';
+
+/* TODO (ka 2019-4-9): Revist temporary styling once UX has given input */
+.module_data {
+  display: flex;
+  padding-left: 25%;
+  padding-right: 20%;
+  margin-bottom: 1rem;
+}
+
+.span_50 {
+  width: 50%;
+  margin: 0 1.125rem 0 0;
+}
+
+.temperature_form {
+  display: flex;
+  padding-left: 25%;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+  align-items: flex-end;
+}
+
+.target_field {
+  width: 8rem;
+}
+
+.target_label {
+  @apply --font-body-1-dark;
+
+  font-weight: var(--fw-semibold);
+}
+
+.target_input {
+  @apply --font-form-default;
+
+  width: 8rem;
+  height: 2.3rem;
+  background-color: var(--c-light-gray);
+  border-radius: var(--bd-radius-form-field);
+  border-width: 0;
+  padding: 0.25rem 0.25rem 0.25rem 0.5rem;
+  margin-top: 0.5rem;
+
+  &:focus {
+    outline: none;
+    background-color: var(--c-white);
+    box-shadow: 0 0.125rem 0.25rem 0 color(var(--c-black) alpha(0.5));
+  }
+}
+
+.set_button {
+  width: 8rem;
+
+  &:active,
+  &:focus {
+    background-color: transparent;
+  }
+
+  &:hover {
+    background-color: color(var(--c-bg-light) shade(10%));
+  }
+}

--- a/app/src/components/ModuleItem/NoModulesMessage.js
+++ b/app/src/components/ModuleItem/NoModulesMessage.js
@@ -9,8 +9,7 @@ export default function NoModulesMessage() {
       <p className={styles.modules_description}>No modules detected.</p>
 
       <p className={styles.modules_description}>
-        Connect a module to your robot via USB, then power it on. Press the
-        refresh icon to the top to detect your module.
+        Connect a module to your robot via USB, then power it on.
       </p>
     </CardContentFull>
   )

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -2,26 +2,33 @@
 import * as React from 'react'
 
 import type { Module } from '../../http-api-client'
+import type { Robot } from '../../discovery'
 
 import ModuleImage from './ModuleImage'
 import ModuleInfo from './ModuleInfo'
 import ModuleUpdate from './ModuleUpdate'
 import NoModulesMessage from './NoModulesMessage'
 
+import ModuleControls from '../ModuleControls'
 import styles from './styles.css'
 
 type Props = {
+  robot: Robot,
   module: Module,
   availableUpdate?: ?string,
+  showControls: boolean,
 }
 
 export default function ModuleItem(props: Props) {
-  const { module } = props
+  const { module, robot, showControls } = props
   return (
     <div className={styles.module_item}>
-      <ModuleImage name={module.name} />
-      <ModuleInfo module={module} />
-      <ModuleUpdate availableUpdate={props.availableUpdate} />
+      <div className={styles.module_content}>
+        <ModuleImage name={module.name} />
+        <ModuleInfo module={module} />
+        <ModuleUpdate availableUpdate={props.availableUpdate} />
+      </div>
+      {showControls && <ModuleControls robot={robot} module={module} />}
     </div>
   )
 }

--- a/app/src/components/ModuleItem/styles.css
+++ b/app/src/components/ModuleItem/styles.css
@@ -8,14 +8,17 @@
 }
 
 .module_item {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
   padding: 1.5rem 1rem 0;
 
   &:not(:last-child) {
     border-bottom: 1px solid var(--c-light-gray);
   }
+}
+
+.module_content {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
 }
 
 .module_image_wrapper {

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -19,7 +19,7 @@ import StatusItem from './StatusItem'
 import type { State } from '../../types'
 import type {
   TempDeckModule,
-  FetchModuleDataResponse,
+  FetchTemperatureDataResponse,
 } from '../../http-api-client'
 import type { Robot } from '../../discovery'
 
@@ -28,7 +28,7 @@ const POLL_TEMPDECK_INTERVAL_MS = 1000
 type SP = {
   _robot: ?Robot,
   tempdeck: ?TempDeckModule,
-  tempdeckData: ?FetchModuleDataResponse,
+  tempdeckData: ?FetchTemperatureDataResponse,
 }
 
 type DP = {
@@ -38,7 +38,7 @@ type DP = {
 
 type Props = {
   tempdeck: ?TempDeckModule,
-  tempdeckData: ?FetchModuleDataResponse,
+  tempdeckData: ?FetchTemperatureDataResponse,
   fetchModules: () => mixed,
   fetchModuleData: () => mixed,
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -69,7 +69,7 @@ export type Config = {
   // internal development flags
   devInternal?: {
     allPipetteConfig?: boolean,
-    manualIp?: boolean,
+    tempdeckControls?: boolean,
     enableThermocycler?: boolean,
   },
 }

--- a/app/src/http-api-client/modules.js
+++ b/app/src/http-api-client/modules.js
@@ -47,10 +47,24 @@ export type FetchModulesResponse = {
   modules: Array<Module>,
 }
 
-export type FetchModuleDataResponse = {
+export type FetchTemperatureDataResponse = {
   status: string,
-  data: TempDeckData | MagDeckData,
+  data: TempDeckData,
 }
+
+export type SetTemperatureRequest = {
+  command_type: 'set_temperature' | 'deactivate',
+  args?: Array<number>,
+}
+
+export type SetTemperatureResponse = {
+  message: string,
+  returnValue: ?string,
+}
+
+// TODO (ka 2019-4-8): Getting MagDeck data is possible but not in use
+// keeping data response as TD and TC for polling for now
+export type FetchModuleDataResponse = FetchTemperatureDataResponse
 
 type FetchModulesCall = ApiCall<null, FetchModulesResponse>
 
@@ -92,6 +106,24 @@ export function fetchModuleData(
         (resp: FetchModuleDataResponse) =>
           apiSuccess(robot, fetchDataPath, resp),
         (err: ApiRequestError) => apiFailure(robot, fetchDataPath, err)
+      )
+      .then(dispatch)
+  }
+}
+
+export function setTargetTemp(
+  robot: RobotService,
+  serial: string,
+  command: SetTemperatureRequest
+): ThunkPromiseAction {
+  return dispatch => {
+    const setTempPath = `${MODULES}/${serial}`
+    dispatch(apiRequest(robot, setTempPath, command))
+
+    return client(robot, 'POST', setTempPath, command)
+      .then(
+        (resp: SetTemperatureResponse) => apiSuccess(robot, setTempPath, resp),
+        (err: ApiRequestError) => apiFailure(robot, setTempPath, err)
       )
       .then(dispatch)
   }

--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -27,7 +27,7 @@ export default function InstrumentSettingsPage(props: Props) {
   return (
     <React.Fragment>
       <Page titleBarProps={titleBarProps}>
-        <InstrumentSettings {...robot} />
+        <InstrumentSettings robot={robot} />
       </Page>
       <Switch>
         <Route


### PR DESCRIPTION
## overview

This PR implements an initial UI and wires it up to [b-cooper's module POST endpoints](https://github.com/Opentrons/opentrons/pull/3264). This may stay behind a feature flag for a bit but may be immediately useful for internal science work. With the feature flag turned on, you can set a holding temperature for the thermocycler, or deactivate it within the AttachedModulesCard (no protocol necessary).

![2019-04-09 14 57 11](https://user-images.githubusercontent.com/3430313/55827616-9c1b9580-5ad8-11e9-9d7b-8984e78a22c5.gif)

## changelog

refactor(app): Implement temperature module controls behind FF

## review requests

`make -C app dev OT_APP_DEV_INTERNAL__TEMPDECK_CONTROLS=1`

Can be tested on 🌆 