### PR TITLE
refactor(labware-library): Rename troughs to reservoirs and add al. block cat.

### DIFF
--- a/labware-library/src/components/LabwareDetails/Dimensions.js
+++ b/labware-library/src/components/LabwareDetails/Dimensions.js
@@ -3,7 +3,13 @@
 import * as React from 'react'
 import round from 'lodash/round'
 
-import { FOOTPRINT, MM, X_DIM, Y_DIM, Z_DIM } from '../../localization'
+import {
+  FOOTPRINT,
+  MM,
+  LABWARE_X_DIM,
+  LABWARE_Y_DIM,
+  LABWARE_Z_DIM,
+} from '../../localization'
 import { LabeledValueTable, LowercaseText } from '../ui'
 
 import type { LabwareDefinition } from '../../types'
@@ -20,9 +26,9 @@ export default function Dimensions(props: DimensionsProps) {
   const { definition, className } = props
   const { xDimension, yDimension, zDimension } = definition.dimensions
   const dimensions = [
-    { label: X_DIM, value: toFixed(xDimension) },
-    { label: Y_DIM, value: toFixed(yDimension) },
-    { label: Z_DIM, value: toFixed(zDimension) },
+    { label: LABWARE_X_DIM, value: toFixed(xDimension) },
+    { label: LABWARE_Y_DIM, value: toFixed(yDimension) },
+    { label: LABWARE_Z_DIM, value: toFixed(zDimension) },
   ]
 
   return (

--- a/labware-library/src/components/LabwareDetails/InsertDetails.js
+++ b/labware-library/src/components/LabwareDetails/InsertDetails.js
@@ -3,11 +3,10 @@
 import * as React from 'react'
 
 import { getUniqueWellProperties } from '../../definitions'
-import { WellProperties, ManufacturerStats } from '../labware-ui'
+import { getWellLabel, WellProperties, ManufacturerStats } from '../labware-ui'
 import { DetailsBox } from '../ui'
 import WellDimensions from './WellDimensions'
 
-import { MEASUREMENTS } from '../../localization'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -24,34 +23,39 @@ export default function InsertDetails(props: InsertDetailsProps) {
 
   return (
     <>
-      {wellGroups.map((wellProps, i) => (
-        <DetailsBox
-          key={i}
-          aside={
-            wellProps.brand ? (
-              <ManufacturerStats brand={wellProps.brand} />
-            ) : null
-          }
-        >
-          <div className={styles.details_container}>
-            {wellProps.metadata.displayName && (
-              <h3 className={styles.well_group_title}>
-                {wellProps.metadata.displayName}
-              </h3>
-            )}
-            <WellProperties
-              wellProperties={wellProps}
-              displayVolumeUnits={displayVolumeUnits}
-              hideTitle
-            />
-            <WellDimensions
-              title={MEASUREMENTS}
-              wellProperties={wellProps}
-              className={styles.details_table}
-            />
-          </div>
-        </DetailsBox>
-      ))}
+      {wellGroups.map((wellProps, i) => {
+        const wellLabel = getWellLabel(wellProps, definition)
+
+        return (
+          <DetailsBox
+            key={i}
+            aside={
+              wellProps.brand ? (
+                <ManufacturerStats brand={wellProps.brand} />
+              ) : null
+            }
+          >
+            <div className={styles.details_container}>
+              {wellProps.metadata.displayName && (
+                <h3 className={styles.well_group_title}>
+                  {wellProps.metadata.displayName}
+                </h3>
+              )}
+              <WellProperties
+                wellProperties={wellProps}
+                wellLabel={wellLabel}
+                displayVolumeUnits={displayVolumeUnits}
+                hideTitle
+              />
+              <WellDimensions
+                wellProperties={wellProps}
+                wellLabel={wellLabel}
+                className={styles.details_table}
+              />
+            </div>
+          </DetailsBox>
+        )
+      })}
     </>
   )
 }

--- a/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
+++ b/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
@@ -3,14 +3,18 @@
 import * as React from 'react'
 
 import { getUniqueWellProperties } from '../../definitions'
-import { WellCount, WellProperties, ManufacturerStats } from '../labware-ui'
+import {
+  getWellLabel,
+  WellCount,
+  WellProperties,
+  ManufacturerStats,
+} from '../labware-ui'
 import { DetailsBox } from '../ui'
 import InsertDetails from './InsertDetails'
 import Dimensions from './Dimensions'
 import WellDimensions from './WellDimensions'
 import WellSpacing from './WellSpacing'
 
-import { SPACING, MEASUREMENTS } from '../../localization'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -23,8 +27,9 @@ export type LabwareDetailsBoxProps = {|
 export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
   const { definition, className } = props
   const { metadata, brand, wells } = definition
-  const { displayCategory, displayVolumeUnits } = metadata
+  const { displayVolumeUnits } = metadata
   const wellGroups = getUniqueWellProperties(definition)
+  const wellLabel = getWellLabel(definition)
   const hasInserts = wellGroups.some(g => g.metadata.displayCategory)
   const irregular = wellGroups.length > 1
 
@@ -32,13 +37,11 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
     <div className={className}>
       <DetailsBox aside={<ManufacturerStats brand={brand} />}>
         <div className={styles.details_container}>
-          <WellCount
-            displayCategory={displayCategory}
-            count={Object.keys(wells).length}
-          />
+          <WellCount wellLabel={wellLabel} count={Object.keys(wells).length} />
           {!hasInserts && !irregular && (
             <WellProperties
               wellProperties={wellGroups[0]}
+              wellLabel={wellLabel}
               displayVolumeUnits={displayVolumeUnits}
               hideTitle
             />
@@ -49,6 +52,7 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
           />
           {wellGroups.map((wellProps, i) => {
             const { metadata: groupMetadata } = wellProps
+            const wellLabel = getWellLabel(wellProps, definition)
             const groupDisplaySuffix = groupMetadata.displayName
               ? ` - ${groupMetadata.displayName}`
               : ''
@@ -58,12 +62,13 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
                 {!groupMetadata.displayCategory && irregular && (
                   <>
                     <WellCount
-                      className={styles.irregular_well_count}
-                      displayCategory={displayCategory}
                       count={wellProps.wellCount}
+                      wellLabel={wellLabel}
+                      className={styles.irregular_well_count}
                     />
                     <WellProperties
                       wellProperties={wellProps}
+                      wellLabel={wellLabel}
                       displayVolumeUnits={displayVolumeUnits}
                       hideTitle
                     />
@@ -71,14 +76,15 @@ export default function LabwareDetailsBox(props: LabwareDetailsBoxProps) {
                 )}
                 {!groupMetadata.displayCategory && (
                   <WellDimensions
-                    title={`${MEASUREMENTS}${groupDisplaySuffix}`}
                     wellProperties={wellProps}
+                    wellLabel={wellLabel}
+                    labelSuffix={groupDisplaySuffix}
                     className={styles.details_table}
                   />
                 )}
                 <WellSpacing
-                  title={`${SPACING}${groupDisplaySuffix}`}
                   wellProperties={wellProps}
+                  labelSuffix={groupDisplaySuffix}
                   className={styles.details_table}
                 />
               </React.Fragment>

--- a/labware-library/src/components/LabwareDetails/WellDimensions.js
+++ b/labware-library/src/components/LabwareDetails/WellDimensions.js
@@ -3,8 +3,14 @@
 import * as React from 'react'
 import round from 'lodash/round'
 
-import { MM, X_DIM, Y_DIM, DEPTH, DIAMETER } from '../../localization'
-
+import {
+  MEASUREMENTS,
+  WELL_X_DIM,
+  WELL_Y_DIM,
+  DEPTH,
+  DIAMETER,
+  MM,
+} from '../../localization'
 import { LabeledValueTable, LowercaseText } from '../ui'
 
 import type { LabwareWellGroupProperties } from '../../types'
@@ -13,14 +19,16 @@ import type { LabwareWellGroupProperties } from '../../types'
 const toFixed = (n: number): string => round(n, 2).toFixed(2)
 
 export type WellDimensionsProps = {|
-  title: string,
   wellProperties: LabwareWellGroupProperties,
+  wellLabel: string,
+  labelSuffix?: string,
   className?: string,
 |}
 
 export default function WellDimensions(props: WellDimensionsProps) {
-  const { title, wellProperties, className } = props
+  const { wellProperties, wellLabel, labelSuffix, className } = props
   const { shape } = wellProperties
+  const title = `${wellLabel} ${MEASUREMENTS}${labelSuffix || ''}`
   const dimensions = [{ label: DEPTH, value: wellProperties.depth }]
 
   if (shape) {
@@ -28,8 +36,8 @@ export default function WellDimensions(props: WellDimensionsProps) {
       dimensions.push({ label: DIAMETER, value: toFixed(shape.diameter) })
     } else if (shape.shape === 'rectangular') {
       dimensions.push(
-        { label: X_DIM, value: toFixed(shape.xDimension) },
-        { label: Y_DIM, value: toFixed(shape.yDimension) }
+        { label: WELL_X_DIM, value: toFixed(shape.xDimension) },
+        { label: WELL_Y_DIM, value: toFixed(shape.yDimension) }
       )
     }
   }

--- a/labware-library/src/components/LabwareDetails/WellSpacing.js
+++ b/labware-library/src/components/LabwareDetails/WellSpacing.js
@@ -4,13 +4,14 @@ import * as React from 'react'
 import round from 'lodash/round'
 
 import {
-  MM,
+  SPACING,
   X_OFFSET,
   Y_OFFSET,
   X_SPACING,
   Y_SPACING,
   NA,
   VARIOUS,
+  MM,
 } from '../../localization'
 
 import styles from './styles.css'
@@ -33,17 +34,14 @@ const spacingValue = (spacing: number | null) => {
 }
 
 export type WellSpacingProps = {|
-  title: string,
   wellProperties: LabwareWellGroupProperties,
+  labelSuffix?: string,
   className?: string,
 |}
 
 export default function WellSpacing(props: WellSpacingProps) {
-  const { title, wellProperties, className } = props
-  // TODO (ka 2019-5-20): Revist this after grids definition is merged
-  // const wellType =
-  //   WELL_TYPE_BY_CATEGORY[displayCategory] || WELL_TYPE_BY_CATEGORY.other
-
+  const { labelSuffix, wellProperties, className } = props
+  const title = `${SPACING}${labelSuffix || ''}`
   const spacing = [
     { label: X_OFFSET, value: toFixed(wellProperties.xOffsetFromLeft) },
     { label: Y_OFFSET, value: toFixed(wellProperties.yOffsetFromTop) },

--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom'
 import { getPublicPath } from '../../public-path'
 import { Icon } from '@opentrons/components'
 import {
+  getWellLabel,
   Gallery,
   LoadName,
   Tags,
@@ -24,7 +25,7 @@ export type LabwareCardProps = {| definition: LabwareDefinition |}
 
 export default function LabwareCard(props: LabwareCardProps) {
   const { definition } = props
-  const { displayCategory } = definition.metadata
+  const wellLabel = getWellLabel(definition)
 
   return (
     <li className={styles.card}>
@@ -34,8 +35,8 @@ export default function LabwareCard(props: LabwareCardProps) {
         <Gallery definition={definition} className={styles.gallery_container} />
         <div className={styles.stats}>
           <WellCount
+            wellLabel={wellLabel}
             count={Object.keys(definition.wells).length}
-            displayCategory={displayCategory}
             className={styles.well_count}
           />
           <AllWellProperties

--- a/labware-library/src/components/Sidebar/FilterCategory.js
+++ b/labware-library/src/components/Sidebar/FilterCategory.js
@@ -7,7 +7,7 @@ import cx from 'classnames'
 import { getAllCategories, buildFiltersUrl } from '../../filters'
 import styles from './styles.css'
 
-import { CATEGORY_LABELS_BY_CATEGORY } from '../../localization'
+import { PLURAL_CATEGORY_LABELS_BY_CATEGORY } from '../../localization'
 
 import type { FilterParams } from '../../types'
 
@@ -29,7 +29,7 @@ export default function FilterCategory(props: FilterCategoryProps) {
               [styles.selected]: c === filters.category,
             })}
           >
-            {CATEGORY_LABELS_BY_CATEGORY[c]}
+            {PLURAL_CATEGORY_LABELS_BY_CATEGORY[c]}
           </Link>
         </li>
       ))}

--- a/labware-library/src/components/labware-ui/WellCount.js
+++ b/labware-library/src/components/labware-ui/WellCount.js
@@ -1,27 +1,25 @@
 // @flow
 import * as React from 'react'
 
+import { COUNT } from '../../localization'
 import { LabelText, Value, LABEL_LEFT } from '../ui'
-import { NUM_WELLS_BY_CATEGORY } from '../../localization'
 import styles from './styles.css'
-
-import type { LabwareDisplayCategory } from '../../types'
 
 export type WellCountProps = {|
   count: number,
-  displayCategory: LabwareDisplayCategory,
+  wellLabel: string,
   className?: string,
 |}
 
 export function WellCount(props: WellCountProps) {
-  const { count, displayCategory, className } = props
-  const numWellsLabel =
-    NUM_WELLS_BY_CATEGORY[displayCategory] || NUM_WELLS_BY_CATEGORY.other
+  const { count, wellLabel, className } = props
 
   return (
     <div className={className}>
       <div className={styles.well_count_data}>
-        <LabelText position={LABEL_LEFT}>{numWellsLabel}</LabelText>
+        <LabelText position={LABEL_LEFT}>
+          {wellLabel} {COUNT}
+        </LabelText>
         <Value>{count}</Value>
       </div>
     </div>

--- a/labware-library/src/components/labware-ui/WellProperties.js
+++ b/labware-library/src/components/labware-ui/WellProperties.js
@@ -7,10 +7,11 @@ import { getUniqueWellProperties } from '../../definitions'
 import {
   MAX_VOLUME,
   SHAPE,
-  WELL_TYPE_BY_CATEGORY,
   WELL_BOTTOM_VALUES,
   VARIOUS,
 } from '../../localization'
+
+import { getWellLabel } from './labels'
 import { LabelText, Value, LABEL_TOP } from '../ui'
 
 import styles from './styles.css'
@@ -28,6 +29,7 @@ export type AllWellPropertiesProps = {|
 
 export type WellPropertiesProps = {|
   wellProperties: LabwareWellGroupProperties,
+  wellLabel: string,
   displayVolumeUnits: LabwareVolumeUnits,
   hideTitle?: boolean,
 |}
@@ -42,6 +44,7 @@ export function AllWellProperties(props: AllWellPropertiesProps) {
       {uniqueWellProps.map((wellProperties, i) => (
         <WellProperties
           key={i}
+          wellLabel={getWellLabel(wellProperties, definition)}
           wellProperties={wellProperties}
           displayVolumeUnits={displayVolumeUnits}
         />
@@ -57,14 +60,15 @@ const BOTTOM_SHAPE_TO_ICON = {
 }
 
 export function WellProperties(props: WellPropertiesProps) {
-  const { hideTitle, wellProperties, displayVolumeUnits: units } = props
+  const {
+    hideTitle,
+    wellProperties,
+    wellLabel,
+    displayVolumeUnits: units,
+  } = props
+
   const { totalLiquidVolume: vol, metadata } = wellProperties
-  const { displayName, displayCategory, wellBottomShape } = metadata
-
-  const wellType = displayCategory
-    ? WELL_TYPE_BY_CATEGORY[displayCategory]
-    : WELL_TYPE_BY_CATEGORY.other
-
+  const { displayName, wellBottomShape } = metadata
   const wellBottomValue = wellBottomShape
     ? WELL_BOTTOM_VALUES[wellBottomShape]
     : null
@@ -86,7 +90,7 @@ export function WellProperties(props: WellPropertiesProps) {
         <div className={styles.well_properties_column}>
           <div>
             <LabelText position={LABEL_TOP}>
-              {wellType} {SHAPE}
+              {wellLabel} {SHAPE}
             </LabelText>
             <Value>{wellBottomValue}</Value>
           </div>

--- a/labware-library/src/components/labware-ui/index.js
+++ b/labware-library/src/components/labware-ui/index.js
@@ -1,4 +1,5 @@
 // @flow
+export * from './labels'
 export * from './Gallery'
 export * from './LoadName'
 export * from './ManufacturerStats'

--- a/labware-library/src/components/labware-ui/labels.js
+++ b/labware-library/src/components/labware-ui/labels.js
@@ -1,0 +1,32 @@
+// @flow
+import uniqBy from 'lodash/uniqBy'
+
+import { WELL_TYPE_BY_CATEGORY } from '../../localization'
+
+import type { LabwareWellGroupProperties, LabwareDefinition } from '../../types'
+
+export function getWellLabel(
+  spec: LabwareDefinition | LabwareWellGroupProperties,
+  fallback?: LabwareDefinition | LabwareWellGroupProperties
+): string {
+  let { displayCategory } = spec.metadata
+
+  if (spec.groups && spec.groups.length > 0) {
+    const categories = spec.groups.map(g => g.metadata.displayCategory)
+    const uniqCats = uniqBy(categories).filter(Boolean)
+
+    if (uniqCats.length === 1) {
+      displayCategory = uniqCats[0]
+    }
+  }
+
+  if (displayCategory && WELL_TYPE_BY_CATEGORY[displayCategory]) {
+    return WELL_TYPE_BY_CATEGORY[displayCategory]
+  }
+
+  if (fallback) {
+    return getWellLabel(fallback)
+  }
+
+  return WELL_TYPE_BY_CATEGORY.other
+}

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -3,48 +3,30 @@
 
 export const CATEGORY_LABELS_BY_CATEGORY = {
   all: 'All',
+  tubeRack: 'Tube Rack',
+  tipRack: 'Tip Rack',
+  wellPlate: 'Well Plate',
+  reservoir: 'Reservoir',
+  aluminumBlock: 'Aluminum Block',
+  trash: 'Trash',
+  other: 'Other',
+}
+
+export const PLURAL_CATEGORY_LABELS_BY_CATEGORY = {
+  all: 'All',
   tubeRack: 'Tube Racks',
   tipRack: 'Tip Racks',
   wellPlate: 'Well Plates',
-  trough: 'Troughs',
+  reservoir: 'Reservoirs',
+  aluminumBlock: 'Aluminum Blocks',
   trash: 'Trashes',
   other: 'Other',
 }
 
-export const NUM_WELLS_BY_CATEGORY = {
-  tubeRack: 'tube count',
-  tipRack: 'tip count',
-  wellPlate: 'well count',
-  trough: 'well count',
-  trash: 'well count',
-  other: 'well count',
-}
-
-export const WELL_TYPE_BY_CATEGORY = {
+export const WELL_TYPE_BY_CATEGORY: { [string]: string } = {
   tubeRack: 'tube',
   tipRack: 'tip',
-  wellPlate: 'well',
-  trough: 'well',
-  trash: 'well',
   other: 'well',
-}
-
-export const LABWARE_DIMS_BY_CATEGORY = {
-  tubeRack: 'rack dimensions',
-  tipRack: 'rack dimensions',
-  wellPlate: 'plate dimensions',
-  trough: 'trough dimensions',
-  trash: 'trash dimensions',
-  other: 'labware dimensions',
-}
-
-export const WELL_DIMS_BY_CATEGORY = {
-  tubeRack: 'tube dimensions',
-  tipRack: 'tip dimensions',
-  wellPlate: 'well dimensions',
-  trough: 'well dimensions',
-  trash: 'well dimensions',
-  other: 'well dimensions',
 }
 
 export const MANUFACTURER_LABELS_BY_MANUFACTURER = {
@@ -63,13 +45,13 @@ export const CATEGORY = 'category'
 export const FOOTPRINT = 'footprint'
 export const MEASUREMENTS = 'measurements'
 export const SPACING = 'spacing'
+export const COUNT = 'count'
 export const MM = 'mm'
-export const SHORT_X_DIM = 'l'
-export const SHORT_Y_DIM = 'w'
-export const SHORT_Z_DIM = 'h'
-export const X_DIM = 'length'
-export const Y_DIM = 'width'
-export const Z_DIM = 'height'
+export const LABWARE_X_DIM = 'length'
+export const LABWARE_Y_DIM = 'width'
+export const LABWARE_Z_DIM = 'height'
+export const WELL_X_DIM = 'x-size'
+export const WELL_Y_DIM = 'y-size'
 export const X_OFFSET = 'x-offset'
 export const Y_OFFSET = 'y-offset'
 export const X_SPACING = 'x-spacing'

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -27,7 +27,8 @@ const orderedCategories: Array<string> = [
   'tipRack',
   'tubeRack',
   'wellPlate',
-  'trough',
+  'reservoir',
+  'aluminumBlock',
   'trash',
 ]
 

--- a/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
+++ b/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
@@ -6326,7 +6326,7 @@ Object {
           },
         ],
         "metadata": Object {
-          "displayCategory": "trough",
+          "displayCategory": "reservoir",
           "displayName": "12 Channel Trough",
           "displayVolumeUnits": "mL",
         },

--- a/shared-data/definitions2/opentrons_24_aluminumblock_generic_2ml_screwcap.json
+++ b/shared-data/definitions2/opentrons_24_aluminumblock_generic_2ml_screwcap.json
@@ -14,7 +14,7 @@
   "metadata": {
     "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
     "displayVolumeUnits": "mL",
-    "displayCategory": "tubeRack",
+    "displayCategory": "aluminumBlock",
     "tags": []
   },
   "cornerOffsetFromSlot": {

--- a/shared-data/definitions2/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip.json
+++ b/shared-data/definitions2/opentrons_40_aluminumblock_eppendorf_24x2ml_safelock_snapcap_generic_16x0.2ml_pcr_strip.json
@@ -367,7 +367,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 40 Well Aluminum Block with Eppendorf 24x2 mL Safe-Lock Snapcap, Generic 16x0.2 mL PCR Strip",
-    "displayCategory": "tubeRack",
+    "displayCategory": "aluminumBlock",
     "displayVolumeUnits": "mL",
     "tags": []
   },

--- a/shared-data/definitions2/opentrons_96_aluminumblock_biorad_wellplate_200ul.json
+++ b/shared-data/definitions2/opentrons_96_aluminumblock_biorad_wellplate_200ul.json
@@ -20,7 +20,7 @@
   "metadata": {
     "displayName": "Opentrons 96 Well Aluminum Block with Bio-Rad Well Plate 200 µL",
     "displayVolumeUnits": "µL",
-    "displayCategory": "wellPlate",
+    "displayCategory": "aluminumBlock",
     "tags": []
   },
   "cornerOffsetFromSlot": {

--- a/shared-data/definitions2/opentrons_96_aluminumblock_generic_pcr_strip_200ul.json
+++ b/shared-data/definitions2/opentrons_96_aluminumblock_generic_pcr_strip_200ul.json
@@ -20,7 +20,7 @@
   "metadata": {
     "displayName": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL",
     "displayVolumeUnits": "µL",
-    "displayCategory": "tubeRack",
+    "displayCategory": "aluminumBlock",
     "tags": []
   },
   "cornerOffsetFromSlot": {

--- a/shared-data/definitions2/usascientific_12_reservoir_22ml.json
+++ b/shared-data/definitions2/usascientific_12_reservoir_22ml.json
@@ -20,7 +20,7 @@
   "metadata": {
     "displayName": "USA Scientific 12 Well Reservoir 22 mL",
     "displayVolumeUnits": "mL",
-    "displayCategory": "trough",
+    "displayCategory": "reservoir",
     "tags": []
   },
   "cornerOffsetFromSlot": {

--- a/shared-data/fixtures/fixture12Trough.json
+++ b/shared-data/fixtures/fixture12Trough.json
@@ -20,7 +20,7 @@
   "metadata": {
     "displayName": "12 Channel Trough",
     "displayVolumeUnits": "mL",
-    "displayCategory": "trough"
+    "displayCategory": "reservoir"
   },
   "cornerOffsetFromSlot": {
     "x": 0,

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -34,11 +34,12 @@ export type AllLabwareDefinitions = {
 }
 
 export type LabwareDisplayCategory =
+  | 'wellPlate'
   | 'tipRack'
   | 'tubeRack'
-  | 'trough'
+  | 'reservoir'
+  | 'aluminumBlock'
   | 'trash'
-  | 'wellPlate'
   | 'other'
 
 export type LabwareVolumeUnits = 'µL' | 'mL' | 'L'

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -32,7 +32,9 @@ export type LabwareDefinition = {
 export type AllLabwareDefinitions = {
   [name: string]: LabwareDefinition,
 }
-
+// TODO(mc, 2019-05-29): Remove this enum in favor of string + exported
+// constants + unit tests to catch typos in our definitions. Make changes
+// here and in shared-data/labware-json-schema/labwareSchemaV2.json
 export type LabwareDisplayCategory =
   | 'wellPlate'
   | 'tipRack'
@@ -44,6 +46,9 @@ export type LabwareDisplayCategory =
 
 export type LabwareVolumeUnits = 'µL' | 'mL' | 'L'
 
+// TODO(mc, 2019-05-29): Remove this enum in favor of string + exported
+// constants + unit tests to catch typos in our definitions. Make changes
+// here and in shared-data/labware-json-schema/labwareSchemaV2.json
 export type WellBottomShape = 'flat' | 'u' | 'v'
 
 export type LabwareMetadata = {|

--- a/shared-data/labware-json-schema/labwareSchemaV2.json
+++ b/shared-data/labware-json-schema/labwareSchemaV2.json
@@ -33,7 +33,15 @@
     },
     "displayCategory": {
       "type": "string",
-      "enum": ["tipRack", "tubeRack", "trough", "trash", "wellPlate", "other"]
+      "enum": [
+        "tipRack",
+        "tubeRack",
+        "reservoir",
+        "trash",
+        "wellPlate",
+        "aluminumBlock",
+        "other"
+      ]
     },
     "safeString": {
       "description": "a string safe to use for loadName / namespace. Lowercase-only.",


### PR DESCRIPTION
## overview

~**Blocked by #3497**. PR will be rebased once 3497 is merged~ Unblocked

This PR renames "troughs" to "reservoirs" and adds the "aluminumBlock" display category. Closes #3446 and closes #3481.

## changelog

- Rename troughs to reservoirs
- Add aluminum block category

## review requests

<http://sandbox.labware.opentrons.com/lablib_al-blocks-and-reservoirs/>

- [ ] Labware library categories are correct (including pluralization)
- [ ] Labware library well type specifiers are correct in the cards and details pages
- [ ] Protocol designer labware categories are correct