### PR TITLE
refactor(components): move LabwareRender to component lib; split into RobotLabware vs LabwareRender

### DIFF
--- a/components/src/deck/LabwareRender.js
+++ b/components/src/deck/LabwareRender.js
@@ -1,28 +1,28 @@
 // @flow
-// standalone render of RobotLabware component
+// standalone render of a labware framed by a slot
 import * as React from 'react'
 
-import {
-  SLOT_RENDER_WIDTH,
-  SLOT_RENDER_HEIGHT,
-  type LabwareDefinition2,
-} from '@opentrons/shared-data'
+import { SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT } from '@opentrons/shared-data'
 import RobotLabware from './RobotLabware'
 import styles from './labwareRender.css'
 
-type Props = {
-  /** A labware definition object (eg from shared-data) to render */
-  definition: LabwareDefinition2,
-}
+type Props = React.ElementProps<typeof RobotLabware>
 
 export default function LabwareRender(props: Props) {
-  // SVG coordinate system is flipped in Y from our definitions
-  const transform = `translate(0,${SLOT_RENDER_HEIGHT}) scale(1,-1)`
+  // SVG coordinate system is flipped in Y from our robot coordinate system.
+  // Note that this reflection via scaling happens via CSS on the SVG element,
+  // not using `transform` attr on an element inside an SVG, so no translation is needed
+  // and the robot X, Y points are preserved.
+  const transform = `scale(1,-1)`
   const viewBox = `0 0 ${SLOT_RENDER_WIDTH} ${SLOT_RENDER_HEIGHT}`
 
   return (
-    <svg className={styles.labware_render} viewBox={viewBox}>
-      <RobotLabware transform={transform} definition={props.definition} />
+    <svg
+      className={styles.labware_render}
+      viewBox={viewBox}
+      style={{ transform }}
+    >
+      <RobotLabware definition={props.definition} />
     </svg>
   )
 }

--- a/components/src/deck/LabwareRender.js
+++ b/components/src/deck/LabwareRender.js
@@ -1,0 +1,28 @@
+// @flow
+// standalone render of RobotLabware component
+import * as React from 'react'
+
+import {
+  SLOT_RENDER_WIDTH,
+  SLOT_RENDER_HEIGHT,
+  type LabwareDefinition2,
+} from '@opentrons/shared-data'
+import RobotLabware from './RobotLabware'
+import styles from './labwareRender.css'
+
+type Props = {
+  /** A labware definition object (eg from shared-data) to render */
+  definition: LabwareDefinition2,
+}
+
+export default function LabwareRender(props: Props) {
+  // SVG coordinate system is flipped in Y from our definitions
+  const transform = `translate(0,${SLOT_RENDER_HEIGHT}) scale(1,-1)`
+  const viewBox = `0 0 ${SLOT_RENDER_WIDTH} ${SLOT_RENDER_HEIGHT}`
+
+  return (
+    <svg className={styles.labware_render} viewBox={viewBox}>
+      <RobotLabware transform={transform} definition={props.definition} />
+    </svg>
+  )
+}

--- a/components/src/deck/LabwareRender.md
+++ b/components/src/deck/LabwareRender.md
@@ -1,0 +1,7 @@
+```js
+const definition = require('@opentrons/shared-data/fixtures/fixture96Plate')
+;<div>
+  <h1>wooo</h1>
+  <LabwareRender definition={definition} />
+</div>
+```

--- a/components/src/deck/LabwareRender.md
+++ b/components/src/deck/LabwareRender.md
@@ -1,7 +1,4 @@
 ```js
 const definition = require('@opentrons/shared-data/fixtures/fixture96Plate')
-;<div>
-  <h1>wooo</h1>
-  <LabwareRender definition={definition} />
-</div>
+;<LabwareRender definition={definition} />
 ```

--- a/components/src/deck/RobotLabware.js
+++ b/components/src/deck/RobotLabware.js
@@ -1,5 +1,5 @@
 // @flow
-// render labware definition to SVG
+// Render labware definition to SVG. XY is in robot coordinates.
 import * as React from 'react'
 import flatMap from 'lodash/flatMap'
 import cx from 'classnames'
@@ -16,7 +16,6 @@ import type {
 
 type Props = {
   definition: LabwareDefinition2,
-  transform?: string,
 }
 
 type WellProps = {
@@ -30,7 +29,7 @@ export default function RobotLabware(props: Props) {
   const { isTiprack } = parameters
 
   return (
-    <g transform={props.transform}>
+    <g>
       <g className={styles.labware_detail_group}>
         <LabwareOutline
           className={cx({ [styles.tiprack_outline]: isTiprack })}

--- a/components/src/deck/RobotLabware.js
+++ b/components/src/deck/RobotLabware.js
@@ -1,48 +1,42 @@
 // @flow
 // render labware definition to SVG
-// TODO(mc, 2019-03-27): Move this component to components library for usage in
-//   app and protocol-designer
 import * as React from 'react'
 import flatMap from 'lodash/flatMap'
 import cx from 'classnames'
 
-import { SLOT_RENDER_WIDTH, SLOT_RENDER_HEIGHT } from '@opentrons/shared-data'
 import { LabwareOutline } from '@opentrons/components'
-import styles from './styles.css'
+import styles from './robotLabware.css'
 
 import type {
-  LabwareDefinition,
+  LabwareDefinition2,
   LabwareParameters,
   LabwareOffset,
   LabwareWell,
-} from '../../types'
+} from '@opentrons/shared-data'
 
-export type LabwareRenderProps = {
-  definition: LabwareDefinition,
+type Props = {
+  definition: LabwareDefinition2,
+  transform?: string,
 }
 
-export type LabwareWellRenderProps = {
+type WellProps = {
   well: LabwareWell,
   parameters: LabwareParameters,
   cornerOffsetFromSlot: LabwareOffset,
 }
 
-export default function LabwareRender(props: LabwareRenderProps) {
+export default function RobotLabware(props: Props) {
   const { parameters, ordering, cornerOffsetFromSlot, wells } = props.definition
   const { isTiprack } = parameters
 
-  // SVG coordinate system is flipped in Y from our definitions
-  const transform = `translate(0,${SLOT_RENDER_HEIGHT}) scale(1,-1)`
-  const viewBox = `0 0 ${SLOT_RENDER_WIDTH} ${SLOT_RENDER_HEIGHT}`
-
   return (
-    <svg className={styles.labware_render} viewBox={viewBox}>
+    <g transform={props.transform}>
       <g className={styles.labware_detail_group}>
         <LabwareOutline
           className={cx({ [styles.tiprack_outline]: isTiprack })}
         />
       </g>
-      <g className={styles.well_group} transform={transform}>
+      <g className={styles.well_group}>
         {flatMap(
           ordering,
           // all arguments typed to stop Flow from complaining
@@ -60,11 +54,11 @@ export default function LabwareRender(props: LabwareRenderProps) {
           }
         )}
       </g>
-    </svg>
+    </g>
   )
 }
 
-function Well(props: LabwareWellRenderProps) {
+function Well(props: WellProps) {
   const { well, parameters, cornerOffsetFromSlot } = props
   const { isTiprack } = parameters
 

--- a/components/src/deck/index.js
+++ b/components/src/deck/index.js
@@ -4,6 +4,7 @@ import Labware from './Labware'
 import LabwareContainer from './LabwareContainer'
 import LabwareOutline from './LabwareOutline'
 import LabwareLabels from './LabwareLabels'
+import LabwareRender from './LabwareRender'
 import Well from './Well'
 import Tip from './Tip'
 import type { SingleWell } from './Well'
@@ -25,6 +26,7 @@ export {
   LabwareContainer,
   LabwareOutline,
   LabwareLabels,
+  LabwareRender,
   Module,
   ModuleNameOverlay,
   SlotOverlay,

--- a/components/src/deck/labwareRender.css
+++ b/components/src/deck/labwareRender.css
@@ -1,0 +1,7 @@
+@import '@opentrons/components';
+
+.labware_render {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}

--- a/components/src/deck/robotLabware.css
+++ b/components/src/deck/robotLabware.css
@@ -1,11 +1,5 @@
 @import '@opentrons/components';
 
-.labware_render {
-  width: 100%;
-  height: 100%;
-  overflow: visible;
-}
-
 .labware_detail_group {
   fill: none;
   stroke: var(--c-black);

--- a/labware-library/src/components/LabwareList/LabwareGallery.js
+++ b/labware-library/src/components/LabwareList/LabwareGallery.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 
-import LabwareRender from '../LabwareRender'
+import { LabwareRender } from '@opentrons/components'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'


### PR DESCRIPTION
## overview

Closes #3328

Also as per discussion, split out LabwareRender into `RobotLabware` (still in robot coordinates) vs `LabwareRender` (standalone, flipped-y-for-render version).

## changelog

* move LabwareRender into component library
* split out RobotLabware from LabwareRender

## review requests

- Labware Library should still work and look the same
- Component library dev should show LabwareRender
- Names OK?