### PR TITLE
chore(api): Add api-specific user facing release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,19 +313,20 @@ Our release process is still a work-in-progress. All projects are currently vers
 
 1.  `make bump` (see details below)
 2.  Inspect version bumps and changelogs
-3.  Edit the user-facing changelog at `app-shell/build/release-notes.md` to add the new notes
-4.  `git checkout -b release_${version}` (The branch name _must_ match `release_*` to trigger signed builds that can be used as RCs)
-5.  `git add --all`
-6.  `git cz`
+3.  Edit the user-facing changelog at `app-shell/build/release-notes.md` to add the new notes for the app
+4.  Edit the user-facing changelog at `api/release-notes.md` to add the new notes for the robot software
+5.  `git checkout -b release_${version}` (The branch name _must_ match `release_*` to trigger signed builds that can be used as RCs)
+6.  `git add --all`
+7.  `git cz`
     - Type: `chore`
     - Scope: `release`
     - Message: `${version}`
-7.  Open a PR into `edge`
-8.  Squash merge the PR once approved
-9.  Verify that CI is green on `edge` and test the build artifacts
-10. Pull latest `edge` to your machine
-11. `git tag -a v${version} -m 'chore(release): ${version}'`
-12. `git push --tags`
+8.  Open a PR into `edge`
+9.  Squash merge the PR once approved
+10. Verify that CI is green on `edge` and test the build artifacts
+11. Pull latest `edge` to your machine
+12. `git tag -a v${version} -m 'chore(release): ${version}'`
+13. `git push --tags`
 
 #### `make bump` usage
 

--- a/api/buildroot.mk
+++ b/api/buildroot.mk
@@ -16,7 +16,7 @@ PYTHON_OPENTRONS_API_SETUP_TYPE = setuptools
 PYTHON_OPENTRONS_API_SITE_METHOD = local
 PYTHON_OPENTRONS_API_SITE = $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)
 PYTHON_OPENTRONS_API_SUBDIR = api
-PYTHON_OPENTRONS_API_POST_INSTALL_TARGET_HOOKS = PYTHON_OPENTRONS_API_INSTALL_VERSION
+PYTHON_OPENTRONS_API_POST_INSTALL_TARGET_HOOKS = PYTHON_OPENTRONS_API_INSTALL_VERSION PYTHON_OPENTRONS_API_INSTALL_RELEASE_NOTES
 
 define OTAPI_DUMP_BR_VERSION
 	$(shell python $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/scripts/python_build_utils.py api dump_br_version)
@@ -36,6 +36,10 @@ define PYTHON_OPENTRONS_API_INSTALL_INIT_SYSTEMD
 
   ln -sf ../opentrons-api-server.service \
     $(TARGET_DIR)/etc/systemd/system/opentrons.target.wants/opentrons-api-server.service
+endef
+
+define PYTHON_OPENTRONS_API_INSTALL_RELEASE_NOTES
+	$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_OPENTRONS_MONOREPO_PATH)/api/release-notes.md $(BINARIES_DIR)/release-notes.md
 endef
 
 # Calling inner-python-package directly instead of using python-package macro

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -1,0 +1,24 @@
+# Robot Software Changes from 3.8.3 to 3.9.0
+
+For more details, please see the full [technical change log][changelog]
+
+[changelog]: https://github.com/Opentrons/opentrons/blob/edge/CHANGELOG.md
+
+## New Features
+
+- There is a more accurate definition for Opentrons 1000ul tips. You can load it via `opentrons-tiprack-1000ul`
+- Remove hard-coded smoothie timeouts to prevent issues with extremely long aspirations and dispenses.
+- Added support for more upcoming pipette hardware revisions
+- Enable pipette behavior settings to be configurable in the App
+
+## Bug fixes
+
+- Better support firmware updates
+
+## Known issues
+
+- While the underlying definition is correct, there is a known API bug that is causing the robot to think a "50ml" tube in a "15/50ml" tuberack is the same height as the "15ml" tube
+- When attaching or detaching a pipette from the left mount, the robot homes twice in the X direction
+
+
+[schema-v3]: https://github.com/Opentrons/opentrons/blob/edge/shared-data/protocol-json-schema/protocolSchemaV3.json


### PR DESCRIPTION
When we ship buildroot, we will decouple the release of app and robot software -
though we will continue to release them at the same time, they are no longer
bundled. We need to add the release notes, which the app provided for both
projects, to the api separately, so they can be delivered separately. In this
case, they will be plopped in the buildroot binaries dir for buildroot to put in
s3 and include in zip files.

Closes #3626
