### PR TITLE
fix(app): Re-enable change pipette and pipette settings

### DIFF
--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -52,6 +52,7 @@ type OP = {|
   mount: Mount,
   robot: Robot,
   wantedPipette: ?PipetteNameSpecs,
+  setWantedName: (name: string) => mixed,
   baseUrl: string,
   confirmUrl: string,
   exitUrl: string,
@@ -155,7 +156,7 @@ function makeMapStateToProps(): (State, OP) => SP {
 }
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  const { confirmUrl, parentUrl, baseUrl, robot, mount } = ownProps
+  const { confirmUrl, parentUrl, robot, mount } = ownProps
   const disengage = () => dispatch(disengagePipetteMotors(robot, mount))
   const checkPipette = () =>
     disengage().then(() => dispatch(fetchPipettes(robot, true)))
@@ -165,7 +166,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
     exit: () =>
       dispatch(home(robot, mount)).then(() => dispatch(push(parentUrl))),
     back: () => dispatch(goBack()),
-    onPipetteSelect: evt => dispatch(push(`${baseUrl}/${evt.target.value}`)),
+    onPipetteSelect: evt => ownProps.setWantedName(evt.target.value),
     moveToFront: () =>
       dispatch(
         moveRobotTo(robot, {
@@ -178,6 +179,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
 }
 
 export default function ChangePipette(props: Props) {
+  const [wantedName, setWantedName] = React.useState<string | null>(null)
   const {
     robot,
     parentUrl,
@@ -186,13 +188,13 @@ export default function ChangePipette(props: Props) {
 
   return (
     <Route
-      path={`${path}/:mount${RE_MOUNT}/:name?`}
+      path={`${path}/:mount${RE_MOUNT}`}
       render={propsWithMount => {
         const { params, url: baseUrl } = propsWithMount.match
         const mount: Mount = (params.mount: any)
 
-        const wantedPipette = params.name
-          ? getPipetteNameSpecs(params.name)
+        const wantedPipette = wantedName
+          ? getPipetteNameSpecs(wantedName)
           : null
 
         return (
@@ -202,6 +204,7 @@ export default function ChangePipette(props: Props) {
             subtitle={`${mount} mount`}
             mount={mount}
             wantedPipette={wantedPipette}
+            setWantedName={setWantedName}
             parentUrl={parentUrl}
             baseUrl={baseUrl}
             confirmUrl={`${baseUrl}/confirm`}

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -53,14 +53,14 @@ function AttachedPipettesCard(props: Props) {
         <CardContentFlex>
           <InstrumentInfo
             mount="left"
-            name={props.robot.name}
+            robotName={props.robot.name}
             {...props.left}
             onChangeClick={props.clearMove}
             showSettings={props.showLeftSettings}
           />
           <InstrumentInfo
             mount="right"
-            name={props.robot.name}
+            robotName={props.robot.name}
             {...props.right}
             onChangeClick={props.clearMove}
             showSettings={props.showRightSettings}

--- a/app/src/components/InstrumentSettings/AttachedPipettesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedPipettesCard.js
@@ -54,14 +54,14 @@ function AttachedPipettesCard(props: Props) {
           <InstrumentInfo
             mount="left"
             robotName={props.robot.name}
-            {...props.left}
+            model={props.left?.model}
             onChangeClick={props.clearMove}
             showSettings={props.showLeftSettings}
           />
           <InstrumentInfo
             mount="right"
             robotName={props.robot.name}
-            {...props.right}
+            model={props.right?.model}
             onChangeClick={props.clearMove}
             showSettings={props.showRightSettings}
           />

--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -16,7 +16,7 @@ import styles from './styles.css'
 type Props = {
   mount: Mount,
   model: ?string,
-  name: string,
+  robotName: string,
   onChangeClick: () => mixed,
   showSettings: boolean,
 }
@@ -27,14 +27,14 @@ const LABEL_BY_MOUNT = {
 }
 
 export default function PipetteInfo(props: Props) {
-  const { mount, model, name, onChangeClick, showSettings } = props
+  const { mount, model, robotName, onChangeClick, showSettings } = props
   const label = LABEL_BY_MOUNT[mount]
   const pipette = model ? getPipetteModelSpecs(model) : null
   const channels = pipette?.channels
   const direction = model ? 'change' : 'attach'
 
-  const changeUrl = `/robots/${name}/instruments/pipettes/change/${mount}`
-  const configUrl = `/robots/${name}/instruments/pipettes/config/${mount}`
+  const changeUrl = `/robots/${robotName}/instruments/pipettes/change/${mount}`
+  const configUrl = `/robots/${robotName}/instruments/pipettes/config/${mount}`
 
   const className = cx(styles.pipette_card, {
     [styles.right]: mount === 'right',


### PR DESCRIPTION
## overview

This PR serves as a bug report and fix. A recent API update returns both a `name` and `model` for attached pipettes. The `AttatchedInstrumentsCard` and `InstrumentInfo` were using `name` for `robot.name` which caused a conflict resulting in broken routes for change pipette and pipette settings.

This PR changes `name` (robot) prop to `robotName` which fixes the pipette modal routes.

This PR also found another bug with confirming detached pipettes. That should be fixed now as well.

## changelog

- fix(app): Re-enable change pipette and pipette settings (robotName prop)
- fix(app): Swap out pipette name in change pipette routes with React Hook.

## review requests

Please test on a robot with edge installed and one with an older version of the API!

- [ ] attached pipettes card renders as expected
- [ ] clicking [change/attach] opens change pipette modal (please confirm change pipette walkthrough still works as expected)
- [ ] change pipette flow is no longer broken
- [ ] clicking [settings] for an attached pipettes pops up pipette config modal. (please confirm settings are still updatable.

Files that are not affected by this PR but should be double checked if possible:
- [ ] file info page pipettes section is unaffected
- [ ] tip probe pages are unaffected
