### PR TITLE
refactor(labware-library): Match navbar styles with design

### DIFF
--- a/labware-library/src/components/website-navigation/SupportMobileContent.js
+++ b/labware-library/src/components/website-navigation/SupportMobileContent.js
@@ -14,7 +14,7 @@ export default function supportMobileContent(props: Props) {
   return (
     <div className={styles.support_mobile_content}>
       <div className={styles.sales_group}>
-        <h3 className={styles.submenu_title}>Support</h3>
+        <h3 className={styles.submenu_title}>Sales</h3>
         <ul>
           {salesLinks.map(link => (
             <li key={link.name}>
@@ -24,7 +24,7 @@ export default function supportMobileContent(props: Props) {
         </ul>
       </div>
       <div className={styles.support_group}>
-        <h3 className={styles.submenu_title}>Sales</h3>
+        <h3 className={styles.submenu_title}>Support</h3>
         <ul>
           {supportLinks.map(link => (
             <li key={link.name}>

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -208,11 +208,12 @@
   line-height: 1.25rem;
   text-align: left;
   padding-bottom: var(--spacing-link);
-  padding-left: 4rem;
+  padding-left: 5rem;
 
   &.support_nav_link {
     padding-bottom: var(--spacing-5);
     text-align: left;
+    padding-left: 0;
   }
 }
 
@@ -349,7 +350,7 @@
 /* Top Mobile Menu text */
 .mobile_menu_title {
   width: 100%;
-  padding-left: 5rem;
+  padding-left: 6rem;
   text-align: left;
   font-size: var(--fs-default);
   font-weight: var(--fw-semibold);

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -399,6 +399,10 @@
     text-align: center;
   }
 
+  .support_nav_link .link_title {
+    text-align: left;
+  }
+
   .mobile_nav {
     top: var(--size-main-nav);
     min-height: auto;

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -11,6 +11,14 @@
   --spacing-submenu: 1.75rem;
   --spacing-link: 1.75rem;
 
+  --font-menu-title: {
+    font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
+    font-size: var(--fs-body-1);
+    font-weight: var(--fw-light);
+    letter-spacing: 0.7px;
+    color: var(--c-nav-gray);
+  }
+
   --dropdown-base: {
     position: absolute;
     top: 4.25rem;
@@ -178,7 +186,7 @@
 }
 
 .submenu_title {
-  @apply --font-body-2-dark;
+  @apply --font-menu-title;
 
   line-height: 1.25rem;
   flex: 0 0 6rem;
@@ -481,6 +489,6 @@
   .submenu_title {
     flex: 0 0 100%;
     padding: 0;
-    margin-bottom: var(--spacing-5);
+    margin-bottom: var(--spacing-2);
   }
 }

--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -426,6 +426,10 @@
     flex-direction: row;
   }
 
+  .submenu_title {
+    flex: 0 0 8rem;
+  }
+
   .support_group {
     flex-basis: 60%;
     display: flex;

--- a/labware-library/src/styles.global.css
+++ b/labware-library/src/styles.global.css
@@ -3,6 +3,7 @@
 */
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,800');
+@import url('https://fonts.googleapis.com/css?family=Ropa+Sans');
 @import './styles/reset.css';
 
 html,


### PR DESCRIPTION
## overview

This syncs styles with the main website navbar and implements design feedback. Implementing Akko Pro elegantly in the monorepo and adding GTM will be covered in new separate tickets. #3430 #3431 

closes #3382 

## changelog

- refactor(labware-library): Match navbar styles with design

## review requests

http://sandbox.labware.opentrons.com/lablib_navbar-design-review/

- [ ] Navbar matches main website (excluding CTA button)