### PR TITLE
fix(api): Synchronize access to the smoothie and rpc

### DIFF
--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -6,7 +6,7 @@ from .calibration import CalibrationManager
 
 
 class MainRouter:
-    def __init__(self, hardware=None, loop=None):
+    def __init__(self, hardware=None, loop=None, lock=None):
         topics = [Session.TOPIC, CalibrationManager.TOPIC]
         self._broker = Broker()
         self._notifications = Notifications(topics, self._broker, loop=loop)
@@ -16,10 +16,12 @@ class MainRouter:
         self.session_manager = SessionManager(
             hardware=hardware,
             loop=loop,
-            broker=self._broker)
+            broker=self._broker,
+            lock=lock)
         self.calibration_manager = CalibrationManager(hardware=hardware,
                                                       loop=loop,
-                                                      broker=self._broker)
+                                                      broker=self._broker,
+                                                      lock=lock)
 
     @property
     def notifications(self):

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -1,7 +1,7 @@
 import ast
 import asyncio
 from copy import copy
-from functools import reduce
+from functools import reduce, wraps
 import json
 import logging
 from time import time
@@ -28,8 +28,22 @@ log = logging.getLogger(__name__)
 VALID_STATES = {'loaded', 'running', 'finished', 'stopped', 'paused', 'error'}
 
 
+def _motion_lock(func):
+    """ Decorator to make a function require a lock. Only works for instance
+    methods of Session (or SessionManager) """
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        self = args[0]
+        if self._motion_lock:
+            with self._motion_lock:
+                return func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+    return decorated
+
+
 class SessionManager(object):
-    def __init__(self, hardware, loop=None, broker=None):
+    def __init__(self, hardware, loop=None, broker=None, lock=None):
         self._broker = broker or Broker()
         self._loop = loop or asyncio.get_event_loop()
         self.session = None
@@ -38,6 +52,7 @@ class SessionManager(object):
         self._command_logger = logging.getLogger(
             'opentrons.server.command_logger')
         self._broker.set_logger(self._command_logger)
+        self._motion_lock = lock
 
     def __del__(self):
         if isinstance(getattr(self, '_hardware', None),
@@ -59,7 +74,8 @@ class SessionManager(object):
                 text=text,
                 hardware=self._hardware,
                 loop=self._loop,
-                broker=self._broker)
+                broker=self._broker,
+                motion_lock=self._motion_lock)
         finally:
             self._session_lock = False
 
@@ -83,12 +99,12 @@ class Session(object):
     TOPIC = 'session'
 
     @classmethod
-    def build_and_prep(cls, name, text, hardware, loop, broker):
-        sess = cls(name, text, hardware, loop, broker)
+    def build_and_prep(cls, name, text, hardware, loop, broker, motion_lock):
+        sess = cls(name, text, hardware, loop, broker, motion_lock)
         sess.prepare()
         return sess
 
-    def __init__(self, name, text, hardware, loop, broker):
+    def __init__(self, name, text, hardware, loop, broker, motion_lock):
         self._broker = broker
         self._default_logger = self._broker.logger
         self._sim_logger = self._broker.logger.getChild('sim')
@@ -116,6 +132,7 @@ class Session(object):
         self.metadata = {}
 
         self.startTime = None
+        self._motion_lock = motion_lock
 
     def prepare(self):
         self._hardware.discover_modules()
@@ -159,6 +176,7 @@ class Session(object):
         self.command_log.clear()
         self.errors.clear()
 
+    @_motion_lock
     def _simulate(self):
         self._reset()
 
@@ -299,6 +317,7 @@ class Session(object):
         self.set_state('running')
         return self
 
+    @_motion_lock
     def _run(self):  # noqa(C901)
         def on_command(message):
             if message['$'] == 'before':

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -317,8 +317,8 @@ class Session(object):
         self.set_state('running')
         return self
 
-    @_motion_lock
-    def _run(self):  # noqa(C901)
+    @_motion_lock  # noqa(C901)
+    def _run(self):
         def on_command(message):
             if message['$'] == 'before':
                 self.log_append()

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -924,7 +924,6 @@ class SmoothieDriver_3_0_0:
             # be) rare so it's probably fine, but the actual solution to this
             # is locking at a higher level like in APIv2.
             self._reset_from_error()
-            log.exception(f"Smoothie error from command {command}")
             error_axis = se.ret_code.strip()[-1]
             if GCODES['HOME'] not in command and error_axis in 'XYZABC':
                 log.warning(

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -81,8 +81,9 @@ class Controller:
                 raise
 
         self.config = config or opentrons.config.robot_configs.load()
+        # We handle our own locks in the hardware controller thank you
         self._smoothie_driver = driver_3_0.SmoothieDriver_3_0_0(
-            config=self.config)
+            config=self.config, handle_locks=False)
         self._cached_fw_version: Optional[str] = None
 
     def move(self, target_position: Dict[str, float],

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import logging
 from functools import lru_cache
+from threading import Lock
 from typing import Dict, Any
 
 from numpy import add, subtract
@@ -141,6 +142,7 @@ class Robot(CommandPublisher):
 
         self._commands = []
         self._unsubscribe_commands = None
+        self._smoothie_lock = Lock()
         self.reset()
 
     def __del__(self):

--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
+import asyncio
 import logging
+import threading
 import traceback
+
 from typing import TYPE_CHECKING
 from aiohttp import web
 
@@ -38,6 +41,38 @@ async def error_middleware(request, handler):
     return response
 
 
+class ThreadedAsyncLock:
+    """ A thread-safe async lock
+
+    This is required to properly lock access to motion calls, which are
+    a) done in async contexts (rpc methods and http methods) and should
+       block as little as possible
+    b) done from several different threads (rpc workers and main thread)
+
+    This is a code wart that needs to be removed. It can be removed by
+    - making smoothie async so we don't need worker threads anymore
+    - removing said threads
+
+    This object can be used as either an asynchronous context manager using
+    ``async with`` or a synchronous context manager using ``with``.
+    """
+    def __init__(self):
+        self._thread_lock = threading.RLock()
+
+    async def __aenter__(self):
+        while not self._thread_lock.acquire(blocking=False):
+            await asyncio.sleep(0.1)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._thread_lock.release()
+
+    def __enter__(self):
+        self._thread_lock.acquire()
+
+    def __exit__(self, exc_type, exc, tb):
+        self._thread_lock.release()
+
+
 # Support for running using aiohttp CLI.
 # See: https://docs.aiohttp.org/en/stable/web.html#command-line-interface-cli
 def init(loop=None, hardware: 'HardwareAPILike' = None):
@@ -57,7 +92,10 @@ def init(loop=None, hardware: 'HardwareAPILike' = None):
     else:
         checked_hardware = opentrons.hardware
     app['com.opentrons.hardware'] = checked_hardware
-    app['com.opentrons.rpc'] = RPCServer(app, MainRouter(checked_hardware))
+    app['com.opentrons.motion_lock'] = ThreadedAsyncLock()
+    app['com.opentrons.rpc'] = RPCServer(
+        app, MainRouter(
+            checked_hardware, lock=app['com.opentrons.motion_lock']))
     app['com.opentrons.http'] = HTTPServer(app, CONFIG['log_dir'])
 
     return app

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -223,17 +223,15 @@ def test_error_append(run_session):
 @pytest.mark.api1_only
 async def test_get_instruments_and_containers(labware_setup,
                                               virtual_smoothie_env,
-                                              hardware, loop):
+                                              loop,
+                                              session_manager):
     instruments, tip_racks, plates, commands = labware_setup
     p50, p1000 = instruments
 
     instruments, containers, modules, interactions = \
         _accumulate([_get_labware(command) for command in commands])
 
-    session = Session.build_and_prep(name='', text='',
-                                     hardware=hardware,
-                                     loop=loop,
-                                     broker=Broker())
+    session = session_manager.create(name='', text='')
     # We are calling dedupe directly for testing purposes.
     # Normally it is called from within a session
     session._instruments.extend(_dedupe(instruments))

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -2,13 +2,11 @@ import itertools
 
 import pytest
 
-from opentrons.api import Session
 from opentrons.api.session import (
     _accumulate, _get_labware, _dedupe, extract_metadata)
 from tests.opentrons.conftest import state
 from opentrons.legacy_api.robot.robot import Robot
 from functools import partial
-from opentrons.broker import Broker
 
 state = partial(state, 'session')
 


### PR DESCRIPTION
Force synchronization and serialization of motion commands.

These changes operate at two levels. The first, lower, level is synchronization around `_send_command` in the smoothie driver. This is necessary to prevent smoothie driver calls from different threads racing to read the single serial buffer; if this happens, the error recovery mechanisms then race and break various things inside the pyserial `Serial` object. By wrapping `_send_command` in a lock, we avoid this problem.

Unfortunately, while this lock prevents corruption of internal data structures, it still allows strange robot behavior if a client is commanding two higher-level moves at a time. Consider a client that starts a tip probe via rpc, then starts a home. With only the smoothie lock, the many smoothie commands that make up each high level command will be interleaved - we might set the homing current, then move to the front, then set the homing head speed, then move to the tip probe box, etc.

To fix that problem, we also add locks at a higher level: a lock shared by rpc methods that induce motion, like most of the calibration rpc methods, simulate, and run; and the http methods that induce motion. These must now run in sequence, fixing the second problem.

It is certainly still possible for clients to queue actions in a way that would be surprising to a user; consider starting a tip probe and then hitting home again. At this point, the robot would move to front, and then home, and then begin the tip probe. We don't have a concept of the higher level flow of tip probe in the robot, however, so we can't do anything about that; we can just guarantee that each individual endpoint will not race with other endpoints.

## Testing
- Run protocols and calibration.
Closes #3527
