### PR TITLE
refactor(labware-library): Add well details to labware details page

### DIFF
--- a/labware-library/src/components/App/__tests__/App.test.js
+++ b/labware-library/src/components/App/__tests__/App.test.js
@@ -27,7 +27,12 @@ describe('App', () => {
         location={({ search: '' }: any)}
         history={({}: any)}
         match={({}: any)}
-        definition={({}: any)}
+        definition={
+          ({
+            metadata: { displayCategory: 'wellPlate' },
+            brand: { brand: 'generic' },
+          }: any)
+        }
       />
     )
 

--- a/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
+++ b/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
@@ -6,20 +6,38 @@ exports[`App component renders with definition 1`] = `
 >
   <Nav />
   <Breadcrumbs
-    definition={Object {}}
+    definition={
+      Object {
+        "brand": Object {
+          "brand": "generic",
+        },
+        "metadata": Object {
+          "displayCategory": "wellPlate",
+        },
+      }
+    }
   />
   <Page
     content={
       <LabwareDetails
-        definition={Object {}}
+        definition={
+          Object {
+            "brand": Object {
+              "brand": "generic",
+            },
+            "metadata": Object {
+              "displayCategory": "wellPlate",
+            },
+          }
+        }
       />
     }
     sidebar={
       <Sidebar
         filters={
           Object {
-            "category": "all",
-            "manufacturer": "all",
+            "category": "wellPlate",
+            "manufacturer": "generic",
           }
         }
       />

--- a/labware-library/src/components/App/index.js
+++ b/labware-library/src/components/App/index.js
@@ -24,7 +24,7 @@ export class App extends React.Component<DefinitionRouteRenderProps> {
 
   render() {
     const { definition, location } = this.props
-    const filters = getFilters(location)
+    const filters = getFilters(location, definition)
     const breadcrumbsVisibile = Boolean(definition)
 
     return (

--- a/labware-library/src/components/LabwareDetails/Dimensions.js
+++ b/labware-library/src/components/LabwareDetails/Dimensions.js
@@ -1,0 +1,40 @@
+// @flow
+// labware dimensions for details page
+import * as React from 'react'
+import round from 'lodash/round'
+
+import { LABWARE, MM, X_DIM, Y_DIM, Z_DIM } from '../../localization'
+import styles from './styles.css'
+
+import { LabeledValueTable, LowercaseText } from '../ui'
+
+import type { LabwareDefinition } from '../../types'
+
+// safe toFixed
+const toFixed = (n: number): string => round(n, 2).toFixed(2)
+
+export type DimensionsProps = {
+  definition: LabwareDefinition,
+}
+
+export default function Dimensions(props: DimensionsProps) {
+  const { definition } = props
+  const { overallLength, overallWidth, overallHeight } = definition.dimensions
+  const dimensions = [
+    { label: X_DIM, value: toFixed(overallLength) },
+    { label: Y_DIM, value: toFixed(overallWidth) },
+    { label: Z_DIM, value: toFixed(overallHeight) },
+  ]
+
+  return (
+    <LabeledValueTable
+      className={styles.dimensions}
+      label={
+        <>
+          {LABWARE} <LowercaseText>({MM})</LowercaseText>
+        </>
+      }
+      values={dimensions}
+    />
+  )
+}

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -61,8 +61,22 @@ export default function WellDimensions(props: WellDimensionsProps) {
         const spacing = [
           { label: X_OFFSET, value: toFixed(w.xOffset) },
           { label: Y_OFFSET, value: toFixed(w.yOffset) },
-          { label: X_SPACING, value: toFixed(w.xSpacing) },
-          { label: Y_SPACING, value: toFixed(w.ySpacing) },
+          {
+            label: X_SPACING,
+            value: w.xSpacing ? (
+              toFixed(w.xSpacing)
+            ) : (
+              <span className={styles.lighter}>N/A</span>
+            ),
+          },
+          {
+            label: Y_SPACING,
+            value: w.ySpacing ? (
+              toFixed(w.ySpacing)
+            ) : (
+              <span className={styles.lighter}>N/A</span>
+            ),
+          },
         ]
 
         return (

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -30,6 +30,9 @@ import type { LabwareDefinition } from '../../types'
 // safe toFixed
 const toFixed = (n: number): string => round(n, 2).toFixed(2)
 
+const spacingValue = (spacing: number) =>
+  spacing ? toFixed(spacing) : <span className={styles.lighter}>N/A</span>
+
 export type WellDimensionsProps = {
   definition: LabwareDefinition,
 }
@@ -61,22 +64,8 @@ export default function WellDimensions(props: WellDimensionsProps) {
         const spacing = [
           { label: X_OFFSET, value: toFixed(w.xOffset) },
           { label: Y_OFFSET, value: toFixed(w.yOffset) },
-          {
-            label: X_SPACING,
-            value: w.xSpacing ? (
-              toFixed(w.xSpacing)
-            ) : (
-              <span className={styles.lighter}>N/A</span>
-            ),
-          },
-          {
-            label: Y_SPACING,
-            value: w.ySpacing ? (
-              toFixed(w.ySpacing)
-            ) : (
-              <span className={styles.lighter}>N/A</span>
-            ),
-          },
+          { label: X_SPACING, value: spacingValue(w.xSpacing) },
+          { label: Y_SPACING, value: spacingValue(w.ySpacing) },
         ]
 
         return (

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -23,7 +23,14 @@ import { getDisplayVolume } from '@opentrons/shared-data'
 import { getUniqueWellProperties } from '../../definitions'
 import styles from './styles.css'
 
-import { LabeledValueTable, LowercaseText } from '../ui'
+import {
+  LabeledValueTable,
+  TableEntry,
+  LabelText,
+  Value,
+  LowercaseText,
+  LABEL_LEFT,
+} from '../ui'
 
 import type { LabwareDefinition } from '../../types'
 
@@ -58,7 +65,6 @@ export default function WellDimensions(props: WellDimensionsProps) {
           w.width != null ? { label: Y_DIM, value: toFixed(w.width) } : null,
           // TODO(mc, 2019-04-15): change label to icon
           { label: SHAPE, value: w.shape },
-          { label: MAX_VOLUME, value: `${vol} ${displayVolumeUnits}` },
         ].filter(Boolean)
 
         const spacing = [
@@ -78,7 +84,16 @@ export default function WellDimensions(props: WellDimensionsProps) {
                 </>
               }
               values={dimensions}
-            />
+            >
+              <div className={styles.well_volume}>
+                <TableEntry>
+                  <LabelText position={LABEL_LEFT}>{MAX_VOLUME}</LabelText>
+                  <Value>
+                    {vol} {displayVolumeUnits}
+                  </Value>
+                </TableEntry>
+              </div>
+            </LabeledValueTable>
             <LabeledValueTable
               className={styles.well_dimensions}
               label={

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -1,0 +1,93 @@
+// @flow
+// well dimensions and spacing for details page
+import * as React from 'react'
+import round from 'lodash/round'
+
+import {
+  WELL_TYPE_BY_CATEGORY,
+  MAX_VOLUME,
+  SPACING,
+  MM,
+  X_DIM,
+  Y_DIM,
+  X_OFFSET,
+  Y_OFFSET,
+  X_SPACING,
+  Y_SPACING,
+  DEPTH,
+  DIAMETER,
+  SHAPE,
+} from '../../localization'
+
+import { getDisplayVolume } from '@opentrons/shared-data'
+import { getUniqueWellProperties } from '../../definitions'
+import styles from './styles.css'
+
+import { LabeledValueTable, LowercaseText } from '../ui'
+
+import type { LabwareDefinition } from '../../types'
+
+// safe toFixed
+const toFixed = (n: number): string => round(n, 2).toFixed(2)
+
+export type WellDimensionsProps = {
+  definition: LabwareDefinition,
+}
+
+export default function WellDimensions(props: WellDimensionsProps) {
+  const { definition } = props
+  const { displayCategory, displayVolumeUnits } = definition.metadata
+  const wellProps = getUniqueWellProperties(definition)
+  const wellType =
+    WELL_TYPE_BY_CATEGORY[displayCategory] || WELL_TYPE_BY_CATEGORY.other
+
+  return (
+    <div className={styles.well_dimensions_container}>
+      {wellProps.map((w, i) => {
+        const vol = getDisplayVolume(w.totalLiquidVolume, displayVolumeUnits, 2)
+
+        const dimensions = [
+          { label: DEPTH, value: toFixed(w.depth) },
+          w.diameter != null
+            ? { label: DIAMETER, value: toFixed(w.diameter) }
+            : null,
+          w.length != null ? { label: X_DIM, value: toFixed(w.length) } : null,
+          w.width != null ? { label: Y_DIM, value: toFixed(w.width) } : null,
+          // TODO(mc, 2019-04-15): change label to icon
+          { label: SHAPE, value: w.shape },
+          { label: MAX_VOLUME, value: `${vol} ${displayVolumeUnits}` },
+        ].filter(Boolean)
+
+        const spacing = [
+          { label: X_OFFSET, value: toFixed(w.xOffset) },
+          { label: Y_OFFSET, value: toFixed(w.yOffset) },
+          { label: X_SPACING, value: toFixed(w.xSpacing) },
+          { label: Y_SPACING, value: toFixed(w.ySpacing) },
+        ]
+
+        return (
+          <div key={i} className={styles.well_dimensions_row}>
+            <LabeledValueTable
+              className={styles.well_dimensions}
+              label={
+                <>
+                  {wellType} <LowercaseText>({MM})</LowercaseText>
+                </>
+              }
+              values={dimensions}
+            />
+            <LabeledValueTable
+              className={styles.well_dimensions}
+              label={
+                <>
+                  {SPACING} <LowercaseText>({MM})</LowercaseText>
+                </>
+              }
+              values={spacing}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/labware-library/src/components/LabwareDetails/index.js
+++ b/labware-library/src/components/LabwareDetails/index.js
@@ -4,6 +4,8 @@ import * as React from 'react'
 
 import { LabwareGallery, Tags, LoadName } from '../LabwareList'
 import Stats from './Stats'
+import Dimensions from './Dimensions'
+import WellDimensions from './WellDimensions'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -28,6 +30,8 @@ export default function LabwareDetails(props: LabwareDetailsProps) {
       <div className={styles.details_container}>
         <h2 className={styles.title}>{metadata.displayName}</h2>
         <Stats definition={definition} />
+        <Dimensions definition={definition} />
+        <WellDimensions definition={definition} />
       </div>
     </>
   )

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -35,6 +35,10 @@
   margin-right: var(--spacing-7);
 }
 
+.stats {
+  margin-bottom: var(--spacing-5);
+}
+
 .well_dimensions {
   display: inline-block;
   vertical-align: top;

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -58,6 +58,10 @@
   }
 }
 
+.well_volume {
+  padding: 0 var(--spacing-2);
+}
+
 @media (--medium) {
   .gallery_container {
     display: inline-block;

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -24,10 +24,30 @@
   color: var(--c-blue);
 }
 
-.stats {
-  width: var(--size-50p);
-  min-width: var(--size-3);
-  margin: var(--spacing-5) 0;
+.stats,
+.dimensions,
+.well_dimensions {
+  width: calc(var(--size-50p) - 0.5 * var(--spacing-7));
+  margin-right: var(--spacing-7);
+}
+
+.well_dimensions {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.well_dimensions_row {
+  padding-top: var(--spacing-4);
+  margin-top: var(--spacing-5);
+  border-top: var(--bd-light);
+
+  &:first-child {
+    border: none;
+  }
+
+  &:nth-child(even) {
+    margin-right: 0;
+  }
 }
 
 @media (--medium) {
@@ -52,5 +72,31 @@
 @media (--large) {
   .gallery_container {
     width: var(--size-25p);
+  }
+
+  .details_container {
+    width: var(--size-75p);
+  }
+
+  .dimensions,
+  .well_dimensions_container {
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .stats,
+  .dimensions {
+    width: calc(var(--size-third) - 2 * var(--spacing-7) / 3);
+  }
+
+  .well_dimensions_container {
+    width: calc(var(--size-two-thirds) - var(--spacing-7) / 3);
+  }
+
+  .well_dimensions_row {
+    &:first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
   }
 }

--- a/labware-library/src/components/LabwareDetails/styles.css
+++ b/labware-library/src/components/LabwareDetails/styles.css
@@ -24,6 +24,10 @@
   color: var(--c-blue);
 }
 
+.lighter {
+  opacity: 0.5;
+}
+
 .stats,
 .dimensions,
 .well_dimensions {
@@ -34,6 +38,10 @@
 .well_dimensions {
   display: inline-block;
   vertical-align: top;
+
+  &:nth-child(even) {
+    margin-right: 0;
+  }
 }
 
 .well_dimensions_row {
@@ -43,10 +51,6 @@
 
   &:first-child {
     border: none;
-  }
-
-  &:nth-child(even) {
-    margin-right: 0;
   }
 }
 

--- a/labware-library/src/components/ui/LabeledValueTable.js
+++ b/labware-library/src/components/ui/LabeledValueTable.js
@@ -17,10 +17,11 @@ export type LabledValueTableProps = {
   values: Array<ValueEntry>,
   direction?: TableDirection,
   className?: string,
+  children?: React.Node,
 }
 
 export function LabeledValueTable(props: LabledValueTableProps) {
-  const { label, values, direction, className } = props
+  const { label, values, direction, className, children } = props
 
   return (
     <div className={className}>
@@ -33,6 +34,7 @@ export function LabeledValueTable(props: LabledValueTableProps) {
           </TableEntry>
         ))}
       </Table>
+      {children}
     </div>
   )
 }

--- a/labware-library/src/components/ui/LabeledValueTable.js
+++ b/labware-library/src/components/ui/LabeledValueTable.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react'
+
+import { Table, TableEntry, TABLE_COLUMN } from './Table'
+import { LabelText, LABEL_TOP, LABEL_LEFT } from './LabelText'
+import { Value } from './Value'
+
+import type { TableDirection } from './Table'
+
+export type ValueEntry = {
+  label: React.Node,
+  value: React.Node,
+}
+
+export type LabledValueTableProps = {
+  label: React.Node,
+  values: Array<ValueEntry>,
+  direction?: TableDirection,
+  className?: string,
+}
+
+export function LabeledValueTable(props: LabledValueTableProps) {
+  const { label, values, direction, className } = props
+
+  return (
+    <div className={className}>
+      <LabelText position={LABEL_TOP}>{label}</LabelText>
+      <Table direction={direction || TABLE_COLUMN}>
+        {values.map((v, i) => (
+          <TableEntry key={i}>
+            <LabelText position={LABEL_LEFT}>{v.label}</LabelText>
+            <Value>{v.value}</Value>
+          </TableEntry>
+        ))}
+      </Table>
+    </div>
+  )
+}

--- a/labware-library/src/components/ui/LowercaseText.js
+++ b/labware-library/src/components/ui/LowercaseText.js
@@ -1,0 +1,16 @@
+// @flow
+import * as React from 'react'
+
+import styles from './styles.css'
+
+export type LowercaseTextProps = {
+  /** text to display in lowercase */
+  children: React.Node,
+}
+
+/**
+ * LowercaseText - <span> that transforms all text to lowercase
+ */
+export function LowercaseText(props: LowercaseTextProps) {
+  return <span className={styles.lowercase_text}>{props.children}</span>
+}

--- a/labware-library/src/components/ui/index.js
+++ b/labware-library/src/components/ui/index.js
@@ -2,6 +2,8 @@
 // generic UI components
 // some of these are likely candidates for promotion to components library
 
+export * from './LabeledValueTable'
 export * from './Table'
 export * from './LabelText'
+export * from './LowercaseText'
 export * from './Value'

--- a/labware-library/src/components/ui/styles.css
+++ b/labware-library/src/components/ui/styles.css
@@ -18,6 +18,10 @@
   }
 }
 
+.lowercase_text {
+  text-transform: lowercase;
+}
+
 .value {
   @apply --font-body-2-dark;
 

--- a/labware-library/src/filters.js
+++ b/labware-library/src/filters.js
@@ -8,7 +8,7 @@ import { getAllDefinitions } from './definitions'
 import { getPublicPath } from './public-path'
 
 import type { Location } from 'react-router-dom'
-import type { FilterParams } from './types'
+import type { FilterParams, LabwareDefinition } from './types'
 
 export const FILTER_OFF = 'all'
 
@@ -24,7 +24,17 @@ export function getAllManufacturers(): Array<string> {
   return [FILTER_OFF].concat(uniq(manufacturers))
 }
 
-export function getFilters(location: Location): FilterParams {
+export function getFilters(
+  location: Location,
+  definition: LabwareDefinition | null
+): FilterParams {
+  if (definition) {
+    return {
+      category: definition.metadata.displayCategory,
+      manufacturer: definition.brand.brand,
+    }
+  }
+
   const queryParams = queryString.parse(location.search)
   const category = queryParams.category || FILTER_OFF
   const manufacturer = queryParams.manufacturer || FILTER_OFF

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -38,7 +38,6 @@ export const WELL_TYPE_BY_CATEGORY = {
   other: 'wells',
 }
 
-// TODO(mc, 2019-03-18): i18n
 export const LABWARE_DIMS_BY_CATEGORY = {
   tubeRack: 'rack dimensions',
   tipRack: 'rack dimensions',
@@ -48,7 +47,6 @@ export const LABWARE_DIMS_BY_CATEGORY = {
   other: 'labware dimensions',
 }
 
-// TODO(mc, 2019-03-18): i18n
 export const WELL_DIMS_BY_CATEGORY = {
   tubeRack: 'tube dimensions',
   tipRack: 'tip dimensions',
@@ -73,6 +71,12 @@ export const SHORT_Y_DIM = 'w'
 export const SHORT_Z_DIM = 'h'
 export const X_DIM = 'length'
 export const Y_DIM = 'width'
+export const Z_DIM = 'height'
+export const X_OFFSET = 'x-offset'
+export const Y_OFFSET = 'y-offset'
+export const X_SPACING = 'x-spacing'
+export const Y_SPACING = 'y-spacing'
 export const DIAMETER = 'diameter'
 export const DEPTH = 'depth'
 export const MAX_VOLUME = 'max volume'
+export const SHAPE = 'shape'

--- a/labware-library/src/styles/spacing.css
+++ b/labware-library/src/styles/spacing.css
@@ -28,6 +28,7 @@
   --size-40p: 40%;
   --size-50p: 50%;
   --size-60p: 60%;
+  --size-75p: 75%;
   --size-third: calc(100% / 3);
   --size-two-thirds: calc(200% / 3);
 

--- a/labware-library/src/types.js
+++ b/labware-library/src/types.js
@@ -1,5 +1,8 @@
 // @flow
-import type { LabwareDefinition2 as LabwareDefinition } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2 as LabwareDefinition,
+  LabwareWellProperties,
+} from '@opentrons/shared-data'
 
 export type {
   LabwareDefinition2 as LabwareDefinition,
@@ -9,6 +12,14 @@ export type {
   LabwareWellProperties,
   LabwareWellMap,
 } from '@opentrons/shared-data'
+
+export type LabwareWellGroupProperties = {|
+  ...LabwareWellProperties,
+  xOffset: number,
+  yOffset: number,
+  xSpacing: number,
+  ySpacing: number,
+|}
 
 export type LabwareList = Array<LabwareDefinition>
 


### PR DESCRIPTION
## overview

This PR adds well information to the labware details page. Closes #3077

## changelog

- refactor(labware-library): Add well details to labware details page

## review requests

<http://sandbox.labware.opentrons.com/lablib-finish-detail-page>

### not covered by this PR / ticket

- Well bottom/shape icons: #3245 (blocked by #3241)
- Measurement guide: #3353 

### deviations from screens

@howisthisnamenottakenyet during implementation, I made a few deviations from the screens that were meant to better capture what (I think) the design intent was. Let me know if any of these changes were incorrect:

- Moved "max volume" into well/tube/tip measurements table

![Screenshot 2019-04-15 14 15 18](https://user-images.githubusercontent.com/2963448/56155449-e7c2b900-5f88-11e9-90f1-658343d1f281.png)

- Moved well dimensions table to always be side-by-side with spacing table

![Screenshot 2019-04-15 14 14 54](https://user-images.githubusercontent.com/2963448/56155426-dd082400-5f88-11e9-85d3-bee28df72a02.png)

- Extended well-group separating line when more than one grid exists across both dimensions and spacing table columns

![Screenshot 2019-04-15 14 16 07](https://user-images.githubusercontent.com/2963448/56155492-04f78780-5f89-11e9-9711-4e2f11e52416.png)
