### PR TITLE
fix(api): Correctly specify jsonschema in setup.py install_requires

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -108,7 +108,7 @@ INSTALL_REQUIRES = [
     'aiohttp==2.3.8',
     'numpy>=1.12.1',
     'urwid==1.3.1',
-    'jsonschema==*',
+    'jsonschema',
 ]
 
 


### PR DESCRIPTION
In install_requires format, you don't do ==* to unlock a version, you just don't
use a version specifier. ==* causes the install to fail.

This pull requests serves as a bug report and fix.