### PR TITLE
fix(app,pd): Truncate long labware names

### DIFF
--- a/api/tests/opentrons/data/calibration-validation.py
+++ b/api/tests/opentrons/data/calibration-validation.py
@@ -8,27 +8,20 @@ metadata = {
     'source': 'Opentrons Repository'
 }
 
-tiprack_s1 = containers.load('tiprack-200ul', '6', label='s1')
-tiprack_s2 = containers.load('tiprack-200ul', '3', label='s2')
+tiprack_s1 = containers.load('opentrons_96_tiprack_300ul', '10', label='s1')
+tiprack_s2 = containers.load('opentrons_96_tiprack_300ul', '3', label='s2')
 
-tiprack_m1 = containers.load('tiprack-200ul', '4', label='m1')
-tiprack_m2 = containers.load('tiprack-200ul', '1', label='m2')
+tiprack_m1 = containers.load('opentrons_96_tiprack_300ul', '4', label='m1')
+tiprack_m2 = containers.load('opentrons_96_tiprack_300ul', '1', label='m2')
 
-trough = containers.load('trough-12row', '8')
-plate = containers.load('96-PCR-flat', '5')
+trough = containers.load('usascientific_12_reservoir_22ml', '11')
+plate = containers.load('biorad_96_wellplate_200ul_pcr', '5')
 
-multi = instruments.Pipette(
-    name="p200",
-    tip_racks=[tiprack_m2, tiprack_m1],
-    mount="left",
-    channels=8
-)
+multi = instruments.P300_Multi(
+    tip_racks=[tiprack_m2, tiprack_m1], mount='left')
 
-single = instruments.Pipette(
-    name="p200s",
-    tip_racks=[tiprack_s2, tiprack_s1],
-    mount="right"
-)
+single = instruments.P300_Single(
+    tip_racks=[tiprack_s2, tiprack_s1], mount='right')
 
 single.pick_up_tip(tiprack_s1[0])
 single.aspirate(25, trough[0])

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -8,22 +8,22 @@ metadata = {
 }
 
 # a 12 row trough for sources, and 96 well plate for output
-trough = containers.load('usascientific_12_reservoir_22ml', '3', 'trough')
-plate = containers.load('biorad_96_wellplate_200ul_pcr', '1', 'plate')
+trough = containers.load('trough-12row', '3', 'trough')
+plate = containers.load('96-PCR-flat', '1', 'plate')
 
 # a tip rack for our pipette
-p300rack = containers.load('opentrons_96_tiprack_300ul', '2', 'tiprack')
+p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
 
-# create a p300 pipette on robot axis B
-p300 = instruments.P300_Single(mount="left", tip_racks=[p300rack])
+# create a p200 pipette on robot axis B
+p200 = instruments.P300_Single(mount="left", tip_racks=[p200rack])
 
 # simple, atomic commands to control fine details
-p300.pick_up_tip()
-p300.aspirate(50, trough.wells('A1'))
-p300.dispense(plate.wells('D1'))
+p200.pick_up_tip()
+p200.aspirate(50, trough.wells('A1'))
+p200.dispense(plate.wells('D1'))
 
 # macro commands like .distribute() make writing long sequences easier
-p300.distribute(
+p200.distribute(
     50,
     trough.wells('A1'),
     plate.wells(
@@ -37,7 +37,7 @@ p300.distribute(
     disposal_vol=0
 )
 
-p300.distribute(
+p200.distribute(
     50,
     trough.wells('A2'),
     plate.wells(

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -8,22 +8,22 @@ metadata = {
 }
 
 # a 12 row trough for sources, and 96 well plate for output
-trough = containers.load('trough-12row', '3', 'trough')
-plate = containers.load('96-PCR-flat', '1', 'plate')
+trough = containers.load('usascientific_12_reservoir_22ml', '3', 'trough')
+plate = containers.load('biorad_96_wellplate_200ul_pcr', '1', 'plate')
 
 # a tip rack for our pipette
-p200rack = containers.load('tiprack-200ul', '2', 'tiprack')
+p300rack = containers.load('opentrons_96_tiprack_300ul', '2', 'tiprack')
 
-# create a p200 pipette on robot axis B
-p200 = instruments.P300_Single(mount="left", tip_racks=[p200rack])
+# create a p300 pipette on robot axis B
+p300 = instruments.P300_Single(mount="left", tip_racks=[p300rack])
 
 # simple, atomic commands to control fine details
-p200.pick_up_tip()
-p200.aspirate(50, trough.wells('A1'))
-p200.dispense(plate.wells('D1'))
+p300.pick_up_tip()
+p300.aspirate(50, trough.wells('A1'))
+p300.dispense(plate.wells('D1'))
 
 # macro commands like .distribute() make writing long sequences easier
-p200.distribute(
+p300.distribute(
     50,
     trough.wells('A1'),
     plate.wells(
@@ -37,7 +37,7 @@ p200.distribute(
     disposal_vol=0
 )
 
-p200.distribute(
+p300.distribute(
     50,
     trough.wells('A2'),
     plate.wells(

--- a/app/src/__mocks__/getLabware.js
+++ b/app/src/__mocks__/getLabware.js
@@ -1,0 +1,11 @@
+// @flow
+// TODO(mc, 2019-06-27): replace this mock with one in shared-data based on
+// jest.fn and glob
+
+export function getLegacyLabwareDef(loadName: ?string): null {
+  return null
+}
+
+export function getLatestLabwareDef(loadName: ?string): null {
+  return null
+}

--- a/app/src/components/CalibrateLabware/ConfirmModal.js
+++ b/app/src/components/CalibrateLabware/ConfirmModal.js
@@ -5,6 +5,7 @@ import cx from 'classnames'
 
 import type { Labware } from '../../robot'
 
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { ModalPage } from '@opentrons/components'
 import ConfirmModalContents from './ConfirmModalContents'
 import styles from './styles.css'
@@ -22,16 +23,22 @@ export default function ConfirmModal(props: Props) {
   const backClickDisabled =
     labware.isMoving || labware.calibration === 'picked-up'
 
-  // TODO (ka 2018-4-18): this is a temporary workaround for a stlye over ride for in progress screens with transparate bg
+  // TODO (ka 2018-4-18): this is a temporary workaround for a style override
+  // for in progress screens with transparent bg
   const contentsStyle = labware.calibration.match(
     /^(moving-to-slot|picking-up|dropping-tip|confirming)$/
   )
     ? cx(styles.modal_contents, styles.in_progress_contents)
     : styles.modal_contents
 
+  const labwareDisplayName = labware.definition
+    ? getLabwareDisplayName(labware.definition)
+    : labware.name
+
   const titleBar = {
-    title: 'Calibrate Deck',
-    subtitle: labware.type,
+    title: 'Calibrate Labware',
+    // subtitle is capitalized by CSS, and "µL" capitalized looks is "µL"
+    subtitle: labwareDisplayName.replace('µL', 'uL'),
     back: { onClick: onBackClick, disabled: backClickDisabled },
   }
 
@@ -39,7 +46,11 @@ export default function ConfirmModal(props: Props) {
     <ModalPage
       titleBar={titleBar}
       contentsClassName={contentsStyle}
-      heading={`Calibrate pipette to ${labware.type}`}
+      heading={
+        <span className={styles.wizard_title}>
+          Calibrate pipette to {labwareDisplayName}
+        </span>
+      }
     >
       <ConfirmModalContents
         labware={labware}

--- a/app/src/components/CalibrateLabware/ConfirmModal.js
+++ b/app/src/components/CalibrateLabware/ConfirmModal.js
@@ -37,7 +37,7 @@ export default function ConfirmModal(props: Props) {
 
   const titleBar = {
     title: 'Calibrate Labware',
-    // subtitle is capitalized by CSS, and "µL" capitalized looks is "µL"
+    // subtitle is capitalized by CSS, and "µL" capitalized is "ML"
     subtitle: labwareDisplayName.replace('µL', 'uL'),
     back: { onClick: onBackClick, disabled: backClickDisabled },
   }

--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -10,6 +10,7 @@ import {
   actions as robotActions,
 } from '../../robot'
 
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { PrimaryButton } from '@opentrons/components'
 import CalibrationInfoBox from '../CalibrationInfoBox'
 import CalibrationInfoContent from '../CalibrationInfoContent'
@@ -30,7 +31,7 @@ type SP = {|
 
 type DP = {| dispatch: Dispatch |}
 
-type Props = {
+type Props = {|
   ...OP,
   button: ?{
     type: LabwareType,
@@ -38,7 +39,7 @@ type Props = {
     isConfirmed: ?boolean,
     onClick: () => void,
   },
-}
+|}
 
 export default connect<Props, OP, SP, {||}, State, Dispatch>(
   mapStateToProps,
@@ -57,7 +58,9 @@ function InfoBox(props: Props) {
   if (labware) {
     const labwareType = robotSelectors.labwareType(labware)
 
-    title = labware.type
+    title = labware.definition
+      ? getLabwareDisplayName(labware.definition)
+      : labware.type
     confirmed = labware.confirmed
     description = confirmed
       ? `${capitalize(labwareType)} is calibrated`

--- a/app/src/components/CalibrateLabware/styles.css
+++ b/app/src/components/CalibrateLabware/styles.css
@@ -78,3 +78,7 @@
   width: 100%;
   height: 100%;
 }
+
+.wizard_title {
+  text-transform: none;
+}

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -1,20 +1,21 @@
 // @flow
 import * as React from 'react'
 
-import type { Labware } from '../../robot'
-
-import { ListItem } from '@opentrons/components'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
 
-type LabwareItemProps = {
+import type { Labware } from '../../robot'
+
+type LabwareListItemProps = {|
+  ...$Exact<Labware>,
   isDisabled: boolean,
   onClick: () => mixed,
-}
+|}
 
-type Props = Labware & LabwareItemProps
-
-export default function LabwareListItem(props: Props) {
+export default function LabwareListItem(props: LabwareListItemProps) {
   const {
+    name,
     type,
     slot,
     calibratorMount,
@@ -22,10 +23,12 @@ export default function LabwareListItem(props: Props) {
     confirmed,
     isDisabled,
     onClick,
+    definition,
   } = props
 
   const url = `/calibrate/labware/${slot}`
   const iconName = confirmed ? 'check-circle' : 'checkbox-blank-circle-outline'
+  const displayName = definition ? getLabwareDisplayName(definition) : type
 
   return (
     <ListItem
@@ -36,17 +39,35 @@ export default function LabwareListItem(props: Props) {
       activeClassName={styles.active}
     >
       <div className={styles.item_info}>
-        <span>Slot {slot}</span>
+        <span className={styles.item_info_location}>Slot {slot}</span>
         {isTiprack && (
-          <span>
-            <span className={styles.tiprack_item_mount}>
-              {calibratorMount && calibratorMount.charAt(0).toUpperCase()}
-            </span>
-            Tiprack
+          <span className={styles.tiprack_item_mount}>
+            {calibratorMount && calibratorMount.charAt(0).toUpperCase()}
           </span>
         )}
-        <span>{type}</span>
+        <HoverTooltip
+          tooltipComponent={
+            <LabwareNameTooltip name={name} displayName={displayName} />
+          }
+        >
+          {handlers => (
+            <span {...handlers} className={styles.labware_item_name}>
+              {displayName}
+            </span>
+          )}
+        </HoverTooltip>
       </div>
     </ListItem>
+  )
+}
+
+function LabwareNameTooltip(props: {| name: string, displayName: string |}) {
+  const { name, displayName } = props
+
+  return (
+    <div className={styles.item_info_tooltip}>
+      <p>{name}</p>
+      <p>{displayName}</p>
+    </div>
   )
 }

--- a/app/src/components/CalibratePanel/PipetteListItem.js
+++ b/app/src/components/CalibratePanel/PipetteListItem.js
@@ -23,12 +23,7 @@ export default function PipetteListItem(props: Props) {
     ? 'check-circle'
     : 'checkbox-blank-circle-outline'
 
-  const description = pipette
-    ? `${capitalize(pipette.channels === 8 ? 'multi' : 'single')}-channel`
-    : 'N/A'
-
-  const name = pipette ? pipette.name : 'N/A'
-
+  const description = pipette?.modelSpecs?.displayName || 'N/A'
   return (
     <ListItem
       isDisabled={isDisabled}
@@ -38,9 +33,8 @@ export default function PipetteListItem(props: Props) {
       activeClassName={styles.active}
     >
       <div className={styles.item_info}>
-        <span>{capitalize(mount)}</span>
+        <span className={styles.item_info_location}>{capitalize(mount)}</span>
         <span>{description}</span>
-        <span>{name}</span>
       </div>
     </ListItem>
   )

--- a/app/src/components/CalibratePanel/styles.css
+++ b/app/src/components/CalibratePanel/styles.css
@@ -6,18 +6,40 @@
   }
 }
 
-.tiprack_item_mount {
-  font-weight: var(--fw-bold);
-  padding-right: 0.75rem;
-}
-
 .item_info {
   flex: 1;
   display: flex;
-  justify-content: space-between;
+  overflow: hidden;
 }
 
 .active {
   color: var(--c-highlight);
   background-color: var(--c-bg-selected);
+}
+
+.item_info_location {
+  flex: none;
+  width: 2.5rem;
+  margin-right: 1rem;
+}
+
+.tiprack_item_mount {
+  flex: none;
+  font-weight: var(--fw-semibold);
+  margin-right: 1.5rem;
+}
+
+.labware_item_name {
+  @apply --truncate;
+
+  width: 100%;
+}
+
+.item_info_tooltip {
+  @apply --font-body-1-light;
+
+  & > p:first-child {
+    font-weight: var(--fw-semibold);
+    margin-bottom: 0.5rem;
+  }
 }

--- a/app/src/components/CalibrationInfoBox.js
+++ b/app/src/components/CalibrationInfoBox.js
@@ -4,12 +4,12 @@ import classnames from 'classnames'
 import { Icon } from '@opentrons/components'
 import styles from './calibration-info.css'
 
-type Props = {
+type Props = {|
   title: string,
   confirmed: boolean,
   className?: string,
   children: React.Node,
-}
+|}
 
 export default function CalibrationInfoBox(props: Props) {
   const { className, confirmed, title, children } = props

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -42,7 +42,7 @@ type Props = {
 }
 
 const TITLE = 'Pipette Setup'
-// used to guarentee mount param in route is left or right
+// used to guarantee mount param in route is left or right
 const RE_MOUNT = '(left|right)'
 
 type OP = {|

--- a/app/src/components/DeckMap/LabwareItem.js
+++ b/app/src/components/DeckMap/LabwareItem.js
@@ -66,6 +66,7 @@ export default function LabwareItem(props: LabwareItemProps) {
     ) : (
       <div className={styles.name_overlay}>
         <p className={styles.display_name} title={title}>
+          {/* title is capitalized by CSS, and "µL" capitalized is "ML" */}
           {title.replace('µL', 'uL')}
         </p>
         <p className={styles.subtitle} title={name}>

--- a/app/src/components/DeckMap/LabwareItem.js
+++ b/app/src/components/DeckMap/LabwareItem.js
@@ -2,7 +2,12 @@
 import * as React from 'react'
 import cx from 'classnames'
 import { Link } from 'react-router-dom'
-import { SLOT_RENDER_HEIGHT, SLOT_RENDER_WIDTH } from '@opentrons/shared-data'
+
+import {
+  getLabwareDisplayName,
+  SLOT_RENDER_HEIGHT,
+  SLOT_RENDER_WIDTH,
+} from '@opentrons/shared-data'
 
 import {
   RobotCoordsForeignDiv,
@@ -13,7 +18,7 @@ import {
 } from '@opentrons/components'
 
 import { type Labware } from '../../robot'
-import { getLatestLabwareDef, getLegacyLabwareDef } from '../../getLabware'
+import { getLegacyLabwareDef } from '../../getLabware'
 
 import styles from './styles.css'
 
@@ -28,8 +33,7 @@ export type LabwareItemProps = {
 
 export default function LabwareItem(props: LabwareItemProps) {
   const { labware, highlighted, areTipracksConfirmed, handleClick } = props
-
-  const { isTiprack, confirmed, name, type, slot } = labware
+  const { isTiprack, confirmed, name, type, slot, definition } = labware
 
   const showSpinner = highlighted && labware.calibration === 'moving-to-slot'
   const clickable = highlighted !== null
@@ -37,17 +41,21 @@ export default function LabwareItem(props: LabwareItemProps) {
     clickable &&
     ((isTiprack && confirmed) || (!isTiprack && areTipracksConfirmed === false))
 
-  const title = humanizeLabwareType(type)
+  let title
+  let item
+  let width
+  let height
 
-  let item = <LabwareComponent definition={getLegacyLabwareDef(type)} />
-  let width = SLOT_RENDER_WIDTH
-  let height = SLOT_RENDER_HEIGHT
-
-  const def = getLatestLabwareDef(type)
-  if (!labware.isLegacy && def) {
-    item = <LabwareRender definition={def} />
-    width = def.dimensions.xDimension
-    height = def.dimensions.yDimension
+  if (definition) {
+    item = <LabwareRender definition={definition} />
+    width = definition.dimensions.xDimension
+    height = definition.dimensions.yDimension
+    title = getLabwareDisplayName(definition)
+  } else {
+    item = <LabwareComponent definition={getLegacyLabwareDef(type)} />
+    width = SLOT_RENDER_WIDTH
+    height = SLOT_RENDER_HEIGHT
+    title = humanizeLabwareType(type)
   }
 
   const renderContents = () => {
@@ -58,7 +66,7 @@ export default function LabwareItem(props: LabwareItemProps) {
     ) : (
       <div className={styles.name_overlay}>
         <p className={styles.display_name} title={title}>
-          {title}
+          {title.replace('µL', 'uL')}
         </p>
         <p className={styles.subtitle} title={name}>
           {name}

--- a/app/src/components/DeckMap/styles.css
+++ b/app/src/components/DeckMap/styles.css
@@ -65,18 +65,15 @@
 }
 
 .display_name {
+  @apply --truncate;
+
   font-weight: var(--fw-semibold);
   color: var(--c-font-light);
   text-transform: uppercase;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .subtitle {
+  @apply --truncate;
+
   color: var(--c-font-light);
-  text-transform: uppercase;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -42,11 +42,11 @@ function ProtocolPipettes(props: Props) {
   if (pipettes.length === 0) return null
 
   const pipetteInfo = pipettes.map(p => {
-    const pipetteConfig = getPipetteModelSpecs(p.name)
+    const pipetteConfig = p.modelSpecs
     const actualPipetteConfig = getPipetteModelSpecs(
       actualPipettes[p.mount]?.model || ''
     )
-    const displayName = !pipetteConfig ? 'N/A' : pipetteConfig.displayName
+    const displayName = pipetteConfig?.displayName || 'N/A'
 
     let pipettesMatch = true
 

--- a/app/src/components/ReviewDeck/Prompt.js
+++ b/app/src/components/ReviewDeck/Prompt.js
@@ -2,18 +2,21 @@
 // prompt for ReviewDeck of labware calibration page
 import * as React from 'react'
 
-import { selectors as robotSelectors, type Labware } from '../../robot'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { OutlineButton } from '@opentrons/components'
+import { selectors as robotSelectors, type Labware } from '../../robot'
 
 import styles from './styles.css'
 
-type Props = Labware & {
+type Props = {|
+  ...$Exact<Labware>,
   onClick: () => void,
-}
+|}
 
 export default function Prompt(props: Props) {
-  const { type, slot, onClick } = props
+  const { name, definition, slot, onClick } = props
   const labwareType = robotSelectors.labwareType(props)
+  const labwareTitle = definition ? getLabwareDisplayName(definition) : name
 
   return (
     <div className={styles.prompt}>
@@ -29,7 +32,7 @@ export default function Prompt(props: Props) {
         {`Continue moving to ${labwareType}`}
       </OutlineButton>
       <p className={styles.prompt_details}>
-        {`Pipette will move to ${type} in slot ${slot}`}
+        {`Pipette will move to ${labwareTitle} in slot ${slot}`}
       </p>
     </div>
   )

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import cx from 'classnames'
 
 import type { PipettesState } from '../../robot-api'
-import type { Pipette } from '../../robot'
+import type { Pipette, Labware } from '../../robot'
 import { constants as robotConstants } from '../../robot'
 
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
@@ -13,6 +13,7 @@ import styles from './styles.css'
 
 type Props = {|
   pipettes: Array<Pipette>,
+  labware: Array<Labware>,
   currentPipette: ?Pipette,
   actualPipettes: ?PipettesState,
   changePipetteUrl: string,
@@ -23,22 +24,32 @@ const ATTACH_ALERT = 'Pipette missing'
 const CHANGE_ALERT = 'Incorrect pipette attached'
 
 export default function Pipettes(props: Props) {
-  const { currentPipette, pipettes, actualPipettes, changePipetteUrl } = props
+  const {
+    currentPipette,
+    pipettes,
+    labware,
+    actualPipettes,
+    changePipetteUrl,
+  } = props
   const currentMount = currentPipette && currentPipette.mount
 
   const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
-    const pipetteConfig = getPipetteModelSpecs(pipette?.name || '')
+    const tiprack = labware.find(
+      lw => lw.isTiprack && lw.calibratorMount === mount
+    )
+    const pipetteConfig = pipette?.modelSpecs
     const actualPipetteConfig = getPipetteModelSpecs(
       actualPipettes?.[mount]?.model || ''
     )
 
     const isDisabled = !pipette || mount !== currentMount
     const details = !pipetteConfig
-      ? { description: 'N/A', tipType: 'N/A' }
+      ? { description: 'N/A', tiprackModel: 'N/A' }
       : {
           description: pipetteConfig.displayName,
-          tipType: `${pipetteConfig.maxVolume} µL`,
+          tiprackModel:
+            tiprack?.definition?.metadata.displayName || tiprack?.name || 'N/A',
           channels: pipetteConfig.channels,
         }
 

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -16,7 +16,7 @@ import SessionHeader from '../../components/SessionHeader'
 
 import type { ContextRouter } from 'react-router'
 import type { State, Dispatch } from '../../types'
-import type { Pipette } from '../../robot'
+import type { Pipette, Labware } from '../../robot'
 import type { PipettesState } from '../../robot-api'
 import type { Robot } from '../../discovery'
 
@@ -24,6 +24,7 @@ type OP = ContextRouter
 
 type SP = {|
   pipettes: Array<Pipette>,
+  labware: Array<Labware>,
   currentPipette: ?Pipette,
   actualPipettes: ?PipettesState,
   _robot: ?Robot,
@@ -47,6 +48,7 @@ export default connect<Props, OP, SP, {||}, State, Dispatch>(
 function CalibratePipettesPage(props: Props) {
   const {
     pipettes,
+    labware,
     actualPipettes,
     currentPipette,
     fetchPipettes,
@@ -65,7 +67,13 @@ function CalibratePipettesPage(props: Props) {
       <Page titleBarProps={{ title: <SessionHeader /> }}>
         <PipetteTabs {...{ pipettes, currentPipette }} />
         <Pipettes
-          {...{ pipettes, currentPipette, actualPipettes, changePipetteUrl }}
+          {...{
+            pipettes,
+            labware,
+            currentPipette,
+            actualPipettes,
+            changePipetteUrl,
+          }}
         />
         {!!currentPipette && (
           <TipProbe
@@ -93,12 +101,14 @@ function mapStateToProps(state: State, ownProps: OP): SP {
   const { mount } = ownProps.match.params
   const _robot = getConnectedRobot(state)
   const pipettes = robotSelectors.getPipettes(state)
+  const labware = robotSelectors.getLabware(state)
   const currentPipette = pipettes.find(p => p.mount === mount)
   const actualPipettes = _robot && getPipettesState(state, _robot.name)
 
   return {
     _robot,
     pipettes,
+    labware,
     actualPipettes,
     currentPipette,
   }

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -352,6 +352,7 @@ describe('robot selectors', () => {
           calibration: constants.PROBING,
           probed: true,
           tipOn: false,
+          modelSpecs: null,
         },
         {
           mount: 'right',
@@ -361,6 +362,7 @@ describe('robot selectors', () => {
           calibration: constants.UNPROBED,
           probed: false,
           tipOn: true,
+          modelSpecs: null,
         },
       ])
     })
@@ -545,6 +547,7 @@ describe('robot selectors', () => {
           calibration: 'unconfirmed',
           confirmed: false,
           calibratorMount: 'left',
+          definition: null,
         },
         // then single channel tiprack
         {
@@ -555,6 +558,7 @@ describe('robot selectors', () => {
           calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'right',
+          definition: null,
         },
         // then other labware by slot
         {
@@ -564,6 +568,7 @@ describe('robot selectors', () => {
           isMoving: false,
           calibration: 'unconfirmed',
           confirmed: true,
+          definition: null,
         },
         // then other labware by slot
         {
@@ -574,6 +579,7 @@ describe('robot selectors', () => {
           calibration: 'unconfirmed',
           // note: labware a in slot 7 is confirmed because confirmed in slot 5
           confirmed: true,
+          definition: null,
         },
         {
           slot: '9',
@@ -582,6 +588,7 @@ describe('robot selectors', () => {
           isMoving: false,
           calibration: 'unconfirmed',
           confirmed: false,
+          definition: null,
         },
       ])
     })
@@ -596,6 +603,7 @@ describe('robot selectors', () => {
           calibration: 'unconfirmed',
           confirmed: false,
           calibratorMount: 'left',
+          definition: null,
         },
         {
           slot: '1',
@@ -605,6 +613,7 @@ describe('robot selectors', () => {
           calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'right',
+          definition: null,
         },
       ])
     })
@@ -619,6 +628,7 @@ describe('robot selectors', () => {
           calibration: 'unconfirmed',
           confirmed: false,
           calibratorMount: 'left',
+          definition: null,
         },
         {
           slot: '1',
@@ -628,6 +638,7 @@ describe('robot selectors', () => {
           calibration: 'moving-to-slot',
           confirmed: false,
           calibratorMount: 'right',
+          definition: null,
         },
         {
           slot: '9',
@@ -636,6 +647,7 @@ describe('robot selectors', () => {
           isMoving: false,
           calibration: 'unconfirmed',
           confirmed: false,
+          definition: null,
         },
       ])
     })
@@ -649,6 +661,7 @@ describe('robot selectors', () => {
         calibration: 'unconfirmed',
         confirmed: false,
         calibratorMount: 'left',
+        definition: null,
       })
 
       const nextState = {
@@ -672,6 +685,7 @@ describe('robot selectors', () => {
         isMoving: false,
         calibration: 'unconfirmed',
         confirmed: false,
+        definition: null,
       })
     })
   })

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,6 +1,11 @@
 // @flow
 // common robot types
-import type { PipetteChannels, ModuleType } from '@opentrons/shared-data'
+import type {
+  PipetteModelSpecs,
+  PipetteChannels,
+  ModuleType,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import type { Mount } from '@opentrons/components'
 import typeof reducer from './reducer'
 
@@ -92,7 +97,7 @@ export type StatePipette = {
   // TLDR: this `name` needs to be renamed in a future PR to `model`
   name: string,
   // volume of the instrument
-  // TODO(mc, 2018-01-17): this is used to drive tip propbe setup
+  // TODO(mc, 2018-01-17): this is used to drive tip probe setup
   // instructions which is incorrect and needs to be rethought
   volume: number,
 }
@@ -102,6 +107,7 @@ export type Pipette = {
   calibration: PipetteCalibrationStatus,
   probed: boolean,
   tipOn: boolean,
+  modelSpecs: PipetteModelSpecs | null,
 }
 
 // labware as stored in redux state
@@ -118,7 +124,7 @@ export type StateLabware = {|
   isTiprack: boolean,
   // whether or not the labware is a legacy labware (labwareSchemaVersion === 1)
   isLegacy: boolean,
-  // intrument mount to use as the calibrator if isTiprack is true
+  // instrument mount to use as the calibrator if isTiprack is true
   calibratorMount: ?Mount,
 |}
 
@@ -127,6 +133,7 @@ export type Labware = {
   calibration: LabwareCalibrationStatus,
   confirmed: boolean,
   isMoving: boolean,
+  definition: LabwareDefinition2 | null,
 }
 
 export type LabwareType = 'tiprack' | 'labware'

--- a/components/src/__tests__/__snapshots__/instrument-diagram.test.js.snap
+++ b/components/src/__tests__/__snapshots__/instrument-diagram.test.js.snap
@@ -38,18 +38,6 @@ exports[`InstrumentGroup Renders correctly 1`] = `
           p300 8-Channel
         </span>
       </div>
-      <div>
-        <h2
-          className="title"
-        >
-          suggested tip type
-        </h2>
-        <span
-          className="value"
-        >
-          150
-        </span>
-      </div>
     </div>
     <div
       className="pipette_icon"
@@ -75,18 +63,6 @@ exports[`InstrumentGroup Renders correctly 1`] = `
           className="value"
         >
           p10 Single
-        </span>
-      </div>
-      <div>
-        <h2
-          className="title"
-        >
-          suggested tip type
-        </h2>
-        <span
-          className="value"
-        >
-          10
         </span>
       </div>
     </div>

--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -167,7 +167,7 @@ exports[`modals ModalPage renders correctly 1`] = `
     className="title_bar title_bar"
   >
     <button
-      className="button_flat inverted"
+      className="button_flat title_button inverted"
       onClick={[Function]}
       title="Back"
       type="button"
@@ -186,25 +186,21 @@ exports[`modals ModalPage renders correctly 1`] = `
       </svg>
       back
     </button>
-    <div
-      className="title_wrapper"
+    <h1
+      className="title right"
     >
-      <h1
-        className="title"
-      >
-        Title
-      </h1>
-      <span
-        className="separator"
-      >
-        |
-      </span>
-      <h2
-        className="subtitle"
-      >
-        Subtitle
-      </h2>
-    </div>
+      Title
+    </h1>
+    <span
+      className="separator"
+    >
+      |
+    </span>
+    <h2
+      className="subtitle"
+    >
+      Subtitle
+    </h2>
   </header>
   <div
     className="modal_page_contents"
@@ -229,7 +225,7 @@ exports[`modals SpinnerModalPage renders correctly 1`] = `
     className="title_bar title_bar"
   >
     <button
-      className="button_flat inverted"
+      className="button_flat title_button inverted"
       disabled={true}
       title="Back"
       type="button"
@@ -248,25 +244,21 @@ exports[`modals SpinnerModalPage renders correctly 1`] = `
       </svg>
       back
     </button>
-    <div
-      className="title_wrapper"
+    <h1
+      className="title right"
     >
-      <h1
-        className="title"
-      >
-        Title
-      </h1>
-      <span
-        className="separator"
-      >
-        |
-      </span>
-      <h2
-        className="subtitle"
-      >
-        Subtitle
-      </h2>
-    </div>
+      Title
+    </h1>
+    <span
+      className="separator"
+    >
+      |
+    </span>
+    <h2
+      className="subtitle"
+    >
+      Subtitle
+    </h2>
   </header>
   <div
     className="modal"

--- a/components/src/__tests__/__snapshots__/structure.test.js.snap
+++ b/components/src/__tests__/__snapshots__/structure.test.js.snap
@@ -154,7 +154,7 @@ exports[`TitleBar renders TitleBar with back button correctly 1`] = `
   className="title_bar"
 >
   <button
-    className="button_flat inverted"
+    className="button_flat title_button inverted"
     onClick={[Function]}
     title="Back"
     type="button"
@@ -173,25 +173,21 @@ exports[`TitleBar renders TitleBar with back button correctly 1`] = `
     </svg>
     back
   </button>
-  <div
-    className="title_wrapper"
+  <h1
+    className="title right"
   >
-    <h1
-      className="title"
-    >
-      foo
-    </h1>
-    <span
-      className="separator"
-    >
-      |
-    </span>
-    <h2
-      className="subtitle"
-    >
-      bar
-    </h2>
-  </div>
+    foo
+  </h1>
+  <span
+    className="separator"
+  >
+    |
+  </span>
+  <h2
+    className="subtitle"
+  >
+    bar
+  </h2>
 </header>
 `;
 
@@ -199,25 +195,21 @@ exports[`TitleBar renders TitleBar with subtitle correctly 1`] = `
 <header
   className="title_bar"
 >
-  <div
-    className="title_wrapper"
+  <h1
+    className="title"
   >
-    <h1
-      className="title"
-    >
-      foo
-    </h1>
-    <span
-      className="separator"
-    >
-      |
-    </span>
-    <h2
-      className="subtitle"
-    >
-      bar
-    </h2>
-  </div>
+    foo
+  </h1>
+  <span
+    className="separator"
+  >
+    |
+  </span>
+  <h2
+    className="subtitle"
+  >
+    bar
+  </h2>
 </header>
 `;
 
@@ -225,14 +217,10 @@ exports[`TitleBar renders TitleBar without subtitle correctly 1`] = `
 <header
   className="title_bar"
 >
-  <div
-    className="title_wrapper"
+  <h1
+    className="title"
   >
-    <h1
-      className="title"
-    >
-      foo
-    </h1>
-  </div>
+    foo
+  </h1>
 </header>
 `;

--- a/components/src/instrument-diagram/InstrumentInfo.js
+++ b/components/src/instrument-diagram/InstrumentInfo.js
@@ -8,7 +8,7 @@ import InstrumentDiagram from './InstrumentDiagram'
 
 import styles from './instrument.css'
 
-export type InstrumentInfoProps = {
+export type InstrumentInfoProps = {|
   /** 'left' or 'right' */
   mount: Mount,
   /** if true, show labels 'LEFT PIPETTE' / 'RIGHT PIPETTE' */
@@ -27,7 +27,7 @@ export type InstrumentInfoProps = {
   infoClassName?: string,
   /** children to display under the info */
   children?: React.Node,
-}
+|}
 
 export default function InstrumentInfo(props: InstrumentInfoProps) {
   const className = cx(

--- a/components/src/instrument-diagram/InstrumentInfo.js
+++ b/components/src/instrument-diagram/InstrumentInfo.js
@@ -15,8 +15,6 @@ export type InstrumentInfoProps = {
   showMountLabel?: ?boolean,
   /** human-readable description, eg 'p300 Single-channel' */
   description: string,
-  /** recommended tip type */
-  tipType?: string,
   /** paired tiprack model */
   tiprackModel?: string,
   /** if disabled, pipette & its info are grayed out */
@@ -46,9 +44,6 @@ export default function InstrumentInfo(props: InstrumentInfoProps) {
           title={props.showMountLabel ? `${props.mount} pipette` : 'pipette'}
           value={props.description}
         />
-        {props.tipType && (
-          <InfoItem title={'suggested tip type'} value={props.tipType} />
-        )}
         {props.tiprackModel && (
           <InfoItem title={'tip rack'} value={props.tiprackModel} />
         )}

--- a/components/src/modals/ModalPage.js
+++ b/components/src/modals/ModalPage.js
@@ -7,13 +7,13 @@ import { TitleBar, type TitleBarProps } from '../structure'
 
 import styles from './modals.css'
 
-type Props = {
+type Props = {|
   /** Props for title bar at top of modal page */
   titleBar: TitleBarProps,
   contentsClassName?: string,
-  heading?: string,
+  heading?: React.Node,
   children?: React.Node,
-}
+|}
 
 export default function ModalPage(props: Props) {
   const { titleBar, heading } = props

--- a/components/src/structure/TitleBar.js
+++ b/components/src/structure/TitleBar.js
@@ -51,12 +51,17 @@ export default function TitleBar(props: TitleBarProps) {
 
   return (
     <header className={cx(styles.title_bar, className)}>
-      {back && <FlatButton inverted iconName={'chevron-left'} {...back} />}
-      <div className={styles.title_wrapper}>
-        <h1 className={styles.title}>{title}</h1>
-        {separator}
-        {subheading}
-      </div>
+      {back && (
+        <FlatButton
+          inverted
+          iconName={'chevron-left'}
+          className={styles.title_button}
+          {...back}
+        />
+      )}
+      <h1 className={cx(styles.title, { [styles.right]: back })}>{title}</h1>
+      {separator}
+      {subheading}
     </header>
   )
 }

--- a/components/src/structure/structure.css
+++ b/components/src/structure/structure.css
@@ -12,7 +12,6 @@
 .title_bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   height: 3rem;
   text-transform: uppercase;
   background-color: var(--c-dark-gray);
@@ -26,7 +25,6 @@
 .title,
 .subtitle,
 .separator {
-  display: inline-block;
   font-size: var(--fs-header);
   margin: 0;
 }
@@ -36,16 +34,23 @@
   font-weight: var(--fw-semibold);
 }
 
-.title_wrapper {
-  padding: 1rem 1.5rem;
+.title,
+.subtitle {
+  @apply --truncate;
+
+  padding: 0 1.5rem;
+}
+
+.title.right {
+  margin-left: auto;
 }
 
 .subtitle {
   font-weight: normal;
 }
 
-.separator {
-  padding: 0 1.75rem;
+.title_button {
+  flex: none;
 }
 
 .page_tabs {

--- a/protocol-designer/src/components/ProtocolEditor.css
+++ b/protocol-designer/src/components/ProtocolEditor.css
@@ -13,6 +13,9 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+
+  /* somehow ensure flex children shrink rather than overflow */
+  overflow-x: hidden;
 }
 
 .main_page_content {

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -111,7 +111,10 @@ function mapStateToProps(state: BaseState): SP {
           _page,
           _liquidPlacementMode: liquidPlacementMode,
           title: labwareNickname,
-          subtitle: labwareEntity && getLabwareDisplayName(labwareEntity.def),
+          // TODO(mc, 2019-06-27): µL to uL replacement needed to handle CSS capitalization
+          subtitle:
+            labwareEntity &&
+            getLabwareDisplayName(labwareEntity.def).replace('µL', 'uL'),
           backButtonLabel: 'Deck',
         }
       }
@@ -131,7 +134,9 @@ function mapStateToProps(state: BaseState): SP {
             drilledDownLabwareId
           ]
           title = nickname
-          subtitle = labwareDef && getLabwareDisplayName(labwareDef)
+          // TODO(mc, 2019-06-27): µL to uL replacement needed to handle CSS capitalization
+          subtitle =
+            labwareDef && getLabwareDisplayName(labwareDef).replace('µL', 'uL')
         }
       } else if (selectedStep) {
         if (wellSelectionLabwareKey) {

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -1,7 +1,11 @@
 // @flow
 import type { ElementProps } from 'react'
 import type { DeckSlotId } from '@opentrons/shared-data'
-import type { DropdownOption, Mount } from '@opentrons/components'
+import type {
+  DropdownOption,
+  Mount,
+  InstrumentInfoProps,
+} from '@opentrons/components'
 import { typeof InstrumentGroup as InstrumentGroupProps } from '@opentrons/components'
 import assert from 'assert'
 import forEach from 'lodash/forEach'
@@ -220,14 +224,12 @@ export const getPipettesForInstrumentGroup: Selector<PipettesForInstrumentGroup>
         const pipetteSpec = pipetteOnDeck.spec
         const tiprackDef = pipetteOnDeck.tiprackLabwareDef
 
-        const pipetteForInstrumentGroup = {
+        const pipetteForInstrumentGroup: InstrumentInfoProps = {
           mount: pipetteOnDeck.mount,
           channels: pipetteSpec ? pipetteSpec.channels : undefined,
           description: _getPipetteDisplayName(pipetteOnDeck.name),
           isDisabled: false,
           tiprackModel: getLabwareDisplayName(tiprackDef),
-          // TODO(mc, 2019-06-27): `tiprack` is missing in InstrumentInfoProps; is it used?
-          tiprack: { model: pipetteOnDeck.tiprackDefURI },
         }
 
         return {

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -226,6 +226,7 @@ export const getPipettesForInstrumentGroup: Selector<PipettesForInstrumentGroup>
           description: _getPipetteDisplayName(pipetteOnDeck.name),
           isDisabled: false,
           tiprackModel: getLabwareDisplayName(tiprackDef),
+          // TODO(mc, 2019-06-27): `tiprack` is missing in InstrumentInfoProps; is it used?
           tiprack: { model: pipetteOnDeck.tiprackDefURI },
         }
 

--- a/scripts/setup-global-mocks.js
+++ b/scripts/setup-global-mocks.js
@@ -1,3 +1,4 @@
 'use strict'
 
 jest.mock('../components/src/deck/getDeckDefinitions')
+jest.mock('../app/src/getLabware')


### PR DESCRIPTION
## overview

The displayNames (and loadNames) in labware v2 tend to be much longer than those in v1, which means some of our less well constrained UI components are more likely to misbehave.

This fixes #3617 to ensure that wherever labware names get placed in the UI in the app and PD, they get truncated rather that wrap and cause weird display issues.

- App labware calibration
    - Side panel labware list
    - Calibration wizard title bar
- PD deck setup
    - Edit liquids + labware name title bar

## changelog

- Truncate long labware names in App and PD
    - To do this, **I had to edit `<TitleBar>` in the CL**, so please test carefully
- Other related fixes enabled by ^ and the addition of labware v2 definitions to the app
    - Add tooltips to labware calibration list showing nickname
    - Pipette tip probe screen shows tiprack used by the pipette rather than a made up tip volume (closes #2444)
- Updated a couple example protocols in `api` to use new labware names so I could test
    - Ping @Opentrons/py 

## review requests

- App
    - [ ] App items listed above behave when using a v1 labware protocol
    - [ ] App items listed above behave when using a v2 labware protocol
    - [ ] All `TitleBar`s in app behave regardless of if they are for labware
- PD
    - [ ] Edit liquids and name wizard truncates long names properly
    - [ ] All `TitleBar`s in PD behave regardless of if they are for labware
- API
    - [ ] Test protocol updates are sane
