### PR TITLE
fix(protocol-designer): fix bug with pipette field change

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -35,6 +35,7 @@ export default function getDefaultsForStepType(
         path: 'single',
         aspirate_wells_grouped: false,
 
+        aspirate_flowRate: null,
         aspirate_labware: null,
         aspirate_wells: [],
         aspirate_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
@@ -45,6 +46,7 @@ export default function getDefaultsForStepType(
         aspirate_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
         aspirate_touchTip_checkbox: false,
 
+        dispense_flowRate: null,
         dispense_labware: null,
         dispense_wells: [],
         dispense_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -189,7 +189,9 @@ const updatePatchOnPipetteChange = (
         'dispense_flowRate',
         'aspirate_mix_volume',
         'dispense_mix_volume',
-        'disposalVolume_volume'
+        'disposalVolume_volume',
+        'aspirate_mmFromBottom',
+        'dispense_mmFromBottom'
       ),
     }
   }


### PR DESCRIPTION
## overview

Changing the pipette field now resets flow rate and tip offset fields.

This also affects pipette swapping in the Edit Pipettes modal. Before
this fix, it wouldn't actually clear out the fields the warning modal says it would.

## acceptance criteria

- [ ] Changing the pipette in the edit pipettes model should reset all the fields the modal says it will
- [ ] Changing the pipette in a single form should clear those same fields for the form