### PR TITLE
fix(app): Disable manual ip double submit on enter keypress

### DIFF
--- a/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
+++ b/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
@@ -31,7 +31,12 @@ class IpForm extends React.Component<Props> {
       <Formik
         initialValues={{ ip: '' }}
         onSubmit={(values, actions) => {
-          this.props.addManualIp(values.ip)
+          // guard against double submit on enter keypress
+          if (!values.ip) return
+          // strip all whitespace and carriage returns
+          const ip = values.ip.replace(/\r?\n|\r|\s+/g, '')
+
+          this.props.addManualIp(ip)
 
           const $input = this.inputRef.current
           if ($input) $input.blur()

--- a/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
+++ b/app/src/components/AppSettings/AddManualIp/ManualIpForm.js
@@ -31,10 +31,10 @@ class IpForm extends React.Component<Props> {
       <Formik
         initialValues={{ ip: '' }}
         onSubmit={(values, actions) => {
+          // trim whitespace and carriage returns
+          const ip = values.ip.trim()
           // guard against double submit on enter keypress
-          if (!values.ip) return
-          // strip all whitespace and carriage returns
-          const ip = values.ip.replace(/\r?\n|\r|\s+/g, '')
+          if (!ip) return
 
           this.props.addManualIp(ip)
 


### PR DESCRIPTION
## overview

This PR serves as a bug report and fix. While testing for release, @sfoster1 noticed that clicking the [enter] key to submit a manual IP submitted a blank entry.  Turns out clicking enter submitted the form after it was reset. This PR disables submission if `values.ip` is empty and strips out any whitespace or carriage returns that might have been entered just to be extra paranoid.

## changelog

- fix(app): Disable manual ip double submit on enter keypress

## review requests

To test in dev mode comment out link 55 in `app-shell/Makefile`

```
make -C app dev
make -C api dev
```
- add 'localhost' to manual IP
- submit form by hitting [enter] key

- [ ] localhost is discovered after submit
- [ ] clicking [+]  to submit still works
- [ ] onBlur still submits properly
- [ ] extraneous whitespace is trimmed from any entry (try  'localhost ' or 'localhost\n')
