### PR TITLE
fix(api): Fix default transfer tip behavior

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1293,10 +1293,10 @@ class Pipette(CommandPublisher):
             will be used for each transfer. Default is 'once'.
 
         trash : boolean
-            If `False` (default behavior) tips will be returned to their
-            tip rack. If `True` and a trash container has been attached
+            If `True` (default behavior) and trash container has been attached
             to this `Pipette`, then the tip will be sent to the trash
             container.
+            If `False`, then tips will be returned to their associated tiprack.
 
         touch_tip : boolean
             If `True`, a :any:`touch_tip` will occur following each

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1128,6 +1128,7 @@ class InstrumentContext(CommandPublisher):
                  volume: Union[float, Sequence[float]],
                  source,
                  dest,
+                 trash = True,
                  **kwargs) -> 'InstrumentContext':
         # source: Union[Well, List[Well], List[List[Well]]],
         # dest: Union[Well, List[Well], List[List[Well]]],
@@ -1165,10 +1166,10 @@ class InstrumentContext(CommandPublisher):
                 - 'once': (default) a single tip will be used for all commands.
                 - 'always': use a new tip for each transfer.
 
-            * *return_tip* (``boolean``) --
-              If `False` (default behavior), tips will be
-              returned to the trash container attached this `Pipette`.
-              If `True` tips will be returned to tiprack.
+            * *trash* (``boolean``) --
+              If `True` (default behavior), tips will be
+              dropped in the trash container attached this `Pipette`.
+              If `False` tips will be returned to tiprack.
 
             * *touch_tip* (``boolean``) --
               If `True`, a :py:meth:`touch_tip` will occur following each
@@ -1239,10 +1240,10 @@ class InstrumentContext(CommandPublisher):
         else:
             mix_strategy = transfers.MixStrategy.NEVER
 
-        if kwargs.get('return_tip'):
-            drop_tip = transfers.DropTipStrategy.RETURN
-        else:
+        if trash:
             drop_tip = transfers.DropTipStrategy.TRASH
+        else:
+            drop_tip = transfers.DropTipStrategy.RETURN
 
         new_tip = kwargs.get('new_tip')
         if isinstance(new_tip, str):

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1128,7 +1128,7 @@ class InstrumentContext(CommandPublisher):
                  volume: Union[float, Sequence[float]],
                  source,
                  dest,
-                 trash = True,
+                 trash=True,
                  **kwargs) -> 'InstrumentContext':
         # source: Union[Well, List[Well], List[List[Well]]],
         # dest: Union[Well, List[Well], List[List[Well]]],

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1165,11 +1165,10 @@ class InstrumentContext(CommandPublisher):
                 - 'once': (default) a single tip will be used for all commands.
                 - 'always': use a new tip for each transfer.
 
-            * *trash* (``boolean``) --
+            * *return_tip* (``boolean``) --
               If `False` (default behavior), tips will be
-              returned to their tip rack. If `True` and a trash
-              container has been attached to this `Pipette`,
-              then the tip will be sent to the trash container.
+              returned to the trash container attached this `Pipette`.
+              If `True` tips will be returned to tiprack.
 
             * *touch_tip* (``boolean``) --
               If `True`, a :py:meth:`touch_tip` will occur following each
@@ -1240,10 +1239,10 @@ class InstrumentContext(CommandPublisher):
         else:
             mix_strategy = transfers.MixStrategy.NEVER
 
-        if kwargs.get('trash'):
-            drop_tip = transfers.DropTipStrategy.TRASH
-        else:
+        if kwargs.get('return_tip'):
             drop_tip = transfers.DropTipStrategy.RETURN
+        else:
+            drop_tip = transfers.DropTipStrategy.TRASH
 
         new_tip = kwargs.get('new_tip')
         if isinstance(new_tip, str):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -469,7 +469,7 @@ def test_transfer_options(loop, monkeypatch):
             gradient_function=None,
             disposal_volume=0,
             mix_strategy=tf.MixStrategy.BEFORE,
-            drop_tip_strategy=tf.DropTipStrategy.RETURN,
+            drop_tip_strategy=tf.DropTipStrategy.TRASH,
             blow_out_strategy=tf.BlowOutStrategy.TRASH,
             touch_tip_strategy=tf.TouchTipStrategy.NEVER
         ),
@@ -489,7 +489,7 @@ def test_transfer_options(loop, monkeypatch):
 
     instr.pick_up_tip()
     instr.distribute(50, lw1.rows()[0][0], lw2.columns()[0],
-                     new_tip='never', touch_tip=True, trash=True,
+                     new_tip='never', touch_tip=True, return_tip=True,
                      disposal_vol=10, mix_after=(3, 20))
     instr.drop_tip()
     expected_xfer_options2 = tf.TransferOptions(
@@ -500,7 +500,7 @@ def test_transfer_options(loop, monkeypatch):
             gradient_function=None,
             disposal_volume=10,
             mix_strategy=tf.MixStrategy.AFTER,
-            drop_tip_strategy=tf.DropTipStrategy.TRASH,
+            drop_tip_strategy=tf.DropTipStrategy.RETURN,
             blow_out_strategy=tf.BlowOutStrategy.NONE,
             touch_tip_strategy=tf.TouchTipStrategy.ALWAYS
         ),

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -489,7 +489,7 @@ def test_transfer_options(loop, monkeypatch):
 
     instr.pick_up_tip()
     instr.distribute(50, lw1.rows()[0][0], lw2.columns()[0],
-                     new_tip='never', touch_tip=True, return_tip=True,
+                     new_tip='never', touch_tip=True, trash=False,
                      disposal_vol=10, mix_after=(3, 20))
     instr.drop_tip()
     expected_xfer_options2 = tf.TransferOptions(


### PR DESCRIPTION
## overview
This PR serves as a ticket and a bug fix. During testing of a separate behavior it was found that the default transfer drop tip behavior in V2 is to return to tip rack.

## changelog
- ~Remove `trash` kwarg check and add in `return_tip` kwarg~
- Default to dropping tip in trash instead of in tip rack.

## review requests

Test on Robit using this script
```
def run(ctx):
	tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300_ul', '1')

	plate = ctx.load_labware_by_name('generic_96_wellplate_380_ul', '2')

	pip = ctx.load_instrument('p300_multi', mount='right', tip_racks=[tiprack])

	pip.transfer(10, plate.wells('A1'), plate.wells('A2'))
	pip.transfer(10, plate.wells('A1'), plate.wells('A2'), return_tip=True)

```
