### PR TITLE
chore(flow): fix .flowconfig ignore rules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,15 +3,14 @@
 .*/test/.*
 .*/coverage/.*
 .*/docs/.*
-api/.*
-api-server-lib/.*
-audio/.*
-compute/.*
-update-server/.*
-shared-data/deck/definitions/.*
-shared-data/labware/definitions/.*
-shared-data/module/definitions/.*
-shared-data/pipette/definitions/.*
+<PROJECT_ROOT>/api/.*
+<PROJECT_ROOT>/api-server-lib/.*
+<PROJECT_ROOT>/audio/.*
+<PROJECT_ROOT>/compute/.*
+<PROJECT_ROOT>/update-server/.*
+<PROJECT_ROOT>/shared-data/deck/\(definitions\|fixtures\)/.*
+<PROJECT_ROOT>/shared-data/labware/definitions/.*
+<PROJECT_ROOT>/shared-data/module/\(definitions\|fixtures\)/.*
 
 [include]
 


### PR DESCRIPTION
## overview

according to 'flow ls', flow was not ignoring what it was supposed to! I don't think it ever was :/

See https://flow.org/en/docs/config/ignore/

## changelog


## review requests

Maybe flow will be faster for you now? This shaved 10sec off of `time yarn run flow check` for me though I only compared N=1 with N=1 so who knows