### PR TITLE
refactor(app-shell): Add missing existence check to FF object

### DIFF
--- a/app-shell/src/buildroot.js
+++ b/app-shell/src/buildroot.js
@@ -27,7 +27,7 @@ let updateApiVersion: string
 let updateServerVersion: string
 
 export function registerBuildrootUpdate(dispatch: Dispatch) {
-  const buildrootEnabled = getConfig('devInternal').enableBuildRoot
+  const buildrootEnabled = getConfig('devInternal')?.enableBuildRoot
 
   if (buildrootEnabled) {
     initializeUpdateFileInfo()


### PR DESCRIPTION
## overview

#3629 broke the app's main process because `getConfig('devInternal')` might be `undefined`. This PR adds the missing `?` to protect us from that case

## changelog

- refactor(app-shell): Add missing existence check to FF object

## review requests

App boots normally and the main process works (e.g. app config can be modified, React + redux devtools are installed, etc.)