### PR TITLE
refactor(labware-library): Add top-level labware stats to details page

### DIFF
--- a/labware-library/src/components/LabwareDetails/Stats.js
+++ b/labware-library/src/components/LabwareDetails/Stats.js
@@ -1,0 +1,56 @@
+// @flow
+// top-level labware stats
+import * as React from 'react'
+
+import {
+  MANUFACTURER,
+  CATEGORY,
+  NUM_WELLS_LONG_BY_CATEGORY,
+  CATEGORY_LABELS_BY_CATEGORY,
+  MANUFACTURER_LABELS_BY_MANUFACTURER,
+} from '../../localization'
+
+import { TableEntry, LabelText, Value, LABEL_LEFT } from '../ui'
+
+import styles from './styles.css'
+
+import type { LabwareDefinition } from '../../types'
+
+export type StatsProps = {
+  definition: LabwareDefinition,
+}
+
+export default function Stats(props: StatsProps) {
+  const { definition } = props
+  const { brand } = definition.brand
+  const { displayCategory } = definition.metadata
+  const stats = [
+    {
+      label: MANUFACTURER,
+      value: MANUFACTURER_LABELS_BY_MANUFACTURER[brand] || brand,
+    },
+    {
+      label: CATEGORY,
+      value:
+        CATEGORY_LABELS_BY_CATEGORY[displayCategory] ||
+        CATEGORY_LABELS_BY_CATEGORY.other,
+    },
+    {
+      label:
+        NUM_WELLS_LONG_BY_CATEGORY[displayCategory] ||
+        NUM_WELLS_LONG_BY_CATEGORY.other,
+      value: Object.keys(definition.wells).length,
+    },
+  ]
+
+  return (
+    <div className={styles.stats}>
+      {stats.map((s, i) => (
+        <TableEntry key={i}>
+          <LabelText position={LABEL_LEFT}>{s.label}</LabelText>
+          <Value>{s.value}</Value>
+        </TableEntry>
+      ))}
+    </div>
+  )
+}

--- a/labware-library/src/components/LabwareDetails/index.js
+++ b/labware-library/src/components/LabwareDetails/index.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 
 import { LabwareGallery, Tags, LoadName } from '../LabwareList'
+import Stats from './Stats'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -25,12 +26,9 @@ export default function LabwareDetails(props: LabwareDetailsProps) {
         <LoadName loadName={parameters.loadName} />
       </div>
       <div className={styles.details_container}>
-        <Title>{metadata.displayName}</Title>
+        <h2 className={styles.title}>{metadata.displayName}</h2>
+        <Stats definition={definition} />
       </div>
     </>
   )
-}
-
-function Title(props: { children: React.Node }) {
-  return <h2 className={styles.title}>{props.children}</h2>
 }

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -24,6 +24,12 @@
   color: var(--c-blue);
 }
 
+.stats {
+  width: var(--size-50p);
+  min-width: var(--size-3);
+  margin: var(--spacing-5) 0;
+}
+
 @media (--medium) {
   .gallery_container {
     display: inline-block;

--- a/labware-library/src/components/LabwareList/LoadName.js
+++ b/labware-library/src/components/LabwareList/LoadName.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 
 import { IconButton, Tooltip } from '@opentrons/components'
+import { LabelText, LABEL_TOP } from '../ui'
 import styles from './styles.css'
 
 // TODO(mc, 2019-03-29): i18n
@@ -65,7 +66,7 @@ class LoadName extends React.Component<LoadNameProps, LoadNameState> {
     return (
       <div className={styles.load_name}>
         <label className={styles.load_name_label} onCopy={this.handleCopy}>
-          <p className={styles.top_label}>{EN_API_NAME}</p>
+          <LabelText position={LABEL_TOP}>{EN_API_NAME}</LabelText>
           <input
             ref={this.inputRef}
             className={styles.load_name_input}

--- a/labware-library/src/components/LabwareList/Tags.js
+++ b/labware-library/src/components/LabwareList/Tags.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 
+import { LabelText, Value, LABEL_LEFT } from '../ui'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -18,8 +19,8 @@ export default function Tags(props: TagsProps) {
 
   return (
     <div className={styles.tags}>
-      <p className={styles.left_label}>{EN_TAGS}</p>
-      <p className={styles.value}>{tags.join(', ')}</p>
+      <LabelText position={LABEL_LEFT}>{EN_TAGS}</LabelText>
+      <Value>{tags.join(', ')}</Value>
     </div>
   )
 }

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -123,45 +123,8 @@
   width: var(--size-third);
 }
 
-.stats_bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-2);
-  background-color: var(--c-lightest-gray);
-}
-
-.stats_item {
-  display: flex;
-  align-items: baseline;
-}
-
-.top_label,
-.left_label {
-  flex: none;
-  font-size: var(--fs-caption);
-  font-weight: var(--fw-semibold);
-  line-height: var(--lh-title);
-  text-transform: uppercase;
-  color: var(--c-font-icon);
-}
-
-.left_label {
-  margin-right: var(--spacing-3);
-}
-
-.top_label {
-  margin-bottom: var(--spacing-2);
-}
-
 .units {
   text-transform: none;
-}
-
-.value {
-  @apply --font-body-2-dark;
-
-  line-height: var(--lh-title);
 }
 
 .tags_container {

--- a/labware-library/src/components/Sidebar/FilterCategory.js
+++ b/labware-library/src/components/Sidebar/FilterCategory.js
@@ -7,19 +7,9 @@ import cx from 'classnames'
 import { getAllCategories, buildFiltersUrl } from '../../filters'
 import styles from './styles.css'
 
-import type { FilterParams } from '../../types'
+import { CATEGORY_LABELS_BY_CATEGORY } from '../../localization'
 
-// TODO(mc, 2019-03-18): i18n, duplicated in
-//   labware-library/src/components/LabwareList/LabwareCard.js
-const EN_CATEGORY_LABELS = {
-  all: 'All',
-  tubeRack: 'Tube Rack',
-  tipRack: 'Tip Rack',
-  wellPlate: 'Well Plate',
-  trough: 'Trough',
-  trash: 'Trash',
-  other: 'Other',
-}
+import type { FilterParams } from '../../types'
 
 export type FilterCategoryProps = {
   filters: FilterParams,
@@ -39,7 +29,7 @@ export default function FilterCategory(props: FilterCategoryProps) {
               [styles.selected]: c === filters.category,
             })}
           >
-            {EN_CATEGORY_LABELS[c]}
+            {CATEGORY_LABELS_BY_CATEGORY[c]}
           </Link>
         </li>
       ))}

--- a/labware-library/src/components/Sidebar/FilterManufacturer.js
+++ b/labware-library/src/components/Sidebar/FilterManufacturer.js
@@ -7,17 +7,13 @@ import { SelectField } from '@opentrons/components'
 import { getAllManufacturers, buildFiltersUrl } from '../../filters'
 import styles from './styles.css'
 
+import {
+  MANUFACTURER,
+  MANUFACTURER_LABELS_BY_MANUFACTURER,
+} from '../../localization'
+
 import type { ContextRouter } from 'react-router-dom'
 import type { FilterParams } from '../../types'
-
-// TODO(mc, 2019-03-13): i18n
-const EN_MANUFACTURER = 'manufacturer'
-
-// TODO(mc, 2019-03-18): i18n
-const EN_MANUFACTURER_LABELS = {
-  all: 'All',
-  generic: 'Generic',
-}
 
 export type FilterManufacturerProps = {
   ...ContextRouter,
@@ -29,12 +25,12 @@ export function FilterManufacturer(props: FilterManufacturerProps) {
   const manufacturers = getAllManufacturers()
   const options = manufacturers.map(value => ({
     value,
-    label: EN_MANUFACTURER_LABELS[value] || value,
+    label: MANUFACTURER_LABELS_BY_MANUFACTURER[value] || value,
   }))
 
   return (
     <label className={styles.filter_manufacturer}>
-      <p className={styles.filter_manufacturer_label}>{EN_MANUFACTURER}</p>
+      <p className={styles.filter_manufacturer_label}>{MANUFACTURER}</p>
       <SelectField
         className={styles.filter_manufacturer_select}
         name="manufacturer"

--- a/labware-library/src/components/Sidebar/__tests__/__snapshots__/FilterCategory.test.js.snap
+++ b/labware-library/src/components/Sidebar/__tests__/__snapshots__/FilterCategory.test.js.snap
@@ -23,7 +23,7 @@ exports[`FilterCategory component renders 1`] = `
       className="filter_category_link"
       to="/?category=tubeRack"
     >
-      Tube Rack
+      Tube Racks
     </Link>
   </li>
   <li
@@ -34,7 +34,7 @@ exports[`FilterCategory component renders 1`] = `
       className="filter_category_link"
       to="/?category=wellPlate"
     >
-      Well Plate
+      Well Plates
     </Link>
   </li>
 </ul>

--- a/labware-library/src/components/ui/LabelText.js
+++ b/labware-library/src/components/ui/LabelText.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+
+import styles from './styles.css'
+
+export type LabelPosition = 'top' | 'left'
+
+export const LABEL_TOP: LabelPosition = 'top'
+export const LABEL_LEFT: LabelPosition = 'left'
+
+export type LabelTextProps = {
+  /** location of the label to its siblings; defaults to "top" */
+  position?: LabelPosition,
+  /** contents of the label */
+  children: React.Node,
+}
+
+/**
+ * LabelText - all-caps text, usually used to label a <Value> or <Table>
+ */
+export function LabelText(props: LabelTextProps) {
+  const { children } = props
+  const position = props.position || LABEL_TOP
+  const classes = cx(
+    styles.label_text,
+    position === LABEL_TOP ? styles.top : styles.left
+  )
+
+  return <p className={classes}>{children}</p>
+}

--- a/labware-library/src/components/ui/Table.js
+++ b/labware-library/src/components/ui/Table.js
@@ -1,0 +1,47 @@
+// @flow
+// "table" of data, usually filled with LabelText and Value children
+import * as React from 'react'
+import cx from 'classnames'
+
+import styles from './styles.css'
+
+export type TableDirection = 'row' | 'column'
+
+export const TABLE_COLUMN: TableDirection = 'column'
+export const TABLE_ROW: TableDirection = 'row'
+
+export type TableProps = {
+  /** direction of table; defaults to "column" */
+  direction?: TableDirection,
+  /** contents of the "table" */
+  children: React.Node,
+}
+
+/**
+ * Table - rows or columns of data, usually <TableEntry>
+ */
+export function Table(props: TableProps) {
+  const { children } = props
+  const direction = props.direction || TABLE_COLUMN
+  const classes = cx(
+    styles.table,
+    direction === TABLE_COLUMN ? styles.column : styles.row
+  )
+
+  return <div className={classes}>{children}</div>
+}
+
+export type TableEntryProps = {
+  /** contents of the "table" row or column */
+  children: React.Node,
+}
+
+/**
+ * TableEntry - A row or column in a <Table>, with children that are usually
+ * <LabelText> and <Value> components
+ */
+export function TableEntry(props: TableEntryProps) {
+  const { children } = props
+
+  return <div className={styles.table_entry}>{children}</div>
+}

--- a/labware-library/src/components/ui/Value.js
+++ b/labware-library/src/components/ui/Value.js
@@ -1,0 +1,17 @@
+// @flow
+import * as React from 'react'
+
+import styles from './styles.css'
+
+export type ValueProps = {
+  /** contents of the value */
+  children: React.Node,
+}
+
+/**
+ * Value - display a value, sometimes in a <Table> and usually labeled by a
+ * <LabelText>
+ */
+export function Value(props: ValueProps) {
+  return <p className={styles.value}>{props.children}</p>
+}

--- a/labware-library/src/components/ui/index.js
+++ b/labware-library/src/components/ui/index.js
@@ -1,0 +1,7 @@
+// @flow
+// generic UI components
+// some of these are likely candidates for promotion to components library
+
+export * from './Table'
+export * from './LabelText'
+export * from './Value'

--- a/labware-library/src/components/ui/styles.css
+++ b/labware-library/src/components/ui/styles.css
@@ -1,0 +1,50 @@
+@import '@opentrons/components';
+@import '../../styles/spacing.css';
+
+.label_text {
+  flex: none;
+  font-size: var(--fs-caption);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-title);
+  text-transform: uppercase;
+  color: var(--c-font-icon);
+
+  &.top {
+    margin-bottom: var(--spacing-2);
+  }
+
+  &.left {
+    margin-right: var(--spacing-3);
+  }
+}
+
+.value {
+  @apply --font-body-2-dark;
+
+  line-height: var(--lh-title);
+}
+
+.table_entry {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: var(--spacing-2) 0;
+  width: 100%;
+}
+
+.table {
+  width: 100%;
+  padding: 0 var(--spacing-2);
+  background-color: var(--c-lightest-gray);
+
+  &.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+
+    & > .table_entry {
+      width: auto;
+    }
+  }
+}

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -1,0 +1,78 @@
+// @flow
+// english localizations
+
+export const CATEGORY_LABELS_BY_CATEGORY = {
+  all: 'All',
+  tubeRack: 'Tube Racks',
+  tipRack: 'Tip Racks',
+  wellPlate: 'Well Plates',
+  trough: 'Troughs',
+  trash: 'Trashes',
+  other: 'Other',
+}
+
+export const NUM_WELLS_LONG_BY_CATEGORY = {
+  tubeRack: 'number of tubes',
+  tipRack: 'number of tips',
+  wellPlate: 'number of wells',
+  trough: 'number of wells',
+  trash: 'number of wells',
+  other: 'number of wells',
+}
+
+export const NUM_WELLS_SHORT_BY_CATEGORY = {
+  tubeRack: 'no. of tubes',
+  tipRack: 'no. of tips',
+  wellPlate: 'no. of wells',
+  trough: 'no. of wells',
+  trash: 'no. of wells',
+  other: 'no. of wells',
+}
+
+export const WELL_TYPE_BY_CATEGORY = {
+  tubeRack: 'tubes',
+  tipRack: 'tips',
+  wellPlate: 'wells',
+  trough: 'wells',
+  trash: 'wells',
+  other: 'wells',
+}
+
+// TODO(mc, 2019-03-18): i18n
+export const LABWARE_DIMS_BY_CATEGORY = {
+  tubeRack: 'rack dimensions',
+  tipRack: 'rack dimensions',
+  wellPlate: 'plate dimensions',
+  trough: 'trough dimensions',
+  trash: 'trash dimensions',
+  other: 'labware dimensions',
+}
+
+// TODO(mc, 2019-03-18): i18n
+export const WELL_DIMS_BY_CATEGORY = {
+  tubeRack: 'tube dimensions',
+  tipRack: 'tip dimensions',
+  wellPlate: 'well dimensions',
+  trough: 'well dimensions',
+  trash: 'well dimensions',
+  other: 'well dimensions',
+}
+
+export const MANUFACTURER_LABELS_BY_MANUFACTURER = {
+  all: 'All',
+  generic: 'Generic',
+}
+
+export const MANUFACTURER = 'manufacturer'
+export const CATEGORY = 'category'
+export const LABWARE = 'labware'
+export const SPACING = 'spacing'
+export const MM = 'mm'
+export const SHORT_X_DIM = 'l'
+export const SHORT_Y_DIM = 'w'
+export const SHORT_Z_DIM = 'h'
+export const X_DIM = 'length'
+export const Y_DIM = 'width'
+export const DIAMETER = 'diameter'
+export const DEPTH = 'depth'
+export const MAX_VOLUME = 'max volume'

--- a/labware-library/src/localization/index.js
+++ b/labware-library/src/localization/index.js
@@ -1,0 +1,4 @@
+// i18n constants
+// TODO(mc, 2019-04-12): use a library, load more than en
+
+export * from './en'


### PR DESCRIPTION
## overview

This PR continues work on #3077 by adding top level labware stats to the details page

## changelog

- Centralized some i18n constants
- Centralized some UI components / styles relating to data display
- Added top-level stats to details page

## review requests

<http://sandbox.labware.opentrons.com/lablib-details-measurements>

This PR was on track to get pretty big thanks to the centralization of common i18n and styles, so I opened it after just the top-level stats rather than continuing with all the other data tables. I'm planning to fast follow, so I may request to punt some feedback to the next PR(s)

Screens for reference

### small

#### design

![Screenshot 2019-04-12 14 16 14](https://user-images.githubusercontent.com/2963448/56057753-a2567f80-5d2d-11e9-80f2-447811be1fe7.png)

#### implementation

![Screenshot 2019-04-12 14 16 43](https://user-images.githubusercontent.com/2963448/56057765-a7b3ca00-5d2d-11e9-9f5f-0650468866cf.png)

### medium

#### design

![Screenshot 2019-04-12 14 17 52](https://user-images.githubusercontent.com/2963448/56057805-c7e38900-5d2d-11e9-8351-45ac6cbafab0.png)

#### implementation

![Screenshot 2019-04-12 14 17 33](https://user-images.githubusercontent.com/2963448/56057791-b9956d00-5d2d-11e9-8f16-e60da9ab1097.png)

### large

#### design

![Screenshot 2019-04-12 14 18 30](https://user-images.githubusercontent.com/2963448/56057839-db8eef80-5d2d-11e9-8c59-f79a738812a9.png)

#### implementation

![Screenshot 2019-04-12 14 18 44](https://user-images.githubusercontent.com/2963448/56057849-e5185780-5d2d-11e9-8497-3b18f05da91c.png)

