### PR TITLE
feat(update-server): Add SSH public key management for buildroot

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,5 +1,8 @@
 SHELL := /bin/bash
 
+PATH := $(shell cd .. && yarn bin):$(PATH)
+SHX := npx shx
+
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 PATH := $(shell cd .. && yarn bin):$(PATH)
 
@@ -9,10 +12,17 @@ pipenv_opts += $(and $(CI),--keep-outdated)
 port ?= 34000
 tests ?= tests
 test_opts ?= -s -vv
+wheel_file = dist/*.whl
+# Host key location for buildroot robot
+br_ssh_key ?= ~/.ssh/robot_key
+# Other SSH args for buildroot robots
+br_ssh_opts ?= -o stricthostkeychecking=no
+# Host key for push-key uploading
+pubkey ?= br_ssh_key
 
 
 # make bootstrap wheel file (= rather than := to expand at every use)
-wheel = $(wildcard dist/*.whl)
+wheel_file = $(wildcard dist/otupdate-*.whl)
 
 .PHONY: install
 install:
@@ -62,3 +72,18 @@ bootstrap: wheel
 .PHONY: restart
 restart:
 	curl -X POST http://$(host):31950/server/restart
+
+.PHONY: push-buildroot
+push-buildroot: wheel
+	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
+	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
+"function cleanup () rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-update-server;\
+systemctl stop opentrons-update-server;\
+mount -o remount,rw /;\
+cd /usr/lib/python3.7/site-packages;\
+unzip -o /data/otupdate-*.whl || cleanup && cleanup "
+
+
+.PHONY: push-key
+push-key:
+	curl -X POST -H "Content-Type: application/json" --data-raw "{\"key\": \"$(shell $(SHX) cat $(pubkey))\"}" $(host):31950/server/ssh_keys

--- a/update-server/buildroot_upload.py
+++ b/update-server/buildroot_upload.py
@@ -72,7 +72,7 @@ async def do_update(update_file, host):
                 sys.exit(-1)
 
             print("Restarting...")
-            resp = await session.post(host+'/server/update/restart')
+            resp = await session.post(host+'/server/restart')
 
         print("Done!")
 

--- a/update-server/otupdate/buildroot/README.md
+++ b/update-server/otupdate/buildroot/README.md
@@ -1,0 +1,3 @@
+# otupdate.buildroot: Buildroot system "system server"
+
+This is the implementation for the update server that runs on machines running buildroot. Compared to the balena implementation, the buildroot update server is really a system server: in addition to doing updates, it also manages other system resources. In the future, we’ll express this by taking away privileges and capabilities from the API server that don’t have anything to do with running protocols and put them here instead; for now, this is just the place that new system capabilities should be added.

--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -8,7 +8,7 @@ from aiohttp import web
 
 from . import constants
 
-from . import config, control, update
+from . import config, control, update, ssh_key_management
 
 
 BR_BUILTIN_VERSION_FILE = '/etc/VERSION.json'
@@ -79,5 +79,8 @@ def get_app(system_version_file: str = None,
         web.post('/server/update/{session}/file', update.file_upload),
         web.post('/server/update/{session}/commit', update.commit),
         web.post('/server/update/restart', control.restart),
+        web.get('/server/ssh_keys', ssh_key_management.list_keys),
+        web.post('/server/ssh_keys', ssh_key_management.add),
+        web.delete('/server/ssh_keys/{key_md5}', ssh_key_management.remove),
     ])
     return app

--- a/update-server/otupdate/buildroot/control.py
+++ b/update-server/otupdate/buildroot/control.py
@@ -4,14 +4,16 @@ otupdate.buildroot.control: non-update-specific endpoints for otupdate
 This has endpoints like /restart that aren't specific to update tasks.
 """
 import asyncio
+import logging
 import subprocess
-
 from typing import Callable, Coroutine, Mapping
 
 from aiohttp import web
 
 from .constants import RESTART_LOCK_NAME
 
+
+LOG = logging.getLogger(__name__)
 
 def _do_restart():
     subprocess.check_call(['reboot'])

--- a/update-server/otupdate/buildroot/control.py
+++ b/update-server/otupdate/buildroot/control.py
@@ -15,6 +15,7 @@ from .constants import RESTART_LOCK_NAME
 
 LOG = logging.getLogger(__name__)
 
+
 def _do_restart():
     subprocess.check_call(['reboot'])
 

--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -175,5 +175,8 @@ async def remove(request: web.Request) -> web.Response:
         ak.write('\n'.join(new_keys) + '\n')
 
     return web.json_response(
-        data={'message': f'Key {requested_hash} deleted'},
+        data={
+            'message': f'Key {requested_hash} deleted. '
+            'Restart robot to take effect',
+            'restart_url': '/server/update/restart'},
         status=200)

--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -157,7 +157,7 @@ async def remove(request: web.Request) -> web.Response:
     -> 404 Not Found otherwise
     """
     requested_hash = request.match_info['key_md5']
-    new_keys: List[str]= []
+    new_keys: List[str] = []
     found = False
     for keyhash, key in get_keys():
         if keyhash == requested_hash:

--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -1,0 +1,179 @@
+"""
+ssh_key_management: Endpoints for managing SSH keys on the robot
+"""
+import contextlib
+import functools
+import hashlib
+import ipaddress
+import logging
+from typing import List, Tuple
+
+from aiohttp import web
+
+
+LOG = logging.getLogger(__name__)
+
+
+def require_linklocal(handler):
+    """ Ensure the decorated is only called if the request is linklocal.
+
+    The host ip address should be in the X-Host-IP header (provided by nginx)
+    """
+    @functools.wraps(handler)
+    async def decorated(request: web.Request) -> web.Response:
+        ipaddr_str = request.headers.get('x-host-ip')
+        invalid_req_data = {
+            'error': 'bad-interface',
+            'message': f'The endpoint {request.url} can only be used from '
+            'local connections'
+        }
+        if not ipaddr_str:
+            return web.json_response(
+                data=invalid_req_data,
+                status=403)
+        try:
+            addr = ipaddress.ip_address(ipaddr_str)
+        except ValueError:
+            LOG.exception(f"Couldn't parse host ip address {ipaddr_str}")
+            raise
+
+        if not addr.is_link_local:
+            return web.json_response(data=invalid_req_data, status=403)
+
+        return await handler(request)
+    return decorated
+
+
+@contextlib.contextmanager
+def authorized_keys(mode='r'):
+    """ Open the authorized_keys file. Separate function for mocking.
+
+    :param mode: As :py:meth:`open`
+    """
+    with open('/var/home/.ssh/authorized_keys', mode) as ak:
+        yield ak
+
+
+def get_keys() -> List[Tuple[str, str]]:
+    """ Return a list of tuples of [md5(pubkey), pubkey] """
+    with authorized_keys() as ak:
+        return [(hashlib.new('md5', line.encode()).hexdigest(),
+                 line)
+                for line in ak.read().split('\n')
+                if line.strip()]
+
+
+def remove_by_hash(hashval: str):
+    """ Remove the key whose md5 sum matches hashval.
+
+    :raises: KeyError if the hashval wasn't found
+    """
+    key_details = get_keys()
+    with authorized_keys('w') as ak:
+        for keyhash, key in key_details():
+            if keyhash != hashval:
+                ak.write(f'{key}\n')
+                break
+        else:
+            raise KeyError(hashval)
+
+
+def key_present(hashval: str) -> bool:
+    """ Check if the key whose md5 is hashval is in authorized_keys
+
+    :returns: ``True`` if the key is present, ``False`` otherwise
+    """
+    return hashval in [keyhash for keyhash, _ in get_keys()]
+
+
+@require_linklocal
+async def list_keys(request: web.Request) -> web.Response:
+    """ List keys in the authorized_keys file.
+
+    GET /server/ssh_keys
+    -> 200 OK {"public_keys": [{"key_md5": md5 hex digest, "key": key string}]}
+
+    (or 403 if not from the link-local connection)
+    """
+    return web.json_response(
+        {'public_keys': [{'key_md5': details[0], 'key': details[1]}
+                         for details in get_keys()]},
+        status=200)
+
+
+@require_linklocal
+async def add(request: web.Request) -> web.Response:
+    """ Add a public key to the authorized_keys file.
+
+    POST /server/ssh_keys {"key": key string}
+    -> 201 Created
+
+    If the key string doesn't look like an openssh public key, rejects with 400
+    """
+    body = await request.json()
+    if 'key' not in body or not isinstance(body['key'], str):
+        return web.json_response(
+            data={'error': 'no-key', 'message': 'No "key" element in body'},
+            status=400)
+    pubkey = body['key']
+    # Do some fairly minor sanitization; dropbear will ignore invalid keys but
+    # we still don’t want to have a bunch of invalid data in there
+    alg = pubkey.split()[0]
+    # We don’t allow dss so this has to be rsa or ecdsa and shouldn’t start
+    # with restrictions
+    if alg != 'ssh-rsa' and not alg.startswith('ecdsa'):
+        LOG.warning(f"weird keyfile uploaded: starts with {alg}")
+        return web.json_response(
+            data={'error': 'bad-key',
+                  'message': f'Key starts with invalid algorithm {alg}'},
+            status=400)
+    if '\n' in pubkey[:-1]:
+        LOG.warning(f"Newlines in keyfile that shouldn't be there")
+        return web.json_response(
+            data={'error': 'bad-key', 'message': f'Key has a newline'},
+            status=400)
+
+    if '\n' == pubkey[-1]:
+        pubkey = pubkey[:-1]
+
+    # This is a more or less correct key we can write
+    hashval = hashlib.new('md5', pubkey.encode()).hexdigest()
+    if not key_present(hashval):
+        with authorized_keys('a') as ak:
+            ak.write(f'{pubkey}\n')
+
+    return web.json_response(
+            data={'message': 'Added key {hashval}',
+                  'key_md5': hashval},
+            status=201)
+
+
+@require_linklocal
+async def remove(request: web.Request) -> web.Response:
+    """ Remove a public key from authorized_keys
+
+    DELETE /server/ssh_keys/:key_md5_hexdigest
+    -> 200 OK if the key was found
+    -> 404 Not Found otherwise
+    """
+    requested_hash = request.match_info['key_md5']
+    new_keys: List[str]= []
+    found = False
+    for keyhash, key in get_keys():
+        if keyhash == requested_hash:
+            found = True
+        else:
+            new_keys.append(key)
+
+    if not found:
+        return web.json_response(
+            data={'error': 'invalid-key-hash',
+                  'message': f'No such key md5 {requested_hash}'},
+            status=404)
+
+    with authorized_keys('w') as ak:
+        ak.write('\n'.join(new_keys) + '\n')
+
+    return web.json_response(
+        data={'message': f'Key {requested_hash} deleted'},
+        status=200)

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -65,7 +65,7 @@ async def test_add_key(test_cli, dummy_authorized_keys):
     resp = await test_cli.post('/server/ssh_keys',
                                json={'key': dummy_key},
                                headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 200
+    assert resp.status == 201
     body = await resp.json()
     assert 'message' in body
     assert body['key_md5'] == hashlib.new(
@@ -77,7 +77,7 @@ async def test_add_key(test_cli, dummy_authorized_keys):
     resp = await test_cli.post('/server/ssh_keys',
                                json={'key': dummy_key},
                                headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 200
+    assert resp.status == 201
     body = await resp.json()
     assert 'message' in body
     assert body['key_md5'] == hashlib.new(
@@ -108,7 +108,7 @@ async def test_delete_key(test_cli, dummy_authorized_keys):
     resp = await test_cli.post('/server/ssh_keys',
                                json={'key': dummy_key},
                                headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 200
+    assert resp.status == 201
 
     hashval = hashlib.new(
         'md5', dummy_key.encode()).hexdigest()

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -6,6 +6,7 @@ import pytest
 
 import otupdate.buildroot
 
+
 @pytest.fixture
 def dummy_authorized_keys(tmpdir, monkeypatch):
     path = os.path.join(tmpdir, 'authorized_keys')

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -1,0 +1,126 @@
+import contextlib
+import hashlib
+import os
+
+import pytest
+
+import otupdate.buildroot
+
+@pytest.fixture
+def dummy_authorized_keys(tmpdir, monkeypatch):
+    path = os.path.join(tmpdir, 'authorized_keys')
+    ak = open(path, 'w').write("")
+
+    @contextlib.contextmanager
+    def ak(mode='r'):
+        with open(path, mode) as a:
+            yield a
+
+    monkeypatch.setattr(otupdate.buildroot.ssh_key_management,
+                        'authorized_keys', ak)
+
+    return path
+
+
+async def test_interface_restriction(test_cli, dummy_authorized_keys):
+    resp = await test_cli.get('/server/ssh_keys')
+    assert resp.status == 403
+    body = await resp.json()
+    assert body['error'] == 'bad-interface'
+    assert 'message' in body
+
+    for ok_ip in ['169.254.0.1', 'fe80::e6a5:c57d:7659:266d']:
+        resp = await test_cli.get('/server/ssh_keys',
+                                  headers={'X-Host-IP': ok_ip})
+        assert resp.status == 200
+
+    for bad_ip in ['192.168.0.1', '10.2.6.1']:
+        resp = await test_cli.get('/server/ssh_keys',
+                                  headers={'X-Host-IP': bad_ip})
+        assert resp.status == 403
+
+
+async def test_list_keys(test_cli, dummy_authorized_keys):
+    resp = await test_cli.get('/server/ssh_keys',
+                              headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert body['public_keys'] == []
+
+    dummy_key = "ssh-rsa ahaubsfalsijdbalsjdhbfajsdbfafasdk test@opentrons.com"
+    with open(dummy_authorized_keys, 'w') as ak:
+        ak.write(dummy_key + '\n')
+
+    resp = await test_cli.get('/server/ssh_keys',
+                              headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert body['public_keys'] == [
+        {'key_md5': hashlib.new('md5', dummy_key.encode()).hexdigest(),
+         'key': dummy_key}]
+
+
+async def test_add_key(test_cli, dummy_authorized_keys):
+    dummy_key = "ssh-rsa ahaubsfalsijdbalsjdhbfajsdbfafasdk test@opentrons.com"
+    resp = await test_cli.post('/server/ssh_keys',
+                               json={'key': dummy_key},
+                               headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert 'message' in body
+    assert body['key_md5'] == hashlib.new(
+        'md5', dummy_key.encode()).hexdigest()
+    assert open(dummy_authorized_keys).read() == dummy_key + '\n'
+
+    # Do the same test again to make sure it works but there isn’t a
+    # duplicate key
+    resp = await test_cli.post('/server/ssh_keys',
+                               json={'key': dummy_key},
+                               headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert 'message' in body
+    assert body['key_md5'] == hashlib.new(
+        'md5', dummy_key.encode()).hexdigest()
+    assert open(dummy_authorized_keys).read() == dummy_key + '\n'
+
+    # Send something that looks nothing like a key
+    resp = await test_cli.post('/server/ssh_keys',
+                               json={'key': 'not even close to a pubkey'},
+                               headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 400
+    body = await resp.json()
+    assert body['error'] == 'bad-key'
+    assert 'message' in body
+
+    # Send something that looks kinda like a key but with a newline
+    resp = await test_cli.post('/server/ssh_keys',
+                               json={'key': 'ssh-rsa \ngotcha'},
+                               headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 400
+    body = await resp.json()
+    assert body['error'] == 'bad-key'
+    assert 'message' in body
+
+
+async def test_delete_key(test_cli, dummy_authorized_keys):
+    dummy_key = "ssh-rsa ahaubsfalsijdbalsjdhbfajsdbfafasdk test@opentrons.com"
+    resp = await test_cli.post('/server/ssh_keys',
+                               json={'key': dummy_key},
+                               headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+
+    hashval = hashlib.new(
+        'md5', dummy_key.encode()).hexdigest()
+    resp = await test_cli.delete(f'/server/ssh_keys/{hashval}',
+                                 headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert 'message' in body
+
+    resp = await test_cli.delete(f'/server/ssh_keys/{hashval}',
+                                 headers={'X-Host-IP': '169.254.1.1'})
+    assert resp.status == 404
+    body = await resp.json()
+    assert body['error'] == 'invalid-key-hash'
+    assert 'message' in body


### PR DESCRIPTION
Add new api
GET /server/ssh_keys -> 200 OK {"public_keys": [{"key_md5": md5 hex digest, "key": key string}]}
POST /server/ssh_keys {"key": key string} -> 201 Created {"message": message, "key_md5": md5 hex digest}
DELETE /server/ssh_keys/:key_md5 -> 200 OK

for managing SSH public keys on buildroot machines. These APIs will only work via linklocal connections as long as the appropriate nginx server is running.

Also, adds a makefile target in update server to update the update server without doing a full update and to put a new key on the robot.

Closes #3320

## Testing

- Install this server on a buildroot robot. Do it with a normal update so you get the nginx conf changes.
- List, add, and remove some keys and make sure the changes take (i.e. you can or can't ssh into the robot in between changes)

Requires https://github.com/Opentrons/buildroot/pull/17