### PR TITLE
refactor(labware-library): Add mobile submenus

### DIFF
--- a/labware-library/src/components/App/styles.css
+++ b/labware-library/src/components/App/styles.css
@@ -7,7 +7,7 @@
   height: 100%;
 
   /* nav height */
-  padding-top: var(--size-main-nav);
+  padding-top: var(--size-mobile-nav);
 
   &.breadcrumbs_visible {
     /* nav + breadcrumbs height */
@@ -39,6 +39,10 @@
 }
 
 @media (--medium) {
+  .app {
+    padding-top: var(--size-main-nav);
+  }
+
   .page {
     height: 100%;
     overflow: hidden;

--- a/labware-library/src/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
+++ b/labware-library/src/components/Nav/__tests__/__snapshots__/Nav.test.js.snap
@@ -20,10 +20,7 @@ exports[`Nav component renders 1`] = `
       <div
         className="nav_container"
       >
-        <MainNav
-          isMobileOpen={false}
-          onMobileClick={[Function]}
-        />
+        <MainNav />
       </div>
     </div>
   </nav>

--- a/labware-library/src/components/Nav/index.js
+++ b/labware-library/src/components/Nav/index.js
@@ -1,52 +1,26 @@
 // @flow
 // top nav bar component
 import * as React from 'react'
-import { SubdomainNav, MainNav, MobileNav } from '../website-navigation'
+import { SubdomainNav, MainNav } from '../website-navigation'
 import styles from './styles.css'
 
 export { default as Breadcrumbs } from './Breadcrumbs'
 
-type State = {
-  isOpen: boolean,
-}
-
-type Props = {||}
-
-export default class Nav extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = { isOpen: false }
-  }
-
-  toggle = () => {
-    this.setState({ isOpen: !this.state.isOpen })
-    document.body && document.body.classList.toggle('no_scroll')
-  }
-
-  componentWillUnmount() {
-    document.body && document.body.classList.remove('no_scroll')
-  }
-
-  render() {
-    return (
-      <>
-        <nav className={styles.nav}>
-          <div className={styles.subdomain_nav_wrapper}>
-            <div className={styles.nav_container}>
-              <SubdomainNav />
-            </div>
+export default function Nav() {
+  return (
+    <>
+      <nav className={styles.nav}>
+        <div className={styles.subdomain_nav_wrapper}>
+          <div className={styles.nav_container}>
+            <SubdomainNav />
           </div>
-          <div className={styles.main_nav_wrapper}>
-            <div className={styles.nav_container}>
-              <MainNav
-                onMobileClick={this.toggle}
-                isMobileOpen={this.state.isOpen}
-              />
-            </div>
+        </div>
+        <div className={styles.main_nav_wrapper}>
+          <div className={styles.nav_container}>
+            <MainNav />
           </div>
-        </nav>
-        {this.state.isOpen && <MobileNav />}
-      </>
-    )
-  }
+        </div>
+      </nav>
+    </>
+  )
 }

--- a/labware-library/src/components/Nav/styles.css
+++ b/labware-library/src/components/Nav/styles.css
@@ -76,8 +76,6 @@ are project specific  */
 @media (--medium) {
   .main_nav_wrapper {
     height: var(--size-main-nav);
-    border: none;
-    box-shadow: var(--shadow-1);
   }
 
   .nav_container,
@@ -93,6 +91,11 @@ are project specific  */
     width: 100%;
     height: var(--size-subdomain-nav);
     background-color: var(--c-lightest-gray);
+  }
+
+  .main_nav_wrapper {
+    border: none;
+    box-shadow: var(--shadow-1);
   }
 
   .breadcrumbs {

--- a/labware-library/src/components/website-navigation/MainNav.js
+++ b/labware-library/src/components/website-navigation/MainNav.js
@@ -2,20 +2,15 @@
 import * as React from 'react'
 import Logo from './Logo'
 import { NavList } from './NavList'
-import MenuButton from './MenuButton'
+import MobileNav from './MobileNav'
 import styles from './styles.css'
 
-import type { MobileNavProps } from './types'
-
-export function MainNav(props: MobileNavProps) {
+export function MainNav() {
   return (
     <div className={styles.main_nav_contents}>
       <Logo />
       <NavList />
-      <MenuButton
-        onMobileClick={props.onMobileClick}
-        isMobileOpen={props.isMobileOpen}
-      />
+      <MobileNav />
     </div>
   )
 }

--- a/labware-library/src/components/website-navigation/MobileContent.js
+++ b/labware-library/src/components/website-navigation/MobileContent.js
@@ -1,0 +1,33 @@
+// @flow
+import * as React from 'react'
+import NavLink from './NavLink'
+import styles from './styles.css'
+
+import type { Submenu } from './types'
+
+type Props = {|
+  ...Submenu,
+|}
+
+export default function MobileContent(props: Props) {
+  const { links } = props
+  return (
+    <ul className={styles.mobile_content}>
+      {links.map((link, index) => (
+        <li key={index}>
+          <NavLink url={link.url} name={link.name} />
+        </li>
+      ))}
+
+      {props.bottomLink && (
+        <li>
+          <NavLink
+            url={props.bottomLink.url}
+            name={props.bottomLink.name}
+            cta
+          />
+        </li>
+      )}
+    </ul>
+  )
+}

--- a/labware-library/src/components/website-navigation/MobileList.js
+++ b/labware-library/src/components/website-navigation/MobileList.js
@@ -30,10 +30,6 @@ export default class MobileList extends React.Component<Props, State> {
   toggle = (name: MenuName) =>
     this.setState({ menu: this.state.menu !== name ? name : null })
 
-  componentWillUnmount() {
-    document.body && document.body.classList.remove('no_scroll')
-  }
-
   render() {
     const { menu } = this.state
     return (

--- a/labware-library/src/components/website-navigation/MobileList.js
+++ b/labware-library/src/components/website-navigation/MobileList.js
@@ -1,0 +1,80 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+import MobileMenu from './MobileMenu'
+import MobileContent from './MobileContent'
+import ProtocolMobileContent from './ProtocolMobileContent'
+import SupportMobileContent from './SupportMobileContent'
+
+import {
+  navLinkProps,
+  protocolLinkProps,
+  supportLinkProps,
+  salesLinkProps,
+} from './nav-data'
+
+import type { MenuName } from './types'
+
+type State = {| menu: null | MenuName |}
+
+type Props = {||}
+
+export default class MobileList extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { menu: null }
+  }
+
+  clear = () => this.setState({ menu: null })
+
+  toggle = (name: MenuName) =>
+    this.setState({ menu: this.state.menu !== name ? name : null })
+
+  componentWillUnmount() {
+    document.body && document.body.classList.remove('no_scroll')
+  }
+
+  render() {
+    const { menu } = this.state
+    return (
+      <ul className={styles.mobile_nav}>
+        {navLinkProps.map(subnav => (
+          <li
+            className={styles.mobile_nav_item}
+            key={subnav.name}
+            role="button"
+          >
+            <MobileMenu
+              {...subnav}
+              active={menu === subnav.name}
+              onClick={() => this.toggle(subnav.name)}
+            >
+              <MobileContent {...subnav} />
+            </MobileMenu>
+          </li>
+        ))}
+        <li className={styles.mobile_nav_item} role="button">
+          <MobileMenu
+            {...protocolLinkProps}
+            name="Protocols"
+            active={menu === 'Protocols'}
+            onClick={() => this.toggle('Protocols')}
+          >
+            <ProtocolMobileContent />
+          </MobileMenu>
+        </li>
+        <li className={styles.mobile_nav_item} role="button">
+          <MobileMenu
+            {...supportLinkProps}
+            {...salesLinkProps}
+            name="Support & Sales"
+            active={menu === 'Support'}
+            onClick={() => this.toggle('Support')}
+          >
+            <SupportMobileContent />
+          </MobileMenu>
+        </li>
+      </ul>
+    )
+  }
+}

--- a/labware-library/src/components/website-navigation/MobileMenu.js
+++ b/labware-library/src/components/website-navigation/MobileMenu.js
@@ -9,6 +9,7 @@ import type { Submenu } from './types'
 type Props = {|
   ...Submenu,
   active: boolean,
+  children?: React.Node,
   onClick: () => mixed,
 |}
 
@@ -22,6 +23,7 @@ export default function MobileMenu(props: Props) {
           <Icon className={styles.mobile_menu_icon} name="arrow-left" />
           <h3 className={styles.mobile_menu_title}>{name}</h3>
         </div>
+        {props.children}
       </div>
     </>
   )

--- a/labware-library/src/components/website-navigation/MobileNav.js
+++ b/labware-library/src/components/website-navigation/MobileNav.js
@@ -1,76 +1,38 @@
 // @flow
 import * as React from 'react'
-import styles from './styles.css'
-import MobileMenu from './MobileMenu'
-import MobileContent from './MobileContent'
-import ProtocolMobileContent from './ProtocolMobileContent'
-import SupportMobileContent from './SupportMobileContent'
+import MenuButton from './MenuButton'
+import MobileList from './MobileList'
 
-import {
-  navLinkProps,
-  protocolLinkProps,
-  supportLinkProps,
-  salesLinkProps,
-} from './nav-data'
-
-import type { MenuName } from './types'
-
-type State = {| menu: null | MenuName |}
+type State = {|
+  isOpen: boolean,
+|}
 
 type Props = {||}
 
-export class MobileNav extends React.Component<Props, State> {
+export default class MobileNav extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { menu: null }
+    this.state = { isOpen: false }
   }
 
-  clear = () => this.setState({ menu: null })
+  toggle = () => {
+    this.setState({ isOpen: !this.state.isOpen })
+    document.body && document.body.classList.toggle('no_scroll')
+  }
 
-  toggle = (name: MenuName) =>
-    this.setState({ menu: this.state.menu !== name ? name : null })
+  componentWillUnmount() {
+    document.body && document.body.classList.remove('no_scroll')
+  }
 
   render() {
-    const { menu } = this.state
     return (
-      <ul className={styles.mobile_nav}>
-        {navLinkProps.map(subnav => (
-          <li
-            className={styles.mobile_nav_item}
-            key={subnav.name}
-            role="button"
-          >
-            <MobileMenu
-              {...subnav}
-              active={menu === subnav.name}
-              onClick={() => this.toggle(subnav.name)}
-            >
-              <MobileContent {...subnav} />
-            </MobileMenu>
-          </li>
-        ))}
-        <li className={styles.mobile_nav_item} role="button">
-          <MobileMenu
-            {...protocolLinkProps}
-            name="Protocols"
-            active={menu === 'Protocols'}
-            onClick={() => this.toggle('Protocols')}
-          >
-            <ProtocolMobileContent />
-          </MobileMenu>
-        </li>
-        <li className={styles.mobile_nav_item} role="button">
-          <MobileMenu
-            {...supportLinkProps}
-            {...salesLinkProps}
-            name="Support & Sales"
-            active={menu === 'Support'}
-            onClick={() => this.toggle('Support')}
-          >
-            <SupportMobileContent />
-          </MobileMenu>
-        </li>
-      </ul>
+      <>
+        <MenuButton
+          onMobileClick={this.toggle}
+          isMobileOpen={this.state.isOpen}
+        />
+        {this.state.isOpen && <MobileList />}
+      </>
     )
   }
 }

--- a/labware-library/src/components/website-navigation/MobileNav.js
+++ b/labware-library/src/components/website-navigation/MobileNav.js
@@ -2,12 +2,17 @@
 import * as React from 'react'
 import styles from './styles.css'
 import MobileMenu from './MobileMenu'
+import MobileContent from './MobileContent'
+import ProtocolMobileContent from './ProtocolMobileContent'
+import SupportMobileContent from './SupportMobileContent'
+
 import {
   navLinkProps,
   protocolLinkProps,
   supportLinkProps,
   salesLinkProps,
 } from './nav-data'
+
 import type { MenuName } from './types'
 
 type State = {| menu: null | MenuName |}
@@ -39,7 +44,9 @@ export class MobileNav extends React.Component<Props, State> {
               {...subnav}
               active={menu === subnav.name}
               onClick={() => this.toggle(subnav.name)}
-            />
+            >
+              <MobileContent {...subnav} />
+            </MobileMenu>
           </li>
         ))}
         <li className={styles.mobile_nav_item} role="button">
@@ -48,7 +55,9 @@ export class MobileNav extends React.Component<Props, State> {
             name="Protocols"
             active={menu === 'Protocols'}
             onClick={() => this.toggle('Protocols')}
-          />
+          >
+            <ProtocolMobileContent />
+          </MobileMenu>
         </li>
         <li className={styles.mobile_nav_item} role="button">
           <MobileMenu
@@ -57,7 +66,9 @@ export class MobileNav extends React.Component<Props, State> {
             name="Support & Sales"
             active={menu === 'Support'}
             onClick={() => this.toggle('Support')}
-          />
+          >
+            <SupportMobileContent />
+          </MobileMenu>
         </li>
       </ul>
     )

--- a/labware-library/src/components/website-navigation/NavLink.js
+++ b/labware-library/src/components/website-navigation/NavLink.js
@@ -5,9 +5,14 @@ import styles from './styles.css'
 
 import type { Link } from './types'
 
-export default function NavLink(props: Link) {
+type Props = {
+  ...Link,
+  className?: string,
+}
+
+export default function NavLink(props: Props) {
   return (
-    <div className={styles.link_group}>
+    <div className={cx(styles.link_group, props.className)}>
       <a
         href={props.url}
         className={cx(styles.link_title, { [styles.link_cta]: props.cta })}
@@ -15,7 +20,6 @@ export default function NavLink(props: Link) {
         rel="noopener noreferrer"
       >
         {props.name}
-        {props.cta && <span>&nbsp; &gt;</span>}
       </a>
       {props.description && (
         <div className={styles.link_description}>{props.description}</div>

--- a/labware-library/src/components/website-navigation/NavLink.js
+++ b/labware-library/src/components/website-navigation/NavLink.js
@@ -5,10 +5,10 @@ import styles from './styles.css'
 
 import type { Link } from './types'
 
-type Props = {
+type Props = {|
   ...Link,
   className?: string,
-}
+|}
 
 export default function NavLink(props: Props) {
   return (

--- a/labware-library/src/components/website-navigation/ProtocolMobileContent.js
+++ b/labware-library/src/components/website-navigation/ProtocolMobileContent.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react'
+import map from 'lodash/map'
+import NavLink from './NavLink'
+import styles from './styles.css'
+
+import { protocolLinkProps } from './nav-data'
+
+type Props = {||}
+
+export default function ProtocolMobileContent(props: Props) {
+  const links = map(protocolLinkProps)
+  return (
+    <ul className={styles.mobile_content}>
+      {links.map(link => (
+        <li key={link.name}>
+          <NavLink {...link} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/labware-library/src/components/website-navigation/SupportMobileContent.js
+++ b/labware-library/src/components/website-navigation/SupportMobileContent.js
@@ -1,0 +1,38 @@
+// @flow
+import * as React from 'react'
+import map from 'lodash/map'
+import NavLink from './NavLink'
+import styles from './styles.css'
+
+import { supportLinkProps, salesLinkProps } from './nav-data'
+
+type Props = {||}
+
+export default function supportMobileContent(props: Props) {
+  const supportLinks = map(supportLinkProps)
+  const salesLinks = map(salesLinkProps)
+  return (
+    <div className={styles.support_mobile_content}>
+      <div className={styles.sales_group}>
+        <h3 className={styles.submenu_title}>Support</h3>
+        <ul className={styles.sales_links}>
+          {salesLinks.map(link => (
+            <li key={link.name}>
+              <NavLink {...link} className={styles.support_nav_link} />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className={styles.support_group}>
+        <h3 className={styles.submenu_title}>Sales</h3>
+        <ul className={styles.support_links}>
+          {supportLinks.map(link => (
+            <li key={link.name}>
+              <NavLink {...link} className={styles.support_nav_link} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/labware-library/src/components/website-navigation/SupportMobileContent.js
+++ b/labware-library/src/components/website-navigation/SupportMobileContent.js
@@ -15,7 +15,7 @@ export default function supportMobileContent(props: Props) {
     <div className={styles.support_mobile_content}>
       <div className={styles.sales_group}>
         <h3 className={styles.submenu_title}>Support</h3>
-        <ul className={styles.sales_links}>
+        <ul>
           {salesLinks.map(link => (
             <li key={link.name}>
               <NavLink {...link} className={styles.support_nav_link} />
@@ -25,7 +25,7 @@ export default function supportMobileContent(props: Props) {
       </div>
       <div className={styles.support_group}>
         <h3 className={styles.submenu_title}>Sales</h3>
-        <ul className={styles.support_links}>
+        <ul>
           {supportLinks.map(link => (
             <li key={link.name}>
               <NavLink {...link} className={styles.support_nav_link} />

--- a/labware-library/src/components/website-navigation/__tests__/__snapshots__/MainNav.test.js.snap
+++ b/labware-library/src/components/website-navigation/__tests__/__snapshots__/MainNav.test.js.snap
@@ -6,6 +6,6 @@ exports[`MainNav component renders 1`] = `
 >
   <Logo />
   <NavList />
-  <MenuButton />
+  <MobileNav />
 </div>
 `;

--- a/labware-library/src/components/website-navigation/index.js
+++ b/labware-library/src/components/website-navigation/index.js
@@ -5,4 +5,3 @@
 export * from './SubdomainNav'
 export { MainNav } from './MainNav'
 export { NavList } from './NavList'
-export { MobileNav } from './MobileNav'

--- a/labware-library/src/components/website-navigation/nav-data.js
+++ b/labware-library/src/components/website-navigation/nav-data.js
@@ -139,9 +139,11 @@ export const salesLinkProps: SalesLinks = {
   sales: {
     name: 'Contact Sales',
     url: 'http://opentrons.com/contact',
+    cta: true,
   },
   demo: {
     name: 'Schedule Demo',
     url: 'http://opentrons.com/demo',
+    cta: true,
   },
 }

--- a/labware-library/src/components/website-navigation/nav-data.js
+++ b/labware-library/src/components/website-navigation/nav-data.js
@@ -93,6 +93,7 @@ export const protocolLinkProps: ProtocolLinks = {
   bottomLink: {
     name: 'Request a free custom protocol',
     url: 'https://opentrons.com/request-protocol',
+    cta: true,
   },
 }
 
@@ -126,6 +127,7 @@ export const supportLinkProps: SupportLinks = {
   support: {
     name: 'Contact Support',
     url: 'http://opentrons.com/contact',
+    cta: true,
   },
 }
 

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -9,7 +9,7 @@
   --spacing-subdomain: 2.5rem;
   --spacing-nav: 1.75rem;
   --spacing-submenu: 1.75rem;
-  --spacing-link: 1.25rem;
+  --spacing-link: 1.75rem;
 
   --dropdown-base: {
     position: absolute;
@@ -55,6 +55,7 @@
   --bd-button: var(--bd-width-default) solid var(--c-blue);
 }
 
+/* Subdomain Nav (wrapper and container responsive styles in Nav/) */
 .subdomain_nav_contents {
   @apply --flex-end;
 
@@ -70,6 +71,7 @@
   cursor: pointer;
 }
 
+/* Main Nav (wrapper and container responsive styles in Nav/) */
 .main_nav_contents {
   @apply --flex-between;
 
@@ -107,15 +109,7 @@
   color: var(--c-black);
 }
 
-.clickable_icon {
-  cursor: pointer;
-
-  &:active,
-  &:focus {
-    outline: none;
-  }
-}
-
+/* Dropdown Containers */
 .dropdown_small {
   @apply --font-body-2-dark;
   @apply --dropdown-base;
@@ -177,6 +171,7 @@
   }
 }
 
+/* Dropdown Content */
 .dropdown_content {
   display: flex;
   padding: var(--spacing-submenu);
@@ -187,21 +182,20 @@
   flex: 1 1 var(--size-50p);
 }
 
-.link_group {
+.submenu_title {
+  @apply --font-body-2-dark;
+
   line-height: 1.25rem;
-  text-align: left;
-  padding-bottom: var(--spacing-link);
-  padding-left: 4rem;
+  flex-basis: 8rem;
+  padding: 0 var(--spacing-5);
+  text-transform: uppercase;
 }
 
+/*  Support & Sales Submenu Desktop */
 .support_menu {
   padding: var(--spacing-submenu);
   padding-bottom: var(--spacing-1);
   flex: 1 1 var(--size-two-thirds);
-}
-
-.support_content {
-  display: flex;
 }
 
 .sales_menu {
@@ -210,34 +204,21 @@
   flex: 1 1 var(--size-third);
 }
 
-.support_group {
-  flex: 1 1 60%;
+.support_content {
   display: flex;
-  padding-top: var(--spacing-6);
 }
 
-.sales_group {
-  flex: 1 1 40%;
-  display: flex;
-  padding-top: var(--spacing-6);
-  border-bottom: var(--bd-light);
-}
-
-.submenu_title {
-  @apply --font-body-2-dark;
-
+/* NavLink */
+.link_group {
   line-height: 1.25rem;
-  flex-basis: 6rem;
-  padding-left: var(--spacing-5);
-  text-transform: uppercase;
-}
+  text-align: left;
+  padding-bottom: var(--spacing-link);
+  padding-left: 4rem;
 
-.mobile_content {
-  padding: var(--spacing-5);
-}
-
-.support_submenu {
-  display: flex;
+  &.support_nav_link {
+    padding-bottom: var(--spacing-5);
+    text-align: left;
+  }
 }
 
 .link_title {
@@ -250,11 +231,20 @@
     color: var(--c-blue);
   }
 
+  /* Only add caret to base NavLinks on Mobile */
   &::after {
     content: '\00a0 \3E';
   }
 }
 
+.link_description {
+  font-size: var(--fs-body-1);
+  font-weight: var(--fw-regular);
+  color: var(--c-nav-gray);
+  text-transform: none;
+}
+
+/*  Nav Link CTA */
 .link_cta {
   color: var(--c-blue);
 }
@@ -273,13 +263,6 @@
   }
 }
 
-.link_description {
-  font-size: var(--fs-body-1);
-  font-weight: var(--fw-regular);
-  color: var(--c-nav-gray);
-  text-transform: none;
-}
-
 .bottom_link {
   @apply --flex-start;
   @apply --bottom-link;
@@ -290,6 +273,16 @@
 .bottom_link_center {
   @apply --bottom-link;
   @apply --center-children;
+}
+
+/* Mobile Button / Toggle */
+.clickable_icon {
+  cursor: pointer;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
 }
 
 .menu_button {
@@ -303,6 +296,7 @@
   }
 }
 
+/* Mobile List */
 .mobile_nav {
   position: fixed;
   top: var(--size-mobile-nav);
@@ -310,7 +304,6 @@
   right: 0;
   width: 100%;
   padding: 0;
-  padding-bottom: var(--spacing-5);
   background-color: var(--c-white);
   z-index: 900;
   border-bottom: var(--bd-light);
@@ -320,7 +313,7 @@
   @apply --flex-start;
 
   padding: var(--spacing-7);
-  height: var(--size-2);
+  height: 4.5rem;
   font-weight: var(--fw-semibold);
   cursor: pointer;
 
@@ -329,6 +322,7 @@
   }
 }
 
+/* Mobile Menu container */
 .mobile_menu {
   position: fixed;
   top: var(--size-mobile-nav);
@@ -346,10 +340,11 @@
   }
 }
 
+/* Top Mobile Menu bar */
 .mobile_menu_heading {
   @apply --flex-start;
 
-  height: 4rem;
+  height: 4.5rem;
   border-bottom: var(--bd-light);
 }
 
@@ -359,6 +354,7 @@
   width: var(--size-2);
 }
 
+/* Top Mobile Menu text */
 .mobile_menu_title {
   width: 100%;
   padding-left: 5rem;
@@ -367,20 +363,43 @@
   font-weight: var(--fw-semibold);
 }
 
+.mobile_content {
+  padding: var(--spacing-5);
+  padding-bottom: 0;
+}
+
+/*  Support & Sales Submenu Mobile */
+
+.support_mobile_content {
+  display: flex;
+  flex-direction: column;
+}
+
+.sales_group {
+  display: flex;
+  flex-basis: 100%;
+  padding-top: var(--spacing-6);
+  border-bottom: var(--bd-light);
+}
+
+.support_group {
+  display: flex;
+  flex-basis: 100%;
+  padding-top: var(--spacing-6);
+}
+
+.support_submenu {
+  display: flex;
+}
+
 @media (--medium) {
   .logo {
     height: 2.5rem;
   }
 
   .link_group {
-    line-height: 1.25rem;
     text-align: center;
     padding-left: 0;
-
-    &.support_nav_link {
-      padding-left: 1rem;
-      text-align: left;
-    }
   }
 
   .mobile_nav {
@@ -398,23 +417,23 @@
 
   .mobile_menu {
     top: var(--size-main-nav);
-    min-height: 25rem;
-  }
-
-  .support_group {
-    flex: 1 1 60%;
-    display: flex;
-  }
-
-  .sales_group {
-    flex: 1 1 40%;
-    display: flex;
-    padding-bottom: 0;
-    border-bottom: none;
+    min-height: 29.5rem;
   }
 
   .support_mobile_content {
     flex-direction: row;
+  }
+
+  .support_group {
+    flex-basis: 60%;
+    display: flex;
+  }
+
+  .sales_group {
+    flex-basis: 40%;
+    display: flex;
+    padding-bottom: 0;
+    border-bottom: none;
   }
 }
 

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -204,12 +204,6 @@
   display: flex;
 }
 
-.support_mobile_content {
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-}
-
 .sales_menu {
   padding: var(--spacing-submenu);
   border-left: var(--bd-light);
@@ -311,14 +305,15 @@
 
 .mobile_nav {
   position: fixed;
+  top: var(--size-mobile-nav);
+  left: 0;
+  right: 0;
   width: 100%;
   padding: 0;
   padding-bottom: var(--spacing-5);
   background-color: var(--c-white);
   z-index: 900;
-
-  /* Added this for contrast with page - does not match design */
-  box-shadow: var(--shadow-1);
+  border-bottom: var(--bd-light);
 }
 
 .mobile_nav_item {
@@ -377,6 +372,21 @@
     height: 2.5rem;
   }
 
+  .link_group {
+    line-height: 1.25rem;
+    text-align: center;
+    padding-left: 0;
+
+    &.support_nav_link {
+      padding-left: 1rem;
+      text-align: left;
+    }
+  }
+
+  .mobile_nav {
+    top: var(--size-main-nav);
+  }
+
   .mobile_nav_item {
     justify-content: center;
   }
@@ -388,18 +398,7 @@
 
   .mobile_menu {
     top: var(--size-main-nav);
-    min-height: 30rem;
-  }
-
-  .link_group {
-    line-height: 1.25rem;
-    text-align: center;
-    padding-left: 0;
-
-    &.support_nav_link {
-      padding-left: 1rem;
-      text-align: left;
-    }
+    min-height: 25rem;
   }
 
   .support_group {

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -79,7 +79,7 @@
 }
 
 .logo {
-  height: 100%;
+  height: 2rem;
 }
 
 .nav_list {
@@ -189,7 +189,9 @@
 
 .link_group {
   line-height: 1.25rem;
-  margin: 0 var(--spacing-link) var(--spacing-link) 0;
+  text-align: left;
+  padding-bottom: var(--spacing-link);
+  padding-left: 4rem;
 }
 
 .support_menu {
@@ -202,27 +204,60 @@
   display: flex;
 }
 
+.support_mobile_content {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
 .sales_menu {
   padding: var(--spacing-submenu);
   border-left: var(--bd-light);
   flex: 1 1 var(--size-third);
 }
 
+.support_group {
+  flex: 1 1 60%;
+  display: flex;
+  padding-top: var(--spacing-6);
+}
+
+.sales_group {
+  flex: 1 1 40%;
+  display: flex;
+  padding-top: var(--spacing-6);
+  border-bottom: var(--bd-light);
+}
+
 .submenu_title {
   @apply --font-body-2-dark;
 
-  flex: 0 0 100%;
-  margin-bottom: var(--spacing-5);
+  line-height: 1.25rem;
+  flex-basis: 6rem;
+  padding-left: var(--spacing-5);
   text-transform: uppercase;
+}
+
+.mobile_content {
+  padding: var(--spacing-5);
+}
+
+.support_submenu {
+  display: flex;
 }
 
 .link_title {
   @apply --link-text;
 
+  text-align: left;
   color: var(--c-black);
 
   &:hover {
     color: var(--c-blue);
+  }
+
+  &::after {
+    content: '\00a0 \3E';
   }
 }
 
@@ -246,6 +281,8 @@
 
 .link_description {
   font-size: var(--fs-body-1);
+  font-weight: var(--fw-regular);
+  color: var(--c-nav-gray);
   text-transform: none;
 }
 
@@ -264,7 +301,7 @@
 .menu_button {
   @apply --transition-color;
 
-  flex: 0 0 4rem;
+  flex: 0 0 3rem;
   color: var(--c-font-dark);
 
   &:hover {
@@ -299,10 +336,10 @@
 
 .mobile_menu {
   position: fixed;
-  bottom: 0;
+  top: var(--size-mobile-nav);
   right: 0;
   width: 100%;
-  min-height: calc(100vh - var(--size-main-nav));
+  min-height: calc(100vh - var(--size-mobile-nav));
   margin: 0 -100% 0 0;
   background-color: var(--c-white);
   box-shadow: var(--shadow-1);
@@ -317,7 +354,7 @@
 .mobile_menu_heading {
   @apply --flex-start;
 
-  height: 5rem;
+  height: 4rem;
   border-bottom: var(--bd-light);
 }
 
@@ -329,18 +366,56 @@
 
 .mobile_menu_title {
   width: 100%;
-  text-align: center;
+  padding-left: 5rem;
+  text-align: left;
   font-size: var(--fs-default);
   font-weight: var(--fw-semibold);
 }
 
 @media (--medium) {
+  .logo {
+    height: 2.5rem;
+  }
+
   .mobile_nav_item {
     justify-content: center;
   }
 
+  .mobile_menu_title {
+    padding: 0;
+    text-align: center;
+  }
+
   .mobile_menu {
+    top: var(--size-main-nav);
     min-height: 30rem;
+  }
+
+  .link_group {
+    line-height: 1.25rem;
+    text-align: center;
+    padding-left: 0;
+
+    &.support_nav_link {
+      padding-left: 1rem;
+      text-align: left;
+    }
+  }
+
+  .support_group {
+    flex: 1 1 60%;
+    display: flex;
+  }
+
+  .sales_group {
+    flex: 1 1 40%;
+    display: flex;
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+
+  .support_mobile_content {
+    flex-direction: row;
   }
 }
 
@@ -352,5 +427,35 @@
 
   .nav_list {
     @apply --flex-end;
+  }
+
+  .active {
+    color: var(--c-black);
+  }
+
+  .link_group {
+    line-height: 1.25rem;
+    padding: 0 var(--spacing-link) var(--spacing-link) 0;
+    text-align: left;
+  }
+
+  .link_title {
+    display: block;
+    padding: 0;
+    text-align: left;
+
+    &::after {
+      content: '';
+    }
+  }
+
+  .link_cta::after {
+    content: '\00a0 \3E';
+  }
+
+  .submenu_title {
+    flex: 0 0 100%;
+    padding: 0;
+    margin-bottom: var(--spacing-5);
   }
 }

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -329,7 +329,7 @@
   right: 0;
   width: 100%;
   min-height: calc(100vh - var(--size-mobile-nav));
-  margin: 0 -100% 0 0;
+  margin: 0 -105% 0 0;
   background-color: var(--c-white);
   box-shadow: var(--shadow-1);
   z-index: 950;


### PR DESCRIPTION
## overview

This PR adds in the mobile submenu content and refactors MobileNav (now stateful). 

addresses #3382

## changelog

- refactor: Add mobile submenu
- refactor: Move mobile navigation state from Nav to MobileNav

## review requests

Standard review. 

Please note a follow up PR will address any/all styling/spacing/sizing inconsistencies. I also need to organize the monster stylesheet.
