### PR TITLE
docs(api): Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,7 @@ Your computer will need the following tools installed to be able to develop with
 - macOS 10.11+, Linux, or Windows 10
   - On Windows, please configure Git’s `core.autocrlf` setting (see the [Git config docs](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)) to `input` so that shell scripts required for the robot’s boot process in `api/opentrons/resources` do not have carriage returns inserted.
 - Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux. If `pyenv` is not available for your system or you do not want to use it, you can set the environment variable `OT_PYTHON` to the full path to the Python 3.6 executable)
+- If you wish to use `pyenv` but are experiencing issues with a newer operating system please see the [common build problems section](https://github.com/pyenv/pyenv/wiki/Common-build-problems) of `pyenv` documentation.
 
   ```shell
   pyenv install 3.6.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Your computer will need the following tools installed to be able to develop with
 - macOS 10.11+, Linux, or Windows 10
   - On Windows, please configure Git’s `core.autocrlf` setting (see the [Git config docs](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)) to `input` so that shell scripts required for the robot’s boot process in `api/opentrons/resources` do not have carriage returns inserted.
 - Python 3.6 ([pyenv](https://github.com/pyenv/pyenv) is optional, but recommended for macOS / Linux. If `pyenv` is not available for your system or you do not want to use it, you can set the environment variable `OT_PYTHON` to the full path to the Python 3.6 executable)
-- If you wish to use `pyenv` but are experiencing issues with a newer operating system please see the [common build problems section](https://github.com/pyenv/pyenv/wiki/Common-build-problems) of `pyenv` documentation.
+- If you wish to use `pyenv` but are experiencing issues with macOS Mojave please see the [common build problems section](https://github.com/pyenv/pyenv/wiki/Common-build-problems) of `pyenv` documentation.
 
   ```shell
   pyenv install 3.6.4


### PR DESCRIPTION
## overview

While getting Mel set up to update the docs templates of API, we experienced a Mojave specific issue using pyenv to install Python 3.6.4. This PR updates the docs with a link to documentation from pyenv's wiki that helped us solve the issue.

## changelog

- docs(api): Update contributing guide

## review requests

- I'm particularly terrible at spelling and grammar. Is this worded correctly? In the right spot?
