### PR TITLE
fix(shared_data): Change deep well name, modify tipracks

### DIFF
--- a/shared-data/labware/definitions/2/generic_96_wellplate_1.5ml_deep/1.json
+++ b/shared-data/labware/definitions/2/generic_96_wellplate_1.5ml_deep/1.json
@@ -14,10 +14,7 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "generic",
-    "links": [
-      "https://ecatalog.corning.com/life-sciences/b2c/US/en/Genomics-&-Molecular-Biology/Automation-Consumables/Deep-Well-Plate/Axygen%C2%AE-Deep-Well-and-Assay-Plates/p/P-DW-20-C-S"
-    ]
+    "brand": "generic"
   },
   "metadata": {
     "displayName": "Generic 96 Well Plate 1.5 mL",

--- a/shared-data/labware/definitions/2/generic_96_wellplate_1.5ml_deep/1.json
+++ b/shared-data/labware/definitions/2/generic_96_wellplate_1.5ml_deep/1.json
@@ -14,14 +14,13 @@
     ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
   ],
   "brand": {
-    "brand": "USA Scientific",
-    "brandId": ["1896-2000"],
+    "brand": "generic",
     "links": [
-      "https://www.usascientific.com/2ml-deep96-well-plateone-bulk.aspx"
+      "https://ecatalog.corning.com/life-sciences/b2c/US/en/Genomics-&-Molecular-Biology/Automation-Consumables/Deep-Well-Plate/Axygen%C2%AE-Deep-Well-and-Assay-Plates/p/P-DW-20-C-S"
     ]
   },
   "metadata": {
-    "displayName": "USA Scientific 96 Well Plate 2.4 mL",
+    "displayName": "Generic 96 Well Plate 1.5 mL",
     "displayCategory": "wellPlate",
     "displayVolumeUnits": "mL",
     "tags": []
@@ -42,7 +41,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 11.24,
       "z": 64.57
@@ -51,7 +50,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 20.24,
       "z": 64.57
@@ -60,7 +59,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 29.24,
       "z": 64.57
@@ -69,7 +68,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 38.24,
       "z": 64.57
@@ -78,7 +77,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 47.24,
       "z": 64.57
@@ -87,7 +86,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 56.24,
       "z": 64.57
@@ -96,7 +95,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 65.24,
       "z": 64.57
@@ -105,7 +104,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 14.34,
       "y": 74.24,
       "z": 64.57
@@ -114,7 +113,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 11.24,
       "z": 64.57
@@ -123,7 +122,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 20.24,
       "z": 64.57
@@ -132,7 +131,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 29.24,
       "z": 64.57
@@ -141,7 +140,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 38.24,
       "z": 64.57
@@ -150,7 +149,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 47.24,
       "z": 64.57
@@ -159,7 +158,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 56.24,
       "z": 64.57
@@ -168,7 +167,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 65.24,
       "z": 64.57
@@ -177,7 +176,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 23.34,
       "y": 74.24,
       "z": 64.57
@@ -186,7 +185,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 11.24,
       "z": 64.57
@@ -195,7 +194,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 20.24,
       "z": 64.57
@@ -204,7 +203,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 29.24,
       "z": 64.57
@@ -213,7 +212,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 38.24,
       "z": 64.57
@@ -222,7 +221,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 47.24,
       "z": 64.57
@@ -231,7 +230,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 56.24,
       "z": 64.57
@@ -240,7 +239,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 65.24,
       "z": 64.57
@@ -249,7 +248,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 32.34,
       "y": 74.24,
       "z": 64.57
@@ -258,7 +257,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 11.24,
       "z": 64.57
@@ -267,7 +266,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 20.24,
       "z": 64.57
@@ -276,7 +275,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 29.24,
       "z": 64.57
@@ -285,7 +284,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 38.24,
       "z": 64.57
@@ -294,7 +293,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 47.24,
       "z": 64.57
@@ -303,7 +302,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 56.24,
       "z": 64.57
@@ -312,7 +311,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 65.24,
       "z": 64.57
@@ -321,7 +320,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 41.34,
       "y": 74.24,
       "z": 64.57
@@ -330,7 +329,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 11.24,
       "z": 64.57
@@ -339,7 +338,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 20.24,
       "z": 64.57
@@ -348,7 +347,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 29.24,
       "z": 64.57
@@ -357,7 +356,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 38.24,
       "z": 64.57
@@ -366,7 +365,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 47.24,
       "z": 64.57
@@ -375,7 +374,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 56.24,
       "z": 64.57
@@ -384,7 +383,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 65.24,
       "z": 64.57
@@ -393,7 +392,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 50.34,
       "y": 74.24,
       "z": 64.57
@@ -402,7 +401,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 11.24,
       "z": 64.57
@@ -411,7 +410,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 20.24,
       "z": 64.57
@@ -420,7 +419,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 29.24,
       "z": 64.57
@@ -429,7 +428,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 38.24,
       "z": 64.57
@@ -438,7 +437,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 47.24,
       "z": 64.57
@@ -447,7 +446,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 56.24,
       "z": 64.57
@@ -456,7 +455,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 65.24,
       "z": 64.57
@@ -465,7 +464,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 59.34,
       "y": 74.24,
       "z": 64.57
@@ -474,7 +473,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 11.24,
       "z": 64.57
@@ -483,7 +482,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 20.24,
       "z": 64.57
@@ -492,7 +491,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 29.24,
       "z": 64.57
@@ -501,7 +500,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 38.24,
       "z": 64.57
@@ -510,7 +509,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 47.24,
       "z": 64.57
@@ -519,7 +518,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 56.24,
       "z": 64.57
@@ -528,7 +527,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 65.24,
       "z": 64.57
@@ -537,7 +536,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 68.34,
       "y": 74.24,
       "z": 64.57
@@ -546,7 +545,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 11.24,
       "z": 64.57
@@ -555,7 +554,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 20.24,
       "z": 64.57
@@ -564,7 +563,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 29.24,
       "z": 64.57
@@ -573,7 +572,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 38.24,
       "z": 64.57
@@ -582,7 +581,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 47.24,
       "z": 64.57
@@ -591,7 +590,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 56.24,
       "z": 64.57
@@ -600,7 +599,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 65.24,
       "z": 64.57
@@ -609,7 +608,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 77.34,
       "y": 74.24,
       "z": 64.57
@@ -618,7 +617,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 11.24,
       "z": 64.57
@@ -627,7 +626,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 20.24,
       "z": 64.57
@@ -636,7 +635,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 29.24,
       "z": 64.57
@@ -645,7 +644,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 38.24,
       "z": 64.57
@@ -654,7 +653,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 47.24,
       "z": 64.57
@@ -663,7 +662,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 56.24,
       "z": 64.57
@@ -672,7 +671,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 65.24,
       "z": 64.57
@@ -681,7 +680,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 86.34,
       "y": 74.24,
       "z": 64.57
@@ -690,7 +689,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 11.24,
       "z": 64.57
@@ -699,7 +698,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 20.24,
       "z": 64.57
@@ -708,7 +707,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 29.24,
       "z": 64.57
@@ -717,7 +716,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 38.24,
       "z": 64.57
@@ -726,7 +725,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 47.24,
       "z": 64.57
@@ -735,7 +734,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 56.24,
       "z": 64.57
@@ -744,7 +743,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 65.24,
       "z": 64.57
@@ -753,7 +752,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 95.34,
       "y": 74.24,
       "z": 64.57
@@ -762,7 +761,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 11.24,
       "z": 64.57
@@ -771,7 +770,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 20.24,
       "z": 64.57
@@ -780,7 +779,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 29.24,
       "z": 64.57
@@ -789,7 +788,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 38.24,
       "z": 64.57
@@ -798,7 +797,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 47.24,
       "z": 64.57
@@ -807,7 +806,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 56.24,
       "z": 64.57
@@ -816,7 +815,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 65.24,
       "z": 64.57
@@ -825,7 +824,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 104.34,
       "y": 74.24,
       "z": 64.57
@@ -834,7 +833,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 11.24,
       "z": 64.57
@@ -843,7 +842,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 20.24,
       "z": 64.57
@@ -852,7 +851,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 29.24,
       "z": 64.57
@@ -861,7 +860,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 38.24,
       "z": 64.57
@@ -870,7 +869,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 47.24,
       "z": 64.57
@@ -879,7 +878,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 56.24,
       "z": 64.57
@@ -888,7 +887,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 65.24,
       "z": 64.57
@@ -897,7 +896,7 @@
       "depth": 33.5,
       "shape": "circular",
       "diameter": 7.5,
-      "totalLiquidVolume": 2400,
+      "totalLiquidVolume": 1500,
       "x": 113.34,
       "y": 74.24,
       "z": 64.57

--- a/shared-data/labware/definitions/2/opentrons_96_tiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_tiprack_1000ul/1.json
@@ -32,7 +32,7 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 98.07
+    "zDimension": 96.07
   },
   "otId": "ce7cd5a0-7bdc-11e9-94cb-2f30b79b49f5",
   "cornerOffsetFromSlot": {
@@ -46,864 +46,864 @@
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 4,
+      "z": 85.53
     },
     "G1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 13,
+      "z": 85.53
     },
     "F1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 22,
+      "z": 85.53
     },
     "E1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 31,
+      "z": 85.53
     },
     "D1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 40,
+      "z": 85.53
     },
     "C1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 49,
+      "z": 85.53
     },
     "B1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 58,
+      "z": 85.53
     },
     "A1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 11.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 14.88,
+      "y": 67,
+      "z": 85.53
     },
     "H2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 4,
+      "z": 85.53
     },
     "G2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 13,
+      "z": 85.53
     },
     "F2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 22,
+      "z": 85.53
     },
     "E2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 31,
+      "z": 85.53
     },
     "D2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 40,
+      "z": 85.53
     },
     "C2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 49,
+      "z": 85.53
     },
     "B2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 58,
+      "z": 85.53
     },
     "A2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 20.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 23.88,
+      "y": 67,
+      "z": 85.53
     },
     "H3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 4,
+      "z": 85.53
     },
     "G3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 13,
+      "z": 85.53
     },
     "F3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 22,
+      "z": 85.53
     },
     "E3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 31,
+      "z": 85.53
     },
     "D3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 40,
+      "z": 85.53
     },
     "C3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 49,
+      "z": 85.53
     },
     "B3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 58,
+      "z": 85.53
     },
     "A3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 29.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 32.88,
+      "y": 67,
+      "z": 85.53
     },
     "H4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 4,
+      "z": 85.53
     },
     "G4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 13,
+      "z": 85.53
     },
     "F4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 22,
+      "z": 85.53
     },
     "E4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 31,
+      "z": 85.53
     },
     "D4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 40,
+      "z": 85.53
     },
     "C4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 49,
+      "z": 85.53
     },
     "B4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 58,
+      "z": 85.53
     },
     "A4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 38.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 41.88,
+      "y": 67,
+      "z": 85.53
     },
     "H5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 4,
+      "z": 85.53
     },
     "G5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 13,
+      "z": 85.53
     },
     "F5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 22,
+      "z": 85.53
     },
     "E5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 31,
+      "z": 85.53
     },
     "D5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 40,
+      "z": 85.53
     },
     "C5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 49,
+      "z": 85.53
     },
     "B5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 58,
+      "z": 85.53
     },
     "A5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 47.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 50.88,
+      "y": 67,
+      "z": 85.53
     },
     "H6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 4,
+      "z": 85.53
     },
     "G6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 13,
+      "z": 85.53
     },
     "F6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 22,
+      "z": 85.53
     },
     "E6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 31,
+      "z": 85.53
     },
     "D6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 40,
+      "z": 85.53
     },
     "C6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 49,
+      "z": 85.53
     },
     "B6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 58,
+      "z": 85.53
     },
     "A6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 56.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 59.88,
+      "y": 67,
+      "z": 85.53
     },
     "H7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 4,
+      "z": 85.53
     },
     "G7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 13,
+      "z": 85.53
     },
     "F7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 22,
+      "z": 85.53
     },
     "E7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 31,
+      "z": 85.53
     },
     "D7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 40,
+      "z": 85.53
     },
     "C7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 49,
+      "z": 85.53
     },
     "B7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 58,
+      "z": 85.53
     },
     "A7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 65.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 68.88,
+      "y": 67,
+      "z": 85.53
     },
     "H8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 4,
+      "z": 85.53
     },
     "G8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 13,
+      "z": 85.53
     },
     "F8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 22,
+      "z": 85.53
     },
     "E8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 31,
+      "z": 85.53
     },
     "D8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 40,
+      "z": 85.53
     },
     "C8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 49,
+      "z": 85.53
     },
     "B8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 58,
+      "z": 85.53
     },
     "A8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 74.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 77.88,
+      "y": 67,
+      "z": 85.53
     },
     "H9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 4,
+      "z": 85.53
     },
     "G9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 13,
+      "z": 85.53
     },
     "F9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 22,
+      "z": 85.53
     },
     "E9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 31,
+      "z": 85.53
     },
     "D9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 40,
+      "z": 85.53
     },
     "C9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 49,
+      "z": 85.53
     },
     "B9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 58,
+      "z": 85.53
     },
     "A9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 83.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 86.88,
+      "y": 67,
+      "z": 85.53
     },
     "H10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 4,
+      "z": 85.53
     },
     "G10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 13,
+      "z": 85.53
     },
     "F10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 22,
+      "z": 85.53
     },
     "E10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 31,
+      "z": 85.53
     },
     "D10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 40,
+      "z": 85.53
     },
     "C10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 49,
+      "z": 85.53
     },
     "B10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 58,
+      "z": 85.53
     },
     "A10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 92.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 95.88,
+      "y": 67,
+      "z": 85.53
     },
     "H11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 4,
+      "z": 85.53
     },
     "G11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 13,
+      "z": 85.53
     },
     "F11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 22,
+      "z": 85.53
     },
     "E11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 31,
+      "z": 85.53
     },
     "D11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 40,
+      "z": 85.53
     },
     "C11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 49,
+      "z": 85.53
     },
     "B11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 58,
+      "z": 85.53
     },
     "A11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 101.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 104.88,
+      "y": 67,
+      "z": 85.53
     },
     "H12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 8.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 4,
+      "z": 85.53
     },
     "G12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 17.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 13,
+      "z": 85.53
     },
     "F12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 26.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 22,
+      "z": 85.53
     },
     "E12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 35.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 31,
+      "z": 85.53
     },
     "D12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 44.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 40,
+      "z": 85.53
     },
     "C12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 53.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 49,
+      "z": 85.53
     },
     "B12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 62.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 58,
+      "z": 85.53
     },
     "A12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 7.62,
       "totalLiquidVolume": 1000,
-      "x": 110.18,
-      "y": 71.5,
-      "z": 87.53
+      "x": 113.88,
+      "y": 67,
+      "z": 85.53
     }
   },
   "parameters": {

--- a/shared-data/labware/definitions/2/opentrons_96_tiprack_10ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_tiprack_10ul/1.json
@@ -32,7 +32,7 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 64.89
+    "zDimension": 65.89
   },
   "otId": "55127330-6ab8-11e9-8a70-35657d4f3dc7",
   "cornerOffsetFromSlot": {
@@ -44,866 +44,866 @@
     "H1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A1": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 11.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 16.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A2": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 20.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 25.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A3": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 29.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 34.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A4": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 38.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 43.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A5": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 47.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 52.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A6": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 56.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 61.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A7": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 65.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 70.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A8": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 74.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 79.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A9": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 83.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 88.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A10": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 92.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 97.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A11": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 101.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 106.37,
+      "y": 68.47,
+      "z": 26.46
     },
     "H12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 10.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 5.47,
+      "z": 26.46
     },
     "G12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 19.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 14.47,
+      "z": 26.46
     },
     "F12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 28.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 23.47,
+      "z": 26.46
     },
     "E12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 37.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 32.47,
+      "z": 26.46
     },
     "D12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 46.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 41.47,
+      "z": 26.46
     },
     "C12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 55.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 50.47,
+      "z": 26.46
     },
     "B12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 64.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 59.47,
+      "z": 26.46
     },
     "A12": {
       "depth": 39.2,
       "shape": "circular",
-      "diameter": 4.4,
+      "diameter": 3.5,
       "totalLiquidVolume": 10,
-      "x": 110.47,
-      "y": 73.77,
-      "z": 25.69
+      "x": 115.37,
+      "y": 68.47,
+      "z": 26.46
     }
   },
   "parameters": {

--- a/shared-data/labware/definitions/2/tipone_96_tiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/tipone_96_tiprack_200ul/1.json
@@ -27,7 +27,7 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 62.9
+    "zDimension": 63.9
   },
   "otId": "5d7bf5d0-7bdb-11e9-94cb-2f30b79b49f5",
   "namespace": "opentrons",
@@ -44,864 +44,864 @@
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A1": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 11.79,
+      "x": 13.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A2": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 20.79,
+      "x": 22.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A3": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 29.79,
+      "x": 31.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A4": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 38.79,
+      "x": 40.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A5": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 47.79,
+      "x": 49.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A6": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 56.79,
+      "x": 58.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A7": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 65.79,
+      "x": 67.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A8": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 74.79,
+      "x": 76.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A9": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 83.79,
+      "x": 85.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A10": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 92.79,
+      "x": 94.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A11": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 101.79,
+      "x": 103.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     },
     "H12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 9.25,
-      "z": 52.36
+      "z": 53.36
     },
     "G12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 18.25,
-      "z": 52.36
+      "z": 53.36
     },
     "F12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 27.25,
-      "z": 52.36
+      "z": 53.36
     },
     "E12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 36.25,
-      "z": 52.36
+      "z": 53.36
     },
     "D12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 45.25,
-      "z": 52.36
+      "z": 53.36
     },
     "C12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 54.25,
-      "z": 52.36
+      "z": 53.36
     },
     "B12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 63.25,
-      "z": 52.36
+      "z": 53.36
     },
     "A12": {
       "depth": 10.54,
       "shape": "circular",
       "diameter": 6.4,
       "totalLiquidVolume": 200,
-      "x": 110.79,
+      "x": 112.69,
       "y": 72.25,
-      "z": 52.36
+      "z": 53.36
     }
   },
   "parameters": {


### PR DESCRIPTION
## overview

The offsets for the following tipracks were not quite right: opentrons 10ul, 1000ul tiprack and tipone 200ul tiprack

## changelog

- Update offests for above defs
- Modify name of deep well plate to be generic as usa scientific does not carry circular deep well plates

## review requests

Test on robot if you want
