### PR TITLE
refactor(api): Remove unused splitLabwareDef feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -37,13 +37,6 @@ settings = [
         description='Trash box is 55mm tall (rather than the 77mm default)'
     ),
     Setting(
-        _id='splitLabwareDefinitions',
-        old_id='split-labware-def',
-        title='New JSON labware definitions',
-        description='JSON labware definitions with a separate def file and'
-                    ' offset file for each labware'
-    ),
-    Setting(
         _id='calibrateToBottom',
         old_id='calibrate-to-bottom',
         title='Calibrate to bottom',
@@ -103,7 +96,7 @@ def get_all_adv_settings() -> Dict[str, Dict[str, Union[str, bool, None]]]:
     return {
         key: {**settings_by_id[key].__dict__,
               'value': value}
-        for key, value in values.items()
+        for key, value in values.items() if key in settings_by_id
     }
 
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,6 @@ def test_migrates_empty_object():
     assert(version == 1)
     assert(settings == {
       'shortFixedTrash': None,
-      'splitLabwareDefinitions': None,
       'calibrateToBottom': None,
       'deckCalibrationDots': None,
       'disableHomeOnBoot': None,
@@ -19,7 +18,6 @@ def test_migrates_empty_object():
 def test_migrates_versionless_new_config():
     settings, version = _migrate({
       'shortFixedTrash': True,
-      'splitLabwareDefinitions': False,
       'calibrateToBottom': True,
       'deckCalibrationDots': False,
       'disableHomeOnBoot': True,
@@ -30,7 +28,6 @@ def test_migrates_versionless_new_config():
     assert(version == 1)
     assert(settings == {
       'shortFixedTrash': True,
-      'splitLabwareDefinitions': None,
       'calibrateToBottom': True,
       'deckCalibrationDots': None,
       'disableHomeOnBoot': True,
@@ -42,7 +39,6 @@ def test_migrates_versionless_new_config():
 def test_migrates_versionless_old_config():
     settings, version = _migrate({
       'short-fixed-trash': False,
-      'split-labware-def': True,
       'calibrate-to-bottom': False,
       'dots-deck-type': True,
       'disable-home-on-boot': False,
@@ -51,7 +47,6 @@ def test_migrates_versionless_old_config():
     assert(version == 1)
     assert(settings == {
       'shortFixedTrash': None,
-      'splitLabwareDefinitions': True,
       'calibrateToBottom': None,
       'deckCalibrationDots': True,
       'disableHomeOnBoot': None,
@@ -62,14 +57,13 @@ def test_migrates_versionless_old_config():
 
 def test_ignores_invalid_keys():
     settings, version = _migrate({
-      'foo-bar': True,
-      'bazQux': True
+      'split-labware-def': True,
+      'splitLabwareDefinitions': True
     })
 
     assert(version == 1)
     assert(settings == {
       'shortFixedTrash': None,
-      'splitLabwareDefinitions': None,
       'calibrateToBottom': None,
       'deckCalibrationDots': None,
       'disableHomeOnBoot': None,


### PR DESCRIPTION
## overview

Remove unused splitLabwareDef feature flag (this was the feature flag for the first attempt at replacing the geometry system, which was superseded by APIv2 work)

## changelog

- Remove `splitLabwareDef` feature flag from API server
- Add protection so that if a feature flag is removed, the GET endpoint will not raise an exception on the existence of old keys

## review requests

Sanity ✔️ 