### PR TITLE
feat(protocol-designer): select only latest labware

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -1,10 +1,14 @@
 // @flow
 import React, { useState, useMemo } from 'react'
 import { useOnClickOutside, OutlineButton } from '@opentrons/components'
-import { getLabwareDefURI, type DeckSlotId } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  type DeckSlotId,
+  type LabwareDefinition2,
+} from '@opentrons/shared-data'
 import startCase from 'lodash/startCase'
 import reduce from 'lodash/reduce'
-import { getOnlyLatestDefs } from '../../labware-defs/utils'
+import { getAllAddableLabware } from '../../labware-defs/utils'
 import { Portal } from '../portals/TopPortal'
 import { PDTitledList } from '../lists'
 import LabwareItem from './LabwareItem'
@@ -32,15 +36,16 @@ const orderedCategories: Array<string> = [
 const LabwareDropdown = (props: Props) => {
   const { permittedTipracks, onClose, slot, selectLabware } = props
 
-  const [selectedCategory, selectCategory] = useState(null)
-  const [previewedLabware, previewLabware] = useState(null)
+  const [selectedCategory, selectCategory] = useState<?string>(null)
+  const [previewedLabware, previewLabware] = useState<?LabwareDefinition2>(null)
 
   const labwareByCategory = useMemo(() => {
-    const latestDefs = getOnlyLatestDefs()
+    const defs = getAllAddableLabware()
     return reduce(
-      latestDefs,
-      (acc, def) => {
+      defs,
+      (acc, def: $Values<typeof defs>) => {
         const category = def.metadata.displayCategory
+        // filter out non-permitted tipracks
         if (
           category === 'tipRack' &&
           !permittedTipracks.includes(getLabwareDefURI(def))

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -4,7 +4,7 @@ import { useOnClickOutside, OutlineButton } from '@opentrons/components'
 import { getLabwareDefURI, type DeckSlotId } from '@opentrons/shared-data'
 import startCase from 'lodash/startCase'
 import reduce from 'lodash/reduce'
-import { getAllDefinitions } from '../../labware-defs/utils'
+import { getOnlyLatestDefs } from '../../labware-defs/utils'
 import { Portal } from '../portals/TopPortal'
 import { PDTitledList } from '../lists'
 import LabwareItem from './LabwareItem'
@@ -36,10 +36,9 @@ const LabwareDropdown = (props: Props) => {
   const [previewedLabware, previewLabware] = useState(null)
 
   const labwareByCategory = useMemo(() => {
-    // TODO: Ian 2019-06-04 only show latest versions of labware here (#3525)
-    const allDefs = getAllDefinitions()
+    const latestDefs = getOnlyLatestDefs()
     return reduce(
-      allDefs,
+      latestDefs,
       (acc, def) => {
         const category = def.metadata.displayCategory
         if (

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -10,7 +10,7 @@ import PipetteDiagram from './PipetteDiagram'
 import TiprackDiagram from './TiprackDiagram'
 import styles from './FilePipettesModal.css'
 import formStyles from '../../forms/forms.css'
-import { getAllDefinitions } from '../../../labware-defs/utils'
+import { getAllAddableLabware } from '../../../labware-defs/utils'
 import type { FormPipette } from '../../../step-forms'
 
 const pipetteOptionsWithNone = [{ name: 'None', value: '' }, ...pipetteOptions]
@@ -26,11 +26,10 @@ export default function ChangePipetteFields(props: Props) {
   const { values, handleChange } = props
 
   const tiprackOptions = useMemo(() => {
-    // TODO: Ian 2019-06-04 only show latest versions of labware here (#3525)
-    const allDefs = getAllDefinitions()
+    const defs = getAllAddableLabware()
     return reduce(
-      allDefs,
-      (acc, def: $Values<typeof allDefs>) => {
+      defs,
+      (acc, def: $Values<typeof defs>) => {
         if (def.metadata.displayCategory !== 'tipRack') return acc
         return [
           ...acc,


### PR DESCRIPTION
## overview

Closes #3525 

## changelog


## review requests

- [ ] In PD's Add Pipette modal, the "do not list" tiprack "tipone_96_tiprack_200ul" should not appear
- [ ] In PD's Add Labware Modal, the "do not list" labware should not show up (see `LABWAREV2_DO_NOT_LIST` array in `shared-data/js/getLabware.js`)
- [ ] If you have multiple versions of a v2 def, , then only that latest version should show up in PD's Add Labware Modal. We don't currently have multiple versions of any defs to test, so you have to set up a fake one locally. Put some def in `shared-data/labware/definitions/2/<loadName>/<version>.json` (make sure to also update the def's `"version"` key). 

Here's an example of a 24-well plate with the last well deleted so you can tell which version PD is using -- put it in the correct place in `shared-data` and `make -C protocol-designer dev`, you should see the missing well when you add that labware via the Add Labware modal.

[corning_24_wellplate_3.4ml_flat___V2_EXAMPLE.zip](https://github.com/Opentrons/opentrons/files/3298451/corning_24_wellplate_3.4ml_flat___V2_EXAMPLE.zip)


### NOTES
* Right now the TRASH category is empty, but soon we'll have a definition for that (I think?) otherwise we can filter out any empty categories in a separate tiny ticket
* Also we've talked about pulling out these "getLabware" functions that use `require.context` and putting them into `shared-data` with global jest mocks (like we do for deck defs). Can we do that in a separate ticket?