### PR TITLE
feat(api): Enable Double Drop Quirk

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -254,9 +254,9 @@ def change_quirks(override_quirks, existing, model_configs):
         # for one setting
         existing['quirks'][quirk] = setting
         if setting not in model_configs['quirks']:
-            model_configs['quirks'].append(setting)
-        elif not value:
-            model_configs['quirks'].remove(setting)
+            model_configs['quirks'].append(quirk)
+        elif not setting:
+            model_configs['quirks'].remove(quirk)
     return existing, model_configs
 
 

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -231,9 +231,9 @@ def save_overrides(
         if value is None:
             if existing.get(key):
                 del existing[key]
-        elif key == 'quirks':
+        elif isinstance(value['value'], bool):
             existing, model_configs = change_quirks(
-                value, existing, model_configs)
+                {key: value['value']}, existing, model_configs)
         else:
             if not model_configs[key].get('default'):
                 model_configs[key]['default'] = model_configs[key]['value']
@@ -255,6 +255,8 @@ def change_quirks(override_quirks, existing, model_configs):
         existing['quirks'][quirk] = setting
         if setting not in model_configs['quirks']:
             model_configs['quirks'].append(setting)
+        elif not value:
+            model_configs['quirks'].remove(setting)
     return existing, model_configs
 
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1019,6 +1019,7 @@ class API(HardwareAPILike):
         plunger_ax = Axis.of_plunger(mount)
         droptip = instr.config.drop_tip
         bottom = instr.config.bottom
+
         async def _drop_tip():
             self._backend.set_active_current(plunger_ax,
                                              instr.config.plunger_current)

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1019,14 +1019,19 @@ class API(HardwareAPILike):
         plunger_ax = Axis.of_plunger(mount)
         droptip = instr.config.drop_tip
         bottom = instr.config.bottom
-        self._backend.set_active_current(plunger_ax,
-                                         instr.config.plunger_current)
-        await self._move_plunger(mount, bottom)
-        self._backend.set_active_current(plunger_ax,
-                                         instr.config.drop_tip_current)
-        await self._move_plunger(
-            mount, droptip, speed=instr.config.drop_tip_speed)
-        await self._shake_off_tips(mount)
+        async def _drop_tip():
+            self._backend.set_active_current(plunger_ax,
+                                             instr.config.plunger_current)
+            await self._move_plunger(mount, bottom)
+            self._backend.set_active_current(plunger_ax,
+                                             instr.config.drop_tip_current)
+            await self._move_plunger(
+                mount, droptip, speed=instr.config.drop_tip_speed)
+        if 'doubleDropTip' in instr.config.quirks:
+            await _drop_tip()
+        await _drop_tip()
+        if 'dropTipShake' in instr.config.quirks:
+            await self._shake_off_tips(mount)
         self._backend.set_active_current(plunger_ax,
                                          instr.config.plunger_current)
         instr.set_current_volume(0)

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1101,25 +1101,26 @@ class Pipette(CommandPublisher):
                 x=pos_drop_tip
             )
             self.instrument_actuator.pop_speed()
-
-            self._shake_off_tips(location, 'dropTipShake')
-
             if home_after:
                 self._home_after_drop_tip()
-
-            self.current_volume = 0
-            self.current_tip(None)
-            self._remove_tip(
-                length=self._tip_length
-            )
 
         do_publish(self.broker, commands.drop_tip, self.drop_tip,
                    'before', None, None, self, location)
         if 'doubleDropTip' in self.quirks:
             _drop_tip(location)
+
         _drop_tip(location)
         do_publish(self.broker, commands.drop_tip, self.drop_tip,
                    'after', self, None, self, location)
+
+        self._shake_off_tips(location, 'dropTipShake')
+
+        self.current_volume = 0
+        self.current_tip(None)
+        self._remove_tip(
+            length=self._tip_length
+        )
+
         return self
 
     def _shake_off_tips(self, location, quirk):

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -911,6 +911,8 @@ class Pipette(CommandPublisher):
             self.robot.add_warning(
                 'Pipette has no tip to return, dropping in place')
 
+        if 'doubleDropTip' in self.quirks:
+            self.drop_tip(self.current_tip())
         self.drop_tip(self.current_tip(), home_after=home_after)
         return self
 

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1101,8 +1101,7 @@ class Pipette(CommandPublisher):
                 x=pos_drop_tip
             )
             self.instrument_actuator.pop_speed()
-            if home_after:
-                self._home_after_drop_tip()
+            self._home_after_drop_tip(home_after)
 
         do_publish(self.broker, commands.drop_tip, self.drop_tip,
                    'before', None, None, self, location)
@@ -1152,9 +1151,11 @@ class Pipette(CommandPublisher):
         self.robot.poses = self._jog(
             self.robot.poses, 'z', DROP_TIP_RELEASE_DISTANCE)
 
-    def _home_after_drop_tip(self):
+    def _home_after_drop_tip(self, home_after):
         # incase plunger motor stalled while dropping a tip, add a
         # safety margin of the distance between `bottom` and `drop_tip`
+        if not home_after:
+            return
         b = self._get_plunger_position('bottom')
         d = self._get_plunger_position('drop_tip')
         safety_margin = abs(b - d)

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -911,8 +911,6 @@ class Pipette(CommandPublisher):
             self.robot.add_warning(
                 'Pipette has no tip to return, dropping in place')
 
-        if 'doubleDropTip' in self.quirks:
-            self.drop_tip(self.current_tip())
         self.drop_tip(self.current_tip(), home_after=home_after)
         return self
 
@@ -1117,6 +1115,8 @@ class Pipette(CommandPublisher):
 
         do_publish(self.broker, commands.drop_tip, self.drop_tip,
                    'before', None, None, self, location)
+        if 'doubleDropTip' in self.quirks:
+            _drop_tip(location)
         _drop_tip(location)
         do_publish(self.broker, commands.drop_tip, self.drop_tip,
                    'after', self, None, self, location)

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -191,7 +191,7 @@ async def modify_pipette_settings(request: web.Request) -> web.Response:
         return web.json_response(config_match, status=200)
 
     for key, value in data['fields'].items():
-        if value:
+        if value and not isinstance(value['value'], bool):
             config = value['value']
             default = config_match[key]
             if config < default['min'] or config > default['max']:

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -109,6 +109,10 @@ def test_override_save():
     new_id = 'aoa2109j09cj2a'
     model = 'p300_multi_v1'
 
+    old_pconf = pipette_config.load('p300_multi_v1.4', new_id)
+
+    assert old_pconf.quirks == ['dropTipShake']
+
     pipette_config.save_overrides(new_id, overrides, model)
 
     assert (cdir/f'{new_id}.json').is_file()

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -103,7 +103,7 @@ def test_override_save():
             'value': 1231.213},
         'dropTipSpeed': {
             'value': 121},
-        'quirks': {'dropTipShake': False}
+        'dropTipShake': {'value': False}
     }
 
     new_id = 'aoa2109j09cj2a'

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -665,6 +665,7 @@ Object {
   },
   "quirks": Array [
     "dropTipShake",
+    "doubleDropTip",
   ],
   "tipLength": Object {
     "max": 100,
@@ -2092,6 +2093,7 @@ Object {
   },
   "quirks": Array [
     "dropTipShake",
+    "doubleDropTip",
   ],
   "tipLength": Object {
     "max": 100,
@@ -3209,6 +3211,7 @@ Object {
   },
   "quirks": Array [
     "dropTipShake",
+    "doubleDropTip",
   ],
   "tipLength": Object {
     "max": 100,

--- a/shared-data/robot-data/pipetteModelSpecs.json
+++ b/shared-data/robot-data/pipetteModelSpecs.json
@@ -927,7 +927,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": ["dropTipShake", "doubleDropTip"]
     },
     "p+20_single_v2.0": {
       "name": "p+20_single",
@@ -1841,7 +1841,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": ["dropTipShake", "doubleDropTip"]
     },
     "p300_single_v1": {
       "name": "p300_single",
@@ -2842,7 +2842,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": ["dropTipShake", "doubleDropTip"]
     },
     "p1000_single_v1": {
       "name": "p1000_single",


### PR DESCRIPTION
## overview

Closes #3345. This feature allows a user to specify whether v1.5 multi-channels can double drop tip or not.

## changelog

- Add double drop tip quirk to pipette config
- Check for it in V1 and V2
- Modify save settings format slightly for @Kadee80 such that to modify a setting you should type:
```
quirkName: {value: true/false}
```


## review requests
You can test at your convenience in V1 or V2 on bitter-wood using the following scripts:
V1
```
from opentrons import labware, instruments, robot

tiprack = labware.load('opentrons-tiprack-300ul', '1')

plate = labware.load('96-flat', '2')

pip = instruments.P300_Multi(mount='right', tip_racks=[tiprack])

pip.transfer(10, plate.wells('A1'), plate.wells('A2'))

pip.pick_up_tip()
pip.drop_tip()

pip.pick_up_tip()
pip.return_tip()
```

V2
```
def run(ctx):
	tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300_ul', '1')

	plate = ctx.load_labware_by_name('generic_96_wellplate_380_ul', '2')

	pip = ctx.load_instrument('p300_multi', mount='right', tip_racks=[tiprack])

	pip.transfer(10, plate.wells('A1'), plate.wells('A2'))

	pip.pick_up_tip()
	pip.drop_tip()

	pip.pick_up_tip()
	pip.return_tip()

```
