### PR TITLE
feat(api): Add backwards compatibility to old pipette constructors

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -293,8 +293,9 @@ class InstrumentsWrapper(object):
 
         if attached_model and expected_model_substring in attached_model:
             return attached_model
-        elif attached_model and expected_model_substring.split('p')[1]\
-                in attached_model.split('+'):
+        elif attached_model and '+' in attached_model and\
+                expected_model_substring.split('p')[1] in\
+                attached_model.split('+')[1]:
             # Allow for backwards compatibility in old pipette constructors
             return attached_model
         else:

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -1,9 +1,11 @@
+import logging
 from . import (robot as _robot_module,
                instruments as inst,
                containers as cnt,
                modules)
 from opentrons.config import pipette_config
 
+log = logging.getLogger(__name__)
 # Ignore the type here because well, this is exactly why this is the legacy_api
 robot = _robot_module.Robot()  # type: ignore
 modules.provide_singleton(robot)
@@ -205,6 +207,13 @@ class InstrumentsWrapper(object):
             mount, name_or_model)
         config = pipette_config.load(pipette_model_version, pip_id)
 
+        if pip_id and name_or_model not in pipette_model_version:
+            log.warning(
+                f"Using a deprecated constructor for {pipette_model_version}")
+            constructor_config = pipette_config.name_config()[name_or_model]
+            config = config._replace(
+                min_volume=constructor_config['minVolume'],
+                max_volume=constructor_config['maxVolume'])
         return self._create_pipette_from_config(
             config=config,
             mount=mount,
@@ -274,7 +283,19 @@ class InstrumentsWrapper(object):
 
         attached_model = robot.get_attached_pipettes()[mount]['model']
 
+        if attached_model and\
+                'p+20' in attached_model and 'p10' in expected_model_substring:
+            # Special use-case where volume does not match, but we still
+            # want a valid model name to be passed
+            if attached_model.split('_')[1] ==\
+                    expected_model_substring.split('_')[1]:
+                return attached_model
+
         if attached_model and expected_model_substring in attached_model:
+            return attached_model
+        elif attached_model and expected_model_substring.split('p')[1]\
+                in attached_model.split('+')[1]:
+            # Allow for backwards compatibility in old pipette constructors
             return attached_model
         else:
             # pass a default pipette model-version for when robot is simulating

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -294,7 +294,7 @@ class InstrumentsWrapper(object):
         if attached_model and expected_model_substring in attached_model:
             return attached_model
         elif attached_model and expected_model_substring.split('p')[1]\
-                in attached_model.split('+')[1]:
+                in attached_model.split('+'):
             # Allow for backwards compatibility in old pipette constructors
             return attached_model
         else:


### PR DESCRIPTION
## overview
Closes #3434. Adds backwards compatibility for old pipette constructors when new pipette models are attached to the robot.

**Note** The P50 constructor will _not_ be supported moving forward with new pipette models as the volume range is too different.

## changelog
- Check that the volume string matches when a pipette+ is found but old constructor is used
- Load in pipette+ configs, but old min/max volumes of pipette model
- Add test to check that this works

## review requests
You can test using Alise's Robot with the script below. Unfortunately we do not have any pipette+'s in house except the `P1000_Single` but you can see that the robot thinks the correct pipette is attached and you can run the protocol as expected.

```
from opentrons import labware, instruments, robot

tiprack1 = labware.load('tiprack-1000ul', '1')

plate1 = labware.load('opentrons-tuberack-2ml-eppendorf', '2')
plate2 = labware.load('opentrons-tuberack-15_50ml', '3')
plate3 = labware.load('small_vial_rack_16x45', '4')

pip = instruments.P300_Single(mount='right', tip_racks=[tiprack1])

robot.comment(f"{pip.min_volume}")
robot.comment(f"{pip.max_volume}")
pip.transfer(100, plate1.wells(0), plate2.wells(0))
pip.transfer(100, plate1.wells(0), plate3.wells(0))

```