### PR TITLE
feat(api): Allow loading labware v2 definitions directly into apiv1

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -152,7 +152,7 @@ def save_custom_container(data):
         "labware, please use opentrons.containers.create()")
 
 
-def _load_new_well(well_data, saved_offset, format):
+def _load_new_well(well_data, saved_offset, lw_format):
     props = {
         'depth': well_data['depth'],
         'total-liquid-volume': well_data['totalLiquidVolume'],
@@ -166,7 +166,7 @@ def _load_new_well(well_data, saved_offset, format):
             f"Bad definition for well shape: {well_data['shape']}")
     well = Well(properties=props)
 
-    if format == 'trough':
+    if lw_format == 'trough':
         well_tuple = (
             well_data['x'] - well_data['xDimension']/2 + saved_offset.x,
             well_data['y'] + well_data['yDimension']/2 + saved_offset.y,
@@ -220,11 +220,11 @@ def load_new_labware_def(definition):
     log.info(f"Container name {container_name}")
     container.properties['type'] = container_name
     container.properties['otId'] = labware_id
-    format = definition['parameters']['format']
+    lw_format = definition['parameters']['format']
 
     container._coordinates = Vector(definition['cornerOffsetFromSlot'])
     for well_name in itertools.chain(*definition['ordering']):
         well_obj, well_pos = _load_new_well(
-            definition['wells'][well_name], saved_offset, format)
+            definition['wells'][well_name], saved_offset, lw_format)
         container.add(well_obj, well_name, well_pos)
     return container

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -202,22 +202,29 @@ def save_new_offsets(otId, delta):
 
 
 def load_new_labware(container_name):
-    """ Load a labware in the new schema into a placeable.
+    """ Load a labware in the new schema into a placeable, by name
 
     :raises KeyError: If the labware name is not found
     """
     defn = new_labware.load_definition_by_name(container_name)
-    labware_id = defn['otId']
+    return load_new_labware_def(defn)
+
+
+def load_new_labware_def(definition):
+    """ Load a labware definition in the new schema into a placeable
+    """
+    labware_id = definition['otId']
     saved_offset = _look_up_offsets(labware_id)
     container = Container()
+    container_name = definition['parameters']['loadName']
     log.info(f"Container name {container_name}")
     container.properties['type'] = container_name
     container.properties['otId'] = labware_id
-    format = defn['parameters']['format']
+    format = definition['parameters']['format']
 
-    container._coordinates = Vector(defn['cornerOffsetFromSlot'])
-    for well_name in itertools.chain(*defn['ordering']):
+    container._coordinates = Vector(definition['cornerOffsetFromSlot'])
+    for well_name in itertools.chain(*definition['ordering']):
         well_obj, well_pos = _load_new_well(
-            defn['wells'][well_name], saved_offset, format)
+            definition['wells'][well_name], saved_offset, format)
         container.add(well_obj, well_name, well_pos)
     return container


### PR DESCRIPTION
This is necessary for implementing the json protocol v3 format, which contains
labware definitions inline in the protocol.

Rather than go through labware.load, clients can now call
robot.add_container_by_definition with a definition dict and a string slot name
to load the container.
