### PR TITLE
fix(shared_data): Fix module path in shared data

### DIFF
--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -1,5 +1,5 @@
 // @flow
-import moduleSpecs from '../module/schemas/1.json'
+import moduleSpecs from '../module/definitions/1.json'
 
 export type ModuleType = 'magdeck' | 'tempdeck'
 


### PR DESCRIPTION
## overview

This PR serves as a ticket and fix. Somehow the path to the modules definition in shared-data was incorrect. Instead of pointing to the definition itself, the path was pointing to the schema.

This caused the app to white screen on edge whenever someone clicked on the `pipettes and modules` page.

## changelog
- Edit the path to point to modules definitions

## review requests

Try on edge, then on this branch to see the difference. 🌆 2.0 has modules connected.
