### PR TITLE
fix(api): Handle smoothie update better

### DIFF
--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1052,6 +1052,7 @@ class Robot(CommandPublisher):
         msg = await self._driver.update_firmware(
             filename, checked_loop, explicit_modeset)
         self.fw_version = self._driver.get_fw_version()
+        self.connect()
         return msg
 
     @property

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -72,7 +72,7 @@ def initialize_robot(loop):
                     "Failed to update smoothie: did not connect after update")
         else:
             log.error("Could not update smoothie, forcing virtual")
-            os.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
+            os.environ['ENABLE_VIRTUAL_SMOOTHIE'] = 'true'
             hardware.connect()
     else:
         log.info("FW version OK: {}".format(packed_smoothie_fw_ver))

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -597,7 +597,7 @@ async def _call(cmd: List[str], suppress_err: bool = False) -> Tuple[str, str]:
     sanitized = sanitize_args(to_exec)
     log.debug('{}: stdout={}'.format(' '.join(sanitized), out_str))
     if err_str and not suppress_err:
-        log.info('{}: stderr={}'.format(' '.join(sanitized), err_str))
+        log.warning('{}: stderr={}'.format(' '.join(sanitized), err_str))
     return out_str, err_str
 
 


### PR DESCRIPTION
The smoothie update detection machinery assumes that when the server starts, if
the smoothie does not respond it must be in programming mode. However, this can
also be true if the api server is booting for the first time and expects a
smoothie version that isn't present, like the recent change. In that case, the
update will fail because the smoothie is never set to programming mode. This
commit adds a couple retries for smoothei update, and forces programming mode
for attempts past the first.

In addition, failed firmware updates currently could in theory make the api
server stop because of an uncaught exception. Instead, force the smoothie to be virtual.

## Testing
- Use this to update some robots still on edge-616 smoothie firmware and make sure it works
- See if you can force the smoothie into programming mode when booting and make sure that case still works too