### PR TITLE
feat(app): display pipettes gen2 in pipettes card

### DIFF
--- a/app/src/components/InstrumentSettings/InstrumentInfo.js
+++ b/app/src/components/InstrumentSettings/InstrumentInfo.js
@@ -29,8 +29,10 @@ const LABEL_BY_MOUNT = {
 export default function PipetteInfo(props: Props) {
   const { mount, model, robotName, onChangeClick, showSettings } = props
   const label = LABEL_BY_MOUNT[mount]
-  const pipette = model ? getPipetteModelSpecs(model) : null
-  const channels = pipette?.channels
+  const pipette = model && getPipetteModelSpecs(model)
+
+  const { displayName, channels } = pipette || {}
+
   const direction = model ? 'change' : 'attach'
 
   const changeUrl = `/robots/${robotName}/instruments/pipettes/change/${mount}`
@@ -44,7 +46,8 @@ export default function PipetteInfo(props: Props) {
     <div className={className}>
       <LabeledValue
         label={label}
-        value={(model || 'None').split('_').join(' ')}
+        value={(displayName || 'None').replace(/-/, '‑')} // non breaking hyphen
+        valueClassName={styles.pipette_display_name}
       />
 
       <div className={styles.button_group}>

--- a/app/src/components/InstrumentSettings/styles.css
+++ b/app/src/components/InstrumentSettings/styles.css
@@ -21,6 +21,10 @@
   }
 }
 
+.pipette_display_name {
+  width: min-content;
+}
+
 .image {
   height: 8rem;
   width: 2.25rem;

--- a/components/src/structure/LabeledValue.js
+++ b/components/src/structure/LabeledValue.js
@@ -13,6 +13,8 @@ type Props = {
   value: React.Node,
   /** Additional className */
   className?: string,
+  /** Additional value className */
+  valueClassName?: string,
 }
 
 export default function LabeledValue(props: Props) {
@@ -22,7 +24,9 @@ export default function LabeledValue(props: Props) {
   return (
     <div className={className}>
       <p className={styles.labeled_value_label}>{label}:</p>
-      <p className={styles.labeled_value_value}>{value}</p>
+      <p className={cx(styles.labeled_value_value, props.valueClassName)}>
+        {value}
+      </p>
     </div>
   )
 }


### PR DESCRIPTION
Correctly format display name for old pipettes and gen2 pipettes.

Closes #3594