### PR TITLE
refactor(labware-library): Fix RWS usage by re-adding width and height

### DIFF
--- a/labware-library/src/components/labware-ui/Gallery.js
+++ b/labware-library/src/components/labware-ui/Gallery.js
@@ -20,6 +20,7 @@ export function Gallery(props: GalleryProps) {
     <RobotWorkSpace
       key="center"
       viewBox={`0 0 ${dims.xDimension} ${dims.yDimension}`}
+      className={styles.robot_workspace}
     >
       {() => <LabwareRender definition={definition} />}
     </RobotWorkSpace>

--- a/labware-library/src/components/labware-ui/styles.css
+++ b/labware-library/src/components/labware-ui/styles.css
@@ -32,6 +32,11 @@
   @apply --aspect-1-1;
 }
 
+.robot_workspace {
+  width: 100%;
+  height: 100%;
+}
+
 .load_name {
   display: flex;
 }


### PR DESCRIPTION
## overview

#3590 made a change to `<RobotWorkSpace>` to remove its intrinsic `width: 100%; height: 100%` in favor of passing in a className at use time.

I missed updating the `RobotWorkSpace` usage in LL. This PR fixes that oversight to get the labware renders working again.

## changelog

- Fix RWS usage in labware-library by re-adding width and height

## review requests

<http://sandbox.labware.opentrons.com/refactor_fix-ll-rws>

Please check that labware renders actually show up now