### PR TITLE
fix(protocol-designer): redo disambiguation nums for labware

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.js
@@ -18,7 +18,6 @@ type Props = { ...OP, ...SP }
 const NameOverlay = (props: Props) => {
   const { labwareOnDeck, nickname } = props
   const title = nickname || labwareOnDeck.def.metadata.displayName
-
   return <LabwareNameOverlay title={title} />
 }
 

--- a/protocol-designer/src/components/EditableTextField.js
+++ b/protocol-designer/src/components/EditableTextField.js
@@ -24,7 +24,8 @@ export default class EditableTextField extends React.Component<Props, State> {
     }
   }
 
-  enterEditMode = () => this.setState({ editing: true })
+  enterEditMode = () =>
+    this.setState({ editing: true, transientValue: this.props.value })
 
   handleCancel = () => {
     this.setState({

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/index.js
@@ -8,8 +8,7 @@ import { selectors as uiLabwareSelectors } from '../../../ui/labware'
 import { selectors as labwareIngredSelectors } from '../../../labware-ingred/selectors'
 import * as labwareIngredActions from '../../../labware-ingred/actions'
 import type { ElementProps } from 'react'
-import type { Dispatch } from 'redux'
-import type { BaseState } from '../../../types'
+import type { BaseState, ThunkDispatch } from '../../../types'
 
 type Props = ElementProps<typeof LabwareDetailsCard>
 
@@ -47,7 +46,7 @@ function mapStateToProps(state: BaseState): SP {
 
 function mergeProps(
   stateProps: SP,
-  dispatchProps: { dispatch: Dispatch<*> }
+  dispatchProps: { dispatch: ThunkDispatch<*> }
 ): Props {
   const dispatch = dispatchProps.dispatch
   const { _labwareId, ...passThruProps } = stateProps

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.js
@@ -51,58 +51,28 @@ describe('DELETE_CONTAINER action', () => {
   })
 })
 
-// TODO: BC 2018-7-25 test SWAP_SLOT_CONTENTS && DUPLICATE_LABWARE
-describe.skip('COPY_LABWARE action', () => {
-  test('copy correct container', () => {
+describe('DUPLICATE_LABWARE action', () => {
+  test('duplicate correct labware', () => {
     expect(
       containers(
         {
-          clonePlate: {
-            id: 'clonePlate',
-            type: '96-flat',
-            name: 'Samples Plate',
-            slot: '1',
-            disambiguationNumber: 1,
-          },
-          otherPlate: {
-            id: 'otherPlate',
-            type: '384-flat',
-            name: 'Destination Plate',
-            slot: '2',
-            disambiguationNumber: 1,
-          },
+          clonePlate: { nickname: 'Samples Plate' },
+          otherPlate: { nickname: 'Destination Plate' },
         },
         {
-          type: 'COPY_LABWARE',
+          type: 'DUPLICATE_LABWARE',
           payload: {
-            fromContainer: 'clonePlate',
-            toContainer: 'newContainer',
+            templateLabwareId: 'clonePlate',
+            duplicateLabwareId: 'newContainer',
+            duplicateLabwareNickname: 'Samples Plate (1)',
             toSlot: '5',
           },
         }
       )
     ).toEqual({
-      clonePlate: {
-        id: 'clonePlate',
-        type: '96-flat',
-        name: 'Samples Plate',
-        slot: '1',
-        disambiguationNumber: 1,
-      },
-      newContainer: {
-        id: 'newContainer',
-        type: '96-flat',
-        name: 'Samples Plate',
-        slot: '5',
-        disambiguationNumber: 2,
-      },
-      otherPlate: {
-        id: 'otherPlate',
-        type: '384-flat',
-        name: 'Destination Plate',
-        slot: '2',
-        disambiguationNumber: 1,
-      },
+      clonePlate: { nickname: 'Samples Plate' },
+      newContainer: { nickname: 'Samples Plate (1)' },
+      otherPlate: { nickname: 'Destination Plate' },
     })
   })
 })

--- a/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/ingredients.test.js
@@ -1,14 +1,13 @@
 import { ingredients, ingredLocations } from '../reducers'
 jest.mock('../../labware-defs/utils')
 
-// TODO: BC 2018-7-24 test SWAP_SLOT_CONTENTS && DUPLICATE_LABWARE instead
-describe.skip('COPY_LABWARE action', () => {
-  test('copy ingredient locations from cloned container', () => {
+describe('DUPLICATE_LABWARE action', () => {
+  test('duplicate ingredient locations from cloned container', () => {
     const copyLabwareAction = {
-      type: 'COPY_LABWARE',
+      type: 'DUPLICATE_LABWARE',
       payload: {
-        fromContainer: 'myTrough',
-        toContainer: 'newContainer',
+        templateLabwareId: 'myTrough',
+        duplicateLabwareId: 'newContainer',
         toSlot: '5',
       },
     }

--- a/protocol-designer/src/labware-ingred/__tests__/utils.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/utils.test.js
@@ -21,6 +21,12 @@ describe('getNextNickname', () => {
       expected: 'cool (1)',
     },
     {
+      desc: 'increments (1) suffix to (2) when duplicating',
+      allNicknames: ['cool', 'cool(1)'],
+      proposed: 'cool (1)',
+      expected: 'cool (2)',
+    },
+    {
       desc: 'adds (2) suffix on second match',
       allNicknames: ['cool', 'cool (1)'],
       proposed: 'cool',

--- a/protocol-designer/src/labware-ingred/__tests__/utils.test.js
+++ b/protocol-designer/src/labware-ingred/__tests__/utils.test.js
@@ -1,0 +1,61 @@
+import { getNextNickname } from '../utils'
+
+describe('getNextNickname', () => {
+  const testCases = [
+    {
+      desc: 'first nickname adds no disambig number',
+      allNicknames: [],
+      proposed: 'test',
+      expected: 'test',
+    },
+    {
+      desc: 'ignores non-matching nicknames',
+      allNicknames: ['otherThing'],
+      proposed: 'coolNew',
+      expected: 'coolNew',
+    },
+    {
+      desc: 'adds (1) suffix on first match',
+      allNicknames: ['cool'],
+      proposed: 'cool',
+      expected: 'cool (1)',
+    },
+    {
+      desc: 'adds (2) suffix on second match',
+      allNicknames: ['cool', 'cool (1)'],
+      proposed: 'cool',
+      expected: 'cool (2)',
+    },
+    {
+      desc: "doesn't care about gaps, just uses highest number",
+      allNicknames: ['cool', 'cool (6)'],
+      proposed: 'cool',
+      expected: 'cool (7)',
+    },
+    {
+      desc: 'handles multiple digits',
+      allNicknames: ['cool (11)'],
+      proposed: 'cool',
+      expected: 'cool (12)',
+    },
+    {
+      desc: 'handles parentheses in name',
+      allNicknames: ['cool (purified)'],
+      proposed: 'cool (purified)',
+      expected: 'cool (purified) (1)',
+    },
+    {
+      desc: 'trims whitespace',
+      allNicknames: ['  cool '],
+      proposed: ' cool',
+      expected: 'cool (1)',
+    },
+  ]
+
+  testCases.forEach(({ desc, allNicknames, proposed, expected }) => {
+    test(desc, () => {
+      const result = getNextNickname(allNicknames, proposed)
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/protocol-designer/src/labware-ingred/actions/actions.js
+++ b/protocol-designer/src/labware-ingred/actions/actions.js
@@ -55,7 +55,6 @@ export type CreateContainerAction = {
   payload: {
     ...CreateContainerArgs,
     id: string,
-    disambiguationNumber: number,
   },
 }
 
@@ -70,21 +69,6 @@ export const deleteContainer = createAction<
   'DELETE_CONTAINER',
   $PropertyType<DeleteContainerAction, 'payload'>
 >('DELETE_CONTAINER')
-
-export type RenameLabwareAction = {
-  type: 'RENAME_LABWARE',
-  payload: {
-    labwareId: string,
-    name: ?string,
-  },
-}
-
-export const renameLabware = (
-  payload: $PropertyType<RenameLabwareAction, 'payload'>
-): RenameLabwareAction => ({
-  type: 'RENAME_LABWARE',
-  payload,
-})
 
 // ===========
 
@@ -111,7 +95,7 @@ export type DuplicateLabwareAction = {
   payload: {
     templateLabwareId: string,
     duplicateLabwareId: string,
-    duplicateDisambiguationNumber: number,
+    duplicateLabwareNickname: string,
     slot: DeckSlotId,
   },
 }

--- a/protocol-designer/src/labware-ingred/actions/thunks.js
+++ b/protocol-designer/src/labware-ingred/actions/thunks.js
@@ -1,46 +1,22 @@
 // @flow
 import assert from 'assert'
 import { uuid } from '../../utils'
-import { selectors as labwareIngredsSelectors } from '../selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
+import { selectors as uiLabwareSelectors } from '../../ui/labware'
 import type {
   CreateContainerArgs,
   CreateContainerAction,
   DuplicateLabwareAction,
 } from './actions'
-import type { BaseState, GetState, ThunkDispatch } from '../../types'
+import type { GetState, ThunkDispatch } from '../../types'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
-import { getNextAvailableSlot } from '../utils'
-
-function getNextDisambiguationNumber(
-  state: BaseState,
-  newLabwareType: string
-): number {
-  const labwareEntities = stepFormSelectors.getLabwareEntities(state)
-  const labwareNamesMap = labwareIngredsSelectors.getLabwareNameInfo(state)
-  const allIds = Object.keys(labwareEntities)
-  const sameTypeLabware = allIds.filter(
-    labwareId => labwareEntities.type === newLabwareType
-  )
-  const disambigNumbers = sameTypeLabware.map(
-    labwareId =>
-      (labwareNamesMap[labwareId] &&
-        labwareNamesMap[labwareId].disambiguationNumber) ||
-      0
-  )
-
-  return disambigNumbers.length > 0 ? Math.max(...disambigNumbers) + 1 : 1
-}
+import { getNextAvailableSlot, getNextNickname } from '../utils'
 
 export const createContainer = (args: CreateContainerArgs) => (
   dispatch: ThunkDispatch<CreateContainerAction>,
   getState: GetState
 ) => {
   const state = getState()
-  const disambiguationNumber = getNextDisambiguationNumber(
-    state,
-    args.labwareDefURI
-  )
   const initialSetupStep = stepFormSelectors.getSavedStepForms(state)[
     INITIAL_DECK_SETUP_STEP_ID
   ]
@@ -54,7 +30,6 @@ export const createContainer = (args: CreateContainerArgs) => (
       payload: {
         ...args,
         id: `${uuid()}:${args.labwareDefURI}`,
-        disambiguationNumber,
         slot,
       },
     })
@@ -86,18 +61,55 @@ export const duplicateLabware = (templateLabwareId: string) => (
   if (!duplicateSlot)
     console.warn('no slots available, cannot duplicate labware')
 
+  const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
+  const templateNickname = allNicknamesById[templateLabwareId]
+  const duplicateLabwareNickname = getNextNickname(
+    Object.keys(allNicknamesById).map((id: string) => allNicknamesById[id]), // NOTE: flow won't do Object.values here >:(
+    templateNickname
+  )
+
   if (templateLabwareDefURI && duplicateSlot) {
     dispatch({
       type: 'DUPLICATE_LABWARE',
       payload: {
-        duplicateDisambiguationNumber: getNextDisambiguationNumber(
-          state,
-          templateLabwareDefURI
-        ),
+        duplicateLabwareNickname,
         templateLabwareId,
         duplicateLabwareId: uuid(),
         slot: duplicateSlot,
       },
     })
   }
+}
+
+export type RenameLabwareAction = {
+  type: 'RENAME_LABWARE',
+  payload: {
+    labwareId: string,
+    name?: ?string,
+  },
+}
+
+export const renameLabware = (
+  args: $PropertyType<RenameLabwareAction, 'payload'>
+) => (dispatch: ThunkDispatch<RenameLabwareAction>, getState: GetState) => {
+  const { labwareId } = args
+  const state = getState()
+
+  const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
+  const defaultNickname = allNicknamesById[labwareId]
+  const nextNickname = getNextNickname(
+    Object.keys(allNicknamesById)
+      .filter(id => id !== labwareId)
+      .map((id: string) => allNicknamesById[id]), // NOTE: flow won't do Object.values here >:(
+    args.name || defaultNickname
+  )
+  console.log({ allNicknamesById, defaultNickname, nextNickname })
+
+  return dispatch({
+    type: 'RENAME_LABWARE',
+    payload: {
+      labwareId,
+      name: nextNickname,
+    },
+  })
 }

--- a/protocol-designer/src/labware-ingred/actions/thunks.js
+++ b/protocol-designer/src/labware-ingred/actions/thunks.js
@@ -99,11 +99,10 @@ export const renameLabware = (
   const defaultNickname = allNicknamesById[labwareId]
   const nextNickname = getNextNickname(
     Object.keys(allNicknamesById)
-      .filter(id => id !== labwareId)
+      .filter((id: string) => id !== labwareId)
       .map((id: string) => allNicknamesById[id]), // NOTE: flow won't do Object.values here >:(
     args.name || defaultNickname
   )
-  console.log({ allNicknamesById, defaultNickname, nextNickname })
 
   return dispatch({
     type: 'RENAME_LABWARE',

--- a/protocol-designer/src/labware-ingred/reducers/index.js
+++ b/protocol-designer/src/labware-ingred/reducers/index.js
@@ -24,6 +24,7 @@ import type {
   EditLiquidGroupAction,
   SelectLiquidAction,
   SetWellContentsAction,
+  RenameLabwareAction,
 } from '../actions'
 
 // REDUCERS
@@ -102,7 +103,6 @@ const selectedLiquidGroup = handleActions(
 
 const initialLabwareState: ContainersState = {
   [FIXED_TRASH_ID]: {
-    disambiguationNumber: 1,
     nickname: 'Trash',
   },
 }
@@ -117,7 +117,6 @@ export const containers = handleActions<ContainersState, *>(
       return {
         ...state,
         [id]: {
-          disambiguationNumber: action.payload.disambiguationNumber,
           nickname: null, // create with null nickname, so we force explicit naming.
         },
       }
@@ -132,7 +131,7 @@ export const containers = handleActions<ContainersState, *>(
       ),
     RENAME_LABWARE: (
       state: ContainersState,
-      action: ActionType<typeof actions.renameLabware>
+      action: RenameLabwareAction
     ): ContainersState => {
       const { labwareId, name } = action.payload
       // ignore renaming to whitespace
@@ -150,15 +149,11 @@ export const containers = handleActions<ContainersState, *>(
       state: ContainersState,
       action: DuplicateLabwareAction
     ): ContainersState => {
-      const {
-        duplicateLabwareId,
-        duplicateDisambiguationNumber,
-      } = action.payload
+      const { duplicateLabwareId, duplicateLabwareNickname } = action.payload
       return {
         ...state,
         [duplicateLabwareId]: {
-          disambiguationNumber: duplicateDisambiguationNumber,
-          nickname: null, // create with null nickname, so we force explicit naming.
+          nickname: duplicateLabwareNickname,
         },
       }
     },
@@ -209,7 +204,7 @@ export const savedLabware = handleActions<SavedLabwareState, *>(
     }),
     RENAME_LABWARE: (
       state: SavedLabwareState,
-      action: ActionType<typeof actions.renameLabware>
+      action: RenameLabwareAction
     ) => ({
       ...state,
       [action.payload.labwareId]: true,

--- a/protocol-designer/src/labware-ingred/types.js
+++ b/protocol-designer/src/labware-ingred/types.js
@@ -6,7 +6,6 @@ import type { LocationLiquidState } from '../step-generation'
 
 export type DisplayLabware = {|
   nickname: ?string,
-  disambiguationNumber: number,
 |}
 
 export type LabwareTypeById = { [labwareId: string]: ?string }

--- a/protocol-designer/src/labware-ingred/utils.js
+++ b/protocol-designer/src/labware-ingred/utils.js
@@ -1,24 +1,6 @@
 // @flow
 import type { DeckSlotId } from '@opentrons/shared-data'
 import { sortedSlotnames } from '@opentrons/components'
-import {
-  getLabwareDisplayName,
-  type LabwareDefinition2,
-} from '@opentrons/shared-data'
-import type { DisplayLabware } from './types'
-
-export const labwareToDisplayName = (
-  displayLabware: ?DisplayLabware,
-  labwareDef: LabwareDefinition2
-) => {
-  const disambiguationNumber = displayLabware
-    ? displayLabware.disambiguationNumber
-    : ''
-  return (
-    (displayLabware && displayLabware.nickname) ||
-    `${getLabwareDisplayName(labwareDef)} (${disambiguationNumber})`
-  )
-}
 
 export function getNextAvailableSlot(labwareLocations: {
   [labwareId: string]: DeckSlotId,
@@ -27,4 +9,30 @@ export function getNextAvailableSlot(labwareLocations: {
   return sortedSlotnames.find(
     slot => !filledLocations.some(filledSlot => filledSlot === slot)
   )
+}
+
+const nameOnlyPattern = /^(.*)\(\d+\)$/
+const numOnlyPattern = /^.*\((\d+)\)$/
+export function getNextNickname(
+  allNicknames: Array<string>,
+  _proposedNickname: string
+): string {
+  const proposedNickname = _proposedNickname.trim()
+  const parsed = allNicknames.reduce((acc, nickname) => {
+    const nameOnly = (
+      (nameOnlyPattern.exec(nickname) || [])[1] || nickname
+    ).trim()
+    const numOnlyMatch = numOnlyPattern.exec(nickname)
+    // if no number, use zero
+    const num = numOnlyMatch ? Number(numOnlyMatch[1]) : 0
+    if (nameOnly === proposedNickname) {
+      return [...acc, { nameOnly, num }]
+    }
+    return acc
+  }, [])
+
+  const topMatchNum = Math.max(...parsed.map(({ num }) => num))
+  return Number.isFinite(topMatchNum)
+    ? `${proposedNickname.trim()} (${topMatchNum + 1})`
+    : proposedNickname
 }

--- a/protocol-designer/src/ui/labware/selectors.js
+++ b/protocol-designer/src/ui/labware/selectors.js
@@ -2,11 +2,13 @@
 import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
-
-import { getIsTiprack, getLabwareFormat } from '@opentrons/shared-data'
+import {
+  getIsTiprack,
+  getLabwareDisplayName,
+  getLabwareFormat,
+} from '@opentrons/shared-data'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
-import { labwareToDisplayName } from '../../labware-ingred/utils'
 
 import type { Options } from '@opentrons/components'
 import type { Selector } from '../../types'
@@ -18,8 +20,10 @@ export const getLabwareNicknamesById: Selector<{
   stepFormSelectors.getLabwareEntities,
   labwareIngredSelectors.getLabwareNameInfo,
   (labwareEntities, displayLabware): { [labwareId: string]: string } =>
-    mapValues(labwareEntities, (labwareEntity: LabwareEntity, id: string) =>
-      labwareToDisplayName(displayLabware[id], labwareEntity.def)
+    mapValues(
+      labwareEntities,
+      (labwareEntity: LabwareEntity, id: string): string =>
+        displayLabware[id]?.nickname || getLabwareDisplayName(labwareEntity.def)
     )
 )
 


### PR DESCRIPTION
## overview

"Disambiguation numbers" are the UI elements that distinguish labware with the same names eg "Some Trough" vs "Some Trough (1)".

Right now on `edge` disambiguation numbers are not working right at all, this fixes that which closes #2424

## review requests

This `getNextNickname` fn was a good place to use TDD so I have tests that should cover all the cases. If any cases are missing please comment.

See #2424 for details but basically test combinations of: 
- create several new labware with default and custom names
- delete then create
- duplicate labware
- rename already-named labware via the "Name & Liquids" menu.