### PR TITLE
chore(docs): Fix touch tip atomic command example

### DIFF
--- a/api/docs/source/atomic commands.rst
+++ b/api/docs/source/atomic commands.rst
@@ -257,7 +257,7 @@ When calling ``touch_tip()`` on a pipette, we have the option to specify a locat
 .. code-block:: python
 
     pipette.touch_tip()                  # touch tip within current location
-    pipette.touch_tip(-2)                # touch tip 2mm below the top of the current location
+    pipette.touch_tip(v_offset=-2)       # touch tip 2mm below the top of the current location
     pipette.touch_tip(plate.wells('B1')) # touch tip within plate:B1
 
 


### PR DESCRIPTION
You need to specify z_offset as a kwarg since it isn't the first positional
