### PR TITLE
fix(protocol-designer): add "fixed-trash" labware type to v1->v2 shim

### DIFF
--- a/protocol-designer/src/labware-defs/selectors.js
+++ b/protocol-designer/src/labware-defs/selectors.js
@@ -54,6 +54,7 @@ export const V1_NAME_TO_V2_OTID = {
   'tiprack-300ul': '88154cc0-ffde-11e8-abfa-95044b186e81', // NOT REAL DEF, shim using 10uL tiprack
   'tiprack-1000ul': 'd4e462c0-ffde-11e8-abfa-95044b186e81',
   'trough-12row': 'a41d9ef0-f4b6-11e8-90c2-7106f0eae5a7',
+  'fixed-trash': '629d3b80-ecfe-11e8-b073-3da0bb8daec9',
 }
 
 const otIdToLoadName = reduce(


### PR DESCRIPTION
## overview

PD is still held together with funky shims while we move to v2 labware defs. Right now there is a default `type: fixed-trash` labware on the deck, and it whitescreens PD because `fixed-trash` mapping is not included in the shim. This fixes the whitescreening by mapping `fixed-trash` to the new 1.1L trash defn.

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
