### PR TITLE
feat(api): Detect and change behavior for buildroot system

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -151,7 +151,7 @@ push: wheel
 push-buildroot: wheel
 	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-api-server; } ;\
+"function cleanup () { rm -f /data/opentrons*.whl && mount -o remount,ro / && systemctl start opentrons-api-server; } ;\
 systemctl stop opentrons-api-server &&\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\

--- a/api/opentrons-api-server.service
+++ b/api/opentrons-api-server.service
@@ -6,7 +6,9 @@ After=nginx.service
 [Service]
 Type=exec
 ExecStart=python -m opentrons.main -U /run/aiohttp.sock
-Environment=OT_SMOOTHIE_ID=AMA
+# Stop the button blinking
+ExecStartPost=systemctl stop opentrons-gpio-setup.service
+Environment=OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true
 
 [Install]
 WantedBy=opentrons.target

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -14,7 +14,8 @@ from numpy import dot, array
 import opentrons
 from opentrons import robot, instruments, types
 from opentrons.hardware_control import adapters
-from opentrons.config import robot_configs, feature_flags, OT_SYSTEM_VERSION
+from opentrons.config import (robot_configs, feature_flags,
+                              SystemArchitecture, ARCHITECTURE)
 from opentrons.util.calibration_functions import probe_instrument
 from opentrons.util.linal import solve, add_z, apply_transform
 from . import (
@@ -544,7 +545,7 @@ def main():
 
 def notify_and_restart():
     print('Exiting configuration tool and restarting system')
-    if OT_SYSTEM_VERSION < 2:
+    if ARCHITECTURE == SystemArchitecture.BALENA:
         os.system("kill 1")
     else:
         os.system('reboot')

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -14,7 +14,7 @@ from numpy import dot, array
 import opentrons
 from opentrons import robot, instruments, types
 from opentrons.hardware_control import adapters
-from opentrons.config import robot_configs, feature_flags
+from opentrons.config import robot_configs, feature_flags, OT_SYSTEM_VERSION
 from opentrons.util.calibration_functions import probe_instrument
 from opentrons.util.linal import solve, add_z, apply_transform
 from . import (
@@ -544,7 +544,10 @@ def main():
 
 def notify_and_restart():
     print('Exiting configuration tool and restarting system')
-    os.system("kill 1")
+    if OT_SYSTEM_VERSION < 2:
+        os.system("kill 1")
+    else:
+        os.system('reboot')
 
 
 if __name__ == "__main__":

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -7,7 +7,7 @@ from opentrons import server
 from opentrons.server.main import build_arg_parser
 from argparse import ArgumentParser
 from opentrons import hardware, __version__
-from opentrons.config import feature_flags as ff, CONFIG
+from opentrons.config import feature_flags as ff, CONFIG, name
 from logging.config import dictConfig
 from opentrons.system import udev, resin
 
@@ -163,6 +163,7 @@ def initialize_robot(loop):
                 "Could not connect to motor driver after fw update")
     else:
         log.info("FW version OK: {}".format(packed_smoothie_fw_ver))
+    log.info(f"Name: {name()}")
 
 
 def run(**kwargs):

--- a/api/src/opentrons/server/endpoints/__init__.py
+++ b/api/src/opentrons/server/endpoints/__init__.py
@@ -1,25 +1,20 @@
-import os
 import json
 import logging
 from aiohttp import web
-from opentrons import __version__
+from opentrons import __version__, config
 
 log = logging.getLogger(__name__)
-
-# TODO(mc, 2018-02-22): this naming logic is copied instead of shared
-#   from compute/scripts/anounce_mdns.py
-NAME = 'opentrons-{}'.format(
-    os.environ.get('RESIN_DEVICE_NAME_AT_INIT', 'dev'))
 
 
 async def health(request: web.Request) -> web.Response:
     static_paths = ['/logs/serial.log', '/logs/api.log']
+
     res = {
-        'name': NAME,
+        'name': config.name(),
         'api_version': __version__,
         'fw_version': request.app['com.opentrons.hardware'].fw_version,
         'logs': static_paths,
-        'system_version': os.environ.get('OT_SYSTEM_VERSION', 'unknown')
+        'system_version': config.OT_SYSTEM_VERSION
     }
     return web.json_response(
         headers={'Access-Control-Allow-Origin': '*'},

--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -1,0 +1,152 @@
+import asyncio
+import collections
+import datetime
+import json
+import logging
+import syslog
+from typing import Any, Deque, Dict, List
+
+from aiohttp import web
+import systemd.journal as journal
+
+
+LOG = logging.getLogger(__name__)
+
+MAX_RECORDS = 1000000
+
+
+async def _get_options(request: web.Request,
+                       default_length: int) -> Dict[str, Any]:
+    """ Parse options from a request. Should leave the request able to
+    be read again since it only uses the content-preserving
+    :py:meth:`aiohttp.web.Request.json`. Will not fail; malformed
+    requests will just use defaults.
+    """
+    response = {
+        'format': 'json',
+        'records': default_length
+    }
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        LOG.exception("Bad request format to logs.get_options")
+        return response
+
+    if 'format' in body:
+        if body['format'] not in ('text', 'json'):
+            LOG.error(f"Bad log format requested: {body['format']}")
+        else:
+            response['format'] = body['format']
+
+    if 'records' in body:
+        try:
+            records = int(body['records'])
+            if records <= 0 or records > MAX_RECORDS:
+                raise ValueError(records)
+        except (ValueError, TypeError):
+            LOG.exception(f"Bad records count requested: {body['records']}")
+        else:
+            response['records'] = records
+    return response
+
+
+async def _get_records(syslog_selector: str, record_count: int)\
+          -> Deque[Dict[str, Any]]:
+    """ Get log records up to record count.
+    """
+    loop = asyncio.get_event_loop()
+    log_deque: Deque[Dict[str, Any]] = collections.deque(maxlen=record_count)
+    with journal.Reader(journal.SYSTEM_ONLY) as r:
+        r.add_match(SYSLOG_IDENTIFIER=syslog_selector)
+        last_time = loop.time()
+        for record in r:
+            log_deque.append(record)
+            now = loop.time()
+            if (now-last_time) > 0.1:
+                last_time = now
+                await asyncio.sleep(0.01)
+    return log_deque
+
+
+def _format_record_text(record: Dict[str, Any]) -> str:
+    dict_rec = _format_record_dict(record)
+    return f'{dict_rec["time"]} {dict_rec["logger"]} '\
+        f'[{dict_rec["level_name"]}]: {dict_rec["message"]}'
+
+
+def _format_text(records: Deque[Dict[str, Any]]) -> str:
+    return '\n'.join([_format_record_text(record) for record in records])
+
+
+_SYSLOG_PRIORITY_TO_NAME = {
+    syslog.LOG_EMERG: 'emergency',
+    syslog.LOG_CRIT: 'critical',
+    syslog.LOG_ERR: 'error',
+    syslog.LOG_WARNING: 'warning',
+    syslog.LOG_INFO: 'info',
+    syslog.LOG_DEBUG: 'debug',
+    syslog.LOG_ALERT: 'alert',
+    syslog.LOG_NOTICE: 'notice'
+}
+
+
+def _format_record_dict(record: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        'logger': record.get('LOGGER', '<unknown>'),
+        'level': record.get('PRIORITY'),
+        'level_name': _SYSLOG_PRIORITY_TO_NAME.get(  # type: ignore
+            record.get('PRIORITY'), '<unknown>'),
+        'file': record.get('CODE_FILE', '<unknown>'),
+        'line': record.get('CODE_LINE', '<unknown>'),
+        'func': record.get('CODE_FUNC', '<unknown>'),
+        'time': record.get(
+            '__REALTIME_TIMESTAMP',
+            datetime.datetime.fromtimestamp(0)).isoformat(),
+        'boot': str(record.get('_BOOT_ID', '<unknown>')),
+        'message': record.get('MESSAGE', '<unknown>')
+    }
+
+
+def _prep_for_json(records: Deque[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [_format_record_dict(rec) for rec in records]
+
+
+async def _get_log_response(syslog_selector: str, record_count: int,
+                            record_format: str) -> web.Response:
+    records = await _get_records(syslog_selector, record_count)
+    if record_format == 'json':
+        return web.json_response(data=_prep_for_json(records))
+    else:
+        return web.Response(text=_format_text(records))
+
+
+async def get_serial_log(request: web.Request) -> web.Response:
+    """ Get the robot serial log.
+
+    GET /logs/api.log -> 200 OK, log contents in body
+
+    Optionally, the request body can be json with any of the following keys:
+    - ``'format'``: ``'json'`` or ``'text'`` (default: text). Controls log
+      format.
+    - ``records``: int. Count of records to limit the dump to.
+      Default: 40000. Limit: 1000000
+    """
+    opts = await _get_options(request, 40000)
+    return await _get_log_response(
+        'opentrons-api-serial', opts['records'], opts['format'])
+
+
+async def get_api_log(request: web.Request) -> web.Response:
+    """ Get the robot API log.
+
+    GET /logs/api.log -> 200 OK, log contents in body
+
+    Optionally, the request body can be json with any of the following keys:
+    - ``'format'``: ``'json'`` or ``'text'`` (default: text). Controls log
+      format.
+    - ``records``: int. Count of records to limit the dump to. Default: 15000.
+      Limit: 1000000
+    """
+    opts = await _get_options(request, 15000)
+    return await _get_log_response(
+        'opentrons-api', opts['records'], opts['format'])

--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -29,7 +29,6 @@ async def _get_options(request: web.Request,
     try:
         body = await request.json()
     except json.JSONDecodeError:
-        LOG.exception("Bad request format to logs.get_options")
         return response
 
     if 'format' in body:

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -49,13 +49,15 @@ class HTTPServer(object):
             '/update/ignore', endpoints.get_ignore_version)
         self.app.router.add_post(
             '/update/ignore', endpoints.set_ignore_version)
-        if config.OT_SYSTEM_VERSION < 2:
-            self.app.router.add_static(
-                '/logs', self.log_file_path, show_index=True)
-        else:
+
+        if config.ARCHITECTURE == config.SystemArchitecture.BUILDROOT:
             from .endpoints import logs
             self.app.router.add_get('/logs/{syslog_identifier}',
                                     logs.get_logs_by_id)
+        else:
+            self.app.router.add_static(
+                '/logs', self.log_file_path, show_index=True)
+
         self.app.router.add_post(
             '/server/restart', endpoints.restart)
         self.app.router.add_post(

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -54,8 +54,8 @@ class HTTPServer(object):
                 '/logs', self.log_file_path, show_index=True)
         else:
             from .endpoints import logs
-            self.app.router.add_get('/logs/serial.log', logs.get_serial_log)
-            self.app.router.add_get('/logs/api.log', logs.get_api_log)
+            self.app.router.add_get('/logs/{syslog_identifier}',
+                                    logs.get_logs_by_id)
         self.app.router.add_post(
             '/server/restart', endpoints.restart)
         self.app.router.add_post(

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -83,6 +83,8 @@ class HTTPServer(object):
         self.app.router.add_post(
             '/settings', settings.set_advanced_setting)
         self.app.router.add_post(
+            '/settings/log_level', settings.set_log_level)
+        self.app.router.add_post(
             '/settings/reset', settings.reset)
         self.app.router.add_get(
             '/settings/reset/options', settings.available_resets)

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -1,5 +1,6 @@
 import logging
 from . import endpoints as endp
+from opentrons import config
 from .endpoints import (networking, control, settings, update)
 from opentrons.deck_calibration import endpoints as dc_endp
 
@@ -48,8 +49,13 @@ class HTTPServer(object):
             '/update/ignore', endpoints.get_ignore_version)
         self.app.router.add_post(
             '/update/ignore', endpoints.set_ignore_version)
-        self.app.router.add_static(
-            '/logs', self.log_file_path, show_index=True)
+        if config.OT_SYSTEM_VERSION < 2:
+            self.app.router.add_static(
+                '/logs', self.log_file_path, show_index=True)
+        else:
+            from .endpoints import logs
+            self.app.router.add_get('/logs/serial.log', logs.get_serial_log)
+            self.app.router.add_get('/logs/api.log', logs.get_api_log)
         self.app.router.add_post(
             '/server/restart', endpoints.restart)
         self.app.router.add_post(

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -380,8 +380,9 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
             if ta['type'] == 'file':
                 # Keyfiles must be prepended with file:// so nm-cli
                 # knows that we’re not giving it DER-encoded blobs
-                _make_host_symlink_if_necessary()
-                path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
+                if config.OT_SYSTEM_VERSION < 2:
+                    _make_host_symlink_if_necessary()
+                    path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
                 val = 'file://' + path
             else:
                 val = eap_args[ta['name']]

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -386,7 +386,7 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
             if ta['type'] == 'file':
                 # Keyfiles must be prepended with file:// so nm-cli
                 # knows that we’re not giving it DER-encoded blobs
-                if config.OT_SYSTEM_VERSION < 2:
+                if config.ARCHITECTURE != config.SystemArchitecture.BALENA:
                     _make_host_symlink_if_necessary()
                     path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
                 else:

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -386,7 +386,7 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
             if ta['type'] == 'file':
                 # Keyfiles must be prepended with file:// so nm-cli
                 # knows that we’re not giving it DER-encoded blobs
-                if config.ARCHITECTURE != config.SystemArchitecture.BALENA:
+                if config.ARCHITECTURE == config.SystemArchitecture.BALENA:
                     _make_host_symlink_if_necessary()
                     path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
                 else:

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -265,6 +265,12 @@ async def available_ssids() -> List[Dict[str, Any]]:
     Returns a list of the SSIDs. They may contain spaces and should be escaped
     if later passed to a shell.
     """
+    # Force nmcli to actually scan rather than reuse cached results. We ignore
+    # errors here because NetworkManager yells at you if you do it twice in a
+    # row without another operation in between
+    cmd = ['device', 'wifi', 'rescan']
+    _1, _2 = await _call(cmd, suppress_err=True)
+
     fields = ['ssid', 'signal', 'active', 'security']
     cmd = ['--terse',
            '--fields',
@@ -383,6 +389,8 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
                 if config.OT_SYSTEM_VERSION < 2:
                     _make_host_symlink_if_necessary()
                     path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
+                else:
+                    path = eap_args[ta['name']]
                 val = 'file://' + path
             else:
                 val = eap_args[ta['name']]
@@ -568,7 +576,7 @@ async def iface_info(which_iface: NETWORK_IFACES) -> Dict[str, Optional[str]]:
     return info
 
 
-async def _call(cmd: List[str]) -> Tuple[str, str]:
+async def _call(cmd: List[str], suppress_err: bool = False) -> Tuple[str, str]:
     """
     Runs the command in a subprocess and returns the captured stdout output.
     :param cmd: a list of arguments to nmcli. Should not include nmcli itself.
@@ -588,7 +596,7 @@ async def _call(cmd: List[str]) -> Tuple[str, str]:
     out_str, err_str = out.decode().strip(), err.decode().strip()
     sanitized = sanitize_args(to_exec)
     log.debug('{}: stdout={}'.format(' '.join(sanitized), out_str))
-    if err_str:
+    if err_str and not suppress_err:
         log.info('{}: stderr={}'.format(' '.join(sanitized), err_str))
     return out_str, err_str
 

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -66,13 +66,13 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
         'handlers': {
             'api': {
                 'class': 'systemd.journal.JournalHandler',
-                'level': level_value,
+                'level': logging.DEBUG,
                 'formatter': 'message_only',
                 'SYSLOG_IDENTIFIER': 'opentrons-api',
             },
             'serial': {
                 'class': 'systemd.journal.JournalHandler',
-                'level': level_value,
+                'level': logging.DEBUG,
                 'formatter': 'message_only',
                 'SYSLOG_IDENTIFIER': 'opentrons-api-serial',
             }
@@ -80,7 +80,7 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
         'loggers': {
             'opentrons.drivers.serial_communication': {
                 'handlers': ['serial'],
-                'level': level_value,
+                'level': logging.DEBUG,
             },
             'opentrons': {
                 'handlers': ['api'],

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -48,7 +48,11 @@ def _balena_config(level_value: int) -> Dict[str, Any]:
                 'handlers': ['serial'],
                 'level': logging.DEBUG,
                 'propagate': False
-            }
+            },
+            '__main__': {
+                'handlers': ['api'],
+                'level': level_value
+            },
         }
     }
 
@@ -87,6 +91,10 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
             'opentrons': {
                 'handlers': ['api'],
                 'level': level_value,
+            },
+            '__main__': {
+                'handlers': ['api'],
+                'level': level_value
             },
         },
 

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -1,0 +1,115 @@
+import logging
+from logging.config import dictConfig
+import sys
+from typing import Any, Dict
+
+from opentrons.config import CONFIG, OT_SYSTEM_VERSION
+
+
+def _balena_config(level_value: int) -> Dict[str, Any]:
+    serial_log_filename = CONFIG['serial_log_file']
+    api_log_filename = CONFIG['api_log_file']
+    return {
+        'formatters': {
+            'basic': {
+                'format':
+                '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'  # noqa: E501
+            },
+        },
+        'handlers': {
+            'debug': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'basic',
+                'level': level_value
+            },
+            'serial': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'basic',
+                'filename': serial_log_filename,
+                'maxBytes': 5000000,
+                'level': logging.DEBUG,
+                'backupCount': 3
+            },
+            'api': {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'basic',
+                'filename': api_log_filename,
+                'maxBytes': 1000000,
+                'level': logging.DEBUG,
+                'backupCount': 5
+            }
+        },
+        'loggers': {
+            'opentrons': {
+                'handlers': ['debug', 'api'],
+                'level': level_value,
+            },
+            'opentrons.drivers.serial_communication': {
+                'handlers': ['serial'],
+                'level': logging.DEBUG
+            }
+        }
+    }
+
+
+def _buildroot_config(level_value: int) -> Dict[str, Any]:
+    # Import systemd.journald here since it is generally unavailble on non
+    # linux systems and we probably don't want to use it on linux desktops
+    # either
+    return {
+        'version': 1,
+        'formatters': {
+            'message_only': {
+                'format': '%(message)s'
+            },
+        },
+        'handlers': {
+            'api': {
+                'class': 'systemd.journal.JournalHandler',
+                'level': level_value,
+                'formatter': 'message_only',
+                'SYSLOG_IDENTIFIER': 'opentrons-api',
+            },
+            'serial': {
+                'class': 'systemd.journal.JournalHandler',
+                'level': level_value,
+                'formatter': 'message_only',
+                'SYSLOG_IDENTIFIER': 'opentrons-api-serial',
+            }
+        },
+        'loggers': {
+            'opentrons.drivers.serial_communication': {
+                'handlers': ['serial'],
+                'level': level_value,
+            },
+            'opentrons': {
+                'handlers': ['api'],
+                'level': level_value,
+            },
+        },
+
+    }
+
+
+def _config(system_version: int, level_value: int) -> Dict[str, Any]:
+    if system_version < 2:
+        return _balena_config(level_value)
+    else:
+        return _buildroot_config(level_value)
+
+
+def log_init(level_name: str):
+    """
+    Function that sets log levels and format strings. Checks for the
+    OT_API_LOG_LEVEL environment variable otherwise defaults to INFO
+    """
+    fallback_log_level = 'INFO'
+    ot_log_level = level_name.upper()
+    if ot_log_level not in logging._nameToLevel:
+        sys.stderr.write(
+            f'OT Log Level {ot_log_level} not found. '
+            f'Defaulting to {fallback_log_level}\n')
+        ot_log_level = fallback_log_level
+    level_value = logging._nameToLevel[ot_log_level]
+    logging_config = _config(OT_SYSTEM_VERSION, level_value)
+    dictConfig(logging_config)

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -46,7 +46,8 @@ def _balena_config(level_value: int) -> Dict[str, Any]:
             },
             'opentrons.drivers.serial_communication': {
                 'handlers': ['serial'],
-                'level': logging.DEBUG
+                'level': logging.DEBUG,
+                'propagate': False
             }
         }
     }
@@ -81,6 +82,7 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
             'opentrons.drivers.serial_communication': {
                 'handlers': ['serial'],
                 'level': logging.DEBUG,
+                'propagate': False
             },
             'opentrons': {
                 'handlers': ['api'],

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -12,7 +12,7 @@ async def test_health(virtual_smoothie_env, loop, test_client):
         'api_version': __version__,
         'fw_version': 'Virtual Smoothie',
         'logs': ['/logs/serial.log', '/logs/api.log'],
-        'system_version': 'unknown'
+        'system_version': 0
     })
     resp = await cli.get('/health')
     text = await resp.text()

--- a/api/tests/opentrons/server/test_health_endpoints.py
+++ b/api/tests/opentrons/server/test_health_endpoints.py
@@ -12,7 +12,7 @@ async def test_health(virtual_smoothie_env, loop, test_client):
         'api_version': __version__,
         'fw_version': 'Virtual Smoothie',
         'logs': ['/logs/serial.log', '/logs/api.log'],
-        'system_version': 0
+        'system_version': '0.0.0'
     })
     resp = await cli.get('/health')
     text = await resp.text()

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -324,3 +324,25 @@ async def test_incorrect_modify_pipette_settings(
         '/settings/pipettes/{}'.format(test_id),
         json=out_of_range)
     assert resp.status == 412
+
+
+async def test_set_log_level(
+        async_server, loop, async_client):
+    # Check input sanitization
+    resp = await async_client.post('/settings/log_level', json={})
+    assert resp.status == 400
+    body = await resp.json()
+    assert 'message' in body
+    resp = await async_client.post('/settings/log_level',
+                                   json={'log_level': 'oafajhshda'})
+    assert resp.status == 400
+    body = await resp.json()
+    assert 'message'in body
+
+    assert async_server['com.opentrons.hardware'].config.log_level != 'error'
+    resp = await async_client.post('/settings/log_level',
+                                   json={'log_level': 'error'})
+    assert resp.status == 200
+    body = await resp.json()
+    assert 'message' in body
+    assert async_server['com.opentrons.hardware'].config.log_level == 'error'

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -339,10 +339,10 @@ async def test_set_log_level(
     body = await resp.json()
     assert 'message'in body
 
-    assert async_server['com.opentrons.hardware'].config.log_level != 'error'
+    assert async_server['com.opentrons.hardware'].config.log_level != 'ERROR'
     resp = await async_client.post('/settings/log_level',
                                    json={'log_level': 'error'})
     assert resp.status == 200
     body = await resp.json()
     assert 'message' in body
-    assert async_server['com.opentrons.hardware'].config.log_level == 'error'
+    assert async_server['com.opentrons.hardware'].config.log_level == 'ERROR'

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -61,8 +61,10 @@ mock_connected:60:yes:WPA2
 mock_bad_security:50:no:foobar
 --:40:no:'''
 
-    expected_cmd = ['--terse', '--fields',
-                    'ssid,signal,active,security', 'device', 'wifi', 'list']
+    expected_cmds = iter(
+        (['device', 'wifi', 'rescan'],
+         ['--terse', '--fields',
+          'ssid,signal,active,security', 'device', 'wifi', 'list']))
 
     expected = [
         {'ssid': 'mock_wpa2', 'signal': 90, 'active': False,
@@ -78,8 +80,8 @@ mock_bad_security:50:no:foobar
         # note entry for 'ssid': '--' is expected to be filterd out
     ]
 
-    async def mock_call(cmd):
-        assert cmd == expected_cmd
+    async def mock_call(cmd, suppress_err=False):
+        assert cmd == next(expected_cmds)
         return mock_nmcli_output, ''
 
     monkeypatch.setattr(nmcli, '_call', mock_call)


### PR DESCRIPTION
We detect that we're running on buildroot by the presence of /etc/VERSION.json,
which is also where we take some versioning information. Based on that
information, we have:

### Small Changes For Buildroot Only
- Get the device name from hostnamectl to match up with what the update server
  set
- Don't mess around with key paths in nmcli
- Force rescans in nmcli since balena won't be doing it for us
- Get logs from journald rather than static files

### New Features for All Machines
POST `/settings/log_level` with a json body of `{"log_level": "debug"/"info"/"warning"/"error"}` will set the robot's log level both for the current boot and subsequent boots (so no restart is required).

### New Features For Buildroot Only
- /logs/{api,serial}.log has been changed for buildroot robots to actually accept and valid syslog identifier, so anything that something is logging under. `api.log` and `serial.log` are special-cased to `opentrons-api` and `opentrons-api-serial` respectively. This lets you get logs for anything on the system, try something like `GET /logs/kernel`! The log endpoints optionally can be given a json body with a `"format": "json" or "text"` (default json) to change the log format and `"records": int` to limit the number of log records the system returns.
- The button light should flash while the robot is booting and become solid when the server is started

Closes #3357 
Requires https://github.com/Opentrons/buildroot/pull/18
## Testing
Run through the robot-relevant sections of QA:
- [ ] Home button
- [ ] Lights button
- [ ] Download logs
- [ ] Factory reset various things
- [ ] Upload and run a protocol
- [ ] Upload and run a protocol that creates custom labware
- [ ] HTTP deck cal
- [ ] CLI deck cal