### PR TITLE
fix(components): fix console error with invalid transform

### DIFF
--- a/components/src/deck/RobotCoordsForeignDiv.js
+++ b/components/src/deck/RobotCoordsForeignDiv.js
@@ -27,7 +27,7 @@ const RobotCoordsForeignDiv = (props: Props) => {
   return (
     <foreignObject
       {...{ x, y, height, width, className }}
-      transform={transformWithSVG ? 'scale(1, -1)' : 'none'}
+      transform={transformWithSVG ? 'scale(1, -1)' : null}
     >
       <div
         style={{

--- a/components/src/lists/ListItem.md
+++ b/components/src/lists/ListItem.md
@@ -17,7 +17,7 @@ If the ListItem is passed a `url` prop, it will wrap its children in a `react-ro
 // <StaticRouter> used here for example purposes
 const { StaticRouter } = require('react-router-dom')
 
-;<StaticRouter>
+;<StaticRouter context={{}}>
   <TitledList title="List Title Here">
     <ListItem url="#">Go somewhere</ListItem>
     <ListItem url="#" isDisabled>


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

Resolve issue with transform="none":
- Chrome was logging `Error: <foreignObject> attribute transform: Expected transform function, "none".`
- Firefox was logging `Unexpected value none parsing transform attribute.`


Also while I'm at it, fixes component library error about `StaticRouter` requiring `context`

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

PD should work the same