### PR TITLE
fix(api): Account for tip length in deck cal move-to-front

### DIFF
--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -355,6 +355,15 @@ async def move(data):
                 y = point[1] + pipette_config.Y_OFFSET_MULTI * 2
                 z = point[2]
                 point = (x, y, z)
+            # hack: z=150mm is not a safe point for a gen2 pipette with a tip
+            # attached, since their home location is z=+172mm and both 300ul
+            # and 1000ul tips are more than 22mm long. This isn't an issue for
+            # apiv2 because it can select the NOZZLE critical point.
+            if pipette.tip_attached and point_name == 'attachTip':
+                point = (point[0],
+                         point[1],
+                         point[2]-pipette._tip_length)
+
             pipette.move_to((session.adapter.deck, point), strategy='arc')
         else:
             if not point_name == 'attachTip':


### PR DESCRIPTION
This PR is both a bug report and a fix.

When the robot moves to the "attachTip" point in apiv1 deck cal, it moves to
z=150. This is normally fine. However, a gen2 pipette tops out at z=172, which
means that if a tip is longer than 22mm in config, when the robot moves to
attachTip at the end of deck calibration (with a tip attached) it will move high
enough to trigger the home switch.

The fix is to take the length of a tip into account when moving to the attachTip position when a tip is already attached, effectively using the nozzle critical point.

Tested by successfully running deck calibration using a gen2 p20 single (the original bug report was from @ChrisYarka ).
