### PR TITLE
feat(api): support running v3 protocols in APIv1

### DIFF
--- a/api/src/opentrons/protocols/__init__.py
+++ b/api/src/opentrons/protocols/__init__.py
@@ -1,252 +1,36 @@
-from numpy import add
-import time
-import datetime
-from itertools import chain
-from opentrons import instruments, labware, robot
+from . import execute_v1, execute_v3
+from opentrons.protocol_api.execute import (
+    get_protocol_schema_version, validate_protocol)
 
 
-def _sleep(seconds):
-    if not robot.is_simulating():
-        time.sleep(seconds)
+def execute_protocol(protocol_json):
+    protocol_version = get_protocol_schema_version(protocol_json)
+    if protocol_version > 3:
+        raise RuntimeError(
+            f'JSON Protocol version {protocol_version} is not yet ' +
+            'supported in this version of the API')
 
+    validate_protocol(protocol_json)
 
-def load_pipettes(protocol_data):
-    pipettes = protocol_data.get('pipettes', {})
-    pipettes_by_id = {}
+    if protocol_version == 3:
+        ins = execute_v3.load_pipettes(
+            protocol_json)
+        lw = execute_v3.load_labware(
+            protocol_json)
+        execute_v3.dispatch_commands(protocol_json, ins, lw)
+    else:
+        ins = execute_v1.load_pipettes(
+            protocol_json)
+        lw = execute_v1.load_labware(
+            protocol_json)
+        execute_v1.dispatch_commands(protocol_json, ins, lw)
 
-    for pipette_id, props in pipettes.items():
-        model = props.get('model')
-        mount = props.get('mount')
-
-        # TODO: Ian 2018-11-06 remove this fallback to 'model' when
-        # backwards-compatability for JSON protocols with versioned
-        # pipettes is dropped (next JSON protocol schema major bump)
-        name = props.get('name')
-        if not name:
-            name = model.split('_v')[0]
-        pipette = instruments.pipette_by_name(mount, name)
-
-        pipettes_by_id[pipette_id] = pipette
-
-    return pipettes_by_id
-
-
-def load_labware(protocol_data):
-    data = protocol_data.get('labware', {})
-    loaded_labware = {}
-    for labware_id, props in data.items():
-        slot = props.get('slot')
-        # TODO: Ian 2019-03-19 throw error if slot is number, only allow string
-        model = props.get('model')
-        display_name = props.get('display-name')
-
-        if slot == '12':
-            if model == 'fixed-trash':
-                # pass in the pre-existing fixed-trash
-                loaded_labware[labware_id] = robot.fixed_trash
-            else:
-                # share the slot with the fixed-trash
-                loaded_labware[labware_id] = labware.load(
-                    model,
-                    slot,
-                    display_name,
-                    share=True
-                )
-        else:
-            loaded_labware[labware_id] = labware.load(
-                model,
-                slot,
-                display_name
-            )
-
-    return loaded_labware
-
-
-def _get_location(loaded_labware, command_type, params, default_values):
-    labwareId = params.get('labware')
-    if not labwareId:
-        # not all commands use labware param
-        return None
-    well = params.get('well')
-    labware = loaded_labware.get(labwareId)
-    if not labware:
-        raise ValueError(
-            'Command tried to use labware "{}", but that ID does not exist ' +
-            'in protocol\'s "labware" section'.format(labwareId))
-
-    # default offset from bottom for aspirate/dispense commands
-    offset_default = default_values.get(
-        '{}-mm-from-bottom'.format(command_type))
-
-    # optional command-specific value, fallback to default
-    offset_from_bottom = params.get(
-        'offsetFromBottomMm', offset_default)
-
-    if offset_from_bottom is None:
-        # not all commands use offsets
-
-        # touch-tip uses offset from top, not bottom, as default
-        # when offsetFromBottomMm command-specific value is unset
-        if command_type == 'touch-tip':
-            # TODO: Ian 2018-10-29 remove this `-1` when
-            # touch-tip-mm-from-top is a required field
-            return labware.wells(well).top(
-                z=default_values.get('touch-tip-mm-from-top', -1))
-
-        return labware.wells(well)
-
-    return labware.wells(well).bottom(offset_from_bottom)
-
-
-def _get_pipette(command_params, loaded_pipettes):
-    pipetteId = command_params.get('pipette')
-    return loaded_pipettes.get(pipetteId)
-
-
-# TODO (Ian 2018-08-22) once Pipette has more sensible way of managing
-# flow rate value (eg as an argument in aspirate/dispense fns), remove this
-def _set_flow_rate(
-        pipette_name, pipette, command_type, params, default_values):
-    """
-    Set flow rate in uL/mm, to value obtained from command's params,
-    or if unspecified in command params, then from protocol's "default-values".
-    """
-    default_aspirate = default_values.get(
-        'aspirate-flow-rate', {}).get(pipette_name)
-
-    default_dispense = default_values.get(
-        'dispense-flow-rate', {}).get(pipette_name)
-
-    flow_rate_param = params.get('flow-rate')
-
-    if flow_rate_param is not None:
-        if command_type == 'aspirate':
-            pipette.set_flow_rate(
-                aspirate=flow_rate_param,
-                dispense=default_dispense)
-            return
-        if command_type == 'dispense':
-            pipette.set_flow_rate(
-                aspirate=default_aspirate,
-                dispense=flow_rate_param)
-            return
-
-    pipette.set_flow_rate(
-        aspirate=default_aspirate,
-        dispense=default_dispense
-    )
-
-
-# C901 code complexity is due to long elif block, ok in this case (Ian+Ben)
-def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: C901 E501
-    subprocedures = [
-        p.get('subprocedure', [])
-        for p in protocol_data.get('procedure', [])]
-
-    default_values = protocol_data.get('default-values', {})
-    flat_subs = chain.from_iterable(subprocedures)
-
-    for command_item in flat_subs:
-        command_type = command_item.get('command')
-        params = command_item.get('params', {})
-
-        pipette = _get_pipette(params, loaded_pipettes)
-        protocol_pipette_data = protocol_data\
-            .get('pipettes', {})\
-            .get(params.get('pipette'), {})
-        pipette_name = protocol_pipette_data.get('name')
-
-        if (not pipette_name):
-            # TODO: Ian 2018-11-06 remove this fallback to 'model' when
-            # backwards-compatability for JSON protocols with versioned
-            # pipettes is dropped (next JSON protocol schema major bump)
-            pipette_name = protocol_pipette_data.get('model')
-
-        location = _get_location(
-            loaded_labware, command_type, params, default_values)
-        volume = params.get('volume')
-
-        if pipette:
-            # Aspirate/Dispense flow rate must be set each time for commands
-            # which use pipettes right now.
-            # Flow rate is persisted inside the Pipette object
-            # and is settable but not easily gettable
-            _set_flow_rate(
-                pipette_name, pipette, command_type, params, default_values)
-
-        if command_type == 'delay':
-            wait = params.get('wait')
-            message = params.get('message')
-            if wait is None:
-                raise ValueError('Delay cannot be null')
-            elif wait is True:
-                message = message or 'Pausing until user resumes'
-                robot.pause(msg=message)
-            else:
-                text = f'Delaying for {datetime.timedelta(seconds=wait)}'
-                if message:
-                    text = f"{text}. {message}"
-                robot.comment(text)
-                _sleep(wait)
-
-        elif command_type == 'blowout':
-            pipette.blow_out(location)
-
-        elif command_type == 'pick-up-tip':
-            pipette.pick_up_tip(location)
-
-        elif command_type == 'drop-tip':
-            pipette.drop_tip(location)
-
-        elif command_type == 'aspirate':
-            pipette.aspirate(volume, location)
-
-        elif command_type == 'dispense':
-            pipette.dispense(volume, location)
-
-        elif command_type == 'touch-tip':
-            # NOTE: if touch_tip can take a location tuple,
-            # this can be much simpler
-            (well_object, loc_tuple) = location
-
-            # Use the offset baked into the well_object.
-            # Do not allow API to apply its v_offset kwarg default value,
-            # and do not apply the JSON protocol's default offset.
-            z_from_bottom = loc_tuple[2]
-            offset_from_top = (
-                well_object.properties['depth'] - z_from_bottom) * -1
-
-            pipette.touch_tip(well_object, v_offset=offset_from_top)
-
-        elif command_type == 'move-to-slot':
-            slot = params.get('slot')
-            if slot not in [str(s+1) for s in range(12)]:
-                raise ValueError('"move-to-slot" requires a valid slot, got {}'
-                                 .format(slot))
-            x_offset = params.get('offset', {}).get('x', 0)
-            y_offset = params.get('offset', {}).get('y', 0)
-            z_offset = params.get('offset', {}).get('z', 0)
-            slot_placeable = robot.deck[slot]
-            slot_offset = (x_offset, y_offset, z_offset)
-
-            strategy = 'direct' if params.get('force-direct') else None
-
-            # NOTE: Robot.move_to subtracts the offset from Slot.top()[1],
-            # so in order not to translate our desired offset,
-            # we have to compensate by adding it here :/
-            pipette.move_to(
-                (slot_placeable,
-                 add(slot_offset, tuple(slot_placeable.top()[1]))),
-                strategy=strategy)
-
-
-def execute_protocol(protocol):
-    loaded_pipettes = load_pipettes(protocol)
-    loaded_labware = load_labware(protocol)
-
-    dispatch_commands(protocol, loaded_pipettes, loaded_labware)
+    # loaded_pipettes = execute_v1.load_pipettes(protocol)
+    # loaded_labware = execute_v1.load_labware(protocol)
+    #
+    # execute_v1.dispatch_commands(protocol, loaded_pipettes, loaded_labware)
 
     return {
-        'pipettes': loaded_pipettes,
-        'labware': loaded_labware
+        'pipettes': ins,
+        'labware': lw
     }

--- a/api/src/opentrons/protocols/__init__.py
+++ b/api/src/opentrons/protocols/__init__.py
@@ -25,11 +25,6 @@ def execute_protocol(protocol_json):
             protocol_json)
         execute_v1.dispatch_commands(protocol_json, ins, lw)
 
-    # loaded_pipettes = execute_v1.load_pipettes(protocol)
-    # loaded_labware = execute_v1.load_labware(protocol)
-    #
-    # execute_v1.dispatch_commands(protocol, loaded_pipettes, loaded_labware)
-
     return {
         'pipettes': ins,
         'labware': lw

--- a/api/src/opentrons/protocols/execute_v1.py
+++ b/api/src/opentrons/protocols/execute_v1.py
@@ -68,8 +68,8 @@ def _get_location(loaded_labware, command_type, params, default_values):
         # not all commands use labware param
         return None
     well = params.get('well')
-    labware = loaded_labware.get(labwareId)
-    if not labware:
+    lw = loaded_labware.get(labwareId)
+    if not lw:
         raise ValueError(
             'Command tried to use labware "{}", but that ID does not exist ' +
             'in protocol\'s "labware" section'.format(labwareId))
@@ -90,12 +90,12 @@ def _get_location(loaded_labware, command_type, params, default_values):
         if command_type == 'touch-tip':
             # TODO: Ian 2018-10-29 remove this `-1` when
             # touch-tip-mm-from-top is a required field
-            return labware.wells(well).top(
+            return lw.wells(well).top(
                 z=default_values.get('touch-tip-mm-from-top', -1))
 
-        return labware.wells(well)
+        return lw.wells(well)
 
-    return labware.wells(well).bottom(offset_from_bottom)
+    return lw.wells(well).bottom(offset_from_bottom)
 
 
 def _get_pipette(command_params, loaded_pipettes):

--- a/api/src/opentrons/protocols/execute_v1.py
+++ b/api/src/opentrons/protocols/execute_v1.py
@@ -1,0 +1,240 @@
+from numpy import add
+import time
+import datetime
+from itertools import chain
+from opentrons import instruments, labware, robot
+
+
+def _sleep(seconds):
+    if not robot.is_simulating():
+        time.sleep(seconds)
+
+
+def load_pipettes(protocol_data):
+    pipettes = protocol_data.get('pipettes', {})
+    pipettes_by_id = {}
+
+    for pipette_id, props in pipettes.items():
+        model = props.get('model')
+        mount = props.get('mount')
+
+        # TODO: Ian 2018-11-06 remove this fallback to 'model' when
+        # backwards-compatability for JSON protocols with versioned
+        # pipettes is dropped (next JSON protocol schema major bump)
+        name = props.get('name')
+        if not name:
+            name = model.split('_v')[0]
+        pipette = instruments.pipette_by_name(mount, name)
+
+        pipettes_by_id[pipette_id] = pipette
+
+    return pipettes_by_id
+
+
+def load_labware(protocol_data):
+    data = protocol_data.get('labware', {})
+    loaded_labware = {}
+    for labware_id, props in data.items():
+        slot = props.get('slot')
+        # TODO: Ian 2019-03-19 throw error if slot is number, only allow string
+        model = props.get('model')
+        display_name = props.get('display-name')
+
+        if slot == '12':
+            if model == 'fixed-trash':
+                # pass in the pre-existing fixed-trash
+                loaded_labware[labware_id] = robot.fixed_trash
+            else:
+                # share the slot with the fixed-trash
+                loaded_labware[labware_id] = labware.load(
+                    model,
+                    slot,
+                    display_name,
+                    share=True
+                )
+        else:
+            loaded_labware[labware_id] = labware.load(
+                model,
+                slot,
+                display_name
+            )
+
+    return loaded_labware
+
+
+def _get_location(loaded_labware, command_type, params, default_values):
+    labwareId = params.get('labware')
+    if not labwareId:
+        # not all commands use labware param
+        return None
+    well = params.get('well')
+    labware = loaded_labware.get(labwareId)
+    if not labware:
+        raise ValueError(
+            'Command tried to use labware "{}", but that ID does not exist ' +
+            'in protocol\'s "labware" section'.format(labwareId))
+
+    # default offset from bottom for aspirate/dispense commands
+    offset_default = default_values.get(
+        '{}-mm-from-bottom'.format(command_type))
+
+    # optional command-specific value, fallback to default
+    offset_from_bottom = params.get(
+        'offsetFromBottomMm', offset_default)
+
+    if offset_from_bottom is None:
+        # not all commands use offsets
+
+        # touch-tip uses offset from top, not bottom, as default
+        # when offsetFromBottomMm command-specific value is unset
+        if command_type == 'touch-tip':
+            # TODO: Ian 2018-10-29 remove this `-1` when
+            # touch-tip-mm-from-top is a required field
+            return labware.wells(well).top(
+                z=default_values.get('touch-tip-mm-from-top', -1))
+
+        return labware.wells(well)
+
+    return labware.wells(well).bottom(offset_from_bottom)
+
+
+def _get_pipette(command_params, loaded_pipettes):
+    pipetteId = command_params.get('pipette')
+    return loaded_pipettes.get(pipetteId)
+
+
+# TODO (Ian 2018-08-22) once Pipette has more sensible way of managing
+# flow rate value (eg as an argument in aspirate/dispense fns), remove this
+def _set_flow_rate(
+        pipette_name, pipette, command_type, params, default_values):
+    """
+    Set flow rate in uL/mm, to value obtained from command's params,
+    or if unspecified in command params, then from protocol's "default-values".
+    """
+    default_aspirate = default_values.get(
+        'aspirate-flow-rate', {}).get(pipette_name)
+
+    default_dispense = default_values.get(
+        'dispense-flow-rate', {}).get(pipette_name)
+
+    flow_rate_param = params.get('flow-rate')
+
+    if flow_rate_param is not None:
+        if command_type == 'aspirate':
+            pipette.set_flow_rate(
+                aspirate=flow_rate_param,
+                dispense=default_dispense)
+            return
+        if command_type == 'dispense':
+            pipette.set_flow_rate(
+                aspirate=default_aspirate,
+                dispense=flow_rate_param)
+            return
+
+    pipette.set_flow_rate(
+        aspirate=default_aspirate,
+        dispense=default_dispense
+    )
+
+
+# C901 code complexity is due to long elif block, ok in this case (Ian+Ben)
+def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: C901 E501
+    subprocedures = [
+        p.get('subprocedure', [])
+        for p in protocol_data.get('procedure', [])]
+
+    default_values = protocol_data.get('default-values', {})
+    flat_subs = chain.from_iterable(subprocedures)
+
+    for command_item in flat_subs:
+        command_type = command_item.get('command')
+        params = command_item.get('params', {})
+
+        pipette = _get_pipette(params, loaded_pipettes)
+        protocol_pipette_data = protocol_data\
+            .get('pipettes', {})\
+            .get(params.get('pipette'), {})
+        pipette_name = protocol_pipette_data.get('name')
+
+        if (not pipette_name):
+            # TODO: Ian 2018-11-06 remove this fallback to 'model' when
+            # backwards-compatability for JSON protocols with versioned
+            # pipettes is dropped (next JSON protocol schema major bump)
+            pipette_name = protocol_pipette_data.get('model')
+
+        location = _get_location(
+            loaded_labware, command_type, params, default_values)
+        volume = params.get('volume')
+
+        if pipette:
+            # Aspirate/Dispense flow rate must be set each time for commands
+            # which use pipettes right now.
+            # Flow rate is persisted inside the Pipette object
+            # and is settable but not easily gettable
+            _set_flow_rate(
+                pipette_name, pipette, command_type, params, default_values)
+
+        if command_type == 'delay':
+            wait = params.get('wait')
+            message = params.get('message')
+            if wait is None:
+                raise ValueError('Delay cannot be null')
+            elif wait is True:
+                message = message or 'Pausing until user resumes'
+                robot.pause(msg=message)
+            else:
+                text = f'Delaying for {datetime.timedelta(seconds=wait)}'
+                if message:
+                    text = f"{text}. {message}"
+                robot.comment(text)
+                _sleep(wait)
+
+        elif command_type == 'blowout':
+            pipette.blow_out(location)
+
+        elif command_type == 'pick-up-tip':
+            pipette.pick_up_tip(location)
+
+        elif command_type == 'drop-tip':
+            pipette.drop_tip(location)
+
+        elif command_type == 'aspirate':
+            pipette.aspirate(volume, location)
+
+        elif command_type == 'dispense':
+            pipette.dispense(volume, location)
+
+        elif command_type == 'touch-tip':
+            # NOTE: if touch_tip can take a location tuple,
+            # this can be much simpler
+            (well_object, loc_tuple) = location
+
+            # Use the offset baked into the well_object.
+            # Do not allow API to apply its v_offset kwarg default value,
+            # and do not apply the JSON protocol's default offset.
+            z_from_bottom = loc_tuple[2]
+            offset_from_top = (
+                well_object.properties['depth'] - z_from_bottom) * -1
+
+            pipette.touch_tip(well_object, v_offset=offset_from_top)
+
+        elif command_type == 'move-to-slot':
+            slot = params.get('slot')
+            if slot not in [str(s+1) for s in range(12)]:
+                raise ValueError('"move-to-slot" requires a valid slot, got {}'
+                                 .format(slot))
+            x_offset = params.get('offset', {}).get('x', 0)
+            y_offset = params.get('offset', {}).get('y', 0)
+            z_offset = params.get('offset', {}).get('z', 0)
+            slot_placeable = robot.deck[slot]
+            slot_offset = (x_offset, y_offset, z_offset)
+
+            strategy = 'direct' if params.get('force-direct') else None
+
+            # NOTE: Robot.move_to subtracts the offset from Slot.top()[1],
+            # so in order not to translate our desired offset,
+            # we have to compensate by adding it here :/
+            pipette.move_to(
+                (slot_placeable,
+                 add(slot_offset, tuple(slot_placeable.top()[1]))),
+                strategy=strategy)

--- a/api/src/opentrons/protocols/execute_v3.py
+++ b/api/src/opentrons/protocols/execute_v3.py
@@ -40,13 +40,8 @@ def load_labware(protocol_data):
                 # pass in the pre-existing fixed-trash
                 loaded_labware[labware_id] = robot.fixed_trash
             else:
-                # share the slot with the fixed-trash
-                loaded_labware[labware_id] = robot.add_container_by_definition(
-                    definition,
-                    slot,
-                    label=display_name,
-                    share=True
-                )
+                raise RuntimeError(
+                    'Only fixed trash labware can be placed in slot 12')
         else:
             loaded_labware[labware_id] = robot.add_container_by_definition(
                 definition,

--- a/api/src/opentrons/protocols/execute_v3.py
+++ b/api/src/opentrons/protocols/execute_v3.py
@@ -1,0 +1,218 @@
+from numpy import add
+import time
+import datetime
+from opentrons import instruments, labware, robot
+
+
+def _sleep(seconds):
+    if not robot.is_simulating():
+        time.sleep(seconds)
+
+
+def load_pipettes(protocol_data):
+    pipettes = protocol_data.get('pipettes', {})
+    pipettes_by_id = {}
+
+    for pipette_id, props in pipettes.items():
+        mount = props.get('mount')
+        name = props.get('name')
+        pipette = instruments.pipette_by_name(mount, name)
+        pipettes_by_id[pipette_id] = pipette
+
+    return pipettes_by_id
+
+
+def load_labware(protocol_data):
+    data = protocol_data.get('labware', {})
+    loaded_labware = {}
+    for labware_id, props in data.items():
+        slot = props.get('slot')
+        model = props.get('model')
+        display_name = props.get('displayName')
+
+        if slot == '12':
+            if model == 'fixed-trash':
+                # pass in the pre-existing fixed-trash
+                loaded_labware[labware_id] = robot.fixed_trash
+            else:
+                # share the slot with the fixed-trash
+                loaded_labware[labware_id] = labware.load(
+                    model,
+                    slot,
+                    display_name,
+                    share=True
+                )
+        else:
+            loaded_labware[labware_id] = labware.load(
+                model,
+                slot,
+                display_name
+            )
+
+    return loaded_labware
+
+
+def _get_location(loaded_labware, command_type, params, default_values):
+    labwareId = params.get('labware')
+    if not labwareId:
+        # not all commands use labware param
+        return None
+    well = params.get('well')
+    labware = loaded_labware.get(labwareId)
+    if not labware:
+        raise ValueError(
+            'Command tried to use labware "{}", but that ID does not exist ' +
+            'in protocol\'s "labware" section'.format(labwareId))
+
+    # default offset from bottom for aspirate/dispense commands
+    offset_default = default_values.get(
+        '{}MmFromBottom'.format(command_type))
+
+    # optional command-specific value, fallback to default
+    offset_from_bottom = params.get(
+        'offsetFromBottomMm', offset_default)
+
+    if offset_from_bottom is None:
+        # not all commands use offsets
+
+        # touch-tip uses offset from top, not bottom, as default
+        # when offsetFromBottomMm command-specific value is unset
+        if command_type == 'touchTip':
+            return labware.wells(well).top(
+                z=default_values['touchTipMmFromTop'])
+
+        return labware.wells(well)
+
+    return labware.wells(well).bottom(offset_from_bottom)
+
+
+def _get_pipette(command_params, loaded_pipettes):
+    pipetteId = command_params.get('pipette')
+    return loaded_pipettes.get(pipetteId)
+
+
+# TODO (Ian 2018-08-22) once Pipette has more sensible way of managing
+# flow rate value (eg as an argument in aspirate/dispense fns), remove this
+def _set_flow_rate(
+        pipette_name, pipette, command_type, params, default_values):
+    """
+    Set flow rate in uL/mm, to value obtained from command's params,
+    or if unspecified in command params, then from protocol's "defaultValues".
+    """
+    default_aspirate = default_values.get(
+        'aspirateFlowRate', {}).get(pipette_name)
+
+    default_dispense = default_values.get(
+        'dispenseFlowRate', {}).get(pipette_name)
+
+    flow_rate_param = params.get('flowRate')
+
+    if flow_rate_param is not None:
+        if command_type == 'aspirate':
+            pipette.set_flow_rate(
+                aspirate=flow_rate_param,
+                dispense=default_dispense)
+            return
+        if command_type == 'dispense':
+            pipette.set_flow_rate(
+                aspirate=default_aspirate,
+                dispense=flow_rate_param)
+            return
+
+    pipette.set_flow_rate(
+        aspirate=default_aspirate,
+        dispense=default_dispense
+    )
+
+
+# C901 code complexity is due to long elif block, ok in this case (Ian+Ben)
+def dispatch_commands(protocol_data, loaded_pipettes, loaded_labware):  # noqa: C901 E501
+    commands = protocol_data['commands']
+    default_values = protocol_data.get('defaultValues', {})
+
+    for command_item in commands:
+        command_type = command_item['command']
+        params = command_item.get('params', {})
+
+        pipette = _get_pipette(params, loaded_pipettes)
+        protocol_pipette_data = protocol_data\
+            .get('pipettes', {})\
+            .get(params.get('pipette'), {})
+        pipette_name = protocol_pipette_data.get('name')
+
+        location = _get_location(
+            loaded_labware, command_type, params, default_values)
+        volume = params.get('volume')
+
+        if pipette:
+            # Aspirate/Dispense flow rate must be set each time for commands
+            # which use pipettes right now.
+            # Flow rate is persisted inside the Pipette object
+            # and is settable but not easily gettable
+            _set_flow_rate(
+                pipette_name, pipette, command_type, params, default_values)
+
+        if command_type == 'delay':
+            wait = params.get('wait')
+            message = params.get('message')
+            if wait is None:
+                raise ValueError('Delay cannot be null')
+            elif wait is True:
+                message = message or 'Pausing until user resumes'
+                robot.pause(msg=message)
+            else:
+                text = f'Delaying for {datetime.timedelta(seconds=wait)}'
+                if message:
+                    text = f"{text}. {message}"
+                robot.comment(text)
+                _sleep(wait)
+
+        elif command_type == 'blowout':
+            pipette.blow_out(location)
+
+        elif command_type == 'pickUpTip':
+            pipette.pick_up_tip(location)
+
+        elif command_type == 'dropTip':
+            pipette.drop_tip(location)
+
+        elif command_type == 'aspirate':
+            pipette.aspirate(volume, location)
+
+        elif command_type == 'dispense':
+            pipette.dispense(volume, location)
+
+        elif command_type == 'touchTip':
+            # NOTE: if touch_tip can take a location tuple,
+            # this can be much simpler
+            (well_object, loc_tuple) = location
+
+            # Use the offset baked into the well_object.
+            # Do not allow API to apply its v_offset kwarg default value,
+            # and do not apply the JSON protocol's default offset.
+            z_from_bottom = loc_tuple[2]
+            offset_from_top = (
+                well_object.properties['depth'] - z_from_bottom) * -1
+
+            pipette.touch_tip(well_object, v_offset=offset_from_top)
+
+        elif command_type == 'moveToSlot':
+            slot = params.get('slot')
+            if slot not in [str(s+1) for s in range(12)]:
+                raise ValueError('"moveToSlot" requires a valid slot, got {}'
+                                 .format(slot))
+            x_offset = params.get('offset', {}).get('x', 0)
+            y_offset = params.get('offset', {}).get('y', 0)
+            z_offset = params.get('offset', {}).get('z', 0)
+            slot_placeable = robot.deck[slot]
+            slot_offset = (x_offset, y_offset, z_offset)
+
+            strategy = 'direct' if params.get('forceDirect') else None
+
+            # NOTE: Robot.move_to subtracts the offset from Slot.top()[1],
+            # so in order not to translate our desired offset,
+            # we have to compensate by adding it here :/
+            pipette.move_to(
+                (slot_placeable,
+                 add(slot_offset, tuple(slot_placeable.top()[1]))),
+                strategy=strategy)

--- a/api/tests/opentrons/protocols/test_execute_v1.py
+++ b/api/tests/opentrons/protocols/test_execute_v1.py
@@ -1,0 +1,214 @@
+from opentrons import robot, labware, instruments
+from opentrons.protocols import execute_v1
+# TODO: Modify all calls to get a Well to use the `wells` method
+
+
+def test_load_pipettes():
+    # TODO Ian 2018-11-07 when `model` is dropped, delete its test case
+    test_cases = [
+        # deprecated case
+        {
+            "pipettes": {
+                "leftPipetteHere": {
+                    "mount": "left",
+                    "model": "p10_single_v1.3"
+                }
+            }
+        },
+        # future case
+        {
+            "pipettes": {
+                "leftPipetteHere": {
+                    "mount": "left",
+                    "name": "p10_single"
+                }
+            }
+        }
+    ]
+
+    for data in test_cases:
+        robot.reset()
+
+        loaded_pipettes = execute_v1.load_pipettes(data)
+        robot_instruments = robot.get_instruments()
+
+        assert len(robot_instruments) == 1
+        mount, pipette = robot_instruments[0]
+        assert mount == 'left'
+        # loaded pipette in result dict should match that in robot_instruments
+        assert pipette == loaded_pipettes['leftPipetteHere']
+
+
+def test_get_location():
+    robot.reset()
+
+    command_type = 'aspirate'
+    plate = labware.load("96-flat", 1)
+    well = "B2"
+
+    default_values = {
+        'aspirate-mm-from-bottom': 2
+    }
+
+    loaded_labware = {
+        "someLabwareId": plate
+    }
+
+    # test with nonzero and with zero command-specific offset
+    for offset in [5, 0]:
+        command_params = {
+            "labware": "someLabwareId",
+            "well": well,
+            "offsetFromBottomMm": offset
+        }
+        result = execute_v1._get_location(
+            loaded_labware, command_type, command_params, default_values)
+        assert result == plate.well(well).bottom(offset)
+
+    command_params = {
+        "labware": "someLabwareId",
+        "well": well
+    }
+
+    # no command-specific offset, use default
+    result = execute_v1._get_location(
+        loaded_labware, command_type, command_params, default_values)
+    assert result == plate.well(well).bottom(
+        default_values['aspirate-mm-from-bottom'])
+
+
+def test_load_labware():
+    robot.reset()
+    data = {
+        "labware": {
+            "sourcePlateId": {
+              "slot": "10",
+              "model": "trough-12row",
+              "display-name": "Source (Buffer)"
+            },
+            "destPlateId": {
+              "slot": "11",
+              "model": "96-flat",
+              "display-name": "Destination Plate"
+            },
+        }
+    }
+    loaded_labware = execute_v1.load_labware(data)
+
+    # objects in loaded_labware should be same objs as labware objs in the deck
+    assert loaded_labware['sourcePlateId'] in robot.deck['10']
+    assert loaded_labware['destPlateId'] in robot.deck['11']
+
+
+def test_load_labware_trash():
+    robot.reset()
+    data = {
+        "labware": {
+            "someTrashId": {
+                "slot": "12",
+                "model": "fixed-trash"
+            }
+        }
+    }
+    result = execute_v1.load_labware(data)
+
+    assert result['someTrashId'] == robot.fixed_trash
+
+
+def test_dispatch_commands(monkeypatch):
+    robot.reset()
+    cmd = []
+    flow_rates = []
+
+    def mock_sleep(seconds):
+        cmd.append(("sleep", seconds))
+
+    def mock_aspirate(volume, location):
+        cmd.append(("aspirate", volume, location))
+
+    def mock_dispense(volume, location):
+        cmd.append(("dispense", volume, location))
+
+    def mock_set_flow_rate(aspirate, dispense):
+        flow_rates.append((aspirate, dispense))
+
+    pipette = instruments.P10_Single('left')
+
+    loaded_pipettes = {
+        'pipetteId': pipette
+    }
+
+    source_plate = labware.load('96-flat', '1')
+    dest_plate = labware.load('96-flat', '2')
+
+    loaded_labware = {
+        'sourcePlateId': source_plate,
+        'destPlateId': dest_plate
+    }
+
+    monkeypatch.setattr(pipette, 'aspirate', mock_aspirate)
+    monkeypatch.setattr(pipette, 'dispense', mock_dispense)
+    monkeypatch.setattr(pipette, 'set_flow_rate', mock_set_flow_rate)
+    monkeypatch.setattr(execute_v1, '_sleep', mock_sleep)
+
+    protocol_data = {
+        "default-values": {
+            "aspirate-flow-rate": {
+                "p300_single_v1": 101
+            },
+            "dispense-flow-rate": {
+                "p300_single_v1": 102
+            }
+        },
+        "pipettes": {
+            "pipetteId": {
+                "mount": "left",
+                "model": "p300_single_v1"
+            }
+        },
+        "procedure": [
+            {
+                "subprocedure": [
+                    {
+                        "command": "aspirate",
+                        "params": {
+                            "pipette": "pipetteId",
+                            "labware": "sourcePlateId",
+                            "well": "A1",
+                            "volume": 5,
+                            "flow-rate": 123
+                        }
+                    },
+                    {
+                        "command": "delay",
+                        "params": {
+                            "wait": 42
+                        }
+                    },
+                    {
+                        "command": "dispense",
+                        "params": {
+                            "pipette": "pipetteId",
+                            "labware": "destPlateId",
+                            "well": "B1",
+                            "volume": 4.5
+                        }
+                    },
+                ]
+            }
+        ]
+    }
+
+    execute_v1.dispatch_commands(
+        protocol_data, loaded_pipettes, loaded_labware)
+
+    assert cmd == [
+        ("aspirate", 5, source_plate['A1']),
+        ("sleep", 42),
+        ("dispense", 4.5, dest_plate['B1'])
+    ]
+
+    assert flow_rates == [
+        (123, 102),
+        (101, 102)
+    ]

--- a/api/tests/opentrons/protocols/test_execute_v3.py
+++ b/api/tests/opentrons/protocols/test_execute_v3.py
@@ -1,6 +1,12 @@
+import os
+import json
 from opentrons import robot, labware, instruments
 from opentrons.protocols import execute_v3
 # TODO: Modify all calls to get a Well to use the `wells` method
+
+with open(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..',
+          'shared-data', 'fixtures', 'fixture96Plate.json'), 'r') as f:
+    fixture_96_plate = json.load(f)
 
 
 def test_load_pipettes():
@@ -66,15 +72,18 @@ def test_get_location():
 def test_load_labware():
     robot.reset()
     data = {
+        "labwareDefinitions": {
+            "someDefId": fixture_96_plate
+        },
         "labware": {
             "sourcePlateId": {
               "slot": "10",
-              "model": "trough-12row",
+              "definitionId": "someDefId",
               "displayName": "Source (Buffer)"
             },
             "destPlateId": {
               "slot": "11",
-              "model": "96-flat",
+              "definitionId": "someDefId",
               "displayName": "Destination Plate"
             },
         }
@@ -89,10 +98,17 @@ def test_load_labware():
 def test_load_labware_trash():
     robot.reset()
     data = {
+        "labwareDefinitions": {
+            "someTrashLabwareId": {
+                "parameters": {
+                    "quirks": ["fixedTrash"]
+                }
+            }
+        },
         "labware": {
             "someTrashId": {
                 "slot": "12",
-                "model": "fixed-trash"
+                "definitionId": "someTrashLabwareId"
             }
         }
     }


### PR DESCRIPTION
## overview

Closes #3449

NOTE: this also validates v1 JSON protocols and returns an error if they fail to validate. That's a new behavior for APIv1.

## changelog

## review requests

- Test v3 protocol on robot running on APIv1 -- try this protocol for example 
[full-forSethBot.json.zip](https://github.com/Opentrons/opentrons/files/3208408/full-forSethBot.json.zip)
 on the robot called... ":office::heavy_check_mark::coffee:"

- Make sure v1 JSON protocols still work on APIv1
