### PR TITLE
feat(app): Enable pipette quirks in pipette config

### DIFF
--- a/app/src/components/ConfigurePipette/ConfigForm.js
+++ b/app/src/components/ConfigurePipette/ConfigForm.js
@@ -13,7 +13,10 @@ import set from 'lodash/set'
 import isEmpty from 'lodash/isEmpty'
 
 import FormButtonBar from './FormButtonBar'
-import ConfigFormGroup, { FormColumn } from './ConfigFormGroup'
+import ConfigFormGroup, {
+  FormColumn,
+  ConfigQuirkGroup,
+} from './ConfigFormGroup'
 
 import type { Pipette } from '../../http-api-client'
 import type {
@@ -26,6 +29,12 @@ import type { FormValues } from './ConfigFormGroup'
 
 export type DisplayFieldProps = {|
   ...PipetteSettingsField,
+  name: string,
+  displayName: string,
+|}
+
+export type DisplayQuirkFieldProps = {|
+  [quirkId: string]: boolean,
   name: string,
   displayName: string,
 |}
@@ -53,6 +62,22 @@ export default class ConfigForm extends React.Component<Props> {
       const name = k
       return {
         ...field,
+        name,
+        displayName,
+      }
+    })
+  }
+
+  getKnownQuirks = (): Array<DisplayQuirkFieldProps> => {
+    const quirks = this.props.pipetteConfig.fields.quirks
+    if (!quirks) return []
+    const quirkKeys = Object.keys(quirks)
+    return quirkKeys.map(key => {
+      const value = quirks[key]
+      const name = key
+      const displayName = startCase(key)
+      return {
+        [key]: value,
         name,
         displayName,
       }
@@ -143,6 +168,8 @@ export default class ConfigForm extends React.Component<Props> {
     const plungerFields = this.getFieldsByKey(PLUNGER_KEYS, fields)
     const powerFields = this.getFieldsByKey(POWER_KEYS, fields)
     const tipFields = this.getFieldsByKey(TIP_KEYS, fields)
+    const quirkFields = this.getKnownQuirks()
+    const quirksPresent = !!quirkFields[0]
     const devFields = this.getFieldsByKey(UNKNOWN_KEYS, fields)
 
     return (
@@ -174,6 +201,12 @@ export default class ConfigForm extends React.Component<Props> {
                   groupLabel="Tip Pickup / Drop"
                   formFields={tipFields}
                 />
+                {quirksPresent && (
+                  <ConfigQuirkGroup
+                    groupLabel="Pipette Quirks"
+                    quirks={quirkFields}
+                  />
+                )}
                 {this.props.__showHiddenFields && (
                   <ConfigFormGroup
                     groupLabel="For Dev Use Only"

--- a/app/src/components/ConfigurePipette/ConfigFormGroup.js
+++ b/app/src/components/ConfigurePipette/ConfigFormGroup.js
@@ -1,11 +1,11 @@
 // @flow
 import * as React from 'react'
 import { Field } from 'formik'
-import { FormGroup, InputField } from '@opentrons/components'
+import { FormGroup, InputField, CheckboxField } from '@opentrons/components'
 
 import styles from './styles.css'
 
-import type { DisplayFieldProps } from './ConfigForm'
+import type { DisplayFieldProps, DisplayQuirkFieldProps } from './ConfigForm'
 
 type FormColProps = {
   children: React.Node,
@@ -94,5 +94,46 @@ export function ConfigInput(props: ConfigInputProps) {
         )}
       </Field>
     </ConfigFormRow>
+  )
+}
+
+type ConfigBooleanProps = {
+  field: DisplayQuirkFieldProps,
+  className?: string,
+}
+
+export function ConfigCheckbox(props: ConfigBooleanProps) {
+  const { field, className } = props
+  const { name, displayName } = field
+  const id = makeId(name)
+  return (
+    <ConfigFormRow label={displayName} labelFor={id}>
+      <Field name={name}>
+        {fieldProps => (
+          <CheckboxField
+            {...{
+              ...fieldProps.field,
+              className,
+            }}
+          />
+        )}
+      </Field>
+    </ConfigFormRow>
+  )
+}
+
+type QuirkGroupProps = {
+  groupLabel: string,
+  quirks: Array<DisplayQuirkFieldProps>,
+}
+
+export function ConfigQuirkGroup(props: QuirkGroupProps) {
+  const { groupLabel, quirks } = props
+  return (
+    <FormGroup label={groupLabel} className={styles.form_group}>
+      {quirks.map((field, index) => {
+        return <ConfigCheckbox field={field} key={index} />
+      })}
+    </FormGroup>
   )
 }

--- a/app/src/robot-api/resources/types.js
+++ b/app/src/robot-api/resources/types.js
@@ -78,6 +78,7 @@ export type RobotSettingsFieldUpdate = {|
 
 export type PipetteSettingsFieldsMap = {|
   [fieldId: string]: PipetteSettingsField,
+  quirks?: PipetteQuirksField,
 |}
 
 export type PipetteSettingsField = {|
@@ -88,6 +89,10 @@ export type PipetteSettingsField = {|
   units?: string,
   type?: string,
 |}
+
+export type PipetteQuirksField = {
+  [quirkId: string]: boolean,
+}
 
 export type PipetteSettingsUpdate = {|
   fields: {|


### PR DESCRIPTION
## overview

This PR closes #3342 by adding a Pipette Quirks section to pipette config if/when valid quirks are returned from the API. 

## changelog

- feat(app): Enable pipette quirks in pipette config

## review requests

Since quirks are grouped/shaped/typed differently than other fields, some additional functions are necessary to get initialValues, and quirkFields.

This PR/Branch will only work with the API changes from #3485 installed on a robot.

- [ ] No pipette quirks section present in pipette config for robots without 3485 installed
- [ ] Pipette quirks visible and gettable and settable for robots with 3485 installed
- [ ] Validation for all other fields still works
- [ ] Quirks have no validation
