### PR TITLE
refactor(js): Upgrade flow to 0.97.0 and fix new typecheck failures 

### DIFF
--- a/app-shell/src/api-update.js
+++ b/app-shell/src/api-update.js
@@ -66,8 +66,7 @@ function getVersionFromFilename(filename: string): string {
 
   assert(match, `could not parse version from "${filename}"`)
 
-  // $FlowFixMe: assert above means `match` exists here
-  const [baseVersion, shortLabel, labelVersion] = match.slice(1)
+  const [baseVersion, shortLabel, labelVersion] = (match || []).slice(1)
   const label =
     shortLabel && labelVersion
       ? `-${SHORT_LABEL_TO_LABEL[shortLabel]}.${labelVersion}`

--- a/app-shell/src/config.js
+++ b/app-shell/src/config.js
@@ -14,8 +14,8 @@ import type { Action } from '@opentrons/app/src/types'
 import type { Config } from '@opentrons/app/src/config'
 
 // make sure all arguments are included in production
-// $FlowFixMe: process.defaultApp exists in electron
-const argv = process.defaultApp ? process.argv.slice(2) : process.argv.slice(1)
+const argv =
+  'defaultApp' in process ? process.argv.slice(2) : process.argv.slice(1)
 
 const PARSE_ARGS_OPTS = {
   envPrefix: 'OT_APP',

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   },
   "dependencies": {

--- a/app/src/components/AppSettings/AddManualIp/IpList.js
+++ b/app/src/components/AppSettings/AddManualIp/IpList.js
@@ -10,6 +10,8 @@ import type { Robot, ReachableRobot } from '../../../discovery'
 
 import IpItem from './IpItem'
 
+type OP = {||}
+
 type SP = {|
   robots: Array<Robot | ReachableRobot>,
   candidates: DiscoveryCandidates,
@@ -56,7 +58,7 @@ function mapDispatchToProps(dispatch: Dispatch): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   mapStateToProps,
   mapDispatchToProps
 )(IpList)

--- a/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
+++ b/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
@@ -10,22 +10,22 @@ import IpField from './IpField'
 import type { State, Dispatch } from '../../../types'
 import type { DiscoveryCandidates } from '../../../config'
 
-type SP = {|
-  candidates: DiscoveryCandidates,
-|}
+type OP = {||}
 
-type DP = {|
-  addManualIp: (ip: string) => mixed,
-|}
+type SP = {| candidates: DiscoveryCandidates |}
+
+type DP = {| addManualIp: (ip: string) => mixed |}
 
 type Props = { ...SP, ...DP }
 
 class IpForm extends React.Component<Props> {
   inputRef: { current: null | HTMLInputElement }
-  constructor(props) {
+
+  constructor(props: Props) {
     super(props)
     this.inputRef = React.createRef()
   }
+
   render() {
     return (
       <Formik
@@ -50,18 +50,13 @@ class IpForm extends React.Component<Props> {
   }
 }
 
-export default connect(
-  STP,
-  DTP
-)(IpForm)
-
-function STP(state: State): SP {
+function mapStateToProps(state: State): SP {
   return {
     candidates: getConfig(state).discovery.candidates,
   }
 }
 
-function DTP(dispatch: Dispatch): DP {
+function mapDispatchToProps(dispatch: Dispatch): DP {
   return {
     addManualIp: ip => {
       dispatch(addManualIp(ip))
@@ -69,3 +64,8 @@ function DTP(dispatch: Dispatch): DP {
     },
   }
 }
+
+export default connect<Props, OP, _, _, _, _>(
+  mapStateToProps,
+  mapDispatchToProps
+)(IpForm)

--- a/app/src/components/CalibrateDeck/ClearDeckAlert.js
+++ b/app/src/components/CalibrateDeck/ClearDeckAlert.js
@@ -5,18 +5,19 @@ import { push } from 'react-router-redux'
 import { deckCalibrationCommand as dcCommand } from '../../http-api-client'
 import ClearDeckAlertModal from '../ClearDeckAlertModal'
 
+import type { Dispatch } from '../../types'
 import type { CalibrateDeckProps } from './types'
 
-type OP = CalibrateDeckProps
+type OP = $Exact<CalibrateDeckProps>
 
 type DP = {|
   onContinue: () => mixed,
   onCancel: () => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...DP }
+type Props = { ...OP, ...DP }
 
-export default connect(
+export default connect<Props, OP, _, DP, _, _>(
   null,
   mapDispatchToProps
 )(ClearDeckAlert)

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -71,7 +71,6 @@ function InstructionsModal(props: Props) {
       }}
       heading={getHeading(props)}
     >
-      {/* $FlowFixMe: `...props` type doesn't include necessary keys */}
       <StepInstructions {...props} />
     </ModalPage>
   )

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -5,8 +5,6 @@ import { push } from 'react-router-redux'
 import { Link } from 'react-router-dom'
 import capitalize from 'lodash/capitalize'
 
-import type { CalibrateDeckStartedProps } from './types'
-
 import {
   restartRobotServer,
   deckCalibrationCommand as dcCommand,
@@ -17,17 +15,18 @@ import { ModalPage, SpinnerModalPage } from '@opentrons/components'
 import AttachTip from './AttachTip'
 import ConfirmPosition from './ConfirmPosition'
 
-type OP = CalibrateDeckStartedProps
+import type { Dispatch } from '../../types'
+import type { CalibrateDeckStartedProps } from './types'
 
-type DP = {|
-  proceed: () => mixed,
-|}
+type OP = $Exact<CalibrateDeckStartedProps>
 
-type Props = { ...$Exact<OP>, ...DP }
+type DP = {| proceed: () => mixed |}
+
+type Props = { ...OP, ...DP }
 
 const TITLE = 'Deck Calibration'
 
-export default connect(
+export default connect<Props, OP, _, _, _, _>(
   null,
   mapDispatchToProps
 )(InstructionsModal)

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -5,7 +5,14 @@ import { push, goBack } from 'react-router-redux'
 import { Switch, Route, withRouter } from 'react-router'
 
 import type { State, Dispatch } from '../../types'
-import type { OP, SP, DP, CalibrateDeckProps, CalibrationStep } from './types'
+import type {
+  WithRouterOP,
+  OP,
+  SP,
+  DP,
+  CalibrateDeckProps,
+  CalibrationStep,
+} from './types'
 
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import { chainActions } from '../../util'
@@ -33,8 +40,8 @@ const BAD_PIPETTE_ERROR = 'Unexpected pipette response from robot'
 const ERROR_DESCRIPTION =
   'An unexpected error has cleared your deck calibration progress, please try again.'
 
-export default withRouter(
-  connect(
+export default withRouter<WithRouterOP>(
+  connect<CalibrateDeckProps, OP, SP, _, _, _>(
     makeMapStateToProps,
     mapDispatchToProps
   )(CalibrateDeck)
@@ -100,7 +107,7 @@ function CalibrateDeck(props: CalibrateDeckProps) {
           }
 
           if (pipetteProps && pipetteProps.pipette) {
-            return <ClearDeckAlert {...props} {...pipetteProps} />
+            return <ClearDeckAlert {...props} />
           }
 
           return null

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Match } from 'react-router'
+import type { ContextRouter } from 'react-router'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { RobotService, Mount } from '../../robot'
 import type {
@@ -10,11 +10,15 @@ import type { Jog } from '../JogControls'
 
 export type CalibrationStep = '1' | '2' | '3' | '4' | '5' | '6'
 
-export type OP = {
+export type WithRouterOP = {|
   robot: RobotService,
   parentUrl: string,
-  match: Match,
-}
+|}
+
+export type OP = {|
+  ...ContextRouter,
+  ...WithRouterOP,
+|}
 
 export type SP = {|
   startRequest: DeckCalStartState,
@@ -32,7 +36,7 @@ export type DP = {|
   back: () => mixed,
 |}
 
-export type CalibrateDeckProps = { ...$Exact<OP>, ...SP, ...DP }
+export type CalibrateDeckProps = { ...OP, ...SP, ...DP }
 
 export type CalibrateDeckStartedProps = {
   ...$Exact<CalibrateDeckProps>,

--- a/app/src/components/CalibrateLabware/ConfirmModal.js
+++ b/app/src/components/CalibrateLabware/ConfirmModal.js
@@ -42,7 +42,7 @@ export default function ConfirmModal(props: Props) {
       heading={`Calibrate pipette to ${labware.type}`}
     >
       <ConfirmModalContents
-        {...labware}
+        labware={labware}
         calibrateToBottom={calibrateToBottom}
       />
     </ModalPage>

--- a/app/src/components/CalibrateLabware/ConfirmModalContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmModalContents.js
@@ -13,27 +13,35 @@ import ConfirmPositionContents from './ConfirmPositionContents'
 import ConfirmPickupContents from './ConfirmPickupContents'
 import InProgressContents from './InProgressContents'
 
-type OP = Labware
+type OP = {| labware: Labware, calibrateToBottom: boolean |}
 
-type SP = {|
-  calibrator: ?Pipette,
-|}
+type SP = {| calibrator: ?Pipette |}
 
-type Props = { ...$Exact<OP>, ...SP }
+type Props = { ...OP, ...SP }
 
-export default connect(mapStateToProps)(ConfirmModalContents)
+export default connect<Props, OP, _, _, _, _>(mapStateToProps)(
+  ConfirmModalContents
+)
 
 function ConfirmModalContents(props: Props) {
-  if (!props.calibrator) return null
+  const { labware, calibrator, calibrateToBottom } = props
+  if (!calibrator) return null
 
-  switch (props.calibration) {
+  switch (labware.calibration) {
     case 'unconfirmed':
     case 'over-slot':
     case 'jogging':
-      return <ConfirmPositionContents {...props} />
+      return (
+        <ConfirmPositionContents
+          labware={labware}
+          calibrator={calibrator}
+          calibrateToBottom={calibrateToBottom}
+        />
+      )
 
-    case 'picked-up':
-      return <ConfirmPickupContents {...props} />
+    case 'picked-up': {
+      return <ConfirmPickupContents labware={labware} calibrator={calibrator} />
+    }
 
     case 'moving-to-slot':
     case 'picking-up':
@@ -47,7 +55,7 @@ function ConfirmModalContents(props: Props) {
 }
 
 function mapStateToProps(state, ownProps: OP): SP {
-  const calibratorMount = ownProps.calibratorMount
+  const { calibratorMount } = ownProps.labware
   const pipettes = robotSelectors.getPipettes(state)
   const calibrator =
     pipettes.find(i => i.mount === calibratorMount) ||

--- a/app/src/components/CalibrateLabware/ConfirmPickupContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPickupContents.js
@@ -1,36 +1,33 @@
 // @flow
 // pickup confirmation contents container for ConfirmModal
-import type { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 
-import {
-  actions as robotActions,
-  type Labware,
-  type Pipette,
-} from '../../robot'
-
+import { actions as robotActions } from '../../robot'
 import ConfirmPickupPrompt from './ConfirmPickupPrompt'
 
-type OwnProps = Labware & {
-  calibrator: Pipette,
-}
+import type { Dispatch } from '../../types'
+import type { Labware, Pipette } from '../../robot'
 
-type DispatchProps = {
+type OP = {|
+  labware: Labware,
+  calibrator: Pipette,
+|}
+
+type DP = {|
   onNoClick: () => void,
   onYesClick: () => void,
-}
+|}
 
-export default connect(
+type Props = { ...OP, ...DP }
+
+export default connect<Props, OP, _, _, _, _>(
   null,
   mapDispatchToProps
 )(ConfirmPickupPrompt)
 
-function mapDispatchToProps(
-  dispatch: Dispatch<*>,
-  ownProps: OwnProps
-): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const {
-    slot,
+    labware: { slot },
     calibrator: { mount },
   } = ownProps
 

--- a/app/src/components/CalibrateLabware/ConfirmPickupPrompt.js
+++ b/app/src/components/CalibrateLabware/ConfirmPickupPrompt.js
@@ -2,12 +2,12 @@
 // pickup confirmation prompt component for ConfirmPickupContents
 import * as React from 'react'
 
-import type { Labware, Pipette } from '../../robot'
+import type { Pipette } from '../../robot'
 
 import { PrimaryButton } from '@opentrons/components'
 import styles from './styles.css'
 
-type Props = Labware & {
+type Props = {
   calibrator: Pipette,
   onNoClick: () => void,
   onYesClick: () => void,

--- a/app/src/components/CalibrateLabware/ConfirmPositionContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionContents.js
@@ -11,36 +11,37 @@ import { PrimaryButton } from '@opentrons/components'
 import ConfirmPositionDiagram from './ConfirmPositionDiagram'
 import JogControls, { type Jog } from '../JogControls'
 
-type DP = {
-  onConfirmClick: () => mixed,
-  jog: Jog,
-}
-
-type OP = Labware & {
+type OP = {|
+  labware: Labware,
   calibrator: Pipette,
   calibrateToBottom: boolean,
-}
+|}
 
-type Props = DP & OP
+type DP = {|
+  onConfirmClick: () => mixed,
+  jog: Jog,
+|}
 
-export default connect(
+type Props = { ...OP, ...DP }
+
+export default connect<Props, OP, _, _, _, _>(
   null,
   mapDispatchToProps
 )(ConfirmPositionContents)
 
 function ConfirmPositionContents(props: Props) {
   const {
-    isTiprack,
     onConfirmClick,
+    labware: { isTiprack },
     calibrator: { channels },
   } = props
+
   const confirmButtonText = isTiprack
     ? `pick up tip${channels === 8 ? 's' : ''}`
     : 'save calibration'
 
   return (
     <div>
-      {/* $FlowFixMe: `...props` type doesn't include necessary keys */}
       <ConfirmPositionDiagram {...props} buttonText={confirmButtonText} />
       <JogControls {...props} />
       <PrimaryButton title="confirm" onClick={onConfirmClick}>
@@ -52,10 +53,10 @@ function ConfirmPositionContents(props: Props) {
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const {
-    slot,
-    isTiprack,
+    labware: { slot, isTiprack },
     calibrator: { mount },
   } = ownProps
+
   const onConfirmAction = isTiprack
     ? robotActions.pickupAndHome(mount, slot)
     : robotActions.updateOffset(mount, slot)

--- a/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
+++ b/app/src/components/CalibrateLabware/ConfirmPositionDiagram.js
@@ -8,15 +8,17 @@ import InstructionStep from '../InstructionStep'
 import { getInstructionsByType, getDiagramSrc } from './instructions-data'
 import styles from '../InstructionStep/styles.css'
 
-export type LabwareCalibrationProps = Labware & {
+export type LabwareCalibrationProps = {
+  labware: Labware,
   calibrator: Pipette,
-  buttonText: string,
   calibrateToBottom: boolean,
+  buttonText: string,
 }
 
 export default function ConfirmPositionDiagram(props: LabwareCalibrationProps) {
   const instructions = getInstructionsByType(props)
   const diagrams = getDiagramSrc(props)
+
   return (
     diagrams && (
       <div className={styles.instructions}>

--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -1,7 +1,6 @@
 // @flow
 // info panel for labware calibration page
 import * as React from 'react'
-import type { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 import capitalize from 'lodash/capitalize'
@@ -9,33 +8,30 @@ import capitalize from 'lodash/capitalize'
 import {
   selectors as robotSelectors,
   actions as robotActions,
-  type Mount,
-  type Labware,
-  type LabwareType,
 } from '../../robot'
 
 import { PrimaryButton } from '@opentrons/components'
 import CalibrationInfoBox from '../CalibrationInfoBox'
 import CalibrationInfoContent from '../CalibrationInfoContent'
 
+import type { Mount, Labware, LabwareType } from '../../robot'
+import type { State, Dispatch } from '../../types'
+
 // TODO(mc, 2018-02-05): match screens instead of using this old component
 // import ConfirmCalibrationPrompt from '../deck/ConfirmCalibrationPrompt'
 
-type OwnProps = {
-  labware: ?Labware,
-}
+type OP = {| labware: ?Labware |}
 
-type StateProps = {
+type SP = {|
   _buttonTarget: ?Labware,
   _buttonTargetIsNext: boolean,
   _calibratorMount: ?Mount,
-}
+|}
 
-type DispatchProps = {
-  dispatch: Dispatch<*>,
-}
+type DP = {| dispatch: Dispatch |}
 
-type Props = OwnProps & {
+type Props = {
+  ...OP,
   button: ?{
     type: LabwareType,
     isNext: boolean,
@@ -44,7 +40,7 @@ type Props = OwnProps & {
   },
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   mapStateToProps,
   null,
   mergeProps
@@ -94,7 +90,7 @@ function InfoBox(props: Props) {
   )
 }
 
-function mapStateToProps(state, ownProps: OwnProps): StateProps {
+function mapStateToProps(state: State, ownProps: OP): SP {
   const { labware } = ownProps
   const _nextLabware =
     !labware || labware.calibration === 'confirmed'
@@ -116,11 +112,7 @@ function mapStateToProps(state, ownProps: OwnProps): StateProps {
   }
 }
 
-function mergeProps(
-  stateProps: StateProps,
-  dispatchProps: DispatchProps,
-  ownProps: OwnProps
-): Props {
+function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   const { _buttonTarget, _buttonTargetIsNext, _calibratorMount } = stateProps
   const { dispatch } = dispatchProps
   const targetConfirmed = _buttonTarget && _buttonTarget.confirmed
@@ -137,6 +129,7 @@ function mergeProps(
           dispatch(robotActions.moveTo(_calibratorMount, _buttonTarget.slot))
           dispatch(push(`/calibrate/labware/${_buttonTarget.slot}`))
         } else if (_calibratorMount) {
+          // $FlowFixMe: robotActions.returnTip is not typed
           dispatch(robotActions.returnTip(_calibratorMount))
           dispatch(push(`/run`))
         }

--- a/app/src/components/CalibrateLabware/index.js
+++ b/app/src/components/CalibrateLabware/index.js
@@ -6,15 +6,14 @@ import type { Labware } from '../../robot'
 import DeckMap from '../DeckMap'
 import InfoBox from './InfoBox'
 
-type Props = {
-  labware: ?Labware,
-}
-export default withRouter(CalibrateLabware)
+type Props = { labware: ?Labware }
+
+export default withRouter<$Exact<Props>>(CalibrateLabware)
 
 function CalibrateLabware(props: Props) {
   return (
     <div>
-      <InfoBox {...props} />
+      <InfoBox labware={props.labware} />
       <DeckMap />
     </div>
   )

--- a/app/src/components/CalibrateLabware/instructions-data.js
+++ b/app/src/components/CalibrateLabware/instructions-data.js
@@ -324,7 +324,7 @@ export function getInstructionsByType(props: LabwareCalibrationProps) {
 }
 
 function getTypeKey(props: LabwareCalibrationProps) {
-  const { type, isTiprack } = props
+  const { type, isTiprack } = props.labware
   let typeKey
   if (isTiprack) {
     typeKey = 'tiprack'
@@ -341,9 +341,7 @@ function getTypeKey(props: LabwareCalibrationProps) {
 }
 
 function getChannelsKey(props: LabwareCalibrationProps) {
-  const {
-    calibrator: { channels },
-  } = props
+  const { channels } = props.calibrator
   const channelsKey = channels === 8 ? 'multi' : 'single'
   return channelsKey
 }

--- a/app/src/components/CalibratePanel/LabwareGroup.js
+++ b/app/src/components/CalibratePanel/LabwareGroup.js
@@ -1,19 +1,21 @@
 // @flow
+import * as React from 'react'
 import { connect } from 'react-redux'
-import { SidePanelGroup } from '@opentrons/components'
 
+import { SidePanelGroup } from '@opentrons/components'
 import { selectors as robotSelectors } from '../../robot'
 
 const TITLE = 'Labware Calibration'
 
-type StateProps = {
-  title: string,
-  disabled: boolean,
-}
+type SP = {| title: string, disabled: boolean |}
 
-export default connect(mapStateToProps)(SidePanelGroup)
+type OP = $Rest<$Exact<React.ElementProps<typeof SidePanelGroup>>, SP>
 
-function mapStateToProps(state): StateProps {
+type Props = { ...OP, ...SP }
+
+export default connect<Props, OP, SP, _, _, _>(mapStateToProps)(SidePanelGroup)
+
+function mapStateToProps(state): SP {
   const isRunning = robotSelectors.getIsRunning(state)
   const disabled = isRunning
 

--- a/app/src/components/CalibratePanel/LabwareList.js
+++ b/app/src/components/CalibratePanel/LabwareList.js
@@ -29,8 +29,8 @@ type Props = {
   setLabware: (labware: Labware) => mixed,
 }
 
-export default withRouter(
-  connect(
+export default withRouter<{||}>(
+  connect<Props, _, SP, {||}, State, Dispatch>(
     mapStateToProps,
     null,
     mergeProps

--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 
@@ -19,7 +19,9 @@ type Props = {
 
 const TITLE = 'Pipette Calibration'
 
-export default withRouter(connect(mapStateToProps)(PipetteList))
+export default withRouter<{||}>(
+  connect<Props, _, _, _, _, _>(mapStateToProps)(PipetteList)
+)
 
 function PipetteList(props: Props) {
   const { pipettes, isRunning } = props
@@ -38,7 +40,7 @@ function PipetteList(props: Props) {
   )
 }
 
-function mapStateToProps(state): Props {
+function mapStateToProps(state): $Exact<Props> {
   return {
     pipettes: robotSelectors.getPipettes(state),
     isRunning: robotSelectors.getIsRunning(state),

--- a/app/src/components/CalibratePanel/TipRackList.js
+++ b/app/src/components/CalibratePanel/TipRackList.js
@@ -29,8 +29,8 @@ type Props = {
   setLabware: (labware: Labware) => mixed,
 }
 
-export default withRouter(
-  connect(
+export default withRouter<{||}>(
+  connect<Props, _, SP, {||}, State, Dispatch>(
     mapStateToProps,
     null,
     mergeProps

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -45,49 +45,7 @@ const RE_MOUNT = '(left|right)'
 // used to guarentee model param in route is a pipettes model
 const RE_NAME = `(${getPipetteDisplayNames().join('|')})`
 
-const ConnectedChangePipetteRouter = withRouter(
-  connect(
-    makeMapStateToProps,
-    mapDispatchToProps
-  )(ChangePipetteRouter)
-)
-
-export default function ChangePipette(props: Props) {
-  const {
-    robot,
-    parentUrl,
-    match: { path },
-  } = props
-
-  return (
-    <Route
-      path={`${path}/:mount${RE_MOUNT}/:name${RE_NAME}?`}
-      render={propsWithMount => {
-        const {
-          match: { params, url: baseUrl },
-        } = propsWithMount
-        const mount: Mount = (params.mount: any)
-        const wantedPipetteName = params.name || null
-
-        return (
-          <ConnectedChangePipetteRouter
-            robot={robot}
-            title={TITLE}
-            subtitle={`${mount} mount`}
-            mount={mount}
-            wantedPipetteName={wantedPipetteName}
-            parentUrl={parentUrl}
-            baseUrl={baseUrl}
-            confirmUrl={`${baseUrl}/confirm`}
-            exitUrl={`${baseUrl}/exit`}
-          />
-        )
-      }}
-    />
-  )
-}
-
-type OP = {
+type OP = {|
   title: string,
   subtitle: string,
   mount: Mount,
@@ -97,9 +55,9 @@ type OP = {
   confirmUrl: string,
   exitUrl: string,
   parentUrl: string,
-}
+|}
 
-type SP = {
+type SP = {|
   moveRequest: RobotMove,
   homeRequest: RobotHome,
   actualPipette: ?PipetteModelSpecs,
@@ -107,16 +65,23 @@ type SP = {
   direction: Direction,
   success: boolean,
   attachedWrong: boolean,
-}
+|}
 
-type DP = {
+type DP = {|
   exit: () => mixed,
   back: () => mixed,
   onPipetteSelect: $PropertyType<PipetteSelectionProps, 'onChange'>,
   moveToFront: () => mixed,
   checkPipette: () => mixed,
   confirmPipette: () => mixed,
-}
+|}
+
+const ConnectedChangePipetteRouter = withRouter<OP>(
+  connect<ChangePipetteProps, _, SP, DP, State, Dispatch>(
+    makeMapStateToProps,
+    mapDispatchToProps
+  )(ChangePipetteRouter)
+)
 
 function ChangePipetteRouter(props: ChangePipetteProps) {
   const { baseUrl, confirmUrl, exitUrl, moveRequest, homeRequest } = props
@@ -151,12 +116,12 @@ function ChangePipetteRouter(props: ChangePipetteProps) {
   )
 }
 
-function makeMapStateToProps() {
+function makeMapStateToProps(): (State, OP) => SP {
   const getRobotMove = makeGetRobotMove()
   const getRobotHome = makeGetRobotHome()
   const getRobotPipettes = makeGetRobotPipettes()
 
-  return (state: State, ownProps: OP): SP => {
+  return (state, ownProps) => {
     const { mount, wantedPipetteName } = ownProps
     const pipettes = getRobotPipettes(state, ownProps.robot).response
     const model = pipettes && pipettes[mount] && pipettes[mount].model
@@ -205,4 +170,37 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
       ).then(disengage),
     confirmPipette: () => checkPipette().then(() => dispatch(push(confirmUrl))),
   }
+}
+
+export default function ChangePipette(props: Props) {
+  const {
+    robot,
+    parentUrl,
+    match: { path },
+  } = props
+
+  return (
+    <Route
+      path={`${path}/:mount${RE_MOUNT}/:name${RE_NAME}?`}
+      render={propsWithMount => {
+        const { params, url: baseUrl } = propsWithMount.match
+        const mount: Mount = (params.mount: any)
+        const wantedPipetteName = params.name || null
+
+        return (
+          <ConnectedChangePipetteRouter
+            robot={robot}
+            title={TITLE}
+            subtitle={`${mount} mount`}
+            mount={mount}
+            wantedPipetteName={wantedPipetteName}
+            parentUrl={parentUrl}
+            baseUrl={baseUrl}
+            confirmUrl={`${baseUrl}/confirm`}
+            exitUrl={`${baseUrl}/exit`}
+          />
+        )
+      }}
+    />
+  )
 }

--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -59,8 +59,9 @@ export default class ConfigForm extends React.Component<Props> {
     })
   }
 
-  getVisibleFields = () => {
+  getVisibleFields = (): PipetteConfigFields => {
     if (this.props.showHiddenFields) return this.props.pipetteConfig.fields
+
     return pick(this.props.pipetteConfig.fields, [
       ...PLUNGER_KEYS,
       ...POWER_KEYS,
@@ -68,8 +69,8 @@ export default class ConfigForm extends React.Component<Props> {
     ])
   }
 
-  getUnknownKeys = () => {
-    return keys(
+  getUnknownKeys = (): Array<string> => {
+    return keys<string>(
       omit(this.props.pipetteConfig.fields, [
         ...PLUNGER_KEYS,
         ...POWER_KEYS,

--- a/app/src/components/ConfigurePipette/index.js
+++ b/app/src/components/ConfigurePipette/index.js
@@ -19,7 +19,7 @@ import ConfigMessage from './ConfigMessage'
 import ConfigForm from './ConfigForm'
 import ConfigErrorBanner from './ConfigErrorBanner'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { Mount } from '../../robot'
 import type { Robot } from '../../discovery'
 import type {
@@ -46,10 +46,9 @@ type DP = {|
   updateConfig: (id: string, PipetteConfigRequest) => mixed,
 |}
 
-// type Props = SP & OP & DP
-type Props = { ...$Exact<OP>, ...$Exact<SP>, ...$Exact<DP> }
+type Props = { ...OP, ...SP, ...DP }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   makeMapStateToProps,
   mapDispatchToProps
 )(ConfigurePipette)
@@ -84,6 +83,7 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getRobotPipettes = makeGetRobotPipettes()
   const getRobotPipetteConfigs = makeGetRobotPipetteConfigs()
   const getPipetteRequestById = makeGetPipetteRequestById()
+
   return (state, ownProps) => {
     const pipettesCall = getRobotPipettes(state, ownProps.robot)
     const pipettes = pipettesCall && pipettesCall.response
@@ -107,6 +107,7 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const { robot, parentUrl } = ownProps
+
   return {
     updateConfig: (id, params) =>
       dispatch(

--- a/app/src/components/ConfirmTipProbeModal/index.js
+++ b/app/src/components/ConfirmTipProbeModal/index.js
@@ -1,7 +1,6 @@
 // @flow
 // container to prompt the user to clear the deck before continuing tip probe
 import * as React from 'react'
-import type { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 
@@ -10,17 +9,15 @@ import { ContinueModal } from '@opentrons/components'
 import { Portal } from '../portal'
 import Contents from './Contents'
 
-type OwnProps = {
-  mount: Mount,
-  backUrl: string,
-}
+import type { Dispatch } from '../../types'
 
-type Props = {
-  onContinueClick: () => void,
-  onCancelClick: () => void,
-}
+type OP = {| mount: Mount, backUrl: string |}
 
-export default connect(
+type DP = {| onContinueClick: () => void, onCancelClick: () => void |}
+
+type Props = { ...OP, ...DP }
+
+export default connect<Props, OP, {||}, DP, _, Dispatch>(
   null,
   mapDispatchToProps
 )(ContinueTipProbeModal)
@@ -38,15 +35,17 @@ function ContinueTipProbeModal(props: Props) {
   )
 }
 
-function mapDispatchToProps(dispatch: Dispatch<*>, ownProps: OwnProps) {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const { mount, backUrl } = ownProps
 
   return {
     // TODO(mc, 2018-01-23): refactor to remove double dispatch
     onContinueClick: () => {
+      // $FlowFixMe: robotActions.moveToFront is not typed
       dispatch(robotActions.moveToFront(mount))
       dispatch(push(backUrl))
     },
+    // $FlowFixMe: react-router-redux action creators are not typed
     onCancelClick: () => dispatch(push(backUrl)),
   }
 }

--- a/app/src/components/ConnectModulesModal/ReviewModuleItem.js
+++ b/app/src/components/ConnectModulesModal/ReviewModuleItem.js
@@ -12,14 +12,15 @@ import type { LabwareComponentProps } from '@opentrons/components'
 import type { State } from '../../types'
 import type { SessionModule } from '../../robot'
 
-type OP = LabwareComponentProps
+type OP = $Exact<LabwareComponentProps>
 
-type Props = {
-  module: ?SessionModule,
-  present: boolean,
-}
+type SP = {| module: ?SessionModule, present: boolean |}
 
-export default connect(makeMapStateToProps)(ReviewModuleItem)
+type Props = { ...OP, ...SP }
+
+export default connect<Props, OP, SP, _, _, _>(makeMapStateToProps)(
+  ReviewModuleItem
+)
 
 function ReviewModuleItem(props: Props) {
   if (!props.module) return null
@@ -32,7 +33,7 @@ function ReviewModuleItem(props: Props) {
   )
 }
 
-function makeMapStateToProps(): (state: State, ownProps: OP) => Props {
+function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   // TODO(mc, 2018-07-23): this logic is duplicated because can only get props
   // into Deck.props.LabwareComponent via redux
   const getRobotModules = makeGetRobotModules()

--- a/app/src/components/ConnectModulesModal/index.js
+++ b/app/src/components/ConnectModulesModal/index.js
@@ -15,27 +15,19 @@ import { Modal } from '../modals'
 import Prompt from './Prompt'
 import ReviewModuleItem from './ReviewModuleItem'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { RobotService, SessionModule } from '../../robot'
 import type { Module } from '../../http-api-client'
 
-type OP = {
-  robot: RobotService,
-}
+type OP = {| robot: RobotService |}
 
-type SP = {
-  modulesRequired: boolean,
-  modulesMissing: boolean,
-}
+type SP = {| modulesRequired: boolean, modulesMissing: boolean |}
 
-type DP = {
-  setReviewed: () => mixed,
-  fetchModules: () => mixed,
-}
+type DP = {| setReviewed: () => mixed, fetchModules: () => mixed |}
 
-type Props = OP & SP & DP
+type Props = { ...OP, ...SP, ...DP }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   makeMapStateToProps,
   mapDispatchToProps
 )(ConnectModulesModal)

--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -3,52 +3,42 @@
 import { connect } from 'react-redux'
 import { withRouter, type ContextRouter } from 'react-router'
 
-import type { State, Dispatch } from '../../types'
-import type { ViewableRobot } from '../../discovery'
 import { actions as robotActions } from '../../robot'
 import { makeGetRobotUpdateInfo } from '../../http-api-client'
 import { RobotListItem } from './RobotListItem.js'
 
-type OP = {|
-  ...$Exact<ViewableRobot>,
-  ...ContextRouter,
-|}
+import type { State, Dispatch } from '../../types'
+import type { ViewableRobot } from '../../discovery'
 
-type SP = {|
-  upgradable: boolean,
-  selected: boolean,
-|}
+type WithRouterOP = {| robot: ViewableRobot |}
 
-type DP = {|
-  connect: () => mixed,
-  disconnect: () => mixed,
-|}
+type OP = {| ...ContextRouter, ...WithRouterOP |}
 
-export type RobotItemProps = {
-  ...OP,
-  ...SP,
-  ...DP,
-}
+type SP = {| upgradable: boolean, selected: boolean |}
 
-export default withRouter(
-  connect(
+type DP = {| connect: () => mixed, disconnect: () => mixed |}
+
+export type RobotItemProps = { ...OP, ...SP, ...DP }
+
+export default withRouter<WithRouterOP>(
+  connect<RobotItemProps, OP, SP, DP, State, Dispatch>(
     makeMapStateToProps,
     mapDispatchToProps
   )(RobotListItem)
 )
 
-function makeMapStateToProps() {
+function makeMapStateToProps(): (State, OP) => SP {
   const getUpdateInfo = makeGetRobotUpdateInfo()
 
-  return (state: State, ownProps: OP): SP => ({
-    upgradable: getUpdateInfo(state, ownProps).type === 'upgrade',
-    selected: ownProps.match.params.name === ownProps.name,
+  return (state, ownProps) => ({
+    upgradable: getUpdateInfo(state, ownProps.robot).type === 'upgrade',
+    selected: ownProps.match.params.name === ownProps.robot.name,
   })
 }
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   return {
-    connect: () => dispatch(robotActions.connect(ownProps.name)),
+    connect: () => dispatch(robotActions.connect(ownProps.robot.name)),
     disconnect: () => dispatch(robotActions.disconnect()),
   }
 }

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -12,17 +12,10 @@ import styles from './styles.css'
 import type { RobotItemProps } from './RobotItem'
 
 export function RobotListItem(props: RobotItemProps) {
-  const {
-    name,
-    displayName,
-    local,
-    status,
-    selected,
-    upgradable,
-    connect,
-    disconnect,
-  } = props
-  const connected = props.connected != null && props.connected === true
+  const { robot, selected, upgradable, connect, disconnect } = props
+  const { name, displayName, local, status } = robot
+  // unnecessary existence check to satisfy flow
+  const connected = robot.connected != null && robot.connected === true
   const connectable = status === CONNECTABLE
   const onClick = connected ? disconnect : connect
 

--- a/app/src/components/ConnectPanel/index.js
+++ b/app/src/components/ConnectPanel/index.js
@@ -21,7 +21,7 @@ import UnreachableRobotItem from './UnreachableRobotItem'
 
 import type { Robot, ReachableRobot, UnreachableRobot } from '../../discovery'
 
-type StateProps = {|
+type SP = {|
   robots: Array<Robot>,
   reachableRobots: Array<ReachableRobot>,
   unreachableRobots: Array<UnreachableRobot>,
@@ -29,16 +29,11 @@ type StateProps = {|
   isScanning: boolean,
 |}
 
-type DispatchProps = {|
-  onScanClick: () => mixed,
-|}
+type DP = {| onScanClick: () => mixed |}
 
-type Props = {
-  ...StateProps,
-  ...DispatchProps,
-}
+type Props = { ...SP, ...DP }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, State, Dispatch>(
   mapStateToProps,
   mapDispatchToProps
 )(ConnectPanel)
@@ -49,10 +44,10 @@ function ConnectPanel(props: Props) {
       <ScanStatus {...props} />
       <RobotList>
         {props.robots.map(robot => (
-          <RobotItem key={robot.name} {...robot} />
+          <RobotItem key={robot.name} robot={robot} />
         ))}
         {props.reachableRobots.map(robot => (
-          <RobotItem key={robot.name} {...robot} />
+          <RobotItem key={robot.name} robot={robot} />
         ))}
         {props.unreachableRobots.map(robot => (
           <UnreachableRobotItem key={robot.name} {...robot} />
@@ -66,7 +61,7 @@ const robotOrder = [['connected', 'local', 'name'], ['desc', 'desc', 'asc']]
 const reachableOrder = [['local', 'name'], ['desc', 'asc']]
 const unreachableOrder = [['name'], ['asc']]
 
-function mapStateToProps(state: State): StateProps {
+function mapStateToProps(state: State): SP {
   const robots = getConnectableRobots(state)
   const reachableRobots = getReachableRobots(state)
   const unreachableRobots = getUnreachableRobots(state)
@@ -80,7 +75,7 @@ function mapStateToProps(state: State): StateProps {
   }
 }
 
-function mapDispatchToProps(dispatch: Dispatch): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch): DP {
   return {
     onScanClick: () => dispatch(startDiscovery()),
   }

--- a/app/src/components/DeckMap/ConnectedSlotItem.js
+++ b/app/src/components/DeckMap/ConnectedSlotItem.js
@@ -1,38 +1,42 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { withRouter, type Match } from 'react-router'
-
-import type { State, Dispatch } from '../../types'
+import { withRouter } from 'react-router'
 
 import {
   selectors as robotSelectors,
   actions as robotActions,
-  type Mount,
-  type SessionModule,
 } from '../../robot'
 
 import { Module as ModuleItem } from '@opentrons/components'
-import type { LabwareComponentProps } from '@opentrons/components'
 import LabwareItem, { type LabwareItemProps } from './LabwareItem'
 
-type OP = LabwareComponentProps & { match: Match }
+import type { ContextRouter } from 'react-router'
+import type { LabwareComponentProps } from '@opentrons/components'
+import type { Mount, SessionModule } from '../../robot'
+import type { State, Dispatch } from '../../types'
 
-type SP = {
-  _calibrator?: ?Mount,
-  _labware?: $PropertyType<LabwareItemProps, 'labware'>,
-  module?: SessionModule,
-}
+type WithRouterOP = $Exact<LabwareComponentProps>
 
-type DP = { dispatch: Dispatch }
+type OP = {| ...ContextRouter, ...WithRouterOP |}
 
-type Props = LabwareComponentProps & {
+type SP = {|
+  _calibrator: Mount | null,
+  _labware: $PropertyType<LabwareItemProps, 'labware'> | null,
+  module: SessionModule | null,
+|}
+
+type DP = {| dispatch: Dispatch |}
+
+type Props = {
+  ...OP,
+  ...SP,
   labware?: $PropertyType<LabwareItemProps, 'labware'>,
   module?: SessionModule,
 }
 
-export default withRouter(
-  connect(
+export default withRouter<WithRouterOP>(
+  connect<Props, OP, SP, {||}, State, Dispatch>(
     mapStateToProps,
     null,
     mergeProps
@@ -71,7 +75,7 @@ function mapStateToProps(state: State, ownProps: OP): SP {
   const highlighted = slot === selectedSlot
   const module = robotSelectors.getModulesBySlot(state)[slot]
 
-  const stateProps: SP = {}
+  const stateProps: SP = { _calibrator: null, _labware: null, module: null }
 
   if (labware) {
     const { isTiprack, confirmed, calibratorMount } = labware

--- a/app/src/components/DeckMap/LabwareItem.js
+++ b/app/src/components/DeckMap/LabwareItem.js
@@ -17,8 +17,10 @@ import {
 import LabwareSpinner from './LabwareSpinner'
 import styles from './styles.css'
 
-export type LabwareItemProps = LabwareComponentProps & {
-  labware: Labware & {
+export type LabwareItemProps = {
+  ...$Exact<LabwareComponentProps>,
+  labware: {
+    ...$Exact<Labware>,
     highlighted?: boolean,
     disabled?: boolean,
     showSpinner?: boolean,

--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -8,13 +8,7 @@ import LabwareItem from './LabwareItem'
 import styles from './styles.css'
 
 export default function DeckMap() {
-  return (
-    <Deck
-      // $FlowFixMe: I think ReactRouter type is causing problems here?
-      LabwareComponent={ConnectedSlotItem}
-      className={styles.deck}
-    />
-  )
+  return <Deck LabwareComponent={ConnectedSlotItem} className={styles.deck} />
 }
 
 export { LabwareItem }

--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -28,7 +28,9 @@ const INFO_TITLE = 'Information'
 const DESCRIPTION_TITLE = 'Description'
 const DATE_FORMAT = 'DD MMM Y, hh:mmA'
 
-export default connect(mapStateToProps)(InformationCard)
+export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(
+  InformationCard
+)
 
 function InformationCard(props: Props) {
   const { name, author, method, description } = props
@@ -63,7 +65,7 @@ function InformationCard(props: Props) {
   )
 }
 
-function mapStateToProps(state: State): Props {
+function mapStateToProps(state: State): $Exact<Props> {
   return {
     name: getProtocolName(state),
     author: getProtocolAuthor(state),

--- a/app/src/components/FileInfo/ProtocolLabwareCard.js
+++ b/app/src/components/FileInfo/ProtocolLabwareCard.js
@@ -17,7 +17,9 @@ type Props = {
 
 const TITLE = 'Required Labware'
 
-export default connect(mapStateToProps)(ProtocolLabwareCard)
+export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(
+  ProtocolLabwareCard
+)
 
 function ProtocolLabwareCard(props: Props) {
   const { labware } = props
@@ -38,7 +40,7 @@ function ProtocolLabwareCard(props: Props) {
     </InfoSection>
   )
 }
-function mapStateToProps(state: State): Props {
+function mapStateToProps(state: State): $Exact<Props> {
   return {
     labware: robotSelectors.getLabware(state),
   }

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -17,11 +17,11 @@ import { SectionContentHalf } from '../layout'
 import InstrumentItem from './InstrumentItem'
 import InstrumentWarning from './InstrumentWarning'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { SessionModule } from '../../robot'
 import type { Robot } from '../../discovery'
 
-type OP = { robot: Robot }
+type OP = {| robot: Robot |}
 
 type SP = {|
   modules: Array<SessionModule>,
@@ -31,11 +31,11 @@ type SP = {|
 
 type DP = {| fetchModules: () => mixed |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Required Modules'
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   makeMapStateToProps,
   mapDispatchToProps
 )(ProtocolModulesCard)

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -12,12 +12,12 @@ import { SectionContentHalf } from '../layout'
 import InfoSection from './InfoSection'
 import InstrumentWarning from './InstrumentWarning'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { Pipette } from '../../robot'
 import type { PipettesResponse } from '../../http-api-client'
 import type { Robot } from '../../discovery'
 
-type OP = { robot: Robot }
+type OP = {| robot: Robot |}
 
 type SP = {|
   pipettes: Array<Pipette>,
@@ -29,11 +29,11 @@ type DP = {|
   changePipetteUrl: string,
 |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Required Pipettes'
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   makeMapStateToProps,
   mapDispatchToProps
 )(ProtocolPipettes)

--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -12,9 +12,7 @@ import type { State, Dispatch } from '../../types'
 import type { Module } from '../../http-api-client'
 import type { Robot } from '../../discovery'
 
-type OP = {
-  robot: Robot,
-}
+type OP = {| robot: Robot |}
 
 type SP = {|
   modules: ?Array<Module>,
@@ -24,13 +22,13 @@ type SP = {|
 
 type DP = {| refresh: () => mixed |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Modules'
 
-export default connect(
-  makeSTP,
-  DTP
+export default connect<Props, OP, SP, DP, State, Dispatch>(
+  makeMapStateToProps,
+  mapDispatchToProps
 )(AttachedModulesCard)
 
 function AttachedModulesCard(props: Props) {
@@ -47,7 +45,7 @@ function AttachedModulesCard(props: Props) {
   )
 }
 
-function makeSTP(): (state: State, ownProps: OP) => SP {
+function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getRobotModules = makeGetRobotModules()
 
   return (state, ownProps) => {
@@ -63,7 +61,7 @@ function makeSTP(): (state: State, ownProps: OP) => SP {
   }
 }
 
-function DTP(dispatch: Dispatch, ownProps: OP): DP {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   return {
     refresh: () => dispatch(fetchModules(ownProps.robot)),
   }

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -16,13 +16,13 @@ import InstrumentInfo from './InstrumentInfo'
 import { CardContentFlex } from '../layout'
 import { Card, IntervalWrapper } from '@opentrons/components'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { Robot } from '../../discovery'
 import type { Pipette } from '../../http-api-client'
 
-type OP = {
+type OP = {|
   robot: Robot,
-}
+|}
 
 type SP = {|
   inProgress: boolean,
@@ -36,11 +36,11 @@ type DP = {|
   clearMove: () => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Pipettes'
 
-export default connect(
+export default connect<Props, OP, SP, _, _, _>(
   makeMapStateToProps,
   mapDispatchToProps
 )(AttachedPipettesCard)

--- a/app/src/components/LostConnectionAlert/index.js
+++ b/app/src/components/LostConnectionAlert/index.js
@@ -14,14 +14,15 @@ import { AlertModal } from '@opentrons/components'
 import { Portal } from '../portal'
 import ModalCopy from './ModalCopy'
 
+import type { ContextRouter } from 'react-router'
 import type { State, Dispatch } from '../../types'
 
 type SP = {| ok: ?boolean |}
 type DP = {| disconnect: () => mixed |}
 type Props = { ...SP, ...DP }
 
-export default withRouter(
-  connect(
+export default withRouter<{||}>(
+  connect<Props, ContextRouter, SP, DP, State, Dispatch>(
     mapStateToProps,
     mapDispatchToProps
   )(LostConnectionAlert)

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -37,7 +37,7 @@ type DP = {|
 
 type Props = { ...OP, ...SP, ...DP }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   makeSTP,
   mapDTP
 )(ModuleControls)

--- a/app/src/components/ReviewDeckModal/LabwareComponent.js
+++ b/app/src/components/ReviewDeckModal/LabwareComponent.js
@@ -18,9 +18,11 @@ type SP = {|
   module: ?SessionModule,
 |}
 
-type Props = { ...$Exact<LabwareComponentProps>, ...SP }
+type Props = { ...OP, ...SP }
 
-export default connect(mapStateToProps)(LabwareComponent)
+export default connect<Props, OP, SP, _, _, _>(mapStateToProps)(
+  LabwareComponent
+)
 
 function LabwareComponent(props: Props) {
   const { labware, module } = props

--- a/app/src/components/ReviewDeckModal/index.js
+++ b/app/src/components/ReviewDeckModal/index.js
@@ -15,18 +15,15 @@ import { Modal } from '../modals'
 import Prompt from './Prompt'
 import ReviewDeck from './ReviewDeck'
 
-type OP = { slot: ?string }
+type OP = {| slot: ?string |}
 
-type SP = {
-  currentLabware: ?Labware,
-  _calibratorMount: ?Mount,
-}
+type SP = {| currentLabware: ?Labware, _calibratorMount: ?Mount |}
 
-type DP = { dispatch: Dispatch }
+type DP = {| dispatch: Dispatch |}
 
-type Props = SP & { onClick: () => void }
+type Props = { ...SP, onClick: () => void }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   mapStateToProps,
   null,
   mergeProps

--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -22,10 +22,10 @@ import type { ViewableRobot } from '../../discovery'
 import type { Setting } from '../../http-api-client'
 import type { ToggleRef } from './PipetteUpdateWarningModal'
 
-type OP = {
+type OP = {|
   robot: ViewableRobot,
   resetUrl: string,
-}
+|}
 
 type SP = {|
   settings: Array<Setting>,
@@ -38,7 +38,7 @@ type DP = {|
   download: () => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 type BooleanSettingProps = {
   id: string,
@@ -180,7 +180,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   makeMapStateToProps,
   mapDispatchToProps
 )(AdvancedSettingsCard)

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -9,26 +9,27 @@ import { startDeckCalibration } from '../../http-api-client'
 import { Card, OutlineButton } from '@opentrons/components'
 import { CardContentFlex, CardContentFull } from '../layout'
 
+import type { Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 
-type OP = {
+type OP = {|
   robot: ViewableRobot,
   calibrateDeckUrl: string,
   disabled: boolean,
-}
+|}
 
 type DP = {|
   start: () => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...DP }
+type Props = { ...OP, ...DP }
 
 const TITLE = 'Deck Calibration'
 // const LAST_RUN_LABEL = 'Last Run'
 const CALIBRATION_MESSAGE =
   'Calibrate your robot to initial factory settings to ensure accuracy.'
 
-export default connect(
+export default connect<Props, OP, _, _, _, _>(
   null,
   mapDispatchToProps
 )(CalibrationCard)

--- a/app/src/components/RobotSettings/ConnectionCard.js
+++ b/app/src/components/RobotSettings/ConnectionCard.js
@@ -14,7 +14,7 @@ import type { State } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 import type { InternetStatus, NetworkInterface } from '../../http-api-client'
 
-type OP = { robot: ViewableRobot }
+type OP = {| robot: ViewableRobot |}
 
 type SP = {|
   internetStatus: ?InternetStatus,
@@ -22,9 +22,11 @@ type SP = {|
   ethernetNetwork: ?NetworkInterface,
 |}
 
-type Props = { ...$Exact<OP>, ...SP }
+type Props = { ...OP, ...SP }
 
-export default connect(makeMapStateToProps)(ConnectionCard)
+export default connect<Props, OP, SP, _, _, _>(makeMapStateToProps)(
+  ConnectionCard
+)
 
 const TITLE = 'Connectivity'
 function ConnectionCard(props: Props) {

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -20,10 +20,10 @@ import { LabeledToggle, LabeledButton } from '../controls'
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 
-type OP = {
+type OP = {|
   robot: ViewableRobot,
   calibrateDeckUrl: string,
-}
+|}
 
 type SP = {|
   lightsOn: boolean,
@@ -35,7 +35,7 @@ type DP = {|
 |}
 
 type Props = {
-  ...$Exact<OP>,
+  ...OP,
   ...SP,
   homeAll: () => mixed,
   fetchLights: () => mixed,
@@ -45,7 +45,7 @@ type Props = {
 
 const TITLE = 'Robot Controls'
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   makeMakeStateToProps,
   null,
   mergeProps

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -17,28 +17,28 @@ import type { State, Dispatch } from '../../types'
 import type { RobotUpdateInfo } from '../../http-api-client'
 import type { ViewableRobot } from '../../discovery'
 
-type OwnProps = {
+type OP = {|
   robot: ViewableRobot,
   updateUrl: string,
-}
+|}
 
-type StateProps = {|
+type SP = {|
   updateInfo: RobotUpdateInfo,
 |}
 
-type DispatchProps = {|
+type DP = {|
   fetchHealth: () => mixed,
   checkAppUpdate: () => mixed,
 |}
 
-type Props = { ...$Exact<OwnProps>, ...StateProps, ...DispatchProps }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
 
-export default connect(
+export default connect<Props, OP, SP, _, _, _>(
   makeMapStateToProps,
   mapDispatchToProps
 )(InformationCard)
@@ -75,18 +75,15 @@ function InformationCard(props: Props) {
   )
 }
 
-function makeMapStateToProps() {
+function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getUpdateInfo = makeGetRobotUpdateInfo()
 
-  return (state: State, ownProps: OwnProps): StateProps => ({
+  return (state, ownProps) => ({
     updateInfo: getUpdateInfo(state, ownProps.robot),
   })
 }
 
-function mapDispatchToProps(
-  dispatch: Dispatch,
-  ownProps: OwnProps
-): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   return {
     // TODO(mc, 2018-10-10): only need to fetch ignored
     fetchHealth: () => dispatch(fetchHealthAndIgnored(ownProps.robot)),

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -25,19 +25,18 @@ import { AlertModal } from '@opentrons/components'
 import { Portal } from '../portal'
 import { LabeledCheckbox } from '../controls'
 
-type OP = {
-  robot: RobotService,
-}
+type OP = {| robot: RobotService |}
 
-type SP = {
+type SP = {|
   options: ?Array<ResetOption>,
   resetRequest: ResetRobotRequest,
   restartRequest: RobotServerRestart,
-}
+|}
 
-type DP = { dispatch: Dispatch }
+type DP = {| dispatch: Dispatch |}
 
-type Props = SP & {
+type Props = {
+  ...SP,
   fetchOptions: () => mixed,
   closeModal: () => mixed,
   reset: (options: ResetRobotRequest) => mixed,
@@ -53,7 +52,7 @@ class ResetRobotModal extends React.Component<Props, ResetRobotRequest> {
     this.state = {}
   }
 
-  toggle = name => {
+  toggle = (name: string) => {
     return () => this.setState({ [name]: !this.state[name] })
   }
 
@@ -116,7 +115,7 @@ class ResetRobotModal extends React.Component<Props, ResetRobotRequest> {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   makeMapStateToProps,
   null,
   mergeProps
@@ -126,6 +125,7 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getResetOptions = makeGetRobotResetOptions()
   const getResetRequest = makeGetRobotResetRequest()
   const getRobotRestartRequest = makeGetRobotRestartRequest()
+
   return (state, ownProps) => {
     const { robot } = ownProps
     const optionsRequest = getResetOptions(state, robot)

--- a/app/src/components/RobotSettings/SelectNetwork/index.js
+++ b/app/src/components/RobotSettings/SelectNetwork/index.js
@@ -41,7 +41,7 @@ import type {
   ApiRequestError,
 } from '../../../http-api-client'
 
-type OP = { robot: ViewableRobot }
+type OP = {| robot: ViewableRobot |}
 
 type SP = {|
   list: ?WifiNetworkList,
@@ -62,7 +62,7 @@ type DP = {|
   clearConfigure: () => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = { ...OP, ...SP, ...DP }
 
 type SelectNetworkState = {
   ssid: ?string,
@@ -73,7 +73,7 @@ type SelectNetworkState = {
 const LIST_REFRESH_MS = 15000
 
 class SelectNetwork extends React.Component<Props, SelectNetworkState> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     // prepopulate selected SSID with currently connected network, if any
     this.state = {
@@ -224,7 +224,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, _, _, _>(
   makeMapStateToProps,
   mapDispatchToProps
 )(SelectNetwork)

--- a/app/src/components/RobotSettings/StatusCard.js
+++ b/app/src/components/RobotSettings/StatusCard.js
@@ -16,25 +16,20 @@ import { CardContentHalf } from '../layout'
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 
-type OwnProps = { robot: ViewableRobot }
+type OP = {| robot: ViewableRobot |}
 
-type StateProps = {|
-  status: string,
-  connectButtonText: string,
-|}
+type SP = {| status: string, connectButtonText: string |}
 
-type DispatchProps = {|
-  onClick: () => mixed,
-|}
+type DP = {| onClick: () => mixed |}
 
-type Props = { ...$Exact<OwnProps>, ...StateProps, ...DispatchProps }
+type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Status'
 const STATUS_LABEL = 'This robot is currently'
 const STATUS_VALUE_DISCONNECTED = 'Unknown - connect to view status'
 const STATUS_VALUE_DEFAULT = 'Idle'
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   mapStateToProps,
   mapDispatchToProps
 )(StatusCard)
@@ -57,7 +52,7 @@ function StatusCard(props: Props) {
   )
 }
 
-function mapStateToProps(state: State, ownProps: OwnProps): StateProps {
+function mapStateToProps(state: State, ownProps: OP): SP {
   const { robot } = ownProps
   const connected = robot.connected != null && robot.connected === true
   const sessionStatus = robotSelectors.getSessionStatus(state)
@@ -70,10 +65,7 @@ function mapStateToProps(state: State, ownProps: OwnProps): StateProps {
   return { status, connectButtonText }
 }
 
-function mapDispatchToProps(
-  dispatch: Dispatch,
-  ownProps: OwnProps
-): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const { robot } = ownProps
   const onClickAction =
     robot.connected === true

--- a/app/src/components/RobotSettings/UpdateRobot/RestartRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/RestartRobotModal.js
@@ -12,16 +12,13 @@ import { AlertModal } from '@opentrons/components'
 import type { Dispatch } from '../../../types'
 import type { ViewableRobot } from '../../../discovery'
 
-type OP = { robot: ViewableRobot }
+type OP = {| robot: ViewableRobot |}
 
-type DP = {|
-  restart: () => mixed,
-  close: () => mixed,
-|}
+type DP = {| restart: () => mixed, close: () => mixed |}
 
-type Props = { ...$Exact<OP>, ...DP }
+type Props = { ...OP, ...DP }
 
-export default connect(
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDispatchToProps
 )(RestartRobotModal)

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -23,7 +23,7 @@ import type { ShellUpdateState } from '../../../shell'
 import type { ViewableRobot } from '../../../discovery'
 import type { RobotUpdateInfo } from '../../../http-api-client'
 
-type OP = { robot: ViewableRobot, appUpdate: ShellUpdateState }
+type OP = {| robot: ViewableRobot, appUpdate: ShellUpdateState |}
 
 type SP = {|
   appVersion: string,
@@ -31,10 +31,10 @@ type SP = {|
   robotUpdateInfo: RobotUpdateInfo,
 |}
 
-type DP = { dispatch: Dispatch }
+type DP = {| dispatch: Dispatch |}
 
 type Props = {
-  ...$Exact<OP>,
+  ...OP,
   ...SP,
   parentUrl: string,
   ignoreUpdate: () => mixed,
@@ -46,7 +46,7 @@ type UpdateRobotState = {
 }
 
 class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { ignoreAppUpdate: false }
   }
@@ -120,15 +120,15 @@ function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
     : close
 
   return {
-    ...stateProps,
     ...ownProps,
+    ...stateProps,
     parentUrl,
     ignoreUpdate,
     update: () => dispatch(updateRobotServer(robot)),
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   makeMapStateToProps,
   null,
   mergeProps

--- a/app/src/components/RobotSettings/UpdateRobot/index.js
+++ b/app/src/components/RobotSettings/UpdateRobot/index.js
@@ -13,41 +13,32 @@ import type { ViewableRobot } from '../../../discovery'
 import type { ShellUpdateState } from '../../../shell'
 import type { RobotServerUpdate } from '../../../http-api-client'
 
-type OP = { robot: ViewableRobot, appUpdate: ShellUpdateState }
+type OP = {| robot: ViewableRobot, appUpdate: ShellUpdateState |}
 
-type SP = {|
-  updateRequest: RobotServerUpdate,
-|}
+type SP = {| updateRequest: RobotServerUpdate |}
 
-type Props = {
-  ...$Exact<OP>,
-  ...SP,
-}
+type Props = { ...OP, ...SP }
 
-export default connect(
-  makeMapStateToProps,
-  null
-)(UpdateRobot)
+export default connect<Props, OP, SP, _, _, _>(makeMapStateToProps)(UpdateRobot)
 
 function UpdateRobot(props: Props) {
   const { updateRequest, robot, appUpdate } = props
+
   if (updateRequest.response) {
     return <RestartRobotModal robot={robot} />
   }
+
   if (updateRequest.inProgress) {
     return <SpinnerModal message="Robot is updating" alertOverlay />
-  } else {
-    return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
   }
+
+  return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
 }
 
-function makeMapStateToProps(): (State, OP) => Props {
+function makeMapStateToProps(): (State, OP) => SP {
   const getRobotUpdateRequest = makeGetRobotUpdateRequest()
 
-  return (state, ownProps) => {
-    return {
-      ...ownProps,
-      updateRequest: getRobotUpdateRequest(state, ownProps.robot),
-    }
-  }
+  return (state, ownProps) => ({
+    updateRequest: getRobotUpdateRequest(state, ownProps.robot),
+  })
 }

--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -9,14 +9,14 @@ import styles from './styles.css'
 
 import type { SessionStatus } from '../../robot'
 
-type Props = {
+export type CommandListProps = {|
   commands: Array<any>,
   sessionStatus: SessionStatus,
   showSpinner: boolean,
   onResetClick: () => mixed,
-}
+|}
 
-export default class CommandList extends React.Component<Props> {
+export default class CommandList extends React.Component<CommandListProps> {
   componentDidUpdate() {
     // TODO(mc, 2018-07-24): use new refs
     if (this.refs.ensureVisible) this.refs.ensureVisible.scrollIntoView(true) // eslint-disable-line react/no-string-refs

--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -43,7 +43,7 @@ function ExitAlertModal(props: Props) {
   )
 }
 
-export default connect(
+export default connect<Props, {||}, {||}, _, _, _>(
   null,
   mapDispatchToProps
 )(ExitAlertModal)

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -1,15 +1,18 @@
 // @flow
 import { connect } from 'react-redux'
-import type { State } from '../../types'
+
 import {
   actions as robotActions,
   selectors as robotSelectors,
 } from '../../robot'
 
 import CommandList from './CommandList'
-import ConfirmCancelModal from './ConfirmCancelModal'
 
+import type { State, Dispatch } from '../../types'
 import type { SessionStatus } from '../../robot'
+import type { CommandListProps } from './CommandList'
+
+export { default as ConfirmCancelModal } from './ConfirmCancelModal'
 
 type SP = {|
   commands: Array<any>,
@@ -21,11 +24,10 @@ type DP = {|
   onResetClick: () => mixed,
 |}
 
-export default connect(
+export default connect<CommandListProps, {||}, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(CommandList)
-export { ConfirmCancelModal }
 
 function mapStateToProps(state: State): SP {
   return {

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -6,10 +6,13 @@ import {
   actions as robotActions,
   selectors as robotSelectors,
 } from '../../robot'
+
 import { SidePanel, SidePanelGroup } from '@opentrons/components'
 import RunTimer from './RunTimer'
 import RunControls from './RunControls'
 import TempDeckStatusCard from '../TempDeckStatusCard'
+
+import type { State, Dispatch } from '../../types'
 
 type SP = {|
   isRunning: boolean,
@@ -29,7 +32,7 @@ type DP = {|
 
 type Props = { ...SP, ...DP }
 
-const mapStateToProps = (state): SP => ({
+const mapStateToProps = (state: State): SP => ({
   isRunning: robotSelectors.getIsRunning(state),
   isPaused: robotSelectors.getIsPaused(state),
   startTime: robotSelectors.getStartTime(state),
@@ -41,9 +44,12 @@ const mapStateToProps = (state): SP => ({
     robotSelectors.getSessionLoadInProgress(state),
 })
 
-const mapDispatchToProps = (dispatch): DP => ({
+const mapDispatchToProps = (dispatch: Dispatch): DP => ({
+  // $FlowFixMe: robotActions.run is not typed
   onRunClick: () => dispatch(robotActions.run()),
+  // $FlowFixMe: robotActions.pause is not typed
   onPauseClick: () => dispatch(robotActions.pause()),
+  // $FlowFixMe: robotActions.resume is not typed
   onResumeClick: () => dispatch(robotActions.resume()),
   onResetClick: () => dispatch(robotActions.refreshSession()),
 })
@@ -60,7 +66,7 @@ function RunPanel(props: Props) {
   )
 }
 
-export default connect(
+export default connect<Props, {||}, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(RunPanel)

--- a/app/src/components/SessionHeader/index.js
+++ b/app/src/components/SessionHeader/index.js
@@ -9,13 +9,13 @@ import type { State } from '../../types'
 
 type Props = { sessionName: ?string }
 
-export default connect(mapStateToProps)(SessionHeader)
+export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(SessionHeader)
 
 function SessionHeader(props: Props) {
   return <Link to="/upload">{props.sessionName}</Link>
 }
 
-function mapStateToProps(state: State): Props {
+function mapStateToProps(state: State): $Exact<Props> {
   return {
     sessionName: getProtocolFilename(state),
   }

--- a/app/src/components/TempDeckStatusCard/index.js
+++ b/app/src/components/TempDeckStatusCard/index.js
@@ -16,7 +16,7 @@ import StatusCard from './StatusCard'
 import CardContentRow from './CardContentRow'
 import StatusItem from './StatusItem'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type {
   TempDeckModule,
   FetchTemperatureDataResponse,
@@ -25,16 +25,16 @@ import type { Robot } from '../../discovery'
 
 const POLL_TEMPDECK_INTERVAL_MS = 1000
 
-type SP = {
+type SP = {|
   _robot: ?Robot,
   tempdeck: ?TempDeckModule,
   tempdeckData: ?FetchTemperatureDataResponse,
-}
+|}
 
-type DP = {
+type DP = {|
   _fetchModules: (_robot: Robot) => mixed,
   _fetchModuleData: (_robot: Robot, serial: string) => mixed,
-}
+|}
 
 type Props = {
   tempdeck: ?TempDeckModule,
@@ -88,6 +88,7 @@ class TempDeckStatusCard extends React.Component<Props> {
 function makeSTP(): (state: State) => SP {
   const getRobotModules = makeGetRobotModules()
   const getRobotModuleData = makeGetRobotModuleData()
+
   return state => {
     const _robot = getConnectedRobot(state)
     const modulesCall = _robot && getRobotModules(state, _robot)
@@ -131,7 +132,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP): Props {
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, State, Dispatch>(
   makeSTP,
   mapDTP,
   mergeProps

--- a/app/src/components/TipProbe/AttachTipPanel.js
+++ b/app/src/components/TipProbe/AttachTipPanel.js
@@ -1,31 +1,28 @@
 // @flow
 import * as React from 'react'
-import { type Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import CalibrationInfoContent from '../CalibrationInfoContent'
 import { PrimaryButton } from '@opentrons/components'
 
+import { actions as robotActions } from '../../robot'
 import attachSingle from '../../img/attach_tip_single.png'
 import attachMulti from '../../img/attach_tip_multi.png'
 
-import { actions as robotActions, type Mount, type Channels } from '../../robot'
+import type { Dispatch } from '../../types'
+import type { TipProbeProps } from './types'
 
-type OwnProps = {
-  mount: Mount,
-  channels: Channels,
-  volume: number,
-}
+type OP = TipProbeProps
 
-type DispatchProps = {
-  onProbeTipClick: () => void,
-}
+type DP = {| onProbeTipClick: () => void |}
 
-export default connect(
+type Props = { ...OP, ...DP }
+
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDispatchToProps
 )(AttachTipPanel)
 
-function AttachTipPanel(props: OwnProps & DispatchProps) {
+function AttachTipPanel(props: Props) {
   const { volume, channels, onProbeTipClick } = props
 
   const leftChildren = (
@@ -53,14 +50,12 @@ function AttachTipPanel(props: OwnProps & DispatchProps) {
   )
 }
 
-function mapDispatchToProps(
-  dispatch: Dispatch<*>,
-  ownProps: OwnProps
-): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const mount = ownProps.mount
 
   return {
     onProbeTipClick: () => {
+      // $FlowFixMe: robotActions.probeTip is not typed
       dispatch(robotActions.probeTip(mount))
     },
   }

--- a/app/src/components/TipProbe/ContinuePanel.js
+++ b/app/src/components/TipProbe/ContinuePanel.js
@@ -3,22 +3,27 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 
-import type { State } from '../../types'
 import { PrimaryButton } from '@opentrons/components'
 import CalibrationInfoContent from '../CalibrationInfoContent'
-
 import { selectors as robotSelectors } from '../../robot'
 
-type SP = {
+import type { State } from '../../types'
+import type { TipProbeProps } from './types'
+
+type OP = TipProbeProps
+
+type SP = {|
   done: boolean,
   buttonText: string,
-}
+|}
 
-type Props = SP
+type Props = { ...OP, ...SP }
 
-export default connect(mapStateToProps)(RemoveTipPanel)
+export default connect<Props, OP, SP, _, _, _, _>(mapStateToProps)(
+  ContinuePanel
+)
 
-function RemoveTipPanel(props: Props) {
+function ContinuePanel(props: Props) {
   const { done, buttonText } = props
 
   return (

--- a/app/src/components/TipProbe/InstrumentMovingPanel.js
+++ b/app/src/components/TipProbe/InstrumentMovingPanel.js
@@ -5,7 +5,9 @@ import { Icon } from '@opentrons/components'
 import CalibrationInfoContent from '../CalibrationInfoContent'
 import styles from './tip-probe.css'
 
-export default function UnprobedPanel() {
+import type { TipProbeProps } from './types'
+
+export default function UnprobedPanel(props: TipProbeProps) {
   return (
     <CalibrationInfoContent
       leftChildren={<Icon name="ot-spinner" spin className={styles.spinner} />}

--- a/app/src/components/TipProbe/RemoveTipPanel.js
+++ b/app/src/components/TipProbe/RemoveTipPanel.js
@@ -1,36 +1,29 @@
 // @flow
 import * as React from 'react'
-import type { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 
 import { PrimaryButton } from '@opentrons/components'
 import CalibrationInfoContent from '../CalibrationInfoContent'
 
+import { actions as robotActions } from '../../robot'
 import removeSingle from '../../img/remove_tip_single.png'
 import removeMulti from '../../img/remove_tip_multi.png'
 
-import { actions as robotActions, type Channels, type Mount } from '../../robot'
+import type { Dispatch } from '../../types'
+import type { TipProbeProps } from './types'
 
-type OwnProps = {
-  mount: Mount,
-  channels: Channels,
-}
+type OP = TipProbeProps
 
-type DispatchProps = {
-  onConfirmClick: () => void,
-}
+type DP = {| onConfirmClick: () => void |}
 
-type RemoveTipProps = {
-  channels: Channels,
-  onConfirmClick: () => void,
-}
+type Props = {| ...OP, ...DP |}
 
-export default connect(
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDispatchToProps
 )(RemoveTipPanel)
 
-function RemoveTipPanel(props: RemoveTipProps) {
+function RemoveTipPanel(props: Props) {
   const { channels, onConfirmClick } = props
 
   const imgSrc = channels === 1 ? removeSingle : removeMulti
@@ -50,10 +43,7 @@ function RemoveTipPanel(props: RemoveTipProps) {
   )
 }
 
-function mapDispatchToProps(
-  dispatch: Dispatch<*>,
-  ownProps: OwnProps
-): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const { mount } = ownProps
 
   return {

--- a/app/src/components/TipProbe/UnprobedPanel.js
+++ b/app/src/components/TipProbe/UnprobedPanel.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import type { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 
@@ -10,29 +9,20 @@ import { PrimaryButton } from '@opentrons/components'
 import {
   actions as robotActions,
   selectors as robotSelectors,
-  type Mount,
 } from '../../robot'
 
-type OwnProps = {
-  mount: Mount,
-  probed: boolean,
-  confirmTipProbeUrl: string,
-}
+import type { State, Dispatch } from '../../types'
+import type { TipProbeProps } from './types'
 
-type StateProps = {
-  _showContinueModal: boolean,
-}
+type OP = TipProbeProps
 
-type DispatchProps = {
-  dispatch: Dispatch<*>,
-}
+type SP = {| _showContinueModal: boolean |}
 
-type Props = {
-  probed: boolean,
-  onPrepareClick: () => void,
-}
+type DP = {| dispatch: Dispatch |}
 
-export default connect(
+type Props = {| ...OP, onPrepareClick: () => void |}
+
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   mapStateToProps,
   null,
   mergeProps
@@ -57,7 +47,7 @@ function UnprobedPanel(props: Props) {
   return <CalibrationInfoContent leftChildren={leftChildren} />
 }
 
-function mapStateToProps(state, ownProps: OwnProps): StateProps {
+function mapStateToProps(state, ownProps: OP): SP {
   const deckPopulated = robotSelectors.getDeckPopulated(state)
 
   return {
@@ -65,11 +55,7 @@ function mapStateToProps(state, ownProps: OwnProps): StateProps {
   }
 }
 
-function mergeProps(
-  stateProps: StateProps,
-  dispatchProps: DispatchProps,
-  ownProps: OwnProps
-): Props {
+function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
   const { _showContinueModal } = stateProps
   const { dispatch } = dispatchProps
   const { mount, confirmTipProbeUrl } = ownProps
@@ -79,6 +65,7 @@ function mergeProps(
         dispatch(push(confirmTipProbeUrl))
       }
     : () => {
+        // $FlowFixMe: robotActions.moveToFront is not typed
         dispatch(robotActions.moveToFront(mount))
       }
 

--- a/app/src/components/TipProbe/index.js
+++ b/app/src/components/TipProbe/index.js
@@ -2,7 +2,8 @@
 // TipProbe controls
 import * as React from 'react'
 
-import type { Pipette, PipetteCalibrationStatus } from '../../robot'
+import type { PipetteCalibrationStatus } from '../../robot'
+import type { TipProbeProps } from './types'
 
 import CalibrationInfoBox from '../CalibrationInfoBox'
 import UnprobedPanel from './UnprobedPanel'
@@ -11,12 +12,8 @@ import AttachTipPanel from './AttachTipPanel'
 import RemoveTipPanel from './RemoveTipPanel'
 import ContinuePanel from './ContinuePanel'
 
-type Props = Pipette & {
-  confirmTipProbeUrl: string,
-}
-
 const PANEL_BY_CALIBRATION: {
-  [PipetteCalibrationStatus]: React.ComponentType<Props>,
+  [PipetteCalibrationStatus]: React.ComponentType<TipProbeProps>,
 } = {
   unprobed: UnprobedPanel,
   'preparing-to-probe': InstrumentMovingPanel,
@@ -26,7 +23,7 @@ const PANEL_BY_CALIBRATION: {
   probed: ContinuePanel,
 }
 
-export default function TipProbe(props: Props) {
+export default function TipProbe(props: TipProbeProps) {
   const { mount, probed, calibration } = props
   const title = `${mount} pipette calibration`
 

--- a/app/src/components/TipProbe/index.js
+++ b/app/src/components/TipProbe/index.js
@@ -31,7 +31,6 @@ export default function TipProbe(props: TipProbeProps) {
 
   return (
     <CalibrationInfoBox confirmed={probed} title={title}>
-      {/* $FlowFixMe: `...props` type doesn't include necessary keys */}
       <Panel {...props} />
     </CalibrationInfoBox>
   )

--- a/app/src/components/TipProbe/types.js
+++ b/app/src/components/TipProbe/types.js
@@ -1,0 +1,7 @@
+// @flow
+import type { Pipette } from '../../robot'
+
+export type TipProbeProps = {|
+  ...$Exact<Pipette>,
+  confirmTipProbeUrl: string,
+|}

--- a/app/src/components/UploadPanel/Upload.js
+++ b/app/src/components/UploadPanel/Upload.js
@@ -36,8 +36,7 @@ export default class Upload extends React.Component<Props, State> {
       this.props.createSession(files[0])
     }
 
-    // $FlowFixMe
-    event.target.value = null
+    event.currentTarget.value = ''
   }
 
   confirmUpload = () => {

--- a/app/src/components/UploadPanel/index.js
+++ b/app/src/components/UploadPanel/index.js
@@ -10,19 +10,19 @@ import Upload from './Upload'
 
 import type { State, Dispatch } from '../../types'
 
-type SP = {
+type SP = {|
   filename: ?string,
   sessionLoaded: ?boolean,
   uploadError: ?{ message: string },
-}
+|}
 
-type DP = {
+type DP = {|
   createSession: File => mixed,
-}
+|}
 
-type Props = SP & DP
+type Props = { ...SP, ...DP }
 
-export default connect(
+export default connect<Props, {||}, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(UploadPanel)

--- a/app/src/components/analytics-settings/AnalyticsSettingsModal.js
+++ b/app/src/components/analytics-settings/AnalyticsSettingsModal.js
@@ -10,20 +10,18 @@ import AnalyticsToggle from './AnalyticsToggle'
 import { Portal } from '../portal'
 import type { State, Dispatch } from '../../types'
 
-type SP = {
-  seen: boolean,
-}
+type OP = {||}
 
-type DP = {
-  setSeen: () => mixed,
-}
+type SP = {| seen: boolean |}
 
-type Props = SP & DP
+type DP = {| setSeen: () => mixed |}
+
+type Props = { ...SP, ...DP }
 
 const TITLE = 'Privacy Settings'
 const CONTINUE = 'continue'
 
-export default connect(
+export default connect<Props, OP, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(AnalyticsSettingsModal)

--- a/app/src/components/analytics-settings/AnalyticsToggle.js
+++ b/app/src/components/analytics-settings/AnalyticsToggle.js
@@ -6,17 +6,15 @@ import type { State, Dispatch } from '../../types'
 import { toggleAnalyticsOptedIn, getAnalyticsOptedIn } from '../../analytics'
 import { LabeledToggle } from '../controls'
 
-type SP = {
-  optedIn: boolean,
-}
+type OP = {||}
 
-type DP = {
-  toggleOptedIn: () => mixed,
-}
+type SP = {| optedIn: boolean |}
 
-type Props = SP & DP
+type DP = {| toggleOptedIn: () => mixed |}
 
-export default connect(
+type Props = { ...SP, ...DP }
+
+export default connect<Props, OP, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(AnalyticsToggle)

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -13,17 +13,20 @@ import { getConnectedRobotUpgradeAvailable } from '../../http-api-client'
 import { getAvailableShellUpdate } from '../../shell'
 import { NavButton } from '@opentrons/components'
 
+import type { ContextRouter } from 'react-router'
 import type { State } from '../../types'
 
-type OP = {
-  name: string,
-}
+type WithRouterOP = {| name: string |}
+
+type OP = {| ...ContextRouter, ...WithRouterOP |}
 
 type Props = React.ElementProps<typeof NavButton>
 
-export default withRouter(connect(mapStateToProps)(NavButton))
+export default withRouter<WithRouterOP>(
+  connect<Props, OP, _, _, _, _>(mapStateToProps)(NavButton)
+)
 
-function mapStateToProps(state: State, ownProps: OP): Props {
+function mapStateToProps(state: State, ownProps: OP): $Exact<Props> {
   const { name } = ownProps
   const isProtocolLoaded = robotSelectors.getSessionIsLoaded(state)
   const isProtocolRunning = robotSelectors.getIsRunning(state)

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -45,7 +45,9 @@ const RESTART_DISCOVERY_TIMEOUT_MS = 60000
 export const RESTART_PENDING: RestartStatus = 'pending'
 export const RESTART_DOWN: RestartStatus = 'down'
 
-export function startDiscovery(timeout = DISCOVERY_TIMEOUT_MS): ThunkAction {
+export function startDiscovery(
+  timeout: number = DISCOVERY_TIMEOUT_MS
+): ThunkAction {
   const start: StartAction = { type: 'discovery:START', meta: { shell: true } }
   const finish: FinishAction = {
     type: 'discovery:FINISH',

--- a/app/src/http-api-client/actions.js
+++ b/app/src/http-api-client/actions.js
@@ -63,14 +63,18 @@ export function buildRequestMaker<Request: ?{}>(
   path: string
 ): RequestMaker<Request> {
   return (robot, request = null) => dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, path, request))
 
-    return client(robot, method, path, request)
-      .then(
-        response => apiSuccess(robot, path, response),
-        error => apiFailure(robot, path, error)
-      )
-      .then(dispatch)
+    return (
+      client(robot, method, path, request)
+        .then(
+          response => apiSuccess(robot, path, response),
+          error => apiFailure(robot, path, error)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 

--- a/app/src/http-api-client/calibration.js
+++ b/app/src/http-api-client/calibration.js
@@ -115,6 +115,7 @@ export function deckCalibrationCommand(
     const token = startState.response && startState.response.token
 
     if (request.command === 'release') {
+      // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
       dispatch(clearApiResponse(robot, DECK_START))
     }
 

--- a/app/src/http-api-client/health.js
+++ b/app/src/http-api-client/health.js
@@ -28,7 +28,7 @@ export type HealthState = {|
 
 const HEALTH: 'health' = 'health'
 
-export const fetchHealth = buildRequestMaker('GET', HEALTH)
+export const fetchHealth = buildRequestMaker<void>('GET', HEALTH)
 
 export const makeGetRobotHealth = () => {
   const selector: OutputSelector<

--- a/app/src/http-api-client/index.js
+++ b/app/src/http-api-client/index.js
@@ -12,8 +12,9 @@ import { robotReducer, type RobotAction } from './robot'
 import { serverReducer, type ServerAction } from './server'
 import type { SettingsAction } from './settings'
 import type { NetworkingAction } from './networking'
+import type { Action } from '../types'
 
-export const reducer = combineReducers({
+export const reducer = combineReducers<_, Action>({
   calibration: calibrationReducer,
   robot: robotReducer,
   server: serverReducer,
@@ -43,7 +44,7 @@ export type { RobotMove, RobotHome, RobotLights } from './robot'
 
 export type State = $Call<typeof reducer>
 
-export type Action =
+export type HttpApiAction =
   | CalibrationAction
   | HealthAction
   | ModulesAction

--- a/app/src/http-api-client/modules.js
+++ b/app/src/http-api-client/modules.js
@@ -80,14 +80,18 @@ const MODULES: 'modules' = 'modules'
 
 export function fetchModules(robot: RobotService): ThunkPromiseAction {
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
     dispatch(apiRequest(robot, MODULES, null))
 
-    return client(robot, 'GET', MODULES)
-      .then(
-        (resp: FetchModulesResponse) => apiSuccess(robot, MODULES, resp),
-        (err: ApiRequestError) => apiFailure(robot, MODULES, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'GET', MODULES)
+        .then(
+          (resp: FetchModulesResponse) => apiSuccess(robot, MODULES, resp),
+          (err: ApiRequestError) => apiFailure(robot, MODULES, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -99,15 +103,19 @@ export function fetchModuleData(
 ): ThunkPromiseAction {
   return dispatch => {
     const fetchDataPath = `${MODULES}/${serial}/${DATA}`
+    // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
     dispatch(apiRequest(robot, fetchDataPath, null))
 
-    return client(robot, 'GET', fetchDataPath)
-      .then(
-        (resp: FetchModuleDataResponse) =>
-          apiSuccess(robot, fetchDataPath, resp),
-        (err: ApiRequestError) => apiFailure(robot, fetchDataPath, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'GET', fetchDataPath)
+        .then(
+          (resp: FetchModuleDataResponse) =>
+            apiSuccess(robot, fetchDataPath, resp),
+          (err: ApiRequestError) => apiFailure(robot, fetchDataPath, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -118,14 +126,19 @@ export function setTargetTemp(
 ): ThunkPromiseAction {
   return dispatch => {
     const setTempPath = `${MODULES}/${serial}`
+    // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
     dispatch(apiRequest(robot, setTempPath, command))
 
-    return client(robot, 'POST', setTempPath, command)
-      .then(
-        (resp: SetTemperatureResponse) => apiSuccess(robot, setTempPath, resp),
-        (err: ApiRequestError) => apiFailure(robot, setTempPath, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'POST', setTempPath, command)
+        .then(
+          (resp: SetTemperatureResponse) =>
+            apiSuccess(robot, setTempPath, resp),
+          (err: ApiRequestError) => apiFailure(robot, setTempPath, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -142,7 +155,7 @@ export function makeGetRobotModules() {
       const modulesCall = state[MODULES]
 
       // TODO: remove this block when feature flag removed
-      if (modulesCall?.response) {
+      if (modulesCall && modulesCall.response) {
         return {
           ...modulesCall,
           response: {

--- a/app/src/http-api-client/motors.js
+++ b/app/src/http-api-client/motors.js
@@ -40,6 +40,7 @@ export function disengagePipetteMotors(
   return (dispatch, getState) => {
     const pipettesState = getState().api.api[robot.name].pipettes
 
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, DISENGAGE, { mounts }))
 
     // pull motor axes from state if available, otherwise hit GET /pipettes
@@ -48,23 +49,26 @@ export function disengagePipetteMotors(
         ? Promise.resolve(pipettesState.response)
         : client(robot, 'GET', 'pipettes')
 
-    return getPipettes
-      .then((pipettes: PipettesResponse) => {
-        const axes = mounts.reduce(
-          (result, mount) =>
-            result.concat(
-              pipettes[mount].mount_axis,
-              pipettes[mount].plunger_axis
-            ),
-          []
-        )
+    return (
+      getPipettes
+        .then((pipettes: PipettesResponse) => {
+          const axes = mounts.reduce(
+            (result, mount) =>
+              result.concat(
+                pipettes[mount].mount_axis,
+                pipettes[mount].plunger_axis
+              ),
+            []
+          )
 
-        return client(robot, 'POST', 'motors/disengage', { axes })
-      })
-      .then(
-        response => apiSuccess(robot, DISENGAGE, response),
-        error => apiFailure(robot, DISENGAGE, error)
-      )
-      .then(dispatch)
+          return client(robot, 'POST', 'motors/disengage', { axes })
+        })
+        .then(
+          response => apiSuccess(robot, DISENGAGE, response),
+          error => apiFailure(robot, DISENGAGE, error)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }

--- a/app/src/http-api-client/networking.js
+++ b/app/src/http-api-client/networking.js
@@ -145,13 +145,16 @@ export const SECURITY_TYPE_FIELD = 'securityType'
 export const EAP_CONFIG_FIELD = 'eapConfig'
 export const EAP_TYPE_FIELD = `${EAP_CONFIG_FIELD}.eapType`
 
-export const fetchNetworkingStatus = buildRequestMaker('GET', STATUS)
-export const fetchWifiList = buildRequestMaker('GET', LIST)
-export const fetchWifiEapOptions = buildRequestMaker('GET', EAP_OPTIONS)
-export const fetchWifiKeys = buildRequestMaker('GET', KEYS)
-export const configureWifi = buildRequestMaker('POST', CONFIGURE)
+export const fetchNetworkingStatus = buildRequestMaker<void>('GET', STATUS)
+export const fetchWifiList = buildRequestMaker<void>('GET', LIST)
+export const fetchWifiEapOptions = buildRequestMaker<void>('GET', EAP_OPTIONS)
+export const fetchWifiKeys = buildRequestMaker<void>('GET', KEYS)
+export const configureWifi = buildRequestMaker<WifiConfigureRequest>(
+  'POST',
+  CONFIGURE
+)
 export const clearConfigureWifiResponse = (robot: BaseRobot) =>
-  clearApiResponse(robot, CONFIGURE)
+  clearApiResponse<WifiConfigurePath>(robot, CONFIGURE)
 
 // slightly custom action creator to call `POST /wifi/keys` (see TODO below)
 export function addWifiKey(
@@ -159,6 +162,7 @@ export function addWifiKey(
   file: File
 ): ThunkPromiseAction {
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
     dispatch(apiRequest(robot, KEYS, { key: file.name }))
 
     const request = new FormData()
@@ -179,6 +183,7 @@ export function addWifiKey(
         // $FlowFixMe: see above
         return apiSuccess(robot, KEYS, response)
       },
+      // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
       error => dispatch(apiFailure(robot, KEYS, error))
     )
   }
@@ -193,6 +198,7 @@ type GetConfigureWifiCall = Sel<State, BaseRobot, ConfigureWifiCall>
 export const makeGetRobotNetworkingStatus = (): GetNetworkingStatusCall =>
   createSelector(
     getRobotApiState,
+    // $FlowFixMe: (mc, 2019-04-18) http-api-client types need to be redone
     state => state[STATUS] || { inProgress: false }
   )
 

--- a/app/src/http-api-client/pipettes.js
+++ b/app/src/http-api-client/pipettes.js
@@ -47,14 +47,18 @@ export function fetchPipettes(
   if (refresh) path += '?refresh=true'
 
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, path, null))
 
-    return client(robot, 'GET', path)
-      .then(
-        (resp: PipettesResponse) => apiSuccess(robot, PIPETTES, resp),
-        (err: ApiRequestError) => apiFailure(robot, PIPETTES, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'GET', path)
+        .then(
+          (resp: PipettesResponse) => apiSuccess(robot, PIPETTES, resp),
+          (err: ApiRequestError) => apiFailure(robot, PIPETTES, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 

--- a/app/src/http-api-client/reset.js
+++ b/app/src/http-api-client/reset.js
@@ -47,15 +47,19 @@ export type ResetState = {|
 
 export function fetchResetOptions(robot: RobotService): ThunkPromiseAction {
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, OPTIONS_PATH, null))
 
-    return client(robot, 'GET', OPTIONS_PATH)
-      .then(
-        (resp: FetchResetOptionsResponse) =>
-          apiSuccess(robot, OPTIONS_PATH, resp),
-        (err: ApiRequestError) => apiFailure(robot, OPTIONS_PATH, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'GET', OPTIONS_PATH)
+        .then(
+          (resp: FetchResetOptionsResponse) =>
+            apiSuccess(robot, OPTIONS_PATH, resp),
+          (err: ApiRequestError) => apiFailure(robot, OPTIONS_PATH, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -65,14 +69,18 @@ export function resetRobotData(
 ): ThunkPromiseAction {
   const request: ResetRobotRequest = options
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, RESET_PATH, request))
 
-    return client(robot, 'POST', RESET_PATH, request)
-      .then(
-        (resp: ResetRobotResponse) => apiSuccess(robot, RESET_PATH, resp),
-        (err: ApiRequestError) => apiFailure(robot, RESET_PATH, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'POST', RESET_PATH, request)
+        .then(
+          (resp: ResetRobotResponse) => apiSuccess(robot, RESET_PATH, resp),
+          (err: ApiRequestError) => apiFailure(robot, RESET_PATH, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -96,6 +104,7 @@ export function makeGetRobotResetRequest() {
     ResetRobotRequest
   > = createSelector(
     getRobotApiState,
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     state => state[RESET_PATH] || { inProgress: false }
   )
   return selector

--- a/app/src/http-api-client/robot.js
+++ b/app/src/http-api-client/robot.js
@@ -51,8 +51,8 @@ type RobotMoveResponse = {
 }
 
 type RobotHomeRequest =
-  | { target: 'robot' }
-  | { target: 'pipette', mount: Mount }
+  | {| target: 'robot' |}
+  | {| target: 'pipette', mount: Mount |}
 
 type RobotHomeResponse = {
   message: string,
@@ -118,27 +118,31 @@ export function moveRobotTo(
   const { position, mount } = request
 
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, MOVE, request))
 
-    return client(robot, 'GET', POSITIONS)
-      .then((response: RobotPositionsResponse) => {
-        const positionInfo = response.positions
-        const { target } = positionInfo[position]
-        const point =
-          position === 'change_pipette'
-            ? positionInfo[position][mount]
-            : positionInfo[position].point
+    return (
+      client(robot, 'GET', POSITIONS)
+        .then((response: RobotPositionsResponse) => {
+          const positionInfo = response.positions
+          const { target } = positionInfo[position]
+          const point =
+            position === 'change_pipette'
+              ? positionInfo[position][mount]
+              : positionInfo[position].point
 
-        let body = { target, point, mount }
-        if (request.pipette) body = { ...body, model: request.pipette.model }
+          let body = { target, point, mount }
+          if (request.pipette) body = { ...body, model: request.pipette.model }
 
-        return client(robot, 'POST', MOVE, body)
-      })
-      .then(
-        (resp: RobotMoveResponse) => apiSuccess(robot, MOVE, resp),
-        (err: ApiRequestError) => apiFailure(robot, MOVE, err)
-      )
-      .then(dispatch)
+          return client(robot, 'POST', MOVE, body)
+        })
+        .then(
+          (resp: RobotMoveResponse) => apiSuccess(robot, MOVE, resp),
+          (err: ApiRequestError) => apiFailure(robot, MOVE, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -146,27 +150,35 @@ export function home(robot: RobotService, mount?: Mount): ThunkPromiseAction {
   return dispatch => {
     const body = mount ? { target: 'pipette', mount } : { target: 'robot' }
 
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, HOME, body))
 
-    return client(robot, 'POST', HOME, body)
-      .then(
-        (resp: RobotHomeResponse) => apiSuccess(robot, HOME, resp),
-        (err: ApiRequestError) => apiFailure(robot, HOME, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'POST', HOME, body)
+        .then(
+          (resp: RobotHomeResponse) => apiSuccess(robot, HOME, resp),
+          (err: ApiRequestError) => apiFailure(robot, HOME, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
 export function fetchRobotLights(robot: RobotService): ThunkPromiseAction {
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, LIGHTS, null))
 
-    return client(robot, 'GET', LIGHTS)
-      .then(
-        (resp: RobotLightsResponse) => apiSuccess(robot, LIGHTS, resp),
-        (err: ApiRequestError) => apiFailure(robot, LIGHTS, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'GET', LIGHTS)
+        .then(
+          (resp: RobotLightsResponse) => apiSuccess(robot, LIGHTS, resp),
+          (err: ApiRequestError) => apiFailure(robot, LIGHTS, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 
@@ -189,14 +201,18 @@ export function setRobotLights(
   const request: RobotLightsRequest = { on }
 
   return dispatch => {
+    // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
     dispatch(apiRequest(robot, LIGHTS, request))
 
-    return client(robot, 'POST', LIGHTS, request)
-      .then(
-        (resp: RobotLightsResponse) => apiSuccess(robot, LIGHTS, resp),
-        (err: ApiRequestError) => apiFailure(robot, LIGHTS, err)
-      )
-      .then(dispatch)
+    return (
+      client(robot, 'POST', LIGHTS, request)
+        .then(
+          (resp: RobotLightsResponse) => apiSuccess(robot, LIGHTS, resp),
+          (err: ApiRequestError) => apiFailure(robot, LIGHTS, err)
+        )
+        // $FlowFixMe: (mc, 2019-04-17): http-api-client types need to be redone
+        .then(dispatch)
+    )
   }
 }
 

--- a/app/src/pages/Calibrate/Labware.js
+++ b/app/src/pages/Calibrate/Labware.js
@@ -35,8 +35,8 @@ type DP = {| onBackClick: () => mixed |}
 
 type Props = { ...OP, ...SP, ...DP }
 
-export default withRouter(
-  connect(
+export default withRouter<{||}>(
+  connect<Props, OP, SP, _, _, _>(
     makeMapStateToProps,
     mapDispatchToProps
   )(SetupDeckPage)

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -15,7 +15,7 @@ import { PipetteTabs, Pipettes } from '../../components/calibrate-pipettes'
 import SessionHeader from '../../components/SessionHeader'
 
 import type { ContextRouter } from 'react-router'
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { Pipette } from '../../robot'
 import type { PipettesResponse } from '../../http-api-client'
 import type { Robot } from '../../discovery'
@@ -38,7 +38,7 @@ type Props = {
   changePipetteUrl: string,
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
   makeMapStateToProps,
   null,
   mergeProps

--- a/app/src/pages/Calibrate/index.js
+++ b/app/src/pages/Calibrate/index.js
@@ -11,23 +11,21 @@ import { selectors as robotSelectors } from '../../robot'
 import CalibratePipettes from './Pipettes'
 import CalibrateLabware from './Labware'
 
-type SP = {
+type OP = {| match: Match |}
+
+type SP = {|
   nextPipette: Pipette,
   labware: Array<Labware>,
   nextLabware: Labware,
   isTipsProbed: boolean,
-}
+|}
 
-type Props = SP & {
-  match: Match,
-}
+type Props = { ...OP, ...SP }
 
-export default connect(mapStateToProps)(Calibrate)
+export default connect<Props, OP, SP, _, _, _>(mapStateToProps)(Calibrate)
 
 function Calibrate(props: Props) {
-  const {
-    match: { path },
-  } = props
+  const { path } = props.match
 
   return (
     <Switch>
@@ -47,7 +45,7 @@ function mapStateToProps(state: State): SP {
   }
 }
 
-function getRedirectUrl(props: Props) {
+function getRedirectUrl(props: Props): string {
   const { nextPipette, labware, nextLabware, isTipsProbed } = props
 
   if (!isTipsProbed && nextPipette) {

--- a/app/src/pages/More/AppSettings.js
+++ b/app/src/pages/More/AppSettings.js
@@ -19,7 +19,7 @@ import AppSettings from '../../components/AppSettings'
 import UpdateApp from '../../components/AppSettings/UpdateApp'
 import { ErrorModal } from '../../components/modals'
 
-import type { State } from '../../types'
+import type { State, Dispatch } from '../../types'
 import type { ShellUpdateState } from '../../shell'
 
 type OP = ContextRouter
@@ -38,7 +38,7 @@ type DP = {|
 
 type Props = { ...OP, ...SP, ...DP }
 
-export default connect(
+export default connect<Props, OP, SP, DP, State, Dispatch>(
   mapStateToProps,
   mapDispatchToProps
 )(AppSettingsPage)

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -2,7 +2,7 @@
 // connect and configure robots page
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { withRouter, Route, Switch, Redirect, type Match } from 'react-router'
+import { withRouter, Route, Switch, Redirect } from 'react-router'
 
 import {
   selectors as robotSelectors,
@@ -29,15 +29,20 @@ import ConnectBanner from '../../components/RobotSettings/ConnectBanner'
 import ReachableRobotBanner from '../../components/RobotSettings/ReachableRobotBanner'
 import ResetRobotModal from '../../components/RobotSettings/ResetRobotModal'
 
+import type { ContextRouter } from 'react-router'
 import type { State, Dispatch, Error } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 import type { ShellUpdateState } from '../../shell'
 
-type OP = {
+type WithRouterOP = {|
   robot: ViewableRobot,
   appUpdate: ShellUpdateState,
-  match: Match,
-}
+|}
+
+type OP = {|
+  ...ContextRouter,
+  ...WithRouterOP,
+|}
 
 type SP = {|
   showUpdateModal: boolean,
@@ -49,14 +54,14 @@ type SP = {|
 type DP = {| dispatch: Dispatch |}
 
 type Props = {
-  ...$Exact<OP>,
+  ...OP,
   ...SP,
   closeHomeAlert?: () => mixed,
   closeConnectAlert: () => mixed,
 }
 
-export default withRouter(
-  connect(
+export default withRouter<WithRouterOP>(
+  connect<Props, OP, SP, {||}, State, Dispatch>(
     makeMapStateToProps,
     null,
     mergeProps
@@ -113,9 +118,7 @@ function RobotSettingsPage(props: Props) {
 
         <Route
           path={`${path}/${CALIBRATE_DECK_FRAGMENT}`}
-          render={props => (
-            <CalibrateDeck match={props.match} robot={robot} parentUrl={url} />
-          )}
+          render={props => <CalibrateDeck robot={robot} parentUrl={url} />}
         />
 
         <Route

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -2,7 +2,7 @@
 // connect and configure robots page
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { withRouter, Route, Switch, Redirect, type Match } from 'react-router'
+import { withRouter, Route, Switch, Redirect } from 'react-router'
 import find from 'lodash/find'
 
 import createLogger from '../../logger'
@@ -21,27 +21,25 @@ import Page from '../../components/Page'
 import RobotSettings from './RobotSettings'
 import InstrumentSettings from './InstrumentSettings'
 
+import type { ContextRouter } from 'react-router'
 import type { State } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 import type { ShellUpdateState } from '../../shell'
 
-type SP = {
+type OP = ContextRouter
+
+type SP = {|
   robot: ?ViewableRobot,
   connectedName: ?string,
   appUpdate: ShellUpdateState,
-}
+|}
 
-type OP = { match: Match }
-
-type Props = SP & OP
+type Props = { ...OP, ...SP }
 
 const log = createLogger(__filename)
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    null
-  )(Robots)
+export default withRouter<{||}>(
+  connect<Props, ContextRouter, SP, _, _, _>(mapStateToProps)(Robots)
 )
 
 function Robots(props: Props) {
@@ -96,11 +94,7 @@ function Robots(props: Props) {
 }
 
 function mapStateToProps(state: State, ownProps: OP): SP {
-  const {
-    match: {
-      params: { name },
-    },
-  } = ownProps
+  const { name } = ownProps.match.params
   const robots: Array<ViewableRobot> = getConnectableRobots(state).concat(
     getReachableRobots(state)
   )

--- a/app/src/pages/Upload/index.js
+++ b/app/src/pages/Upload/index.js
@@ -28,9 +28,11 @@ type SP = {|
 
 type Props = { ...OP, ...SP }
 
-export default withRouter(connect(mapStateToProps)(UploadPage))
+export default withRouter<{||}>(
+  connect<Props, OP, SP, _, _, _>(mapStateToProps)(UploadPage)
+)
 
-function mapStateToProps(state: State, ownProps: OP): SP {
+function mapStateToProps(state: State): SP {
   return {
     robot: getConnectedRobot(state),
     filename: getProtocolFilename(state),

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -112,7 +112,7 @@ const getAuthor: StringGetter = getter('metadata.author')
 const getDesc: StringGetter = getter('metadata.description')
 const getCreated: NumberGetter = getter('metadata.created')
 const getLastModified: NumberGetter = getter('metadata.last-modified')
-const getSource: NumberGetter = getter('metadata.source')
+const getSource: StringGetter = getter('metadata.source')
 const getAppName: StringGetter = getter('designer-application.application-name')
 const getAppVersion: StringGetter = getter(
   'designer-application.application-version'

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -4,12 +4,7 @@
 // import {getter} from '@thi.ng/paths'
 import createLogger from '../logger'
 
-import type {
-  ProtocolFile,
-  ProtocolMetadata,
-  ProtocolState,
-  ProtocolType,
-} from './types'
+import type { ProtocolFile, ProtocolData, ProtocolType } from './types'
 
 const log = createLogger(__filename)
 
@@ -29,8 +24,8 @@ export function parseProtocolData(
   file: ProtocolFile,
   contents: string,
   // optional Python protocol metadata
-  metadata: ?$PropertyType<ProtocolMetadata, 'metadata'>
-): $PropertyType<ProtocolState, 'data'> {
+  metadata: ?$PropertyType<ProtocolData, 'metadata'>
+): ProtocolData | null {
   if (fileIsJson(file)) {
     try {
       return JSON.parse(contents)
@@ -52,9 +47,9 @@ export function filenameToMimeType(name: string): string | null {
   return null
 }
 
-export function fileToType(file: ProtocolFile): ProtocolType | null {
-  if (file.type === MIME_TYPE_JSON) return 'json'
-  if (file.type === MIME_TYPE_PYTHON) return 'python'
+export function fileToType(file: ?ProtocolFile): ProtocolType | null {
+  if (file?.type === MIME_TYPE_JSON) return 'json'
+  if (file?.type === MIME_TYPE_PYTHON) return 'python'
   return null
 }
 

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -15,7 +15,6 @@ export function fileToProtocolFile(file: File): ProtocolFile {
   return {
     name: file.name,
     type: file.type,
-    // $FlowFixMe: upgrade to flow v0.80 for fixed File typedef
     lastModified: file.lastModified,
   }
 }

--- a/app/src/protocol/types.js
+++ b/app/src/protocol/types.js
@@ -2,13 +2,11 @@
 // protocol type defs
 import type { SchemaV1ProtocolFile } from '@opentrons/shared-data'
 
-export type ProtocolData = SchemaV1ProtocolFile<{}>
+// data may be a full JSON protocol or just a metadata dict from Python
+export type ProtocolData =
+  | SchemaV1ProtocolFile<{}>
+  | { metadata: $PropertyType<SchemaV1ProtocolFile<{}>, 'metadata'> }
 // NOTE: add union of additional versions after schema is bumped
-
-// A fragment with only the metadata part
-export type ProtocolMetadata = {
-  metadata: $PropertyType<SchemaV1ProtocolFile<{}>, 'metadata'>,
-}
 
 export type ProtocolFile = {
   name: string,
@@ -19,7 +17,7 @@ export type ProtocolFile = {
 export type ProtocolState = {
   file: ?ProtocolFile,
   contents: ?string,
-  data: ?(ProtocolData | ProtocolMetadata),
+  data: ?ProtocolData,
 }
 
 export type ProtocolType = 'json' | 'python'

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -21,7 +21,9 @@ import { discoveryReducer } from './discovery'
 // protocol state
 import { protocolReducer } from './protocol'
 
-export default combineReducers({
+import type { Action } from './types'
+
+export default combineReducers<_, Action>({
   robot: robotReducer,
   api: httpApiReducer,
   config: configReducer,

--- a/app/src/robot/reducer/index.js
+++ b/app/src/robot/reducer/index.js
@@ -7,7 +7,9 @@ import connectionReducer from './connection'
 import sessionReducer from './session'
 import calibrationReducer from './calibration'
 
-export default combineReducers({
+import type { Action } from '../../types'
+
+export default combineReducers<_, Action>({
   connection: connectionReducer,
   session: sessionReducer,
   calibration: calibrationReducer,

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -133,12 +133,14 @@ function traverseCommands(commandsById, parentIsCurrent) {
   }
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getCommands = createSelector(
   (state: State) => session(state).protocolCommands,
   (state: State) => session(state).protocolCommandsById,
   (commands, commandsById) => commands.map(traverseCommands(commandsById, true))
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getRunProgress = createSelector(
   getCommands,
   (commands): number => {
@@ -165,6 +167,7 @@ export function getStartTime(state: State) {
   return session(state).startTime
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getRunSeconds = createSelector(
   getStartTime,
   (state: State) => session(state).runTime,
@@ -175,6 +178,7 @@ export const getRunSeconds = createSelector(
   }
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getRunTime = createSelector(
   getRunSeconds,
   (runSeconds): string => {
@@ -194,6 +198,7 @@ export function getPipettesByMount(state: State) {
   return session(state).pipettesByMount
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getPipettes = createSelector(
   getPipettesByMount,
   (state: State) => calibration(state).probedByMount,
@@ -242,6 +247,7 @@ export const getPipettes = createSelector(
   }
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getNextPipette = createSelector(
   getPipettes,
   (pipettes): ?Pipette => {
@@ -253,6 +259,7 @@ export const getNextPipette = createSelector(
 
 // returns the mount of the pipette to use for deckware calibration
 // TODO(mc, 2018-02-07): be smarter about the backup case
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getCalibrator = createSelector(
   getPipettes,
   (pipettes): ?Pipette => pipettes.find(i => i.tipOn) || pipettes[0]
@@ -260,13 +267,14 @@ export const getCalibrator = createSelector(
 
 // TODO(mc, 2018-02-07): remove this selector in favor of the one above
 export function getCalibratorMount(state: State): ?Mount {
-  const calibrator = getCalibrator(state)
+  const calibrator: ?Pipette = getCalibrator(state)
 
   if (!calibrator) return null
 
   return calibrator.mount
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getPipettesCalibrated = createSelector(
   getPipettes,
   (pipettes): boolean => pipettes.length !== 0 && pipettes.every(i => i.probed)
@@ -289,7 +297,7 @@ export const getModules: OutputSelector<
     let modules = modulesBySlot
     if (!tcEnabled) {
       modules = omitBy(modulesBySlot, m => {
-        return m.name === 'thermocycler'
+        return m?.name === 'thermocycler'
       })
     }
     return Object.keys(modules)
@@ -302,6 +310,7 @@ export function getLabwareBySlot(state: State) {
   return session(state).labwareBySlot
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getLabware = createSelector(
   getPipettesByMount,
   getLabwareBySlot,
@@ -370,37 +379,44 @@ export function getDeckPopulated(state: State) {
   return calibration(state).deckPopulated
 }
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getUnconfirmedLabware = createSelector(
   getLabware,
   labware => labware.filter(lw => lw.type && !lw.confirmed)
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getTipracks = createSelector(
   getLabware,
   labware => labware.filter(lw => lw.type && lw.isTiprack)
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getNotTipracks = createSelector(
   getLabware,
   labware => labware.filter(lw => lw.type && !lw.isTiprack)
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getUnconfirmedTipracks = createSelector(
   getUnconfirmedLabware,
   labware => labware.filter(lw => lw.type && lw.isTiprack)
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getNextLabware = createSelector(
   getUnconfirmedTipracks,
   getUnconfirmedLabware,
   (tipracks, labware) => tipracks[0] || labware[0]
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getTipracksConfirmed = createSelector(
   getUnconfirmedTipracks,
   (remaining): boolean => remaining.length === 0
 )
 
+// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
 export const getLabwareConfirmed = createSelector(
   getUnconfirmedLabware,
   (remaining): boolean => remaining.length === 0
@@ -420,9 +436,11 @@ export function getOffsetUpdateInProgress(state: State): boolean {
 
 // get current pipette selector factory
 // to be used by a react-router Route component
-export const makeGetCurrentPipette = () =>
-  createSelector(
+export const makeGetCurrentPipette = () => {
+  // $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
+  return createSelector(
     (_, props: ContextRouter) => props.match.params.mount,
     getPipettes,
     (mount, pipettes) => pipettes.find(i => i.mount === mount)
   )
+}

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -97,7 +97,8 @@ export type StatePipette = {
   volume: number,
 }
 
-export type Pipette = StatePipette & {
+export type Pipette = {
+  ...$Exact<StatePipette>,
   calibration: PipetteCalibrationStatus,
   probed: boolean,
   tipOn: boolean,

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -7,12 +7,24 @@ import { updateReducer } from './update'
 import { apiUpdateReducer } from './api-update'
 
 import type { Service } from '@opentrons/discovery-client'
-import type { Middleware, ThunkAction } from '../types'
+import type {
+  Middleware,
+  ThunkAction,
+  Action,
+  Dispatch,
+  GetState,
+} from '../types'
 import type { ViewableRobot } from '../discovery'
 import type { Config } from '../config'
 import type { ShellUpdateAction } from './update'
 
-export type ShellAction = ShellUpdateAction
+type ShellLogsDownloadAction = {|
+  type: 'shell:DOWNLOAD_LOGS',
+  payload: {| logUrls: Array<string> |},
+  meta: {| shell: true |},
+|}
+
+export type ShellAction = ShellUpdateAction | ShellLogsDownloadAction
 
 const {
   ipcRenderer,
@@ -32,7 +44,7 @@ const API_RELEASE_NOTES = CURRENT_RELEASE_NOTES.replace(
 )
 export { CURRENT_VERSION, CURRENT_RELEASE_NOTES, API_RELEASE_NOTES }
 
-export const shellReducer = combineReducers({
+export const shellReducer = combineReducers<_, Action>({
   update: updateReducer,
   apiUpdate: apiUpdateReducer,
 })
@@ -63,7 +75,7 @@ export function getShellRobots(): Array<Service> {
 }
 
 export function downloadLogs(robot: ViewableRobot): ThunkAction {
-  return (dispatch, getState) => {
+  return (dispatch: Dispatch, getState: GetState) => {
     const logPaths = robot.health && robot.health.logs
 
     if (logPaths) {

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -2,20 +2,15 @@
 // @flow
 // application types
 import type { Store as ReduxStore, Dispatch as ReduxDispatch } from 'redux'
-
 import type { RouterAction } from 'react-router-redux'
 
 import typeof reducer from './reducer'
 import type { Action as RobotAction } from './robot'
-import type { Action as HttpApiAction } from './http-api-client'
+import type { HttpApiAction } from './http-api-client'
 import type { ShellAction } from './shell'
 import type { ConfigAction } from './config'
 import type { DiscoveryAction } from './discovery'
 import type { ProtocolAction } from './protocol'
-
-export type State = $Call<reducer>
-
-export type GetState = () => State
 
 export type Action =
   | RobotAction
@@ -25,6 +20,10 @@ export type Action =
   | RouterAction
   | DiscoveryAction
   | ProtocolAction
+
+export type State = $Call<reducer, {}, Action>
+
+export type GetState = () => State
 
 export type ActionType = $PropertyType<Action, 'type'>
 

--- a/components/package.json
+++ b/components/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons#readme",
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   },
   "peerDependencies": {
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "react-popper": "^1.0.0",
-    "react-select": "^2.3.0"
+    "react-select": "^2.4.3"
   }
 }

--- a/components/src/deck/Deck.js
+++ b/components/src/deck/Deck.js
@@ -15,15 +15,17 @@ import { EmptyDeckSlot } from './EmptyDeckSlot'
 
 import styles from './Deck.css'
 
-export type LabwareComponentProps = {
+export type LabwareComponentProps = {|
   slot: DeckSlot,
   width: number,
   height: number,
-}
+|}
+
+export type LabwareComponentType = React.ComponentType<LabwareComponentProps>
 
 type Props = {
   className?: string,
-  LabwareComponent?: React.ComponentType<LabwareComponentProps>,
+  LabwareComponent?: LabwareComponentType,
   DragPreviewLayer?: any, // TODO: BC 2019-01-03 flow doesn't like portals
 }
 
@@ -78,30 +80,35 @@ export default class Deck extends React.Component<Props> {
   }
 }
 
-function renderLabware(LabwareComponent): React.Node[] {
+function renderLabware(
+  LabwareComponent: ?LabwareComponentType
+): Array<React.Node> {
   return flatMap(
     SLOTNAME_MATRIX,
-    (columns: Array<DeckSlot>, row: number): React.Node[] => {
-      return columns.map((slot: DeckSlot, col: number) => {
-        if (slot === TRASH_SLOTNAME) return null
+    (columns: Array<DeckSlot>, row: number): Array<React.Node> => {
+      return columns.map(
+        (slot: DeckSlot, col: number): React.Node => {
+          if (slot === TRASH_SLOTNAME) return null
 
-        const props = {
-          slot,
-          width: SLOT_RENDER_WIDTH,
-          height: SLOT_RENDER_HEIGHT,
+          const props = {
+            slot,
+            width: SLOT_RENDER_WIDTH,
+            height: SLOT_RENDER_HEIGHT,
+          }
+          const transform = `translate(${[
+            SLOT_RENDER_WIDTH * col + SLOT_SPACING_MM * (col + 1),
+            SLOT_RENDER_HEIGHT * row + SLOT_SPACING_MM * (row + 1),
+          ].join(',')})`
+
+          return (
+            // $FlowFixMe: (mc, 2019-04-18) don't know why flow doesn't like this, don't care because this is going away
+            <g key={slot} transform={transform}>
+              <EmptyDeckSlot {...props} />
+              {LabwareComponent && <LabwareComponent {...props} />}
+            </g>
+          )
         }
-        const transform = `translate(${[
-          SLOT_RENDER_WIDTH * col + SLOT_SPACING_MM * (col + 1),
-          SLOT_RENDER_HEIGHT * row + SLOT_SPACING_MM * (row + 1),
-        ].join(',')})`
-
-        return (
-          <g key={slot} transform={transform}>
-            <EmptyDeckSlot {...props} />
-            {LabwareComponent && <LabwareComponent {...props} />}
-          </g>
-        )
-      })
+      )
     }
   )
 }

--- a/components/src/forms/SelectField.js
+++ b/components/src/forms/SelectField.js
@@ -90,9 +90,11 @@ export default class SelectField extends React.Component<SelectProps> {
         <Select
           id={id}
           name={name}
+          // $FlowFixMe: our types are more strict than react-select
           options={options}
           value={value}
           error={error}
+          // $FlowFixMe: our types are more strict than react-select
           onChange={this.handleChange}
           onBlur={this.handleBlur}
           isDisabled={disabled}
@@ -106,7 +108,7 @@ export default class SelectField extends React.Component<SelectProps> {
             IndicatorSeparator: null,
           }}
           className={className}
-          menuPosition={menuPosition}
+          menuPosition={menuPosition || 'absolute'}
         />
         {caption && <p className={captionCx}>{caption}</p>}
       </div>

--- a/components/src/icons/NotificationIcon.js
+++ b/components/src/icons/NotificationIcon.js
@@ -4,7 +4,8 @@ import * as React from 'react'
 import Icon, { type IconProps } from './Icon'
 import iconData, { type IconName } from './icon-data'
 
-type Props = IconProps & {
+type Props = {
+  ...$Exact<IconProps>,
   /** name constant of the optional notifcation icon to display */
   childName: ?IconName,
   /** classes to apply (e.g. for color) to notification icon */
@@ -35,7 +36,6 @@ export default function NotificationIcon(props: Props) {
   const scaledHeight = height / SCALE_FACTOR
 
   return (
-    // $FlowFixMe: doesn't type properly with upgrade to flow@0.76
     <Icon {...props}>
       {childName && (
         <Icon

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons#readme",
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   },
   "dependencies": {

--- a/discovery-client/src/mdns-browser.js
+++ b/discovery-client/src/mdns-browser.js
@@ -1,7 +1,7 @@
 // @flow
 // mdns browser wrapper
 import mdns, { ServiceType } from 'mdns-js'
-import type { Browser } from 'mdns-js'
+import type { Browser, NetworkConnection } from 'mdns-js'
 import keys from 'lodash/keys'
 import flatMap from 'lodash/flatMap'
 
@@ -15,11 +15,14 @@ export function getKnownIps(maybeBrowser: ?Browser): Array<string> {
   if (!maybeBrowser) return []
   const browser: Browser = maybeBrowser
 
-  // $FlowFixMe: https://github.com/flow-typed/flow-typed/issues/2463
-  return flatMap(browser.networking.connections, connection => {
-    const { addresses } = browser.connections[connection.networkInterface] || {}
-    return keys(addresses)
-  })
+  return flatMap<NetworkConnection, string>(
+    browser.networking.connections,
+    (connection: NetworkConnection, i: number, _: Array<NetworkConnection>) => {
+      const { addresses } =
+        browser.connections[connection.networkInterface] || {}
+      return keys(addresses)
+    }
+  )
 }
 
 function monkeyPatchThrowers() {

--- a/discovery-client/src/service.js
+++ b/discovery-client/src/service.js
@@ -45,8 +45,8 @@ export function makeService(
     ok: defaultTo(ok, null),
     serverOk: defaultTo(serverOk, null),
     advertising: defaultTo(advertising, null),
-    health: defaultTo(health, null),
-    serverHealth: defaultTo(serverHealth, null),
+    health: health || null,
+    serverHealth: serverHealth || null,
   }
 }
 
@@ -58,7 +58,7 @@ export function updateService(
 ): Service {
   const next: Service | ServiceUpdate = update
 
-  return Object.keys(update).reduce((result, key) => {
+  return Object.keys(update).reduce<Service>((result: Service, key: string) => {
     const prevVal = result[key]
     const nextVal = defaultTo(next[key], prevVal)
     // use isEqual to deep compare response objects

--- a/flow-typed/npm/lodash_v4.x.x.js
+++ b/flow-typed/npm/lodash_v4.x.x.js
@@ -1,7 +1,8 @@
-// flow-typed signature: 911f4ab10b9a871625482b7b6622b76b
-// flow-typed version: a0e86fa7fb/lodash_v4.x.x/flow_>=v0.63.x
+// flow-typed signature: 85643356ccdcde77e00470b66f694123
+// flow-typed version: fd2cfc021e/lodash_v4.x.x/flow_>=v0.63.x
 
 declare module "lodash" {
+  declare type Path = $ReadOnlyArray<string | number> | string | number;
   declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
   declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
 
@@ -161,7 +162,7 @@ declare module "lodash" {
 
   declare type NestedArray<T> = Array<Array<T>>;
 
-  declare type matchesIterateeShorthand = Object;
+  declare type matchesIterateeShorthand = {[key: any]: any};
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -438,9 +439,9 @@ declare module "lodash" {
       a4: $ReadOnlyArray<T>,
       comparator?: Comparator<T>
     ): Array<T>;
-    uniq<T>(array?: ?Array<T>): Array<T>;
-    uniqBy<T>(array?: ?Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
-    uniqWith<T>(array?: ?Array<T>, comparator?: ?Comparator<T>): Array<T>;
+    uniq<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
+    uniqBy<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    uniqWith<T>(array?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
     unzip<T>(array?: ?Array<T>): Array<T>;
     unzipWith<T>(array: ?Array<T>, iteratee?: ?Iteratee<T>): Array<T>;
     without<T>(array?: ?$ReadOnlyArray<T>, ...values?: Array<?T>): Array<T>;
@@ -634,12 +635,12 @@ declare module "lodash" {
     includes(str: string, value: string, fromIndex?: number): boolean;
     invokeMap<T>(
       array?: ?$ReadOnlyArray<T>,
-      path?: ?((value: T) => Array<string> | string) | Array<string> | string,
+      path?: ?((value: T) => Path) | Path,
       ...args?: Array<any>
     ): Array<any>;
     invokeMap<T: Object>(
       object: T,
-      path: ((value: any) => Array<string> | string) | Array<string> | string,
+      path: ((value: any) => Path) | Path,
       ...args?: Array<any>
     ): Array<any>;
     keyBy<T, V>(
@@ -674,13 +675,13 @@ declare module "lodash" {
       iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
       orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
     ): Array<T>;
-    orderBy<V, T: Object>(
+    orderBy<V, T: {}>(
       object: T,
       iteratees?: $ReadOnlyArray<OIteratee<*>> | string,
       orders?: $ReadOnlyArray<"asc" | "desc"> | string
     ): Array<V>;
     partition<T>(
-      array?: ?Array<T>,
+      array?: ?$ReadOnlyArray<T>,
       predicate?: ?Predicate<T>
     ): [Array<T>, Array<T>];
     partition<V, A, T: { [id: any]: A }>(
@@ -749,8 +750,8 @@ declare module "lodash" {
     shuffle<T>(array: ?Array<T>): Array<T>;
     shuffle<V, T: Object>(object: T): Array<V>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
-    some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
+    some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
     some<A, T: { [id: any]: A }>(
       object?: ?T,
       predicate?: OPredicate<A, T>
@@ -779,33 +780,33 @@ declare module "lodash" {
     after(n: number, fn: Function): Function;
     ary(func: Function, n?: number): Function;
     before(n: number, fn: Function): Function;
-    bind(func: Function, thisArg: any, ...partials: Array<any>): Function;
+    bind<F:(...any[]) => any>(func: F, thisArg: any, ...partials: Array<any>): F;
     bindKey(obj?: ?Object, key?: ?string, ...partials?: Array<?any>): Function;
     curry: Curry;
     curry(func: Function, arity?: number): Function;
     curryRight(func: Function, arity?: number): Function;
-    debounce<F: Function>(func: F, wait?: number, options?: DebounceOptions): F;
-    defer(func: Function, ...args?: Array<any>): TimeoutID;
+    debounce<F: (...any[]) => any>(func: F, wait?: number, options?: DebounceOptions): F;
+    defer(func: (...any[]) => any, ...args?: Array<any>): TimeoutID;
     delay(func: Function, wait: number, ...args?: Array<any>): TimeoutID;
-    flip(func: Function): Function;
-    memoize<F: Function>(func: F, resolver?: Function): F;
-    negate(predicate: Function): Function;
-    once(func: Function): Function;
+    flip<R>(func: (...any[]) => R): (...any[]) => R;
+    memoize<A, R>(func: (...A) => R, resolver?: (...A) => any): (...A) => R;
+    negate<A, R>(predicate: (...A) => R): (...A) => boolean;
+    once<F: (...any[]) => any>(func: F): F;
     overArgs(func?: ?Function, ...transforms?: Array<Function>): Function;
     overArgs(func?: ?Function, transforms?: ?Array<Function>): Function;
-    partial(func: Function, ...partials: any[]): Function;
-    partialRight(func: Function, ...partials: Array<any>): Function;
-    partialRight(func: Function, partials: Array<any>): Function;
+    partial<R>(func: (...any[]) => R, ...partials: any[]): (...any[]) => R;
+    partialRight<R>(func: (...any[]) => R, ...partials: Array<any>): (...any[]) => R;
+    partialRight<R>(func: (...any[]) => R, partials: Array<any>): (...any[]) => R;
     rearg(func: Function, ...indexes: Array<number>): Function;
     rearg(func: Function, indexes: Array<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
-    throttle(
-      func: Function,
+    throttle<F: (...any[]) => any>(
+      func: F,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
-    unary(func: Function): Function;
+    ): F;
+    unary<F: (...any[]) => any>(func: F): F;
     wrap(value?: any, wrapper?: ?Function): Function;
 
     // Lang
@@ -894,12 +895,10 @@ declare module "lodash" {
     isNull(value: any): false;
     isNumber(value: number): true;
     isNumber(value: any): false;
-    isObject(value: Object): true;
-    isObject(value: any): false;
+    isObject(value: any): boolean;
     isObjectLike(value: void | null): false;
     isObjectLike(value: any): boolean;
-    isPlainObject(value: Object): true;
-    isPlainObject(value: any): false;
+    isPlainObject(value: any): boolean;
     isRegExp(value: RegExp): true;
     isRegExp(value: any): false;
     isSafeInteger(value: number): boolean;
@@ -950,7 +949,7 @@ declare module "lodash" {
     round(number: number, precision?: number): number;
     subtract(minuend: number, subtrahend: number): number;
     sum(array: Array<*>): number;
-    sumBy<T>(array: Array<T>, iteratee?: Iteratee<T>): number;
+    sumBy<T>(array: $ReadOnlyArray<T>, iteratee?: Iteratee<T>): number;
 
     // number
     clamp(number?: number, lower?: ?number, upper?: ?number): number;
@@ -1069,7 +1068,8 @@ declare module "lodash" {
     ): Object;
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
     at(object?: ?Object, paths: Array<string>): Array<any>;
-    create<T>(prototype: T, properties: Object): $Supertype<T>;
+    create(prototype: void | null, properties: void | null): {};
+    create<T>(prototype: T, properties: Object): T;
     create(prototype: any, properties: void | null): {};
     defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
@@ -1161,22 +1161,22 @@ declare module "lodash" {
     functionsIn(object?: ?Object): Array<string>;
     get(
       object?: ?Object | ?$ReadOnlyArray<any> | void | null,
-      path?: ?$ReadOnlyArray<string | number> | string | number,
+      path?: ?Path,
       defaultValue?: any
     ): any;
-    has(object: Object, path: Array<string> | string): boolean;
+    has(object: Object, path: Path): boolean;
     has(object: Object, path: void | null): false;
-    has(object: void | null, path?: ?Array<string> | ?string): false;
-    hasIn(object: Object, path: Array<string> | string): boolean;
+    has(object: void | null, path?: ?Path): false;
+    hasIn(object: Object, path: Path): boolean;
     hasIn(object: Object, path: void | null): false;
-    hasIn(object: void | null, path?: ?Array<string> | ?string): false;
+    hasIn(object: void | null, path?: ?Path): false;
     invert(object: Object, multiVal?: ?boolean): Object;
     invert(object: void | null, multiVal?: ?boolean): {};
     invertBy(object: Object, iteratee?: ?Function): Object;
     invertBy(object: void | null, iteratee?: ?Function): {};
     invoke(
       object?: ?Object,
-      path?: ?Array<string> | string,
+      path?: ?Path,
       ...args?: Array<any>
     ): any;
     keys<K>(object?: ?{ [key: K]: any }): Array<K>;
@@ -1244,7 +1244,9 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): Object;
     omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
-    pick(object?: ?Object, ...props: Array<string>): Object;
+    // NOTE(mc, 2019-04-17): I commented out this def because we don't use it
+    // and flow isnt't able to infer our usage properly
+    // pick(object?: ?Object, ...props: Array<string>): Object;
     pick(object?: ?Object, props: Array<string>): Object;
     pickBy<A, T: { [id: any]: A } | { [id: number]: A }>(
       object: T,
@@ -1253,24 +1255,24 @@ declare module "lodash" {
     pickBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
     result(
       object?: ?Object,
-      path?: ?Array<string> | string,
+      path?: ?Path,
       defaultValue?: any
     ): any;
-    set(object: Object, path?: ?Array<string> | string, value: any): Object;
+    set(object: Object, path?: ?Path, value: any): Object;
     set<T: void | null>(
       object: T,
-      path?: ?Array<string> | string,
+      path?: ?Path,
       value?: ?any
     ): T;
     setWith<T>(
       object: T,
-      path?: ?Array<string> | string,
+      path?: ?Path,
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
     setWith<T: void | null>(
       object: T,
-      path?: ?Array<string> | string,
+      path?: ?Path,
       value?: ?any,
       customizer?: ?(nsValue: any, key: string, nsObject: T) => any
     ): T;
@@ -1286,23 +1288,23 @@ declare module "lodash" {
       iteratee?: ?OIteratee<*>,
       accumulator?: ?any
     ): {};
-    unset(object: Object, path?: ?Array<string> | ?string): boolean;
-    unset(object: void | null, path?: ?Array<string> | ?string): true;
-    update(object: Object, path: string[] | string, updater: Function): Object;
+    unset(object: void | null, path?: ?Path): true;
+    unset(object: Object, path?: ?Path): boolean;
+    update(object: Object, path: Path, updater: Function): Object;
     update<T: void | null>(
       object: T,
-      path?: ?(string[]) | ?string,
+      path?: ?Path,
       updater?: ?Function
     ): T;
     updateWith(
       object: Object,
-      path?: ?(string[]) | ?string,
+      path?: ?Path,
       updater?: ?Function,
       customizer?: ?Function
     ): Object;
     updateWith<T: void | null>(
       object: T,
-      path?: ?(string[]) | ?string,
+      path?: ?Path,
       updater?: ?Function,
       customizer?: ?Function
     ): T;
@@ -1396,20 +1398,20 @@ declare module "lodash" {
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
     constant<T>(value: T): () => T;
-    defaultTo<T1: string | boolean | Object, T2>(
+    defaultTo<T1: void | null, T2>(value: T1, defaultValue: T2): T2;
+    defaultTo<T1: string | boolean, T2>(
       value: T1,
       defaultValue: T2
     ): T1;
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(value: T1, defaultValue: T2): T1 | T2;
-    defaultTo<T1: void | null, T2>(value: T1, defaultValue: T2): T2;
     flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
     flowRight: $Compose & ((funcs: Array<Function>) => Function);
     identity<T>(value: T): T;
     iteratee(func?: any): Function;
     matches(source?: ?Object): Function;
-    matchesProperty(path?: ?Array<string> | string, srcValue: any): Function;
-    method(path?: ?Array<string> | string, ...args?: Array<any>): Function;
+    matchesProperty(path?: ?Path, srcValue: any): Function;
+    method(path?: ?Path, ...args?: Array<any>): Function;
     methodOf(object?: ?Object, ...args?: Array<any>): Function;
     mixin<T: Function | Object>(
       object?: T,
@@ -1425,7 +1427,7 @@ declare module "lodash" {
     overEvery(predicates: Array<Function>): Function;
     overSome(...predicates: Array<Function>): Function;
     overSome(predicates: Array<Function>): Function;
-    property(path?: ?Array<string> | string): Function;
+    property(path?: ?Path): Function;
     propertyOf(object?: ?Object): Function;
     range(start: number, end: number, step?: number): Array<number>;
     range(end: number, step?: number): Array<number>;
@@ -1452,6 +1454,7 @@ declare module "lodash" {
 }
 
 declare module "lodash/fp" {
+  declare type Path = $ReadOnlyArray<string | number> | string | number;
   declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
   declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
 
@@ -1611,7 +1614,7 @@ declare module "lodash/fp" {
 
   declare type NestedArray<T> = Array<Array<T>>;
 
-  declare type matchesIterateeShorthand = Object;
+  declare type matchesIterateeShorthand = {[string | number]: any};
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -2184,14 +2187,14 @@ declare module "lodash/fp" {
     ): (collection: Array<T>) => boolean;
     includesFrom<T>(value: T, fromIndex: number, collection: Array<T>): boolean;
     invokeMap<T>(
-      path: ((value: T) => Array<string> | string) | Array<string> | string
+      path: ((value: T) => Path) | Path
     ): (collection: Array<T> | { [id: any]: T }) => Array<any>;
     invokeMap<T>(
-      path: ((value: T) => Array<string> | string) | Array<string> | string,
+      path: ((value: T) => Path) | Path,
       collection: Array<T> | { [id: any]: T }
     ): Array<any>;
     invokeArgsMap<T>(
-      path: ((value: T) => Array<string> | string) | Array<string> | string
+      path: ((value: T) => Path) | Path
     ): ((
       collection: Array<T> | { [id: any]: T }
     ) => (args: Array<any>) => Array<any>) &
@@ -2200,11 +2203,11 @@ declare module "lodash/fp" {
         args: Array<any>
       ) => Array<any>);
     invokeArgsMap<T>(
-      path: ((value: T) => Array<string> | string) | Array<string> | string,
+      path: ((value: T) => Path) | Path,
       collection: Array<T> | { [id: any]: T }
     ): (args: Array<any>) => Array<any>;
     invokeArgsMap<T>(
-      path: ((value: T) => Array<string> | string) | Array<string> | string,
+      path: ((value: T) => Path) | Path,
       collection: Array<T> | { [id: any]: T },
       args: Array<any>
     ): Array<any>;
@@ -2354,14 +2357,14 @@ declare module "lodash/fp" {
     curryRight(func: Function): Function;
     curryRightN(arity: number): (func: Function) => Function;
     curryRightN(arity: number, func: Function): Function;
-    debounce(wait: number): <F: Function>(func: F) => F;
-    debounce<F: Function>(wait: number, func: F): F;
-    defer(func: Function): TimeoutID;
+    debounce(wait: number): <A, R>(func: (...A) => R) => (...A) => R;
+    debounce<A, R>(wait: number, func: (...A) => R): (...A) => R;
+    defer(func: (...any[]) => any): TimeoutID;
     delay(wait: number): (func: Function) => TimeoutID;
     delay(wait: number, func: Function): TimeoutID;
     flip(func: Function): Function;
     memoize<F: Function>(func: F): F;
-    negate(predicate: Function): Function;
+    negate<A, R>(predicate: (...A) => R): (...A) => boolean;
     complement(predicate: Function): Function;
     once(func: Function): Function;
     overArgs(func: Function): (transforms: Array<Function>) => Function;
@@ -2382,9 +2385,9 @@ declare module "lodash/fp" {
     apply(func: Function): Function;
     spreadFrom(start: number): (func: Function) => Function;
     spreadFrom(start: number, func: Function): Function;
-    throttle(wait: number): (func: Function) => Function;
-    throttle(wait: number, func: Function): Function;
-    unary(func: Function): Function;
+    throttle<A, R>(wait: number): (func: (...A) => R) => (...A) => R;
+    throttle<A, R>(wait: number, func: (...A) => R): (...A) => R;
+    unary<T, R>(func: (T, ...any[]) => R): (T) => R;
     wrap(wrapper: Function): (value: any) => Function;
     wrap(wrapper: Function, value: any): Function;
 
@@ -2485,8 +2488,7 @@ declare module "lodash/fp" {
     ): boolean;
     isError(value: any): boolean;
     isFinite(value: any): boolean;
-    isFunction(value: Function): true;
-    isFunction(value: number | string | void | null | Object): false;
+    isFunction(value: any): boolean;
     isInteger(value: any): boolean;
     isLength(value: any): boolean;
     isMap(value: any): boolean;
@@ -2728,7 +2730,7 @@ declare module "lodash/fp" {
     props(paths: Array<string>, object: Object): Array<any>;
     paths(paths: Array<string>): (object: Object) => Array<any>;
     paths(paths: Array<string>, object: Object): Array<any>;
-    create<T>(prototype: T): $Supertype<T>;
+    create<T>(prototype: T): T;
     defaults(source: Object): (object: Object) => Object;
     defaults(source: Object, object: Object): Object;
     defaultsAll(objects: Array<Object>): Object;
@@ -2798,84 +2800,84 @@ declare module "lodash/fp" {
     functions(object: Object): Array<string>;
     functionsIn(object: Object): Array<string>;
     get(
-      path: $ReadOnlyArray<string | number> | string | number
+      path: Path
     ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
     get(
-      path: $ReadOnlyArray<string | number> | string | number,
+      path: Path,
       object: Object | $ReadOnlyArray<any> | void | null
     ): any;
-    prop(path: Array<string> | string): (object: Object | Array<any>) => any;
-    prop(path: Array<string> | string, object: Object | Array<any>): any;
-    path(path: Array<string> | string): (object: Object | Array<any>) => any;
-    path(path: Array<string> | string, object: Object | Array<any>): any;
+    prop(path: Path): (object: Object | Array<any>) => any;
+    prop(path: Path, object: Object | Array<any>): any;
+    path(path: Path): (object: Object | Array<any>) => any;
+    path(path: Path, object: Object | Array<any>): any;
     getOr(
       defaultValue: any
     ): ((
-      path: Array<string> | string
+      path: Path
     ) => (object: Object | Array<any>) => any) &
       ((
-        path: Array<string> | string,
+        path: Path,
         object: Object | $ReadOnlyArray<any> | void | null
       ) => any);
     getOr(
       defaultValue: any,
-      path: Array<string> | string
+      path: Path
     ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
     getOr(
       defaultValue: any,
-      path: Array<string> | string,
+      path: Path,
       object: Object | $ReadOnlyArray<any> | void | null
     ): any;
     propOr(
       defaultValue: any
     ): ((
-      path: Array<string> | string
+      path: Path
     ) => (object: Object | Array<any>) => any) &
-      ((path: Array<string> | string, object: Object | Array<any>) => any);
+      ((path: Path, object: Object | Array<any>) => any);
     propOr(
       defaultValue: any,
-      path: Array<string> | string
+      path: Path
     ): (object: Object | Array<any>) => any;
     propOr(
       defaultValue: any,
-      path: Array<string> | string,
+      path: Path,
       object: Object | Array<any>
     ): any;
     pathOr(
       defaultValue: any
     ): ((
-      path: Array<string> | string
+      path: Path
     ) => (object: Object | Array<any>) => any) &
-      ((path: Array<string> | string, object: Object | Array<any>) => any);
+      ((path: Path, object: Object | Array<any>) => any);
     pathOr(
       defaultValue: any,
-      path: Array<string> | string
+      path: Path
     ): (object: Object | Array<any>) => any;
     pathOr(
       defaultValue: any,
-      path: Array<string> | string,
+      path: Path,
       object: Object | Array<any>
     ): any;
-    has(path: Array<string> | string): (object: Object) => boolean;
-    has(path: Array<string> | string, object: Object): boolean;
-    hasIn(path: Array<string> | string): (object: Object) => boolean;
-    hasIn(path: Array<string> | string, object: Object): boolean;
+    has(path: Path): (object: Object) => boolean;
+    has(path: Path, object: Object): boolean;
+    hasIn(path: Path): (object: Object) => boolean;
+    hasIn(path: Path, object: Object): boolean;
     invert(object: Object): Object;
     invertObj(object: Object): Object;
     invertBy(iteratee: Function): (object: Object) => Object;
     invertBy(iteratee: Function, object: Object): Object;
-    invoke(path: Array<string> | string): (object: Object) => any;
-    invoke(path: Array<string> | string, object: Object): any;
+    invoke(path: Path): (object: Object) => any;
+    invoke(path: Path, object: Object): any;
     invokeArgs(
-      path: Array<string> | string
+      path: Path
     ): ((object: Object) => (args: Array<any>) => any) &
       ((object: Object, args: Array<any>) => any);
     invokeArgs(
-      path: Array<string> | string,
+      path: Path,
       object: Object
     ): (args: Array<any>) => any;
     invokeArgs(
-      path: Array<string> | string,
+      path: Path,
       object: Object,
       args: Array<any>
     ): any;
@@ -2954,50 +2956,50 @@ declare module "lodash/fp" {
       predicate: OPredicate<A>
     ): (object: T) => Object;
     pickBy<A, T: { [id: any]: A }>(predicate: OPredicate<A>, object: T): Object;
-    result(path: Array<string> | string): (object: Object) => any;
-    result(path: Array<string> | string, object: Object): any;
+    result(path: Path): (object: Object) => any;
+    result(path: Path, object: Object): any;
     set(
-      path: Array<string> | string
+      path: Path
     ): ((value: any) => (object: Object) => Object) &
       ((value: any, object: Object) => Object);
-    set(path: Array<string> | string, value: any): (object: Object) => Object;
-    set(path: Array<string> | string, value: any, object: Object): Object;
+    set(path: Path, value: any): (object: Object) => Object;
+    set(path: Path, value: any, object: Object): Object;
     assoc(
-      path: Array<string> | string
+      path: Path
     ): ((value: any) => (object: Object) => Object) &
       ((value: any, object: Object) => Object);
-    assoc(path: Array<string> | string, value: any): (object: Object) => Object;
-    assoc(path: Array<string> | string, value: any, object: Object): Object;
+    assoc(path: Path, value: any): (object: Object) => Object;
+    assoc(path: Path, value: any, object: Object): Object;
     assocPath(
-      path: Array<string> | string
+      path: Path
     ): ((value: any) => (object: Object) => Object) &
       ((value: any, object: Object) => Object);
     assocPath(
-      path: Array<string> | string,
+      path: Path,
       value: any
     ): (object: Object) => Object;
-    assocPath(path: Array<string> | string, value: any, object: Object): Object;
+    assocPath(path: Path, value: any, object: Object): Object;
     setWith<T>(
       customizer: (nsValue: any, key: string, nsObject: T) => any
     ): ((
-      path: Array<string> | string
+      path: Path
     ) => ((value: any) => (object: T) => Object) &
       ((value: any, object: T) => Object)) &
-      ((path: Array<string> | string, value: any) => (object: T) => Object) &
-      ((path: Array<string> | string, value: any, object: T) => Object);
+      ((path: Path, value: any) => (object: T) => Object) &
+      ((path: Path, value: any, object: T) => Object);
     setWith<T>(
       customizer: (nsValue: any, key: string, nsObject: T) => any,
-      path: Array<string> | string
+      path: Path
     ): ((value: any) => (object: T) => Object) &
       ((value: any, object: T) => Object);
     setWith<T>(
       customizer: (nsValue: any, key: string, nsObject: T) => any,
-      path: Array<string> | string,
+      path: Path,
       value: any
     ): (object: T) => Object;
     setWith<T>(
       customizer: (nsValue: any, key: string, nsObject: T) => any,
-      path: Array<string> | string,
+      path: Path,
       value: any,
       object: T
     ): Object;
@@ -3018,45 +3020,45 @@ declare module "lodash/fp" {
       accumulator: any,
       collection: Object | $ReadOnlyArray<any>
     ): any;
-    unset(path: Array<string> | string): (object: Object) => Object;
-    unset(path: Array<string> | string, object: Object): Object;
-    dissoc(path: Array<string> | string): (object: Object) => Object;
-    dissoc(path: Array<string> | string, object: Object): Object;
-    dissocPath(path: Array<string> | string): (object: Object) => Object;
-    dissocPath(path: Array<string> | string, object: Object): Object;
+    unset(path: Path): (object: Object) => Object;
+    unset(path: Path, object: Object): Object;
+    dissoc(path: Path): (object: Object) => Object;
+    dissoc(path: Path, object: Object): Object;
+    dissocPath(path: Path): (object: Object) => Object;
+    dissocPath(path: Path, object: Object): Object;
     update(
-      path: string[] | string
+      path: Path
     ): ((updater: Function) => (object: Object) => Object) &
       ((updater: Function, object: Object) => Object);
     update(
-      path: string[] | string,
+      path: Path,
       updater: Function
     ): (object: Object) => Object;
-    update(path: string[] | string, updater: Function, object: Object): Object;
+    update(path: Path, updater: Function, object: Object): Object;
     updateWith(
       customizer: Function
     ): ((
-      path: string[] | string
+      path: Path
     ) => ((updater: Function) => (object: Object) => Object) &
       ((updater: Function, object: Object) => Object)) &
       ((
-        path: string[] | string,
+        path: Path,
         updater: Function
       ) => (object: Object) => Object) &
-      ((path: string[] | string, updater: Function, object: Object) => Object);
+      ((path: Path, updater: Function, object: Object) => Object);
     updateWith(
       customizer: Function,
-      path: string[] | string
+      path: Path
     ): ((updater: Function) => (object: Object) => Object) &
       ((updater: Function, object: Object) => Object);
     updateWith(
       customizer: Function,
-      path: string[] | string,
+      path: Path,
       updater: Function
     ): (object: Object) => Object;
     updateWith(
       customizer: Function,
-      path: string[] | string,
+      path: Path,
       updater: Function,
       object: Object
     ): Object;
@@ -3157,18 +3159,18 @@ declare module "lodash/fp" {
     cond(pairs: NestedArray<Function>): Function;
     constant<T>(value: T): () => T;
     always<T>(value: T): () => T;
-    defaultTo<T1: string | boolean | Object, T2>(
+    defaultTo<T1: void | null, T2>(defaultValue: T2): (value: T1) => T2;
+    defaultTo<T1: void | null, T2>(defaultValue: T2, value: T1): T2;
+    defaultTo<T1: string | boolean, T2>(
       defaultValue: T2
     ): (value: T1) => T1;
-    defaultTo<T1: string | boolean | Object, T2>(
+    defaultTo<T1: string | boolean, T2>(
       defaultValue: T2,
       value: T1
     ): T1;
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(defaultValue: T2): (value: T1) => T1 | T2;
     defaultTo<T1: number, T2>(defaultValue: T2, value: T1): T1 | T2;
-    defaultTo<T1: void | null, T2>(defaultValue: T2): (value: T1) => T2;
-    defaultTo<T1: void | null, T2>(defaultValue: T2, value: T1): T2;
     flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
     pipe: $ComposeReverse & ((funcs: Array<Function>) => Function);
     flowRight: $Compose & ((funcs: Array<Function>) => Function);
@@ -3178,13 +3180,13 @@ declare module "lodash/fp" {
     iteratee(func: any): Function;
     matches(source: Object): (object: Object) => boolean;
     matches(source: Object, object: Object): boolean;
-    matchesProperty(path: Array<string> | string): (srcValue: any) => Function;
-    matchesProperty(path: Array<string> | string, srcValue: any): Function;
-    propEq(path: Array<string> | string): (srcValue: any) => Function;
-    propEq(path: Array<string> | string, srcValue: any): Function;
-    pathEq(path: Array<string> | string): (srcValue: any) => Function;
-    pathEq(path: Array<string> | string, srcValue: any): Function;
-    method(path: Array<string> | string): Function;
+    matchesProperty(path: Path): (srcValue: any) => Function;
+    matchesProperty(path: Path, srcValue: any): Function;
+    propEq(path: Path): (srcValue: any) => Function;
+    propEq(path: Path, srcValue: any): Function;
+    pathEq(path: Path): (srcValue: any) => Function;
+    pathEq(path: Path, srcValue: any): Function;
+    method(path: Path): Function;
     methodOf(object: Object): Function;
     mixin<T: Function | Object>(
       object: T
@@ -3209,11 +3211,11 @@ declare module "lodash/fp" {
     overSome(predicates: Array<Function>): Function;
     anyPass(predicates: Array<Function>): Function;
     property(
-      path: Array<string> | string
+      path: Path
     ): (object: Object | Array<any>) => any;
-    property(path: Array<string> | string, object: Object | Array<any>): any;
-    propertyOf(object: Object): (path: Array<string> | string) => Function;
-    propertyOf(object: Object, path: Array<string> | string): Function;
+    property(path: Path, object: Object | Array<any>): any;
+    propertyOf(object: Object): (path: Path) => Function;
+    propertyOf(object: Object, path: Path): Function;
     range(start: number): (end: number) => Array<number>;
     range(start: number, end: number): Array<number>;
     rangeStep(

--- a/flow-typed/npm/mdns-js_v1.0.x.js
+++ b/flow-typed/npm/mdns-js_v1.0.x.js
@@ -8,7 +8,7 @@ declare module 'mdns-js' {
     discover(): void;
     stop(): void;
     networking: {
-      connections: Array<{interfaceIndex: number, networkInterface: string}>,
+      connections: Array<NetworkConnection>,
     };
     connections: {
       services?: {
@@ -52,5 +52,10 @@ declare module 'mdns-js' {
     host?: string,
     interfaceIndex: number,
     networkInterface: string,
+  }
+
+  declare type NetworkConnection = {
+    interfaceIndex: number,
+    networkInterface: string
   }
 }

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,132 +1,276 @@
-// flow-typed signature: 9a12aedd08545d50c2069919fdd910b9
-// flow-typed version: dcd1531faf/react-redux_v5.x.x/flow_>=v0.54.x <=v0.61.x
+// flow-typed signature: f06f00c3ad0cfedb90c0c6de04b219f3
+// flow-typed version: 3a6d556e4b/react-redux_v5.x.x/flow_>=v0.89.x
 
-import type { Dispatch, Store } from "redux";
+/**
+The order of type arguments for connect() is as follows:
+
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
+
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
+
+connect<Props, OwnProps, _, _, _, _>(…)
+
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
+
+Decrypting the abbreviations:
+  WC = Component being wrapped
+  S = State
+  D = Dispatch
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
+*/
 
 declare module "react-redux" {
-  /*
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
 
-    S = State
-    A = Action
-    OP = OwnProps
-    SP = StateProps
-    DP = DispatchProps
+  declare export type Options<S, OP, SP, MP> = {|
+    pure?: boolean,
+    withRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
+  |};
 
-  */
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
 
-  declare type MapStateToProps<S, OP: Object, SP: Object> = (
-    state: S,
-    ownProps: OP
-  ) => ((state: S, ownProps: OP) => SP) | SP;
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
 
-  declare type MapDispatchToProps<A, OP: Object, DP: Object> =
-    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
-    | DP;
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
 
-  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
+  declare class ConnectedComponent<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponent<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
     stateProps: SP,
     dispatchProps: DP,
-    ownProps: OP
+    ownProps: OP,
   ) => P;
 
-  declare type Context = { store: Store<*, *> };
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
 
-  declare type ComponentWithDefaultProps<DP: {}, P: {}, CP: P> = Class<
-    React$Component<CP>
-  > & { defaultProps: DP };
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
 
-  declare class ConnectedComponentWithDefaultProps<
-    OP,
-    DP,
-    CP
-  > extends React$Component<OP> {
-    static defaultProps: DP, // <= workaround for https://github.com/facebook/flow/issues/4644
-    static WrappedComponent: Class<React$Component<CP>>,
-    getWrappedInstance(): React$Component<CP>,
-    props: OP,
-    state: void
-  }
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
 
-  declare class ConnectedComponent<OP, P> extends React$Component<OP> {
-    static WrappedComponent: Class<React$Component<P>>,
-    getWrappedInstance(): React$Component<P>,
-    props: OP,
-    state: void
-  }
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
 
-  declare type ConnectedComponentWithDefaultPropsClass<OP, DP, CP> = Class<
-    ConnectedComponentWithDefaultProps<OP, DP, CP>
-  >;
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
 
-  declare type ConnectedComponentClass<OP, P> = Class<
-    ConnectedComponent<OP, P>
-  >;
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
 
-  declare type Connector<OP, P> = (<DP: {}, CP: {}>(
-    component: ComponentWithDefaultProps<DP, P, CP>
-  ) => ConnectedComponentWithDefaultPropsClass<OP, DP, CP>) &
-    ((component: React$ComponentType<P>) => ConnectedComponentClass<OP, P>);
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
 
-  declare class Provider<S, A> extends React$Component<{
-    store: Store<S, A>,
-    children?: any
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
   }> {}
 
-  declare function createProvider(
+  declare export function createProvider(
     storeKey?: string,
-    subKey?: string
-  ): Provider<*, *>;
+    subKey?: string,
+  ): Class<Provider<*>>;
 
-  declare type ConnectOptions = {
-    pure?: boolean,
-    withRef?: boolean
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    withRef?: boolean,
   };
 
-  declare type Null = null | void;
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    withRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+  };
 
-  declare function connect<A, OP>(
-    ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
 
-  declare function connect<A, OP>(
-    mapStateToProps: Null,
-    mapDispatchToProps: Null,
-    mergeProps: Null,
-    options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  declare type SelectorFactory<
+    Com: React$ComponentType<*>,
+    Dispatch,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
 
-  declare function connect<S, A, OP, SP>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: Null,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  declare export function connectAdvanced<
+    Com: React$ComponentType<*>,
+    D,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: { [_: $Keys<Com>]: any },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
 
-  declare function connect<A, OP, DP>(
-    mapStateToProps: Null,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<DP & OP>>;
-
-  declare function connect<S, A, OP, SP, DP>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & DP & OP>>;
-
-  declare function connect<S, A, OP, SP, DP, P>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: Null,
-    mergeProps: MergeProps<SP, DP, OP, P>,
-    options?: ConnectOptions
-  ): Connector<OP, P>;
-
-  declare function connect<S, A, OP, SP, DP, P>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: MergeProps<SP, DP, OP, P>,
-    options?: ConnectOptions
-  ): Connector<OP, P>;
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+  };
 }

--- a/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,42 +1,40 @@
-// flow-typed signature: 53be1849af6037db65e90a7abc558afe
-// flow-typed version: f4e99ca1ed/react-router-dom_v4.x.x/flow_>=v0.63.x
+// flow-typed signature: b7f98c6a7afc32bb93cf5d468d7d757a
+// flow-typed version: b999c93144/react-router-dom_v4.x.x/flow_>=v0.63.x
 
 declare module "react-router-dom" {
-  import type { ComponentType, ElementConfig, Node, Component } from 'react';
-
-  declare export var BrowserRouter: Class<Component<{|
+  declare export var BrowserRouter: React$ComponentType<{|
     basename?: string,
     forceRefresh?: boolean,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
-    children?: Node
-  |}>>
+    children?: React$Node
+  |}>
 
-  declare export var HashRouter: Class<Component<{|
+  declare export var HashRouter: React$ComponentType<{|
     basename?: string,
     getUserConfirmation?: GetUserConfirmation,
     hashType?: "slash" | "noslash" | "hashbang",
-    children?: Node
-  |}>>
+    children?: React$Node
+  |}>
 
-  declare export var Link: Class<Component<{
+  declare export var Link: React$ComponentType<{
     className?: string,
     to: string | LocationShape,
     replace?: boolean,
-    children?: Node
-  }>>
+    children?: React$Node
+  }>
 
-  declare export var NavLink: Class<Component<{
+  declare export var NavLink: React$ComponentType<{
     to: string | LocationShape,
     activeClassName?: string,
     className?: string,
     activeStyle?: Object,
     style?: Object,
     isActive?: (match: Match, location: Location) => boolean,
-    children?: Node,
+    children?: React$Node,
     exact?: boolean,
     strict?: boolean
-  }>>
+  }>
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-native types as well.
@@ -108,60 +106,56 @@ declare module "react-router-dom" {
     url?: string
   };
 
-  declare export var StaticRouter: Class<Component<{|
+  declare export var StaticRouter: React$ComponentType<{|
     basename?: string,
     location?: string | Location,
     context: StaticRouterContext,
-    children?: Node
-  |}>>
+    children?: React$Node
+  |}>
 
-  declare export var MemoryRouter: Class<Component<{|
+  declare export var MemoryRouter: React$ComponentType<{|
     initialEntries?: Array<LocationShape | string>,
     initialIndex?: number,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
-    children?: Node
-  |}>>
+    children?: React$Node
+  |}>
 
-  declare export var Router: Class<Component<{|
+  declare export var Router: React$ComponentType<{|
     history: RouterHistory,
-    children?: Node
-  |}>>
+    children?: React$Node
+  |}>
 
-  declare export var Prompt: Class<Component<{|
+  declare export var Prompt: React$ComponentType<{|
     message: string | ((location: Location) => string | boolean),
     when?: boolean
-  |}>>
+  |}>
 
-  declare export var Redirect: Class<Component<{|
+  declare export var Redirect: React$ComponentType<{|
     to: string | LocationShape,
     push?: boolean,
     from?: string,
     exact?: boolean,
     strict?: boolean
-  |}>>
+  |}>
 
-  declare export var Route: Class<Component<{|
-    component?: ComponentType<*>,
-    render?: (router: ContextRouter) => Node,
-    children?: ComponentType<ContextRouter> | Node,
-    path?: string,
+  declare export var Route: React$ComponentType<{|
+    component?: React$ComponentType<*>,
+    render?: (router: ContextRouter) => React$Node,
+    children?: React$ComponentType<ContextRouter> | React$Node,
+    path?: string | Array<string>,
     exact?: boolean,
     strict?: boolean,
     location?: LocationShape,
     sensitive?: boolean
-  |}>>
+  |}>
 
-  declare export var Switch: Class<Component<{|
-    children?: Node,
+  declare export var Switch: React$ComponentType<{|
+    children?: React$Node,
     location?: Location
-  |}>>
+  |}>
 
-  declare export function withRouter<WrappedComponent: ComponentType<*>>(
-    Component: WrappedComponent
-  ): ComponentType<
-    $Diff<ElementConfig<$Supertype<WrappedComponent>>, ContextRouterVoid>
-    >;
+  declare export function withRouter<Props : {}, Component: React$ComponentType<Props>>(WrappedComponent: Component) : React$ComponentType<$Diff<React$ElementConfig<$Supertype<Component>>, ContextRouterVoid>>;
 
   declare type MatchPathOptions = {
     path?: string,

--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: cca4916b0213065533df8335c3285a4a
-// flow-typed version: cab04034e7/redux_v3.x.x/flow_>=v0.55.x
+// flow-typed signature: c3750a3880ad4d408ad84f215d77722a
+// flow-typed version: 2c899a110b/redux_v3.x.x/flow_>=v0.55.x <=v0.88.x
 
 declare module 'redux' {
 
@@ -53,7 +53,7 @@ declare module 'redux' {
   declare export function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
   declare export function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
 
-  declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+  declare export function combineReducers<O: {}, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 
   declare export var compose: $Compose;
 }

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -22,7 +22,7 @@
     "@opentrons/shared-data": "3.8.1"
   },
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   }
 }

--- a/labware-library/src/definitions.js
+++ b/labware-library/src/definitions.js
@@ -16,8 +16,8 @@ import type {
 } from './types'
 
 // require all definitions in the definitions2 directory
-// $FlowFixMe: require.context is webpack-specific method
-const definitionsContext = require.context(
+// require.context is webpack-specific method
+const definitionsContext = (require: any).context(
   '@opentrons/shared-data/definitions2',
   true, // traverse subdirectories
   /\.json$/, // import filter

--- a/labware-library/src/index.js
+++ b/labware-library/src/index.js
@@ -7,8 +7,6 @@ import { BrowserRouter } from 'react-router-dom'
 import './public-path'
 import './styles.global.css'
 
-// $FlowFixMe: upgrade Flow for React.lazy
-// const LazyApp = React.lazy(() => import('./components/App'))
 const $root = document.getElementById('root')
 
 if (!$root) {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "express": "^4.16.4",
     "favicons-webpack-plugin": "^0.0.9",
     "file-loader": "^2.0.0",
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-copy-source": "^2.0.2",
     "flow-mono-cli": "^1.3.4",
     "flow-typed": "^2.5.1",

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -43,7 +43,7 @@
     "yup": "^0.26.6"
   },
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1",
     "reselect-tools": "^0.0.7"
   }

--- a/protocol-designer/src/analytics/reducers.js
+++ b/protocol-designer/src/analytics/reducers.js
@@ -25,4 +25,5 @@ export type RootState = {
   hasOptedIn: OptInState,
 }
 
-export const rootReducer = combineReducers(_allReducers)
+// TODO(mc, 2019-04-17): PD should have a "global" Action type
+export const rootReducer = combineReducers<_, {}>(_allReducers)

--- a/protocol-designer/src/analytics/reducers.js
+++ b/protocol-designer/src/analytics/reducers.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import { rehydrate } from '../persist'
 
+import type { Action } from '../types'
 import type { SetOptIn } from './actions'
 
 type OptInState = boolean | null
@@ -25,5 +26,4 @@ export type RootState = {
   hasOptedIn: OptInState,
 }
 
-// TODO(mc, 2019-04-17): PD should have a "global" Action type
-export const rootReducer = combineReducers<_, {}>(_allReducers)
+export const rootReducer = combineReducers<_, Action>(_allReducers)

--- a/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/ConnectedFileSidebar.js
@@ -15,26 +15,23 @@ import type { BaseState, ThunkDispatch } from '../../types'
 
 type Props = React.ElementProps<typeof FileSidebar>
 
-type SP = {
+type SP = {|
   canDownload: boolean,
   downloadData: ?{
     fileData: Object,
     fileName: string,
   },
-}
-
-type MP = {
   _canCreateNew: ?boolean,
   _hasUnsavedChanges: ?boolean,
-}
+|}
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps
 )(FileSidebar)
 
-function mapStateToProps(state: BaseState): SP & MP {
+function mapStateToProps(state: BaseState): SP {
   const protocolName =
     fileDataSelectors.getFileMetadata(state)['protocol-name'] || 'untitled'
   const fileData = fileDataSelectors.createFile(state)
@@ -55,7 +52,7 @@ function mapStateToProps(state: BaseState): SP & MP {
 }
 
 function mergeProps(
-  stateProps: SP & MP,
+  stateProps: SP,
   dispatchProps: { dispatch: ThunkDispatch<*> }
 ): Props {
   const {

--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -13,12 +13,12 @@ import EXAMPLE_WATCH_LIQUIDS_MOVE_IMAGE from '../../images/example_watch_liquids
 import type { HintKey } from '../../tutorial'
 import type { BaseState, ThunkDispatch } from '../../types'
 
-type SP = { hint: ?HintKey }
-type DP = {
+type SP = {| hint: ?HintKey |}
+type DP = {|
   removeHint: (HintKey, boolean) => mixed,
   selectTerminalItem: TerminalItemId => mixed,
-}
-type Props = SP & DP
+|}
+type Props = {| ...SP, ...DP |}
 
 type State = { rememberDismissal: boolean }
 
@@ -32,12 +32,12 @@ class Hints extends React.Component<Props, State> {
     this.setState({ rememberDismissal: !this.state.rememberDismissal })
   }
 
-  makeHandleCloseClick = hint => {
+  makeHandleCloseClick = (hint: HintKey) => {
     const { rememberDismissal } = this.state
     return () => this.props.removeHint(hint, rememberDismissal)
   }
 
-  renderHintContents = hint => {
+  renderHintContents = (hint: HintKey) => {
     switch (hint) {
       case 'add_liquids_and_labware':
         return (
@@ -114,7 +114,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
     dispatch(stepsActions.selectTerminalItem(terminalId)),
 })
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(Hints)

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -13,11 +13,10 @@ import type { BaseState } from '../../../types'
 
 type Props = ElementProps<typeof LabwareDetailsCard>
 
-type DP = {
-  renameLabware: $PropertyType<Props, 'renameLabware'>,
-}
-
-type SP = $Diff<Props, DP> & { _labwareId?: string }
+type SP = {|
+  ...$Diff<$Exact<Props>, {| renameLabware: * |}>,
+  _labwareId?: string,
+|}
 
 function mapStateToProps(state: BaseState): SP {
   const labwareNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
@@ -71,7 +70,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -12,10 +12,10 @@ import type { BaseState, ThunkDispatch } from '../../types'
 
 type Props = React.ElementProps<typeof LabwareSelectionModal>
 
-type SP = {
+type SP = {|
   slot: $PropertyType<Props, 'slot'>,
   permittedTipracks: $PropertyType<Props, 'permittedTipracks'>,
-}
+|}
 
 function mapStateToProps(state: BaseState): SP {
   return {
@@ -43,7 +43,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/LiquidPlacementForm/index.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/index.js
@@ -15,19 +15,25 @@ import type { Dispatch } from 'redux'
 import type { ValidFormValues } from './LiquidPlacementForm'
 import type { BaseState } from '../../types'
 
+// type SP = {|
+//
+// |}
+
 type Props = React.ElementProps<typeof LiquidPlacementForm>
 
-type DP = {
-  cancelForm: $PropertyType<Props, 'cancelForm'>,
-  clearWells: $PropertyType<Props, 'clearWells'>,
-  saveForm: $PropertyType<Props, 'saveForm'>,
-}
-
-type SP = $Diff<Props, DP> & {
-  _labwareId: ?string,
-  _selectedWells: ?Array<string>,
-  _selectionHasLiquids: boolean,
-}
+type SP = $Rest<
+  {|
+    ...$Exact<Props>,
+    _labwareId: ?string,
+    _selectedWells: ?Array<string>,
+    _selectionHasLiquids: boolean,
+  |},
+  {|
+    cancelForm: $PropertyType<Props, 'cancelForm'>,
+    clearWells: $PropertyType<Props, 'clearWells'>,
+    saveForm: $PropertyType<Props, 'saveForm'>,
+  |}
+>
 
 function mapStateToProps(state: BaseState): SP {
   const selectedWells = Object.keys(
@@ -130,7 +136,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/LiquidPlacementForm/index.js
+++ b/protocol-designer/src/components/LiquidPlacementForm/index.js
@@ -15,10 +15,6 @@ import type { Dispatch } from 'redux'
 import type { ValidFormValues } from './LiquidPlacementForm'
 import type { BaseState } from '../../types'
 
-// type SP = {|
-//
-// |}
-
 type Props = React.ElementProps<typeof LiquidPlacementForm>
 
 type SP = $Rest<

--- a/protocol-designer/src/components/LiquidPlacementModal.js
+++ b/protocol-designer/src/components/LiquidPlacementModal.js
@@ -23,23 +23,25 @@ import { selectWells, deselectWells } from '../well-selection/actions'
 import type { BaseState } from '../types'
 import type { WellIngredientNames } from '../steplist'
 
-type SP = {
+type SP = {|
   selectedWells: Wells,
   wellContents: ContentsByWell,
   containerType: string,
   liquidNamesById: WellIngredientNames,
-}
-type DP = {
+|}
+
+type DP = {|
   selectWells: Wells => mixed,
   deselectWells: Wells => mixed,
-}
-type Props = SP & DP
+|}
+
+type Props = { ...SP, ...DP }
 
 type State = { highlightedWells: Wells }
 
 class LiquidPlacementModal extends React.Component<Props, State> {
   state = { highlightedWells: {} }
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = { highlightedWells: {} }
   }
@@ -113,7 +115,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
   selectWells: wells => dispatch(selectWells(wells)),
 })
 
-export default connect(
+export default connect<Props, {||}, _, _, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(LiquidPlacementModal)

--- a/protocol-designer/src/components/LiquidsPage/index.js
+++ b/protocol-designer/src/components/LiquidsPage/index.js
@@ -14,12 +14,12 @@ import type { BaseState, ThunkDispatch } from '../../types'
 type Props = React.ElementProps<typeof LiquidEditForm>
 type WrapperProps = { showForm: boolean, formKey: string, formProps: Props }
 
-type SP = {
-  ...LiquidGroup,
+type SP = {|
+  ...$Exact<LiquidGroup>,
   _liquidGroupId: ?string,
   showForm: boolean,
   canDelete: $ElementType<Props, 'canDelete'>,
-}
+|}
 
 function LiquidEditFormWrapper(props: WrapperProps) {
   const { showForm, formKey, formProps } = props
@@ -69,6 +69,7 @@ function mergeProps(
 ): WrapperProps {
   const { dispatch } = dispatchProps
   const { showForm, _liquidGroupId, ...passThruFormProps } = stateProps
+
   return {
     showForm,
     formKey: _liquidGroupId || '__new_form__',
@@ -89,7 +90,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<WrapperProps, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/LiquidsSidebar/index.js
+++ b/protocol-designer/src/components/LiquidsSidebar/index.js
@@ -9,21 +9,19 @@ import listButtonStyles from '../listButtons.css'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
 import type { OrderedLiquids } from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
-import type { BaseState } from '../../types'
+import type { BaseState, ThunkDispatch } from '../../types'
 
-type Props = {
+type SP = {|
   liquids: OrderedLiquids,
   selectedLiquid: ?string,
+|}
+
+type DP = {|
   createNewLiquid: () => mixed,
   selectLiquid: (liquidId: string) => mixed,
-}
+|}
 
-type SP = {
-  liquids: $PropertyType<Props, 'liquids'>,
-  selectedLiquid: $PropertyType<Props, 'selectedLiquid'>,
-}
-
-type DP = $Diff<Props, SP>
+type Props = {| ...SP, ...DP |}
 
 function LiquidsSidebar(props: Props) {
   const { liquids, selectedLiquid, createNewLiquid, selectLiquid } = props
@@ -58,7 +56,7 @@ function mapStateToProps(state: BaseState): SP {
   }
 }
 
-function mapDispatchToProps(dispatch: Dispatch<*>): DP {
+function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   return {
     selectLiquid: liquidGroupId =>
       dispatch(labwareIngredActions.selectLiquidGroup(liquidGroupId)),
@@ -67,7 +65,7 @@ function mapDispatchToProps(dispatch: Dispatch<*>): DP {
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(LiquidsSidebar)

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.js
@@ -17,7 +17,7 @@ import {
   actions as tutorialActions,
   selectors as tutorialSelectors,
 } from '../../tutorial'
-import type { BaseState } from '../../types'
+import type { BaseState, ThunkDispatch } from '../../types'
 import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
 
 type Props = {
@@ -27,10 +27,10 @@ type Props = {
   toggleOptedIn: () => mixed,
 }
 
-type SP = {
+type SP = {|
   canClearHintDismissals: $PropertyType<Props, 'canClearHintDismissals'>,
   hasOptedIn: $PropertyType<Props, 'hasOptedIn'>,
-}
+|}
 
 function SettingsApp(props: Props) {
   const {
@@ -100,7 +100,7 @@ function mapStateToProps(state: BaseState): SP {
 
 function mergeProps(
   stateProps: SP,
-  dispatchProps: { dispatch: Dispatch<*> }
+  dispatchProps: { dispatch: ThunkDispatch<*> }
 ): Props {
   const { dispatch } = dispatchProps
   const { hasOptedIn } = stateProps
@@ -115,7 +115,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, BaseState, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsSidebar.js
@@ -9,10 +9,11 @@ import i18n from '../../localization'
 import { PDTitledList } from '../lists'
 import styles from './SettingsPage.css'
 
-type SP = { currentPage: Page }
-type DP = { makeNavigateToPage: Page => () => mixed }
+type SP = {| currentPage: Page |}
+type DP = {| makeNavigateToPage: Page => () => mixed |}
+type Props = { ...SP, ...DP }
 
-const SettingsSidebar = (props: SP & DP) => (
+const SettingsSidebar = (props: Props) => (
   <SidePanel title={i18n.t('nav.tab_name.settings')}>
     <PDTitledList
       className={styles.sidebar_item}
@@ -38,7 +39,7 @@ const DTP = (dispatch: ThunkDispatch<*>): DP => ({
     dispatch(actions.navigateToPage(pageName)),
 })
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   STP,
   DTP
 )(SettingsSidebar)

--- a/protocol-designer/src/components/SettingsPage/index.js
+++ b/protocol-designer/src/components/SettingsPage/index.js
@@ -8,9 +8,9 @@ import SettingsApp from './SettingsApp'
 
 export { default as SettingsSidebar } from './SettingsSidebar'
 
-type SP = { currentPage: Page }
+type Props = { currentPage: Page }
 
-const SettingsPage = (props: SP) => {
+const SettingsPage = (props: Props) => {
   switch (props.currentPage) {
     case 'settings-features': {
       // TODO: BC 2018-09-01 when we have feature flags put them here
@@ -22,8 +22,8 @@ const SettingsPage = (props: SP) => {
   }
 }
 
-const STP = (state: BaseState): SP => ({
+const STP = (state: BaseState): $Exact<Props> => ({
   currentPage: selectors.getCurrentPage(state),
 })
 
-export default connect(STP)(SettingsPage)
+export default connect<Props, {||}, $Exact<Props>, _, _, _>(STP)(SettingsPage)

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -8,11 +8,13 @@ import { stepIconsByType, type StepType } from '../form-types'
 import type { ThunkDispatch } from '../types'
 import styles from './listButtons.css'
 
-type DP = { makeAddStep: StepType => (SyntheticEvent<>) => mixed }
+type Props = { makeAddStep: StepType => (SyntheticEvent<>) => mixed }
 
 type State = { expanded?: boolean }
 
-class StepCreationButton extends React.Component<DP, State> {
+type DP = $Exact<Props>
+
+class StepCreationButton extends React.Component<Props, State> {
   state = { expanded: false }
 
   handleExpandClick = (e: SyntheticEvent<>) => {
@@ -65,12 +67,12 @@ class StepCreationButton extends React.Component<DP, State> {
   }
 }
 
-const mapDTP = (dispatch: ThunkDispatch<*>) => ({
+const mapDTP = (dispatch: ThunkDispatch<*>): DP => ({
   makeAddStep: (stepType: StepType) => (e: SyntheticEvent<>) =>
     dispatch(steplistActions.addStep({ stepType })),
 })
 
-export default connect(
+export default connect<Props, {||}, {||}, DP, _, _>(
   null,
   mapDTP
 )(StepCreationButton)

--- a/protocol-designer/src/components/StepEditForm/ButtonRow.js
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow.js
@@ -9,16 +9,19 @@ import { selectors as stepsSelectors } from '../../ui/steps'
 import type { BaseState, ThunkDispatch } from '../../types'
 import styles from './StepEditForm.css'
 
-type OP = {
+type OP = {|
   onClickMoreOptions: (event: SyntheticEvent<>) => mixed,
   onDelete?: (event: SyntheticEvent<>) => mixed,
-}
-type SP = { canSave?: ?boolean }
-type DP = {
+|}
+
+type SP = {| canSave?: ?boolean |}
+
+type DP = {|
   onCancel: (event: SyntheticEvent<>) => mixed,
   onSave: (event: SyntheticEvent<>) => mixed,
-}
-type Props = OP & SP & DP
+|}
+
+type Props = { ...OP, ...SP, ...DP }
 
 const ButtonRow = (props: Props) => {
   const { canSave, onDelete, onSave, onCancel, onClickMoreOptions } = props
@@ -62,7 +65,7 @@ const DTP = (dispatch: ThunkDispatch<*>): DP => ({
   onSave: () => dispatch(steplistActions.saveStepForm()),
 })
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   STP,
   DTP
 )(ButtonRow)

--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -20,16 +20,16 @@ import type { BaseState } from '../../types'
 
 type Props = React.ElementProps<typeof Alerts>
 
-type SP = {
+type SP = {|
   errors: $PropertyType<Props, 'errors'>,
   warnings: $PropertyType<Props, 'warnings'>,
   stepId: ?(StepIdType | string),
-}
+|}
 
-type OP = {
+type OP = {|
   focusedField: ?StepFieldName,
   dirtyFields: Array<StepFieldName>,
-}
+|}
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
   const { focusedField, dirtyFields } = ownProps
@@ -75,7 +75,7 @@ const mergeProps = (
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocation.js
@@ -14,11 +14,14 @@ import type { FocusHandlers } from '../types'
 
 // TODO: 2019-01-24 i18n for these options
 
-type BlowoutLocationDropdownOP = {
+type BlowoutLocationDropdownOP = {|
+  ...$Exact<FocusHandlers>,
   name: StepFieldName,
   className?: string,
-} & FocusHandlers
-type BlowoutLocationDropdownSP = { options: Options }
+|}
+
+type BlowoutLocationDropdownSP = {| options: Options |}
+
 const BlowoutLocationDropdownSTP = (
   state: BaseState,
   ownProps: BlowoutLocationDropdownOP
@@ -34,42 +37,53 @@ const BlowoutLocationDropdownSTP = (
 
   return { options }
 }
-export const BlowoutLocationDropdown = connect(BlowoutLocationDropdownSTP)(
-  (props: BlowoutLocationDropdownOP & BlowoutLocationDropdownSP) => {
-    const {
-      options,
-      name,
-      className,
-      focusedField,
-      dirtyFields,
-      onFieldBlur,
-      onFieldFocus,
-    } = props
-    return (
-      <FieldConnector
-        name={name}
-        focusedField={focusedField}
-        dirtyFields={dirtyFields}
-        render={({ value, updateValue, disabled }) => (
-          <DropdownField
-            className={cx(styles.large_field, className)}
-            options={options}
-            disabled={disabled}
-            onBlur={() => {
-              onFieldBlur(name)
-            }}
-            onFocus={() => {
-              onFieldFocus(name)
-            }}
-            value={value ? String(value) : null}
-            onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
-              updateValue(e.currentTarget.value)
-            }}
-          />
-        )}
-      />
-    )
-  }
-)
+
+type BlowoutLocationDropdownProps = {
+  ...BlowoutLocationDropdownOP,
+  ...BlowoutLocationDropdownSP,
+}
+
+export const BlowoutLocationDropdown = connect<
+  BlowoutLocationDropdownProps,
+  BlowoutLocationDropdownOP,
+  BlowoutLocationDropdownSP,
+  _,
+  _,
+  _
+>(BlowoutLocationDropdownSTP)((props: BlowoutLocationDropdownProps) => {
+  const {
+    options,
+    name,
+    className,
+    focusedField,
+    dirtyFields,
+    onFieldBlur,
+    onFieldFocus,
+  } = props
+  return (
+    <FieldConnector
+      name={name}
+      focusedField={focusedField}
+      dirtyFields={dirtyFields}
+      render={({ value, updateValue, disabled }) => (
+        <DropdownField
+          className={cx(styles.large_field, className)}
+          options={options}
+          disabled={disabled}
+          onBlur={() => {
+            onFieldBlur(name)
+          }}
+          onFocus={() => {
+            onFieldFocus(name)
+          }}
+          value={value ? String(value) : null}
+          onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
+            updateValue(e.currentTarget.value)
+          }}
+        />
+      )}
+    />
+  )
+})
 
 export default BlowoutLocationDropdown

--- a/protocol-designer/src/components/StepEditForm/fields/ChangeTip/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ChangeTip/index.js
@@ -9,7 +9,8 @@ import type { FormData } from '../../../../form-types'
 import type { ChangeTipOptions } from '../../../../step-generation/types'
 
 type Props = ElementProps<typeof ChangeTip>
-type OP = { name: $PropertyType<Props, 'name'> }
+type OP = {| name: $PropertyType<Props, 'name'> |}
+type SP = $Diff<$Exact<Props>, OP>
 
 const ALL_CHANGE_TIP_VALUES: Array<ChangeTipOptions> = [
   'always',
@@ -53,12 +54,13 @@ function getDisabledChangeTipOptions(
   }
 }
 
-const mapSTP = (state: BaseState, ownProps: OP): $Diff<Props, OP> => {
+const mapSTP = (state: BaseState, ownProps: OP): SP => {
   const rawForm = stepFormSelectors.getUnsavedForm(state)
+
   return {
     options: ALL_CHANGE_TIP_VALUES, // TODO Ian 2019-01-28 these may vary for different step types
     disabledOptions: rawForm ? getDisabledChangeTipOptions(rawForm) : null,
   }
 }
 
-export default connect(mapSTP)(ChangeTip)
+export default connect<Props, OP, SP, _, _, _>(mapSTP)(ChangeTip)

--- a/protocol-designer/src/components/StepEditForm/fields/ConditionalOnField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ConditionalOnField.js
@@ -6,17 +6,17 @@ import { selectors as stepFormSelectors } from '../../../step-forms'
 import type { BaseState } from '../../../types'
 import type { StepFieldName } from '../../../form-types'
 
-type SP = {
-  value: mixed,
-}
-
-type OP = {
+type OP = {|
   name: StepFieldName,
   condition: (value: mixed) => boolean,
   children: React.Node,
-}
+|}
 
-type Props = SP & OP
+type SP = {|
+  value: mixed,
+|}
+
+type Props = { ...OP, ...SP }
 
 function ConditionalOnField(props: Props) {
   return props.condition(props.value) ? props.children : null
@@ -29,4 +29,4 @@ function STP(state: BaseState, ownProps: OP): SP {
   }
 }
 
-export default connect(STP)(ConditionalOnField)
+export default connect<Props, OP, SP, _, _, _>(STP)(ConditionalOnField)

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolume.js
@@ -22,12 +22,14 @@ import type { BaseState } from '../../../types'
 import type { FocusHandlers } from '../types'
 import styles from '../StepEditForm.css'
 
-type SP = {
+type OP = {| focusHandlers: FocusHandlers |}
+
+type SP = {|
   disposalDestinationOptions: Options,
   maxDisposalVolume: ?number,
-}
+|}
 
-type Props = SP & { focusHandlers: FocusHandlers }
+type Props = { ...OP, ...SP }
 
 const DisposalVolumeField = (props: Props) => (
   <FormGroup label={i18n.t('form.step_edit_form.multiDispenseOptionsLabel')}>
@@ -120,4 +122,4 @@ const mapSTP = (state: BaseState): SP => {
   }
 }
 
-export default connect(mapSTP)(DisposalVolumeField)
+export default connect<Props, OP, SP, _, _, _>(mapSTP)(DisposalVolumeField)

--- a/protocol-designer/src/components/StepEditForm/fields/FieldConnector.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FieldConnector.js
@@ -17,6 +17,7 @@ type FieldRenderProps = {
   hoverTooltipHandlers?: ?HoverTooltipHandlers,
   disabled: boolean,
 }
+
 type OP = {
   name: StepFieldName,
   render: FieldRenderProps => React.Node, // TODO: type StepField
@@ -24,9 +25,12 @@ type OP = {
   focusedField?: StepFieldName,
   tooltipComponent?: React.Node,
 }
-type SP = { value?: ?mixed, stepType: ?string, disabled: boolean }
-type DP = { updateValue: (?mixed) => void }
-type StepFieldProps = OP & SP & DP
+
+type SP = {| value?: ?mixed, stepType: ?string, disabled: boolean |}
+
+type DP = {| updateValue: (?mixed) => void |}
+
+type StepFieldProps = { ...$Exact<OP>, ...SP, ...DP }
 
 const FieldConnector = (props: StepFieldProps) => {
   const {
@@ -94,7 +98,14 @@ const DTP = (dispatch: ThunkDispatch<*>, ownProps: OP): DP => ({
   },
 })
 
-const ConnectedFieldConnector = connect(
+const ConnectedFieldConnector = connect<
+  StepFieldProps,
+  $Exact<OP>,
+  SP,
+  DP,
+  _,
+  _
+>(
   STP,
   DTP
 )(FieldConnector)

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRate/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRate/FlowRateInput.js
@@ -27,7 +27,7 @@ type Props = {
   maxFlowRate: number,
   updateValue: (flowRate: ?number) => mixed,
   pipetteDisplayName: ?string,
-  className: ?string,
+  className?: string,
 }
 
 type State = {

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRate/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRate/index.js
@@ -8,23 +8,24 @@ import { getDisabledFields } from '../../../../steplist/formLevel'
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { BaseState, ThunkDispatch } from '../../../../types'
 
-type Props = React.ElementProps<typeof FlowRateInput> & {
+type Props = {
+  ...$Exact<React.ElementProps<typeof FlowRateInput>>,
   innerKey: string,
 }
 
-type OP = {
+type OP = {|
   name: StepFieldName,
   pipetteFieldName: StepFieldName,
   flowRateType: $PropertyType<Props, 'flowRateType'>,
   label?: $PropertyType<Props, 'label'>,
   className?: string,
-}
+|}
 
-type DP = {
+type DP = {|
   updateValue: $PropertyType<Props, 'updateValue'>,
-}
+|}
 
-type SP = $Diff<Props, { ...DP, ...OP }>
+type SP = $Rest<$Exact<Props>, {| ...OP, ...DP |}>
 
 // Add a key to force re-constructing component when values change
 function FlowRateInputWithKey(props: Props) {
@@ -63,8 +64,6 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
     defaultFlowRate,
     disabled: formData ? getDisabledFields(formData).has(name) : false,
     formFlowRate,
-    flowRateType,
-    label: ownProps.label,
     minFlowRate: 0,
     // NOTE: since we only have rule-of-thumb, max is entire volume in 1 second
     maxFlowRate: pipette ? pipette.spec.maxVolume : Infinity,
@@ -85,7 +84,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>, ownProps: OP): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(FlowRateInputWithKey)

--- a/protocol-designer/src/components/StepEditForm/fields/Labware.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Labware.js
@@ -10,16 +10,22 @@ import type { FocusHandlers } from '../types'
 import styles from '../StepEditForm.css'
 import StepField from './FieldConnector'
 
-type LabwareFieldOP = {
+type OP = {|
+  ...$Exact<FocusHandlers>,
   name: StepFieldName,
   className?: string,
-} & FocusHandlers
-type LabwareFieldSP = { labwareOptions: Options }
-const LabwareFieldSTP = (state: BaseState): LabwareFieldSP => ({
+|}
+
+type SP = {| labwareOptions: Options |}
+
+type Props = { ...OP, ...SP }
+
+const LabwareFieldSTP = (state: BaseState): SP => ({
   labwareOptions: uiLabwareSelectors.getLabwareOptions(state),
 })
-const LabwareField = connect(LabwareFieldSTP)(
-  (props: LabwareFieldOP & LabwareFieldSP) => {
+
+const LabwareField = connect<Props, OP, SP, _, _, _>(LabwareFieldSTP)(
+  (props: Props) => {
     const {
       labwareOptions,
       name,

--- a/protocol-designer/src/components/StepEditForm/fields/Path/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Path/index.js
@@ -11,7 +11,8 @@ import type { FormData, PathOption } from '../../../../form-types'
 import type { BaseState } from '../../../../types'
 
 type Props = ElementProps<typeof Path>
-type SP = { disabledPathMap: $PropertyType<Props, 'disabledPathMap'> }
+type SP = {| disabledPathMap: $PropertyType<Props, 'disabledPathMap'> |}
+type OP = $Diff<$Exact<Props>, SP>
 
 function getDisabledPathMap(
   rawForm: ?FormData,
@@ -97,4 +98,4 @@ function mapSTP(state: BaseState): SP {
   }
 }
 
-export default connect(mapSTP)(Path)
+export default connect<Props, OP, SP, _, _, _>(mapSTP)(Path)

--- a/protocol-designer/src/components/StepEditForm/fields/Pipette.js
+++ b/protocol-designer/src/components/StepEditForm/fields/Pipette.js
@@ -11,45 +11,49 @@ import styles from '../StepEditForm.css'
 import type { FocusHandlers } from '../types'
 import StepField from './FieldConnector'
 
-type PipetteFieldOP = {
+type OP = {|
+  ...$Exact<FocusHandlers>,
   name: StepFieldName,
   stepType?: StepType,
-} & FocusHandlers
-type PipetteFieldSP = { pipetteOptions: Options }
-type PipetteFieldProps = PipetteFieldOP & PipetteFieldSP
-const PipetteFieldSTP = (
-  state: BaseState,
-  ownProps: PipetteFieldOP
-): PipetteFieldSP => ({
+|}
+
+type SP = {| pipetteOptions: Options |}
+
+type Props = { ...OP, ...SP }
+
+const PipetteFieldSTP = (state: BaseState, ownProps: OP): SP => ({
   pipetteOptions: stepFormSelectors.getEquippedPipetteOptions(state),
 })
-const PipetteField = connect(PipetteFieldSTP)((props: PipetteFieldProps) => (
-  <StepField
-    name={props.name}
-    focusedField={props.focusedField}
-    dirtyFields={props.dirtyFields}
-    render={({ value, updateValue, hoverTooltipHandlers }) => (
-      <FormGroup
-        label={i18n.t('form.step_edit_form.field.pipette.label')}
-        className={styles.large_field}
-        hoverTooltipHandlers={hoverTooltipHandlers}
-      >
-        <DropdownField
-          options={props.pipetteOptions}
-          value={value ? String(value) : null}
-          onBlur={() => {
-            props.onFieldBlur(props.name)
-          }}
-          onFocus={() => {
-            props.onFieldFocus(props.name)
-          }}
-          onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
-            updateValue(e.currentTarget.value)
-          }}
-        />
-      </FormGroup>
-    )}
-  />
-))
+
+const PipetteField = connect<Props, OP, SP, _, _, _>(PipetteFieldSTP)(
+  (props: Props) => (
+    <StepField
+      name={props.name}
+      focusedField={props.focusedField}
+      dirtyFields={props.dirtyFields}
+      render={({ value, updateValue, hoverTooltipHandlers }) => (
+        <FormGroup
+          label={i18n.t('form.step_edit_form.field.pipette.label')}
+          className={styles.large_field}
+          hoverTooltipHandlers={hoverTooltipHandlers}
+        >
+          <DropdownField
+            options={props.pipetteOptions}
+            value={value ? String(value) : null}
+            onBlur={() => {
+              props.onFieldBlur(props.name)
+            }}
+            onFocus={() => {
+              props.onFieldFocus(props.name)
+            }}
+            onChange={(e: SyntheticEvent<HTMLSelectElement>) => {
+              updateValue(e.currentTarget.value)
+            }}
+          />
+        </FormGroup>
+      )}
+    />
+  )
+)
 
 export default PipetteField

--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/TipPositionModal.js
@@ -26,22 +26,23 @@ import {
   type TipOffsetFields,
 } from '../../../../form-types'
 
+import type { ThunkDispatch } from '../../../../types'
+
 const SMALL_STEP_MM = 1
 const LARGE_STEP_MM = 10
 const DECIMALS_ALLOWED = 1
 
-type DP = { updateValue: (?number) => mixed }
-
-type OP = {
+type OP = {|
   mmFromBottom: number,
   wellHeightMM: number,
   isOpen: boolean,
   closeModal: () => mixed,
-  defaultMm: number,
   fieldName: TipOffsetFields,
-}
+|}
 
-type Props = OP & DP
+type DP = {| updateValue: (?number) => mixed |}
+
+type Props = { ...OP, ...DP }
 type State = { value: ?number }
 
 const roundValue = (value: number | string): number =>
@@ -55,7 +56,7 @@ class TipPositionModal extends React.Component<Props, State> {
       : roundValue(this.getDefaultMmFromBottom())
     this.state = { value: initialValue }
   }
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (prevProps.wellHeightMM !== this.props.wellHeightMM) {
       this.setState({ value: roundValue(this.props.mmFromBottom) })
     }
@@ -245,7 +246,7 @@ class TipPositionModal extends React.Component<Props, State> {
   }
 }
 
-const mapDTP = (dispatch: Dispatch, ownProps: OP): DP => {
+const mapDTP = (dispatch: ThunkDispatch<*>, ownProps: OP): DP => {
   return {
     updateValue: value => {
       dispatch(
@@ -255,7 +256,7 @@ const mapDTP = (dispatch: Dispatch, ownProps: OP): DP => {
   }
 }
 
-export default connect(
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDTP
 )(TipPositionModal)

--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/index.js
@@ -27,15 +27,19 @@ function getLabwareFieldForPositioningField(
   return fieldMap[fieldName]
 }
 
-type OP = { fieldName: TipOffsetFields, className?: string }
-type SP = {
+type OP = {| fieldName: TipOffsetFields, className?: string |}
+
+type SP = {|
   disabled: boolean,
   mmFromBottom: ?string,
   wellHeightMM: ?number,
-}
+|}
+
+type Props = { ...OP, ...SP }
 
 type TipPositionInputState = { isModalOpen: boolean }
-class TipPositionInput extends React.Component<OP & SP, TipPositionInputState> {
+
+class TipPositionInput extends React.Component<Props, TipPositionInputState> {
   state: TipPositionInputState = { isModalOpen: false }
 
   handleOpen = () => {
@@ -84,6 +88,7 @@ class TipPositionInput extends React.Component<OP & SP, TipPositionInputState> {
               fieldName={fieldName}
               closeModal={this.handleClose}
               wellHeightMM={wellHeightMM}
+              // $FlowFixMe: mmFromBottom is typed as a number in TipPositionModal
               mmFromBottom={mmFromBottom}
               isOpen={this.state.isModalOpen}
             />
@@ -126,4 +131,4 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   }
 }
 
-export default connect(mapSTP)(TipPositionInput)
+export default connect<Props, OP, SP, _, _, _>(mapSTP)(TipPositionInput)

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrder/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrder/WellOrderModal.js
@@ -15,7 +15,7 @@ import {
 import modalStyles from '../../../modals/modal.css'
 import { actions } from '../../../../steplist'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
-import type { BaseState } from '../../../../types'
+import type { BaseState, ThunkDispatch } from '../../../../types'
 import type { WellOrderOption } from '../../../../form-types'
 
 import WellOrderViz from './WellOrderViz'
@@ -31,24 +31,26 @@ const WELL_ORDER_VALUES: Array<WellOrderOption> = [
   ...HORIZONTAL_VALUES,
 ]
 
-type SP = {
+type SP = {|
   initialFirstValue: ?WellOrderOption,
   initialSecondValue: ?WellOrderOption,
-}
-type DP = {
+|}
+
+type DP = {|
   updateValues: (
     firstValue: ?WellOrderOption,
     secondValue: ?WellOrderOption
   ) => mixed,
-}
+|}
 
-type OP = {
+type OP = {|
   isOpen: boolean,
   closeModal: () => mixed,
   prefix: 'aspirate' | 'dispense' | 'mix',
-}
+|}
 
-type Props = OP & SP & DP
+type Props = {| ...OP, ...SP, ...DP |}
+
 type State = {
   firstValue: ?WellOrderOption,
   secondValue: ?WellOrderOption,
@@ -208,7 +210,7 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   }
 }
 
-const mapDTP = (dispatch: Dispatch, ownProps: OP): DP => ({
+const mapDTP = (dispatch: ThunkDispatch<*>, ownProps: OP): DP => ({
   updateValues: (firstValue, secondValue) => {
     dispatch(
       actions.changeFormInput({
@@ -221,7 +223,7 @@ const mapDTP = (dispatch: Dispatch, ownProps: OP): DP => ({
   },
 })
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   mapSTP,
   mapDTP
 )(WellOrderModal)

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrder/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrder/index.js
@@ -13,15 +13,19 @@ import type { BaseState } from '../../../../types'
 import stepEditStyles from '../../StepEditForm.css'
 import styles from './WellOrderInput.css'
 
-type OP = {
+type OP = {|
   className?: ?string,
   label?: string,
   prefix: 'aspirate' | 'dispense' | 'mix',
-}
-type SP = { iconClassNames: Array<string> }
+|}
+
+type SP = {| iconClassNames: Array<string> |}
+
+type Props = { ...OP, ...SP }
 
 type WellOrderInputState = { isModalOpen: boolean }
-class WellOrderInput extends React.Component<OP & SP, WellOrderInputState> {
+
+class WellOrderInput extends React.Component<Props, WellOrderInputState> {
   state: WellOrderInputState = { isModalOpen: false }
 
   handleOpen = () => {
@@ -77,4 +81,4 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   return { iconClassNames }
 }
 
-export default connect(mapSTP)(WellOrderInput)
+export default connect<Props, OP, SP, _, _, _>(mapSTP)(WellOrderInput)

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionInput.js
@@ -16,16 +16,17 @@ import type { StepIdType, StepFieldName } from '../../../../form-types'
 import type { BaseState } from '../../../../types'
 import type { FocusHandlers } from '../../types'
 
-type SP = {
+type SP = {|
   stepId: ?StepIdType,
   wellSelectionLabwareKey: ?string,
-}
-type DP = {
+|}
+
+type DP = {|
   onOpen: string => mixed,
   onClose: () => mixed,
-}
+|}
 
-type OP = {
+type OP = {|
   name: StepFieldName,
   primaryWellCount?: number,
   disabled: boolean,
@@ -35,9 +36,9 @@ type OP = {
   labwareId: ?string,
   onFieldBlur: $PropertyType<FocusHandlers, 'onFieldBlur'>,
   onFieldFocus: $PropertyType<FocusHandlers, 'onFieldFocus'>,
-}
+|}
 
-type Props = OP & SP & DP
+type Props = {| ...OP, ...SP, ...DP |}
 
 class WellSelectionInput extends React.Component<Props> {
   handleOpen = () => {
@@ -104,7 +105,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
   onClose: () => dispatch(stepsActions.clearWellSelectionLabwareKey()),
 })
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(WellSelectionInput)

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelection/WellSelectionModal.js
@@ -26,28 +26,30 @@ import WellSelectionInstructions from '../../../WellSelectionInstructions'
 import styles from './WellSelectionModal.css'
 import modalStyles from '../../../modals/modal.css'
 
-type OP = {
+type OP = {|
   pipetteId: ?string,
   labwareId: ?string,
   isOpen: boolean,
   onCloseClick: (e: ?SyntheticEvent<*>) => mixed,
   name: StepFieldName,
-}
-type SP = {
+|}
+
+type SP = {|
   pipetteSpec: ?PipetteNameSpecs,
   initialSelectedWells: Array<string>,
   wellContents: ContentsByWell,
   containerType: string,
   ingredNames: WellIngredientNames,
-}
-type DP = { saveWellSelection: Wells => mixed }
+|}
 
-type Props = OP & SP & DP
+type DP = {| saveWellSelection: Wells => mixed |}
+
+type Props = {| ...OP, ...SP, ...DP |}
 type State = { selectedWells: Wells, highlightedWells: Wells }
 
 class WellSelectionModal extends React.Component<Props, State> {
   state = { selectedWells: {}, highlightedWells: {} }
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     const initialSelectedWells = reduce(
       this.props.initialSelectedWells,
@@ -169,7 +171,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>, ownProps: OP): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(WellSelectionModal)

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelection/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelection/index.js
@@ -12,7 +12,7 @@ import { showFieldErrors } from '../FieldConnector'
 
 type Props = React.ElementProps<typeof WellSelectionInput>
 
-type OP = {
+type OP = {|
   name: StepFieldName,
   pipetteFieldName: StepFieldName,
   labwareFieldName: StepFieldName,
@@ -20,16 +20,16 @@ type OP = {
   onFieldFocus: $PropertyType<FocusHandlers, 'onFieldFocus'>,
   focusedField: $PropertyType<FocusHandlers, 'focusedField'>,
   dirtyFields: $PropertyType<FocusHandlers, 'dirtyFields'>,
-}
+|}
 
-type SP = {
+type SP = {|
   disabled: boolean,
   isMulti: $PropertyType<Props, 'isMulti'>,
   primaryWellCount: $PropertyType<Props, 'primaryWellCount'>,
   _pipetteId: ?string,
   _selectedLabwareId: ?string,
   _wellFieldErrors: Array<string>,
-}
+|}
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
   const formData = stepFormSelectors.getUnsavedForm(state)
@@ -81,7 +81,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -156,8 +156,7 @@ class MixForm extends React.Component<Props, State> {
         </div>
         <div className={styles.section_wrapper}>
           <div className={styles.form_row}>
-            {/* $FlowFixMe: (mc, 2019-04-18): is stepType needed? */}
-            <ChangeTipField stepType="mix" name="changeTip" />
+            <ChangeTipField name="changeTip" />
           </div>
         </div>
       </div>

--- a/protocol-designer/src/components/StepEditForm/forms/Mix.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Mix.js
@@ -43,11 +43,7 @@ class MixForm extends React.Component<Props, State> {
           </span>
         </div>
         <div className={styles.form_row}>
-          <PipetteField
-            className={styles.large_field}
-            name="pipette"
-            {...focusHandlers}
-          />
+          <PipetteField name="pipette" {...focusHandlers} />
           <VolumeField
             label={i18n.t('form.step_edit_form.mixVolumeLabel')}
             focusHandlers={focusHandlers}
@@ -160,6 +156,7 @@ class MixForm extends React.Component<Props, State> {
         </div>
         <div className={styles.section_wrapper}>
           <div className={styles.form_row}>
+            {/* $FlowFixMe: (mc, 2019-04-18): is stepType needed? */}
             <ChangeTipField stepType="mix" name="changeTip" />
           </div>
         </div>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquid/index.js
@@ -108,7 +108,7 @@ class MoveLiquidForm extends React.Component<Props, State> {
         </div>
         <div className={styles.section_wrapper}>
           <div className={cx(styles.form_row, styles.section_column)}>
-            <ChangeTipField stepType={stepType} name="changeTip" />
+            <ChangeTipField name="changeTip" />
             <PathField focusHandlers={focusHandlers} />
           </div>
           <div

--- a/protocol-designer/src/components/StepEditForm/forms/Pause.js
+++ b/protocol-designer/src/components/StepEditForm/forms/Pause.js
@@ -91,7 +91,8 @@ function PauseForm(props: PauseFormProps): React.Element<'div'> {
           <div className={styles.form_row}>
             {/* TODO: Ian 2019-03-25 consider making this a component eg `TextAreaField.js` if used anywhere else */}
             <StepField
-              {...focusHandlers}
+              dirtyFields={focusHandlers.dirtyFields}
+              focusedField={focusHandlers.focusedField}
               name="pauseMessage"
               render={({ value, updateValue }) => (
                 <FormGroup

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -31,11 +31,12 @@ const STEP_FORM_MAP: { [StepType]: * } = {
   moveLiquid: MoveLiquidForm,
 }
 
-type SP = {
+type SP = {|
   formData?: ?FormData,
   isNewStep?: boolean,
-}
-type DP = { deleteStep: StepIdType => mixed }
+|}
+
+type DP = {| deleteStep: StepIdType => mixed |}
 
 type StepEditFormState = {
   showConfirmDeleteModal: boolean,
@@ -44,7 +45,7 @@ type StepEditFormState = {
   dirtyFields: Array<StepFieldName>,
 }
 
-type Props = SP & DP
+type Props = { ...SP, ...DP }
 
 // TODO: type fieldNames, don't use `any`
 const getDirtyFields = (
@@ -85,7 +86,7 @@ class StepEditForm extends React.Component<Props, StepEditFormState> {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     // NOTE: formData is sometimes undefined between steps
     if (get(this.props, 'formData.id') !== get(prevProps, 'formData.id')) {
       const { isNewStep, formData } = this.props
@@ -149,7 +150,7 @@ class StepEditForm extends React.Component<Props, StepEditFormState> {
         )}
         {this.state.showMoreOptionsModal && (
           <MoreOptionsModal
-            formData={this.props.formData}
+            formData={formData}
             close={this.toggleMoreOptionsModal}
           />
         )}
@@ -187,7 +188,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
   deleteStep: (stepId: StepIdType) => dispatch(actions.deleteStep(stepId)),
 })
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(StepEditForm)

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -56,13 +56,14 @@ const getDirtyFields = (
   if (!isNewStep && formData) {
     dirtyFields = Object.keys(formData)
   } else if (formData && formData.stepType) {
+    const data = formData
     // new step, but may have auto-populated fields.
     // "Dirty" any fields that differ from default new form values
     const defaultFormData = getDefaultsForStepType(formData.stepType)
     dirtyFields = Object.keys(defaultFormData).reduce(
       (acc, fieldName: StepFieldName) => {
-        // $FlowFixMe formData is no longer a Maybe type b/c of the `if` above, but flow forgets
-        const currentValue = formData[fieldName]
+        // formData is no longer a Maybe type b/c of the `if` above, but flow forgets
+        const currentValue = data[fieldName]
         const initialValue = defaultFormData[fieldName]
 
         return isEqual(currentValue, initialValue) ? acc : [...acc, fieldName]

--- a/protocol-designer/src/components/alerts/TimelineAlerts.js
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.js
@@ -17,11 +17,11 @@ import Alerts from './Alerts'
 
 type Props = React.ElementProps<typeof Alerts>
 
-type SP = {
+type SP = {|
   errors: $PropertyType<Props, 'errors'>,
   warnings: $PropertyType<Props, 'warnings'>,
   _stepId: ?StepIdType,
-}
+|}
 
 /** Errors and Warnings from step-generation are written for developers
  * who are using step-generation as an API for writing Opentrons protocols.
@@ -74,7 +74,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.js
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.js
@@ -29,16 +29,17 @@ import modalStyles from '../modals/modal.css'
 import styles from './labware.css'
 import WellTooltip from './WellTooltip'
 
-type SP = {
+type SP = {|
   wellContents: ContentsByWell,
   labwareType: string,
   ingredNames: WellIngredientNames,
-}
-type DP = {
-  drillUp: () => mixed,
-}
+|}
 
-type Props = SP & DP
+type DP = {|
+  drillUp: () => mixed,
+|}
+
+type Props = {| ...SP, ...DP |}
 
 class BrowseLabwareModal extends React.Component<Props> {
   handleClose = () => {
@@ -125,7 +126,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   return { drillUp: () => dispatch(labwareIngredsActions.drillUpFromLabware()) }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(BrowseLabwareModal)

--- a/protocol-designer/src/components/labware/LabwareOnDeck.js
+++ b/protocol-designer/src/components/labware/LabwareOnDeck.js
@@ -271,7 +271,7 @@ type LabwareOnDeckProps = {
 
   deleteLabware: () => mixed,
   duplicateLabware: StepIdType => mixed,
-  swapSlotContents: (DeckSlot, DeckSlot) => void,
+  swapSlotContents: (DeckSlot, DeckSlot) => mixed,
 
   setLabwareName: (name: ?string) => mixed,
   setDefaultLabwareName: () => mixed,

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -14,22 +14,28 @@ import {
 } from '../../../step-forms'
 import FilePipettesModal from '../FilePipettesModal'
 import type { BaseState, ThunkDispatch } from '../../../types'
-import type { PipetteOnDeck, NormalizedPipette } from '../../../step-forms'
+import type {
+  PipetteOnDeck,
+  FormPipettesByMount,
+  NormalizedPipette,
+} from '../../../step-forms'
 import type { StepIdType } from '../../../form-types'
 
 type Props = ElementProps<typeof FilePipettesModal>
 
-type SP = {
+type SP = {|
+  initialPipetteValues: FormPipettesByMount,
   _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
   _orderedStepIds: Array<StepIdType>,
-}
+|}
 
-type OP = {
+type OP = {|
   closeModal: () => mixed,
-}
+|}
 
 const mapSTP = (state: BaseState): SP => {
   const initialPipettes = stepFormSelectors.getPipettesForEditPipetteForm(state)
+
   return {
     initialPipetteValues: initialPipettes,
     _prevPipettes: stepFormSelectors.getInitialDeckSetup(state).pipettes, // TODO: Ian 2019-01-02 when multi-step editing is supported, don't use initial deck state. Instead, show the pipettes available for the selected step range
@@ -172,7 +178,7 @@ const mergeProps = (
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, _, _>(
   mapSTP,
   null,
   mergeProps

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/index.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/index.js
@@ -11,11 +11,11 @@ import type { BaseState } from '../../../types'
 
 type Props = React.ElementProps<typeof FileUploadMessageModal>
 
-type SP = {
+type SP = {|
   message: $PropertyType<Props, 'message'>,
-}
+|}
 
-type DP = $Diff<Props, SP>
+type DP = $Rest<$Exact<Props>, SP>
 
 function mapStateToProps(state: BaseState): SP {
   return {
@@ -29,7 +29,7 @@ function mapDispatchToProps(dispatch: Dispatch<*>): DP {
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(FileUploadMessageModal)

--- a/protocol-designer/src/components/modals/GateModal/index.js
+++ b/protocol-designer/src/components/modals/GateModal/index.js
@@ -10,7 +10,7 @@ import {
   actions as analyticsActions,
   selectors as analyticsSelectors,
 } from '../../../analytics'
-import type { BaseState } from '../../../types'
+import type { BaseState, ThunkDispatch } from '../../../types'
 import settingsStyles from '../../SettingsPage/SettingsPage.css'
 import modalStyles from '../modal.css'
 import SignUpForm from './SignUpForm'
@@ -21,11 +21,11 @@ type Props = {
   optOut: () => mixed,
 }
 
-type SP = {
+type SP = {|
   hasOptedIn: $PropertyType<Props, 'hasOptedIn'>,
-}
+|}
 
-type DP = $Diff<Props, SP>
+type DP = $Rest<$Exact<Props>, SP>
 
 type State = { gateStage: GateStage, errorMessage: ?string }
 
@@ -141,14 +141,14 @@ function mapStateToProps(state: BaseState): SP {
   return { hasOptedIn: analyticsSelectors.getHasOptedIn(state) }
 }
 
-function mapDispatchToProps(dispatch: Dispatch<*>): DP {
+function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   return {
     optIn: () => dispatch(analyticsActions.optIn()),
     optOut: () => dispatch(analyticsActions.optOut()),
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(GateModal)

--- a/protocol-designer/src/components/modals/MoreOptionsModal.js
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.js
@@ -11,15 +11,18 @@ import type { ThunkDispatch } from '../../types'
 import styles from './MoreOptionsModal.css'
 import modalStyles from './modal.css'
 
-type OP = {
+type OP = {|
   close: (event: ?SyntheticEvent<>) => mixed,
   formData: FormData,
-}
-type DP = {
+|}
+
+type DP = {|
   saveValuesToForm: ({ [StepFieldName]: ?mixed }) => mixed,
-}
-type Props = OP & DP
+|}
+
+type Props = {| ...OP, ...DP |}
 type State = { [StepFieldName]: ?mixed }
+
 class MoreOptionsModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
@@ -85,7 +88,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
     dispatch(steplistActions.changeFormInput({ update })),
 })
 
-export default connect(
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDispatchToProps
 )(MoreOptionsModal)

--- a/protocol-designer/src/components/modals/NewFileModal/index.js
+++ b/protocol-designer/src/components/modals/NewFileModal/index.js
@@ -19,26 +19,27 @@ import FilePipettesModal from '../FilePipettesModal'
 import type { BaseState, ThunkDispatch } from '../../../types'
 import type { PipetteOnDeck, NormalizedPipette } from '../../../step-forms'
 
-export default connect(
+type Props = ElementProps<typeof FilePipettesModal>
+
+type OP = {|
+  useProtocolFields: $PropertyType<Props, 'useProtocolFields'>,
+|}
+
+type SP = {|
+  hideModal: $PropertyType<Props, 'hideModal'>,
+  _hasUnsavedChanges: ?boolean,
+|}
+
+type DP = {|
+  onCancel: () => mixed,
+  _createNewProtocol: $PropertyType<Props, 'onSave'>,
+|}
+
+export default connect<Props, OP, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps,
   mergeProps
 )(FilePipettesModal)
-
-type Props = ElementProps<typeof FilePipettesModal>
-
-type OP = {
-  useProtocolFields: $PropertyType<Props, 'useProtocolFields'>,
-}
-
-type SP = {
-  hideModal: $PropertyType<Props, 'hideModal'>,
-  _hasUnsavedChanges: ?boolean,
-}
-type DP = {
-  onCancel: () => mixed,
-  _createNewProtocol: $PropertyType<Props, 'onSave'>,
-}
 
 function mapStateToProps(state: BaseState): SP {
   return {

--- a/protocol-designer/src/components/steplist/ContextMenu.js
+++ b/protocol-designer/src/components/steplist/ContextMenu.js
@@ -10,17 +10,21 @@ import styles from './StepItem.css'
 
 const MENU_OFFSET_PX = 5
 
-type DP = {
-  deleteStep: StepIdType => {},
-  duplicateStep: StepIdType => {},
-}
-type Props = {
+type OP = {|
   children: ({
     makeStepOnContextMenu: StepIdType => (
       event: SyntheticMouseEvent<>
     ) => mixed,
   }) => React.Node,
-} & DP
+|}
+
+type DP = {|
+  deleteStep: StepIdType => {},
+  duplicateStep: StepIdType => {},
+|}
+
+type Props = {| ...DP, ...OP |}
+
 type State = {
   visible: boolean,
   left: ?number,
@@ -45,7 +49,9 @@ class ContextMenu extends React.Component<Props, State> {
     global.removeEventListener('click', this.handleClick)
   }
 
-  makeHandleContextMenu = (stepId: StepIdType) => event => {
+  makeHandleContextMenu = (stepId: StepIdType) => (
+    event: SyntheticMouseEvent<*>
+  ) => {
     event.preventDefault()
 
     const clickX = event.clientX
@@ -136,14 +142,14 @@ class ContextMenu extends React.Component<Props, State> {
   }
 }
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<*>) => ({
+const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
   deleteStep: (stepId: StepIdType) =>
     dispatch(steplistActions.deleteStep(stepId)),
   duplicateStep: (stepId: StepIdType) =>
     dispatch(steplistActions.duplicateStep(stepId)),
 })
 
-export default connect(
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDispatchToProps
 )(ContextMenu)

--- a/protocol-designer/src/components/steplist/DraggableStepItems.js
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.js
@@ -20,19 +20,23 @@ const DND_TYPES: { STEP_ITEM: 'STEP_ITEM' } = {
   STEP_ITEM: 'STEP_ITEM',
 }
 
-type DragDropStepItemProps = React.ElementProps<typeof StepItem> & {
+type DragDropStepItemProps = {|
+  ...$Exact<React.ElementProps<typeof StepItem>>,
   connectDragSource: mixed => React.Element<any>,
   connectDropTarget: mixed => React.Element<any>,
   stepId: StepIdType,
   stepNumber: number,
+  isDragging: boolean,
   findStepIndex: StepIdType => number,
   onDrag: () => void,
   moveStep: (StepIdType, number) => void,
-}
+|}
+
 const DragSourceStepItem = (props: DragDropStepItemProps) =>
   props.connectDragSource(
     props.connectDropTarget(
       <div style={{ opacity: props.isDragging ? 0.3 : 1 }}>
+        {/* $FlowFixMe: (mc, 2019-04-18): connected components have exact props, which makes flow complain here */}
         <StepItem {...props} />
       </div>
     )
@@ -151,14 +155,18 @@ class StepItems extends React.Component<StepItemsProps, StepItemsState> {
 
 const NAV_OFFSET = 64
 
-type StepDragPreviewSP = { stepType: ?StepType, stepName: ?string }
-type StepDragPreviewProps = {
+type StepDragPreviewSP = {| stepType: ?StepType, stepName: ?string |}
+
+type StepDragPreviewOP = {|
   currentOffset?: { y: number, x: number },
   itemType: string,
   isDragging: boolean,
   item: { stepId: StepIdType },
-}
-const StepDragPreview = (props: StepDragPreviewProps & StepDragPreviewSP) => {
+|}
+
+type StepDragPreviewProps = {| ...StepDragPreviewOP, ...StepDragPreviewSP |}
+
+const StepDragPreview = (props: StepDragPreviewProps) => {
   const { itemType, isDragging, currentOffset, stepType, stepName } = props
   if (
     itemType !== DND_TYPES.STEP_ITEM ||

--- a/protocol-designer/src/components/steplist/SourceDestSubstep.js
+++ b/protocol-designer/src/components/steplist/SourceDestSubstep.js
@@ -49,7 +49,7 @@ export default function SourceDestSubstep(props: SourceDestSubstepProps) {
   }
 
   // single-channel row item
-  return substeps.rows.map((row, substepIndex) => (
+  return substeps.rows.map<React.Node>((row, substepIndex) => (
     <SubstepRow
       key={substepIndex}
       className={cx(styles.step_subitem, {

--- a/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
+++ b/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.js
@@ -12,6 +12,8 @@ type Props = {
   showHint: boolean,
 }
 
+type SP = $Exact<Props>
+
 function StartingDeckStateTerminalItem(props: Props) {
   const { showHint } = props
   const hintContents = (
@@ -27,11 +29,13 @@ function StartingDeckStateTerminalItem(props: Props) {
   )
 }
 
-function mapStateToProps(state: BaseState): Props {
+function mapStateToProps(state: BaseState): SP {
   // since default-trash counts as 1, labwareCount <= 1 means "user did not add labware"
   const noLabware =
     Object.keys(stepFormSelectors.getLabwareEntities(state)).length <= 1
   return { showHint: noLabware }
 }
 
-export default connect(mapStateToProps)(StartingDeckStateTerminalItem)
+export default connect<Props, {||}, SP, _, _, _>(mapStateToProps)(
+  StartingDeckStateTerminalItem
+)

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -151,5 +151,4 @@ function SubstepRow(props: SubstepRowProps) {
   )
 }
 
-// TODO: Ian 2019-02-04 need to update Flow defs for React.memo $FlowFixMe
-export default React.memo(SubstepRow)
+export default React.memo<SubstepRowProps>(SubstepRow)

--- a/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.js
@@ -8,10 +8,11 @@ import { type TerminalItemId } from '../../../steplist'
 import i18n from '../../../localization'
 import styles from './styles.css'
 
-type OP = { terminalId: TerminalItemId }
-type DP = { selectTerminalItem: TerminalItemId => mixed }
+type OP = {| terminalId: TerminalItemId |}
+type DP = {| selectTerminalItem: TerminalItemId => mixed |}
+type Props = {| ...OP, ...DP |}
 
-class TerminalItemLink extends React.Component<OP & DP> {
+class TerminalItemLink extends React.Component<Props> {
   handleClick = () => {
     this.props.selectTerminalItem(this.props.terminalId)
   }
@@ -29,7 +30,8 @@ const mapDTP = (dispatch: ThunkDispatch<*>): DP => ({
   selectTerminalItem: terminalId =>
     dispatch(stepsActions.selectTerminalItem(terminalId)),
 })
-export default connect(
+
+export default connect<Props, OP, {||}, DP, _, _>(
   null,
   mapDTP
 )(TerminalItemLink)

--- a/protocol-designer/src/components/steplist/TerminalItem/index.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.js
@@ -13,16 +13,16 @@ export { default as TerminalItemLink } from './TerminalItemLink'
 
 type Props = React.ElementProps<typeof PDTitledList>
 
-type OP = {
+type OP = {|
   id: TerminalItemId,
   title: string,
   children?: React.Node,
-}
+|}
 
-type SP = {
+type SP = {|
   hovered: $ElementType<Props, 'hovered'>,
   selected: $ElementType<Props, 'selected'>,
-}
+|}
 
 function mapStateToProps(state: BaseState, ownProps: OP): SP {
   const { id } = ownProps
@@ -52,7 +52,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -4,6 +4,8 @@ import thunk from 'redux-thunk'
 import { makePersistSubscriber, rehydratePersistedAction } from './persist'
 import { fileUploadMessage } from './load-file/actions'
 
+import type { BaseState, Action, ThunkDispatch } from './types'
+
 const ReselectTools =
   process.env.NODE_ENV === 'development' ? require('reselect-tools') : undefined
 
@@ -54,7 +56,8 @@ export default function configureStore() {
 
   const composeEnhancers: any =
     window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
-  const store = createStore(
+
+  const store = createStore<BaseState, Action, ThunkDispatch<*>>(
     reducer,
     /* preloadedState, */
     composeEnhancers(applyMiddleware(thunk))

--- a/protocol-designer/src/containers/ConnectedDeckSetup.js
+++ b/protocol-designer/src/containers/ConnectedDeckSetup.js
@@ -23,36 +23,28 @@ import { selectors as stepsSelectors } from '../ui/steps'
 
 import type { BaseState, ThunkDispatch } from '../types'
 
-type StateProps = {
+type SP = {|
   selectedTerminalItemId: ?TerminalItemId,
   ingredSelectionMode: boolean,
   drilledDown: boolean,
-}
-type DispatchProps = {
-  drillUpFromLabware: () => mixed,
-}
-type Props = {
-  selectedTerminalItemId: ?TerminalItemId,
-  drilledDown: boolean,
-  ingredSelectionMode: boolean,
-  handleClickOutside: () => void,
-}
+|}
 
-const mapStateToProps = (state: BaseState): StateProps => ({
+type DP = {| drillUpFromLabware: () => mixed |}
+
+type Props = {| ...SP, handleClickOutside: () => mixed |}
+
+const mapStateToProps = (state: BaseState): SP => ({
   selectedTerminalItemId: stepsSelectors.getSelectedTerminalItemId(state),
   ingredSelectionMode:
     labwareIngredSelectors.getSelectedLabwareId(state) != null,
   drilledDown: labwareIngredSelectors.getDrillDownLabwareId(state) != null,
 })
 
-const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DispatchProps => ({
+const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
   drillUpFromLabware: () => dispatch(labwareIngredActions.drillUpFromLabware()),
 })
 
-const mergeProps = (
-  stateProps: StateProps,
-  dispatchProps: DispatchProps
-): Props => ({
+const mergeProps = (stateProps: SP, dispatchProps: DP): Props => ({
   selectedTerminalItemId: stateProps.selectedTerminalItemId,
   ingredSelectionMode: stateProps.ingredSelectionMode,
   drilledDown: stateProps.drilledDown,
@@ -120,7 +112,7 @@ class DeckSetup extends React.Component<Props> {
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps,
   mergeProps

--- a/protocol-designer/src/containers/ConnectedFilePage.js
+++ b/protocol-designer/src/containers/ConnectedFilePage.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux'
 import * as React from 'react'
 import mapValues from 'lodash/mapValues'
-import type { BaseState } from '../types'
+import type { BaseState, ThunkDispatch } from '../types'
 import FilePage from '../components/FilePage'
 import { actions, selectors as fileSelectors } from '../file-data'
 import { selectors as stepFormSelectors } from '../step-forms'
@@ -14,11 +14,11 @@ import { actions as navActions } from '../navigation'
 
 type Props = React.ElementProps<typeof FilePage>
 
-type SP = {
+type SP = {|
   instruments: $PropertyType<Props, 'instruments'>,
   formValues: $PropertyType<Props, 'formValues'>,
   _initialDeckSetup: InitialDeckSetup,
-}
+|}
 
 const mapStateToProps = (state: BaseState): SP => {
   return {
@@ -30,7 +30,7 @@ const mapStateToProps = (state: BaseState): SP => {
 
 function mergeProps(
   stateProps: SP,
-  dispatchProps: { dispatch: Dispatch<*> }
+  dispatchProps: { dispatch: ThunkDispatch<*> }
 ): Props {
   const { _initialDeckSetup, ...passThruProps } = stateProps
   const { dispatch } = dispatchProps
@@ -55,7 +55,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/containers/ConnectedMainPanel.js
+++ b/protocol-designer/src/containers/ConnectedMainPanel.js
@@ -11,9 +11,9 @@ import LiquidsPage from '../components/LiquidsPage'
 import type { BaseState } from '../types'
 import { selectors, type Page } from '../navigation'
 
-export default connect(mapStateToProps)(MainPanel)
-
 type Props = { page: Page }
+
+export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(MainPanel)
 
 function MainPanel(props: Props) {
   const { page } = props
@@ -31,7 +31,7 @@ function MainPanel(props: Props) {
   }
 }
 
-function mapStateToProps(state: BaseState): Props {
+function mapStateToProps(state: BaseState): $Exact<Props> {
   return {
     page: selectors.getCurrentPage(state),
   }

--- a/protocol-designer/src/containers/ConnectedNav.js
+++ b/protocol-designer/src/containers/ConnectedNav.js
@@ -9,11 +9,14 @@ import i18n from '../localization'
 import { type Page, actions, selectors } from '../navigation'
 import { selectors as fileSelectors } from '../file-data'
 
-type Props = {
+type SP = {|
   currentPage: Page,
   currentProtocolExists: boolean,
-  handleClick: Page => (e: ?SyntheticEvent<>) => void,
-}
+|}
+
+type DP = {| handleClick: Page => (e: ?SyntheticEvent<>) => void |}
+
+type Props = {| ...SP, ...DP |}
 
 function Nav(props: Props) {
   const noCurrentProtocol = !props.currentProtocolExists
@@ -67,21 +70,22 @@ function Nav(props: Props) {
   )
 }
 
-function mapStateToProps(state: BaseState) {
+function mapStateToProps(state: BaseState): SP {
   return {
     currentPage: selectors.getCurrentPage(state),
     currentProtocolExists: fileSelectors.getCurrentProtocolExists(state),
   }
 }
 
-function mapDispatchToProps(dispatch: ThunkDispatch<*>) {
+function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   return {
-    handleClick: (pageName: Page) => () =>
-      dispatch(actions.navigateToPage(pageName)),
+    handleClick: (pageName: Page) => () => {
+      dispatch(actions.navigateToPage(pageName))
+    },
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(Nav)

--- a/protocol-designer/src/containers/ConnectedSidebar.js
+++ b/protocol-designer/src/containers/ConnectedSidebar.js
@@ -38,7 +38,7 @@ function Sidebar(props: Props) {
   return null
 }
 
-function mapStateToProps(state: BaseState): Props {
+function mapStateToProps(state: BaseState): $Exact<Props> {
   const page = selectors.getCurrentPage(state)
   const liquidPlacementMode =
     labwareIngredSelectors.getSelectedLabwareId(state) != null
@@ -49,4 +49,4 @@ function mapStateToProps(state: BaseState): Props {
   }
 }
 
-export default connect(mapStateToProps)(Sidebar)
+export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(Sidebar)

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -24,10 +24,10 @@ import StepItem from '../components/steplist/StepItem' // TODO Ian 2018-05-10 wh
 
 type Props = React.ElementProps<typeof StepItem>
 
-type OP = {
+type OP = {|
   stepId: $PropertyType<Props, 'stepId'>,
   stepNumber: $PropertyType<Props, 'stepNumber'>,
-}
+|}
 
 type SP = {|
   stepType: $PropertyType<Props, 'stepType'>,
@@ -49,13 +49,13 @@ type SP = {|
   ingredNames: $PropertyType<Props, 'ingredNames'>,
 |}
 
-type DP = $Diff<$Diff<Props, SP>, OP>
+type DP = $Diff<$Diff<$Exact<Props>, SP>, OP>
 
-const makeMapStateToProps = () => {
+const makeMapStateToProps: () => (BaseState, OP) => SP = () => {
   const getArgsAndErrors = stepFormSelectors.makeGetArgsAndErrorsWithId()
   const getStep = stepFormSelectors.makeGetStepWithId()
 
-  return (state: BaseState, ownProps: OP): SP => {
+  return (state, ownProps) => {
     const { stepId } = ownProps
 
     const argsAndErrors = getArgsAndErrors(state, { stepId })
@@ -115,7 +115,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, DP, _, _>(
   makeMapStateToProps,
   mapDispatchToProps
 )(StepItem)

--- a/protocol-designer/src/containers/ConnectedStepList.js
+++ b/protocol-designer/src/containers/ConnectedStepList.js
@@ -10,11 +10,9 @@ import { StepList } from '../components/steplist'
 
 type Props = React.ElementProps<typeof StepList>
 
-type SP = {
-  orderedStepIds: $PropertyType<Props, 'orderedStepIds'>,
-}
+type SP = {| orderedStepIds: $PropertyType<Props, 'orderedStepIds'> |}
 
-type DP = $Diff<Props, SP>
+type DP = $Diff<$Exact<Props>, SP>
 
 function mapStateToProps(state: BaseState): SP {
   return {
@@ -33,7 +31,7 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, DP, _, _>(
   mapStateToProps,
   mapDispatchToProps
 )(StepList)

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -21,15 +21,19 @@ import { closeIngredientSelector } from '../labware-ingred/actions'
 import { stepIconsByType } from '../form-types'
 import { selectors, type Page } from '../navigation'
 
+import type { TitleBarProps } from '@opentrons/components'
 import type { BaseState } from '../types'
 
 type Props = React.ElementProps<typeof TitleBar>
-type DP = { onBackClick: $PropertyType<Props, 'onBackClick'> }
-type SP = $Diff<Props, DP> & {
+
+type DP = {| onBackClick: $PropertyType<Props, 'onBackClick'> |}
+
+type SP = {|
+  ...$Diff<$Exact<Props>, DP>,
   _page: Page,
   _liquidPlacementMode?: boolean,
   _wellSelectionMode?: boolean,
-}
+|}
 
 type TitleWithIconProps = {
   iconName?: ?IconName,
@@ -190,11 +194,11 @@ function mergeProps(
   }
 }
 
-const StickyTitleBar = props => (
+const StickyTitleBar = (props: TitleBarProps) => (
   <TitleBar {...props} className={styles.sticky_bar} />
 )
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/containers/HighlightableLabware.js
+++ b/protocol-designer/src/containers/HighlightableLabware.js
@@ -24,7 +24,7 @@ type OP = {
   containerId?: string,
 }
 
-type SP = $Diff<Props, OP>
+type SP = $Diff<$Exact<Props>, OP>
 
 function mapStateToProps(state: BaseState, ownProps: OP): SP {
   const selectedContainerId = selectors.getSelectedLabwareId(state)
@@ -124,4 +124,6 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
   }
 }
 
-export default connect(mapStateToProps)(HighlightableLabware)
+export default connect<Props, OP, SP, _, _, _>(mapStateToProps)(
+  HighlightableLabware
+)

--- a/protocol-designer/src/containers/IngredientsList.js
+++ b/protocol-designer/src/containers/IngredientsList.js
@@ -11,11 +11,10 @@ import IngredientsList from '../components/IngredientsList'
 
 type Props = React.ElementProps<typeof IngredientsList>
 
-type DP = {
-  removeWellsContents: $ElementType<Props, 'removeWellsContents'>,
-}
-
-type SP = $Diff<Props, DP> & { _labwareId: ?string }
+type SP = {|
+  ...$Diff<$Exact<Props>, {| removeWellsContents: * |}>,
+  _labwareId: ?string,
+|}
 
 function mapStateToProps(state: BaseState): SP {
   const selectedLabwareId = labwareIngredSelectors.getSelectedLabwareId(state)
@@ -43,12 +42,15 @@ function mergeProps(
   const { _labwareId, ...passThruProps } = stateProps
   return {
     ...passThruProps,
-    removeWellsContents: args =>
-      dispatch(removeWellsContents({ ...args, labwareId: _labwareId })),
+    removeWellsContents: args => {
+      if (_labwareId) {
+        dispatch(removeWellsContents({ ...args, labwareId: _labwareId }))
+      }
+    },
   }
 }
 
-export default connect(
+export default connect<Props, {||}, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/containers/LabwareContainer.js
+++ b/protocol-designer/src/containers/LabwareContainer.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import noop from 'lodash/noop'
 import { getLabware, getIsTiprackDeprecated } from '@opentrons/shared-data'
 import { selectors as labwareIngredSelectors } from '../labware-ingred/selectors'
 import { selectors as uiLabwareSelectors } from '../ui/labware'
@@ -21,7 +20,7 @@ import { selectors as stepsSelectors } from '../ui/steps'
 
 import { LabwareOnDeck } from '../components/labware'
 import type { StepIdType } from '../form-types'
-import type { BaseState } from '../types'
+import type { BaseState, ThunkDispatch } from '../types'
 import type { DeckSlot } from '@opentrons/components'
 
 type OP = {
@@ -30,22 +29,22 @@ type OP = {
 
 type Props = React.ElementProps<typeof LabwareOnDeck>
 
-type DP = {
+type DP = {|
   addLabware: () => mixed,
   editLiquids: () => mixed,
   deleteLabware: () => mixed,
   duplicateLabware: StepIdType => mixed,
-  swapSlotContents: (DeckSlot, DeckSlot) => void,
+  swapSlotContents: (DeckSlot, DeckSlot) => mixed,
   setLabwareName: (name: ?string) => mixed,
   setDefaultLabwareName: () => mixed,
-}
+|}
 
-type MP = {
+type MP = {|
   drillDown: () => mixed,
   drillUp: () => mixed,
-}
+|}
 
-type SP = $Diff<Props, { ...DP, ...MP }>
+type SP = $Diff<$Exact<Props>, { ...DP, ...MP }>
 
 function mapStateToProps(state: BaseState, ownProps: OP): SP {
   const { slot } = ownProps
@@ -90,9 +89,6 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
   ]
   const showNameOverlay = !isTiprack && !labwareHasName
 
-  const setDefaultLabwareName =
-    labwareId != null ? () => renameLabware({ labwareId, name: null }) : noop
-
   // labware definition's metadata.isValidSource defaults to true,
   // only use it when it is defined as false
   let canAddIngreds: boolean = !showNameOverlay
@@ -104,10 +100,8 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
   return {
     slotHasLabware: true,
     addLabwareMode,
-    setDefaultLabwareName,
     canAddIngreds,
     isTiprack,
-    labwareInfo,
 
     showNameOverlay,
     highlighted:
@@ -130,7 +124,7 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
 
 function mergeProps(
   stateProps: SP,
-  dispatchProps: { dispatch: Dispatch<*> },
+  dispatchProps: { dispatch: ThunkDispatch<*> },
   ownProps: OP
 ): Props {
   const { slot } = ownProps
@@ -174,7 +168,7 @@ function mergeProps(
   }
 }
 
-export default connect(
+export default connect<Props, OP, SP, {||}, _, _>(
   mapStateToProps,
   null,
   mergeProps

--- a/protocol-designer/src/dismiss/reducers.js
+++ b/protocol-designer/src/dismiss/reducers.js
@@ -4,7 +4,7 @@ import { handleActions } from 'redux-actions'
 import omit from 'lodash/omit'
 import type { DismissFormWarning, DismissTimelineWarning } from './actions'
 import { getPDMetadata } from '../file-types'
-import type { BaseState } from '../types'
+import type { BaseState, Action } from '../types'
 import type { LoadFileAction } from '../load-file'
 import type { DeleteStepAction } from '../steplist/actions'
 import type { StepIdType } from '../form-types'
@@ -18,7 +18,7 @@ export type DismissedWarningState = {
   form: DismissedWarningsAllSteps,
   timeline: DismissedWarningsAllSteps,
 }
-const dismissedWarnings = handleActions(
+const dismissedWarnings = handleActions<DismissedWarningState, *>(
   {
     DISMISS_FORM_WARNING: (
       state: DismissedWarningState,
@@ -83,7 +83,7 @@ export type RootState = {
   dismissedWarnings: DismissedWarningState,
 }
 
-const rootReducer = combineReducers(_allReducers)
+const rootReducer = combineReducers<_, Action>(_allReducers)
 
 export default rootReducer
 

--- a/protocol-designer/src/file-data/reducers/index.js
+++ b/protocol-designer/src/file-data/reducers/index.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux'
 import { handleActions, type ActionType } from 'redux-actions'
 
 import { saveFileMetadata } from '../actions'
+import type { Action } from '../../types'
 import type { FileMetadataFields } from '../types'
 import type { LoadFileAction, NewProtocolFields } from '../../load-file'
 
@@ -69,4 +70,4 @@ const _allReducers = {
   fileMetadata,
 }
 
-export const rootReducer = combineReducers(_allReducers)
+export const rootReducer = combineReducers<_, Action>(_allReducers)

--- a/protocol-designer/src/file-data/selectors/fileFields.js
+++ b/protocol-designer/src/file-data/selectors/fileFields.js
@@ -1,20 +1,24 @@
 // @flow
 import { createSelector } from 'reselect'
-import type { BaseState } from '../../types'
+import type { BaseState, Selector } from '../../types'
 import type { RootState } from '../reducers'
+import type { FileMetadataFields } from '../types'
 
 export const rootSelector = (state: BaseState): RootState => state.fileData
 
-export const getCurrentProtocolExists = createSelector(
+export const getCurrentProtocolExists: Selector<boolean> = createSelector(
   rootSelector,
   rootState => rootState.currentProtocolExists
 )
 
-export const protocolName = createSelector(
+export const protocolName: Selector<
+  $PropertyType<FileMetadataFields, 'protocol-name'>
+> = createSelector(
   rootSelector,
   state => state.fileMetadata['protocol-name']
 )
-export const getFileMetadata = createSelector(
+
+export const getFileMetadata: Selector<FileMetadataFields> = createSelector(
   rootSelector,
   state => state.fileMetadata
 )

--- a/protocol-designer/src/labware-defs/reducers.js
+++ b/protocol-designer/src/labware-defs/reducers.js
@@ -1,6 +1,7 @@
 // @flow
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
+import type { Action } from '../types'
 import type { CreateCustomLabwareDef } from './actions'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 type CustomDefs = { [defId: string]: LabwareDefinition2 }
@@ -26,4 +27,4 @@ const _allReducers = {
   customDefs,
 }
 
-export const rootReducer = combineReducers(_allReducers)
+export const rootReducer = combineReducers<_, Action>(_allReducers)

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -11,38 +11,36 @@ type IngredInputsExact = $Exact<IngredInputs>
 
 // ===== Labware selector actions =====
 
-export const openAddLabwareModal = createAction(
+export const openAddLabwareModal = createAction<
   'OPEN_ADD_LABWARE_MODAL',
-  (args: { slot: DeckSlot }) => args
-)
+  { slot: DeckSlot }
+>('OPEN_ADD_LABWARE_MODAL')
 
-export const closeLabwareSelector = createAction(
+export const closeLabwareSelector = createAction<
   'CLOSE_LABWARE_SELECTOR',
-  () => {}
-)
+  void
+>('CLOSE_LABWARE_SELECTOR')
 
 // ===== Open and close Ingredient Selector modal ====
 
-export const openIngredientSelector = createAction(
+export const openIngredientSelector = createAction<
   'OPEN_INGREDIENT_SELECTOR',
-  (containerId: string) => containerId
-)
+  string
+>('OPEN_INGREDIENT_SELECTOR')
 
-export const closeIngredientSelector = createAction(
+export const closeIngredientSelector = createAction<
   'CLOSE_INGREDIENT_SELECTOR',
-  () => {}
-)
+  void
+>('CLOSE_INGREDIENT_SELECTOR')
 
 // ===== Drill Down on Labware ====
 
-export const drillDownOnLabware = createAction(
-  'DRILL_DOWN_ON_LABWARE',
-  (labwareId: string) => labwareId
+export const drillDownOnLabware = createAction<'DRILL_DOWN_ON_LABWARE', string>(
+  'DRILL_DOWN_ON_LABWARE'
 )
 
-export const drillUpFromLabware = createAction(
-  'DRILL_UP_FROM_LABWARE',
-  () => {}
+export const drillUpFromLabware = createAction<'DRILL_UP_FROM_LABWARE', void>(
+  'DRILL_UP_FROM_LABWARE'
 )
 
 // ==== Create/delete/modify labware =====
@@ -67,10 +65,11 @@ export type DeleteContainerAction = {
     labwareId: string,
   },
 }
-export const deleteContainer = createAction(
+
+export const deleteContainer = createAction<
   'DELETE_CONTAINER',
-  (args: $PropertyType<DeleteContainerAction, 'payload'>) => args
-)
+  $PropertyType<DeleteContainerAction, 'payload'>
+>('DELETE_CONTAINER')
 
 export type RenameLabwareAction = {
   type: 'RENAME_LABWARE',

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -9,6 +9,7 @@ import * as actions from '../actions'
 import { FIXED_TRASH_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'
 import type { DeckSlot } from '@opentrons/components'
+import type { Action } from '../../types'
 import type {
   SingleLabwareLiquidState,
   LabwareLiquidState,
@@ -106,7 +107,7 @@ const initialLabwareState: ContainersState = {
   },
 }
 
-export const containers = handleActions(
+export const containers = handleActions<ContainersState, *>(
   {
     CREATE_CONTAINER: (
       state: ContainersState,
@@ -197,7 +198,7 @@ export const containers = handleActions(
 
 type SavedLabwareState = { [labwareId: string]: boolean }
 /** Keeps track of which labware have saved nicknames */
-export const savedLabware = handleActions(
+export const savedLabware = handleActions<SavedLabwareState, *>(
   {
     DELETE_CONTAINER: (
       state: SavedLabwareState,
@@ -229,7 +230,7 @@ export const savedLabware = handleActions(
 )
 
 type IngredientsState = LiquidGroupsById
-export const ingredients = handleActions(
+export const ingredients = handleActions<IngredientsState, *>(
   {
     EDIT_LIQUID_GROUP: (
       state: IngredientsState,
@@ -258,7 +259,7 @@ export const ingredients = handleActions(
 
 type LocationsState = LabwareLiquidState
 
-export const ingredLocations = handleActions(
+export const ingredLocations = handleActions<LocationsState, *>(
   {
     SET_WELL_CONTENTS: (
       state: LocationsState,
@@ -339,7 +340,7 @@ export type RootState = {|
 |}
 
 // TODO Ian 2018-01-15 factor into separate files
-const rootReducer = combineReducers({
+const rootReducer = combineReducers<_, Action>({
   modeLabwareSelection,
   selectedContainerId,
   selectedLiquidGroup,

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -1,12 +1,13 @@
 // @flow
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
+import type { Action } from '../types'
 import type { FileUploadMessage, LoadFileAction } from './types'
 import type { FileUploadMessageAction } from './actions'
 
 // Keep track of file upload errors / messages
 type FileUploadMessageState = ?FileUploadMessage
-const fileUploadMessage = handleActions(
+const fileUploadMessage = handleActions<FileUploadMessageState, *>(
   {
     FILE_UPLOAD_MESSAGE: (
       state,
@@ -66,6 +67,6 @@ export type RootState = {
   unsavedChanges: boolean,
 }
 
-const rootReducer = combineReducers(_allReducers)
+const rootReducer = combineReducers<_, Action>(_allReducers)
 
 export default rootReducer

--- a/protocol-designer/src/navigation/reducers/index.js
+++ b/protocol-designer/src/navigation/reducers/index.js
@@ -4,10 +4,10 @@ import { handleActions } from 'redux-actions'
 import type { ActionType } from 'redux-actions'
 
 import { navigateToPage, toggleNewProtocolModal } from '../actions'
-import type { BaseState } from '../../types'
+import type { BaseState, Action } from '../../types'
 import type { Page } from '../types'
 
-const page = handleActions(
+const page = handleActions<Page, *>(
   {
     LOAD_FILE: (): Page => 'file-detail',
     CREATE_NEW_PROTOCOL: (): Page => 'file-detail',
@@ -17,7 +17,7 @@ const page = handleActions(
   'file-splash'
 )
 
-const newProtocolModal = handleActions(
+const newProtocolModal = handleActions<boolean, *>(
   {
     TOGGLE_NEW_PROTOCOL_MODAL: (
       state,
@@ -38,7 +38,7 @@ export type RootState = {
   newProtocolModal: boolean,
 }
 
-const rootReducer = combineReducers(_allReducers)
+const rootReducer = combineReducers<_, Action>(_allReducers)
 
 export default rootReducer
 

--- a/protocol-designer/src/pipettes/pipetteData.js
+++ b/protocol-designer/src/pipettes/pipetteData.js
@@ -1,6 +1,5 @@
 // @flow
 import assert from 'assert'
-import compact from 'lodash/compact'
 import { getPipetteNameSpecs, getTiprackVolume } from '@opentrons/shared-data'
 import type { PipetteEntity } from '../step-forms/types'
 
@@ -16,12 +15,12 @@ const supportedPipetteNames = [
 
 // TODO: should a version of pipetteOptions be moved to shared-data,
 // and used for both PD and Run App?
-export const pipetteOptions = compact(
-  supportedPipetteNames.map((name: string) => {
+export const pipetteOptions = supportedPipetteNames
+  .map((name: string) => {
     const pipette = getPipetteNameSpecs(name)
     return pipette ? { name: pipette.displayName, value: pipette.name } : null
   })
-)
+  .filter(Boolean)
 
 // NOTE: this is similar to getPipetteWithTipMaxVol, the fns could potentially
 // be merged once multiple tiprack types per pipette is supported

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -396,7 +396,10 @@ const initialLabwareState: NormalizedLabwareById = {
 }
 
 // MIGRATION NOTE: copied from `containers` reducer. Slot + UI stuff stripped out.
-export const labwareInvariantProperties = handleActions(
+export const labwareInvariantProperties = handleActions<
+  NormalizedLabwareById,
+  *
+>(
   {
     CREATE_CONTAINER: (
       state: NormalizedLabwareById,
@@ -441,7 +444,11 @@ export const labwareInvariantProperties = handleActions(
 )
 
 const initialPipetteState = {}
-export const pipetteInvariantProperties = handleActions(
+
+export const pipetteInvariantProperties = handleActions<
+  NormalizedPipetteById,
+  *
+>(
   {
     LOAD_FILE: (
       state: NormalizedPipetteById,
@@ -489,7 +496,7 @@ export const pipetteInvariantProperties = handleActions(
 
 type OrderedStepIdsState = Array<StepIdType>
 const initialOrderedStepIdsState = []
-export const orderedStepIds = handleActions(
+export const orderedStepIds = handleActions<OrderedStepIdsState, *>(
   {
     ADD_STEP: (state: OrderedStepIdsState, action: AddStepAction) => [
       ...state,
@@ -544,7 +551,7 @@ export const orderedStepIds = handleActions(
 // move to not having "pristine" steps
 type LegacyStepsState = { [StepIdType]: StepItemData }
 const initialLegacyStepState: LegacyStepsState = {}
-export const legacySteps = handleActions(
+export const legacySteps = handleActions<LegacyStepsState, *>(
   {
     ADD_STEP: (state, action: AddStepAction): LegacyStepsState => ({
       ...state,

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -37,6 +37,7 @@ import type {
   StepItemData,
   StepFormContextualState,
 } from '../../steplist/types'
+import type { CommandCreatorArgs } from '../../step-generation/types'
 import type {
   InitialDeckSetup,
   NormalizedLabwareById,
@@ -345,7 +346,13 @@ const getStepFormWithId = (state: BaseState, props: { stepId: StepIdType }) => {
 }
 
 export const makeGetArgsAndErrorsWithId = () => {
-  return createSelector(
+  return createSelector<
+    BaseState,
+    { stepId: StepIdType },
+    { stepArgs: CommandCreatorArgs | null, errors?: StepFormAndFieldErrors },
+    _,
+    _
+  >(
     getStepFormWithId,
     getHydrationContext,
     (stepForm, contextualState) => {
@@ -361,6 +368,7 @@ export const makeGetArgsAndErrorsWithId = () => {
 // TODO: Brian&Ian 2019-04-02 this is TEMPORARY, should be removed once legacySteps reducer is removed
 // only need it because stepType should exist evergreen outside of legacySteps but doesn't yet
 export const makeGetStepWithId = () => {
+  // $FlowFixMe: selector is untyped. hiding error due to TODO above
   return createSelector(
     getStepFormWithId,
     getLegacyStepWithId,
@@ -404,7 +412,7 @@ export const getArgsAndErrorsByStepId: Selector<{
 
 // TODO: BC&IL 2019-04-02 this is being recomputed every time any field in unsaved forms is changed
 // this should only be computed once when a form is opened
-export const getIsNewStepForm = createSelector(
+export const getIsNewStepForm: Selector<boolean> = createSelector(
   getUnsavedForm,
   getSavedStepForms,
   (formData, savedForms) =>

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -13,8 +13,8 @@ import type { RobotState } from './'
 
 // SELECTOR UTILITIES
 
-export function sortLabwareBySlot(robotState: RobotState) {
-  return sortBy(Object.keys(robotState.labware), id =>
+export function sortLabwareBySlot(robotState: RobotState): Array<string> {
+  return sortBy<string>(Object.keys(robotState.labware), (id: string) =>
     parseInt(robotState.labware[id].slot)
   )
 }

--- a/protocol-designer/src/tutorial/reducers.js
+++ b/protocol-designer/src/tutorial/reducers.js
@@ -4,6 +4,8 @@ import { handleActions } from 'redux-actions'
 import pickBy from 'lodash/pickBy'
 import uniq from 'lodash/uniq'
 import { rehydrate } from '../persist'
+
+import type { Action } from '../types'
 import type { HintKey } from './index'
 import type { AddHintAction, RemoveHintAction } from './actions'
 
@@ -55,4 +57,4 @@ export type RootState = {
   dismissedHints: DismissedHintReducerState,
 }
 
-export const rootReducer = combineReducers(_allReducers)
+export const rootReducer = combineReducers<_, Action>(_allReducers)

--- a/protocol-designer/src/tutorial/selectors.js
+++ b/protocol-designer/src/tutorial/selectors.js
@@ -2,10 +2,11 @@
 import { createSelector } from 'reselect'
 import isEmpty from 'lodash/isEmpty'
 import type { BaseState, Selector } from '../types'
+import type { HintKey } from '.'
 
 const rootSelector = (state: BaseState) => state.tutorial
 
-export const getHint = createSelector(
+export const getHint: Selector<?HintKey> = createSelector(
   rootSelector,
   tutorial => {
     const dismissedKeys = Object.keys(tutorial.dismissedHints)

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -32,6 +32,9 @@ export type ThunkAction<A> = (
   getState: GetState
 ) => A
 
+// TODO(mc, 2018-04-18): make actual Action union type for PD
+export type Action = { type: string, payload?: mixed, metadata?: mixed }
+
 export type WellVolumes = { [wellName: string]: number }
 // TODO LATER Ian 2018-02-19 type for containers.json
 export type JsonWellData = {

--- a/protocol-designer/src/ui/index.js
+++ b/protocol-designer/src/ui/index.js
@@ -2,6 +2,7 @@
 import { combineReducers } from 'redux'
 
 import stepsReducer, { type StepsState } from './steps/reducers'
+import type { Action } from '../types'
 
 export type RootState = {|
   steps: StepsState,
@@ -11,4 +12,4 @@ export const _uiSubReducers = {
   steps: stepsReducer,
 }
 
-export const rootReducer = combineReducers(_uiSubReducers)
+export const rootReducer = combineReducers<_, Action>(_uiSubReducers)

--- a/protocol-designer/src/ui/steps/reducers.js
+++ b/protocol-designer/src/ui/steps/reducers.js
@@ -6,6 +6,7 @@ import omit from 'lodash/omit'
 
 import { getPDMetadata } from '../../file-types'
 
+import type { Action } from '../../types'
 import type { LoadFileAction } from '../../load-file'
 import type { StepIdType } from '../../form-types'
 import {
@@ -24,7 +25,8 @@ import {
   type SelectTerminalItemAction,
 } from './actions'
 
-type CollapsedStepsState = { [StepIdType]: boolean }
+export type CollapsedStepsState = { [StepIdType]: boolean }
+
 const collapsedSteps: Reducer<CollapsedStepsState, *> = handleActions(
   {
     ADD_STEP: (state: CollapsedStepsState, action: AddStepAction) => ({
@@ -106,7 +108,7 @@ const hoveredItem: Reducer<HoveredItemState, *> = handleActions(
   null
 )
 
-const hoveredSubstep = handleActions(
+const hoveredSubstep = handleActions<SubstepIdentifier, *>(
   {
     HOVER_ON_SUBSTEP: (
       state: SubstepIdentifier,
@@ -116,7 +118,7 @@ const hoveredSubstep = handleActions(
   null
 )
 
-const wellSelectionLabwareKey = handleActions(
+const wellSelectionLabwareKey = handleActions<string | null, *>(
   {
     SET_WELL_SELECTION_LABWARE_KEY: (state, action: { payload: string }) =>
       action.payload,
@@ -141,6 +143,6 @@ export const _allReducers = {
   wellSelectionLabwareKey,
 }
 
-const rootReducer = combineReducers(_allReducers)
+const rootReducer = combineReducers<_, Action>(_allReducers)
 
 export default rootReducer

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -10,8 +10,13 @@ import {
   initialSelectedItemState,
   type SelectableItem,
   type StepsState,
+  type CollapsedStepsState,
 } from './reducers'
-import type { SubstepIdentifier, TerminalItemId } from '../../steplist/types'
+import type {
+  SubstepIdentifier,
+  TerminalItemId,
+  StepItemData,
+} from '../../steplist/types'
 
 const rootSelector = (state: BaseState): StepsState => state.ui.steps
 
@@ -115,12 +120,12 @@ const getActiveItem: Selector<SelectableItem> = createSelector(
 )
 
 // TODO: BC 2018-12-17 refactor as react state
-const getCollapsedSteps = createSelector(
+const getCollapsedSteps: Selector<CollapsedStepsState> = createSelector(
   rootSelector,
   (state: StepsState) => state.collapsedSteps
 )
 
-const getSelectedStep = createSelector(
+const getSelectedStep: Selector<StepItemData | null> = createSelector(
   stepFormSelectors.getAllSteps,
   getSelectedStepId,
   (allSteps, selectedStepId) => {

--- a/protocol-designer/src/well-selection/actions.js
+++ b/protocol-designer/src/well-selection/actions.js
@@ -1,23 +1,21 @@
 // @flow
 import { createAction } from 'redux-actions'
-
 import type { Wells } from '../labware-ingred/types'
 
 // ===== Preselect / select wells in plate
 
 // these actions all use PRIMARY WELLS (see reducers for definition)
-const _wellSelectPayloadMapper = (args: Wells): Wells => args
 
-export const highlightWells = createAction(
-  'HIGHLIGHT_WELLS',
-  _wellSelectPayloadMapper
+export const highlightWells = createAction<'HIGHLIGHT_WELLS', Wells>(
+  'HIGHLIGHT_WELLS'
 )
 
-export const selectWells = createAction('SELECT_WELLS', (wells: Wells) => wells)
+export const selectWells = createAction<'SELECT_WELLS', Wells>('SELECT_WELLS')
 
-export const deselectWells = createAction(
-  'DESELECT_WELLS',
-  _wellSelectPayloadMapper
+export const deselectWells = createAction<'DESELECT_WELLS', Wells>(
+  'DESELECT_WELLS'
 )
 
-export const deselectAllWells = createAction('DESELECT_ALL_WELLS')
+export const deselectAllWells = createAction<'DESELECT_ALL_WELLS', void>(
+  'DESELECT_ALL_WELLS'
+)

--- a/protocol-designer/src/well-selection/reducers.js
+++ b/protocol-designer/src/well-selection/reducers.js
@@ -3,6 +3,7 @@ import omit from 'lodash/omit'
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 
+import type { Action } from '../types'
 import type { Wells } from '../labware-ingred/types'
 
 type WellSelectionAction = {
@@ -58,7 +59,7 @@ export type RootState = {|
   selectedWells: SelectedWellsState,
 |}
 
-const rootReducer = combineReducers({
+const rootReducer = combineReducers<_, Action>({
   selectedWells,
 })
 

--- a/protocol-designer/src/well-selection/utils.js
+++ b/protocol-designer/src/well-selection/utils.js
@@ -63,7 +63,7 @@ function _getWellSetForMultichannelDeprecated(
   return allWellSets.find((wellSet: Array<string>) => wellSet.includes(well))
 }
 
-export const getWellSetForMultichannelDeprecated = memoize(
+export const getWellSetForMultichannelDeprecated = memoize<Array<string>, _>(
   _getWellSetForMultichannelDeprecated,
   (labwareName: string, well: string) => `$LABWARE:${labwareName}--WELL:${well}`
 )

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -29,7 +29,7 @@
     "react-router-dom": "^4.1.1"
   },
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   }
 }

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "main": "js/index.js",
   "devDependencies": {
-    "flow-bin": "^0.82.0",
+    "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1"
   },
   "dependencies": {

--- a/shared-data/protocol-json-schema/jsonProtocolTypeV1.js
+++ b/shared-data/protocol-json-schema/jsonProtocolTypeV1.js
@@ -96,6 +96,7 @@ export type SchemaV1ProtocolFile<DesignerApplicationData> = {
     'touch-tip-mm-from-top'?: number,
   },
 
+  // TODO(mc, 2019-04-17): this key isn't marked required in JSON schema
   'designer-application': {
     'application-name': string,
     'application-version': ?string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5863,9 +5863,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.82.0:
-  version "0.82.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.82.0.tgz#fbec84c0d6cab7877565eca8214d655f3aefb8db"
+flow-bin@^0.97.0:
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
+  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
 
 flow-copy-source@^2.0.2:
   version "2.0.2"
@@ -5895,6 +5896,7 @@ flow-mono-cli@^1.3.4:
 flow-typed@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/flow-typed/-/flow-typed-2.5.1.tgz#0ff565cc94d2af8c557744ba364b6f14726a6b9f"
+  integrity sha1-D/VlzJTSr4xVd0S6NktvFHJqa58=
   dependencies:
     "@octokit/rest" "^15.2.6"
     babel-polyfill "^6.26.0"
@@ -8923,9 +8925,10 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
-memoize-one@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+memoize-one@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
+  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
 
 memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
@@ -11640,13 +11643,14 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-select@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.3.0.tgz#990429622445eb2b4a6e985b8069fe7d498cae91"
+react-select@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.4.3.tgz#62efdf76d7e33e9bde22d907a0cc8abd0aeab656"
+  integrity sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==
   dependencies:
     classnames "^2.2.5"
     emotion "^9.1.2"
-    memoize-one "^4.0.0"
+    memoize-one "^5.0.0"
     prop-types "^15.6.0"
     raf "^3.4.0"
     react-input-autosize "^2.2.1"


### PR DESCRIPTION
## overview

AKA the one where I drag our JS codebase, kicking and screaming, up to flow v0.97.0. I used the following guides to help me out:

- https://medium.com/flow-type/upgrading-flow-codebases-40ef8dd3ccd8
- https://gist.github.com/jbrown215/f425203ef30fdc8a28c213b90ba7a794

## changelog

- refactor(js): Upgrade flow to 0.97.0 and fix new typecheck failures 

(After the upgrade, there were **532** new Flow failures)

## review requests

New JS dependencies added, please **remember to run `make install-js`**

### motivation

Our Flow version has become very out of date, with a number of improvements landing in the interem that would improve both our QoL and typechecking correctness:

- Flow can run commands in parallel and continue to report type data while rechecking
- Alleged ~15% reduction in memory usage 
- React.AbstractComponent for [HOCs](https://flow.org/en/docs/react/hoc/)
- [Stopped suppressing missing type annotations](https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) that caused implicit `any`s
    - Adding those missing annotations was the bulk of the work in this PR
- Support for wildcard `_` type argument in functions and constructors
- Bugfixes with type loss at module boundries

#### Missing type annotations in `connect` calls

Most of our "missing" type annotations where in calls to `react-redux`. With this flow upgrade and an upgraded libdef for `react-redux`, the recommended way to type our connected components (see gist link above) is:

```js
// top-level state and dispatch types
import type {State, Dispatch} from '../types'

// own props, state props, dispatch props, props
type OP = {| foo: string |}
type SP = {| bar: string |}
type DP = {| baz: string |}
type Props = {| ...OP, ...SP, ...DP |}

// anonymous or named function incidental for this example
const mapStateToProps = (state: State, ownProps: OP): SP => { /* ... */ }
const mapDispatchToProps = (dispatch: Dispatch, ownProps: OP): DP => { /* ... */ }

function Component(props: Props) {
  // ...
}

export default connect<Props, OP, SP, DP, State, Dispatch>(
  mapStateToProps,
  mapDispatchToProps
)(Component)
```

If you're not using a particular `mapXtoY` function, use an empty exact object `{||}` for the type argument. Also, a lot of the time, it only really needs `Props` and `OP`, the rest can be `_`. According to the [flow docs, however](https://flow.org/en/docs/types/generics/#toc-supplying-type-arguments-to-callables), type inference with `_` means you take a performance hit, so I think it's good to put as many in as you have if you feel like it

**Important to note**

Please note the use of exact objects `{||}` rather than inexact objects `{}`. We're doing this because:

- This is what the react-redux libdef requires
- Flow will be [switching to exact objects by default](https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf) at some point

Exact objects for props has some upsides and downsides:

1. Con: Flow doesn't like prop spreads if there are extra props in the object you're spreading
2. Pro: Flow will let you know if you accidentally pass an unnecessary prop into a component

(1) is frustrating, but I think the value in (2) in terms of refactoring outweighs the annoyance of (1). During this refactor, I `$FlowFixMe`'d exactly 1 inexact spread but caught several no-longer-used props (or required props that were not getting passed in).

TypeScript is also exact-objects-by-default, and after using it in a non-trival React project I have come around to the idea that exact objects are the way to go

### high risk areas to test

In a few places, it was easier to refactor the shape of component props than it was to try to get the types to work. These refactors touched:

- [ ] Deck calibration
- [ ] Labware calibration
- [ ] Change pipette
- [ ] Tip Probe

### $FlowFixMe accounting

- Added by this PR: **59**
- Removed by this PR: **14**

Which leaves us with
- Total: **101**
- App: **64**
    - 31 are in `app/src/http-api-client`, which has been problematic for a little while
    - 17 are in `app/src/robot/selectors`, which select stuff from RPC state and have been untyped for some time
    - Almost all the remaining 16 are legacy RPC API action creators that have never been typed
- PD: **32**
    - 18 are in unit tests
- Components: **3**
- Discovery Client: **2**
