### PR TITLE
fix(update-server): Fix some issues with br update, test, fast flow

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -151,11 +151,11 @@ push: wheel
 push-buildroot: wheel
 	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-api-server;\
-systemctl stop opentrons-api-server;\
-mount -o remount,rw /;\
-cd /usr/lib/python3.7/site-packages;\
-unzip -o /data/opentrons-*.whl || cleanup && cleanup "
+"function cleanup () { rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-api-server; } ;\
+systemctl stop opentrons-api-server &&\
+mount -o remount,rw / &&\
+cd /usr/lib/python3.7/site-packages &&\
+unzip -o /data/opentrons-*.whl && cleanup || cleanup"
 
 .PHONY: flash
 flash:

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -78,11 +78,11 @@ restart:
 push-buildroot: wheel
 	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-update-server;\
-systemctl stop opentrons-update-server;\
-mount -o remount,rw /;\
-cd /usr/lib/python3.7/site-packages;\
-unzip -o /data/otupdate-*.whl || cleanup && cleanup "
+"function cleanup () { rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-update-server; } ;\
+systemctl stop opentrons-update-server &&\
+mount -o remount,rw / &&\
+cd /usr/lib/python3.7/site-packages &&\
+unzip -o /data/otupdate-*.whl && cleanup || cleanup"
 
 
 .PHONY: push-key

--- a/update-server/otupdate/buildroot/update.py
+++ b/update-server/otupdate/buildroot/update.py
@@ -128,6 +128,7 @@ def _begin_validation(
         else:
             rootfs_file = fut.result()
             loop.call_soon_threadsafe(_begin_write,
+                                      session,
                                       loop,
                                       rootfs_file)
     validation_future.add_done_callback(validation_done)

--- a/update-server/tests/migration/test_migration_api.py
+++ b/update-server/tests/migration/test_migration_api.py
@@ -112,9 +112,10 @@ async def test_commit_fails_wrong_state(otupdate_test_client, update_session):
     assert resp.status == 409
 
 
-async def test_future_chain(downloaded_update_file, loop, monkeypatch,
-                            state_partition, data_partition, resin_data_dir,
-                            unused_sysroot):
+async def test_migration_future_chain(
+        downloaded_update_file, loop, monkeypatch,
+        state_partition, data_partition, resin_data_dir,
+        unused_sysroot):
     dl_path = os.dirname(downloaded_update_file)
     session = otupdate.buildroot.update_session.UpdateSession(
         dl_path)


### PR DESCRIPTION
Fixes a number of stupid mistakes around buildroot:

- Tests not running because there were yield statements in them, which it turns out do not in fact spin the asyncio loop, because why would they
- main update not working and not being caught by said statements because it was missing an argument
- fast-flow not restarting the servers they update or cleaning up after themselves because that's not how bash functions work

To test, update a unit with `make push-buildroot` (making sure to ssh in and manually `systemctl start opentrons-update-server` afterwards), then

- Do another `make push-buildroot` in `update-server` and in `api`, sshing back in afterwards to note that the update server and api are in fact restarted afterwards now
- Do a buildroot update with `buildroot_upload` in update server and note that it works