### PR TITLE
fix(update-server): Create ~/.ssh/authorized_keys if needed

### DIFF
--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -6,6 +6,7 @@ import functools
 import hashlib
 import ipaddress
 import logging
+import os
 from typing import List, Tuple
 
 from aiohttp import web
@@ -50,7 +51,11 @@ def authorized_keys(mode='r'):
 
     :param mode: As :py:meth:`open`
     """
-    with open('/var/home/.ssh/authorized_keys', mode) as ak:
+    path = '/var/home/.ssh/authorized_keys'
+    if not os.path.exists(path):
+        os.makedirs(os.path.dirname(path))
+        open(path, 'w').close()
+    with open(path, mode) as ak:
         yield ak
 
 


### PR DESCRIPTION
When you migrate a robot from balena to buildroot, it doesn't create an authorized_keys dir - and in general, we should be sensitive of the possibility that file is not present, since it's on the writable filesystem. To deal with this, just make sure the file is present.

Testing:

- Install the update server on a system (either by doing a full update or using the `push-buildroot` makefile target in update-server
- SSH in and delete ~/.ssh/authorized_keys
- Note that you can still push a key with make push-key