### PR TITLE
chore(api): Make a makefile target for installing an ssh key on br

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -42,6 +42,8 @@ pypi_password ?=
 
 # Host key location for buildroot robot
 br_ssh_key ?= ~/.ssh/robot_key
+# Pubkey location for buildroot robot to install with install-key
+br_ssh_pubkey ?= $(br_ssh_key).pub
 # Other SSH args for buildroot robots
 br_ssh_opts ?= -o stricthostkeychecking=no
 
@@ -164,6 +166,12 @@ systemctl stop opentrons-api-server &&\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
 unzip -o /data/opentrons-*.whl && cleanup || cleanup"
+
+.PHONY: install-key
+install-key:
+	curl -X POST $(host):31950/server/ssh_keys\
+		-H "Content-Type: application/json"\
+		-d "{\"key\":\"$(shell cat $(br_ssh_pubkey))\"}"
 
 .PHONY: flash
 flash:


### PR DESCRIPTION
make install-key in api will try and install an ssh public key.

It needs the host option
With no key options, it will try and load ~/.ssh/robot_key.pub
With br_ssh_key set, it will try and load $(br_ssh_key).pub
With br_ssh_pubkey set, it will try and load that file directly

This can be used to remote into robots with your own key, or robots that don't
have a key installed.
