### PR TITLE
fix(app-shell): Clean up main window and DC on app quit

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -42,6 +42,7 @@ module.exports = {
 
   app: {
     getPath: () => '__mock-app-path__',
+    once: jest.fn(),
   },
 
   ipcRenderer: {

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -1,5 +1,6 @@
 // @flow
 // app shell discovery module
+import { app } from 'electron'
 import Store from 'electron-store'
 import throttle from 'lodash/throttle'
 
@@ -49,6 +50,8 @@ export function registerDiscovery(dispatch: Action => void) {
   handleConfigChange('discovery.candidates', value =>
     client.setCandidates(['[fd00:0:cafe:fefe::1]'].concat(value))
   )
+
+  app.once('will-quit', () => client.stop())
 
   return function handleIncomingAction(action: Action) {
     log.debug('handling action in discovery', { action })

--- a/app-shell/src/main.js
+++ b/app-shell/src/main.js
@@ -28,7 +28,8 @@ if (config.devtools) {
 let mainWindow
 let rendererLogger
 
-app.on('ready', startUp)
+app.once('ready', startUp)
+app.once('window-all-closed', () => app.quit())
 
 function startUp() {
   log.info('Starting App')
@@ -37,6 +38,7 @@ function startUp() {
   mainWindow = createUi()
   rendererLogger = createRendererLogger()
 
+  mainWindow.once('closed', () => (mainWindow = null))
   initializeMenu()
 
   // wire modules to UI dispatches


### PR DESCRIPTION
## overview

Several Windows users (e.g. see #3482) have reported "phantom" processes sticking around after the app is quit. The processes seem to stack, and in some cases cause connectivity issues.

Upon further inspection, the app's main process was not properly cleaning up:

- Its reference to the main application window
- The discovery client

This PR fixes those oversights and closes #3482. Due to the nature of the bug, it's possible (or even likely) that these phantom processes are present on macOS and Linux and just haven't been observed.

## changelog

-  Clean up main window and stop discovery client on app quit

## review requests

1. Install sandbox app build from this branch on a Windows machine
    - https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.9.0-win-b10888-app-shell_exit-cleanup.exe
2. Open app
3. Observe app and processes in the task manager
4. Close app
5. Confirm all processes are gone

We should also check for any regressions in the Linux and macOS apps:

- [ ] Linux app opens and closes normally
    - https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.9.0-linux-b16013-app-shell_exit-cleanup.AppImage
- [ ] macOS app opens and closes normally
    - https://s3.amazonaws.com/opentrons-app/builds/Opentrons-v3.9.0-mac-b16013-app-shell_exit-cleanup.zip