### PR TITLE
refactor(app): Add a feature flag to hide pipette+ options

### DIFF
--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -33,7 +33,10 @@ export default function Instructions(props: ChangePipetteProps) {
       contentsClassName={styles.modal_contents}
     >
       {!actualPipette && !wantedPipette && (
-        <PipetteSelection onChange={props.onPipetteSelect} />
+        <PipetteSelection
+          onChange={props.onPipetteSelect}
+          __pipettePlusEnabled={props.__pipettePlusEnabled}
+        />
       )}
 
       {(actualPipette || wantedPipette) && (

--- a/app/src/components/ChangePipette/PipetteSelection.js
+++ b/app/src/components/ChangePipette/PipetteSelection.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import filter from 'lodash/filter'
 
 import { getAllPipetteNames, getPipetteNameSpecs } from '@opentrons/shared-data'
 import { DropdownField } from '@opentrons/components'
@@ -9,6 +10,7 @@ const LABEL = 'Select the pipette you wish to attach:'
 
 export type PipetteSelectionProps = {
   onChange: $PropertyType<React.ElementProps<typeof DropdownField>, 'onChange'>,
+  __pipettePlusEnabled: boolean,
 }
 
 const OPTIONS = getAllPipetteNames().map(name => ({
@@ -17,10 +19,19 @@ const OPTIONS = getAllPipetteNames().map(name => ({
 }))
 
 export default function PipetteSelection(props: PipetteSelectionProps) {
+  let pipetteOptions
+  if (props.__pipettePlusEnabled) {
+    pipetteOptions = OPTIONS
+  } else {
+    pipetteOptions = filter(OPTIONS, function(pipette) {
+      return !pipette.name.includes('+')
+    })
+  }
+
   return (
     <label className={styles.pipette_selection}>
       <span className={styles.pipette_selection_label}>{LABEL}</span>
-      <DropdownField {...props} options={OPTIONS} />
+      <DropdownField {...props} options={pipetteOptions} />
     </label>
   )
 }

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -7,6 +7,7 @@ import {
   getPipetteNameSpecs,
   getPipetteModelSpecs,
 } from '@opentrons/shared-data'
+import { getConfig } from '../../config'
 
 import type {
   PipetteNameSpecs,
@@ -65,6 +66,7 @@ type SP = {|
   direction: Direction,
   success: boolean,
   attachedWrong: boolean,
+  __pipettePlusEnabled: boolean,
 |}
 
 type DP = {|
@@ -145,6 +147,9 @@ function makeMapStateToProps(): (State, OP) => SP {
       displayName,
       moveRequest: getRobotMove(state, ownProps.robot),
       homeRequest: getRobotHome(state, ownProps.robot),
+      __pipettePlusEnabled: Boolean(
+        getConfig(state).devInternal?.enablePipettePlus
+      ),
     }
   }
 }

--- a/app/src/components/ChangePipette/types.js
+++ b/app/src/components/ChangePipette/types.js
@@ -33,4 +33,5 @@ export type ChangePipetteProps = {
   onPipetteSelect: $PropertyType<PipetteSelectionProps, 'onChange'>,
   checkPipette: () => mixed,
   confirmPipette: () => mixed,
+  __pipettePlusEnabled: boolean,
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -71,6 +71,7 @@ export type Config = {
     allPipetteConfig?: boolean,
     tempdeckControls?: boolean,
     enableThermocycler?: boolean,
+    enablePipettePlus?: boolean,
   },
 }
 


### PR DESCRIPTION
## overview
This PR serves as both a ticket and a refactor to add in a feature flag that hides pipette+ display names.

## changelog
- Add in a feature flag that will automatically filter out pipette+ display names in attach pipette unless set to true

## review requests
Anything look amiss 🕵️‍♀️ ?
Run on your laptop. Without feature flag see that the list only includes old pipette names, with feature flag enabled see that all pipette names show up.

Use the feature flag: `OT_APP_DEV_INTERNAL__ENABLE_PIPETTE_PLUS=1`