### PR TITLE
feat(api): do not use labware otId

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -179,9 +179,9 @@ def _load_new_well(well_data, saved_offset, lw_format):
     return (well, well_tuple)
 
 
-def _look_up_offsets(otId):
+def _look_up_offsets(labware_hash):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v4']
-    labware_offset_path = calibration_path/'{}.json'.format(otId)
+    labware_offset_path = calibration_path/'{}.json'.format(labware_hash)
     if labware_offset_path.exists():
         calibration_data = new_labware._read_file(str(labware_offset_path))
         offset_array = calibration_data['default']['offset']
@@ -190,11 +190,11 @@ def _look_up_offsets(otId):
         return Point(x=0, y=0, z=0)
 
 
-def save_new_offsets(otId, delta):
+def save_new_offsets(labware_hash, delta):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v4']
     if not calibration_path.exists():
         calibration_path.mkdir(parents=True, exist_ok=True)
-    labware_offset_path = calibration_path/'{}.json'.format(otId)
+    labware_offset_path = calibration_path/'{}.json'.format(labware_hash)
     calibration_data = new_labware._helper_offset_data_format(
         str(labware_offset_path), delta)
     with labware_offset_path.open('w') as f:
@@ -213,13 +213,13 @@ def load_new_labware(container_name):
 def load_new_labware_def(definition):
     """ Load a labware definition in the new schema into a placeable
     """
-    labware_id = definition['otId']
-    saved_offset = _look_up_offsets(labware_id)
+    labware_hash = new_labware._hash_labware_def(definition)
+    saved_offset = _look_up_offsets(labware_hash)
     container = Container()
     container_name = definition['parameters']['loadName']
     log.info(f"Container name {container_name}")
+    container.properties['labware_hash'] = labware_hash
     container.properties['type'] = container_name
-    container.properties['otId'] = labware_id
     lw_format = definition['parameters']['format']
 
     container._coordinates = Vector(definition['cornerOffsetFromSlot'])

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -217,7 +217,7 @@ def load_new_labware_def(definition):
     saved_offset = _look_up_offsets(labware_hash)
     container = Container()
     container_name = definition['parameters']['loadName']
-    log.info(f"Container name {container_name}")
+    log.info(f"Container name {container_name}, hash {labware_hash}")
     container.properties['labware_hash'] = labware_hash
     container.properties['type'] = container_name
     lw_format = definition['parameters']['format']

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1033,8 +1033,8 @@ class Robot(CommandPublisher):
         pose_tree = pose_tracker.update(pose_tree, container, new_coordinates)
         container._coordinates = container._coordinates + delta
 
-        if save and container.properties.get('otId'):
-            save_new_offsets(container.properties['otId'], delta)
+        if save and container.properties.get('labware_hash'):
+            save_new_offsets(container.properties['labware_hash'], delta)
         elif save and new_container_name:
             database.save_new_container(container, new_container_name)
         elif save:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -214,7 +214,6 @@ class Labware:
         self._wells: List[Well] = []
         # Directly from definition
         self._well_definition = definition['wells']
-        self._id = definition['otId']
         self._parameters = definition['parameters']
         offset = definition['cornerOffsetFromSlot']
         self._dimensions = definition['dimensions']

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -10,7 +10,6 @@ minimalLabwareDef = {
         "y": 10,
         "z": 5
     },
-    "otId": "minimalLabwareDef",
     "parameters": {
         "isTiprack": False,
     },
@@ -51,7 +50,6 @@ minimalLabwareDef2 = {
             "y": 10,
             "z": 5
     },
-    "otId": "minimalLabwareDef2",
     "parameters": {
         "isTiprack": False,
     },

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -19,7 +19,6 @@ minimalLabwareDef = {
         "y": 10,
         "z": 5
     },
-    "otId": "minimalLabwareDef",
     "parameters": {
         "isTiprack": True,
         "tipLength": 55.3,


### PR DESCRIPTION
## overview

Part of #3471. Because custom labware cannot be assigned an otId, we cannot use it in the API. This removes the last references in the API to `otId`.

## changelog

* remove all references to `otId` from API

## review requests

* Please sanity check!
* This affects APIv1 calibration. When this commit is released, users' calibration offsets that used `{otId}.json` will not be deleted but they will no longer be accessed. Those users will have to re-calibrate. I believe that only v2 labware will be affected. Are external users working with labware loaded via `load_new_labware_def` from APIv1?