### PR TITLE
refactor(app): Show migration warning for balena robots

### DIFF
--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -5,11 +5,12 @@ import styles from './styles.css'
 
 type Props = {
   ignoreUpdate: () => mixed,
+  viewUpdate: () => mixed,
 }
 
 const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
-  const { ignoreUpdate } = props
+  const { ignoreUpdate, viewUpdate } = props
   return (
     <AlertModal
       heading={HEADING}
@@ -17,6 +18,7 @@ export default function UpdateBuildroot(props: Props) {
         { children: 'not now', onClick: ignoreUpdate },
         {
           children: 'view robot update',
+          onClick: viewUpdate,
           className: styles.view_update_button,
         },
       ]}

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -1,27 +1,20 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { AlertModal } from '@opentrons/components'
 import styles from './styles.css'
 
 type Props = {
-  parentUrl: string,
-  ignoreBuildrootUpdate: () => mixed,
+  ignoreUpdate: () => mixed,
 }
+
 const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
-  const { parentUrl, ignoreBuildrootUpdate } = props
-  const notNowButton = {
-    Component: Link,
-    to: parentUrl,
-    children: 'not now',
-    onClick: ignoreBuildrootUpdate,
-  }
+  const { ignoreUpdate } = props
   return (
     <AlertModal
       heading={HEADING}
       buttons={[
-        notNowButton,
+        { children: 'not now', onClick: ignoreUpdate },
         {
           children: 'view robot update',
           className: styles.view_update_button,
@@ -31,7 +24,7 @@ export default function UpdateBuildroot(props: Props) {
       contentsClassName={styles.system_update_modal}
     >
       <p className={styles.system_update_warning}>
-        This update is a little different than previous updates.{' '}
+        This update is a little different than previous updates.
       </p>
 
       <p>

--- a/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/SyncRobotModal.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
+import UpdateBuildroot from '../UpdateBuildroot'
 import { ScrollableAlertModal } from '../../modals'
 import ReleaseNotes from '../../ReleaseNotes'
 
@@ -20,6 +21,9 @@ type Props = {
   ignoreUpdate: () => mixed,
   update: () => mixed,
   showReleaseNotes: boolean,
+  __buildrootEnabled: boolean,
+  buildrootUpdateAvailable: boolean,
+  buildrootUpdateSeen: boolean,
 }
 
 type SyncRobotState = {
@@ -46,6 +50,9 @@ export default class SyncRobotModal extends React.Component<
       update,
       ignoreUpdate,
       parentUrl,
+      buildrootUpdateSeen,
+      __buildrootEnabled,
+      buildrootUpdateAvailable,
     } = this.props
 
     const { version } = updateInfo
@@ -78,6 +85,16 @@ export default class SyncRobotModal extends React.Component<
           onClick: update,
         },
       ]
+    }
+
+    const showMigrationModal =
+      buildrootUpdateAvailable &&
+      showReleaseNotes &&
+      __buildrootEnabled &&
+      !buildrootUpdateSeen
+
+    if (showMigrationModal) {
+      return <UpdateBuildroot ignoreUpdate={ignoreUpdate} />
     }
 
     return (

--- a/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateRobot/UpdateRobotModal.js
@@ -10,7 +10,7 @@ import {
   setIgnoredUpdate,
 } from '../../../http-api-client'
 
-import { getRobotApiVersion } from '../../../discovery'
+import { getRobotApiVersion, getRobotBuildrootStatus } from '../../../discovery'
 
 import {
   CURRENT_VERSION,
@@ -27,7 +27,7 @@ import ReinstallModal from './ReinstallModal'
 import type { State, Dispatch } from '../../../types'
 import type { ShellUpdateState } from '../../../shell'
 
-import type { ViewableRobot } from '../../../discovery'
+import type { ViewableRobot, BuildrootStatus } from '../../../discovery'
 import type { RobotUpdateInfo } from '../../../http-api-client'
 
 type OP = {|
@@ -44,6 +44,7 @@ type SP = {|
   robotUpdateInfo: RobotUpdateInfo,
   buildrootUpdateSeen: boolean,
   buildrootUpdateAvailable: boolean,
+  buildrootStatus: BuildrootStatus | null,
 |}
 
 type DP = {| dispatch: Dispatch |}
@@ -108,6 +109,7 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
           __buildrootEnabled={this.props.__buildrootEnabled}
           buildrootUpdateAvailable={this.props.buildrootUpdateAvailable}
           buildrootUpdateSeen={this.props.buildrootUpdateSeen}
+          buildrootStatus={this.props.buildrootStatus}
           showReleaseNotes={buildrootUpdateSeen && isUpgrade && ignoreAppUpdate}
         />
       )
@@ -132,6 +134,7 @@ function makeMapStateToProps(): (State, OP) => SP {
       robotUpdateInfo,
       buildrootUpdateAvailable,
       buildrootUpdateSeen: getBuildrootUpdateSeen(state),
+      buildrootStatus: getRobotBuildrootStatus(ownProps.robot),
     }
   }
 }

--- a/app/src/components/RobotSettings/UpdateRobot/index.js
+++ b/app/src/components/RobotSettings/UpdateRobot/index.js
@@ -13,7 +13,13 @@ import type { ViewableRobot } from '../../../discovery'
 import type { ShellUpdateState } from '../../../shell'
 import type { RobotServerUpdate } from '../../../http-api-client'
 
-type OP = {| robot: ViewableRobot, appUpdate: ShellUpdateState |}
+type OP = {|
+  robot: ViewableRobot,
+  appUpdate: ShellUpdateState,
+  appVersion: string,
+  robotVersion: string,
+  __buildrootEnabled: boolean,
+|}
 
 type SP = {| updateRequest: RobotServerUpdate |}
 
@@ -22,7 +28,7 @@ type Props = { ...OP, ...SP }
 export default connect<Props, OP, SP, _, _, _>(makeMapStateToProps)(UpdateRobot)
 
 function UpdateRobot(props: Props) {
-  const { updateRequest, robot, appUpdate } = props
+  const { updateRequest, robot, appUpdate, appVersion, robotVersion } = props
 
   if (updateRequest.response) {
     return <RestartRobotModal robot={robot} />
@@ -32,7 +38,15 @@ function UpdateRobot(props: Props) {
     return <SpinnerModal message="Robot is updating" alertOverlay />
   }
 
-  return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
+  return (
+    <UpdateRobotModal
+      robot={robot}
+      appUpdate={appUpdate}
+      appVersion={appVersion}
+      robotVersion={robotVersion}
+      __buildrootEnabled={props.__buildrootEnabled}
+    />
+  )
 }
 
 function makeMapStateToProps(): (State, OP) => SP {

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -13,6 +13,8 @@ import ConnectAlertModal from './ConnectAlertModal'
 import type { ViewableRobot } from '../../discovery'
 
 type Props = {
+  appVersion: string,
+  robotVersion: string,
   robot: ViewableRobot,
   updateUrl: string,
   calibrateDeckUrl: string,
@@ -20,7 +22,14 @@ type Props = {
 }
 
 export default function RobotSettings(props: Props) {
-  const { robot, updateUrl, calibrateDeckUrl, resetUrl } = props
+  const {
+    robot,
+    updateUrl,
+    calibrateDeckUrl,
+    resetUrl,
+    appVersion,
+    robotVersion,
+  } = props
 
   return (
     <CardContainer>
@@ -28,7 +37,12 @@ export default function RobotSettings(props: Props) {
         <StatusCard robot={robot} />
       </CardRow>
       <CardRow>
-        <InformationCard robot={robot} updateUrl={updateUrl} />
+        <InformationCard
+          robot={robot}
+          updateUrl={updateUrl}
+          appVersion={appVersion}
+          robotVersion={robotVersion}
+        />
       </CardRow>
       <CardRow>
         <ControlsCard robot={robot} calibrateDeckUrl={calibrateDeckUrl} />

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -13,6 +13,7 @@ import { CONNECTABLE, REACHABLE, getRobotApiVersion } from '../../discovery'
 import {
   CURRENT_VERSION,
   getUpdateInfo as getBuildrootUpdateInfo,
+  getBuildrootUpdateSeen,
 } from '../../shell'
 
 import {
@@ -203,13 +204,16 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     const __buildrootEnabled = Boolean(
       getConfig(state).devInternal?.enableBuildRoot
     )
+
     const updateInfo = __buildrootEnabled
       ? getBuildrootUpdateInfo(appVersion, robotVersion)
       : getRobotUpdateInfo(state, ownProps.robot)
 
+    const buildrootUpdateSeen = getBuildrootUpdateSeen(state)
+
     let showUpdateModal: ?boolean
     if (__buildrootEnabled) {
-      showUpdateModal = robotVersion !== appVersion
+      showUpdateModal = robotVersion !== appVersion && !buildrootUpdateSeen
     } else {
       showUpdateModal =
         // only show the alert modal if there's an upgrade available

--- a/app/src/shell/buildroot.js
+++ b/app/src/shell/buildroot.js
@@ -13,6 +13,13 @@ export type BuildrootState = {
   info: BuildrootUpdateInfo | null,
 }
 
+// TODO (ka 2019-6-27): These types are the same as in http-api-update server
+// Once feature flag removed, swap out all instances of the server version with these
+
+export type RobotUpdateType = 'upgrade' | 'downgrade' | null
+
+export type RobotUpdateInfo = { version: string, type: RobotUpdateType }
+
 const {
   buildroot: { getUpdateFileContents },
 } = global.APP_SHELL
@@ -79,4 +86,18 @@ export function getBuildrootUpdateAvailable(
     return compareCurrentVersionToUpdate(currentVersion, updateVersion)
   }
   return false
+}
+
+export function getUpdateInfo(
+  appVersion: string,
+  robotVersion: string
+): RobotUpdateInfo {
+  const current = semver.valid(robotVersion)
+  let type = null
+  if (current && semver.gt(appVersion, robotVersion)) {
+    type = 'upgrade'
+  } else if (current && semver.lt(appVersion, robotVersion)) {
+    type = 'downgrade'
+  }
+  return { version: appVersion, type: type }
 }

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -9,12 +9,19 @@ export type HealthResponse = {
   logs?: Array<string>,
 }
 
+export type Capability = 'buildroot-migration' | 'buildroot-update' | 'restart'
+
+export type CapabilityMap = {
+  [capabilityName: Capability]: string,
+}
+
 export type ServerHealthResponse = {
   name: string,
   apiServerVersion: string,
   updateServerVersion: string,
   smoothieVersion: string,
   systemVersion: string,
+  capabilities?: CapabilityMap,
 }
 
 export type Candidate = {


### PR DESCRIPTION
## overview

addresses  #3561 by adding migration warning modal if a robot is on balena, and a buildroot update is available. (behind FF)

Note: Implement release notes from buildroot files not current API release notes implementation + dynamic title to be covered in #3562 and is not implemented in this PR/Issue

## changelog
- refactor(app): Show migration warning for balena robots

## review requests

`make -C app dev`

- [ ] Existing behavior unaffected - can still upgrade, downgrade, reinstall 

`make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1`
- This PR assumes a successful download of buildroot files in background (ping me for files/location)
- This PR assumes app and buildroot updates are coversioned

- [ ] auto show update modal if app and robot versions are out of sync (can fake this in package.json)
- [ ] sync robot modal shows accurate information (TODO)
- [ ] clicking [view robot update] shows migration warning for robots still on balena
- [ ] robots one buildroot do not get migration warning
- [ ] clicking [not now] button at any time sets buildroot update seen (sync robot or migration modal warning)
- [ ] clicking [view robot update] in migration warning modal shows release notes with disabled install button