### PR TITLE
refactor(labware-library): Add labware/tube brand info to UI and filters

### DIFF
--- a/components/src/__tests__/__snapshots__/icons.test.js.snap
+++ b/components/src/__tests__/__snapshots__/icons.test.js.snap
@@ -436,6 +436,21 @@ exports[`icons minus renders correctly 1`] = `
 </svg>
 `;
 
+exports[`icons open-in-new renders correctly 1`] = `
+<svg
+  aria-hidden="true"
+  className="foo"
+  fill="currentColor"
+  version="1.1"
+  viewBox="0 0 24 24"
+>
+  <path
+    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+    fillRule="evenodd"
+  />
+</svg>
+`;
+
 exports[`icons ot-arrow-down renders correctly 1`] = `
 <svg
   aria-hidden="true"

--- a/components/src/icons/icon-data.js
+++ b/components/src/icons/icon-data.js
@@ -323,6 +323,11 @@ const ICON_DATA_BY_NAME = {
     path:
       'M23 0h1v12a.5.5 0 0 1-.146.354l-11.5 11.5a.5.5 0 0 1-.708 0l-11.5-11.5A.5.5 0 0 1 0 12V0h1v11.793l11 11 11-11V0z',
   },
+  'open-in-new': {
+    viewBox: '0 0 24 24',
+    path:
+      'M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z',
+  },
 }
 
 export type IconName = $Keys<typeof ICON_DATA_BY_NAME>

--- a/labware-library/src/components/LabwareList/LabwareCard.js
+++ b/labware-library/src/components/LabwareList/LabwareCard.js
@@ -4,6 +4,7 @@
 //   many of which will be common to LabwareCard and LabwarePage
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import uniq from 'lodash/uniq'
 
 import { getPublicPath } from '../../public-path'
 import { Icon } from '@opentrons/components'
@@ -16,7 +17,10 @@ import {
   AllWellProperties,
 } from '../labware-ui'
 
-import { CATEGORY_LABELS_BY_CATEGORY } from '../../localization'
+import {
+  CATEGORY_LABELS_BY_CATEGORY,
+  MANUFACTURER_VALUES,
+} from '../../localization'
 import styles from './styles.css'
 
 import type { LabwareDefinition } from '../../types'
@@ -52,11 +56,18 @@ export default function LabwareCard(props: LabwareCardProps) {
 }
 
 function TopBar(props: LabwareCardProps) {
-  const { metadata, brand } = props.definition
+  const { metadata, brand, groups } = props.definition
+  const groupBrands: Array<string> = groups
+    .map(group => group.brand?.brand)
+    .filter(Boolean)
+
+  const brands = uniq([brand.brand, ...groupBrands])
+    .map(b => MANUFACTURER_VALUES[b] || b)
+    .join(', ')
 
   return (
     <p className={styles.top_bar}>
-      <span>{brand.brand}</span>
+      <span>{brands}</span>
       {' | '}
       <span>{CATEGORY_LABELS_BY_CATEGORY[metadata.displayCategory]}</span>
     </p>

--- a/labware-library/src/components/LabwareList/index.js
+++ b/labware-library/src/components/LabwareList/index.js
@@ -2,16 +2,12 @@
 // main LabwareList component
 import * as React from 'react'
 
-import { getAllDefinitions } from '../../definitions'
-import { FILTER_OFF } from '../../filters'
+import { getFilteredDefinitions } from '../../filters'
 import LabwareCard from './LabwareCard'
 import NoResults from './NoResults'
 import styles from './styles.css'
 
 import type { FilterParams } from '../../types'
-
-const filterMatches = (filter: ?string, value: string): boolean =>
-  !filter || filter === FILTER_OFF || filter === value
 
 export type LabwareListProps = {|
   filters: FilterParams,
@@ -20,12 +16,7 @@ export type LabwareListProps = {|
 export { default as NoResults } from './NoResults'
 
 export default function LabwareList(props: LabwareListProps) {
-  const { category, manufacturer } = props.filters
-  const definitions = getAllDefinitions().filter(
-    d =>
-      filterMatches(category, d.metadata.displayCategory) &&
-      filterMatches(manufacturer, d.brand.brand)
-  )
+  const definitions = getFilteredDefinitions(props.filters)
 
   return definitions.length === 0 ? (
     <NoResults />

--- a/labware-library/src/components/Nav/styles.css
+++ b/labware-library/src/components/Nav/styles.css
@@ -63,7 +63,8 @@ are project specific  */
   overflow: hidden;
   text-overflow: ellipsis;
 
-  &:hover {
+  &:hover,
+  &:active {
     color: color(var(--c-blue) alpha(0.6));
   }
 }

--- a/labware-library/src/components/Sidebar/FilterManufacturer.js
+++ b/labware-library/src/components/Sidebar/FilterManufacturer.js
@@ -6,10 +6,7 @@ import { SelectField } from '@opentrons/components'
 import { getAllManufacturers, buildFiltersUrl } from '../../filters'
 import styles from './styles.css'
 
-import {
-  MANUFACTURER,
-  MANUFACTURER_LABELS_BY_MANUFACTURER,
-} from '../../localization'
+import { MANUFACTURER, MANUFACTURER_VALUES } from '../../localization'
 
 import type { ContextRouter } from 'react-router-dom'
 import type { FilterParams } from '../../types'
@@ -24,7 +21,7 @@ export function FilterManufacturer(props: FilterManufacturerProps) {
   const manufacturers = getAllManufacturers()
   const options = manufacturers.map(value => ({
     value,
-    label: MANUFACTURER_LABELS_BY_MANUFACTURER[value] || value,
+    label: MANUFACTURER_VALUES[value] || value,
   }))
 
   return (

--- a/labware-library/src/components/labware-ui/ManufacturerStats.js
+++ b/labware-library/src/components/labware-ui/ManufacturerStats.js
@@ -2,30 +2,46 @@
 // labware details page title and category
 import * as React from 'react'
 
-import { LabelText, Value, LABEL_TOP } from '../ui'
-
 import {
   MANUFACTURER,
-  MANUFACTURER_LABELS_BY_MANUFACTURER,
+  MANUFACTURER_NO,
+  MANUFACTURER_VALUES,
 } from '../../localization'
+import { ExternalLink, LabelText, Value, LABEL_TOP } from '../ui'
+import styles from './styles.css'
 
 import type { LabwareBrand } from '../../types'
 
 export type ManufacturerStatsProps = {|
   brand: LabwareBrand,
-  className?: string,
 |}
 
 export function ManufacturerStats(props: ManufacturerStatsProps) {
-  const { brand, className } = props
-  const { brand: brandName } = brand
-  const manfacturerValue =
-    MANUFACTURER_LABELS_BY_MANUFACTURER[brandName] || brandName
+  const { brand } = props
+  const { brand: brandName, brandId, links } = brand
+  const manfacturerValue = MANUFACTURER_VALUES[brandName] || brandName
 
   return (
-    <div className={className}>
-      <LabelText position={LABEL_TOP}>{MANUFACTURER}</LabelText>
-      <Value>{manfacturerValue}</Value>
-    </div>
+    <>
+      <div className={styles.manufacturer_stats}>
+        <LabelText position={LABEL_TOP}>{MANUFACTURER}</LabelText>
+        <Value>{manfacturerValue}</Value>
+        {links &&
+          links.length > 0 &&
+          links.map((href, key) => (
+            <ExternalLink key={key} href={href}>
+              website
+            </ExternalLink>
+          ))}
+      </div>
+      {brandId && brandId.length > 0 && (
+        <div className={styles.manufacturer_stats}>
+          <LabelText position={LABEL_TOP}>{MANUFACTURER_NO}</LabelText>
+          <Value>
+            <p className={styles.manufacturer_brand_id}>{brandId.join(', ')}</p>
+          </Value>
+        </div>
+      )}
+    </>
   )
 }

--- a/labware-library/src/components/labware-ui/styles.css
+++ b/labware-library/src/components/labware-ui/styles.css
@@ -75,6 +75,14 @@ button.load_name_button {
   }
 }
 
+.manufacturer_stats:not(:last-child) {
+  margin-bottom: var(--spacing-7);
+}
+
+.manufacturer_brand_id {
+  line-height: var(--lh-copy);
+}
+
 .tags_data {
   display: flex;
   align-items: center;

--- a/labware-library/src/components/ui/ExternalLink.js
+++ b/labware-library/src/components/ui/ExternalLink.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react'
+import { Icon } from '@opentrons/components'
+
+import styles from './styles.css'
+
+export type ExternalLinkProps = {
+  href: string,
+  children: React.Node,
+}
+
+export function ExternalLink(props: ExternalLinkProps) {
+  const { href, children } = props
+
+  return (
+    <a
+      className={styles.external_link}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+      <Icon className={styles.icon} name="open-in-new" />
+    </a>
+  )
+}

--- a/labware-library/src/components/ui/index.js
+++ b/labware-library/src/components/ui/index.js
@@ -4,6 +4,7 @@
 
 export * from './ClickableIcon'
 export * from './DetailsBox'
+export * from './ExternalLink'
 export * from './LabeledValueTable'
 export * from './Table'
 export * from './LabelText'

--- a/labware-library/src/components/ui/styles.css
+++ b/labware-library/src/components/ui/styles.css
@@ -11,6 +11,26 @@
   }
 }
 
+.external_link {
+  @apply --flex-start;
+  @apply --transition-color;
+
+  margin-top: var(--spacing-3);
+  font-size: var(--fs-body-2);
+  font-weight: var(--fw-semibold);
+  color: var(--c-blue);
+
+  &:hover,
+  &:active {
+    color: color(var(--c-blue) alpha(0.6));
+  }
+
+  & .icon {
+    padding-left: var(--spacing-1);
+    width: var(--size-1);
+  }
+}
+
 .info_button {
   width: 1.25rem;
   color: var(--c-med-gray);

--- a/labware-library/src/definitions.js
+++ b/labware-library/src/definitions.js
@@ -28,7 +28,7 @@ const definitionsContext = (require: any).context(
   'sync' // load every definition into one synchronous chunk
 )
 
-let definitions = null
+let definitions: LabwareList | null = null
 
 export function getAllDefinitions(): LabwareList {
   // TODO(mc, 2019-03-28): revisit decision to hide trash labware

--- a/labware-library/src/filters.js
+++ b/labware-library/src/filters.js
@@ -1,6 +1,7 @@
 // @flow
 // filter helpers
 import queryString from 'query-string'
+import flatMap from 'lodash/flatMap'
 import pickBy from 'lodash/pickBy'
 import uniq from 'lodash/uniq'
 
@@ -8,7 +9,7 @@ import { getAllDefinitions } from './definitions'
 import { getPublicPath } from './public-path'
 
 import type { Location } from 'react-router-dom'
-import type { FilterParams, LabwareDefinition } from './types'
+import type { FilterParams, LabwareDefinition, LabwareList } from './types'
 
 export const FILTER_OFF = 'all'
 
@@ -19,9 +20,15 @@ export function getAllCategories(): Array<string> {
 }
 
 export function getAllManufacturers(): Array<string> {
-  const manufacturers = getAllDefinitions().map(d => d.brand.brand)
+  const definitions = getAllDefinitions()
+  const brands = definitions.map(d => d.brand.brand)
+  const wellGroupBrands = flatMap<LabwareDefinition, string>(
+    definitions,
+    (d: LabwareDefinition, i: number, c: LabwareList) =>
+      d.groups.map(g => g.brand?.brand).filter(Boolean)
+  )
 
-  return [FILTER_OFF].concat(uniq(manufacturers))
+  return uniq([FILTER_OFF, ...brands, ...wellGroupBrands])
 }
 
 export function getFilters(
@@ -46,4 +53,35 @@ export function buildFiltersUrl(filters: FilterParams): string {
   const params = pickBy(filters, v => v !== FILTER_OFF)
 
   return `${getPublicPath()}?${queryString.stringify(params)}`
+}
+
+export function getFilteredDefinitions(filters: FilterParams): LabwareList {
+  return getAllDefinitions().filter(
+    def =>
+      testCategory(filters.category, def) &&
+      testManufacturer(filters.manufacturer, def)
+  )
+}
+
+export function testManufacturer(
+  manufacturer: ?string,
+  definition: LabwareDefinition
+): boolean {
+  return (
+    !manufacturer ||
+    manufacturer === FILTER_OFF ||
+    manufacturer === definition.brand.brand ||
+    definition.groups.some(g => g.brand?.brand === manufacturer)
+  )
+}
+
+export function testCategory(
+  category: ?string,
+  definition: LabwareDefinition
+): boolean {
+  return (
+    !category ||
+    category === FILTER_OFF ||
+    category === definition.metadata.displayCategory
+  )
 }

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -29,7 +29,7 @@ export const WELL_TYPE_BY_CATEGORY: { [string]: string } = {
   other: 'well',
 }
 
-export const MANUFACTURER_LABELS_BY_MANUFACTURER = {
+export const MANUFACTURER_VALUES = {
   all: 'All',
   generic: 'Generic',
 }
@@ -41,6 +41,7 @@ export const WELL_BOTTOM_VALUES = {
 }
 
 export const MANUFACTURER = 'manufacturer'
+export const MANUFACTURER_NO = 'manufacturer / catalog #'
 export const CATEGORY = 'category'
 export const FOOTPRINT = 'footprint'
 export const MEASUREMENTS = 'measurements'

--- a/labware-library/src/types.js
+++ b/labware-library/src/types.js
@@ -33,7 +33,7 @@ export type LabwareWellGroupProperties = {|
   brand: LabwareBrand | null,
 |}
 
-export type LabwareList = Array<LabwareDefinition>
+export type LabwareList = $ReadOnlyArray<LabwareDefinition>
 
 export type FilterParams = {
   category: string,


### PR DESCRIPTION
## overview

This PR adds brand links and SKUs for labware and inserts to the card and details page. It also adds insert brands to the manufacturer filters. Closes #3477

## changelog

- Add labware/tube brand info to UI and filters

## review requests

<http://sandbox.labware.opentrons.com/lablib_add-brand-info>

Acceptance criteria from ticket:

- [ ] Insert brand name displayed in labware card title
- [ ] Link to labware manufacturer in details page (if available)
- [ ] Link to insert manufacturers in details page (if available)
- [ ] Labware SKUs listed in manufacturer bar on details page (if available)
- [ ] Insert SKUs are listed in insert manufacturer bar on details page (if available)
- [ ] Manufacturer filter selects based on labware and insert brands

This PR doesn't add any new responsive behavior, so please also make sure everything displays / expands in a sane manner