### PR TITLE
refactor(labware-library): Add mobile nav toggle

### DIFF
--- a/labware-library/src/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/labware-library/src/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -1,26 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Nav component renders 1`] = `
-<nav
-  className="nav"
->
-  <div
-    className="subdomain_nav_wrapper"
+<Fragment>
+  <nav
+    className="nav"
   >
     <div
-      className="nav_container"
+      className="subdomain_nav_wrapper"
     >
-      <SubdomainNav />
+      <div
+        className="nav_container"
+      >
+        <SubdomainNav />
+      </div>
     </div>
-  </div>
-  <div
-    className="main_nav_wrapper"
-  >
     <div
-      className="nav_container"
+      className="main_nav_wrapper"
     >
-      <MainNav />
+      <div
+        className="nav_container"
+      >
+        <MainNav
+          isMobileOpen={false}
+          onMobileClick={[Function]}
+        />
+      </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</Fragment>
 `;

--- a/labware-library/src/components/Nav/index.js
+++ b/labware-library/src/components/Nav/index.js
@@ -1,24 +1,48 @@
 // @flow
 // top nav bar component
 import * as React from 'react'
-import { SubdomainNav, MainNav } from '../website-navigation'
+import { SubdomainNav, MainNav, MobileNav } from '../website-navigation'
 import styles from './styles.css'
 
 export { default as Breadcrumbs } from './Breadcrumbs'
 
-export default function Nav() {
-  return (
-    <nav className={styles.nav}>
-      <div className={styles.subdomain_nav_wrapper}>
-        <div className={styles.nav_container}>
-          <SubdomainNav />
-        </div>
-      </div>
-      <div className={styles.main_nav_wrapper}>
-        <div className={styles.nav_container}>
-          <MainNav />
-        </div>
-      </div>
-    </nav>
-  )
+type State = {
+  isOpen: boolean,
+}
+
+type Props = {||}
+
+export default class Nav extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { isOpen: false }
+  }
+
+  toggle = () => {
+    this.setState({ isOpen: !this.state.isOpen })
+    document.body && document.body.classList.toggle('no_scroll')
+  }
+
+  render() {
+    return (
+      <>
+        <nav className={styles.nav}>
+          <div className={styles.subdomain_nav_wrapper}>
+            <div className={styles.nav_container}>
+              <SubdomainNav />
+            </div>
+          </div>
+          <div className={styles.main_nav_wrapper}>
+            <div className={styles.nav_container}>
+              <MainNav
+                onMobileClick={() => this.toggle()}
+                isMobileOpen={this.state.isOpen}
+              />
+            </div>
+          </div>
+        </nav>
+        {this.state.isOpen && <MobileNav />}
+      </>
+    )
+  }
 }

--- a/labware-library/src/components/Nav/index.js
+++ b/labware-library/src/components/Nav/index.js
@@ -23,6 +23,10 @@ export default class Nav extends React.Component<Props, State> {
     document.body && document.body.classList.toggle('no_scroll')
   }
 
+  componentWillUnmount() {
+    document.body && document.body.classList.remove('no_scroll')
+  }
+
   render() {
     return (
       <>
@@ -35,7 +39,7 @@ export default class Nav extends React.Component<Props, State> {
           <div className={styles.main_nav_wrapper}>
             <div className={styles.nav_container}>
               <MainNav
-                onMobileClick={() => this.toggle()}
+                onMobileClick={this.toggle}
                 isMobileOpen={this.state.isOpen}
               />
             </div>

--- a/labware-library/src/components/Nav/styles.css
+++ b/labware-library/src/components/Nav/styles.css
@@ -23,9 +23,9 @@ are project specific  */
 
 .main_nav_wrapper {
   width: 100%;
-  height: var(--size-main-nav);
+  height: var(--size-mobile-nav);
   background-color: var(--c-white);
-  box-shadow: var(--shadow-1);
+  border-bottom: var(--bd-light);
 }
 
 .nav_container {
@@ -74,6 +74,12 @@ are project specific  */
 }
 
 @media (--medium) {
+  .main_nav_wrapper {
+    height: var(--size-main-nav);
+    border: none;
+    box-shadow: var(--shadow-1);
+  }
+
   .nav_container,
   .breadcrumbs_contents {
     padding-left: var(--spacing-7);

--- a/labware-library/src/components/website-navigation/MainNav.js
+++ b/labware-library/src/components/website-navigation/MainNav.js
@@ -1,4 +1,4 @@
-// flow
+// @flow
 import * as React from 'react'
 import Logo from './Logo'
 import { NavList } from './NavList'

--- a/labware-library/src/components/website-navigation/MainNav.js
+++ b/labware-library/src/components/website-navigation/MainNav.js
@@ -5,12 +5,17 @@ import { NavList } from './NavList'
 import MenuButton from './MenuButton'
 import styles from './styles.css'
 
-export function MainNav() {
+import type { MobileNavProps } from './types'
+
+export function MainNav(props: MobileNavProps) {
   return (
     <div className={styles.main_nav_contents}>
       <Logo />
       <NavList />
-      <MenuButton />
+      <MenuButton
+        onMobileClick={props.onMobileClick}
+        isMobileOpen={props.isMobileOpen}
+      />
     </div>
   )
 }

--- a/labware-library/src/components/website-navigation/MenuButton.js
+++ b/labware-library/src/components/website-navigation/MenuButton.js
@@ -3,29 +3,19 @@ import * as React from 'react'
 import cx from 'classnames'
 import styles from './styles.css'
 import { Icon } from '@opentrons/components'
-import type { ButtonProps, IconProps } from '@opentrons/components'
+import type { IconProps } from '@opentrons/components'
+import type { MobileNavProps } from './types'
 
-type State = {
-  isOpen: boolean,
-}
-
-export default class MenuButton extends React.Component<ButtonProps, State> {
-  constructor(props: ButtonProps) {
-    super(props)
-    this.state = { isOpen: false }
-  }
-
-  render() {
-    const iconName = this.state.isOpen ? 'close' : 'menu'
-    return (
-      <ClickableIcon
-        title="menu"
-        name={iconName}
-        className={styles.menu_button}
-        onClick={() => this.setState({ isOpen: !this.state.isOpen })}
-      />
-    )
-  }
+export default function MenuButton(props: MobileNavProps) {
+  const iconName = props.isMobileOpen ? 'close' : 'menu'
+  return (
+    <ClickableIcon
+      title="menu"
+      name={iconName}
+      className={styles.menu_button}
+      onClick={props.onMobileClick}
+    />
+  )
 }
 
 // ONEOFF: Needed for overriding button styles, possible candidate for ui/

--- a/labware-library/src/components/website-navigation/MobileMenu.js
+++ b/labware-library/src/components/website-navigation/MobileMenu.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import { Icon } from '@opentrons/components'
+import styles from './styles.css'
+
+import type { Submenu } from './types'
+
+type Props = {|
+  ...Submenu,
+  active: boolean,
+  onClick: () => mixed,
+|}
+
+export default function MobileMenu(props: Props) {
+  const { name, active, onClick } = props
+  return (
+    <>
+      <span onClick={onClick}>{name}</span>
+      <div className={cx(styles.mobile_menu, { [styles.active]: active })}>
+        <div className={styles.mobile_menu_heading} onClick={onClick}>
+          <Icon className={styles.mobile_menu_icon} name="arrow-left" />
+          <h3 className={styles.mobile_menu_title}>{name}</h3>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/labware-library/src/components/website-navigation/MobileNav.js
+++ b/labware-library/src/components/website-navigation/MobileNav.js
@@ -1,0 +1,16 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+// TODO (ka 2019-4-25): Mobile nav items to toggle menu state/submenu
+export function MobileNav() {
+  return (
+    <ul className={styles.mobile_nav}>
+      <li className={styles.mobile_nav_item}>About</li>
+      <li className={styles.mobile_nav_item}>Products</li>
+      <li className={styles.mobile_nav_item}>Applications</li>
+      <li className={styles.mobile_nav_item}>Protocols</li>
+      <li className={styles.mobile_nav_item}>Support & Sales</li>
+    </ul>
+  )
+}

--- a/labware-library/src/components/website-navigation/MobileNav.js
+++ b/labware-library/src/components/website-navigation/MobileNav.js
@@ -1,16 +1,65 @@
 // @flow
 import * as React from 'react'
 import styles from './styles.css'
+import MobileMenu from './MobileMenu'
+import {
+  navLinkProps,
+  protocolLinkProps,
+  supportLinkProps,
+  salesLinkProps,
+} from './nav-data'
+import type { MenuName } from './types'
 
-// TODO (ka 2019-4-25): Mobile nav items to toggle menu state/submenu
-export function MobileNav() {
-  return (
-    <ul className={styles.mobile_nav}>
-      <li className={styles.mobile_nav_item}>About</li>
-      <li className={styles.mobile_nav_item}>Products</li>
-      <li className={styles.mobile_nav_item}>Applications</li>
-      <li className={styles.mobile_nav_item}>Protocols</li>
-      <li className={styles.mobile_nav_item}>Support & Sales</li>
-    </ul>
-  )
+type State = {| menu: null | MenuName |}
+
+type Props = {||}
+
+export class MobileNav extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { menu: null }
+  }
+
+  clear = () => this.setState({ menu: null })
+
+  toggle = (name: MenuName) =>
+    this.setState({ menu: this.state.menu !== name ? name : null })
+
+  render() {
+    const { menu } = this.state
+    return (
+      <ul className={styles.mobile_nav}>
+        {navLinkProps.map(subnav => (
+          <li
+            className={styles.mobile_nav_item}
+            key={subnav.name}
+            role="button"
+          >
+            <MobileMenu
+              {...subnav}
+              active={menu === subnav.name}
+              onClick={() => this.toggle(subnav.name)}
+            />
+          </li>
+        ))}
+        <li className={styles.mobile_nav_item} role="button">
+          <MobileMenu
+            {...protocolLinkProps}
+            name="Protocols"
+            active={menu === 'Protocols'}
+            onClick={() => this.toggle('Protocols')}
+          />
+        </li>
+        <li className={styles.mobile_nav_item} role="button">
+          <MobileMenu
+            {...supportLinkProps}
+            {...salesLinkProps}
+            name="Support & Sales"
+            active={menu === 'Support'}
+            onClick={() => this.toggle('Support')}
+          />
+        </li>
+      </ul>
+    )
+  }
 }

--- a/labware-library/src/components/website-navigation/index.js
+++ b/labware-library/src/components/website-navigation/index.js
@@ -5,3 +5,4 @@
 export * from './SubdomainNav'
 export { MainNav } from './MainNav'
 export { NavList } from './NavList'
+export { MobileNav } from './MobileNav'

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -273,12 +273,12 @@
 }
 
 .mobile_nav {
-  display: block;
   position: fixed;
   width: 100%;
+  padding: 0;
+  padding-bottom: var(--spacing-5);
+  background-color: var(--c-white);
   z-index: 900;
-  padding: 1rem;
-  background-color: white;
 
   /* Added this for contrast with page - does not match design */
   box-shadow: var(--shadow-1);
@@ -287,15 +287,60 @@
 .mobile_nav_item {
   @apply --flex-start;
 
-  padding: 2rem;
-  height: 3rem;
+  padding: var(--spacing-7);
+  height: var(--size-2);
   font-weight: var(--fw-semibold);
   cursor: pointer;
+
+  &:first-child {
+    padding-top: 2.5rem;
+  }
+}
+
+.mobile_menu {
+  position: fixed;
+  top: var(--size-main-nav);
+  right: 0;
+  width: 100%;
+  min-height: calc(100vh - var(--size-main-nav));
+  margin: 0 -100% 0 0;
+  background-color: var(--c-white);
+  box-shadow: var(--shadow-1);
+  z-index: 950;
+  transition: margin 0.5s linear;
+
+  &.active {
+    margin: 0;
+  }
+}
+
+.mobile_menu_heading {
+  @apply --flex-start;
+
+  height: 5rem;
+  border-bottom: var(--bd-light);
+}
+
+.mobile_menu_icon {
+  position: absolute;
+  left: 0;
+  width: 3rem;
+}
+
+.mobile_menu_title {
+  width: 100%;
+  text-align: center;
+  font-size: var(--fs-default);
+  font-weight: var(--fw-semibold);
 }
 
 @media (--medium) {
   .mobile_nav_item {
     justify-content: center;
+  }
+
+  .mobile_menu {
+    min-height: 30rem;
   }
 }
 

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -75,7 +75,7 @@
 
   height: 100%;
   width: 100%;
-  padding: var(--spacing-5) 0;
+  padding: var(--spacing-3) 0;
 }
 
 .logo {
@@ -264,7 +264,7 @@
 .menu_button {
   @apply --transition-color;
 
-  flex: 0 0 5rem;
+  flex: 0 0 4rem;
   color: var(--c-font-dark);
 
   &:hover {
@@ -299,7 +299,7 @@
 
 .mobile_menu {
   position: fixed;
-  top: var(--size-main-nav);
+  bottom: 0;
   right: 0;
   width: 100%;
   min-height: calc(100vh - var(--size-main-nav));
@@ -324,7 +324,7 @@
 .mobile_menu_icon {
   position: absolute;
   left: 0;
-  width: 3rem;
+  width: var(--size-2);
 }
 
 .mobile_menu_title {

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -272,8 +272,36 @@
   }
 }
 
+.mobile_nav {
+  display: block;
+  position: fixed;
+  width: 100%;
+  z-index: 900;
+  padding: 1rem;
+  background-color: white;
+
+  /* Added this for contrast with page - does not match design */
+  box-shadow: var(--shadow-1);
+}
+
+.mobile_nav_item {
+  @apply --flex-start;
+
+  padding: 2rem;
+  height: 3rem;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+}
+
+@media (--medium) {
+  .mobile_nav_item {
+    justify-content: center;
+  }
+}
+
 @media (--desktop) {
-  .menu_button {
+  .menu_button,
+  .mobile_nav {
     display: none;
   }
 

--- a/labware-library/src/components/website-navigation/types.js
+++ b/labware-library/src/components/website-navigation/types.js
@@ -51,3 +51,8 @@ export type SalesSubmenuName = 'order' | 'sales' | 'demo'
 export type SalesLinks = {
   [SalesSubmenuName]: Link,
 }
+
+export type MobileNavProps = {|
+  isMobileOpen: boolean,
+  onMobileClick?: (event: SyntheticMouseEvent<>) => mixed,
+|}

--- a/labware-library/src/components/website-navigation/types.js
+++ b/labware-library/src/components/website-navigation/types.js
@@ -53,6 +53,6 @@ export type SalesLinks = {
 }
 
 export type MobileNavProps = {|
-  isMobileOpen: boolean,
+  isMobileOpen?: boolean,
   onMobileClick?: (event: SyntheticMouseEvent<>) => mixed,
 |}

--- a/labware-library/src/styles.global.css
+++ b/labware-library/src/styles.global.css
@@ -10,3 +10,8 @@ body,
 #root {
   height: 100%;
 }
+
+/* disable scroll when mobile nav open */
+body.no_scroll {
+  overflow: hidden;
+}

--- a/labware-library/src/styles/spacing.css
+++ b/labware-library/src/styles/spacing.css
@@ -35,6 +35,7 @@
   /* main navigation specific width and height sizes */
   --size-subdomain-nav: 2rem; /* 32px */
   --size-main-nav: 5rem; /* 80px */
+  --size-mobile-nav: 4rem; /* 64px */
   --size-total-nav: calc(var(--size-subdomain-nav) + var(--size-main-nav));
 
   /* aspect ratios */


### PR DESCRIPTION
## overview

This PR refactors a few of the nav components to keep track of mobile nav toggle and adds in hardcoded starter for the mobile menu. 
 
addresses #3382 

## changelog

- refactor(labware-library): Add mobile nav toggle

## review requests

Opened this PR now to make sure this refactor makes sense before going to far. 

Disabled scroll on page for mobile, but can't seem to figure out how to affect content_scroller div on tablet size. Suggestions welcome.

I also added a drop shadow to the bottom of the mobile nav since the white on white didn't seem to have enough contrast with the page content.

- [ ] desktop nav unaffected
- [ ] clicking mobile nav toggles icon and main mobile nav visibility
- [ ] clicking mobile nav links slides in correct submenu skelton component

http://sandbox.labware.opentrons.com/lablib_mobile-nav/

## TODO (next PR)
- populate subnav content/links
- possibly split up mobile and desktop nav components/styles into separate directories?