### PR TITLE
feat(api): Add pipette v2.0 config

### DIFF
--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -15,7 +15,8 @@ defs = json.loads(
                          [c for c in pipette_config.config_models if not
                           (c.startswith('p1000')
                            or c.startswith('p300_multi')
-                           or c.endswith('1.5'))])
+                           or c.endswith('1.5')
+                           or c.endswith('v2'))])
 def test_versioned_aspiration(pipette_model, monkeypatch):
 
     monkeypatch.setattr(ff, 'use_old_aspiration_functions',

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -923,7 +923,7 @@
       }
     },
     "p20_single_v2": {
-      "name": "p20_single_v2",
+      "name": "p20_single",
       "top": {
         "value": 19.5,
         "min": -45,
@@ -2295,7 +2295,7 @@
       }
     },
     "p300_single_v2": {
-      "name": "p300_single_v2",
+      "name": "p300_single",
       "top": {
         "value": 19.5,
         "min": 5,
@@ -3257,7 +3257,7 @@
       }
   },
   "p1000_single_v2": {
-    "name": "p1000_single_v2",
+    "name": "p1000_single",
     "top": {
       "value": 19.5,
       "min": 5,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -960,7 +960,7 @@
         "type": "float"
       },
       "pickUpDistance": {
-        "value": 11,
+        "value": 14,
         "min": 1,
         "max": 20,
         "units": "mm",
@@ -1023,7 +1023,7 @@
       ],
       "quirks": [],
       "tipLength": {
-        "value": 30.9,
+        "value": 31.15,
         "units": "mm",
         "type": "float",
         "min": 0,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -923,7 +923,7 @@
       }
     },
     "p20_single_v2": {
-      "name": "p20_single",
+      "name": "p20_single_v2",
       "top": {
         "value": 19.5,
         "min": -45,
@@ -2295,7 +2295,7 @@
       }
     },
     "p300_single_v2": {
-      "name": "p300_single",
+      "name": "p300_single_v2",
       "top": {
         "value": 19.5,
         "min": 5,
@@ -3257,7 +3257,7 @@
       }
   },
   "p1000_single_v2": {
-    "name": "p1000_single",
+    "name": "p1000_single_v2",
     "top": {
       "value": 19.5,
       "min": 5,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -922,6 +922,114 @@
         "max": 100
       }
     },
+    "p20_single_v2": {
+      "name": "p20_single",
+      "top": {
+        "value": 19.5,
+        "min": -45,
+        "max": 45,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": -8.5,
+        "min": -45,
+        "max": 45,
+        "type": "float",
+        "units": "mm"
+      },
+      "blowout": {
+        "value": -13,
+        "min": -45,
+        "max": 45,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -25,
+        "min": -45,
+        "max": 45,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpCurrent": {
+        "value": 0.1,
+        "min": 0.01,
+        "max": 1.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "pickUpDistance": {
+        "value": 11,
+        "min": 1,
+        "max": 20,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpIncrement": {
+        "value": 0.0,
+        "min": 0.01,
+        "max": 20.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpPresses": {
+        "value": 1,
+        "min": 1,
+        "max": 5,
+        "units": "presses",
+        "type": "int"
+      },
+      "pickUpSpeed": {
+        "value": 10,
+        "min": 1,
+        "max": 40,
+        "units": "mm/s",
+        "type": "float"
+      },
+      "modelOffset": [0.0, 0.0, 6.05],
+      "plungerCurrent": {
+        "value": 1.0,
+        "min": 0.01,
+        "max": 2.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipCurrent": {
+        "value": 1.0,
+        "min": 0.01,
+        "max": 2.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipSpeed": {
+        "value": 15,
+        "min": 1,
+        "max": 100,
+        "units": "mm/sec",
+        "type": "float"
+      },
+      "ulPerMm": [
+        {
+          "aspirate": [
+            [1.8263, -0.0958, 1.088],
+            [2.5222, -0.104, 1.1031],
+            [3.2354, -0.0447, 0.9536],
+            [12.5135, -0.0021, 0.8079],
+            [26, 0, 0.8]
+          ],
+          "dispense": [[26, 0, 0.8]]
+        }
+      ],
+      "quirks": [],
+      "tipLength": {
+        "value": 30.9,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
+    },
     "p50_single_v1": {
       "name": "p50_single",
       "top": {
@@ -2186,6 +2294,112 @@
         "max": 100
       }
     },
+    "p300_single_v2": {
+      "name": "p300_single",
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": -14.5,
+        "min": -20,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -19,
+        "min": -30,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -35,
+        "min": -50,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpCurrent": {
+        "value": 0.1,
+        "min": 0.05,
+        "max": 2.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "pickUpDistance": {
+        "value": 11,
+        "min": 1,
+        "max": 30,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpIncrement": {
+        "value": 0.0,
+        "min": 0.0,
+        "max": 10.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpPresses": {
+        "value": 1,
+        "min": 0,
+        "max": 10,
+        "units": "presses",
+        "type": "int"
+      },
+      "pickUpSpeed": {
+        "value": 10,
+        "min": 1,
+        "max": 100,
+        "units": "mm/s",
+        "type": "float"
+      },
+      "modelOffset": [0.0, 0.0, 12.95],
+      "ulPerMm": [
+        {
+          "aspirate": [
+            [30.0, 0.015, 8.7],
+            [70,0.0045, 8.95],
+            [350, 0.0005, 9.25]
+          ],
+          "dispense": [[300, 0, 9.62]]
+        }
+      ],
+      "plungerCurrent": {
+        "value": 1.0,
+        "min": 0.1,
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipCurrent": {
+        "value": 1.0,
+        "min": 0.1,
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipSpeed": {
+        "value": 15,
+        "min": 0.001,
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
+      },
+      "quirks": [],
+      "tipLength": {
+        "value": 52.1,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      }
+    },
     "p300_multi_v1": {
       "name": "p300_multi",
       "top": {
@@ -3041,7 +3255,112 @@
         "min": 0,
         "max": 100
       }
+  },
+  "p1000_single_v2": {
+    "name": "p1000_single",
+    "top": {
+      "value": 19.5,
+      "min": 5,
+      "max": 19.5,
+      "units": "mm",
+      "type": "float"
+    },
+    "bottom": {
+      "value": -18.5,
+      "min": -20,
+      "max": 19,
+      "units": "mm",
+      "type": "float"
+    },
+    "blowout": {
+      "value": -23,
+      "min": -30,
+      "max": 10,
+      "units": "mm",
+      "type": "float"
+    },
+    "dropTip": {
+      "value": -35,
+      "min": -45,
+      "max": 2,
+      "units": "mm",
+      "type": "float"
+    },
+    "pickUpCurrent": {
+      "value": 0.1,
+      "min": 0.05,
+      "max": 2.0,
+      "units": "amps",
+      "type": "float"
+    },
+    "pickUpDistance": {
+      "value": 12,
+      "min": 1,
+      "max": 30,
+      "units": "mm",
+      "type": "float"
+    },
+    "pickUpIncrement": {
+      "value": 0.0,
+      "min": 0.0,
+      "max": 10.0,
+      "units": "mm",
+      "type": "float"
+    },
+    "pickUpPresses": {
+      "value": 1,
+      "min": 0,
+      "max": 10,
+      "units": "presses",
+      "type": "int"
+    },
+    "pickUpSpeed": {
+      "value": 10,
+      "min": 1,
+      "max": 100,
+      "units": "mm/s",
+      "type": "float"
+    },
+    "modelOffset": [0.0, 0.0, 33.64],
+    "ulPerMm": [
+      {
+        "aspirate": [
+          [300, 0.005, 26.2],
+          [1000, 0.0007, 26.75]
+        ],
+        "dispense": [[1000, 0, 26.5]]
+      }
+    ],
+    "plungerCurrent": {
+      "value": 1.0,
+      "min": 0.1,
+      "max": 0.5,
+      "units": "amps",
+      "type": "float"
+    },
+    "dropTipCurrent": {
+      "value": 1.0,
+      "min": 0.1,
+      "max": 0.8,
+      "units": "amps",
+      "type": "float"
+    },
+    "dropTipSpeed": {
+      "value": 15,
+      "min": 0.001,
+      "max": 30,
+      "units": "mm/sec",
+      "type": "float"
+    },
+    "quirks": [],
+    "tipLength": {
+      "value": 79.5,
+      "units": "mm",
+      "type": "float",
+      "min": 0,
+      "max": 100
     }
+  }
   },
   "mutableConfigs": [
     "top",

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -885,7 +885,7 @@
           "aspirate": [
             [1.774444444, -0.1917910448, 1.2026],
             [2.151481481, -0.0706286837, 1.0125],
-            [2.898518519, -0.04343083788, 0.9540],
+            [2.898518519, -0.04343083788, 0.954],
             [6.373333333, -0.00905990194, 0.8544],
             [11.00259259, -0.002325900358, 0.8115]
           ],
@@ -923,7 +923,7 @@
       }
     },
     "p20_single_v2": {
-      "name": "p20_single",
+      "name": "p+20_single",
       "top": {
         "value": 19.5,
         "min": -45,
@@ -2295,7 +2295,7 @@
       }
     },
     "p300_single_v2": {
-      "name": "p300_single",
+      "name": "p+300_single",
       "top": {
         "value": 19.5,
         "min": 5,
@@ -2364,7 +2364,7 @@
         {
           "aspirate": [
             [30.0, 0.015, 8.7],
-            [70,0.0045, 8.95],
+            [70, 0.0045, 8.95],
             [350, 0.0005, 9.25]
           ],
           "dispense": [[300, 0, 9.62]]
@@ -3255,112 +3255,109 @@
         "min": 0,
         "max": 100
       }
-  },
-  "p1000_single_v2": {
-    "name": "p1000_single",
-    "top": {
-      "value": 19.5,
-      "min": 5,
-      "max": 19.5,
-      "units": "mm",
-      "type": "float"
     },
-    "bottom": {
-      "value": -18.5,
-      "min": -20,
-      "max": 19,
-      "units": "mm",
-      "type": "float"
-    },
-    "blowout": {
-      "value": -23,
-      "min": -30,
-      "max": 10,
-      "units": "mm",
-      "type": "float"
-    },
-    "dropTip": {
-      "value": -35,
-      "min": -45,
-      "max": 2,
-      "units": "mm",
-      "type": "float"
-    },
-    "pickUpCurrent": {
-      "value": 0.1,
-      "min": 0.05,
-      "max": 2.0,
-      "units": "amps",
-      "type": "float"
-    },
-    "pickUpDistance": {
-      "value": 12,
-      "min": 1,
-      "max": 30,
-      "units": "mm",
-      "type": "float"
-    },
-    "pickUpIncrement": {
-      "value": 0.0,
-      "min": 0.0,
-      "max": 10.0,
-      "units": "mm",
-      "type": "float"
-    },
-    "pickUpPresses": {
-      "value": 1,
-      "min": 0,
-      "max": 10,
-      "units": "presses",
-      "type": "int"
-    },
-    "pickUpSpeed": {
-      "value": 10,
-      "min": 1,
-      "max": 100,
-      "units": "mm/s",
-      "type": "float"
-    },
-    "modelOffset": [0.0, 0.0, 33.64],
-    "ulPerMm": [
-      {
-        "aspirate": [
-          [300, 0.005, 26.2],
-          [1000, 0.0007, 26.75]
-        ],
-        "dispense": [[1000, 0, 26.5]]
+    "p1000_single_v2": {
+      "name": "p+1000_single",
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": -18.5,
+        "min": -20,
+        "max": 19,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": -23,
+        "min": -30,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -35,
+        "min": -45,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpCurrent": {
+        "value": 0.1,
+        "min": 0.05,
+        "max": 2.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "pickUpDistance": {
+        "value": 12,
+        "min": 1,
+        "max": 30,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpIncrement": {
+        "value": 0.0,
+        "min": 0.0,
+        "max": 10.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpPresses": {
+        "value": 1,
+        "min": 0,
+        "max": 10,
+        "units": "presses",
+        "type": "int"
+      },
+      "pickUpSpeed": {
+        "value": 10,
+        "min": 1,
+        "max": 100,
+        "units": "mm/s",
+        "type": "float"
+      },
+      "modelOffset": [0.0, 0.0, 33.64],
+      "ulPerMm": [
+        {
+          "aspirate": [[300, 0.005, 26.2], [1000, 0.0007, 26.75]],
+          "dispense": [[1000, 0, 26.5]]
+        }
+      ],
+      "plungerCurrent": {
+        "value": 1.0,
+        "min": 0.1,
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipCurrent": {
+        "value": 1.0,
+        "min": 0.1,
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipSpeed": {
+        "value": 15,
+        "min": 0.001,
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
+      },
+      "quirks": [],
+      "tipLength": {
+        "value": 79.5,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
       }
-    ],
-    "plungerCurrent": {
-      "value": 1.0,
-      "min": 0.1,
-      "max": 0.5,
-      "units": "amps",
-      "type": "float"
-    },
-    "dropTipCurrent": {
-      "value": 1.0,
-      "min": 0.1,
-      "max": 0.8,
-      "units": "amps",
-      "type": "float"
-    },
-    "dropTipSpeed": {
-      "value": 15,
-      "min": 0.001,
-      "max": 30,
-      "units": "mm/sec",
-      "type": "float"
-    },
-    "quirks": [],
-    "tipLength": {
-      "value": 79.5,
-      "units": "mm",
-      "type": "float",
-      "min": 0,
-      "max": 100
     }
-  }
   },
   "mutableConfigs": [
     "top",

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -31,7 +31,7 @@
     },
     "channels": 8
   },
-  "p20_single": {
+  "p+20_single": {
     "displayName": "P20 Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 5,
@@ -95,6 +95,22 @@
     "minVolume": 30,
     "maxVolume": 300
   },
+  "p+300_single": {
+    "displayName": "P300 Single-Channel",
+    "defaultAspirateFlowRate": {
+      "value": 150,
+      "min": 0.001,
+      "max": 600
+    },
+    "defaultDispenseFlowRate": {
+      "value": 300,
+      "min": 0.001,
+      "max": 600
+    },
+    "channels": 1,
+    "minVolume": 20,
+    "maxVolume": 300
+  },
   "p300_multi": {
     "displayName": "P300 8-Channel",
     "defaultAspirateFlowRate": {
@@ -112,6 +128,22 @@
     "maxVolume": 300
   },
   "p1000_single": {
+    "displayName": "P1000 Single-Channel",
+    "defaultAspirateFlowRate": {
+      "value": 500,
+      "min": 50,
+      "max": 2000
+    },
+    "defaultDispenseFlowRate": {
+      "value": 1000,
+      "min": 50,
+      "max": 2000
+    },
+    "channels": 1,
+    "minVolume": 100,
+    "maxVolume": 1000
+  },
+  "p+1000_single": {
     "displayName": "P1000 Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 500,

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -32,7 +32,7 @@
     "channels": 8
   },
   "p+20_single": {
-    "displayName": "P20 Single-Channel",
+    "displayName": "P20+ Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
@@ -96,7 +96,7 @@
     "maxVolume": 300
   },
   "p+300_single": {
-    "displayName": "P300 Single-Channel",
+    "displayName": "P300+ Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -144,7 +144,7 @@
     "maxVolume": 1000
   },
   "p+1000_single": {
-    "displayName": "P1000 Single-Channel",
+    "displayName": "P1000+ Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -31,8 +31,8 @@
     },
     "channels": 8
   },
-  "p20_single_v2": {
-    "displayName": "P+20 Single-Channel",
+  "p20_single": {
+    "displayName": "P20 Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
@@ -95,22 +95,6 @@
     "minVolume": 30,
     "maxVolume": 300
   },
-  "p300_single_v2": {
-    "displayName": "P+300 Single-Channel",
-    "defaultAspirateFlowRate": {
-      "value": 150,
-      "min": 0.001,
-      "max": 5000
-    },
-    "defaultDispenseFlowRate": {
-      "value": 300,
-      "min": 0.001,
-      "max": 5000
-    },
-    "minVolume": 20,
-    "maxVolume": 300,
-    "channels": 1
-  },
   "p300_multi": {
     "displayName": "P300 8-Channel",
     "defaultAspirateFlowRate": {
@@ -129,22 +113,6 @@
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
-    "defaultAspirateFlowRate": {
-      "value": 500,
-      "min": 50,
-      "max": 2000
-    },
-    "defaultDispenseFlowRate": {
-      "value": 1000,
-      "min": 50,
-      "max": 2000
-    },
-    "channels": 1,
-    "minVolume": 100,
-    "maxVolume": 1000
-  },
-  "p1000_single_v2": {
-    "displayName": "P+1000 Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -45,7 +45,7 @@
     },
     "minVolume": 1,
     "maxVolume": 20,
-    "channels": 1,
+    "channels": 1
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
@@ -109,7 +109,7 @@
     },
     "minVolume": 20,
     "maxVolume": 300,
-    "channels": 1,
+    "channels": 1
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",

--- a/shared-data/robot-data/pipetteNameSpecs.json
+++ b/shared-data/robot-data/pipetteNameSpecs.json
@@ -31,6 +31,22 @@
     },
     "channels": 8
   },
+  "p20_single_v2": {
+    "displayName": "P+20 Single-Channel",
+    "defaultAspirateFlowRate": {
+      "value": 5,
+      "min": 0.001,
+      "max": 5000
+    },
+    "defaultDispenseFlowRate": {
+      "value": 10,
+      "min": 0.001,
+      "max": 5000
+    },
+    "minVolume": 1,
+    "maxVolume": 20,
+    "channels": 1,
+  },
   "p50_single": {
     "displayName": "P50 Single-Channel",
     "defaultAspirateFlowRate": {
@@ -79,6 +95,22 @@
     "minVolume": 30,
     "maxVolume": 300
   },
+  "p300_single_v2": {
+    "displayName": "P+300 Single-Channel",
+    "defaultAspirateFlowRate": {
+      "value": 150,
+      "min": 0.001,
+      "max": 5000
+    },
+    "defaultDispenseFlowRate": {
+      "value": 300,
+      "min": 0.001,
+      "max": 5000
+    },
+    "minVolume": 20,
+    "maxVolume": 300,
+    "channels": 1,
+  },
   "p300_multi": {
     "displayName": "P300 8-Channel",
     "defaultAspirateFlowRate": {
@@ -97,6 +129,22 @@
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
+    "defaultAspirateFlowRate": {
+      "value": 500,
+      "min": 50,
+      "max": 2000
+    },
+    "defaultDispenseFlowRate": {
+      "value": 1000,
+      "min": 50,
+      "max": 2000
+    },
+    "channels": 1,
+    "minVolume": 100,
+    "maxVolume": 1000
+  },
+  "p1000_single_v2": {
+    "displayName": "P+1000 Single-Channel",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,


### PR DESCRIPTION
## overview
Add Pipette + single-channel Models in pipetteModelSpecs and pipetteNameSpecs 
closes #3039

## review requests
Pipette + models connected to a robot should be recognized in the App as v2

Note: As of right now, pipette v2 is defined to have the same min and max volume as its v1 counterpart, even though v2 has a different volume range than that of v1. Should we define min and max volume of each pipette model in pipetteModelSpecs rather than pipetteNameSepcs? 