### PR TITLE
style(js): use recommended "rules of hooks" lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,10 +13,12 @@ module.exports = {
     'prettier/standard',
   ],
 
-  plugins: ['flowtype', 'react', 'json', 'prettier'],
+  plugins: ['flowtype', 'react', 'react-hooks', 'json', 'prettier'],
 
   rules: {
     camelcase: 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 
   globals: {},

--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
     "webpack-merge": "^4.1.4",
     "worker-loader": "^2.0.0",
     "ws": "3.1.0"
+  },
+  "dependencies": {
+    "eslint-plugin-react-hooks": "^1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,6 +5119,11 @@ eslint-plugin-promise@^4.0.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
   integrity sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.12.4:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
## overview

![image](https://user-images.githubusercontent.com/11590381/57654773-01b0e500-75a3-11e9-97ee-14369661c6c0.png)

## changelog

- add lint rules for React hooks

## review requests

Run `yarn`, try to write some disallowed hook stuff and see the linting give you clear errors :sunglasses: 

Is the order of new plugin/rules in `.eslintrc.js` ok?