### PR TITLE
refactor(api): Make the hardware control API fully async

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -238,7 +238,6 @@ class Session(object):
                     run_protocol(protocol_code=self._protocol,
                                  simulate=True,
                                  context=self._simulating_ctx)
-                sim.join()
             else:
                 self._hardware.broker = self._broker
                 self._hardware.cache_instrument_models()

--- a/api/src/opentrons/deck_calibration/__init__.py
+++ b/api/src/opentrons/deck_calibration/__init__.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from opentrons.config import feature_flags as ff
 from opentrons import types
 

--- a/api/src/opentrons/deck_calibration/__init__.py
+++ b/api/src/opentrons/deck_calibration/__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from opentrons.config import feature_flags as ff
 from opentrons import types
 

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -93,7 +93,9 @@ class CLITool:
             unhandled_input=self._on_key_press,
             event_loop=loop
         )
-        self._config = self.hardware.config
+
+        self._asyncio_loop = loop
+
         self.current_transform = identity_deck_transform()
 
         # Other state
@@ -351,10 +353,13 @@ class CLITool:
         log.debug("save_transform calibration_matrix: {}".format(
             gantry_calibration))
 
-        self.hardware.update_config(gantry_calibration=gantry_calibration)
+        self.hardware.update_config(
+            gantry_calibration=gantry_calibration)
         res = str(self.hardware.config)
 
-        return '{}\n{}'.format(res, save_config(self.hardware.config))
+        return '{}\n{}'.format(
+            res,
+            save_config(self.hardware.config))
 
     def save_z_value(self) -> str:
         actual_z = self._position()[-1]
@@ -524,7 +529,7 @@ def get_calibration_points():
     }
 
 
-def main():
+def main(loop=None):
     """
     A CLI application for performing factory calibration of an Opentrons robot
 
@@ -560,7 +565,8 @@ def main():
     #  - For xyz coordinates, (0, 0, 0) is the lower-left corner of the robot
     cli = CLITool(
         point_set=get_calibration_points(),
-        tip_length=51.7)
+        tip_length=51.7,
+        loop=loop)
     hardware = cli.hardware
     backup_configuration_and_reload(hardware)
     if not feature_flags.use_protocol_api_v2():

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -580,7 +580,10 @@ def main(loop=None):
     cli.ui_loop.run()
     if feature_flags.use_protocol_api_v2():
         hardware.set_lights(rails=False)
-    print('Robot config: \n', cli._config)
+    try:
+        print('Robot config: \n', cli.hardware.config)
+    except Exception:
+        pass
 
 
 def notify_and_restart():

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -95,7 +95,10 @@ def initialize_robot(loop):
         log.exception("Error while connecting to motor driver: {}".format(e))
         fw_version = None
     else:
-        fw_version = hardware.fw_version
+        if ff.use_protocol_api_v2():
+            fw_version = loop.run_until_complete(hardware.fw_version)
+        else:
+            fw_version = hardware.fw_version
     log.info("Smoothie FW version: {}".format(fw_version))
     if fw_version != packed_smoothie_fw_ver:
         log.info("Executing smoothie update: current vers {}, packed vers {}"
@@ -119,8 +122,14 @@ def run(**kwargs):
     an additional argument of 'patch_old_init'. kwargs are hence used to allow
     the use of different length args
     """
-    logging_config.log_init(hardware.config.log_level)
     loop = asyncio.get_event_loop()
+    if ff.use_protocol_api_v2():
+        robot_conf = loop.run_until_complete(hardware.config)
+    else:
+        robot_conf = hardware.config
+
+    logging_config.log_init(robot_conf.log_level)
+
     log.info("API server version:  {}".format(__version__))
     if not os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"):
         initialize_robot(loop)

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -114,7 +114,7 @@ def initialize_robot(loop):
     log.info(f"Name: {name()}")
 
 
-def run(**kwargs):
+def run(**kwargs):  # noqa(C901)
     """
     This function was necessary to separate from main() to accommodate for
     server startup path on system 3.0, which is server.main. In the case where

--- a/api/src/opentrons/server/endpoints/__init__.py
+++ b/api/src/opentrons/server/endpoints/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 from aiohttp import web
@@ -8,11 +9,17 @@ log = logging.getLogger(__name__)
 
 async def health(request: web.Request) -> web.Response:
     static_paths = ['/logs/serial.log', '/logs/api.log']
+    # This conditional handles the case where we have just changed the
+    # use protocol api v2 feature flag, so it does not match the type
+    # of hardware we're actually using.
+    fw_version = request.app['com.opentrons.hardware'].fw_version
+    if inspect.iscoroutine(fw_version):
+        fw_version = await fw_version
 
     res = {
         'name': config.name(),
         'api_version': __version__,
-        'fw_version': request.app['com.opentrons.hardware'].fw_version,
+        'fw_version': fw_version,
         'logs': static_paths,
         'system_version': config.OT_SYSTEM_VERSION
     }

--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -239,8 +239,14 @@ async def set_log_level(request: web.Request) -> web.Response:
 
     logging.getLogger('opentrons').setLevel(level_val)
     hw = request.app['com.opentrons.hardware']
-    hw.update_config(log_level=log_level)
-    rc.save_robot_settings(hw.config)
+
+    if ff.use_protocol_api_v2():
+        await hw.update_config(log_level=log_level)
+        conf = await hw.config
+    else:
+        hw.update_config(log_level=log_level)
+        conf = hw.config
+    rc.save_robot_settings(conf)
     return web.json_response(
         status=200,
         data={'message': f'log_level set to {log_level}'})

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from opentrons.config import (CONFIG,
                               robot_configs,
-                              advanced_settings as advs,
-                              feature_flags as ff)
+                              advanced_settings as advs)
 from opentrons.types import Mount
 from opentrons.deck_calibration import dc_main
 from opentrons.deck_calibration.dc_main import get_calibration_points

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from opentrons.config import (CONFIG,
                               robot_configs,
-                              advanced_settings as advs)
+                              advanced_settings as advs,
+                              feature_flags as ff)
 from opentrons.types import Mount
 from opentrons.deck_calibration import dc_main
 from opentrons.deck_calibration.dc_main import get_calibration_points
@@ -29,13 +30,12 @@ def test_clear_config(mock_config, async_server):
     assert hardware.config == robot_configs.build_config({}, {})
 
 
-def test_save_and_clear_config(mock_config, async_server):
+def test_save_and_clear_config(mock_config, sync_hardware, loop):
     # Clear should happen automatically after the following import, resetting
     # the deck cal to the default value
+    hardware = sync_hardware
     from opentrons.deck_calibration import dc_main
     import os
-
-    hardware = async_server['com.opentrons.hardware']
 
     hardware.config.gantry_calibration[0][3] = 10
 
@@ -45,7 +45,6 @@ def test_save_and_clear_config(mock_config, async_server):
     tag = "testing"
     root, ext = os.path.splitext(base_filename)
     filename = "{}-{}{}".format(root, tag, ext)
-
     dc_main.backup_configuration_and_reload(hardware, tag=tag)
     # After reset gantry calibration should be I(4,4)
     assert hardware.config.gantry_calibration\
@@ -159,6 +158,7 @@ def test_mount_offset(mock_config, loop, monkeypatch, async_server):
 
     monkeypatch.setattr(
         hardware, 'config', mock_config)
+
     tip_length = 51.7
     tool = dc_main.CLITool(
         point_set=get_calibration_points(), tip_length=tip_length, loop=loop)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -37,7 +37,8 @@ async def test_cache_instruments(dummy_instruments, loop):
         attached_instruments=dummy_instruments,
         loop=loop)
     await hw_api.cache_instruments()
-    assert sorted(hw_api.attached_instruments[types.Mount.LEFT].keys()) == \
+    attached = await hw_api.attached_instruments
+    assert sorted(attached[types.Mount.LEFT].keys()) == \
         instrument_keys
 
 
@@ -63,9 +64,9 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
                         'read_pipette_id', mock_driver_id)
 
     await hw_api_cntrlr.cache_instruments()
-
+    attached = await hw_api_cntrlr.attached_instruments
     assert sorted(
-        hw_api_cntrlr.attached_instruments[types.Mount.LEFT].keys()) == \
+        attached[types.Mount.LEFT].keys()) == \
         instrument_keys
 
     # If we pass a conflicting expectation we should get an error
@@ -75,8 +76,9 @@ async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
     # If we pass a matching expects it should work
     await hw_api_cntrlr.cache_instruments(
         {types.Mount.LEFT: LEFT_PIPETTE_PREFIX})
+    attached = await hw_api_cntrlr.attached_instruments
     assert sorted(
-        hw_api_cntrlr.attached_instruments[types.Mount.LEFT].keys()) == \
+        attached[types.Mount.LEFT].keys()) == \
         instrument_keys
 
 
@@ -84,28 +86,32 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     sim = hc.API.build_hardware_simulator(loop=loop)
     # With nothing specified at init or expected, we should have nothing
     await sim.cache_instruments()
-    assert sim.attached_instruments == {
+    attached = await sim.attached_instruments
+    assert attached == {
         types.Mount.LEFT: {}, types.Mount.RIGHT: {}}
     # When we expect instruments, we should get what we expect since nothing
     # was specified at init time
     await sim.cache_instruments({types.Mount.LEFT: 'p10_single_v1.3'})
-    assert sim.attached_instruments[types.Mount.LEFT]['model']\
+    attached = await sim.attached_instruments
+    assert attached[types.Mount.LEFT]['model']\
         == 'p10_single_v1.3'
-    assert sim.attached_instruments[types.Mount.LEFT]['name']\
+    assert attached[types.Mount.LEFT]['name']\
         == 'p10_single'
     # If we use prefixes, that should work too
     await sim.cache_instruments({types.Mount.RIGHT: 'p300_single'})
-    assert sim.attached_instruments[types.Mount.RIGHT]['model']\
+    attached = await sim.attached_instruments
+    assert attached[types.Mount.RIGHT]['model']\
         == 'p300_single_v1'
-    assert sim.attached_instruments[types.Mount.RIGHT]['name']\
+    assert attached[types.Mount.RIGHT]['name']\
         == 'p300_single'
     # If we specify instruments at init time, we should get them without
     # passing an expectation
     sim = hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments)
     await sim.cache_instruments()
+    attached = await sim.attached_instruments
     assert sorted(
-        sim.attached_instruments[types.Mount.LEFT].keys()) == \
+        attached[types.Mount.LEFT].keys()) == \
         instrument_keys
     # If we specify conflicting expectations and init arguments we should
     # get a RuntimeError

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -22,10 +22,11 @@ async def test_controller_home(loop):
                                                        [0, 0, 1, 30],
                                                        [0, 0, 0, 1]],
                                    mount_offset=[0, 0, 10])
-    assert c.config.gantry_calibration == [[1, 0, 0, 10],
-                                           [0, 1, 0, 20],
-                                           [0, 0, 1, 30],
-                                           [0, 0, 0, 1]]
+    conf = await c.config
+    assert conf.gantry_calibration == [[1, 0, 0, 10],
+                                       [0, 1, 0, 20],
+                                       [0, 0, 1, 30],
+                                       [0, 0, 0, 1]]
     await c.home()
     # Check that we correctly apply the inverse gantry calibration
     assert c._current_position == {Axis.X: 408,
@@ -199,7 +200,7 @@ async def test_deck_cal_applied(monkeypatch, loop):
 
     hardware_api = hc.API.build_hardware_simulator(loop=loop)
     monkeypatch.setattr(hardware_api._backend, 'move', mock_move)
-    old_config = hardware_api.config
+    old_config = await hardware_api.config
     hardware_api._config = old_config._replace(
         gantry_calibration=new_gantry_cal)
     await hardware_api.home()

--- a/api/tests/opentrons/hardware_control/test_socket_server.py
+++ b/api/tests/opentrons/hardware_control/test_socket_server.py
@@ -212,8 +212,9 @@ async def test_complex_method(hc_stream_server, loop, monkeypatch):
     gai_resp = await decoder.read_object()
     assert gai_resp['id'] == 2
     assert 'result' in gai_resp
+    attached = await server._api.attached_instruments
     assert gai_resp['result']['LEFT']\
-        == server._api.attached_instruments[Mount.LEFT]
+        == attached[Mount.LEFT]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/test_tip_probe.py
+++ b/api/tests/opentrons/hardware_control/test_tip_probe.py
@@ -108,15 +108,15 @@ async def test_update_instrument_offset(hardware_api, mount, pipette_model):
     await hardware_api.cache_instruments({mount: pipette_model})
     p = Point(1, 2, 3)
     with pytest.raises(ValueError):
-        hardware_api.update_instrument_offset(mount)
-    hardware_api.update_instrument_offset(mount, new_offset=p)
+        await hardware_api.update_instrument_offset(mount)
+    await hardware_api.update_instrument_offset(mount, new_offset=p)
     pip_type = 'multi' if 'multi' in pipette_model else 'single'
     assert\
         hardware_api._config.instrument_offset[mount.name.lower()][pip_type]\
         == [1, 2, 3]
     assert hardware_api._attached_instruments[mount]._instrument_offset == p
     center = Point(*hardware_api._config.tip_probe.center) + Point(3, 2, 1)
-    hardware_api.update_instrument_offset(mount, from_tip_probe=center)
+    await hardware_api.update_instrument_offset(mount, from_tip_probe=center)
     assert\
         hardware_api._config.instrument_offset[mount.name.lower()][pip_type]\
         == [-3, -2, -1]

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -368,5 +368,6 @@ async def test_transform_from_moves_v2(
         [const_zero, const_zero, const_one_, delta_z___],
         [const_zero, const_zero, const_zero, const_one_]]
 
-    actual_transform = hardware.config.gantry_calibration
+    conf = await hardware.config
+    actual_transform = conf.gantry_calibration
     assert np.allclose(actual_transform, expected_transform)

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -470,6 +470,7 @@ async def test_set_and_jog_integration(
     monkeypatch.setattr(endpoints, '_get_uuid', uuid_mock)
 
     token_res = await async_client.post('/calibration/deck/start')
+    assert token_res.status == 201, token_res
     token_text = await token_res.json()
     token = token_text['token']
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -313,6 +313,7 @@ async def test_incorrect_modify_pipette_settings(
 async def test_set_log_level(
         async_server, loop, async_client):
     # Check input sanitization
+    hardware = async_server['com.opentrons.hardware']
     resp = await async_client.post('/settings/log_level/local', json={})
     assert resp.status == 400
     body = await resp.json()
@@ -322,11 +323,18 @@ async def test_set_log_level(
     assert resp.status == 400
     body = await resp.json()
     assert 'message'in body
-
-    assert async_server['com.opentrons.hardware'].config.log_level != 'ERROR'
+    if async_server['api_version'] == 1:
+        conf = hardware.config
+    else:
+        conf = await hardware.config
+    assert conf.log_level != 'ERROR'
     resp = await async_client.post('/settings/log_level/local',
                                    json={'log_level': 'error'})
     assert resp.status == 200
     body = await resp.json()
     assert 'message' in body
-    assert async_server['com.opentrons.hardware'].config.log_level == 'ERROR'
+    if async_server['api_version'] == 1:
+        conf = hardware.config
+    else:
+        conf = await hardware.config
+    assert conf.log_level == 'ERROR'


### PR DESCRIPTION
## Summary
This is in preparation for making a hardware control socket client that can look
the same as an in-memory hardware controller object.

If the hardware controller has synchronous methods that have to be exposed over
jsonrpc, clients can't exactly duplicate the API because those methods have to
be asynchronous to run the jsonrpc client.

Making all the properties and methods asynchronous complicates things somewhat
but allows for the possibility of drop-in replacement socket clients; and for
consumers that need synchronous access, the SynchronousAdapter still provides
functionality.

This is a large set of changes that probably shouldn't be merged without lots of time to test.

## Testing

Run it on a robot, run some basic protocol actions.