### PR TITLE
fix(api): Remove usage of time.clock()

### DIFF
--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -64,10 +64,10 @@ class ThreadedAsyncLock:
         pref = f"[ThreadedAsyncLock tid {threading.get_ident()} "\
             f"task {asyncio.Task.current_task()}] "
         log.debug(pref + 'will acquire')
-        then = time.clock()
+        then = time.perf_counter()
         while not self._thread_lock.acquire(blocking=False):
             await asyncio.sleep(0.1)
-        now = time.clock()
+        now = time.perf_counter()
         log.debug(pref + f'acquired in {now-then}s')
 
     async def __aexit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## overview

This serves as a ticket report and fix. @ChrisYarka reported a bug when cancelling a protocol which resulted in this error propagating: 
![image](https://user-images.githubusercontent.com/31892318/60209000-b3406880-9827-11e9-8d8a-66bbf6007b7f.png)

According to the [python docs](https://bugs.python.org/issue31803), `time.clock()` has been deprecated since 3.3. The C equivalent of `time.clock` says that [issues may occur ](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.1.0/com.ibm.zos.v2r1.bpxbd00/clock.htm)if the system is ever reset.

`time.perf_counter()` is an alternative, and was decided on based on [this](https://www.webucator.com/blog/2015/08/python-clocks-explained/) break down of python clocks.

## changelog
- change time.clock() to time.perf_counter()


## review requests

Test that you can cancel and reset a protocol without the error above.