### PR TITLE
fix(protocol-designer): cast offsetFromBottomMm values to number

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -63,6 +63,9 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
     castValue: Number,
   },
+  aspirate_mmFromBottom: {
+    castValue: Number,
+  },
   aspirate_wells: {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     maskValue: defaultTo([]),
@@ -82,6 +85,9 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   dispense_mix_volume: {
     maskValue: composeMaskers(maskToFloat, onlyPositiveNumbers),
+    castValue: Number,
+  },
+  dispense_mmFromBottom: {
     castValue: Number,
   },
   dispense_wells: {


### PR DESCRIPTION
Some string values were being written to the the offsetFromBottomMm key of certain commands, this
patch casts those values in the field level so that stepFromToArgs only receives numbers for tip
position fields

This ticket serves as the issue and fix for a bug that was initially reported by @opatel0 