### PR TITLE
docs(api): update docs for complex liquid handling commands

### DIFF
--- a/api/docs/source/complex commands.rst
+++ b/api/docs/source/complex commands.rst
@@ -10,8 +10,6 @@ The examples below will use the following set-up:
 
     from opentrons import robot, labware, instruments
 
-    robot.clear_commands()
-
     plate = labware.load('96-flat', '1')
 
     tiprack = labware.load('opentrons-tiprack-300ul', '2')
@@ -19,6 +17,8 @@ The examples below will use the following set-up:
     pipette = instruments.P300_Single(
         mount='left',
         tip_racks=[tiprack])
+
+You could simulate the protocol using our protocol simulator, which can be installed by following the instructions [here](https://github.com/Opentrons/opentrons/tree/edge/api#simulating-protocols).
 
 **********************
 
@@ -48,10 +48,7 @@ Volumes larger than the pipette's ``max_volume`` will automatically divide into 
 
     pipette.transfer(700, plate.wells('A2'), plate.wells('B2'))
 
-    for c in robot.commands():
-        print(c)
-
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -74,10 +71,7 @@ Transfer commands are most useful when moving liquid between multiple wells.
 
     pipette.transfer(100, plate.cols('1'), plate.cols('2'))
 
-    for c in robot.commands():
-        print(c)
-
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -110,10 +104,8 @@ You can transfer from a single source to multiple destinations, and the other wa
 
     pipette.transfer(100, plate.wells('A1'), plate.cols('2'))
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -149,10 +141,7 @@ What happens if, for example, you tell your pipette to transfer from 2 source we
         plate.wells('A1', 'A2'),
         plate.wells('B1', 'B2', 'B3', 'B4'))
 
-    for c in robot.commands():
-        print(c)
-
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -180,10 +169,8 @@ Instead of applying a single volume amount to all source/destination wells, you 
         plate.wells('A1'),
         plate.wells('B1', 'B2', 'B3'))
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -209,10 +196,8 @@ Create a linear gradient between a start and ending volume (uL). The start and e
         plate.wells('A1'),
         plate.cols('2'))
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -252,10 +237,7 @@ Volumes going to the same destination well are combined within the same tip, so 
 
     pipette.consolidate(30, plate.cols('2'), plate.wells('A1'))
 
-    for c in robot.commands():
-        print(c)
-
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -279,10 +261,8 @@ If there are multiple destination wells, the pipette will never combine their vo
 
     pipette.consolidate(30, plate.cols('1'), plate.wells('A1', 'A2'))
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -310,10 +290,8 @@ Volumes from the same source well are combined within the same tip, so that one 
 
     pipette.distribute(55, plate.wells('A1'), plate.rows('A'))
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -347,10 +325,7 @@ If there are multiple source wells, the pipette will never combine their volumes
 
     pipette.distribute(30, plate.wells('A1', 'A2'), plate.rows('A'))
 
-    for c in robot.commands():
-        print(c)
-
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -388,10 +363,8 @@ When dispensing multiple times from the same tip, it is recommended to aspirate 
         plate.cols('2'),
         disposal_vol=10)   # include extra liquid to make dispenses more accurate
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -434,10 +407,8 @@ The pipette can optionally get a new tip at the beginning of each aspirate, to h
         plate.wells('B1', 'B2', 'B3'),
         new_tip='always')    # always pick up a new tip
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -472,10 +443,8 @@ For scenarios where you instead are calling ``pick_up_tip()`` and ``drop_tip()``
     ...
     pipette.drop_tip()
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -504,10 +473,8 @@ By default, the transfer command will drop the pipette's tips in the trash conta
         plate.wells('B1'),
         trash=False)       # do not trash tip
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -531,10 +498,8 @@ A touch-tip can be performed after every aspirate and dispense by setting ``touc
         plate.wells('A2'),
         touch_tip=True)     # touch tip to each well's edge
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -559,10 +524,8 @@ A blow-out can be performed after every dispense that leaves the tip empty by se
         plate.wells('A2'),
         blow_out=True)      # blow out droplets when tip is empty
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -587,10 +550,8 @@ A mix can be performed before every aspirate by setting ``mix_before=``. The val
         mix_before=(2, 50), # mix 2 times with 50uL before aspirating
         mix_after=(3, 75))  # mix 3 times with 75uL after dispensing
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 
@@ -625,10 +586,8 @@ An air gap can be performed after every aspirate by setting ``air_gap=int``, whe
         plate.wells('A2'),
         air_gap=20)         # add 20uL of air after each aspirate
 
-    for c in robot.commands():
-        print(c)
 
-will print out...
+will have the steps...
 
 .. code-block:: python
 

--- a/api/docs/source/complex commands.rst
+++ b/api/docs/source/complex commands.rst
@@ -14,7 +14,7 @@ The examples below will use the following set-up:
 
     plate = labware.load('96-flat', '1')
 
-    tiprack = labware.load('tiprack-200ul', '2')
+    tiprack = labware.load('opentrons-tiprack-300ul', '2')
 
     pipette = instruments.P300_Single(
         mount='left',
@@ -55,17 +55,15 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 700 from <Well A2> to <Well B2>
-    Picking up tip <Well A1>
-    Aspirating 200.0 uL from <Well A2> at 1 speed
-    Dispensing 200.0 uL into <Well B2>
-    Aspirating 200.0 uL from <Well A2> at 1 speed
-    Dispensing 200.0 uL into <Well B2>
-    Aspirating 150.0 uL from <Well A2> at 1 speed
-    Dispensing 150.0 uL into <Well B2>
-    Aspirating 150.0 uL from <Well A2> at 1 speed
-    Dispensing 150.0 uL into <Well B2>
-    Dropping tip <Well A1>
+    Transferring 700 from well A2 in "1" to well B2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 300.0 uL from well A2 in "1" at 1 speed
+    Dispensing 300.0 uL into well B2 in "1"
+    Aspirating 200.0 uL from well A2 in "1" at 1 speed
+    Dispensing 200.0 uL into well B2 in "1"
+    Aspirating 200.0 uL from well A2 in "1" at 1 speed
+    Dispensing 200.0 uL into well B2 in "1"
+    Dropping tip well A1 in "12"
 
 Multiple Wells
 --------------
@@ -83,33 +81,25 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3><Well A4><Well A5><Well A6><Well A7><Well A8><Well A9><Well A10><Well A11><Well A12>> to <WellSeries: <Well B1><Well B2><Well B3><Well B4><Well B5><Well B6><Well B7><Well B8><Well B9><Well B10><Well B11><Well B12>>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
-    Aspirating 100.0 uL from <Well A2> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Aspirating 100.0 uL from <Well A3> at 1 speed
-    Dispensing 100.0 uL into <Well B3>
-    Aspirating 100.0 uL from <Well A4> at 1 speed
-    Dispensing 100.0 uL into <Well B4>
-    Aspirating 100.0 uL from <Well A5> at 1 speed
-    Dispensing 100.0 uL into <Well B5>
-    Aspirating 100.0 uL from <Well A6> at 1 speed
-    Dispensing 100.0 uL into <Well B6>
-    Aspirating 100.0 uL from <Well A7> at 1 speed
-    Dispensing 100.0 uL into <Well B7>
-    Aspirating 100.0 uL from <Well A8> at 1 speed
-    Dispensing 100.0 uL into <Well B8>
-    Aspirating 100.0 uL from <Well A9> at 1 speed
-    Dispensing 100.0 uL into <Well B9>
-    Aspirating 100.0 uL from <Well A10> at 1 speed
-    Dispensing 100.0 uL into <Well B10>
-    Aspirating 100.0 uL from <Well A11> at 1 speed
-    Dispensing 100.0 uL into <Well B11>
-    Aspirating 100.0 uL from <Well A12> at 1 speed
-    Dispensing 100.0 uL into <Well B12>
-    Dropping tip <Well A1>
+    Transferring 100 from wells A1...H1 in "1" to wells A2...H2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well A2 in "1"
+    Aspirating 100.0 uL from well B1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Aspirating 100.0 uL from well C1 in "1" at 1 speed
+    Dispensing 100.0 uL into well C2 in "1"
+    Aspirating 100.0 uL from well D1 in "1" at 1 speed
+    Dispensing 100.0 uL into well D2 in "1"
+    Aspirating 100.0 uL from well E1 in "1" at 1 speed
+    Dispensing 100.0 uL into well E2 in "1"
+    Aspirating 100.0 uL from well F1 in "1" at 1 speed
+    Dispensing 100.0 uL into well F2 in "1"
+    Aspirating 100.0 uL from well G1 in "1" at 1 speed
+    Dispensing 100.0 uL into well G2 in "1"
+    Aspirating 100.0 uL from well H1 in "1" at 1 speed
+    Dispensing 100.0 uL into well H2 in "1"
+    Dropping tip well A1 in "12"
 
 One to Many
 -------------
@@ -118,7 +108,7 @@ You can transfer from a single source to multiple destinations, and the other wa
 
 .. code-block:: python
 
-    pipette.transfer(100, plate.wells('A1'), plate.rows('2'))
+    pipette.transfer(100, plate.wells('A1'), plate.cols('2'))
 
     for c in robot.commands():
         print(c)
@@ -127,37 +117,37 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well A2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well C2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well D2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well E2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well F2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well G2>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well H2>
-    Dropping tip <Well A1>
+    Transferring 100 from well A1 in "1" to wells A2...H2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well A2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well C2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well D2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well E2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well F2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well G2 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well H2 in "1"
+    Dropping tip well A1 in "12"
 
 Few to Many
 -------------
 
-What happens if, for example, you tell your pipette to transfer from 4 source wells to 2 destination wells? The transfer command will attempt to divide the wells evenly, or raise an error if the number of wells aren't divisible.
+What happens if, for example, you tell your pipette to transfer from 2 source wells to 4 destination wells? The transfer command will attempt to divide the wells evenly, or raise an error if the number of wells aren't divisible.
 
 .. code-block:: python
 
     pipette.transfer(
         100,
-        plate.wells('A1', 'A2', 'A3', 'A4'),
-        plate.wells('B1', 'B2'))
+        plate.wells('A1', 'A2'),
+        plate.wells('B1', 'B2', 'B3', 'B4'))
 
     for c in robot.commands():
         print(c)
@@ -166,17 +156,17 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3><Well A4>> to <WellSeries: <Well B1><Well B2>>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
-    Aspirating 100.0 uL from <Well A2> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
-    Aspirating 100.0 uL from <Well A3> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Aspirating 100.0 uL from <Well A4> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Dropping tip <Well A1>
+    Transferring 100 from wells A1...A2 in "1" to wells B1...B4 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B1 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Aspirating 100.0 uL from well A2 in "1" at 1 speed
+    Dispensing 100.0 uL into well B3 in "1"
+    Aspirating 100.0 uL from well A2 in "1" at 1 speed
+    Dispensing 100.0 uL into well B4 in "1"
+    Dropping tip well A1 in "12"
 
 List of Volumes
 ---------------
@@ -197,15 +187,15 @@ will print out...
 
 .. code-block:: python
 
-    Transferring [20, 40, 60] from <Well A1> to <WellSeries: <Well B1><Well B2><Well B3>>
-    Picking up tip <Well A1>
-    Aspirating 20.0 uL from <Well A1> at 1 speed
-    Dispensing 20.0 uL into <Well B1>
-    Aspirating 40.0 uL from <Well A1> at 1 speed
-    Dispensing 40.0 uL into <Well B2>
-    Aspirating 60.0 uL from <Well A1> at 1 speed
-    Dispensing 60.0 uL into <Well B3>
-    Dropping tip <Well A1>
+    Transferring [20, 40, 60] from well A1 in "1" to wells B1...B3 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 20.0 uL from well A1 in "1" at 1 speed
+    Dispensing 20.0 uL into well B1 in "1"
+    Aspirating 40.0 uL from well A1 in "1" at 1 speed
+    Dispensing 40.0 uL into well B2 in "1"
+    Aspirating 60.0 uL from well A1 in "1" at 1 speed
+    Dispensing 60.0 uL into well B3 in "1"
+    Dropping tip well A1 in "12"
 
 Volume Gradient
 ---------------
@@ -217,7 +207,7 @@ Create a linear gradient between a start and ending volume (uL). The start and e
     pipette.transfer(
         (100, 30),
         plate.wells('A1'),
-        plate.rows('2'))
+        plate.cols('2'))
 
     for c in robot.commands():
         print(c)
@@ -226,25 +216,25 @@ will print out...
 
 .. code-block:: python
 
-    Transferring (100, 30) from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well A2>
-    Aspirating 90.0 uL from <Well A1> at 1 speed
-    Dispensing 90.0 uL into <Well B2>
-    Aspirating 80.0 uL from <Well A1> at 1 speed
-    Dispensing 80.0 uL into <Well C2>
-    Aspirating 70.0 uL from <Well A1> at 1 speed
-    Dispensing 70.0 uL into <Well D2>
-    Aspirating 60.0 uL from <Well A1> at 1 speed
-    Dispensing 60.0 uL into <Well E2>
-    Aspirating 50.0 uL from <Well A1> at 1 speed
-    Dispensing 50.0 uL into <Well F2>
-    Aspirating 40.0 uL from <Well A1> at 1 speed
-    Dispensing 40.0 uL into <Well G2>
-    Aspirating 30.0 uL from <Well A1> at 1 speed
-    Dispensing 30.0 uL into <Well H2>
-    Dropping tip <Well A1>
+    Transferring (100, 30) from well A1 in "1" to wells A2...H2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well A2 in "1"
+    Aspirating 90.0 uL from well A1 in "1" at 1 speed
+    Dispensing 90.0 uL into well B2 in "1"
+    Aspirating 80.0 uL from well A1 in "1" at 1 speed
+    Dispensing 80.0 uL into well C2 in "1"
+    Aspirating 70.0 uL from well A1 in "1" at 1 speed
+    Dispensing 70.0 uL into well D2 in "1"
+    Aspirating 60.0 uL from well A1 in "1" at 1 speed
+    Dispensing 60.0 uL into well E2 in "1"
+    Aspirating 50.0 uL from well A1 in "1" at 1 speed
+    Dispensing 50.0 uL into well F2 in "1"
+    Aspirating 40.0 uL from well A1 in "1" at 1 speed
+    Dispensing 40.0 uL into well G2 in "1"
+    Aspirating 30.0 uL from well A1 in "1" at 1 speed
+    Dispensing 30.0 uL into well H2 in "1"
+    Dropping tip well A1 in "12"
 
 **********************
 
@@ -260,7 +250,7 @@ Volumes going to the same destination well are combined within the same tip, so 
 
 .. code-block:: python
 
-    pipette.consolidate(30, plate.rows('2'), plate.wells('A1'))
+    pipette.consolidate(30, plate.cols('2'), plate.wells('A1'))
 
     for c in robot.commands():
         print(c)
@@ -269,26 +259,25 @@ will print out...
 
 .. code-block:: python
 
-    Consolidating 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <Well A1>
-    Transferring 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <Well A1>
-    Picking up tip <Well A1>
-    Aspirating 30.0 uL from <Well A2> at 1 speed
-    Aspirating 30.0 uL from <Well B2> at 1 speed
-    Aspirating 30.0 uL from <Well C2> at 1 speed
-    Aspirating 30.0 uL from <Well D2> at 1 speed
-    Aspirating 30.0 uL from <Well E2> at 1 speed
-    Aspirating 30.0 uL from <Well F2> at 1 speed
-    Dispensing 180.0 uL into <Well A1>
-    Aspirating 30.0 uL from <Well G2> at 1 speed
-    Aspirating 30.0 uL from <Well H2> at 1 speed
-    Dispensing 60.0 uL into <Well A1>
-    Dropping tip <Well A1>
+    Consolidating 30 from wells A2...H2 in "1" to well A1 in "1"
+    Transferring 30 from wells A2...H2 in "1" to well A1 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 30.0 uL from well A2 in "1" at 1 speed
+    Aspirating 30.0 uL from well B2 in "1" at 1 speed
+    Aspirating 30.0 uL from well C2 in "1" at 1 speed
+    Aspirating 30.0 uL from well D2 in "1" at 1 speed
+    Aspirating 30.0 uL from well E2 in "1" at 1 speed
+    Aspirating 30.0 uL from well F2 in "1" at 1 speed
+    Aspirating 30.0 uL from well G2 in "1" at 1 speed
+    Aspirating 30.0 uL from well H2 in "1" at 1 speed
+    Dispensing 240.0 uL into well A1 in "1"
+    Dropping tip well A1 in "12"
 
 If there are multiple destination wells, the pipette will never combine their volumes into the same tip.
 
 .. code-block:: python
 
-    pipette.consolidate(30, plate.rows('2'), plate.wells('A1', 'A2'))
+    pipette.consolidate(30, plate.cols('1'), plate.wells('A1', 'A2'))
 
     for c in robot.commands():
         print(c)
@@ -297,20 +286,20 @@ will print out...
 
 .. code-block:: python
 
-    Consolidating 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <WellSeries: <Well A1><Well A2>>
-    Transferring 30 from <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>> to <WellSeries: <Well A1><Well A2>>
-    Picking up tip <Well A1>
-    Aspirating 30.0 uL from <Well A2> at 1 speed
-    Aspirating 30.0 uL from <Well B2> at 1 speed
-    Aspirating 30.0 uL from <Well C2> at 1 speed
-    Aspirating 30.0 uL from <Well D2> at 1 speed
-    Dispensing 120.0 uL into <Well A1>
-    Aspirating 30.0 uL from <Well E2> at 1 speed
-    Aspirating 30.0 uL from <Well F2> at 1 speed
-    Aspirating 30.0 uL from <Well G2> at 1 speed
-    Aspirating 30.0 uL from <Well H2> at 1 speed
-    Dispensing 120.0 uL into <Well A2>
-    Dropping tip <Well A1>
+    Consolidating 30 from wells A1...H1 in "1" to wells A1...A2 in "1"
+    Transferring 30 from wells A1...H1 in "1" to wells A1...A2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 30.0 uL from well A1 in "1" at 1 speed
+    Aspirating 30.0 uL from well B1 in "1" at 1 speed
+    Aspirating 30.0 uL from well C1 in "1" at 1 speed
+    Aspirating 30.0 uL from well D1 in "1" at 1 speed
+    Dispensing 120.0 uL into well A1 in "1"
+    Aspirating 30.0 uL from well E1 in "1" at 1 speed
+    Aspirating 30.0 uL from well F1 in "1" at 1 speed
+    Aspirating 30.0 uL from well G1 in "1" at 1 speed
+    Aspirating 30.0 uL from well H1 in "1" at 1 speed
+    Dispensing 120.0 uL into well A2 in "1"
+    Dropping tip well A1 in "12"
 
 Distribute
 -----------
@@ -319,7 +308,7 @@ Volumes from the same source well are combined within the same tip, so that one 
 
 .. code-block:: python
 
-    pipette.distribute(55, plate.wells('A1'), plate.rows('2'))
+    pipette.distribute(55, plate.wells('A1'), plate.rows('A'))
 
     for c in robot.commands():
         print(c)
@@ -328,28 +317,35 @@ will print out...
 
 .. code-block:: python
 
-    Distributing 55 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Transferring 55 from <Well A1> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 165.0 uL from <Well A1> at 1 speed
-    Dispensing 55.0 uL into <Well A2>
-    Dispensing 55.0 uL into <Well B2>
-    Dispensing 55.0 uL into <Well C2>
-    Aspirating 165.0 uL from <Well A1> at 1 speed
-    Dispensing 55.0 uL into <Well D2>
-    Dispensing 55.0 uL into <Well E2>
-    Dispensing 55.0 uL into <Well F2>
-    Aspirating 110.0 uL from <Well A1> at 1 speed
-    Dispensing 55.0 uL into <Well G2>
-    Dispensing 55.0 uL into <Well H2>
-    Dropping tip <Well A1>
+    Distributing 55 from well A1 in "1" to wells A1...A12 in "1"
+    Transferring 55 from well A1 in "1" to wells A1...A12 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 250.0 uL from well A1 in "1" at 1 speed
+    Dispensing 55.0 uL into well A1 in "1"
+    Dispensing 55.0 uL into well A2 in "1"
+    Dispensing 55.0 uL into well A3 in "1"
+    Dispensing 55.0 uL into well A4 in "1"
+    Blowing out at well A1 in "12"
+    Aspirating 250.0 uL from well A1 in "1" at 1 speed
+    Dispensing 55.0 uL into well A5 in "1"
+    Dispensing 55.0 uL into well A6 in "1"
+    Dispensing 55.0 uL into well A7 in "1"
+    Dispensing 55.0 uL into well A8 in "1"
+    Blowing out at well A1 in "12"
+    Aspirating 250.0 uL from well A1 in "1" at 1 speed
+    Dispensing 55.0 uL into well A9 in "1"
+    Dispensing 55.0 uL into well A10 in "1"
+    Dispensing 55.0 uL into well A11 in "1"
+    Dispensing 55.0 uL into well A12 in "1"
+    Blowing out at well A1 in "12"
+    Dropping tip well A1 in "12"
 
 
 If there are multiple source wells, the pipette will never combine their volumes into the same tip.
 
 .. code-block:: python
 
-    pipette.distribute(30, plate.wells('A1', 'A2'), plate.rows('2'))
+    pipette.distribute(30, plate.wells('A1', 'A2'), plate.rows('A'))
 
     for c in robot.commands():
         print(c)
@@ -358,32 +354,38 @@ will print out...
 
 .. code-block:: python
 
-    Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 120.0 uL from <Well A1> at 1 speed
-    Dispensing 30.0 uL into <Well A2>
-    Dispensing 30.0 uL into <Well B2>
-    Dispensing 30.0 uL into <Well C2>
-    Dispensing 30.0 uL into <Well D2>
-    Aspirating 120.0 uL from <Well A2> at 1 speed
-    Dispensing 30.0 uL into <Well E2>
-    Dispensing 30.0 uL into <Well F2>
-    Dispensing 30.0 uL into <Well G2>
-    Dispensing 30.0 uL into <Well H2>
-    Dropping tip <Well A1>
+    Distributing 30 from wells A1...A2 in "1" to wells A1...A12 in "1"
+    Transferring 30 from wells A1...A2 in "1" to wells A1...A12 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 210.0 uL from well A1 in "1" at 1 speed
+    Dispensing 30.0 uL into well A1 in "1"
+    Dispensing 30.0 uL into well A2 in "1"
+    Dispensing 30.0 uL into well A3 in "1"
+    Dispensing 30.0 uL into well A4 in "1"
+    Dispensing 30.0 uL into well A5 in "1"
+    Dispensing 30.0 uL into well A6 in "1"
+    Blowing out at well A1 in "12"
+    Aspirating 210.0 uL from well A2 in "1" at 1 speed
+    Dispensing 30.0 uL into well A7 in "1"
+    Dispensing 30.0 uL into well A8 in "1"
+    Dispensing 30.0 uL into well A9 in "1"
+    Dispensing 30.0 uL into well A10 in "1"
+    Dispensing 30.0 uL into well A11 in "1"
+    Dispensing 30.0 uL into well A12 in "1"
+    Blowing out at well A1 in "12"
+    Dropping tip well A1 in "12"
 
 Disposal Volume
 ---------------
 
-When dispensing multiple times from the same tip, it is recommended to aspirate an extra amount of liquid to be disposed of after distributing. This added ``disposal_vol`` can be set as an optional argument.
+When dispensing multiple times from the same tip, it is recommended to aspirate an extra amount of liquid to be disposed of after distributing. This added ``disposal_vol`` can be set as an optional argument. There is a default disposal volume (equal to the pipette's minimum volume), which will be blown out at the trash after the dispenses.
 
 .. code-block:: python
 
     pipette.distribute(
         30,
         plate.wells('A1', 'A2'),
-        plate.rows('2'),
+        plate.cols('2'),
         disposal_vol=10)   # include extra liquid to make dispenses more accurate
 
     for c in robot.commands():
@@ -393,59 +395,22 @@ will print out...
 
 .. code-block:: python
 
-    Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 130.0 uL from <Well A1> at 1 speed
-    Dispensing 30.0 uL into <Well A2>
-    Dispensing 30.0 uL into <Well B2>
-    Dispensing 30.0 uL into <Well C2>
-    Dispensing 30.0 uL into <Well D2>
-    Blowing out at <Well A1>
-    Aspirating 130.0 uL from <Well A2> at 1 speed
-    Dispensing 30.0 uL into <Well E2>
-    Dispensing 30.0 uL into <Well F2>
-    Dispensing 30.0 uL into <Well G2>
-    Dispensing 30.0 uL into <Well H2>
-    Blowing out at <Well A1>
-    Dropping tip <Well A1>
-
-.. note::
-
-    If you do not specify a ``disposal_vol``, the pipette will by default use a ``disposal_vol`` equal to it's ``min_volume``. This tutorial has not given the pipette any ``min_volume``, so below is an example of allowing the pipette's ``min_volume`` to be used as a default for ``disposal_vol``.
-
-.. code-block:: python
-
-    pipette.min_volume = 20  # `min_volume` is used as default to `disposal_vol`
-
-    pipette.distribute(
-        30,
-        plate.wells('A1', 'A2'),
-        plate.rows('2'))
-
-    for c in robot.commands():
-        print(c)
-
-will print out...
-
-.. code-block:: python
-
-    Distributing 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Transferring 30 from <WellSeries: <Well A1><Well A2>> to <WellSeries: <Well A2><Well B2><Well C2><Well D2><Well E2><Well F2><Well G2><Well H2>>
-    Picking up tip <Well A1>
-    Aspirating 140.0 uL from <Well A1> at 1 speed
-    Dispensing 30.0 uL into <Well A2>
-    Dispensing 30.0 uL into <Well B2>
-    Dispensing 30.0 uL into <Well C2>
-    Dispensing 30.0 uL into <Well D2>
-    Blowing out at <Well A1>
-    Aspirating 140.0 uL from <Well A2> at 1 speed
-    Dispensing 30.0 uL into <Well E2>
-    Dispensing 30.0 uL into <Well F2>
-    Dispensing 30.0 uL into <Well G2>
-    Dispensing 30.0 uL into <Well H2>
-    Blowing out at <Well A1>
-    Dropping tip <Well A1>
+    Distributing 30 from wells A1...A2 in "1" to wells A2...H2 in "1"
+    Transferring 30 from wells A1...A2 in "1" to wells A2...H2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 130.0 uL from well A1 in "1" at 1 speed
+    Dispensing 30.0 uL into well A2 in "1"
+    Dispensing 30.0 uL into well B2 in "1"
+    Dispensing 30.0 uL into well C2 in "1"
+    Dispensing 30.0 uL into well D2 in "1"
+    Blowing out at well A1 in "12"
+    Aspirating 130.0 uL from well A2 in "1" at 1 speed
+    Dispensing 30.0 uL into well E2 in "1"
+    Dispensing 30.0 uL into well F2 in "1"
+    Dispensing 30.0 uL into well G2 in "1"
+    Dispensing 30.0 uL into well H2 in "1"
+    Blowing out at well A1 in "12"
+    Dropping tip well A1 in "12"
 
 **********************
 
@@ -476,19 +441,19 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3>> to <WellSeries: <Well B1><Well B2><Well B3>>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
-    Dropping tip <Well A1>
-    Picking up tip <Well B1>
-    Aspirating 100.0 uL from <Well A2> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Dropping tip <Well A1>
-    Picking up tip <Well C1>
-    Aspirating 100.0 uL from <Well A3> at 1 speed
-    Dispensing 100.0 uL into <Well B3>
-    Dropping tip <Well A1>
+    Transferring 100 from wells A1...A3 in "1" to wells B1...B3 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B1 in "1"
+    Dropping tip well A1 in "12"
+    Picking up tip well B1 in "2"
+    Aspirating 100.0 uL from well A2 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Dropping tip well A1 in "12"
+    Picking up tip well C1 in "2"
+    Aspirating 100.0 uL from well A3 in "1" at 1 speed
+    Dispensing 100.0 uL into well B3 in "1"
+    Dropping tip well A1 in "12"
 
 Never Get a New Tip
 ------------------------
@@ -497,11 +462,15 @@ For scenarios where you instead are calling ``pick_up_tip()`` and ``drop_tip()``
 
 .. code-block:: python
 
+    pipette.pick_up_tip()
+    ...
     pipette.transfer(
         100,
         plate.wells('A1', 'A2', 'A3'),
         plate.wells('B1', 'B2', 'B3'),
         new_tip='never')    # never pick up or drop a tip
+    ...
+    pipette.drop_tip()
 
     for c in robot.commands():
         print(c)
@@ -510,13 +479,17 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <WellSeries: <Well A1><Well A2><Well A3>> to <WellSeries: <Well B1><Well B2><Well B3>>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
-    Aspirating 100.0 uL from <Well A2> at 1 speed
-    Dispensing 100.0 uL into <Well B2>
-    Aspirating 100.0 uL from <Well A3> at 1 speed
-    Dispensing 100.0 uL into <Well B3>
+    Picking up tip well A1 in "2"
+    ...
+    Transferring 100 from wells A1...A3 in "1" to wells B1...B3 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B1 in "1"
+    Aspirating 100.0 uL from well A2 in "1" at 1 speed
+    Dispensing 100.0 uL into well B2 in "1"
+    Aspirating 100.0 uL from well A3 in "1" at 1 speed
+    Dispensing 100.0 uL into well B3 in "1"
+    ...
+    Dropping tip well A1 in "12"
 
 Trash or Return Tip
 ------------------------
@@ -538,12 +511,12 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <Well B1>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well B1>
+    Transferring 100 from well A1 in "1" to well B1 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well B1 in "1"
     Returning tip
-    Dropping tip <Well A1>
+    Dropping tip well A1 in "2"
 
 Touch Tip
 ---------
@@ -565,13 +538,13 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <Well A2>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
+    Transferring 100 from well A1 in "1" to well A2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
     Touching tip
-    Dispensing 100.0 uL into <Well A2>
+    Dispensing 100.0 uL into well A2 in "1"
     Touching tip
-    Dropping tip <Well A1>
+    Dropping tip well A1 in "12"
 
 Blow Out
 --------
@@ -593,12 +566,12 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <Well A2>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well A2>
+    Transferring 100 from well A1 in "1" to well A2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well A2 in "1"
     Blowing out
-    Dropping tip <Well A1>
+    Dropping tip well A1 in "12"
 
 Mix Before/After
 ----------------
@@ -621,23 +594,23 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <Well A2>
-    Picking up tip <Well A1>
+    Transferring 100 from well A1 in "1" to well A2 in "1"
+    Picking up tip well A1 in "2"
     Mixing 2 times with a volume of 50ul
-    Aspirating 50 uL from <Well A1> at 1.0 speed
-    Dispensing 50 uL into None
-    Aspirating 50 uL from None at 1.0 speed
-    Dispensing 50 uL into None
-    Aspirating 100.0 uL from <Well A1> at 1 speed
-    Dispensing 100.0 uL into <Well A2>
+    Aspirating 50 uL from well A1 in "1" at 1.0 speed
+    Dispensing 50 uL into well A1 in "1"
+    Aspirating 50 uL from well A1 in "1" at 1.0 speed
+    Dispensing 50 uL into well A1 in "1"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
+    Dispensing 100.0 uL into well A2 in "1"
     Mixing 3 times with a volume of 75ul
-    Aspirating 75 uL from <Well A2> at 1.0 speed
-    Dispensing 75 uL into None
-    Aspirating 75 uL from None at 1.0 speed
-    Dispensing 75 uL into None
-    Aspirating 75 uL from None at 1.0 speed
-    Dispensing 75 uL into None
-    Dropping tip <Well A1>
+    Aspirating 75 uL from well A2 in "1" at 1.0 speed
+    Dispensing 75.0 uL into well A2 in "1"
+    Aspirating 75 uL from well A2 in "1" at 1.0 speed
+    Dispensing 75.0 uL into well A2 in "1"
+    Aspirating 75 uL from well A2 in "1" at 1.0 speed
+    Dispensing 75.0 uL into well A2 in "1"
+    Dropping tip well A1 in "12"
 
 Air Gap
 -------
@@ -659,11 +632,11 @@ will print out...
 
 .. code-block:: python
 
-    Transferring 100 from <Well A1> to <Well A2>
-    Picking up tip <Well A1>
-    Aspirating 100.0 uL from <Well A1> at 1 speed
+    Transferring 100 from well A1 in "1" to well A2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 100.0 uL from well A1 in "1" at 1 speed
     Air gap
-    Aspirating 20 uL from None at 1.0 speed
-    Dispensing 20 uL into <Well A2>
-    Dispensing 100.0 uL into <Well A2>
-    Dropping tip <Well A1>
+    Aspirating 20 uL from well A1 in "1" at 1.0 speed
+    Dispensing 20 uL into well A2 in "1"
+    Dispensing 100.0 uL into well A2 in "1"
+    Dropping tip well A1 in "12"


### PR DESCRIPTION
## overview

Some users have noticed inconsistencies in the Complex Liquid Handling commands doc. For example, it seems that some of the printouts were generated from OT-One API. @ethanfjones and I made these edits together

## changelog
Update tip rack load name from `tiprack-200ul` to `opentrons-tiprack-300ul`

Change code and printouts:
- *Large Volumes*
   - transfer volumes in the printout were inconsistent with our current API
- *Multiple Wells*
   - old printouts reflects `rows` rather than `cols` as described in the command
- *One To Many*
   - change code from `rows('2')` to `cols('2')` 
   - update printout to reflect code
- *Few To Many*
   - code previously reflected `many to few` (4 sources & 2 dests) rather than `few to many`
   - update to OT-2 printout
- *Consolidate*
   - change code from `rows('2')` to `cols('2')`  and update printout
- *Distribute*
   - introduce default disposal volume in description
   - change code from `rows('2')` to `rows('B')` and update printout

Update printouts *ONLY*:
-  *List of Volumes*
- *Volume Gradient*
- *Disposal Volume*
- *Always Get a New Tip*
- *Never Get a New Tip*
- *Trash or Return Tip*
- *Touch Tip*
- *Blow Out*
- *Mix Before/After*
- *Blow Out*

## review requests
Please check for correctness