### PR TITLE
refactor(api): Split smoothie command ack timeout from motion

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -848,7 +848,7 @@ class SmoothieDriver_3_0_0:
         self._handle_return(cmd_ret, GCODES['HOME'] in command)
         wait_ret = serial_communication.write_and_return(
             GCODES['WAIT'] + SMOOTHIE_COMMAND_TERMINATOR,
-            SMOOTHIE_ACK, self._connection, timeout=300)
+            SMOOTHIE_ACK, self._connection, timeout=12000)
         wait_ret = self._remove_unwanted_characters(
             GCODES['WAIT'], wait_ret)
         self._handle_return(wait_ret, GCODES['HOME'] in command)

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -146,11 +146,16 @@ def test_dwell_and_activate_axes(smoothie, monkeypatch):
     smoothie.dwell_axes('BCY')
     smoothie._set_saved_current()
     expected = [
-        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'],
-        ['M907 A0.1 B0.5 C0.5 X1.25 Y1.25 Z0.1 G4P0.005 M400'],
-        ['M907 A0.1 B0.5 C0.05 X0.3 Y1.25 Z0.1 G4P0.005 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400']
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.5 C0.5 X1.25 Y1.25 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.5 C0.05 X0.3 Y1.25 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -179,9 +184,12 @@ def test_disable_motor(smoothie, monkeypatch):
     smoothie.disengage_axis('XYZ')
     smoothie.disengage_axis('ABCD')
     expected = [
-        ['M18X M400'],
-        ['M18[XYZ]+ M400'],
-        ['M18[ABC]+ M400']
+        ['M18X'],
+        ['M400'],
+        ['M18[XYZ]+'],
+        ['M400'],
+        ['M18[ABC]+'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -210,23 +218,40 @@ def test_plunger_commands(smoothie, monkeypatch):
 
     smoothie.home()
     expected = [
-        ['M907 A0.8 B0.5 C0.5 X0.3 Y0.3 Z0.8 G4P0.005 G28.2.+[ABCZ].+ M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'],
-        ['M203.1 Y50 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4P0.005 G91 G0Y-28 G0Y10 G90 M400'],  # NOQA
-        ['M203.1 X80 M400'],
-        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G28.2X M400'],
-        ['M203.1 A125 B40 C40 X600 Y400 Z125 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'],
-        ['M203.1 Y80 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4P0.005 G28.2Y M400'],
-        ['M203.1 Y8 M400'],
-        ['G91 G0Y-3 G90 M400'],
-        ['G28.2Y M400'],
-        ['G91 G0Y-3 G90 M400'],
-        ['M203.1 A125 B40 C40 X600 Y400 Z125 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'],
-        ['M114.2 M400']
+        ['M907 A0.8 B0.5 C0.5 X0.3 Y0.3 Z0.8 G4P0.005 G28.2.+[ABCZ].+'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M203.1 Y50'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4P0.005 G91 G0Y-28 G0Y10 G90'],
+        ['M400'],
+        ['M203.1 X80'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G28.2X'],
+        ['M400'],
+        ['M203.1 A125 B40 C40 X600 Y400 Z125'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M203.1 Y80'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4P0.005 G28.2Y'],
+        ['M400'],
+        ['M203.1 Y8'],
+        ['M400'],
+        ['G91 G0Y-3 G90'],
+        ['M400'],
+        ['G28.2Y'],
+        ['M400'],
+        ['G91 G0Y-3 G90'],
+        ['M400'],
+        ['M203.1 A125 B40 C40 X600 Y400 Z125'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
+        ['M114.2'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -235,7 +260,8 @@ def test_plunger_commands(smoothie, monkeypatch):
 
     smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
     expected = [
-        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+ M400']
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -244,8 +270,10 @@ def test_plunger_commands(smoothie, monkeypatch):
 
     smoothie.move({'B': 2})
     expected = [
-        ['M907 A0.1 B0.5 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B2 M400'],
-        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400']
+        ['M907 A0.1 B0.5 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B2'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -261,9 +289,11 @@ def test_plunger_commands(smoothie, monkeypatch):
         'C': 5})
     expected = [
         # Set active axes high
-        ['M907 A0.8 B0.5 C0.5 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+ M400'],
+        ['M907 A0.8 B0.5 C0.5 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],
+        ['M400'],
         # Set plunger current low
-        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 M400'],
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -300,13 +330,20 @@ def test_set_active_current(smoothie, monkeypatch):
     smoothie.set_active_current({'B': 0.42, 'C': 0.42})
     smoothie.home('BC')
     expected = [
-        ['M907 A2 B2 C2 X2 Y2 Z2 G4P0.005 G0A0B0C0X0Y0Z0 M400'],  # move all
-        ['M907 A2 B0 C0 X2 Y2 Z2 G4P0.005 M400'],  # disable BC axes
-        ['M907 A0 B2 C2 X0 Y0 Z0 G4P0.005 G0B1.3C1.3 G0B1C1 M400'],  # move BC
-        ['M907 A0 B0 C0 X0 Y0 Z0 G4P0.005 M400'],  # disable BC axes
-        ['M907 A0 B0.42 C0.42 X0 Y0 Z0 G4P0.005 G28.2BC M400'],  # home BC
-        ['M907 A0 B0 C0 X0 Y0 Z0 G4P0.005 M400'],  # dwell all axes after home
-        ['M114.2 M400']  # update the position
+        ['M907 A2 B2 C2 X2 Y2 Z2 G4P0.005 G0A0B0C0X0Y0Z0'],  # move all
+        ['M400'],
+        ['M907 A2 B0 C0 X2 Y2 Z2 G4P0.005'],  # disable BC axes
+        ['M400'],
+        ['M907 A0 B2 C2 X0 Y0 Z0 G4P0.005 G0B1.3C1.3 G0B1C1'],  # move BC
+        ['M400'],
+        ['M907 A0 B0 C0 X0 Y0 Z0 G4P0.005'],  # disable BC axes
+        ['M400'],
+        ['M907 A0 B0.42 C0.42 X0 Y0 Z0 G4P0.005 G28.2BC'],  # home BC
+        ['M400'],
+        ['M907 A0 B0 C0 X0 Y0 Z0 G4P0.005'],  # dwell all axes after home
+        ['M400'],
+        ['M114.2'],  # update the position
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -342,10 +379,14 @@ def test_set_acceleration(smoothie, monkeypatch):
     smoothie.pop_acceleration()
 
     expected = [
-        ['M204 S10000 A4 B5 C6 X1 Y2 Z3 M400'],
-        ['M204 S10000 A4 B5 C6 X1 Y2 Z3 M400'],
-        ['M204 S10000 A40 B50 C60 X10 Y20 Z30 M400'],
-        ['M204 S10000 A4 B5 C6 X1 Y2 Z3 M400']
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
+        ['M204 S10000 A40 B50 C60 X10 Y20 Z30'],
+        ['M400'],
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -676,16 +717,21 @@ def test_clear_limit_switch(smoothie, monkeypatch):
 
     assert [c.strip() for c in cmd_list] == [
         # attempt to move and fail
-        'M907 A0.1 B0.05 C0.5 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100 M400',
+        'M907 A0.1 B0.05 C0.5 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',
         # recover from failure
-        'M999 M400',
+        'M999',
+        'M400',
         # set current for homing the failed axis (C)
-        'M907 A0.1 B0.05 C0.5 X0.3 Y0.3 Z0.1 G4P0.005 G28.2C M400',
+        'M907 A0.1 B0.05 C0.5 X0.3 Y0.3 Z0.1 G4P0.005 G28.2C',
+        'M400',
         # set current back to idling after home
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400',
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',
+        'M400',
         # update position
-        'M114.2 M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 M400'
+        'M114.2',
+        'M400',
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',
+        'M400',
     ]
 
 
@@ -760,10 +806,10 @@ def test_speed_change(model, monkeypatch):
     pipette.aspirate(10)
     pipette.dispense(10)
     expected = [
-        ['G0F1200 M400'],  # pipette's default aspirate speed in mm/min
-        ['G0F24000 M400'],
-        ['G0F2400 M400'],  # pipette's default dispense speed in mm/min
-        ['G0F24000 M400']
+        ['G0F1200'],  # pipette's default aspirate speed in mm/min
+        ['G0F24000'],
+        ['G0F2400'],  # pipette's default dispense speed in mm/min
+        ['G0F24000'],
     ]
     # from pprint import pprint
     # pprint(command_log)
@@ -795,12 +841,12 @@ def test_max_speed_change(model, monkeypatch):
     robot._driver.set_speed(321)
     robot._driver.pop_speed()
     expected = [
-        ['G0F{} M400'.format(555 * 60)],
-        ['M203.1 A4 B5 C6 X1 Y2 Z3 M400'],
-        ['M203.1 X7 M400'],
-        ['G0F{} M400'.format(123 * 60)],
-        ['G0F{} M400'.format(321 * 60)],
-        ['G0F{} M400'.format(123 * 60)]
+        ['G0F{}'.format(555 * 60)],
+        ['M203.1 A4 B5 C6 X1 Y2 Z3'],
+        ['M203.1 X7'],
+        ['G0F{}'.format(123 * 60)],
+        ['G0F{}'.format(321 * 60)],
+        ['G0F{}'.format(123 * 60)],
     ]
     # from pprint import pprint
     # pprint(command_log)


### PR DESCRIPTION
Currently, after every command we send an M400, which delays until the
smoothie's queue is empty. We couple this with retrying unacked commands. The
problem is, this couples command acknowledgement with command execution. The
timeouts need to be short enough to be responsive if a command isn't
acknowledged, but short timeouts cause problems with commands that take a long
time - like long motions at low speeds.

Instead, write the command and retry it if not acknowledged, but do not do an
M400 until the command is acknowledged. Once that's done, you can use a very
long timeout for the M400 without worrying about having to retry.

Closes #3300, closes #2822

## Testing

Run a bunch of protocols! Especially ones that slow the head speed down. Make sure you don't get timeouts. The protocol from #2822 is a good one to use, although that's the one I already used to test it.