### PR TITLE
feat(api): buildroot: allow separate setting of upstream log level

### DIFF
--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -197,7 +197,7 @@ async def set_syslog_level(request: web.Request) -> web.Response:
     if code != 0:
         msg = f'Could not reload config: {stdout} {stderr}'
         LOG.error(msg)
-        return web.json_response(status=500, message={'message': msg})
+        return web.json_response(status=500, data={'message': msg})
     else:
 
         if log_level:

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -85,7 +85,10 @@ class HTTPServer(object):
         self.app.router.add_post(
             '/settings', settings.set_advanced_setting)
         self.app.router.add_post(
-            '/settings/log_level', settings.set_log_level)
+            '/settings/log_level/local', settings.set_log_level)
+        if config.ARCHITECTURE == config.SystemArchitecture.BUILDROOT:
+            self.app.router.add_post(
+                '/settings/log_level/upstream', logs.set_syslog_level)
         self.app.router.add_post(
             '/settings/reset', settings.reset)
         self.app.router.add_get(

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -329,18 +329,18 @@ async def test_incorrect_modify_pipette_settings(
 async def test_set_log_level(
         async_server, loop, async_client):
     # Check input sanitization
-    resp = await async_client.post('/settings/log_level', json={})
+    resp = await async_client.post('/settings/log_level/local', json={})
     assert resp.status == 400
     body = await resp.json()
     assert 'message' in body
-    resp = await async_client.post('/settings/log_level',
+    resp = await async_client.post('/settings/log_level/local',
                                    json={'log_level': 'oafajhshda'})
     assert resp.status == 400
     body = await resp.json()
     assert 'message'in body
 
     assert async_server['com.opentrons.hardware'].config.log_level != 'ERROR'
-    resp = await async_client.post('/settings/log_level',
+    resp = await async_client.post('/settings/log_level/local',
                                    json={'log_level': 'error'})
     assert resp.status == 200
     body = await resp.json()


### PR DESCRIPTION
Move POST /settings/log_level to POST /settings/log_level/local to make it more
clear it's for local log level only
Add POST /settings/log_level/upstream, which changes the log level filter for
messages going upstream to log aggregation. It takes the same request format as
POST /settings/log_level/local, but you can set the level to 'null' to disable
upstream log aggregation.

Closes #3422

Requires https://github.com/Opentrons/buildroot/pull/22