### PR TITLE
refactor(api): Normalize our use of name and model internally

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -38,7 +38,10 @@ class Instrument:
         self._context = context
 
         self.id = id(instrument)
-        self.name = instrument.name
+        # The name element here is actually the pipette model for historical
+        # reasons
+        self.name = instrument.model
+        self.model_name = instrument.name
         self.channels = instrument.channels
         self.mount = instrument.mount
         self.containers = [

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -200,7 +200,7 @@ class Session(object):
                 instrs = {}
                 for mount, pip in self._hardware.attached_instruments.items():
                     if pip:
-                        instrs[mount] = {'model': pip['name'],
+                        instrs[mount] = {'model': pip['model'],
                                          'id': pip.get('pipette_id', '')}
                 sim = adapters.SynchronousAdapter.build(
                     API.build_hardware_simulator,

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -87,6 +87,10 @@ mutable_configs = model_config()['mutableConfigs']
 #: A list of mutable configs for pipettes
 
 
+def name_for_model(pipette_model: str) -> Optional[str]:
+    return configs.get(pipette_model, {'name': None})['name']
+
+
 def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
     """
     Load pipette config data

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -87,8 +87,8 @@ mutable_configs = model_config()['mutableConfigs']
 #: A list of mutable configs for pipettes
 
 
-def name_for_model(pipette_model: str) -> Optional[str]:
-    return configs.get(pipette_model, {'name': None})['name']
+def name_for_model(pipette_model: str) -> str:
+    return configs[pipette_model]['name']
 
 
 def load(pipette_model: str, pipette_id: str = None) -> pipette_config:

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -194,11 +194,11 @@ def _get_model_name(pipette, hardware):
     id = None
     if pipette:
         if not feature_flags.use_protocol_api_v2():
-            model = pipette.name
+            model = pipette.model
             pip_info = hardware.get_attached_pipettes()[pipette.mount]
             id = pip_info['id']
         else:
-            model = pipette.get('name')
+            model = pipette.get('model')
             mount = Mount.LEFT if pipette['mount'] == 'left' else Mount.RIGHT
             pip_info = hardware.attached_instruments[mount]
             id = pip_info['pipette_id']

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -184,26 +184,26 @@ def set_current_mount(hardware, session):
         pipette = left_pipette
         session.cp = CriticalPoint.FRONT_NOZZLE
 
-    model, id = _get_model_name(pipette, hardware)
-    session.pipette_id = id
+    model, pip_id = _get_model_name(pipette, hardware)
+    session.pipette_id = pip_id
     return {'pipette': pipette, 'model': model}
 
 
 def _get_model_name(pipette, hardware):
     model = None
-    id = None
+    pip_id = None
     if pipette:
         if not feature_flags.use_protocol_api_v2():
             model = pipette.model
             pip_info = hardware.get_attached_pipettes()[pipette.mount]
-            id = pip_info['id']
+            pip_id = pip_info['id']
         else:
             model = pipette.get('model')
             mount = Mount.LEFT if pipette['mount'] == 'left' else Mount.RIGHT
             pip_info = hardware.attached_instruments[mount]
-            id = pip_info['pipette_id']
+            pip_id = pip_info['pipette_id']
 
-    return model, id
+    return model, pip_id
 
 
 async def attach_tip(data):

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -264,9 +264,10 @@ class API(HardwareAPILike):
         for mount, instrument_data in found.items():
             model = instrument_data.get('model')
             if model is not None:
-                p = Pipette(model,
-                            self._config.instrument_offset[mount.name.lower()],
-                            instrument_data['id'])
+                p = Pipette(
+                    model,
+                    self._config.instrument_offset[mount.name.lower()],
+                    instrument_data['id'])
                 self._attached_instruments[mount] = p
                 mount_axis = Axis.by_mount(mount)
                 plunger_axis = Axis.of_plunger(mount)
@@ -300,7 +301,7 @@ class API(HardwareAPILike):
         configs = ['name', 'min_volume', 'max_volume', 'channels',
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
-                   'tip_length']
+                   'tip_length', 'model']
         instruments = {top_types.Mount.LEFT: {},
                        top_types.Mount.RIGHT: {}}
         for mount in top_types.Mount:
@@ -1214,7 +1215,7 @@ class API(HardwareAPILike):
                                     for ax, vals in new_pos.items()})
         self._log.info("Tip probe complete with {} {} on {}. "
                        "New position: {} (default {}), averaged from {}"
-                       .format(pip.name, pip.pipette_id, mount.name,
+                       .format(pip.model, pip.pipette_id, mount.name,
                                to_ret, self._config.tip_probe.center,
                                new_pos))
         return to_ret

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -206,12 +206,13 @@ class SingletonAdapter(HardwareAPILike):
         instrs = {}
         for mount, data in api.attached_instruments.items():
             instrs[mount.name.lower()] = {
-                'model': data.get('name', None),
+                'model': data.get('model', None),
+                'name': data.get('name', None),
                 'id': data.get('pipette_id', None),
                 'mount_axis': Axis.by_mount(mount),
                 'plunger_axis': Axis.of_plunger(mount)
             }
-            if data.get('name'):
+            if data.get('model'):
                 instrs[mount.name.lower()]['tip_length'] \
                     = data.get('tip_length', None)
 

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -22,7 +22,8 @@ class Pipette:
                  inst_offset_config: Dict[str, Tuple[float, float, float]],
                  pipette_id: str = None) -> None:
         self._config = pipette_config.load(model, pipette_id)
-        self._name = model
+        self._name = pipette_config.name_for_model(model)
+        self._model = model
         self._current_volume = 0.0
         self._current_tip_length = 0.0
         self._has_tip = False
@@ -49,6 +50,10 @@ class Pipette:
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def model(self) -> str:
+        return self._model
 
     @property
     def pipette_id(self) -> Optional[str]:
@@ -179,6 +184,7 @@ class Pipette:
         config_dict = self.config._asdict()
         config_dict.update({'current_volume': self.current_volume,
                             'name': self.name,
+                            'model': self.model,
                             'pipette_id': self.pipette_id,
                             'has_tip': self.has_tip})
         return config_dict

--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -258,10 +258,17 @@ class InstrumentsWrapper(object):
             'bottom': config.bottom,
             'blow_out': config.blow_out,
             'drop_tip': config.drop_tip}
+        if '_v' in name:
+            model = name
+            name = name.split('_v')[0]
+        else:
+            model = name
+            name = name
         p = self.Pipette(
             model_offset=config.model_offset,
             mount=mount,
             name=name,
+            model=model,
             trash_container=trash_container,
             tip_racks=tip_racks,
             channels=config.channels,

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -109,13 +109,14 @@ class Pipette(CommandPublisher):
     ...     tip_racks=[tip_rack_300ul]) # doctest: +SKIP
     """
 
-    def __init__(
+    def __init__(  # noqa(C901)
             self,
             robot,
             model_offset=(0, 0, 0),
             mount=None,
             axis=None,
             mount_obj=None,
+            model=None,
             name=None,
             ul_per_mm=None,
             channels=1,
@@ -166,6 +167,9 @@ class Pipette(CommandPublisher):
         if not name:
             name = self.__class__.__name__
         self.name = name
+        if not model:
+            model = self.__class__.__name__
+        self.model = model
 
         if trash_container == '':
             trash_container = self.robot.fixed_trash
@@ -223,8 +227,8 @@ class Pipette(CommandPublisher):
             aspirate=aspirate_flow_rate, dispense=dispense_flow_rate)
 
         # TODO (andy): remove from pipette, move to tip-rack
-        self.robot.config.tip_length[self.name] = \
-            self.robot.config.tip_length.get(self.name, fallback_tip_length)
+        self.robot.config.tip_length[self.model] = \
+            self.robot.config.tip_length.get(self.model, fallback_tip_length)
 
         self.quirks = quirks if isinstance(quirks, list) else []
 
@@ -1678,7 +1682,7 @@ class Pipette(CommandPublisher):
     def _tip_length(self):
         # TODO (andy): tip length should be retrieved from tip-rack's labware
         # definition, unblocking ability to use multiple types of tips
-        return self.robot.config.tip_length[self.name]
+        return self.robot.config.tip_length[self.model]
 
     def set_speed(self, aspirate=None, dispense=None):
         """

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -127,8 +127,10 @@ class Robot(CommandPublisher):
 
         self.INSTRUMENT_DRIVERS_CACHE = {}
         self._instruments = {}
-        self.model_by_mount = {'left': {'model': None, 'id': None},
-                               'right': {'model': None, 'id': None}}
+        self.model_by_mount = {
+            'left': {'model': None, 'id': None, 'name': None},
+            'right': {'model': None, 'id': None, 'name': None}
+        }
 
         self._commands = []
         self._unsubscribe_commands = None
@@ -271,6 +273,7 @@ class Robot(CommandPublisher):
         log.debug("Updating instrument model cache")
         for mount in self.model_by_mount.keys():
             model_value = self._driver.read_pipette_model(mount)
+            name_value = pipette_config.name_for_model(model_value)
             plunger_axis = 'B' if mount == 'left' else 'C'
             mount_axis = 'Z' if mount == 'left' else 'A'
             if model_value and 'v2' in model_value:
@@ -299,7 +302,8 @@ class Robot(CommandPublisher):
                 id_response = None
             self.model_by_mount[mount] = {
                 'model': model_value,
-                'id': id_response
+                'id': id_response,
+                'name': name_value
             }
             log.debug("{}: {} [{}]".format(
                 mount,
@@ -880,6 +884,7 @@ class Robot(CommandPublisher):
                 'mount_axis': 'z',
                 'plunger_axis': 'b',
                 'model': self.model_by_mount['left']['model'],
+                'name': self.model_by_mount['left']['name'],
                 'id': self.model_by_mount['left']['id']
             }
         left_model = left_data.get('model')
@@ -893,6 +898,7 @@ class Robot(CommandPublisher):
                 'mount_axis': 'a',
                 'plunger_axis': 'c',
                 'model': self.model_by_mount['right']['model'],
+                'name': self.model_by_mount['right']['name'],
                 'id': self.model_by_mount['right']['id']
             }
         right_model = right_data.get('model')

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -273,7 +273,10 @@ class Robot(CommandPublisher):
         log.debug("Updating instrument model cache")
         for mount in self.model_by_mount.keys():
             model_value = self._driver.read_pipette_model(mount)
-            name_value = pipette_config.name_for_model(model_value)
+            if model_value:
+                name_value = pipette_config.name_for_model(model_value)
+            else:
+                name_value = None
             plunger_axis = 'B' if mount == 'left' else 'C'
             mount_axis = 'Z' if mount == 'left' else 'A'
             if model_value and 'v2' in model_value:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -345,7 +345,7 @@ class ProtocolContext(CommandPublisher):
             raise RuntimeError("Instrument already present in {} mount: {}"
                                .format(checked_mount.name.lower(),
                                        instr.name))
-        attached = {att_mount: instr.get('name', None)
+        attached = {att_mount: instr.get('model', None)
                     for att_mount, instr
                     in self._hw_manager.hardware.attached_instruments.items()}
         attached[checked_mount] = instrument_name
@@ -1379,7 +1379,7 @@ class InstrumentContext(CommandPublisher):
         elif 'multi' in model:
             return 'multi'
         else:
-            raise RuntimeError("Bad pipette model name: {}".format(model))
+            raise RuntimeError("Bad pipette name: {}".format(model))
 
     @property
     def tip_racks(self) -> List[Labware]:
@@ -1412,9 +1412,16 @@ class InstrumentContext(CommandPublisher):
     @property
     def name(self) -> str:
         """
-        The model string for the pipette.
+        The name string for the pipette (e.g. 'p300_single')
         """
         return self.hw_pipette['name']
+
+    @property
+    def model(self) -> str:
+        """
+        The model string for the pipette (e.g. 'p300_single_v1.3')
+        """
+        return self.hw_pipette['model']
 
     @property
     def min_volume(self) -> float:
@@ -1469,7 +1476,7 @@ class InstrumentContext(CommandPublisher):
 
     def __repr__(self):
         return '<{}: {} in {}>'.format(self.__class__.__name__,
-                                       self.hw_pipette['name'],
+                                       self.hw_pipette['model'],
                                        self._mount.name)
 
     def __str__(self):

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -36,6 +36,7 @@ async def get_attached_pipettes(request):
     {
       'left': {
         'model': 'p300_single_v1',
+        'name': 'p300_single',
         'tip_length': 51.7,
         'mount_axis': 'z',
         'plunger_axis': 'b',
@@ -43,6 +44,7 @@ async def get_attached_pipettes(request):
       },
       'right': {
         'model': 'p10_multi_v1',
+        'name': 'p10_multi',
         'tip_length': 40,
         'mount_axis': 'a',
         'plunger_axis': 'c',
@@ -65,6 +67,7 @@ async def get_attached_pipettes(request):
     for mount, data in hw.get_attached_pipettes().items():
         response[mount] = {
             'model': data['model'],
+            'name': data['name'],
             'mount_axis': str(data['mount_axis']).lower(),
             'plunger_axis': str(data['plunger_axis']).lower(),
             'id': data['id']

--- a/api/src/opentrons/util/calibration_functions.py
+++ b/api/src/opentrons/util/calibration_functions.py
@@ -14,7 +14,7 @@ def probe_instrument(instrument, robot, tip_length=None) -> Point:
     robot.home()
     tp = robot.config.tip_probe
     if tip_length is None:
-        tip_length = robot.config.tip_length[instrument.name]
+        tip_length = robot.config.tip_length[instrument.model]
     instrument._add_tip(tip_length)
 
     # probe_center is the point at the center of the switch pcb
@@ -107,7 +107,7 @@ def update_instrument_config(
     instrument_offset[instrument.mount][instrument.type] = \
         (old_x - dx, old_y - dy, 0.0)
     tip_length = deepcopy(config.tip_length)
-    tip_length[instrument.name] = tip_length[instrument.name] + dz
+    tip_length[instrument.model] = tip_length[instrument.model] + dz
 
     config = config \
         ._replace(instrument_offset=instrument_offset) \

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -14,11 +14,13 @@ def dummy_instruments():
     dummy_instruments_attached = {
         types.Mount.LEFT: {
             'model': LEFT_PIPETTE_MODEL,
-            'id': LEFT_PIPETTE_ID
+            'id': LEFT_PIPETTE_ID,
+            'name': LEFT_PIPETTE_PREFIX,
         },
         types.Mount.RIGHT: {
             'model': None,
-            'id': None
+            'id': None,
+            'name': None,
         }
     }
     return dummy_instruments_attached
@@ -27,7 +29,7 @@ def dummy_instruments():
 instrument_keys = sorted([
     'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
-    'tip_length', 'has_tip'])
+    'tip_length', 'has_tip', 'model'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):
@@ -87,12 +89,16 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     # When we expect instruments, we should get what we expect since nothing
     # was specified at init time
     await sim.cache_instruments({types.Mount.LEFT: 'p10_single_v1.3'})
-    assert sim.attached_instruments[types.Mount.LEFT]['name']\
+    assert sim.attached_instruments[types.Mount.LEFT]['model']\
         == 'p10_single_v1.3'
+    assert sim.attached_instruments[types.Mount.LEFT]['name']\
+        == 'p10_single'
     # If we use prefixes, that should work too
     await sim.cache_instruments({types.Mount.RIGHT: 'p300_single'})
-    assert sim.attached_instruments[types.Mount.RIGHT]['name']\
+    assert sim.attached_instruments[types.Mount.RIGHT]['model']\
         == 'p300_single_v1'
+    assert sim.attached_instruments[types.Mount.RIGHT]['name']\
+        == 'p300_single'
     # If we specify instruments at init time, we should get them without
     # passing an expectation
     sim = hc.API.build_hardware_simulator(

--- a/api/tests/opentrons/labware/test_pipette_constructors.py
+++ b/api/tests/opentrons/labware/test_pipette_constructors.py
@@ -68,8 +68,11 @@ def test_backwards_compatibility(backcompat, monkeypatch):
 
     robot.reset()
 
-    fake_pip = {'left': {'model': None, 'id': None},
-                'right': {'model': expected_name + '_v2.0', 'id': 'FakePip'}}
+    fake_pip = {'left': {'model': None, 'id': None, 'name': None},
+                'right': {
+                    'model': expected_name + '_v2.0',
+                    'id': 'FakePip',
+                    'name': expected_name}}
     monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
 
     old_config = pipette_config.name_config()[old_name]

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -29,7 +29,7 @@ def test_load_instrument(loop):
     ctx = papi.ProtocolContext(loop=loop)
     for config in config_models:
         loaded = ctx.load_instrument(config, Mount.LEFT, replace=True)
-        assert loaded.name == config
+        assert loaded.model == config
         prefix = config.split('_v')[0]
         loaded = ctx.load_instrument(prefix, Mount.RIGHT, replace=True)
         assert loaded.name.startswith(prefix)
@@ -115,10 +115,14 @@ def test_pipette_info(loop):
     left = ctx.load_instrument('p1000_single', Mount.LEFT)
     assert right.type == 'multi'
     name = ctx._hw_manager.hardware.attached_instruments[Mount.RIGHT]['name']
+    model = ctx._hw_manager.hardware.attached_instruments[Mount.RIGHT]['model']
     assert right.name == name
+    assert right.model == model
     assert left.type == 'single'
     name = ctx._hw_manager.hardware.attached_instruments[Mount.LEFT]['name']
+    model = ctx._hw_manager.hardware.attached_instruments[Mount.LEFT]['model']
     assert left.name == name
+    assert left.model == model
 
 
 def test_pick_up_and_drop_tip(loop, load_my_labware):

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -372,7 +372,6 @@ async def test_forcing_new_session(
     overridden.
     """
     test_model = 'p300_multi_v1'
-    test_name = 'p300_multi'
     if async_server['api_version'] == 1:
 
         def dummy_read_model(mount):

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -372,6 +372,7 @@ async def test_forcing_new_session(
     overridden.
     """
     test_model = 'p300_multi_v1'
+    test_name = 'p300_multi'
     if async_server['api_version'] == 1:
 
         def dummy_read_model(mount):
@@ -401,8 +402,13 @@ async def test_forcing_new_session(
         '/calibration/deck/start', json={'force': 'true'})
     text2 = await resp2.json()
     assert resp2.status == 201
-    expected2 = {'token': dummy_token,
-                 'pipette': {'mount': 'right', 'model': test_model}}
+    expected2 = {
+        'token': dummy_token,
+        'pipette': {
+            'mount': 'right',
+            'model': test_model
+        }
+    }
     assert text2 == expected2
 
 


### PR DESCRIPTION
When we introduced our pipetteModelSpecs/pipetteNameSpecs split for our pipette
data, we settled on
pipette 'name' being the _kind_ of pipette - 'p300_single', 'p10_multi', etc
pipette 'model' being the specific model version of pipette -
'p300_single_v1.5', 'p+20_single_v2.0', etc

However, we didn't fully realize this throughout our stack. The name attribute
of both the robot singleton pipette objects and the hardware control pipette
objects (and everything that depended on them) still used 'name' to mean
'model'. This causes confusion for devs and also bugs like
https://github.com/Opentrons/opentrons/pull/3458

This PR fixes that by
- Making the 'name' attributes on both the old and new pipettes return the name
- Making new 'model' attributes on old and new pipettes that return the model
- Piping everything around internally

There's also changes to the tests to adapt their internal mocks for the above.

Though the above pr does fix the bug it mentions, this also provides another way
for clients to avoid confusing the simulated _v1 pipettes and the real versioned
pipettes: check that the pipette _names_ match between the /pipettes endpoint
and the protocol rpc output.

This is also a pretty large PR that touches a lot of parts of the code (though the tests all pass), and i'm open to the concept that this isn't the right time to merge this.

For testing, basically run through uploading a protocol and swapping pipettes, as well as deck cal.