### PR TITLE
docs(components): fix LabwareRender.md

### DIFF
--- a/components/src/deck/LabwareRender.md
+++ b/components/src/deck/LabwareRender.md
@@ -20,7 +20,7 @@ let definition = fixture96Plate
     <LabwareRender
       showLabels
       definition={definition}
-      highlightedWells={new Set(['A1', 'B2'])}
+      highlightedWells={{ A1: null, B2: null }}
       wellFill={{ A1: 'maroon', C3: 'lavender' }}
     />
   )}
@@ -42,8 +42,8 @@ let definition = fixtureTipRack300Ul
   {() => (
     <LabwareRender
       definition={definition}
-      highlightedWells={new Set(['A1', 'B2'])}
-      missingTips={new Set(['C3', 'D4'])}
+      highlightedWells={{ A1: null, B2: null }}
+      missingTips={{ C3: null, D4: null }}
     />
   )}
 </RobotWorkSpace>


### PR DESCRIPTION
## overview

Super minor cleanup, @b-cooper pointed out that I left the `LabwareRender` component library examples broken after changing the type of the props from Set<string> to WellGroup.

## changelog


## review requests

:eyes: 