### PR TITLE
fix(api): Fix gen2 model offsets

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -994,7 +994,7 @@
         "units": "mm/s",
         "type": "float"
       },
-      "modelOffset": [0.0, 0.0, 6.05],
+      "modelOffset": [0.0, 0.0, -14.55],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -2378,7 +2378,7 @@
         "units": "mm/s",
         "type": "float"
       },
-      "modelOffset": [0.0, 0.0, 12.95],
+      "modelOffset": [0.0, 0.0, 4.45],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3359,7 +3359,7 @@
         "units": "mm/s",
         "type": "float"
       },
-      "modelOffset": [0.0, 0.0, 33.64],
+      "modelOffset": [0.0, 0.0, 25.14],
       "ulPerMm": [
         {
           "aspirate": [


### PR DESCRIPTION
The model offsets for gen2 pipettes were incorrect, in some cases incorrect
enough to cause head crashes during tasks like deck calibration. After
consultation with hardware, these are the correct values.

To test,
1. do a deck calibration with a gen1 pipette (or know that this has already happened)
2. start a deck calibration with a gen2 pipette
3. note that the pipettes, and especially the p20, don't smash the tips attached to them