### PR TITLE
chore(labware-library): Fix GTM config from env var

### DIFF
--- a/labware-library/src/index.hbs
+++ b/labware-library/src/index.hbs
@@ -7,17 +7,11 @@
     <meta name='author' content='{{htmlWebpackPlugin.options.author}}'>
     <title>{{htmlWebpackPlugin.options.title}}</title>
     <!-- Google Tag Manager -->
-    <script>
-    // GTM_ID pulled in from environment at build time
-    const GTM_ID = process.env.GTM_ID
-    if (GTM_ID) {
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer', GTM_ID);
-}
-  </script>
+    })(window,document,'script','dataLayer',{{htmlWebpackPlugin.options.gtmId}});</script>
     <!-- End Google Tag Manager -->
   </head>
 

--- a/labware-library/src/index.hbs
+++ b/labware-library/src/index.hbs
@@ -11,7 +11,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer',{{htmlWebpackPlugin.options.gtmId}});</script>
+    })(window,document,'script','dataLayer','{{htmlWebpackPlugin.options.gtmId}}');</script>
     <!-- End Google Tag Manager -->
   </head>
 

--- a/labware-library/webpack.config.js
+++ b/labware-library/webpack.config.js
@@ -55,5 +55,6 @@ function makeHtmlPlugin(page) {
     description: pkg.description,
     author: pkg.author.name,
     filename: path.join(location, 'index.html'),
+    gtmId: process.env.GTM_ID,
   })
 }


### PR DESCRIPTION
## overview

Following up on #3440, this PR ensures the GTM ID is pulled in at build time, not run time

## changelog

- chore(labware-library): Fix GTM config from env var

## review requests

- [x] Ensure GTM works in labware library