### PR TITLE
refactor(api): Infer API version from protocol on upload

### DIFF
--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -1,9 +1,10 @@
 import itertools
 
 import pytest
+import ast
 
 from opentrons.api.session import (
-    _accumulate, _get_labware, _dedupe, extract_metadata)
+    _accumulate, _get_labware, _dedupe, extract_metadata, infer_version)
 from tests.opentrons.conftest import state
 from opentrons.legacy_api.robot.robot import Robot
 from functools import partial
@@ -357,8 +358,6 @@ async def test_session_create_error(main_router):
 
 
 def test_extract_metadata():
-    import ast
-
     expected = {
         'hello': 'world',
         'what?': 'no'
@@ -408,3 +407,103 @@ def run(ctx):
         name='<blank>',
         text=prot)
     assert session.metadata == expected
+
+
+def test_infer_version():
+    prot_api1_no_meta_a = """
+from opentrons import instruments
+
+p = instruments.P10_Single(mount='right')
+"""
+
+    prot_api1_no_meta_b = """
+import opentrons.instruments
+
+p = instruments.P10_Single(mount='right')
+"""
+
+    prot_api1_no_meta_c = """
+from opentrons import instruments as instr
+
+p = instr.P10_Single(mount='right')
+"""
+
+    prot_api1_meta1 = """
+from opentrons import instruments
+
+metadata = {
+  'apiLevel': '1'
+  }
+
+p = instruments.P10_Single(mount='right')
+"""
+
+    prot_api1_meta2 = """
+from opentrons import instruments
+
+metadata = {
+  'apiLevel': '2'
+  }
+
+p = instruments.P10_Single(mount='right')
+"""
+
+    prot_api2_no_meta = """
+from opentrons import types
+
+def run(ctx):
+    right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
+"""
+
+    prot_api2_meta1 = """
+from opentrons import types
+
+metadata = {
+  'apiLevel': '1'
+  }
+
+def run(ctx):
+    right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
+"""
+
+    prot_api2_meta2 = """
+from opentrons import types
+
+metadata = {
+  'apiLevel': '2'
+  }
+
+def run(ctx):
+    right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
+"""
+
+    expected = {
+        prot_api1_no_meta_a: '1',
+        prot_api1_no_meta_b: '1',
+        prot_api1_no_meta_c: '1',
+        prot_api1_meta1: '1',
+        prot_api1_meta2: '2',
+        prot_api2_no_meta: '2',
+        prot_api2_meta1: '1',
+        prot_api2_meta2: '2'
+    }
+
+    def check(prot):
+        parsed = ast.parse(prot, filename='test', mode='exec')
+        metadata = extract_metadata(parsed)
+        return infer_version(metadata, parsed)
+
+    assert check(prot_api1_no_meta_a) == expected[prot_api1_no_meta_a]
+    assert check(prot_api1_no_meta_b) == expected[prot_api1_no_meta_b]
+    assert check(prot_api1_no_meta_c) == expected[prot_api1_no_meta_c]
+    assert check(prot_api1_meta1) == expected[prot_api1_meta1]
+    assert check(prot_api1_meta2) == expected[prot_api1_meta2]
+    assert check(prot_api2_no_meta) == expected[prot_api2_no_meta]
+    assert check(prot_api2_meta1) == expected[prot_api2_meta1]
+    assert check(prot_api2_meta2) == expected[prot_api2_meta2]
+
+    # for protocol, expected_version in expected.items():
+    #     parsed = ast.parse(protocol, filename='test', mode='exec')
+    #     metadata = extract_metadata(parsed)
+    #     detected_version = infer_version(metadata, parsed)
+    #     assert detected_version == expected_version


### PR DESCRIPTION
## overview

Infer API version from protocol on upload. Closes #3537

## changelog

- Add functions to session module to infer protocol version on upload, based on rules in issue #3537

## review requests

Double-check that tests cover all relevant metadata packets and possible ways of writing imports
