### PR TITLE
refactor(protocol-designer): remove PD dependency on old Labware component

### DIFF
--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -12,20 +12,20 @@ import { selectors as stepsSelectors } from '../../ui/steps'
 import { selectors as fileDataSelectors } from '../../file-data'
 import { getWellSetForMultichannel } from '../../well-selection/utils'
 
-import { typeof Labware } from '@opentrons/components'
 import type {
   CommandV1 as Command,
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import type { OutputSelector } from 'reselect'
 import type { BaseState, Selector } from '../../types'
-import type { ElementProps } from 'react'
 
-type GetTipProps = $PropertyType<ElementProps<Labware>, 'getTipProps'>
+type GetTipCallback = (
+  wellName: string
+) => ?{ empty: boolean, highlighted: boolean }
 type GetTipSelector = OutputSelector<
   BaseState,
   { labwareId: string },
-  GetTipProps
+  GetTipCallback
 >
 
 function getLabwareIdProp(state, props: { labwareId: string }) {


### PR DESCRIPTION
## overview

Just a little cleanup towards #3334

## changelog

* avoid indirect dependency between PD and `Labware` component to better decouple PD from v1 defs

## review requests

- just changing flow types, so shouldn't change anything in PD