### PR TITLE
fix(api): Fix first-boot smoothie updates for apiv2

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1537,8 +1537,8 @@ class SmoothieDriver_3_0_0:
         programming mode.
         """
         # ensure there is a reference to the port
-        if self.simulating:
-            return 'Did nothing (simulating)'
+        # if self.simulating:
+        #    return 'Did nothing (simulating)'
 
         try:
             smoothie_update._ensure_programmer_executable()

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1536,10 +1536,6 @@ class SmoothieDriver_3_0_0:
         If explicit_modeset is False, assume the smoothie is already in
         programming mode.
         """
-        # ensure there is a reference to the port
-        # if self.simulating:
-        #    return 'Did nothing (simulating)'
-
         try:
             smoothie_update._ensure_programmer_executable()
         except OSError as ose:

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -7,9 +7,10 @@ from opentrons import server
 from opentrons.server.main import build_arg_parser
 from argparse import ArgumentParser
 from opentrons import hardware, __version__
-from opentrons.config import feature_flags as ff, name
+from opentrons.config import feature_flags as ff, name, robot_configs
 from opentrons.system import udev, resin
 from opentrons.util import logging_config
+from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 
 log = logging.getLogger(__name__)
 
@@ -25,10 +26,49 @@ def _find_smoothie_file():
                   .format(os.path.join(HERE, 'resources')))
 
 
-def _sync_do_smoothie_install(explicit_modeset, filename, loop):
-    loop.run_until_complete(hardware.update_firmware(filename,
-                                                     loop,
-                                                     explicit_modeset))
+async def _do_fw_update(new_fw_path, new_fw_ver):
+    """ Update the connected smoothie board, with retries
+
+    When the API server boots, it talks to the motor controller board for the
+    first time. Sometimes the board is in a bad state - it might have the
+    wrong firmware version (i.e. this is the first boot after an update), or it
+    might just not be communicating correctly. Sometimes, the motor controller
+    not communicating correctly in fact means it needs a firmware update; other
+    times, it might mean it just needs to be reset.
+
+    This function is called when the API server boots if either of the above
+    cases happens. Its job is to make the motor controller board ready by
+    updating its firmware, regardless of the state of the rest of the stack.
+
+    To that end, this function uses the smoothie driver directly (so it can
+    ignore the rest of the stack) and has a couple retries with different
+    hardware line changes in between (so it can catch all failure modes). If
+    this method ultimately fails, it lets the server boot by telling it to
+    consider itself virtual.
+
+    After this function has completed, it is always safe to call
+    hardware.connect() - it just might be virtual
+    """
+    explicit_modeset = False
+    driver = SmoothieDriver_3_0_0(robot_configs.load())
+    for attempts in range(3):
+        try:
+            await driver.update_firmware(
+                new_fw_path,
+                explicit_modeset=explicit_modeset)
+        except RuntimeError:
+            explicit_modeset = True
+            continue
+
+        if driver.get_fw_version() == new_fw_ver:
+            log.info(f"Smoothie fw update complete in {attempts} tries")
+            break
+        else:
+            log.error(
+                "Failed to update smoothie: did not connect after update")
+    else:
+        log.error("Could not update smoothie, forcing virtual")
+        os.environ['ENABLE_VIRTUAL_SMOOTHIE'] = 'true'
 
 
 def initialize_robot(loop):
@@ -45,34 +85,18 @@ def initialize_robot(loop):
         # it (so it can boot again), but we don’t have to do the GPIO
         # manipulations that _put_ it in programming mode
         log.exception("Error while connecting to motor driver: {}".format(e))
-        explicit_modeset = False
         fw_version = None
     else:
-        explicit_modeset = True
         fw_version = hardware.fw_version
     log.info("Smoothie FW version: {}".format(fw_version))
     if fw_version != packed_smoothie_fw_ver:
         log.info("Executing smoothie update: current vers {}, packed vers {}"
                  .format(fw_version, packed_smoothie_fw_ver))
-        for attempts in range(3):
-            try:
-                loop.run_until_complete(
-                    hardware.update_firmware(
-                        packed_smoothie_fw_file,
-                        explicit_modeset=explicit_modeset))
-            except RuntimeError:
-                explicit_modeset = True
-                continue
-
-            if hardware.is_connected():
-                log.info(f"Smoothie fw update complete in {attempts} tries")
-                break
-            else:
-                log.error(
-                    "Failed to update smoothie: did not connect after update")
+        loop.run_until_complete(
+            _do_fw_update(packed_smoothie_fw_file, packed_smoothie_fw_ver))
+        if ff.use_protocol_api_v2():
+            hardware.connect(force=True)
         else:
-            log.error("Could not update smoothie, forcing virtual")
-            os.environ['ENABLE_VIRTUAL_SMOOTHIE'] = 'true'
             hardware.connect()
     else:
         log.info("FW version OK: {}".format(packed_smoothie_fw_ver))


### PR DESCRIPTION
When the api server boots, if it can't communicate with the smoothie (in this
case because there was a non-backwards-compatible smoothie firmware update,
which is a perfectly reasonable thing to have) it programs the attached
smoothie. This works fine on apiv1. Unfortunately, in apiv2, when the server
first fails to communicate with the smoothie it ends up with a simulating
backend, which doesn't actually do the update.

To fix this, factor the initial smoothie firmware update down to its own
function that just uses the driver directly; this is correct for both api
versions and avoids the rest of the stack purposefully. This is normally a
layering violation but here is best thought of as startup bootstrapping code
that only runs once.

Closes #3501

To test, use the attached smoothie hex and upload script (to be run on a robot just to make it easy) and on both an apiv1 and v2 robot, flash the smoothie back to the attached older version then reboot and make sure everything's OK


[smoothie-updates.zip](https://github.com/Opentrons/opentrons/files/3248908/smoothie-updates.zip)
