### PR TITLE
fix(flow): declare node_modules and shared-data defs as untyped

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,9 @@
 <PROJECT_ROOT>/audio/.*
 <PROJECT_ROOT>/compute/.*
 <PROJECT_ROOT>/update-server/.*
+
+[untyped]
+.*/node_modules/.*
 <PROJECT_ROOT>/shared-data/deck/\(definitions\|fixtures\)/.*
 <PROJECT_ROOT>/shared-data/labware/definitions/.*
 <PROJECT_ROOT>/shared-data/module/\(definitions\|fixtures\)/.*
@@ -22,5 +25,3 @@
 module.name_mapper.extension='css' -> '@opentrons/components/interfaces/CSSModule.js'
 merge_timeout=300
 esproposal.optional_chaining=enable
-
-[strict]


### PR DESCRIPTION
## overview

Last `.flowconfig` PR was passing itself, but doesn't get along with the latest `edge`. This fixes the failing `edge` build by treating shared-data definitions as untyped, not ignored.

It also marginally speeds up flow by not type checking any `node_modules`, while not ignoring them completely (so we don't need stubs for everything)

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
