### PR TITLE
feat(update-server): buildroot: use sd-notify and better hostname

### DIFF
--- a/update-server/opentrons-update-server.service
+++ b/update-server/opentrons-update-server.service
@@ -4,7 +4,7 @@ Requires=nginx.service
 After=nginx.service
 
 [Service]
-Type=exec
+Type=notify
 ExecStart=python -m otupdate.buildroot -p 34000
 StateDirectory=otupdate
 

--- a/update-server/tests/buildroot/test_update.py
+++ b/update-server/tests/buildroot/test_update.py
@@ -77,6 +77,7 @@ async def test_future_chain(otupdate_config, downloaded_update_file,
         last_progress = session.state['progress']
         await asyncio.sleep(0.01)
     assert fut.done()
+    last_progress = 0.0
     while session.stage == Stages.WRITING:
         assert session.state['progress'] >= last_progress
         last_progress = session.state['progress']


### PR DESCRIPTION
- %-encoding is ok in uri paths but not internet hostnames, so just drop the %s
- use sd_notify (https://www.freedesktop.org/software/systemd/man/sd_notify.html)
  to let things depend on opentrons-update-server and know that the hostname
  will be set when they start

Testing
 - Put this on a buildroot robot. You can use `push-buildroot`, but you'll also have to manually copy the service file to `/etc/systemd/system`
 - Either restart the robot to check at boot, or do `systemctl daemon-reload` to pick up the changed service file
 - Restart `opentrons-update-server` and then check in the logs, noting that you don't see a line like `systemd[1]: Started Opentrons update server.` until after a line like `opentrons-update[315]: Notifying systemd` (and the logging from `otupdate.buildroot.__main__` previous to invoking `_notify_up`)