### PR TITLE
refactor(labware-library): Add gallery and breadcrumbs to detail page

### DIFF
--- a/labware-library/src/components/App/Page.js
+++ b/labware-library/src/components/App/Page.js
@@ -1,48 +1,37 @@
 // @flow
 import * as React from 'react'
-import { Switch, Route } from 'react-router-dom'
+import cx from 'classnames'
 
-import { getDefinition } from '../../definitions'
-import { getFilters } from '../../filters'
-import { getPublicPath } from '../../public-path'
-import Sidebar from '../Sidebar'
-import LabwareList, { NoResults } from '../LabwareList'
-import LabwareDetails from '../LabwareDetails'
 import styles from './styles.css'
 
-import type { Location } from 'react-router-dom'
-
 export type PageProps = {
-  location: Location,
+  sidebarLargeOnly: boolean,
+  sidebar: React.Node,
+  content: React.Node,
 }
 
 export default function Page(props: PageProps) {
-  const filters = getFilters(props.location)
+  const { sidebarLargeOnly, sidebar, content } = props
 
   return (
-    <div className={styles.page_scroller}>
-      <div className={styles.page}>
-        <Sidebar filters={filters} />
-        <section className={styles.content}>
-          <div className={styles.content_container}>
-            <Switch>
-              <Route
-                path={`${getPublicPath()}:loadName`}
-                render={routeProps => {
-                  const { loadName } = routeProps.match.params
-                  const definition = getDefinition(loadName)
-
-                  return definition ? (
-                    <LabwareDetails definition={definition} />
-                  ) : (
-                    <NoResults />
-                  )
-                }}
-              />
-              <Route render={() => <LabwareList filters={filters} />} />
-            </Switch>
+    <div className={styles.page}>
+      <div className={styles.content_scroller}>
+        <div className={styles.content_width_limiter}>
+          <div
+            className={cx(styles.sidebar_container, {
+              [styles.sidebar_large_only]: sidebarLargeOnly,
+            })}
+          >
+            {sidebar}
           </div>
-        </section>
+          <section
+            className={cx(styles.content_container, {
+              [styles.sidebar_large_only]: sidebarLargeOnly,
+            })}
+          >
+            {content}
+          </section>
+        </div>
       </div>
     </div>
   )

--- a/labware-library/src/components/App/__tests__/App.test.js
+++ b/labware-library/src/components/App/__tests__/App.test.js
@@ -8,12 +8,26 @@ import { App } from '..'
 jest.mock('../../../definitions')
 
 describe('App', () => {
-  test('component renders', () => {
+  test('component renders without definition', () => {
     const tree = shallow(
       <App
         location={({ search: '' }: any)}
         history={({}: any)}
         match={({}: any)}
+        definition={null}
+      />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('component renders with definition', () => {
+    const tree = shallow(
+      <App
+        location={({ search: '' }: any)}
+        history={({}: any)}
+        match={({}: any)}
+        definition={({}: any)}
       />
     )
 

--- a/labware-library/src/components/App/__tests__/Page.test.js
+++ b/labware-library/src/components/App/__tests__/Page.test.js
@@ -8,8 +8,16 @@ import Page from '../Page'
 jest.mock('../../../definitions')
 
 describe('Page', () => {
-  test('component renders', () => {
-    const tree = shallow(<Page location={({ search: '' }: any)} />)
+  test('component renders sidebar and content', () => {
+    const tree = shallow(
+      <Page sidebar="foo" content="bar" sidebarLargeOnly={false} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('component renders with sidebarLargeOnly CSS', () => {
+    const tree = shallow(<Page sidebar="foo" content="bar" sidebarLargeOnly />)
 
     expect(tree).toMatchSnapshot()
   })

--- a/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
+++ b/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
@@ -1,16 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`App component renders 1`] = `
+exports[`App component renders with definition 1`] = `
+<div
+  className="app breadcrumbs_visible"
+>
+  <Nav />
+  <Breadcrumbs
+    definition={Object {}}
+  />
+  <Page
+    content={
+      <LabwareDetails
+        definition={Object {}}
+      />
+    }
+    sidebar={
+      <Sidebar
+        filters={
+          Object {
+            "category": "all",
+            "manufacturer": "all",
+          }
+        }
+      />
+    }
+    sidebarLargeOnly={true}
+  />
+</div>
+`;
+
+exports[`App component renders without definition 1`] = `
 <div
   className="app"
 >
   <Nav />
   <Page
-    location={
-      Object {
-        "search": "",
-      }
+    content={
+      <LabwareList
+        filters={
+          Object {
+            "category": "all",
+            "manufacturer": "all",
+          }
+        }
+      />
     }
+    sidebar={
+      <Sidebar
+        filters={
+          Object {
+            "category": "all",
+            "manufacturer": "all",
+          }
+        }
+      />
+    }
+    sidebarLargeOnly={false}
   />
 </div>
 `;

--- a/labware-library/src/components/App/__tests__/__snapshots__/Page.test.js.snap
+++ b/labware-library/src/components/App/__tests__/__snapshots__/Page.test.js.snap
@@ -1,37 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Page component renders 1`] = `
+exports[`Page component renders sidebar and content 1`] = `
 <div
-  className="page_scroller"
+  className="page"
 >
   <div
-    className="page"
+    className="content_scroller"
   >
-    <Sidebar
-      filters={
-        Object {
-          "category": "all",
-          "manufacturer": "all",
-        }
-      }
-    />
-    <section
-      className="content"
+    <div
+      className="content_width_limiter"
     >
       <div
+        className="sidebar_container"
+      >
+        foo
+      </div>
+      <section
         className="content_container"
       >
-        <Switch>
-          <Route
-            path="/:loadName"
-            render={[Function]}
-          />
-          <Route
-            render={[Function]}
-          />
-        </Switch>
+        bar
+      </section>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Page component renders with sidebarLargeOnly CSS 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="content_scroller"
+  >
+    <div
+      className="content_width_limiter"
+    >
+      <div
+        className="sidebar_container sidebar_large_only"
+      >
+        foo
       </div>
-    </section>
+      <section
+        className="content_container sidebar_large_only"
+      >
+        bar
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/labware-library/src/components/App/index.js
+++ b/labware-library/src/components/App/index.js
@@ -2,20 +2,57 @@
 // main application wrapper component
 import * as React from 'react'
 import { hot } from 'react-hot-loader/root'
+import cx from 'classnames'
 
-import Nav from '../Nav'
+import { DefinitionRoute } from '../../definitions'
+import { getFilters } from '../../filters'
+import Nav, { Breadcrumbs } from '../Nav'
+import Sidebar from '../Sidebar'
 import Page from './Page'
+import LabwareList from '../LabwareList'
+import LabwareDetails from '../LabwareDetails'
 import styles from './styles.css'
 
-import type { ContextRouter } from 'react-router-dom'
+import type { DefinitionRouteRenderProps } from '../../definitions'
 
-export function App(props: ContextRouter) {
-  return (
-    <div className={styles.app}>
-      <Nav />
-      <Page location={props.location} />
-    </div>
-  )
+export class App extends React.Component<DefinitionRouteRenderProps> {
+  componentDidUpdate(prevProps: DefinitionRouteRenderProps): void {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  render() {
+    const { definition, location } = this.props
+    const filters = getFilters(location)
+    const breadcrumbsVisibile = Boolean(definition)
+
+    return (
+      <div
+        className={cx(styles.app, {
+          [styles.breadcrumbs_visible]: breadcrumbsVisibile,
+        })}
+      >
+        <Nav />
+        {breadcrumbsVisibile && <Breadcrumbs definition={definition} />}
+        <Page
+          sidebarLargeOnly={breadcrumbsVisibile}
+          sidebar={<Sidebar filters={filters} />}
+          content={
+            definition ? (
+              <LabwareDetails definition={definition} />
+            ) : (
+              <LabwareList filters={filters} />
+            )
+          }
+        />
+      </div>
+    )
+  }
 }
 
-export default hot(App)
+export function AppWithRoute() {
+  return <DefinitionRoute render={props => <App {...props} />} />
+}
+
+export default hot(AppWithRoute)

--- a/labware-library/src/components/App/styles.css
+++ b/labware-library/src/components/App/styles.css
@@ -8,46 +8,82 @@
 
   /* Nav height */
   padding-top: var(--size-2);
-}
 
-.page_scroller {
-  height: 100%;
-  overflow-y: scroll;
+  &.breadcrumbs_visible {
+    padding-top: calc(2 * var(--size-2));
+  }
 }
 
 .page {
-  margin: auto;
-  max-width: var(--screen-width-xlarge);
+  position: relative;
 }
 
-.content {
+.sidebar_container {
+  padding: var(--spacing-7) var(--spacing-3);
+
+  &.sidebar_large_only {
+    display: none;
+  }
+}
+
+.content_width_limiter {
+  max-width: var(--screen-width-xlarge);
+  margin: auto;
+}
+
+.content_container {
   width: 100%;
-  padding: 0 var(--spacing-3);
-  margin: 0 auto;
+  padding: var(--spacing-3);
+  margin: 0;
 }
 
 @media (--medium) {
-  .content {
+  .page {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .sidebar_container {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--size-3);
+    padding-left: var(--spacing-7);
+    padding-right: var(--spacing-5);
+    overflow-y: auto;
+  }
+
+  .content_scroller {
+    height: 100%;
+    overflow-y: scroll;
+  }
+
+  .content_container {
     padding-top: var(--spacing-7);
     padding-right: var(--spacing-7);
 
     /* spacing + sidebar width */
     padding-left: calc(var(--size-3) + var(--spacing-5));
-  }
 
-  .content_container {
-    margin: 0 auto;
-    max-width: var(--size-5);
+    &.sidebar_large_only {
+      padding-left: var(--spacing-7);
+    }
   }
 }
 
 @media (--large) {
-  .content {
-    /* spacing + sidebar width */
-    padding-left: calc(var(--size-4) + var(--spacing-7));
+  .sidebar_container {
+    width: var(--size-4);
+    padding-left: var(--spacing-7);
+
+    &.sidebar_large_only {
+      display: block;
+    }
   }
 
-  .content_container {
-    max-width: 100%;
+  .content_container,
+  .content_container.sidebar_large_only {
+    /* spacing + sidebar width */
+    padding-left: calc(var(--size-4) + var(--spacing-7));
   }
 }

--- a/labware-library/src/components/LabwareDetails/index.js
+++ b/labware-library/src/components/LabwareDetails/index.js
@@ -2,6 +2,9 @@
 // full-width labware details
 import * as React from 'react'
 
+import { LabwareGallery, Tags, LoadName } from '../LabwareList'
+import styles from './styles.css'
+
 import type { LabwareDefinition } from '../../types'
 
 export type LabwareDetailsProps = {
@@ -9,5 +12,25 @@ export type LabwareDetailsProps = {
 }
 
 export default function LabwareDetails(props: LabwareDetailsProps) {
-  return <p>hello labware {props.definition.metadata.displayName}</p>
+  const { definition } = props
+  const { parameters, metadata } = definition
+
+  return (
+    <>
+      <div className={styles.gallery_container}>
+        <LabwareGallery definition={definition} />
+        <div className={styles.tags_container}>
+          <Tags definition={definition} />
+        </div>
+        <LoadName loadName={parameters.loadName} />
+      </div>
+      <div className={styles.details_container}>
+        <Title>{metadata.displayName}</Title>
+      </div>
+    </>
+  )
+}
+
+function Title(props: { children: React.Node }) {
+  return <h2 className={styles.title}>{props.children}</h2>
 }

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -29,7 +29,7 @@
     display: inline-block;
     vertical-align: top;
     width: var(--size-third);
-    max-width: var(--size-third);
+    max-width: var(--size-5);
   }
 
   .details_container {

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -1,0 +1,50 @@
+@import '@opentrons/components';
+@import '../../styles/breakpoints.css';
+@import '../../styles/spacing.css';
+
+.gallery_container {
+  width: var(--size-two-thirds);
+  max-width: var(--size-4);
+  margin: auto;
+}
+
+.tags_container {
+  margin-top: var(--spacing-3);
+}
+
+.details_container {
+  margin: var(--spacing-7) auto;
+  padding: 0 var(--spacing-5);
+}
+
+.title {
+  font-size: var(--fs-default);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-title);
+  color: var(--c-blue);
+}
+
+@media (--medium) {
+  .gallery_container {
+    display: inline-block;
+    vertical-align: top;
+    width: var(--size-third);
+    max-width: var(--size-third);
+  }
+
+  .details_container {
+    display: inline-block;
+    vertical-align: top;
+    width: var(--size-two-thirds);
+    margin: 0;
+    padding-top: var(--spacing-2);
+    padding-left: var(--spacing-7);
+    padding-right: 0;
+  }
+}
+
+@media (--large) {
+  .gallery_container {
+    width: var(--size-25p);
+  }
+}

--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -13,6 +13,7 @@ import { getPublicPath } from '../../public-path'
 import { Icon } from '@opentrons/components'
 import Gallery from './LabwareGallery'
 import LoadName from './LoadName'
+import Tags from './Tags'
 import styles from './styles.css'
 
 import type {
@@ -32,7 +33,6 @@ const EN_WIDTH = 'width'
 const EN_DIAMETER = 'diameter'
 const EN_DEPTH = 'depth'
 const EN_MAX_VOLUME = 'max volume'
-const EN_TAGS = 'tags'
 
 // TODO(mc, 2019-03-18): i18n
 const EN_NUM_WELLS_BY_CATEGORY = {
@@ -76,13 +76,17 @@ export default function LabwareCard(props: LabwareCardProps) {
     <li className={styles.card}>
       <TopBar {...props} />
       <Title {...props} />
-      <Gallery {...props} />
+      <div className={styles.gallery_container}>
+        <Gallery {...props} />
+      </div>
       <div className={styles.stats}>
         <PlateDimensions {...props} />
         <Wells {...props} />
         <WellProperties {...props} />
       </div>
-      <Tags {...props} />
+      <div className={styles.tags_container}>
+        <Tags {...props} />
+      </div>
       <LoadName loadName={definition.parameters.loadName} />
     </li>
   )
@@ -198,17 +202,6 @@ function WellProperties(props: LabwareCardProps) {
           </div>
         )
       })}
-    </div>
-  )
-}
-
-function Tags(props: LabwareCardProps) {
-  const tags = props.definition.metadata.tags || []
-
-  return (
-    <div className={styles.tags}>
-      <p className={styles.left_label}>{EN_TAGS}</p>
-      <p className={styles.value}>{tags.join(', ')}</p>
     </div>
   )
 }

--- a/labware-library/src/components/LabwareList/Tags.js
+++ b/labware-library/src/components/LabwareList/Tags.js
@@ -1,0 +1,25 @@
+// @flow
+
+import * as React from 'react'
+
+import styles from './styles.css'
+
+import type { LabwareDefinition } from '../../types'
+
+// TODO(mc, 2019-04-08): i18n
+const EN_TAGS = 'tags'
+
+export type TagsProps = {
+  definition: LabwareDefinition,
+}
+
+export default function Tags(props: TagsProps) {
+  const tags = props.definition.metadata.tags || []
+
+  return (
+    <div className={styles.tags}>
+      <p className={styles.left_label}>{EN_TAGS}</p>
+      <p className={styles.value}>{tags.join(', ')}</p>
+    </div>
+  )
+}

--- a/labware-library/src/components/LabwareList/index.js
+++ b/labware-library/src/components/LabwareList/index.js
@@ -2,12 +2,11 @@
 // main LabwareList component
 import * as React from 'react'
 
-import styles from './styles.css'
-
 import { getAllDefinitions } from '../../definitions'
 import { FILTER_OFF } from '../../filters'
 import LabwareCard from './LabwareCard'
 import NoResults from './NoResults'
+import styles from './styles.css'
 
 import type { FilterParams } from '../../types'
 
@@ -17,6 +16,11 @@ const filterMatches = (filter: ?string, value: string): boolean =>
 export type LabwareListProps = {
   filters: FilterParams,
 }
+
+export { default as NoResults } from './NoResults'
+export { default as LabwareGallery } from './LabwareGallery'
+export { default as LoadName } from './LoadName'
+export { default as Tags } from './Tags'
 
 export default function LabwareList(props: LabwareListProps) {
   const { category, manufacturer } = props.filters
@@ -36,5 +40,3 @@ export default function LabwareList(props: LabwareListProps) {
     </ul>
   )
 }
-
-export { NoResults }

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -7,7 +7,7 @@
 .card {
   display: block;
   width: 100%;
-  margin: var(--spacing-7) auto;
+  margin: 0 auto var(--spacing-7) auto;
   box-shadow: var(--shadow-1);
 }
 
@@ -43,7 +43,7 @@
   height: 1.5rem;
 }
 
-.gallery,
+.gallery_container,
 .stats,
 .well_dimensions,
 .well_volume {
@@ -51,11 +51,15 @@
   vertical-align: top;
 }
 
-.gallery {
+.gallery_container {
   width: var(--size-40p);
   padding-top: var(--spacing-1);
   padding-left: var(--spacing-5);
   padding-right: var(--spacing-6);
+}
+
+.gallery {
+  width: 100%;
 }
 
 .stats {
@@ -160,12 +164,15 @@
   line-height: var(--lh-title);
 }
 
+.tags_container {
+  margin-top: var(--spacing-6);
+  background-color: var(--c-bg-light);
+}
+
 .tags {
   display: flex;
   align-items: center;
-  margin-top: var(--spacing-6);
-  padding: var(--spacing-2) var(--spacing-5);
-  background-color: var(--c-bg-light);
+  padding: var(--spacing-3) var(--spacing-5);
 
   & .value {
     font-size: var(--fs-body-1);
@@ -223,6 +230,11 @@ button.load_name_button {
 }
 
 @media (--medium) {
+  .list {
+    margin: 0 auto;
+    max-width: var(--size-5);
+  }
+
   .card {
     margin-top: 0;
   }
@@ -234,6 +246,10 @@ button.load_name_button {
 }
 
 @media (--large) {
+  .list {
+    max-width: 100%;
+  }
+
   .card {
     display: inline-block;
     vertical-align: top;

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -232,7 +232,7 @@ button.load_name_button {
 @media (--medium) {
   .list {
     margin: 0 auto;
-    max-width: var(--size-5);
+    max-width: var(--size-6);
   }
 
   .card {

--- a/labware-library/src/components/Nav/Breadcrumbs.js
+++ b/labware-library/src/components/Nav/Breadcrumbs.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+
+import { getPublicPath } from '../../public-path'
+import styles from './styles.css'
+
+import type { LabwareDefinition } from '../../types'
+
+// TODO(mc, 2019-04-07): i18n
+const EN_LABWARE_LIBRARY = 'Labware Library'
+
+export type BreadcrumbsProps = {
+  definition: LabwareDefinition | null,
+}
+
+export default function Breadcrumbs(props: BreadcrumbsProps) {
+  const { definition } = props
+  if (!definition) return null
+
+  return (
+    <div className={styles.breadcrumbs}>
+      <div className={styles.breadcrumbs_contents}>
+        <Link to={getPublicPath()} className={styles.breadcrumbs_link}>
+          {EN_LABWARE_LIBRARY}
+        </Link>
+        <span className={styles.breadcrumbs_separator}>{' > '}</span>
+        <Link
+          to={`${getPublicPath()}${definition.parameters.loadName}`}
+          className={styles.breadcrumbs_link}
+        >
+          {definition.metadata.displayName}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/labware-library/src/components/Nav/index.js
+++ b/labware-library/src/components/Nav/index.js
@@ -5,6 +5,8 @@ import * as React from 'react'
 import Logo from './Logo'
 import styles from './styles.css'
 
+export { default as Breadcrumbs } from './Breadcrumbs'
+
 export default function Nav() {
   return (
     <nav className={styles.nav}>

--- a/labware-library/src/components/Nav/styles.css
+++ b/labware-library/src/components/Nav/styles.css
@@ -26,14 +26,56 @@
   height: 100%;
 }
 
+.breadcrumbs {
+  position: fixed;
+  top: var(--size-2);
+  left: 0;
+  right: 0;
+  z-index: 888;
+  width: 100%;
+  font-size: var(--fs-default);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-copy);
+  background-color: var(--c-lightest-gray);
+}
+
+.breadcrumbs_contents {
+  display: flex;
+  align-items: center;
+  height: var(--size-2);
+  padding: 0 var(--spacing-5);
+  overflow: visible;
+}
+
+.breadcrumbs_link {
+  @apply --transition-color;
+
+  color: var(--c-blue);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    color: color(var(--c-blue) alpha(0.6));
+  }
+}
+
+.breadcrumbs_separator {
+  flex: none;
+  margin: 0 var(--spacing-2);
+}
+
 @media (--medium) {
-  .nav_contents {
+  .nav_contents,
+  .breadcrumbs_contents {
     padding-left: var(--spacing-7);
+    padding-right: var(--spacing-7);
   }
 }
 
 @media (--large) {
-  .nav_contents {
+  .nav_contents,
+  .breadcrumbs_contents {
     margin: auto;
     max-width: var(--screen-width-xlarge);
   }

--- a/labware-library/src/components/Sidebar/styles.css
+++ b/labware-library/src/components/Sidebar/styles.css
@@ -5,7 +5,7 @@
 
 .sidebar {
   width: 100%;
-  padding: var(--spacing-7) var(--spacing-3) 0 var(--spacing-3);
+  height: 100%;
 }
 
 .labware_guide {
@@ -84,22 +84,16 @@
   line-height: var(--lh-title);
   font-weight: var(--fw-semibold);
 
-  &:hover,
-  &.selected {
+  &:hover {
     color: var(--c-highlight);
+  }
+
+  &.selected {
+    color: var(--c-selected-dark);
   }
 }
 
 @media (--medium) {
-  .sidebar {
-    position: fixed;
-    width: var(--size-3);
-    height: 100%;
-    padding-left: var(--spacing-7);
-    padding-right: var(--spacing-5);
-    overflow-y: auto;
-  }
-
   .filter_category {
     display: block;
     padding: 0;
@@ -108,12 +102,5 @@
   .filter_category_item {
     display: block;
     width: 100%;
-  }
-}
-
-@media (--large) {
-  .sidebar {
-    width: var(--size-4);
-    padding-left: var(--spacing-7);
   }
 }

--- a/labware-library/src/definitions.js
+++ b/labware-library/src/definitions.js
@@ -1,6 +1,12 @@
 // @flow
 // labware definition helpers
 // TODO(mc, 2019-03-18): move to shared-data?
+import * as React from 'react'
+import { Route } from 'react-router-dom'
+
+import { getPublicPath } from './public-path'
+
+import type { ContextRouter } from 'react-router-dom'
 import type { LabwareList, LabwareDefinition } from './types'
 
 // require all definitions in the definitions2 directory
@@ -29,4 +35,30 @@ export function getAllDefinitions(): LabwareList {
 export function getDefinition(loadName: ?string): LabwareDefinition | null {
   const def = getAllDefinitions().find(d => d.parameters.loadName === loadName)
   return def || null
+}
+
+export type DefinitionRouteRenderProps = {|
+  ...ContextRouter,
+  definition: LabwareDefinition | null,
+|}
+
+export type DefinitionRouteProps = {
+  render: (props: DefinitionRouteRenderProps) => React.Node,
+}
+
+export function DefinitionRoute(props: DefinitionRouteProps) {
+  return (
+    <Route
+      path={`${getPublicPath()}:loadName?`}
+      render={routeProps => {
+        const { loadName } = routeProps.match.params
+        const definition = getDefinition(loadName)
+
+        // TODO(mc, 2019-04-10): handle 404 if loadName exists but definition
+        // isn't found
+
+        return props.render({ ...routeProps, definition })
+      }}
+    />
+  )
 }

--- a/labware-library/src/index.js
+++ b/labware-library/src/index.js
@@ -2,7 +2,7 @@
 // labware library entry
 import * as React from 'react'
 import ReactDom from 'react-dom'
-import { BrowserRouter, Route } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 
 import './public-path'
 import './styles.global.css'
@@ -20,7 +20,7 @@ import('./components/App').then(({ default: App }) => {
   // when filters are active
   ReactDom.render(
     <BrowserRouter>
-      <Route component={App} />
+      <App />
     </BrowserRouter>,
     $root
   )

--- a/labware-library/src/prerender.js
+++ b/labware-library/src/prerender.js
@@ -12,7 +12,7 @@ export type PrerenderProps = {
   location: string,
 }
 
-export default function prerender(props: PrerenderProps) {
+export default function prerender(props: PrerenderProps): string {
   return `<div id="root">${ReactDomServer.renderToString(
     <StaticRouter location={props.location} context={{}}>
       <Route component={App} />

--- a/labware-library/src/styles/spacing.css
+++ b/labware-library/src/styles/spacing.css
@@ -20,9 +20,10 @@
   /* width and height sizes (same TODO as above) */
   --size-1: 1.25rem; /* 20px */
   --size-2: 3rem; /* 48px */
-  --size-3: 12rem; /* 48px */
+  --size-3: 12rem; /* 192px */
   --size-4: 16rem; /* 256px */
   --size-5: 32rem; /* 512px */
+  --size-25p: 25%;
   --size-40p: 40%;
   --size-50p: 50%;
   --size-60p: 60%;

--- a/labware-library/src/styles/spacing.css
+++ b/labware-library/src/styles/spacing.css
@@ -22,7 +22,8 @@
   --size-2: 3rem; /* 48px */
   --size-3: 12rem; /* 192px */
   --size-4: 16rem; /* 256px */
-  --size-5: 32rem; /* 512px */
+  --size-5: 20rem; /* 320px */
+  --size-6: 32rem; /* 512px */
   --size-25p: 25%;
   --size-40p: 40%;
   --size-50p: 50%;


### PR DESCRIPTION
## overview

This PR continues work on #3077

## changelog

The following parts of the labware detail page were added

- Navigation breadcrumbs
- Gallery
- Tags
- loadName and copy button
- displayName

## review requests

<http://sandbox.labware.opentrons.com/lablib-detail-page>

@howisthisnamenottakenyet since the screens are only in Sketch, can you please make sure they align with the screens as well as what we discussed in Slack?

Otherwise, please try to test this out on different screen sizes and browsers.

Pathnames:
- [ ] `/`
- [ ] `/:loadName`

Screen sizes:
- [ ] `< 768`
- [ ] `>= 768`
- [ ] `>= 1280`
- [ ] `>= 1600`

Specific things to keep an eye out for:
- Scroll behavior of different components (e.g. sidebar vs page content)
- Scrollbar positioning (especially with a mouse or non-macOS)
- Element widths and layers