### PR TITLE
fix(api): Add separate key for new steps per mm shape

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -110,7 +110,7 @@ DEFAULT_ACCELERATION: Dict[str, float] = {
     'C': C_ACCELERATION
 }
 
-DEFAULT_STEPS_PER_MM: Dict[str, float] = {
+DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
     'X': 80.00,
     'Y': 80.00,
     'Z': 400,
@@ -118,6 +118,8 @@ DEFAULT_STEPS_PER_MM: Dict[str, float] = {
     'B': 768,
     'C': 768
 }
+
+DEFAULT_STEPS_PER_MM = 'M92 X80.00 Y80.00 Z400 A400 B768 C768'
 # This probe height is ~73 from deck to the top surface of the switch body
 # per CAD; 74.3mm is the nominal for engagement from the switch drawing.
 # Note that this has a piece-to-piece tolerance stackup of +-1.5mm
@@ -158,6 +160,7 @@ robot_config = namedtuple(
         'name',
         'version',
         'steps_per_mm',
+        'gantry_steps_per_mm',
         'acceleration',
         'gantry_calibration',
         'instrument_offset',
@@ -264,6 +267,8 @@ def _build_config(deck_cal: List[List[float]],
         version=int(robot_settings.get('version', ROBOT_CONFIG_VERSION)),
         steps_per_mm=_build_conf_dict(
             robot_settings.get('steps_per_mm'), DEFAULT_STEPS_PER_MM),
+        gantry_steps_per_mm=_build_conf_dict(
+            robot_settings.get('steps_per_mm'), DEFAULT_GANTRY_STEPS_PER_MM),
         acceleration=_build_conf_dict(
             robot_settings.get('acceleration'), DEFAULT_ACCELERATION),
         gantry_calibration=deck_cal or DEFAULT_DECK_CALIBRATION,

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -114,9 +114,7 @@ DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
     'X': 80.00,
     'Y': 80.00,
     'Z': 400,
-    'A': 400,
-    'B': 768,
-    'C': 768
+    'A': 400
 }
 
 DEFAULT_STEPS_PER_MM = 'M92 X80.00 Y80.00 Z400 A400 B768 C768'

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1048,7 +1048,7 @@ class SmoothieDriver_3_0_0:
         log.debug("wait for ack done")
         self._reset_from_error()
         log.debug("_reset")
-        self.update_steps_per_mm(self._config.steps_per_mm)
+        self.update_steps_per_mm(self._config.gantry_steps_per_mm)
         log.debug("sent steps")
         self._send_command(GCODES['ABSOLUTE_COORDS'])
         log.debug("sent abs")

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -20,7 +20,7 @@ from opentrons import types as top_types
 from opentrons.util import linal
 from .simulator import Simulator
 from opentrons.config import robot_configs
-from opentrons.config.robot_configs import DEFAULT_STEPS_PER_MM
+from opentrons.config.robot_configs import DEFAULT_GANTRY_STEPS_PER_MM
 from .pipette import Pipette
 try:
     from .controller import Controller
@@ -284,7 +284,7 @@ class API(HardwareAPILike):
                         plunger_axis.name, {'max_travel': 60})
                 else:
                     self._backend._smoothie_driver.update_steps_per_mm(
-                        {plunger_axis.name: DEFAULT_STEPS_PER_MM[
+                        {plunger_axis.name: DEFAULT_GANTRY_STEPS_PER_MM[
                             plunger_axis.name]})
 
                     self._backend._smoothie_driver.update_pipette_config(

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -284,8 +284,7 @@ class API(HardwareAPILike):
                         plunger_axis.name, {'max_travel': 60})
                 else:
                     self._backend._smoothie_driver.update_steps_per_mm(
-                        {plunger_axis.name: DEFAULT_GANTRY_STEPS_PER_MM[
-                            plunger_axis.name]})
+                        {plunger_axis.name: 768})
 
                     self._backend._smoothie_driver.update_pipette_config(
                         mount_axis.name, {'home': 220})

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -20,7 +20,6 @@ from opentrons import types as top_types
 from opentrons.util import linal
 from .simulator import Simulator
 from opentrons.config import robot_configs
-from opentrons.config.robot_configs import DEFAULT_GANTRY_STEPS_PER_MM
 from .pipette import Pipette
 try:
     from .controller import Controller

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -14,7 +14,7 @@ from opentrons.data_storage import database, old_container_loading,\
 from opentrons.drivers.smoothie_drivers import driver_3_0
 from opentrons.trackers import pose_tracker
 from opentrons.config import feature_flags as fflags
-from opentrons.config.robot_configs import load, DEFAULT_GANTRY_STEPS_PER_MM
+from opentrons.config.robot_configs import load
 from opentrons.legacy_api import containers, modules
 from opentrons.legacy_api.containers import Container, load_new_labware,\
     save_new_offsets, load_new_labware_def

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -14,7 +14,7 @@ from opentrons.data_storage import database, old_container_loading,\
 from opentrons.drivers.smoothie_drivers import driver_3_0
 from opentrons.trackers import pose_tracker
 from opentrons.config import feature_flags as fflags
-from opentrons.config.robot_configs import load, DEFAULT_STEPS_PER_MM
+from opentrons.config.robot_configs import load, DEFAULT_GANTRY_STEPS_PER_MM
 from opentrons.legacy_api import containers, modules
 from opentrons.legacy_api.containers import Container, load_new_labware,\
     save_new_offsets, load_new_labware_def
@@ -300,7 +300,7 @@ class Robot(CommandPublisher):
             elif model_value:
                 self._driver.dist_from_eeprom[mount_axis] = 0.0
                 self._driver.update_steps_per_mm(
-                    {plunger_axis: DEFAULT_STEPS_PER_MM[plunger_axis]})
+                    {plunger_axis: DEFAULT_GANTRY_STEPS_PER_MM[plunger_axis]})
 
                 self._driver.update_pipette_config(mount_axis, {'home': 220})
                 self._driver.update_pipette_config(

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -300,7 +300,7 @@ class Robot(CommandPublisher):
             elif model_value:
                 self._driver.dist_from_eeprom[mount_axis] = 0.0
                 self._driver.update_steps_per_mm(
-                    {plunger_axis: DEFAULT_GANTRY_STEPS_PER_MM[plunger_axis]})
+                    {plunger_axis: 768})
 
                 self._driver.update_pipette_config(mount_axis, {'home': 220})
                 self._driver.update_pipette_config(

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -15,7 +15,7 @@ dummy_settings = {
     'version': 42,
     'steps_per_mm': 'M92 X80.00 Y80.00 Z400 A400 B768 C768',
     'gantry_steps_per_mm': {
-        'X': 80.00, 'Y': 80.00, 'Z': 400, 'A': 400, 'B': 768, 'C': 768},
+        'X': 80.00, 'Y': 80.00, 'Z': 400, 'A': 400},
     'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
     'instrument_offset': {
         'left': {

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -13,7 +13,8 @@ dummy_cal = [
 dummy_settings = {
     'name': 'Andy',
     'version': 42,
-    'steps_per_mm': {
+    'steps_per_mm': 'M92 X80.00 Y80.00 Z400 A400 B768 C768',
+    'gantry_steps_per_mm': {
         'X': 80.00, 'Y': 80.00, 'Z': 400, 'A': 400, 'B': 768, 'C': 768},
     'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
     'instrument_offset': {

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from tests.opentrons.conftest import fuzzy_assert
-from opentrons.config.robot_configs import DEFAULT_STEPS_PER_MM
+from opentrons.config.robot_configs import DEFAULT_GANTRY_STEPS_PER_MM
 
 
 def position(x, y, z, a, b, c):
@@ -356,9 +356,9 @@ def test_steps_per_mm(smoothie, monkeypatch):
     # Check that steps_per_mm dict gets loaded with defaults on start
     assert smoothie.steps_per_mm == {}
     smoothie._setup()
-    assert smoothie.steps_per_mm == DEFAULT_STEPS_PER_MM
+    assert smoothie.steps_per_mm == DEFAULT_GANTRY_STEPS_PER_MM
     smoothie.update_steps_per_mm({'Z': 450})
-    expected = DEFAULT_STEPS_PER_MM
+    expected = DEFAULT_GANTRY_STEPS_PER_MM
     expected['Z'] = 450
     assert smoothie.steps_per_mm == expected
 


### PR DESCRIPTION
## overview

In order for users to be able to migrate back and forth between 3.9.0 and some earlier SW version, we need to create a separate key for the new steps per mm shape (which is a dictionary where previously it was a string).

## changelog

- Create new key in robot_config.py called `gantry_steps_per_mm` this is the value the software will use moving forward in order to fallback to a default of the proper shape
- Return `steps_per_mm` to its old string shape which included the GCODE baked into the command.

## review requests

On a robot that hasn't previously been upgraded to 3.9.0:
1. upgrade to 3.9.0
2. downgrade to some other SW version (ensure that this step does not fail)
3. upgrade to 3.9.0 again