### PR TITLE
refactor(labware-library): Add well bottom shape and display name to UI

### DIFF
--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -616,6 +616,21 @@ exports[`icons ot-file renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons ot-flat-bottom renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M23 0h1v24H0V0h1v23h22z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons ot-logo renders correctly 1`] = `
 <svg
   aria-hidden="true"
@@ -716,6 +731,36 @@ exports[`icons ot-transfer renders correctly 1`] = `
 >
   <path
     d="M0 10.8h15.5V8l8.5 5-8.5 4.9v-2.8H0z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons ot-u-bottom renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M0 0h1v12c0 6.075 4.925 11 11 11s11-4.925 11-11V0h1v12c0 6.627-5.373 12-12 12S0 18.627 0 12V0z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
+exports[`icons ot-v-bottom renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M23 0h1v12a.5.5 0 0 1-.146.354l-11.5 11.5a.5.5 0 0 1-.708 0l-11.5-11.5A.5.5 0 0 1 0 12V0h1v11.793l11 11 11-11V0z"
     fillRule="evenodd"
   />
 </svg>

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -309,6 +309,20 @@ const ICON_DATA_BY_NAME = {
     viewBox: '0 0 24 24',
     path: 'M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z',
   },
+  'ot-flat-bottom': {
+    viewBox: '0 0 24 24',
+    path: 'M23 0h1v24H0V0h1v23h22z',
+  },
+  'ot-u-bottom': {
+    viewBox: '0 0 24 24',
+    path:
+      'M0 0h1v12c0 6.075 4.925 11 11 11s11-4.925 11-11V0h1v12c0 6.627-5.373 12-12 12S0 18.627 0 12V0z',
+  },
+  'ot-v-bottom': {
+    viewBox: '0 0 24 24',
+    path:
+      'M23 0h1v12a.5.5 0 0 1-.146.354l-11.5 11.5a.5.5 0 0 1-.708 0l-11.5-11.5A.5.5 0 0 1 0 12V0h1v11.793l11 11 11-11V0z',
+  },
 }
 
 export type IconName = $Keys<typeof ICON_DATA_BY_NAME>

--- a/labware-library/src/components/App/Page.js
+++ b/labware-library/src/components/App/Page.js
@@ -5,17 +5,18 @@ import cx from 'classnames'
 import styles from './styles.css'
 
 export type PageProps = {|
+  scrollRef: { current: HTMLDivElement | null },
   detailPage: boolean,
   sidebar: React.Node,
   content: React.Node,
 |}
 
 export default function Page(props: PageProps) {
-  const { detailPage, sidebar, content } = props
+  const { scrollRef, detailPage, sidebar, content } = props
 
   return (
     <div className={styles.page}>
-      <div className={styles.content_scroller}>
+      <div className={styles.content_scroller} ref={scrollRef}>
         <div className={styles.content_width_limiter}>
           <div
             className={cx(styles.sidebar_container, {

--- a/labware-library/src/components/App/__tests__/Page.test.js
+++ b/labware-library/src/components/App/__tests__/Page.test.js
@@ -10,14 +10,26 @@ jest.mock('../../../definitions')
 describe('Page', () => {
   test('component renders sidebar and content', () => {
     const tree = shallow(
-      <Page sidebar="foo" content="bar" detailPage={false} />
+      <Page
+        scrollRef={{ current: null }}
+        sidebar="foo"
+        content="bar"
+        detailPage={false}
+      />
     )
 
     expect(tree).toMatchSnapshot()
   })
 
   test('component renders with detailPage CSS', () => {
-    const tree = shallow(<Page sidebar="foo" content="bar" detailPage={true} />)
+    const tree = shallow(
+      <Page
+        scrollRef={{ current: null }}
+        sidebar="foo"
+        content="bar"
+        detailPage={true}
+      />
+    )
 
     expect(tree).toMatchSnapshot()
   })

--- a/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
+++ b/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
@@ -33,6 +33,11 @@ exports[`App component renders with definition 1`] = `
       />
     }
     detailPage={true}
+    scrollRef={
+      Object {
+        "current": null,
+      }
+    }
     sidebar={
       <Sidebar
         filters={
@@ -64,6 +69,11 @@ exports[`App component renders without definition 1`] = `
       />
     }
     detailPage={false}
+    scrollRef={
+      Object {
+        "current": null,
+      }
+    }
     sidebar={
       <Sidebar
         filters={

--- a/labware-library/src/components/App/index.js
+++ b/labware-library/src/components/App/index.js
@@ -15,40 +15,38 @@ import styles from './styles.css'
 
 import type { DefinitionRouteRenderProps } from '../../definitions'
 
-export class App extends React.Component<DefinitionRouteRenderProps> {
-  componentDidUpdate(prevProps: DefinitionRouteRenderProps): void {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
-      window.scrollTo(0, 0)
-    }
-  }
+export function App(props: DefinitionRouteRenderProps) {
+  const { definition, location } = props
+  const scrollRef = React.useRef<HTMLDivElement | null>(null)
+  const filters = getFilters(location, definition)
+  const detailPage = Boolean(definition)
 
-  render() {
-    const { definition, location } = this.props
-    const filters = getFilters(location, definition)
-    const detailPage = Boolean(definition)
+  React.useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 0
+  }, [location.pathname])
 
-    return (
-      <div
-        className={cx(styles.app, {
-          [styles.is_detail_page]: detailPage,
-        })}
-      >
-        <Nav />
-        {detailPage && <Breadcrumbs definition={definition} />}
-        <Page
-          detailPage={detailPage}
-          sidebar={<Sidebar filters={filters} />}
-          content={
-            definition ? (
-              <LabwareDetails definition={definition} />
-            ) : (
-              <LabwareList filters={filters} />
-            )
-          }
-        />
-      </div>
-    )
-  }
+  return (
+    <div
+      className={cx(styles.app, {
+        [styles.is_detail_page]: detailPage,
+      })}
+    >
+      <Nav />
+      {detailPage && <Breadcrumbs definition={definition} />}
+      <Page
+        scrollRef={scrollRef}
+        detailPage={detailPage}
+        sidebar={<Sidebar filters={filters} />}
+        content={
+          definition ? (
+            <LabwareDetails definition={definition} />
+          ) : (
+            <LabwareList filters={filters} />
+          )
+        }
+      />
+    </div>
+  )
 }
 
 export function AppWithRoute() {

--- a/labware-library/src/components/LabwareDetails/InsertDetails.js
+++ b/labware-library/src/components/LabwareDetails/InsertDetails.js
@@ -27,13 +27,22 @@ export default function InsertDetails(props: InsertDetailsProps) {
       {wellGroups.map((wellProps, i) => (
         <DetailsBox
           key={i}
-          aside={<ManufacturerStats brand={{ brand: `Brand ${i}` }} />}
+          aside={
+            wellProps.brand ? (
+              <ManufacturerStats brand={wellProps.brand} />
+            ) : null
+          }
         >
           <div className={styles.details_container}>
-            <h3 className={styles.well_group_title}>Group {i}</h3>
+            {wellProps.metadata.displayName && (
+              <h3 className={styles.well_group_title}>
+                {wellProps.metadata.displayName}
+              </h3>
+            )}
             <WellProperties
               wellProperties={wellProps}
               displayVolumeUnits={displayVolumeUnits}
+              hideTitle
             />
             <WellDimensions
               title={MEASUREMENTS}

--- a/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
+++ b/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
@@ -25,11 +25,7 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
   const { metadata, brand, wells } = definition
   const { displayCategory, displayVolumeUnits } = metadata
   const wellGroups = getUniqueWellProperties(definition)
-
-  // TODO(mc, 2019-05-20): clarify this logic with UX. If this logic is
-  // correct, this will require additional checks for aluminum blocks once
-  // that's a thing and data is in place
-  const hasInserts = displayCategory === 'tubeRack'
+  const hasInserts = wellGroups.some(g => g.metadata.displayCategory)
   const irregular = wellGroups.length > 1
 
   return (
@@ -44,41 +40,50 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
             <WellProperties
               wellProperties={wellGroups[0]}
               displayVolumeUnits={displayVolumeUnits}
+              hideTitle
             />
           )}
           <Dimensions
             definition={definition}
             className={styles.details_table}
           />
-          {wellGroups.map((wellProps, i) => (
-            <React.Fragment key={i}>
-              {!hasInserts && irregular && (
-                <>
-                  <WellCount
-                    className={styles.irregular_well_count}
-                    displayCategory={displayCategory}
-                    count={wellProps.wellCount}
-                  />
-                  <WellProperties
+          {wellGroups.map((wellProps, i) => {
+            const { metadata: groupMetadata } = wellProps
+            const groupDisplaySuffix = groupMetadata.displayName
+              ? ` - ${groupMetadata.displayName}`
+              : ''
+
+            return (
+              <React.Fragment key={i}>
+                {!groupMetadata.displayCategory && irregular && (
+                  <>
+                    <WellCount
+                      className={styles.irregular_well_count}
+                      displayCategory={displayCategory}
+                      count={wellProps.wellCount}
+                    />
+                    <WellProperties
+                      wellProperties={wellProps}
+                      displayVolumeUnits={displayVolumeUnits}
+                      hideTitle
+                    />
+                  </>
+                )}
+                {!groupMetadata.displayCategory && (
+                  <WellDimensions
+                    title={`${MEASUREMENTS}${groupDisplaySuffix}`}
                     wellProperties={wellProps}
-                    displayVolumeUnits={displayVolumeUnits}
+                    className={styles.details_table}
                   />
-                </>
-              )}
-              {!hasInserts && (
-                <WellDimensions
-                  title={`${MEASUREMENTS}${irregular ? ` - Group ${i}` : ''}`}
+                )}
+                <WellSpacing
+                  title={`${SPACING}${groupDisplaySuffix}`}
                   wellProperties={wellProps}
                   className={styles.details_table}
                 />
-              )}
-              <WellSpacing
-                title={`${SPACING}${irregular ? ` - Group ${i}` : ''}`}
-                wellProperties={wellProps}
-                className={styles.details_table}
-              />
-            </React.Fragment>
-          ))}
+              </React.Fragment>
+            )
+          })}
         </div>
       </DetailsBox>
       {hasInserts && <InsertDetails definition={definition} />}

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -20,19 +20,19 @@ export type WellDimensionsProps = {|
 
 export default function WellDimensions(props: WellDimensionsProps) {
   const { title, wellProperties, className } = props
+  const { shape } = wellProperties
+  const dimensions = [{ label: DEPTH, value: wellProperties.depth }]
 
-  const dimensions = [
-    { label: DEPTH, value: toFixed(wellProperties.depth) },
-    wellProperties.diameter != null
-      ? { label: DIAMETER, value: toFixed(wellProperties.diameter) }
-      : null,
-    wellProperties.xDimension != null
-      ? { label: X_DIM, value: toFixed(wellProperties.xDimension) }
-      : null,
-    wellProperties.yDimension != null
-      ? { label: Y_DIM, value: toFixed(wellProperties.yDimension) }
-      : null,
-  ].filter(Boolean)
+  if (shape) {
+    if (shape.shape === 'circular') {
+      dimensions.push({ label: DIAMETER, value: toFixed(shape.diameter) })
+    } else if (shape.shape === 'rectangular') {
+      dimensions.push(
+        { label: X_DIM, value: toFixed(shape.xDimension) },
+        { label: Y_DIM, value: toFixed(shape.yDimension) }
+      )
+    }
+  }
 
   return (
     <LabeledValueTable

--- a/labware-library/src/components/LabwareDetails/WellSpacing.js
+++ b/labware-library/src/components/LabwareDetails/WellSpacing.js
@@ -9,6 +9,8 @@ import {
   Y_OFFSET,
   X_SPACING,
   Y_SPACING,
+  NA,
+  VARIOUS,
 } from '../../localization'
 
 import styles from './styles.css'
@@ -20,8 +22,15 @@ import type { LabwareWellGroupProperties } from '../../types'
 // safe toFixed
 const toFixed = (n: number): string => round(n, 2).toFixed(2)
 
-const spacingValue = (spacing: number) =>
-  spacing ? toFixed(spacing) : <span className={styles.lighter}>N/A</span>
+const spacingValue = (spacing: number | null) => {
+  if (!spacing) {
+    return (
+      <span className={styles.lighter}>{spacing === null ? VARIOUS : NA}</span>
+    )
+  }
+
+  return toFixed(spacing)
+}
 
 export type WellSpacingProps = {|
   title: string,

--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -69,7 +69,7 @@ function Title(props: LabwareCardProps) {
   return (
     <Link to={`${getPublicPath()}${loadName}`}>
       <h2 className={styles.title}>
-        {displayName}
+        <span className={styles.title_text}>{displayName}</span>
         <Icon className={styles.title_icon} name="chevron-right" />
       </h2>
     </Link>

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -30,8 +30,6 @@
   color: var(--c-blue);
   background-color: var(--c-white);
 
-  /* maximum two lines */
-  
   &:hover {
     background-color: var(--c-light-gray);
   }

--- a/labware-library/src/components/LabwareList/styles.css
+++ b/labware-library/src/components/LabwareList/styles.css
@@ -25,17 +25,36 @@
 
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-5);
-  line-height: var(--lh-title);
-  font-size: var(--fs-default);
-  font-weight: var(--fw-semibold);
+  margin-bottom: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-5);
   color: var(--c-blue);
   background-color: var(--c-white);
 
+  /* maximum two lines */
+  
   &:hover {
     background-color: var(--c-light-gray);
   }
+}
+
+.title_text {
+  display: block;
+  line-height: var(--lh-title);
+  font-size: var(--fs-default);
+  font-weight: var(--fw-semibold);
+  max-height: calc(2 * (var(--lh-title) * var(--fs-default)));
+  overflow: hidden;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
+  min-width: 0;
+
+  /*
+   * non-standard, but works on all webkit browsers, Edge, and Firefox >= 68
+   * it turns out CSS ellipses for multiline blocks are hard
+   */
+  display: -webkit-box; /* stylelint-disable-line declaration-block-no-duplicate-properties */
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .title_icon {

--- a/labware-library/src/components/labware-ui/WellProperties.js
+++ b/labware-library/src/components/labware-ui/WellProperties.js
@@ -1,9 +1,16 @@
 // @flow
 import * as React from 'react'
 
+import { Icon } from '@opentrons/components'
 import { getDisplayVolume } from '@opentrons/shared-data'
 import { getUniqueWellProperties } from '../../definitions'
-import { MAX_VOLUME } from '../../localization'
+import {
+  MAX_VOLUME,
+  SHAPE,
+  WELL_TYPE_BY_CATEGORY,
+  WELL_BOTTOM_VALUES,
+  VARIOUS,
+} from '../../localization'
 import { LabelText, Value, LABEL_TOP } from '../ui'
 
 import styles from './styles.css'
@@ -22,6 +29,7 @@ export type AllWellPropertiesProps = {|
 export type WellPropertiesProps = {|
   wellProperties: LabwareWellGroupProperties,
   displayVolumeUnits: LabwareVolumeUnits,
+  hideTitle?: boolean,
 |}
 
 export function AllWellProperties(props: AllWellPropertiesProps) {
@@ -42,21 +50,52 @@ export function AllWellProperties(props: AllWellPropertiesProps) {
   )
 }
 
-export function WellProperties(props: WellPropertiesProps) {
-  const { wellProperties, displayVolumeUnits } = props
+const BOTTOM_SHAPE_TO_ICON = {
+  v: 'ot-v-bottom',
+  u: 'ot-u-bottom',
+  flat: 'ot-flat-bottom',
+}
 
-  const vol = getDisplayVolume(
-    wellProperties.totalLiquidVolume,
-    displayVolumeUnits,
-    2
-  )
+export function WellProperties(props: WellPropertiesProps) {
+  const { hideTitle, wellProperties, displayVolumeUnits: units } = props
+  const { totalLiquidVolume: vol, metadata } = wellProperties
+  const { displayName, displayCategory, wellBottomShape } = metadata
+
+  const wellType = displayCategory
+    ? WELL_TYPE_BY_CATEGORY[displayCategory]
+    : WELL_TYPE_BY_CATEGORY.other
+
+  const wellBottomValue = wellBottomShape
+    ? WELL_BOTTOM_VALUES[wellBottomShape]
+    : null
 
   return (
     <div className={styles.well_properties}>
-      <LabelText position={LABEL_TOP}>{MAX_VOLUME}</LabelText>
-      <Value>
-        {vol} {displayVolumeUnits}
-      </Value>
+      {!hideTitle && displayName && (
+        <h3 className={styles.well_properties_title}>{displayName}</h3>
+      )}
+      <div className={styles.well_properties_column}>
+        <div>
+          <LabelText position={LABEL_TOP}>{MAX_VOLUME}</LabelText>
+          <Value>
+            {vol ? `${getDisplayVolume(vol, units, 2)} ${units}` : VARIOUS}
+          </Value>
+        </div>
+      </div>
+      {wellBottomShape && wellBottomValue && (
+        <div className={styles.well_properties_column}>
+          <div>
+            <LabelText position={LABEL_TOP}>
+              {wellType} {SHAPE}
+            </LabelText>
+            <Value>{wellBottomValue}</Value>
+          </div>
+          <Icon
+            className={styles.well_bottom_icon}
+            name={BOTTOM_SHAPE_TO_ICON[wellBottomShape]}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/labware-library/src/components/labware-ui/styles.css
+++ b/labware-library/src/components/labware-ui/styles.css
@@ -122,7 +122,10 @@ button.load_name_button {
 }
 
 .well_bottom_icon {
+  align-self: flex-end;
   width: var(--spacing-6);
   margin-left: var(--spacing-3);
+  padding-bottom: calc(var(--spacing-1));
   overflow: visible;
+  color: var(--c-font-icon);
 }

--- a/labware-library/src/components/labware-ui/styles.css
+++ b/labware-library/src/components/labware-ui/styles.css
@@ -92,6 +92,37 @@ button.load_name_button {
 
 .well_properties {
   margin-top: var(--spacing-5);
-  padding: var(--spacing-5);
+  padding: var(--spacing-5) var(--spacing-5) 0;
   border: var(--bd-light);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.well_properties_title {
+  @apply --font-body-2-dark;
+
+  width: 100%;
+  margin-bottom: var(--spacing-5);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-title);
+}
+
+.well_properties_column {
+  display: flex;
+  width: 50%;
+  min-width: 8rem;
+  align-items: center;
+  margin-bottom: var(--spacing-5);
+}
+
+.well_bottom_shape {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-5);
+}
+
+.well_bottom_icon {
+  width: var(--spacing-6);
+  margin-left: var(--spacing-3);
+  overflow: visible;
 }

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -52,6 +52,12 @@ export const MANUFACTURER_LABELS_BY_MANUFACTURER = {
   generic: 'Generic',
 }
 
+export const WELL_BOTTOM_VALUES = {
+  u: 'U-bottom',
+  v: 'V-bottom',
+  flat: 'Flat-bottom',
+}
+
 export const MANUFACTURER = 'manufacturer'
 export const CATEGORY = 'category'
 export const FOOTPRINT = 'footprint'
@@ -76,3 +82,5 @@ export const BACK_TO_LABWARE_LIBRARY = 'Back to Labware Library'
 export const TAGS = 'tags'
 export const API_NAME = 'api name'
 export const COPIED_TO_CLIPBOARD = 'Copied to clipboard!'
+export const VARIOUS = 'Various'
+export const NA = 'N/A'

--- a/labware-library/src/types.js
+++ b/labware-library/src/types.js
@@ -1,7 +1,9 @@
 // @flow
 import type {
   LabwareDefinition2 as LabwareDefinition,
-  LabwareWellProperties,
+  LabwareWellShapeProperties,
+  LabwareWellGroupMetadata,
+  LabwareBrand,
 } from '@opentrons/shared-data'
 
 export type {
@@ -9,22 +11,26 @@ export type {
   LabwareParameters,
   LabwareOffset,
   LabwareWell,
+  LabwareWellShapeProperties,
   LabwareWellProperties,
   LabwareWellMap,
+  LabwareWellGroupMetadata,
   LabwareVolumeUnits,
   LabwareDisplayCategory,
   LabwareBrand,
 } from '@opentrons/shared-data'
 
 export type LabwareWellGroupProperties = {|
-  ...LabwareWellProperties,
-  xStart: number,
-  yStart: number,
   xOffsetFromLeft: number,
   yOffsetFromTop: number,
-  xSpacing: number,
-  ySpacing: number,
+  xSpacing: number | null,
+  ySpacing: number | null,
   wellCount: number,
+  shape: LabwareWellShapeProperties | null,
+  depth: number | null,
+  totalLiquidVolume: number | null,
+  metadata: LabwareWellGroupMetadata,
+  brand: LabwareBrand | null,
 |}
 
 export type LabwareList = Array<LabwareDefinition>

--- a/shared-data/definitions2/opentrons_24_tuberack_generic_2ml_screwcap.json
+++ b/shared-data/definitions2/opentrons_24_tuberack_generic_2ml_screwcap.json
@@ -289,7 +289,7 @@
       "metadata": {
         "displayName": "Generic 2 mL Screwcap",
         "displayCategory": "tubeRack",
-        "wellBottomShape": "u"
+        "wellBottomShape": "v"
       },
       "brand": {
         "brand": "generic",

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -43,7 +43,7 @@ export type LabwareDisplayCategory =
 
 export type LabwareVolumeUnits = 'µL' | 'mL' | 'L'
 
-export type WellBottomShape = 'flat' | 'u' | 'v' | 'other'
+export type WellBottomShape = 'flat' | 'u' | 'v'
 
 export type LabwareMetadata = {|
   displayName: string,
@@ -82,7 +82,7 @@ export type LabwareBrand = {|
   links?: Array<string>,
 |}
 
-type LabwareWellShapeProperties =
+export type LabwareWellShapeProperties =
   | {|
       shape: 'circular',
       diameter: number,

--- a/shared-data/labware-json-schema/labwareSchemaV2.json
+++ b/shared-data/labware-json-schema/labwareSchemaV2.json
@@ -279,7 +279,7 @@
               "wellBottomShape": {
                 "type": "string",
                 "description": "Bottom shape of the well for UI purposes",
-                "enum": ["flat", "u", "v", "other"]
+                "enum": ["flat", "u", "v"]
               }
             }
           },


### PR DESCRIPTION
## overview

~**Blocked by #3490** - this PR to be rebased once 3490 is merged~ rebase completed

This PR adds well bottom shape and well group display name to the high-level well/tube details box in both the Labware Card and Labware Details Page. Closes #3245

## changelog

- Add well bottom shape and display name to labware library UI

<img width="563" alt="Screenshot 2019-05-28 16 19 28" src="https://user-images.githubusercontent.com/2963448/58509369-69029380-8164-11e9-9cce-4ae438cdcf38.png">

<img width="1164" alt="Screenshot 2019-05-28 16 19 36" src="https://user-images.githubusercontent.com/2963448/58509380-6f910b00-8164-11e9-8398-b83e08a733e9.png">


## review requests

<http://sandbox.labware.opentrons.com/lablib_high-level-well-ui>

- [ ] Well bottom shape icons are correct
- [ ] Well details box is responsive at all screen sizes
- [ ] Labels are correct (e.g. "Well Shape", "Tube Shape", etc.)
