### PR TITLE
refactor(update-server): Allow vairable test execution times

### DIFF
--- a/update-server/tests/buildroot/test_update.py
+++ b/update-server/tests/buildroot/test_update.py
@@ -128,19 +128,18 @@ async def test_update_happypath(test_cli, update_session,
         last_progress = body['progress']
         assert loop.time() - then <= 300
 
-    assert body['stage'] == 'writing'
-
-    # Wait through write
-    then = loop.time()
-    last_progress = 0.0
-    while body['stage'] == 'writing':
-        assert body['progress'] >= last_progress
-        resp = await test_cli.get(session_endpoint(update_session,
-                                                   'status'))
-        assert resp.status == 200
-        body = await resp.json()
-        last_progress = body['progress']
-        assert loop.time() - then <= 300
+    if body['stage'] == 'writing':
+        # Wait through write
+        then = loop.time()
+        last_progress = 0.0
+        while body['stage'] == 'writing':
+            assert body['progress'] >= last_progress
+            resp = await test_cli.get(session_endpoint(update_session,
+                                                       'status'))
+            assert resp.status == 200
+            body = await resp.json()
+            last_progress = body['progress']
+            assert loop.time() - then <= 300
 
     assert body['stage'] == 'done'
 


### PR DESCRIPTION
This test sometimes fails because we don't catch the writing stage.
Fundamentally, we're checking that we progress ok to the done stage, so let's
not fail the test if the asynchronous execution means we miss "writing".
