### PR TITLE
refactor(app): Add upload robot update to advanced settings behind ff

### DIFF
--- a/app/src/components/RobotSettings/AdvancedSettingsCard.js
+++ b/app/src/components/RobotSettings/AdvancedSettingsCard.js
@@ -11,6 +11,7 @@ import {
   getRobotSettingsState,
 } from '../../robot-api'
 
+import { getConfig } from '../../config'
 import { CONNECTABLE } from '../../discovery'
 import { downloadLogs } from '../../shell'
 import { RefreshCard } from '@opentrons/components'
@@ -21,6 +22,7 @@ import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery'
 import type { RobotSettings } from '../../robot-api'
 import type { ToggleRef } from './PipetteUpdateWarningModal'
+import UploadRobotUpdate from './UploadRobotUpdate'
 
 type OP = {|
   robot: ViewableRobot,
@@ -30,6 +32,7 @@ type OP = {|
 type SP = {|
   settings: RobotSettings,
   showPipetteUpdateWarning: boolean,
+  __buildRootEnabled: boolean,
 |}
 
 type DP = {|
@@ -138,6 +141,7 @@ class AdvancedSettingsCard extends React.Component<Props> {
             }
           />
         ))}
+        {this.props.__buildRootEnabled && <UploadRobotUpdate />}
       </RefreshCard>
     )
   }
@@ -158,6 +162,7 @@ function mapStateToProps(state: State, ownProps: OP): SP {
   return {
     settings: settings,
     showPipetteUpdateWarning: pipetteUpdateOptedOut === null,
+    __buildRootEnabled: Boolean(getConfig(state).devInternal?.enableBuildRoot),
   }
 }
 

--- a/app/src/components/RobotSettings/UploadRobotUpdate.js
+++ b/app/src/components/RobotSettings/UploadRobotUpdate.js
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+import { LabeledButton } from '../controls'
+import styles from './styles.css'
+
+// TODO (ka 2019-06-13): Add onChange
+export default function UploadRobotUpdate() {
+  return (
+    <LabeledButton
+      label="Update robot software from file"
+      buttonProps={{
+        Component: 'label',
+        children: (
+          <>
+            browse
+            <input type="file" onChange={null} className={styles.file_input} />
+          </>
+        ),
+      }}
+    >
+      <p>
+        If your robot cannot access the Internet for updates, upload robot
+        software update files here.
+      </p>
+    </LabeledButton>
+  )
+}

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -80,3 +80,8 @@
 .disabled {
   color: var(--c-font-disabled);
 }
+
+.file_input {
+  position: fixed;
+  clip: rect(1px 1px 1px 1px);
+}

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -72,6 +72,7 @@ export type Config = {
     tempdeckControls?: boolean,
     enableThermocycler?: boolean,
     enablePipettePlus?: boolean,
+    enableBuildRoot?: boolean,
   },
 }
 


### PR DESCRIPTION
## overview

addresses #3560 by adding new advanced setting to allow users to select a local file behind a feature flag

Note: Browse button in advanced settings opens browse file window but selecting a file does not do anything yet.

## changelog

- refactor(app): Add upload robot update to advanced settings behind ff

## review requests

Standard code review

`make -C app dev` 
- [ ] RobotSettings > AdvancedSettings card renders as before, no upload update file section

`make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1`
- [ ] RobotSettings > AdvancedSettings card renders `Update robot software from file` section at bottom
