### PR TITLE
refactor(labware-library): Add navbar style fixes

### DIFF
--- a/labware-library/src/components/website-navigation/Logo.js
+++ b/labware-library/src/components/website-navigation/Logo.js
@@ -6,5 +6,9 @@ import logoSrc from './images/ot-logo-full.png'
 import styles from './styles.css'
 
 export default function Logo() {
-  return <img className={styles.logo} src={logoSrc} />
+  return (
+    <a href="https://opentrons.com/" target="_blank" rel="noopener noreferrer">
+      <img className={styles.logo} src={logoSrc} />
+    </a>
+  )
 }

--- a/labware-library/src/components/website-navigation/NavLink.js
+++ b/labware-library/src/components/website-navigation/NavLink.js
@@ -36,7 +36,7 @@ export function NavButton(props: Link) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      {props.name} &nbsp; ›
+      {props.name} ›
     </a>
   )
 }

--- a/labware-library/src/components/website-navigation/NavLink.js
+++ b/labware-library/src/components/website-navigation/NavLink.js
@@ -36,7 +36,7 @@ export function NavButton(props: Link) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      {props.name} &nbsp; &gt;
+      {props.name} &nbsp; ›
     </a>
   )
 }

--- a/labware-library/src/components/website-navigation/NavMenu.js
+++ b/labware-library/src/components/website-navigation/NavMenu.js
@@ -33,7 +33,7 @@ export default function NavMenu(props: Props) {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {bottomLink.name} &nbsp; ›
+              {bottomLink.name} ›
             </a>
           )}
         </div>

--- a/labware-library/src/components/website-navigation/NavMenu.js
+++ b/labware-library/src/components/website-navigation/NavMenu.js
@@ -33,7 +33,7 @@ export default function NavMenu(props: Props) {
               target="_blank"
               rel="noopener noreferrer"
             >
-              {bottomLink.name} &nbsp; &gt;
+              {bottomLink.name} &nbsp; ›
             </a>
           )}
         </div>

--- a/labware-library/src/components/website-navigation/ProtocolMenu.js
+++ b/labware-library/src/components/website-navigation/ProtocolMenu.js
@@ -40,7 +40,7 @@ export default function ProtocolMenu(props: Props) {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {bottomLink.name} &nbsp; ›
+            {bottomLink.name} ›
           </a>
         </div>
       )}

--- a/labware-library/src/components/website-navigation/ProtocolMenu.js
+++ b/labware-library/src/components/website-navigation/ProtocolMenu.js
@@ -40,7 +40,7 @@ export default function ProtocolMenu(props: Props) {
             target="_blank"
             rel="noopener noreferrer"
           >
-            {bottomLink.name} &nbsp; &gt;
+            {bottomLink.name} &nbsp; ›
           </a>
         </div>
       )}

--- a/labware-library/src/components/website-navigation/SubdomainNav.js
+++ b/labware-library/src/components/website-navigation/SubdomainNav.js
@@ -1,12 +1,12 @@
 // @flow
 // top subdomain nav bar component
 import * as React from 'react'
-
+import { Link } from 'react-router-dom'
 import styles from './styles.css'
 
 export const SUBDOMAIN_NAV_LINKS = [
   { name: 'Python API', url: 'https://docs.opentrons.com/' },
-  { name: 'Labware Library', url: './' },
+  { name: 'Labware Library', to: '/' },
   { name: 'Protocol Library', url: 'https://protocols.opentrons.com/' },
   { name: 'Protocol Designer', url: 'https://designer.opentrons.com/' },
 ]
@@ -14,18 +14,29 @@ export const SUBDOMAIN_NAV_LINKS = [
 export function SubdomainNav() {
   return (
     <ul className={styles.subdomain_nav_contents}>
-      {SUBDOMAIN_NAV_LINKS.map((link, index) => (
-        <li key={index}>
-          <a
-            href={link.url}
-            className={styles.subdomain_link}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {link.name}
-          </a>
-        </li>
-      ))}
+      {SUBDOMAIN_NAV_LINKS.map((link, index) => {
+        if (link.to) {
+          return (
+            <li key={index}>
+              <Link to={link.to} className={styles.subdomain_link}>
+                {link.name}
+              </Link>
+            </li>
+          )
+        }
+        return (
+          <li key={index}>
+            <a
+              href={link.url}
+              className={styles.subdomain_link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {link.name}
+            </a>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/labware-library/src/components/website-navigation/SubdomainNav.js
+++ b/labware-library/src/components/website-navigation/SubdomainNav.js
@@ -2,11 +2,12 @@
 // top subdomain nav bar component
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import { getPublicPath } from '../../public-path'
 import styles from './styles.css'
 
 export const SUBDOMAIN_NAV_LINKS = [
   { name: 'Python API', url: 'https://docs.opentrons.com/' },
-  { name: 'Labware Library', to: '/' },
+  { name: 'Labware Library', to: getPublicPath() },
   { name: 'Protocol Library', url: 'https://protocols.opentrons.com/' },
   { name: 'Protocol Designer', url: 'https://designer.opentrons.com/' },
 ]

--- a/labware-library/src/components/website-navigation/__tests__/__snapshots__/Logo.test.js.snap
+++ b/labware-library/src/components/website-navigation/__tests__/__snapshots__/Logo.test.js.snap
@@ -1,8 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Logo component renders 1`] = `
-<img
-  className="logo"
-  src="ot-logo-full.png"
-/>
+<a
+  href="https://opentrons.com/"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <img
+    className="logo"
+    src="ot-logo-full.png"
+  />
+</a>
 `;

--- a/labware-library/src/components/website-navigation/__tests__/__snapshots__/SubdomainNav.test.js.snap
+++ b/labware-library/src/components/website-navigation/__tests__/__snapshots__/SubdomainNav.test.js.snap
@@ -19,14 +19,12 @@ exports[`SecondaryNav component renders 1`] = `
   <li
     key="1"
   >
-    <a
+    <Link
       className="subdomain_link"
-      href="./"
-      rel="noopener noreferrer"
-      target="_blank"
+      to="/"
     >
       Labware Library
-    </a>
+    </Link>
   </li>
   <li
     key="2"

--- a/labware-library/src/components/website-navigation/nav-data.js
+++ b/labware-library/src/components/website-navigation/nav-data.js
@@ -126,7 +126,7 @@ export const supportLinkProps: SupportLinks = {
   },
   support: {
     name: 'Contact Support',
-    url: 'http://opentrons.com/contact',
+    url: 'https://opentrons.com/contact-support',
     cta: true,
   },
 }

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -230,7 +230,7 @@
 
   /* Only add caret to base NavLinks on Mobile */
   &::after {
-    content: '\00a0 ›';
+    content: ' ›';
   }
 }
 
@@ -466,7 +466,7 @@
   }
 
   .link_cta::after {
-    content: '\00a0 ›';
+    content: ' ›';
   }
 
   .submenu_title {

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -303,6 +303,7 @@
   left: 0;
   right: 0;
   width: 100%;
+  min-height: calc(100vh - var(--size-mobile-nav));
   padding: 0;
   background-color: var(--c-white);
   z-index: 900;
@@ -404,6 +405,7 @@
 
   .mobile_nav {
     top: var(--size-main-nav);
+    min-height: auto;
   }
 
   .mobile_nav_item {

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -90,15 +90,10 @@
 
 .nav_link {
   @apply --link-text;
-  @apply --transition-color;
 
   position: relative;
   padding: 2rem var(--spacing-nav);
   color: var(--c-nav-gray);
-
-  &:hover {
-    color: var(--c-black);
-  }
 
   &:last-child {
     padding-right: 0;
@@ -186,7 +181,7 @@
   @apply --font-body-2-dark;
 
   line-height: 1.25rem;
-  flex-basis: 8rem;
+  flex: 0 0 6rem;
   padding: 0 var(--spacing-5);
   text-transform: uppercase;
 }
@@ -224,6 +219,8 @@
 .link_title {
   @apply --link-text;
 
+  display: block;
+  width: 100%;
   text-align: left;
   color: var(--c-black);
 
@@ -233,7 +230,7 @@
 
   /* Only add caret to base NavLinks on Mobile */
   &::after {
-    content: '\00a0 \3E';
+    content: '\00a0 ›';
   }
 }
 
@@ -286,14 +283,8 @@
 }
 
 .menu_button {
-  @apply --transition-color;
-
   flex: 0 0 3rem;
   color: var(--c-font-dark);
-
-  &:hover {
-    color: var(--c-black);
-  }
 }
 
 /* Mobile List */
@@ -403,6 +394,10 @@
     padding-left: 0;
   }
 
+  .link_title {
+    text-align: center;
+  }
+
   .mobile_nav {
     top: var(--size-main-nav);
     min-height: auto;
@@ -461,6 +456,7 @@
 
   .link_title {
     display: block;
+    width: 100%;
     padding: 0;
     text-align: left;
 
@@ -470,7 +466,7 @@
   }
 
   .link_cta::after {
-    content: '\00a0 \3E';
+    content: '\00a0 ›';
   }
 
   .submenu_title {


### PR DESCRIPTION
## overview

This adds mobile nav < 768px dropdown height and changes the `SubdomainNav` to use `Link` for the 'Labware Library' instead of an anchor tag with `target="_blank"`. When the time comes, we will probably have to refactor `NavLink` as well, but that day is not today.

addresses #3382 

## changelog

- refactor(labware-library): Add navbar style fixes
- refactor(labware-library): Update `SubdomainNav` to use `Link` when link is within the project

## review requests

This PR is pre handoff to design review, but these 2 little issues needed to be addressed before that.

Please point out any other glaring issues if you see them. 

http://sandbox.labware.opentrons.com/lablib_navbar-style-tweaks/