### PR TITLE
refactor(app): View buildroot update notification

### DIFF
--- a/app-shell/src/buildroot.js
+++ b/app-shell/src/buildroot.js
@@ -6,6 +6,7 @@ import fse from 'fs-extra'
 import { app } from 'electron'
 
 import createLogger from './log'
+import { getConfig } from './config'
 
 import type { BuildrootUpdateInfo } from '@opentrons/app/src/shell'
 import type { Action } from '@opentrons/app/src/types'
@@ -26,13 +27,19 @@ let updateApiVersion: string
 let updateServerVersion: string
 
 export function registerBuildrootUpdate(dispatch: Dispatch) {
-  initializeUpdateFileInfo()
+  const buildrootEnabled = getConfig('devInternal').enableBuildRoot
+
+  if (buildrootEnabled) {
+    initializeUpdateFileInfo()
+  }
 
   return function handleAction(action: Action) {
-    switch (action.type) {
-      case 'shell:CHECK_UPDATE':
-        const payload = getBuildrootUpdateInfo()
-        dispatch({ type: 'buildroot:UPDATE_INFO', payload })
+    if (buildrootEnabled) {
+      switch (action.type) {
+        case 'shell:CHECK_UPDATE':
+          const payload = getBuildrootUpdateInfo()
+          dispatch({ type: 'buildroot:UPDATE_INFO', payload })
+      }
     }
   }
 }

--- a/app-shell/src/buildroot.js
+++ b/app-shell/src/buildroot.js
@@ -8,6 +8,9 @@ import { app } from 'electron'
 import createLogger from './log'
 
 import type { BuildrootUpdateInfo } from '@opentrons/app/src/shell'
+import type { Action } from '@opentrons/app/src/types'
+
+type Dispatch = Action => void
 
 const log = createLogger(__filename)
 
@@ -22,12 +25,19 @@ let updateFilename: string
 let updateApiVersion: string
 let updateServerVersion: string
 
-export function registerBuildrootUpdate() {
+export function registerBuildrootUpdate(dispatch: Dispatch) {
   initializeUpdateFileInfo()
-  return () => {}
+
+  return function handleAction(action: Action) {
+    switch (action.type) {
+      case 'shell:CHECK_UPDATE':
+        const payload = getBuildrootUpdateInfo()
+        dispatch({ type: 'buildroot:UPDATE_INFO', payload })
+    }
+  }
 }
 
-export function getBuildrootUpdateInfo(): ?BuildrootUpdateInfo {
+export function getBuildrootUpdateInfo(): BuildrootUpdateInfo | null {
   if (updateFilename && updateApiVersion && updateServerVersion) {
     return {
       filename: path.basename(updateFilename),

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -9,7 +9,8 @@ import {
   makeGetRobotUpdateInfo,
 } from '../../http-api-client'
 import { getRobotApiVersion, getRobotFirmwareVersion } from '../../discovery'
-import { checkShellUpdate } from '../../shell'
+import { checkShellUpdate, getBuildrootUpdateAvailable } from '../../shell'
+
 import { RefreshCard, LabeledValue, OutlineButton } from '@opentrons/components'
 import { CardContentQuarter } from '../layout'
 
@@ -23,7 +24,9 @@ type OP = {|
 |}
 
 type SP = {|
+  version: string,
   updateInfo: RobotUpdateInfo,
+  buildrootUpdateAvailable: boolean,
 |}
 
 type DP = {|
@@ -44,9 +47,15 @@ export default connect<Props, OP, SP, _, _, _>(
 )(InformationCard)
 
 function InformationCard(props: Props) {
-  const { robot, updateInfo, fetchHealth, updateUrl, checkAppUpdate } = props
+  const {
+    robot,
+    updateInfo,
+    fetchHealth,
+    updateUrl,
+    checkAppUpdate,
+    version,
+  } = props
   const { name, displayName, serverOk } = robot
-  const version = getRobotApiVersion(robot) || 'Unknown'
   const firmwareVersion = getRobotFirmwareVersion(robot) || 'Unknown'
   const updateText = updateInfo.type || 'Reinstall'
 
@@ -78,9 +87,15 @@ function InformationCard(props: Props) {
 function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
   const getUpdateInfo = makeGetRobotUpdateInfo()
 
-  return (state, ownProps) => ({
-    updateInfo: getUpdateInfo(state, ownProps.robot),
-  })
+  return (state, ownProps) => {
+    const version = getRobotApiVersion(ownProps.robot) || 'Unknown'
+    return {
+      version,
+      updateInfo: getUpdateInfo(state, ownProps.robot),
+      buildrootUpdateAvailable:
+        version && getBuildrootUpdateAvailable(state, version),
+    }
+  }
 }
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -8,6 +8,7 @@ import {
   fetchHealthAndIgnored,
   makeGetRobotUpdateInfo,
 } from '../../http-api-client'
+import { getConfig } from '../../config'
 import { getRobotApiVersion, getRobotFirmwareVersion } from '../../discovery'
 import { checkShellUpdate, getBuildrootUpdateAvailable } from '../../shell'
 
@@ -27,6 +28,7 @@ type SP = {|
   version: string,
   updateInfo: RobotUpdateInfo,
   buildrootUpdateAvailable: boolean,
+  __buildRootEnabled: boolean,
 |}
 
 type DP = {|
@@ -54,10 +56,16 @@ function InformationCard(props: Props) {
     updateUrl,
     checkAppUpdate,
     version,
+    buildrootUpdateAvailable,
   } = props
   const { name, displayName, serverOk } = robot
   const firmwareVersion = getRobotFirmwareVersion(robot) || 'Unknown'
-  const updateText = updateInfo.type || 'Reinstall'
+  let updateText: string
+  if (props.__buildRootEnabled && buildrootUpdateAvailable) {
+    updateText = 'Upgrade'
+  } else {
+    updateText = updateInfo.type || 'Reinstall'
+  }
 
   return (
     <RefreshCard watch={name} refresh={fetchHealth} title={TITLE}>
@@ -94,6 +102,9 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
       updateInfo: getUpdateInfo(state, ownProps.robot),
       buildrootUpdateAvailable:
         version && getBuildrootUpdateAvailable(state, version),
+      __buildRootEnabled: Boolean(
+        getConfig(state).devInternal?.enableBuildRoot
+      ),
     }
   }
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { AlertModal } from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = {
+  parentUrl: string,
+  ignoreBuildrootUpdate: () => mixed,
+}
+const HEADING = 'Robot System Update Available'
+export default function UpdateBuildroot(props: Props) {
+  const { parentUrl, ignoreBuildrootUpdate } = props
+  const notNowButton = {
+    Component: Link,
+    to: parentUrl,
+    children: 'not now',
+    onClick: ignoreBuildrootUpdate,
+  }
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        notNowButton,
+        {
+          children: 'view robot update',
+          className: styles.view_update_button,
+        },
+      ]}
+      alertOverlay
+      contentsClassName={styles.system_update_modal}
+    >
+      <p className={styles.system_update_warning}>
+        This update is a little different than previous updates.{' '}
+      </p>
+
+      <p>
+        In addition to delivering new features, this update changes the robot’s
+        operating system to improve robot stabillity and support.
+      </p>
+
+      <p>
+        Please note that this update will take an estimated 10-15 minutes, will
+        reboot your robot two times, and requires your OT-2 to remain
+        discoverable via USB or Wifi throughout the entire migration process.
+      </p>
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/styles.css
+++ b/app/src/components/RobotSettings/UpdateBuildroot/styles.css
@@ -1,0 +1,13 @@
+@import '@opentrons/components';
+
+.system_update_modal {
+  padding: 4rem 2rem 1rem;
+}
+
+.system_update_warning {
+  font-weight: var(--fw-semibold);
+}
+
+.view_update_button {
+  width: auto;
+}

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -205,7 +205,8 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     const restartRequest = getRestartRequest(state, robot)
     const updateInfo = getRobotUpdateInfo(state, robot)
     const buildrootUpdateAvailable =
-      version && getBuildrootUpdateAvailable(state, version)
+      !!version && getBuildrootUpdateAvailable(state, version)
+
     const buildrootUpdateSeen = getBuildrootUpdateSeen(state)
     const __buildRootEnabled = Boolean(
       getConfig(state).devInternal?.enableBuildRoot

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -198,7 +198,7 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
 
   return (state, ownProps) => {
     const { robot } = ownProps
-    const version = getRobotApiVersion(robot) || 'Unknown'
+    const version = getRobotApiVersion(robot)
     const connectRequest = robotSelectors.getConnectRequest(state)
     const homeRequest = getHomeRequest(state, robot)
     const ignoredRequest = getUpdateIgnoredRequest(state, robot)

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -8,7 +8,14 @@ import {
   selectors as robotSelectors,
   actions as robotActions,
 } from '../../robot'
-import { CONNECTABLE, REACHABLE } from '../../discovery'
+import { getConfig } from '../../config'
+import { CONNECTABLE, REACHABLE, getRobotApiVersion } from '../../discovery'
+import {
+  getBuildrootUpdateAvailable,
+  getBuildrootUpdateSeen,
+  setBuildrootUpdateSeen,
+} from '../../shell'
+
 import {
   makeGetRobotHome,
   clearHomeResponse,
@@ -24,6 +31,7 @@ import RobotSettings, {
   ConnectAlertModal,
 } from '../../components/RobotSettings'
 import UpdateRobot from '../../components/RobotSettings/UpdateRobot'
+import UpdateBuildroot from '../../components/RobotSettings/UpdateBuildroot'
 import CalibrateDeck from '../../components/CalibrateDeck'
 import ConnectBanner from '../../components/RobotSettings/ConnectBanner'
 import ReachableRobotBanner from '../../components/RobotSettings/ReachableRobotBanner'
@@ -49,6 +57,9 @@ type SP = {|
   showConnectAlert: boolean,
   homeInProgress: ?boolean,
   homeError: ?Error,
+  buildrootUpdateAvailable: boolean,
+  __buildRootEnabled: boolean,
+  buildrootUpdateSeen: boolean,
 |}
 
 type DP = {| dispatch: Dispatch |}
@@ -58,6 +69,7 @@ type Props = {
   ...SP,
   closeHomeAlert?: () => mixed,
   closeConnectAlert: () => mixed,
+  ignoreBuildrootUpdate: () => mixed,
 }
 
 export default withRouter<WithRouterOP>(
@@ -82,6 +94,7 @@ function RobotSettingsPage(props: Props) {
     showConnectAlert,
     closeConnectAlert,
     showUpdateModal,
+    ignoreBuildrootUpdate,
     match: { path, url },
   } = props
 
@@ -112,6 +125,19 @@ function RobotSettingsPage(props: Props) {
         <Route
           path={`${path}/${UPDATE_FRAGMENT}`}
           render={() => {
+            if (
+              props.buildrootUpdateAvailable &&
+              props.buildrootUpdateSeen === false &&
+              props.__buildRootEnabled
+            ) {
+              return (
+                <UpdateBuildroot
+                  robot={robot}
+                  parentUrl={url}
+                  ignoreBuildrootUpdate={ignoreBuildrootUpdate}
+                />
+              )
+            }
             return <UpdateRobot robot={robot} appUpdate={appUpdate} />
           }}
         />
@@ -172,25 +198,44 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
 
   return (state, ownProps) => {
     const { robot } = ownProps
+    const version = getRobotApiVersion(robot) || 'Unknown'
     const connectRequest = robotSelectors.getConnectRequest(state)
     const homeRequest = getHomeRequest(state, robot)
     const ignoredRequest = getUpdateIgnoredRequest(state, robot)
     const restartRequest = getRestartRequest(state, robot)
     const updateInfo = getRobotUpdateInfo(state, robot)
-    const showUpdateModal =
-      // only show the alert modal if there's an upgrade available
-      updateInfo.type === 'upgrade' &&
-      // and we haven't already ignored the upgrade
-      ignoredRequest.response &&
-      ignoredRequest.response.version !== updateInfo.version &&
-      // and we're not actively restarting
-      !restartRequest.inProgress &&
-      // TODO(mc, 2018-09-27): clear this state out on disconnect otherwise
-      // restartRequest.response latches this modal closed (which is fine,
-      // but only for this specific modal)
-      !restartRequest.response
+    const buildrootUpdateAvailable =
+      version && getBuildrootUpdateAvailable(state, version)
+    const buildrootUpdateSeen = getBuildrootUpdateSeen(state)
+    const __buildRootEnabled = Boolean(
+      getConfig(state).devInternal?.enableBuildRoot
+    )
+    let showUpdateModal: ?boolean
+    if (__buildRootEnabled) {
+      // TODO (ka 2019-06-24): Layer in ignore and restart complexity
+      showUpdateModal =
+        buildrootUpdateAvailable &&
+        // have not ignored update this session
+        !buildrootUpdateSeen
+    } else {
+      showUpdateModal =
+        // only show the alert modal if there's an upgrade available
+        updateInfo.type === 'upgrade' &&
+        // and we haven't already ignored the upgrade
+        ignoredRequest.response &&
+        ignoredRequest.response.version !== updateInfo.version &&
+        // and we're not actively restarting
+        !restartRequest.inProgress &&
+        // TODO(mc, 2018-09-27): clear this state out on disconnect otherwise
+        // restartRequest.response latches this modal closed (which is fine,
+        // but only for this specific modal)
+        !restartRequest.response
+    }
 
     return {
+      __buildRootEnabled,
+      buildrootUpdateAvailable,
+      buildrootUpdateSeen,
       showUpdateModal: !!showUpdateModal,
       homeInProgress: homeRequest && homeRequest.inProgress,
       homeError: homeRequest && homeRequest.error,
@@ -206,6 +251,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
     ...stateProps,
     ...ownProps,
     closeConnectAlert: () => dispatch(robotActions.clearConnectResponse()),
+    ignoreBuildrootUpdate: () => dispatch(setBuildrootUpdateSeen()),
   }
 
   if (robot) {

--- a/app/src/shell/buildroot.js
+++ b/app/src/shell/buildroot.js
@@ -1,6 +1,6 @@
 // @flow
 import semver from 'semver'
-import type { State } from '../types'
+import type { State, Action } from '../types'
 
 export type BuildrootUpdateInfo = {|
   filename: string,
@@ -8,22 +8,48 @@ export type BuildrootUpdateInfo = {|
   serverVersion: string,
 |}
 
+export type BuildrootState = {
+  seen: boolean,
+  info: BuildrootUpdateInfo | null,
+}
+
 const {
-  buildroot: {
-    getBuildrootUpdateInfo: getBuildrootInitialState,
-    getUpdateFileContents,
-  },
+  buildroot: { getUpdateFileContents },
 } = global.APP_SHELL
 
-export function buildrootReducer(state: ?BuildrootUpdateInfo) {
-  if (state === undefined) return getBuildrootInitialState()
+export type BuildrootAction =
+  | {| type: 'buildroot:UPDATE_INFO', payload: BuildrootUpdateInfo | null |}
+  | {| type: 'buildroot:SET_UPDATE_SEEN' |}
+
+export function setBuildrootUpdateSeen(): BuildrootAction {
+  return { type: 'buildroot:SET_UPDATE_SEEN' }
+}
+
+const INITIAL_STATE = {
+  seen: false,
+  info: null,
+}
+export function buildrootReducer(
+  state: BuildrootState = INITIAL_STATE,
+  action: Action
+) {
+  switch (action.type) {
+    case 'buildroot:UPDATE_INFO':
+      return { ...state, info: action.payload }
+    case 'buildroot:SET_UPDATE_SEEN':
+      return { ...state, seen: true }
+  }
   return state
 }
 
 export function getBuildrootUpdateInfo(
   state: State
 ): BuildrootUpdateInfo | null {
-  return state.shell.buildroot || null
+  return state.shell.buildroot.info || null
+}
+
+export function getBuildrootUpdateSeen(state: State): boolean {
+  return state.shell.buildroot?.seen || false
 }
 
 // caution: this calls an Electron RPC remote, so use sparingly

--- a/app/src/shell/buildroot.js
+++ b/app/src/shell/buildroot.js
@@ -1,4 +1,5 @@
 // @flow
+import semver from 'semver'
 import type { State } from '../types'
 
 export type BuildrootUpdateInfo = {|
@@ -28,4 +29,28 @@ export function getBuildrootUpdateInfo(
 // caution: this calls an Electron RPC remote, so use sparingly
 export function getBuildrootUpdateContents(): Promise<Blob> {
   return getUpdateFileContents().then(contents => new Blob([contents]))
+}
+
+const compareCurrentVersionToUpdate = (
+  currentVersion: ?string,
+  updateVersion: string
+): boolean => {
+  const current = semver.valid(currentVersion)
+  if (!current) return false
+
+  if (current && semver.gt(updateVersion, currentVersion)) {
+    return true
+  }
+  return false
+}
+
+export function getBuildrootUpdateAvailable(
+  state: State,
+  currentVersion: string
+): boolean {
+  const updateVersion = getBuildrootUpdateInfo(state)?.apiVersion
+  if (currentVersion && updateVersion) {
+    return compareCurrentVersionToUpdate(currentVersion, updateVersion)
+  }
+  return false
 }

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -18,6 +18,7 @@ import type {
 import type { ViewableRobot } from '../discovery'
 import type { Config } from '../config'
 import type { ShellUpdateAction } from './update'
+import type { BuildrootAction } from './buildroot'
 
 type ShellLogsDownloadAction = {|
   type: 'shell:DOWNLOAD_LOGS',
@@ -25,7 +26,10 @@ type ShellLogsDownloadAction = {|
   meta: {| shell: true |},
 |}
 
-export type ShellAction = ShellUpdateAction | ShellLogsDownloadAction
+export type ShellAction =
+  | ShellUpdateAction
+  | ShellLogsDownloadAction
+  | BuildrootAction
 
 const {
   ipcRenderer,


### PR DESCRIPTION
## overview

Addresses #3561 by showing System Update (buildroot migration) modal when buildroot files are present and version is greater than robotApiVersion.

## changelog

- refactor: Change robot update button text based on FF enabled and buildrootUpdateAvailable
- refactor: Auto pop up modal when FF enabled and buildrootUpdateAvailable and not set to ignored
- refactor: Add `setBuidrootUpdateIgnored` action to buildroot 
- clicking not now in new `BuildrootUpdate` modal sets update to seen in buildroot state

## review requests

This issue has a lot of acceptance criteria that is dependant on future work, such as showing a buildroot update release notes (which we will not have until [seths PR](https://github.com/Opentrons/opentrons/pull/3628) lands, and detecting if a robot is already migrated off Balena and on buildroot (todo, next PR). 

**Buildroot FF not enabled:**
`make -C app dev`
- [ ] No buildroot files present, FF off, situation normal, nothing breaks in robot update existing flow
- [ ] Buildroot files present, but since FF is off, old api update logic remains in place and unaffected

**Buildroor FF enabled**
`make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1`

- Ping me for the buildroot files and where to put them
- Edit Version.json `opentrons_api_version` and `update_server_version` to be 3.10.0 (fake update > robotApiVersion)
- [ ] Viewing a robot (can be VS) when FF enabled and update available shows new BuildroorUpdate modal
- [ ] Clicking [ not now ] sets `shell.buildroot.seen` to true in state and closes modal
-  Navigate away or to another robot without restarting the app, BuildroorUpdate should not show again
- [ ] Restart app again with FF enabled, `BuildrootUpdate` modal shows again