### PR TITLE
fix(app): Verify attached/protocol pipettes

### DIFF
--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -45,12 +45,14 @@ function ProtocolPipettes(props: Props) {
 
   const pipetteInfo = pipettes.map(p => {
     const pipetteConfig = getPipetteModelSpecs(p.name)
+    const actualPipetteConfig = getPipetteModelSpecs(
+      actualPipettes?.[p.mount].model || ''
+    )
     const displayName = !pipetteConfig ? 'N/A' : pipetteConfig.displayName
 
-    const actualModel = actualPipettes && actualPipettes[p.mount].model
     let pipettesMatch = true
 
-    if (pipetteConfig && actualModel !== p.name) {
+    if (pipetteConfig && pipetteConfig.name !== actualPipetteConfig?.name) {
       pipettesMatch = false
     }
 

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -28,28 +28,33 @@ export default function Pipettes(props: Props) {
 
   const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
-    // TODO(mc, 2018-04-25)
+
     const pipetteConfig = pipette ? getPipetteModelSpecs(pipette.name) : null
+    const actualPipetteConfig = getPipetteModelSpecs(
+      actualPipettes?.[mount].model || ''
+    )
 
     const isDisabled = !pipette || mount !== currentMount
     const details = !pipetteConfig
       ? { description: 'N/A', tipType: 'N/A' }
       : {
           description: pipetteConfig.displayName,
-          tipType: `${pipetteConfig.maxVolume} ul`,
+          tipType: `${pipetteConfig.maxVolume} µL`,
           channels: pipetteConfig.channels,
         }
 
-    const actualModel = actualPipettes && actualPipettes[mount].model
     let showAlert = false
     let alertType = ''
 
     // only show alert if a pipette is on this mount in the protocol
     if (pipetteConfig) {
-      if (actualModel == null) {
+      if (!actualPipetteConfig) {
         showAlert = true
         alertType = 'attach'
-      } else if (pipette && pipette.name !== actualModel) {
+      } else if (
+        actualPipetteConfig &&
+        actualPipetteConfig.name !== pipetteConfig.name
+      ) {
         showAlert = true
         alertType = 'change'
       }


### PR DESCRIPTION
## overview

This PR served as both a Bug Report and a Bug Fix. Support had reported wrong/no pipette attached messages in File Info and Calibrate Pipettes pages even after the user had gone to instrument settings and attached the correct/missing pipettes. The app was comparing models vs name. This PR gets both actual and session pipette names from shared data to avoid pipette version mismatch.

## changelog

- fix(app): Verify attached/protocol pipettes

## review requests
Can be tested on sanniti-bot with `api/tests/opentrons/data/bradford_assay.py`. 

- detach one of the pipettes before loading protocol
- upload protocol and observe missing/wrong pipette message in File Info and Calibrate Pipettes pages
- attach the pipette

- [ ] Missing pipette warning no longer exists in File Info Page
- [ ] Missing pipette warning no longer exists in Calibrate Pipettes Page
