### PR TITLE
feat(protocol-designer): warn on migrating to 3.0.0

### DIFF
--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -1,4 +1,5 @@
 // @flow
+import i18n from '../../../localization'
 import * as React from 'react'
 import { AlertModal } from '@opentrons/components'
 import modalStyles from '../modal.css'
@@ -21,8 +22,12 @@ export default function FileUploadMessageModal(props: Props) {
     <AlertModal
       heading={title}
       buttons={[
-        { children: 'cancel', onClick: cancelProtocolMigration },
-        { children: okButtonText || 'ok', onClick: dismissModal },
+        { children: i18n.t('button.cancel'), onClick: cancelProtocolMigration },
+        {
+          children: okButtonText || 'ok',
+          onClick: dismissModal,
+          className: modalStyles.long_button,
+        },
       ]}
       className={modalStyles.modal}
       alertOverlay

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -26,7 +26,7 @@ export default function FileUploadMessageModal(props: Props) {
         {
           children: okButtonText || 'ok',
           onClick: dismissModal,
-          className: modalStyles.long_button,
+          className: modalStyles.ok_button,
         },
       ]}
       className={modalStyles.modal}

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -7,19 +7,23 @@ import type { FileUploadMessage } from '../../../load-file'
 
 type Props = {
   message: ?FileUploadMessage,
+  cancelProtocolMigration: (SyntheticEvent<*>) => mixed,
   dismissModal: (SyntheticEvent<*>) => mixed,
 }
 
 export default function FileUploadMessageModal(props: Props) {
-  const { message, dismissModal } = props
+  const { message, cancelProtocolMigration, dismissModal } = props
 
   if (!message) return null
 
-  const { title, body } = getModalContents(message)
+  const { title, body, okButtonText } = getModalContents(message)
   return (
     <AlertModal
       heading={title}
-      buttons={[{ children: 'ok', onClick: dismissModal }]}
+      buttons={[
+        { children: 'cancel', onClick: cancelProtocolMigration },
+        { children: okButtonText || 'ok', onClick: dismissModal },
+      ]}
       className={modalStyles.modal}
       alertOverlay
     >

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/index.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/index.js
@@ -25,6 +25,7 @@ function mapStateToProps(state: BaseState): SP {
 
 function mapDispatchToProps(dispatch: Dispatch<*>): DP {
   return {
+    cancelProtocolMigration: () => dispatch(loadFileActions.undoLoadFile()),
     dismissModal: () => dispatch(loadFileActions.dismissFileUploadMessage()),
   }
 }

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
@@ -13,3 +13,27 @@
   margin: 0 1rem;
   color: var(--c-red);
 }
+
+.migration_message {
+  & p,
+  & li {
+    line-height: 1.5;
+  }
+
+  & ol {
+    padding-left: 2rem;
+  }
+
+  & li {
+    margin: 0.5rem 0;
+  }
+}
+
+.section_header {
+  font-weight: var(--fw-semibold);
+  margin: 1.5rem 0 1rem 0;
+
+  &::after {
+    content: ':';
+  }
+}

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
@@ -16,7 +16,7 @@
 
 .migration_message {
   & p {
-    line-height: 1.5;
+    line-height: var(--lh-copy);
   }
 
   & strong {

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
@@ -15,6 +15,9 @@
 }
 
 .migration_message {
+  overflow-y: auto;
+  height: 50vh;
+
   & p,
   & li {
     line-height: 1.5;

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.css
@@ -15,20 +15,12 @@
 }
 
 .migration_message {
-  overflow-y: auto;
-  height: 50vh;
-
-  & p,
-  & li {
+  & p {
     line-height: 1.5;
   }
 
-  & ol {
-    padding-left: 2rem;
-  }
-
-  & li {
-    margin: 0.5rem 0;
+  & strong {
+    font-weight: var(--fw-semibold);
   }
 }
 

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.js
@@ -40,10 +40,10 @@ const invalidJsonModal = (errorMessage: ?string): ModalContents => ({
   ),
 })
 
-const didMigrateModal: ModalContents = {
+const genericDidMigrateMessage: ModalContents = {
   title: 'Your protocol was made in an older version of Protocol Designer',
   body: (
-    <React.Fragment>
+    <>
       <p>
         Your protocol will be automatically updated to the latest version.
         Please note that the updated file will be incompatible with older
@@ -56,8 +56,63 @@ const didMigrateModal: ModalContents = {
         the robot.
       </p>
       <p>As always, please contact us with any questions or feedback.</p>
-    </React.Fragment>
+    </>
   ),
+}
+
+const toV3MigrationMessage: ModalContents = {
+  title:
+    'Your protocol must be updated to work with the updated Protocol Designer',
+  okButtonText: "yes, update my protocol's labware",
+  body: (
+    <div className={styles.migration_message}>
+      <div className={styles.section_header}>What is changing</div>
+      <p>
+        All labware definitions (the information that tells your robot about the
+        geometry of labware) are being updated to a newer version
+      </p>
+
+      <div className={styles.section_header}>Why we made this update</div>
+      <p>
+        {
+          "These definitions should be more accurate and thus more reliable across our users' robots."
+        }
+      </p>
+
+      <div className={styles.section_header}>
+        What this means for your protocol
+      </div>
+      <div>
+        <p>
+          If you update your protocol then all labware in it will be switched to
+          the new definition version. This means that:
+        </p>
+        <ol>
+          <li>You will need to re-calibrate all labware in the protocol.</li>
+          <li>
+            We recommend you do a dry run or one with water just to make sure
+            everything is still working fine.
+          </li>
+        </ol>
+      </div>
+
+      <div className={styles.section_header}>
+        {"What happens if you don't update"}
+      </div>
+      <p>
+        You will still be able to run your protocol as usual with the older
+        labware definitions. However in order to make further updates with the
+        Protocol Designer you will need to update your protocol.
+      </p>
+    </div>
+  ),
+}
+
+function getMigrationMessage(migrationsRan: Array<string>): ModalContents {
+  if (migrationsRan.includes('3.0.0')) {
+    return toV3MigrationMessage
+  }
+  return genericDidMigrateMessage
 }
 
 export default function getModalContents(
@@ -76,8 +131,8 @@ export default function getModalContents(
     }
   }
   switch (uploadResponse.messageKey) {
-    case 'didMigrate':
-      return didMigrateModal
+    case 'DID_MIGRATE':
+      return getMigrationMessage(uploadResponse.migrationsRan)
     default: {
       assert(
         false,

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.js
@@ -8,17 +8,17 @@ import type { FileUploadMessage } from '../../../load-file'
 const INVALID_FILE_TYPE: ModalContents = {
   title: 'Incorrect file type',
   body: (
-    <React.Fragment>
+    <>
       <p>Only JSON files created in the Protocol Designer can be imported.</p>
       <p>At this time Python protocol files are not supported.</p>
-    </React.Fragment>
+    </>
   ),
 }
 
 const invalidJsonModal = (errorMessage: ?string): ModalContents => ({
   title: 'Invalid JSON file',
   body: (
-    <React.Fragment>
+    <>
       <p>
         This file is either missing information it needs to import properly or
         contains sections that the Protocol Designer cannot read.
@@ -36,7 +36,7 @@ const invalidJsonModal = (errorMessage: ?string): ModalContents => ({
         <p>Error message:</p>
         <p className={styles.error_text}>{errorMessage}</p>
       </div>
-    </React.Fragment>
+    </>
   ),
 })
 
@@ -61,49 +61,40 @@ const genericDidMigrateMessage: ModalContents = {
 }
 
 const toV3MigrationMessage: ModalContents = {
-  title:
-    'Your protocol must be updated to work with the updated Protocol Designer',
-  okButtonText: "yes, update my protocol's labware",
+  title: 'Update protocol to use new labware definitions',
+  okButtonText: 'update protocol',
   body: (
     <div className={styles.migration_message}>
-      <div className={styles.section_header}>What is changing</div>
       <p>
-        All labware definitions (the information that tells your robot about the
-        geometry of labware) are being updated to a newer version
-      </p>
-
-      <div className={styles.section_header}>Why we made this update</div>
-      <p>
-        {
-          "These definitions should be more accurate and thus more reliable across our users' robots."
-        }
+        <strong>
+          To import your file successfully, you must update your protocol to use
+          the new labware definitions.
+        </strong>{' '}
+        Your protocol was made using an older version of Protocol Designer.
+        Since then, Protocol Designer has been improved to include new labware
+        definitions which are more accurate and reliable.
       </p>
 
       <div className={styles.section_header}>
         What this means for your protocol
       </div>
-      <div>
-        <p>
-          If you update your protocol then all labware in it will be switched to
-          the new definition version. This means that:
-        </p>
-        <ol>
-          <li>You will need to re-calibrate all labware in the protocol.</li>
-          <li>
-            We recommend you do a dry run or one with water just to make sure
-            everything is still working fine.
-          </li>
-        </ol>
-      </div>
+      <p>
+        Updating your protocol to use the new labware definitions will as a
+        result require you to re-calibrate all labware in your protocol prior to
+        running it on your robot. We recommend you try a dry run or one with
+        water to ensure everything is working as expected.
+      </p>
 
       <div className={styles.section_header}>
         {"What happens if you don't update"}
       </div>
-      <p>
-        You will still be able to run your protocol as usual with the older
-        labware definitions. However in order to make further updates with the
-        Protocol Designer you will need to update your protocol.
-      </p>
+      <div>
+        <p>
+          If you choose not to update, you will still be able to run your
+          protocol as usual with older labware, however you will not be able to
+          make further updates to this protocol using the Protocol Designer.
+        </p>
+      </div>
     </div>
   ),
 }

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/types.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/types.js
@@ -4,4 +4,5 @@ import * as React from 'react'
 export type ModalContents = {
   title: string,
   body: React.Node,
+  okButtonText?: string,
 }

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -39,6 +39,6 @@
   margin-bottom: 1rem;
 }
 
-.long_button {
-  width: 19rem;
+.ok_button {
+  width: 10rem;
 }

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -38,3 +38,7 @@
   height: 26rem;
   margin-bottom: 1rem;
 }
+
+.long_button {
+  width: 19rem;
+}

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -23,8 +23,14 @@ function getRootReducer() {
     wellSelection: require('./well-selection/reducers').default,
   })
 
+  // TODO: Ian 2019-06-25 consider making file loading non-committal
+  // so UNDO_LOAD_FILE doesnt' just reset Redux state
   return (state: any, action) => {
-    if (action.type === 'LOAD_FILE' || action.type === 'CREATE_NEW_PROTOCOL') {
+    if (
+      action.type === 'LOAD_FILE' ||
+      action.type === 'CREATE_NEW_PROTOCOL' ||
+      action.type === 'UNDO_LOAD_FILE'
+    ) {
       // reset entire state, rehydrate from localStorage
       const resetState = rootReducer(undefined, rehydratePersistedAction())
 

--- a/protocol-designer/src/load-file/actions.js
+++ b/protocol-designer/src/load-file/actions.js
@@ -64,6 +64,16 @@ export const loadProtocolFile = (
   }
 }
 
+export type UndoLoadFile = {
+  type: 'UNDO_LOAD_FILE',
+}
+
+// TODO: Ian 2019-06-25 consider making file loading non-committal
+// so UNDO_LOAD_FILE doesnt' just reset Redux state
+export const undoLoadFile = (): UndoLoadFile => ({
+  type: 'UNDO_LOAD_FILE',
+})
+
 export type CreateNewProtocolAction = {
   type: 'CREATE_NEW_PROTOCOL',
   payload: NewProtocolFields,

--- a/protocol-designer/src/load-file/migration/index.js
+++ b/protocol-designer/src/load-file/migration/index.js
@@ -29,7 +29,11 @@ export const getMigrationVersionsToRunFromVersion = (
 
 const masterMigration = (
   file: any
-): { file: PDProtocolFile, didMigrate: boolean } => {
+): {
+  file: PDProtocolFile,
+  didMigrate: boolean,
+  migrationsRan: Array<string>,
+} => {
   const designerApplication =
     file.designerApplication || file['designer-application']
 
@@ -50,6 +54,7 @@ const masterMigration = (
   return {
     file: migratedFile,
     didMigrate: migrationVersionsToRun.length > 0,
+    migrationsRan: migrationVersionsToRun,
   }
 }
 

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -15,7 +15,11 @@ const fileUploadMessage = handleActions<FileUploadMessageState, *>(
     ): FileUploadMessageState => action.payload,
     LOAD_FILE: (state, action: LoadFileAction): FileUploadMessageState =>
       action.payload.didMigrate
-        ? { isError: false, messageKey: 'didMigrate' }
+        ? {
+            isError: false,
+            messageKey: 'DID_MIGRATE',
+            migrationsRan: action.payload.migrationsRan,
+          }
         : state,
     DISMISS_FILE_UPLOAD_MESSAGE: (): FileUploadMessageState => null,
   },

--- a/protocol-designer/src/load-file/types.js
+++ b/protocol-designer/src/load-file/types.js
@@ -3,12 +3,13 @@ import type { PDProtocolFile } from '../file-types'
 
 export type FileUploadErrorType = 'INVALID_FILE_TYPE' | 'INVALID_JSON_FILE'
 
-export type FileUploadMessageKey = 'didMigrate'
+export type FileUploadMessageKey = 'DID_MIGRATE'
 
 export type FileUploadMessage =
   | {
       isError: false,
       messageKey: FileUploadMessageKey,
+      migrationsRan: Array<string>,
     }
   | {
       isError: true,
@@ -25,5 +26,6 @@ export type LoadFileAction = {
   payload: {
     file: PDProtocolFile,
     didMigrate: boolean,
+    migrationsRan: Array<string>,
   },
 }


### PR DESCRIPTION
## overview

Closes #3611

## changelog


## review requests

- Try uploading an old protocol file (eg from current designer.opentrons.com), you should get the modal specified in 3611 (see the latest design that Pantea posted in that issue thread)
- Make sure it works on small laptop screens (it will scroll in y)

### Coder notes
- The `UNDO_LOAD_FILE` action isn't the nicest, because the way files are loaded in PD doesn't support "cancelling" a load after you loaded it. Since we don't have good stories around that, I'm happy with this temporary lightweight `UNDO_LOAD_FILE` thing until we do a more comprehensive approach (later we will also want to finally remove the old `window.confirm`s and may consider some stories around persisting an unsaved file in browser storage and/or remote storage)