### PR TITLE
fix(api): Do not sleep in simulated delays

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -244,7 +244,6 @@ class API(HardwareAPILike):
         """
         await self._backend.delay(duration_s)
 
-
     @_log_call
     async def cache_instruments(self,
                                 require: Dict[top_types.Mount, str] = None):

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -239,6 +239,13 @@ class API(HardwareAPILike):
         self.set_lights(button=True)
 
     @_log_call
+    async def delay(self, duration_s: int):
+        """ Delay execution by pausing and sleeping.
+        """
+        await self._backend.delay(duration_s)
+
+
+    @_log_call
     async def cache_instruments(self,
                                 require: Dict[top_types.Mount, str] = None):
         """

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -246,3 +246,10 @@ class Controller:
         """ Run a probe and return the new position dict
         """
         return self._smoothie_driver.probe_axis(axis, distance)
+
+    async def delay(self, duration_s: int):
+        """ Pause and sleep
+        """
+        self.pause()
+        await asyncio.sleep(duration_s)
+        self.resume()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -241,3 +241,8 @@ class Simulator:
     def probe(self, axis: str, distance: float) -> Dict[str, float]:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position
+
+    async def delay(self, duration_s: int):
+        """ Pause and unpause, but without the actual delay """
+        self.pause()
+        self.resume()

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -419,10 +419,8 @@ class ProtocolContext(CommandPublisher):
 
         If both `seconds` and `minutes` are specified, they will be added.
         """
-        delay_time = seconds + minutes*60
-        self.pause()
-        time.sleep(delay_time)
-        self.resume()
+        delay_time = seconds + minutes * 60
+        self._hw_manager.hardware.delay(delay_time)
 
     @property
     def config(self) -> rc.robot_config:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import logging
-import time
 from .labware import (Well, Labware, load, load_module, ModuleGeometry,
                       quirks_from_any_parent, ThermocyclerGeometry)
 from typing import Any, Dict, List, Optional, Union, Tuple, Sequence


### PR DESCRIPTION
This is something the robot does that apiv2 now does too.

Closes #3346

Testing:

- Use a protocol like 
```
def run(ctx):
  ctx.delay(minutes=2)
```

- Check that `opentrons_simulate` does not delay 2 minutes
- Check that protocol upload does not take 2 minutes
- Check that protocol run does take two minutes