### PR TITLE
feat(api): apiv2: allow returning tips to the tip tracker

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1043,7 +1043,8 @@ class InstrumentContext(CommandPublisher):
                 " However, it is a {}".format(location))
         self.move_to(target)
         self._hw_manager.hardware.drop_tip(self._mount)
-        if target.labware.parent.is_tiprack:
+        if isinstance(target.labware, Well)\
+           and target.labware.parent.is_tiprack:
             # If this is a tiprack we can try and add the tip back to the
             # tracker
             try:

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -140,12 +140,13 @@ def test_pick_up_and_drop_tip(loop, load_my_labware):
     target_location = tiprack.wells_by_index()['A1'].top()
 
     instr.pick_up_tip(target_location)
-
+    assert not tiprack.wells()[0].has_tip
     new_offset = model_offset - Point(0, 0,
                                       tip_length)
     assert pipette.critical_point() == new_offset
 
     instr.drop_tip(target_location)
+    assert tiprack.wells()[0].has_tip
     assert pipette.critical_point() == model_offset
 
 
@@ -165,11 +166,12 @@ def test_return_tip(loop, load_my_labware):
 
     target_location = tiprack.wells_by_index()['A1'].top()
     instr.pick_up_tip(target_location)
-
+    assert not tiprack.wells()[0].has_tip
     assert pipette.has_tip
 
     instr.return_tip()
     assert not pipette.has_tip
+    assert tiprack.wells()[0].has_tip
 
 
 def test_pick_up_tip_no_location(loop, load_my_labware):
@@ -196,6 +198,7 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
 
     assert 'picking up tip' in ','.join([cmd.lower()
                                          for cmd in ctx.commands()])
+    assert not tiprack1.wells()[0].has_tip
 
     new_offset = model_offset - Point(0, 0,
                                       tip_length1)
@@ -203,6 +206,7 @@ def test_pick_up_tip_no_location(loop, load_my_labware):
 
     # TODO: remove argument and verify once trash container is added
     instr.drop_tip(tiprack1.wells()[0].top())
+    assert tiprack1.wells()[0].has_tip
     assert pipette.critical_point() == model_offset
 
     for well in tiprack1.wells():

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -170,7 +170,7 @@ def test_new_tip_always(_instr_labware, monkeypatch):
     options = options._replace(
         transfer=options.transfer._replace(
             new_tip=TransferTipPolicy.ALWAYS,
-            drop_tip_strategy=tx.DropTipStrategy.RETURN))
+            drop_tip_strategy=tx.DropTipStrategy.TRASH))
 
     xfer_plan = tx.TransferPlan(100,
                                 lw1.columns()[0][1:5], lw2.columns()[0][1:5],
@@ -183,25 +183,25 @@ def test_new_tip_always(_instr_labware, monkeypatch):
              'kwargs': {}},
             {'method': 'dispense', 'args': [100, lw2.columns()[0][1], 1.0],
              'kwargs': {}},
-            {'method': 'return_tip', 'args': [], 'kwargs': {}},
+            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
             {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
             {'method': 'aspirate', 'args': [100, lw1.columns()[0][2], 1.0],
              'kwargs': {}},
             {'method': 'dispense', 'args': [100, lw2.columns()[0][2], 1.0],
              'kwargs': {}},
-            {'method': 'return_tip', 'args': [], 'kwargs': {}},
+            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
             {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
             {'method': 'aspirate', 'args': [100, lw1.columns()[0][3], 1.0],
              'kwargs': {}},
             {'method': 'dispense', 'args': [100, lw2.columns()[0][3], 1.0],
              'kwargs': {}},
-            {'method': 'return_tip', 'args': [], 'kwargs': {}},
+            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
             {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
             {'method': 'aspirate', 'args': [100, lw1.columns()[0][4], 1.0],
              'kwargs': {}},
             {'method': 'dispense', 'args': [100, lw2.columns()[0][4], 1.0],
              'kwargs': {}},
-            {'method': 'return_tip', 'args': [], 'kwargs': {}}]
+            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
     assert xfer_plan_list == exp1
     for cmd in xfer_plan_list:
         getattr(i_ctx, cmd['method'])(*cmd['args'], **cmd['kwargs'])


### PR DESCRIPTION
This commit adds `Labware.previous_tip` and `Labware.return_tips`, which are the
inverse of `Labware.next_tip` and `Labware.use_tips` respectively. These
functions allow returning tips to the tip tracker and making them available
again for further use.

ProtocolContext.return_tip and ProtocolContext.drop_tip (if the target location
is a tiprack) will try and return the tip to the tip tracker when called;
however, because this logic is somewhat complex and race conditions are easy to
find, it doesn't raise an error if the tip can't be returned.
