### PR TITLE
refactor(app): Show robot system update modal

### DIFF
--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -56,16 +56,11 @@ function InformationCard(props: Props) {
     updateUrl,
     checkAppUpdate,
     version,
-    buildrootUpdateAvailable,
   } = props
   const { name, displayName, serverOk } = robot
   const firmwareVersion = getRobotFirmwareVersion(robot) || 'Unknown'
-  let updateText: string
-  if (props.__buildRootEnabled && buildrootUpdateAvailable) {
-    updateText = 'Upgrade'
-  } else {
-    updateText = updateInfo.type || 'Reinstall'
-  }
+
+  const updateText = updateInfo.type || 'Reinstall'
 
   return (
     <RefreshCard watch={name} refresh={fetchHealth} title={TITLE}>

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -60,6 +60,7 @@ function InformationCard(props: Props) {
   const { name, displayName, serverOk } = robot
   const firmwareVersion = getRobotFirmwareVersion(robot) || 'Unknown'
 
+  // NOTE: this logic still makes sense when buildroot is associated with a version bump
   const updateText = updateInfo.type || 'Reinstall'
 
   return (

--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -3,22 +3,18 @@
 
 import * as React from 'react'
 import { AlertModal } from '@opentrons/components'
-import styles from './styles.css'
+
+import type { ButtonProps } from '@opentrons/components'
 
 type Props = {
-  ignoreUpdate: () => mixed,
+  notNowButton: ButtonProps,
 }
 
-const HEADING = 'Robot System Update in Progress'
+const HEADING = 'Robot System Update Downloading'
 export default function DownloadUpdate(props: Props) {
-  const { ignoreUpdate } = props
+  const { notNowButton } = props
   return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[{ children: 'cancel', onClick: ignoreUpdate }]}
-      alertOverlay
-      contentsClassName={styles.system_update_modal}
-    >
+    <AlertModal heading={HEADING} buttons={[notNowButton]} alertOverlay>
       <h2>screen not implemented</h2>
     </AlertModal>
   )

--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -6,11 +6,11 @@ import { AlertModal } from '@opentrons/components'
 
 import type { ButtonProps } from '@opentrons/components'
 
-type Props = {
+type Props = {|
   notNowButton: ButtonProps,
   error: string | null,
   progress: number | null,
-}
+|}
 
 const HEADING = 'Robot System Update Downloading'
 export default function DownloadUpdate(props: Props) {

--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -25,11 +25,13 @@ export default function DownloadUpdate(props: Props) {
         <p>Some informative text about connecting to the internet</p>
       </>
     )
+  } else {
+    message = <p>Download progress: 0%</p>
   }
   return (
     <AlertModal heading={HEADING} buttons={[notNowButton]} alertOverlay>
       <h2>Screens not fully implemented!</h2>
-      <h3>{message}</h3>
+      {message}
     </AlertModal>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -8,14 +8,28 @@ import type { ButtonProps } from '@opentrons/components'
 
 type Props = {
   notNowButton: ButtonProps,
+  error: string | null,
+  progress: number | null,
 }
 
 const HEADING = 'Robot System Update Downloading'
 export default function DownloadUpdate(props: Props) {
-  const { notNowButton } = props
+  const { notNowButton, error, progress } = props
+  let message
+  if (progress) {
+    message = <p>Download progress: {progress}%</p>
+  } else if (error) {
+    message = (
+      <>
+        <p>{error}</p>
+        <p>Some informative text about connecting to the internet</p>
+      </>
+    )
+  }
   return (
     <AlertModal heading={HEADING} buttons={[notNowButton]} alertOverlay>
-      <h2>screen not implemented</h2>
+      <h2>Screens not fully implemented!</h2>
+      <h3>{message}</h3>
     </AlertModal>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -1,0 +1,25 @@
+// @flow
+// Placeholder modal for missing/downloading/errored update files
+
+import * as React from 'react'
+import { AlertModal } from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = {
+  ignoreUpdate: () => mixed,
+}
+
+const HEADING = 'Robot System Update in Progress'
+export default function DownloadUpdate(props: Props) {
+  const { ignoreUpdate } = props
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[{ children: 'cancel', onClick: ignoreUpdate }]}
+      alertOverlay
+      contentsClassName={styles.system_update_modal}
+    >
+      <h2>screen not implemented</h2>
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/InstallModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/InstallModal.js
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+
+import { AlertModal } from '@opentrons/components'
+
+type Props = {
+  parentUrl: string,
+  ignoreUpdate: () => mixed,
+}
+
+export default function InstallModal(props: Props) {
+  return (
+    <AlertModal
+      heading="Feature not Implemented"
+      buttons={[
+        {
+          Component: Link,
+          to: props.parentUrl,
+          children: 'not now',
+          onClick: props.ignoreUpdate,
+        },
+      ]}
+      alertOverlay
+    >
+      <p>TODO: Check Migration vs Update</p>
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
@@ -9,7 +9,7 @@ import styles from './styles.css'
 type Props = {
   versionProps: VersionProps,
   parentUrl: string,
-  update: () => mixed,
+  proceed: () => mixed,
 }
 
 const HEADING = 'Robot is up to date'
@@ -17,13 +17,13 @@ const REINSTALL_MESSAGE =
   "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
 
 export default function ReinstallModal(props: Props) {
-  const { parentUrl, update, versionProps } = props
+  const { parentUrl, proceed, versionProps } = props
   return (
     <AlertModal
       heading={HEADING}
       buttons={[
         { Component: Link, to: parentUrl, children: 'not now' },
-        { disabled: true, onClick: update, children: 'Reinstall' },
+        { onClick: proceed, children: 'Reinstall' },
       ]}
       alertOverlay
     >

--- a/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
@@ -12,7 +12,7 @@ type Props = {
   update: () => mixed,
 }
 
-const HEADING = 'Robot Server is up to date'
+const HEADING = 'Robot is up to date'
 const REINSTALL_MESSAGE =
   "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
 
@@ -23,7 +23,7 @@ export default function ReinstallModal(props: Props) {
       heading={HEADING}
       buttons={[
         { Component: Link, to: parentUrl, children: 'not now' },
-        { onClick: update, children: 'Reinstall', disabled: true },
+        { disabled: true, onClick: update, children: 'Reinstall' },
       ]}
       alertOverlay
     >

--- a/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ReinstallModal.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { AlertModal } from '@opentrons/components'
+import VersionList from './VersionList'
+import type { VersionProps } from './types'
+import styles from './styles.css'
+
+type Props = {
+  versionProps: VersionProps,
+  parentUrl: string,
+  update: () => mixed,
+}
+
+const HEADING = 'Robot Server is up to date'
+const REINSTALL_MESSAGE =
+  "It looks like your robot is already up to date, but if you're experiencing issues you can re-apply the latest update."
+
+export default function ReinstallModal(props: Props) {
+  const { parentUrl, update, versionProps } = props
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        { Component: Link, to: parentUrl, children: 'not now' },
+        { onClick: update, children: 'Reinstall', disabled: true },
+      ]}
+      alertOverlay
+    >
+      <p className={styles.reinstall_message}>{REINSTALL_MESSAGE}</p>
+      <VersionList {...versionProps} ignoreAppUpdate />
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/ReleaseNotesModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ReleaseNotesModal.js
@@ -4,14 +4,18 @@ import { ScrollableAlertModal } from '../../modals'
 import ReleaseNotes from '../../ReleaseNotes'
 import styles from './styles.css'
 import type { ButtonProps } from '@opentrons/components'
+import type { BuildrootStatus } from '../../../discovery'
 
 type Props = {
   notNowButton: ButtonProps,
   releaseNotes: ?string,
+  buildrootStatus: BuildrootStatus | null,
 }
 
 export default function ReleaseNotesModal(props: Props) {
-  const { notNowButton, releaseNotes } = props
+  const { notNowButton, releaseNotes, buildrootStatus } = props
+  const heading =
+    buildrootStatus === 'buildroot' ? 'Robot Update' : 'Robot System Update'
   const buttons = [
     notNowButton,
     {
@@ -21,11 +25,7 @@ export default function ReleaseNotesModal(props: Props) {
     },
   ]
   return (
-    <ScrollableAlertModal
-      heading="Robot System Update"
-      buttons={buttons}
-      alertOverlay
-    >
+    <ScrollableAlertModal heading={heading} buttons={buttons} alertOverlay>
       <ReleaseNotes source={releaseNotes} />
     </ScrollableAlertModal>
   )

--- a/app/src/components/RobotSettings/UpdateBuildroot/ReleaseNotesModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ReleaseNotesModal.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react'
+import { ScrollableAlertModal } from '../../modals'
+import ReleaseNotes from '../../ReleaseNotes'
+import styles from './styles.css'
+import type { ButtonProps } from '@opentrons/components'
+
+type Props = {
+  notNowButton: ButtonProps,
+  releaseNotes: ?string,
+}
+
+export default function ReleaseNotesModal(props: Props) {
+  const { notNowButton, releaseNotes } = props
+  const buttons = [
+    notNowButton,
+    {
+      children: 'update robot',
+      className: styles.view_update_button,
+      disabled: true,
+    },
+  ]
+  return (
+    <ScrollableAlertModal
+      heading="Robot System Update"
+      buttons={buttons}
+      alertOverlay
+    >
+      <ReleaseNotes source={releaseNotes} />
+    </ScrollableAlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+type Props = {
+  onClick: () => mixed,
+}
+
+const SKIP_APP_MESSAGE =
+  'If you wish to skip this app update and only sync your robot server with your current app version, please '
+
+export default function SkipAppUpdateMessage(props: Props) {
+  return (
+    <p className={styles.sync_message}>
+      {SKIP_APP_MESSAGE}
+      <a className={styles.sync_link} onClick={props.onClick}>
+        click here
+      </a>
+      .
+    </p>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SkipAppUpdateMessage.js
@@ -13,7 +13,7 @@ export default function SkipAppUpdateMessage(props: Props) {
   return (
     <p className={styles.sync_message}>
       {SKIP_APP_MESSAGE}
-      <a className={styles.sync_link} onClick={props.onClick}>
+      <a className={styles.sync_link} onClick={props.onClick} disabled>
         click here
       </a>
       .

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotMessage.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotMessage.js
@@ -1,0 +1,39 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+import type { RobotUpdateInfo } from '../../../http-api-client'
+type Props = {
+  updateInfo: RobotUpdateInfo,
+}
+
+const notSyncedMessage = (
+  <strong>
+    Your robot server version and app version are out of sync. <br />
+  </strong>
+)
+
+export default function SyncRobotMessage(props: Props) {
+  const {
+    updateInfo: { type, version },
+  } = props
+
+  if (type === 'upgrade') {
+    return (
+      <p className={styles.sync_message}>
+        {notSyncedMessage}
+        For optimal experience, we recommend you upgrade your robot server
+        version to match the app version.
+      </p>
+    )
+  }
+  if (type === 'downgrade') {
+    return (
+      <p className={styles.sync_message}>
+        {notSyncedMessage}
+        You may wish to downgrade to robot server version {version} to ensure
+        compatibility.
+      </p>
+    )
+  }
+  return null
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -1,0 +1,103 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+
+import SyncRobotMessage from './SyncRobotMessage'
+import VersionList from './VersionList'
+import { ScrollableAlertModal } from '../../modals'
+import ReleaseNotes from '../../ReleaseNotes'
+
+import { API_RELEASE_NOTES } from '../../../shell'
+
+import type { RobotUpdateInfo } from '../../../http-api-client'
+import type { VersionProps } from './types'
+import type { ButtonProps } from '@opentrons/components'
+
+type Props = {
+  updateInfo: RobotUpdateInfo,
+  parentUrl: string,
+  versionProps: VersionProps,
+  ignoreUpdate: () => mixed,
+  update: () => mixed,
+  showReleaseNotes: boolean,
+}
+
+type SyncRobotState = {
+  showReleaseNotes: boolean,
+}
+
+export default class SyncRobotModal extends React.Component<
+  Props,
+  SyncRobotState
+> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { showReleaseNotes: this.props.showReleaseNotes }
+  }
+
+  setShowReleaseNotes = () => {
+    this.setState({ showReleaseNotes: true })
+  }
+
+  render() {
+    const {
+      updateInfo,
+      versionProps,
+      update,
+      ignoreUpdate,
+      parentUrl,
+    } = this.props
+
+    const { version } = updateInfo
+    const { showReleaseNotes } = this.state
+
+    const heading = `Robot Server Version ${version} Available`
+    let buttons: Array<?ButtonProps>
+
+    if (showReleaseNotes) {
+      buttons = [
+        { onClick: ignoreUpdate, children: 'not now' },
+        {
+          children: 'Update Robot Server',
+          onClick: update,
+          disabled: true,
+        },
+      ]
+    } else if (updateInfo.type === 'upgrade') {
+      buttons = [
+        { onClick: ignoreUpdate, children: 'not now' },
+        {
+          children: 'View Robot Server Update',
+          onClick: this.setShowReleaseNotes,
+        },
+      ]
+    } else if (updateInfo.type === 'downgrade') {
+      buttons = [
+        { Component: Link, to: parentUrl, children: 'not now' },
+        {
+          children: 'Downgrade Robot',
+          onClick: update,
+          disabled: true,
+        },
+      ]
+    }
+
+    return (
+      <ScrollableAlertModal
+        heading={heading}
+        buttons={buttons}
+        alertOverlay
+        key={String(showReleaseNotes)}
+      >
+        {showReleaseNotes ? (
+          <ReleaseNotes source={API_RELEASE_NOTES} />
+        ) : (
+          <React.Fragment>
+            <SyncRobotMessage updateInfo={updateInfo} />
+            <VersionList {...versionProps} ignoreAppUpdate />
+          </React.Fragment>
+        )}
+      </ScrollableAlertModal>
+    )
+  }
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-
+import { Link } from 'react-router-dom'
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
 import { ScrollableAlertModal } from '../../modals'
@@ -37,7 +37,13 @@ export default class SyncRobotModal extends React.Component<
   }
 
   render() {
-    const { updateInfo, versionProps, update, ignoreUpdate } = this.props
+    const {
+      updateInfo,
+      versionProps,
+      update,
+      ignoreUpdate,
+      parentUrl,
+    } = this.props
 
     const { version } = updateInfo
     const { showReleaseNotes } = this.state
@@ -45,26 +51,33 @@ export default class SyncRobotModal extends React.Component<
     const heading = `Robot Server Version ${version} Available`
     let buttons: Array<?ButtonProps>
 
+    const notNowButton = {
+      Component: Link,
+      to: parentUrl,
+      onClick: ignoreUpdate,
+      children: 'not now',
+    }
+
     if (showReleaseNotes) {
       buttons = [
-        { onClick: ignoreUpdate, children: 'not now' },
+        notNowButton,
         {
-          children: 'Update Robot Server',
+          children: 'Update Robot',
           onClick: update,
           disabled: true,
         },
       ]
     } else if (updateInfo.type === 'upgrade') {
       buttons = [
-        { onClick: ignoreUpdate, children: 'not now' },
+        notNowButton,
         {
-          children: 'View Robot Server Update',
+          children: 'View Robot Update',
           onClick: this.setShowReleaseNotes,
         },
       ]
     } else if (updateInfo.type === 'downgrade') {
       buttons = [
-        { onClick: ignoreUpdate, children: 'not now' },
+        notNowButton,
         {
           children: 'Downgrade Robot',
           onClick: update,

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -41,7 +41,6 @@ export default function SyncRobotModal(props: Props) {
       {
         children: 'Downgrade Robot',
         onClick: proceed,
-        disabled: true,
       },
     ]
   }

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -1,12 +1,8 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
-import DownloadUpdateModal from './DownloadUpdateModal'
 import { ScrollableAlertModal } from '../../modals'
-import ReleaseNotes from '../../ReleaseNotes'
-import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
 
 import type { RobotUpdateInfo } from '../../../http-api-client'
 import type { VersionProps } from './types'
@@ -17,99 +13,45 @@ type Props = {
   parentUrl: string,
   versionProps: VersionProps,
   ignoreUpdate: () => mixed,
-  update: () => mixed,
-  showReleaseNotes: boolean,
-  buildrootUpdateAvailable: boolean,
+  proceed: () => mixed,
 }
 
-type SyncRobotState = {
-  showReleaseNotes: boolean,
-}
+export default function SyncRobotModal(props: Props) {
+  const { updateInfo, versionProps, ignoreUpdate, proceed } = props
 
-export default class SyncRobotModal extends React.Component<
-  Props,
-  SyncRobotState
-> {
-  constructor(props: Props) {
-    super(props)
-    this.state = { showReleaseNotes: this.props.showReleaseNotes }
+  let heading = 'Robot Update Available'
+  let buttons: Array<?ButtonProps>
+
+  const notNowButton = {
+    onClick: ignoreUpdate,
+    children: 'not now',
   }
 
-  setShowReleaseNotes = () => {
-    this.setState({ showReleaseNotes: true })
+  if (updateInfo.type === 'upgrade') {
+    buttons = [
+      notNowButton,
+      {
+        children: 'View Robot Update',
+        onClick: proceed,
+      },
+    ]
+  } else if (updateInfo.type === 'downgrade') {
+    buttons = [
+      notNowButton,
+      {
+        children: 'Downgrade Robot',
+        onClick: proceed,
+        disabled: true,
+      },
+    ]
   }
 
-  render() {
-    const {
-      updateInfo,
-      versionProps,
-      update,
-      ignoreUpdate,
-      parentUrl,
-      buildrootUpdateAvailable,
-    } = this.props
-
-    const { showReleaseNotes } = this.state
-
-    let heading = 'Robot Update Available'
-    let buttons: Array<?ButtonProps>
-
-    const notNowButton = {
-      Component: Link,
-      to: parentUrl,
-      onClick: ignoreUpdate,
-      children: 'not now',
-    }
-
-    if (showReleaseNotes && !buildrootUpdateAvailable) {
-      return <DownloadUpdateModal notNowButton={notNowButton} />
-    }
-
-    if (showReleaseNotes) {
-      heading = 'Robot Update'
-      buttons = [
-        notNowButton,
-        {
-          children: 'Update Robot',
-          onClick: update,
-          disabled: true,
-        },
-      ]
-    } else if (updateInfo.type === 'upgrade') {
-      buttons = [
-        notNowButton,
-        {
-          children: 'View Robot Update',
-          onClick: this.setShowReleaseNotes,
-        },
-      ]
-    } else if (updateInfo.type === 'downgrade') {
-      buttons = [
-        notNowButton,
-        {
-          children: 'Downgrade Robot',
-          onClick: update,
-          disabled: true,
-        },
-      ]
-    }
-
-    return (
-      <ScrollableAlertModal
-        heading={heading}
-        buttons={buttons}
-        alertOverlay
-        key={String(showReleaseNotes)}
-      >
-        {showReleaseNotes ? (
-          <ReleaseNotes source={BUILDROOT_RELEASE_NOTES} />
-        ) : (
-          <React.Fragment>
-            <SyncRobotMessage updateInfo={updateInfo} />
-            <VersionList {...versionProps} ignoreAppUpdate />
-          </React.Fragment>
-        )}
-      </ScrollableAlertModal>
-    )
-  }
+  return (
+    <ScrollableAlertModal heading={heading} buttons={buttons} alertOverlay>
+      <React.Fragment>
+        <SyncRobotMessage updateInfo={updateInfo} />
+        <VersionList {...versionProps} ignoreAppUpdate />
+      </React.Fragment>
+    </ScrollableAlertModal>
+  )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -4,7 +4,8 @@ import * as React from 'react'
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
 import { ScrollableAlertModal } from '../../modals'
-
+import ReleaseNotes from '../../ReleaseNotes'
+import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
 import type { RobotUpdateInfo } from '../../../http-api-client'
 import type { VersionProps } from './types'
 import type { ButtonProps } from '@opentrons/components'
@@ -80,7 +81,7 @@ export default class SyncRobotModal extends React.Component<
         key={String(showReleaseNotes)}
       >
         {showReleaseNotes ? (
-          <h2>TODO: get release notes from buildroot</h2>
+          <ReleaseNotes source={BUILDROOT_RELEASE_NOTES} />
         ) : (
           <React.Fragment>
             <SyncRobotMessage updateInfo={updateInfo} />

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -3,9 +3,11 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
+import DownloadUpdateModal from './DownloadUpdateModal'
 import { ScrollableAlertModal } from '../../modals'
 import ReleaseNotes from '../../ReleaseNotes'
 import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
+
 import type { RobotUpdateInfo } from '../../../http-api-client'
 import type { VersionProps } from './types'
 import type { ButtonProps } from '@opentrons/components'
@@ -17,6 +19,7 @@ type Props = {
   ignoreUpdate: () => mixed,
   update: () => mixed,
   showReleaseNotes: boolean,
+  buildrootUpdateAvailable: boolean,
 }
 
 type SyncRobotState = {
@@ -43,6 +46,7 @@ export default class SyncRobotModal extends React.Component<
       update,
       ignoreUpdate,
       parentUrl,
+      buildrootUpdateAvailable,
     } = this.props
 
     const { version } = updateInfo
@@ -56,6 +60,10 @@ export default class SyncRobotModal extends React.Component<
       to: parentUrl,
       onClick: ignoreUpdate,
       children: 'not now',
+    }
+
+    if (showReleaseNotes && !buildrootUpdateAvailable) {
+      return <DownloadUpdateModal notNowButton={notNowButton} />
     }
 
     if (showReleaseNotes) {

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -49,10 +49,9 @@ export default class SyncRobotModal extends React.Component<
       buildrootUpdateAvailable,
     } = this.props
 
-    const { version } = updateInfo
     const { showReleaseNotes } = this.state
 
-    const heading = `Robot Server Version ${version} Available`
+    let heading = 'Robot Update Available'
     let buttons: Array<?ButtonProps>
 
     const notNowButton = {
@@ -67,6 +66,7 @@ export default class SyncRobotModal extends React.Component<
     }
 
     if (showReleaseNotes) {
+      heading = 'Robot Update'
       buttons = [
         notNowButton,
         {

--- a/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SyncRobotModal.js
@@ -1,13 +1,9 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 
 import SyncRobotMessage from './SyncRobotMessage'
 import VersionList from './VersionList'
 import { ScrollableAlertModal } from '../../modals'
-import ReleaseNotes from '../../ReleaseNotes'
-
-import { API_RELEASE_NOTES } from '../../../shell'
 
 import type { RobotUpdateInfo } from '../../../http-api-client'
 import type { VersionProps } from './types'
@@ -40,13 +36,7 @@ export default class SyncRobotModal extends React.Component<
   }
 
   render() {
-    const {
-      updateInfo,
-      versionProps,
-      update,
-      ignoreUpdate,
-      parentUrl,
-    } = this.props
+    const { updateInfo, versionProps, update, ignoreUpdate } = this.props
 
     const { version } = updateInfo
     const { showReleaseNotes } = this.state
@@ -73,7 +63,7 @@ export default class SyncRobotModal extends React.Component<
       ]
     } else if (updateInfo.type === 'downgrade') {
       buttons = [
-        { Component: Link, to: parentUrl, children: 'not now' },
+        { onClick: ignoreUpdate, children: 'not now' },
         {
           children: 'Downgrade Robot',
           onClick: update,
@@ -90,7 +80,7 @@ export default class SyncRobotModal extends React.Component<
         key={String(showReleaseNotes)}
       >
         {showReleaseNotes ? (
-          <ReleaseNotes source={API_RELEASE_NOTES} />
+          <h2>TODO: get release notes from buildroot</h2>
         ) : (
           <React.Fragment>
             <SyncRobotMessage updateInfo={updateInfo} />

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 
 import { ScrollableAlertModal } from '../../modals'
+import ReleaseNotes from '../../ReleaseNotes'
+import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
 import styles from './styles.css'
 
 import type { ButtonProps } from '@opentrons/components'
@@ -15,6 +17,7 @@ const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
   const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
   const viewReleaseNotes = () => setShowReleaseNotes(true)
+  console.log(BUILDROOT_RELEASE_NOTES)
   const { parentUrl, ignoreUpdate } = props
   const notNowButton = {
     Component: Link,
@@ -45,16 +48,11 @@ export default function UpdateBuildroot(props: Props) {
   }
 
   return (
-    <ScrollableAlertModal
-      heading={HEADING}
-      buttons={buttons}
-      alertOverlay
-      contentsClassName={styles.system_update_modal}
-    >
+    <ScrollableAlertModal heading={HEADING} buttons={buttons} alertOverlay>
       {showReleaseNotes ? (
-        <h2>TODO: get release notes from buildroot</h2>
+        <ReleaseNotes source={BUILDROOT_RELEASE_NOTES} />
       ) : (
-        <>
+        <div className={styles.system_update_modal}>
           <p className={styles.system_update_warning}>
             This update is a little different than previous updates.{' '}
           </p>
@@ -70,7 +68,7 @@ export default function UpdateBuildroot(props: Props) {
             discoverable via USB or Wifi throughout the entire migration
             process.
           </p>
-        </>
+        </div>
       )}
     </ScrollableAlertModal>
   )

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -1,84 +1,47 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 
 import { ScrollableAlertModal } from '../../modals'
-import ReleaseNotes from '../../ReleaseNotes'
-import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
-import DownloadUpdateModal from './DownloadUpdateModal'
 import styles from './styles.css'
 
 import type { ButtonProps } from '@opentrons/components'
-import type { ViewableRobot } from '../../../discovery'
 
 type Props = {
-  robot: ViewableRobot,
-  parentUrl: string,
-  buildrootUpdateAvailable: boolean,
-  ignoreUpdate: () => mixed,
+  notNowButton: ButtonProps,
+  viewReleaseNotes: () => mixed,
 }
+
+const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
-  const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
-  const viewReleaseNotes = () => setShowReleaseNotes(true)
+  const { notNowButton, viewReleaseNotes } = props
 
-  const { parentUrl, ignoreUpdate, buildrootUpdateAvailable } = props
-  const notNowButton = {
-    Component: Link,
-    to: parentUrl,
-    children: 'not now',
-    onClick: ignoreUpdate,
-  }
-  let buttons: Array<?ButtonProps>
-  let heading = 'Robot System Update Available'
-
-  if (showReleaseNotes && !buildrootUpdateAvailable) {
-    return <DownloadUpdateModal notNowButton={notNowButton} />
-  }
-
-  if (showReleaseNotes) {
-    heading = 'Robot System Update'
-    buttons = [
-      notNowButton,
-      {
-        children: 'upgrade',
-        className: styles.view_update_button,
-        disabled: true,
-      },
-    ]
-  } else {
-    buttons = [
-      notNowButton,
-      {
-        children: 'view robot update',
-        className: styles.view_update_button,
-        onClick: viewReleaseNotes,
-      },
-    ]
-  }
+  const buttons: Array<?ButtonProps> = [
+    notNowButton,
+    {
+      children: 'view robot update',
+      className: styles.view_update_button,
+      onClick: viewReleaseNotes,
+    },
+  ]
 
   return (
-    <ScrollableAlertModal heading={heading} buttons={buttons} alertOverlay>
-      {showReleaseNotes ? (
-        <ReleaseNotes source={BUILDROOT_RELEASE_NOTES} />
-      ) : (
-        <div className={styles.system_update_modal}>
-          <p className={styles.system_update_warning}>
-            This update is a little different than previous updates.{' '}
-          </p>
+    <ScrollableAlertModal heading={HEADING} buttons={buttons} alertOverlay>
+      <div className={styles.system_update_modal}>
+        <p className={styles.system_update_warning}>
+          This update is a little different than previous updates.{' '}
+        </p>
 
-          <p>
-            In addition to delivering new features, this update changes the
-            robot’s operating system to improve robot stabillity and support.
-          </p>
+        <p>
+          In addition to delivering new features, this update changes the
+          robot’s operating system to improve robot stabillity and support.
+        </p>
 
-          <p>
-            Please note that this update will take an estimated 10-15 minutes,
-            will reboot your robot two times, and requires your OT-2 to remain
-            discoverable via USB or Wifi throughout the entire migration
-            process.
-          </p>
-        </div>
-      )}
+        <p>
+          Please note that this update will take an estimated 10-15 minutes,
+          will reboot your robot two times, and requires your OT-2 to remain
+          discoverable via USB or Wifi throughout the entire migration process.
+        </p>
+      </div>
     </ScrollableAlertModal>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -17,7 +17,6 @@ type Props = {
   buildrootUpdateAvailable: boolean,
   ignoreUpdate: () => mixed,
 }
-const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
   const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
   const viewReleaseNotes = () => setShowReleaseNotes(true)
@@ -30,12 +29,14 @@ export default function UpdateBuildroot(props: Props) {
     onClick: ignoreUpdate,
   }
   let buttons: Array<?ButtonProps>
+  let heading = 'Robot System Update Available'
 
   if (showReleaseNotes && !buildrootUpdateAvailable) {
     return <DownloadUpdateModal notNowButton={notNowButton} />
   }
 
   if (showReleaseNotes) {
+    heading = 'Robot System Update'
     buttons = [
       notNowButton,
       {
@@ -56,7 +57,7 @@ export default function UpdateBuildroot(props: Props) {
   }
 
   return (
-    <ScrollableAlertModal heading={HEADING} buttons={buttons} alertOverlay>
+    <ScrollableAlertModal heading={heading} buttons={buttons} alertOverlay>
       {showReleaseNotes ? (
         <ReleaseNotes source={BUILDROOT_RELEASE_NOTES} />
       ) : (

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -5,20 +5,24 @@ import { Link } from 'react-router-dom'
 import { ScrollableAlertModal } from '../../modals'
 import ReleaseNotes from '../../ReleaseNotes'
 import { BUILDROOT_RELEASE_NOTES } from '../../../shell'
+import DownloadUpdateModal from './DownloadUpdateModal'
 import styles from './styles.css'
 
 import type { ButtonProps } from '@opentrons/components'
+import type { ViewableRobot } from '../../../discovery'
 
 type Props = {
+  robot: ViewableRobot,
   parentUrl: string,
+  buildrootUpdateAvailable: boolean,
   ignoreUpdate: () => mixed,
 }
 const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
   const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
   const viewReleaseNotes = () => setShowReleaseNotes(true)
-  console.log(BUILDROOT_RELEASE_NOTES)
-  const { parentUrl, ignoreUpdate } = props
+
+  const { parentUrl, ignoreUpdate, buildrootUpdateAvailable } = props
   const notNowButton = {
     Component: Link,
     to: parentUrl,
@@ -26,6 +30,10 @@ export default function UpdateBuildroot(props: Props) {
     onClick: ignoreUpdate,
   }
   let buttons: Array<?ButtonProps>
+
+  if (showReleaseNotes && !buildrootUpdateAvailable) {
+    return <DownloadUpdateModal notNowButton={notNowButton} />
+  }
 
   if (showReleaseNotes) {
     buttons = [

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -1,8 +1,11 @@
 // @flow
 import * as React from 'react'
 import { Link } from 'react-router-dom'
-import { AlertModal } from '@opentrons/components'
+
+import { ScrollableAlertModal } from '../../modals'
 import styles from './styles.css'
+
+import type { ButtonProps } from '@opentrons/components'
 
 type Props = {
   parentUrl: string,
@@ -10,6 +13,8 @@ type Props = {
 }
 const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
+  const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
+  const viewReleaseNotes = () => setShowReleaseNotes(true)
   const { parentUrl, ignoreUpdate } = props
   const notNowButton = {
     Component: Link,
@@ -17,33 +22,56 @@ export default function UpdateBuildroot(props: Props) {
     children: 'not now',
     onClick: ignoreUpdate,
   }
+  let buttons: Array<?ButtonProps>
+
+  if (showReleaseNotes) {
+    buttons = [
+      notNowButton,
+      {
+        children: 'upgrade',
+        className: styles.view_update_button,
+        disabled: true,
+      },
+    ]
+  } else {
+    buttons = [
+      notNowButton,
+      {
+        children: 'view robot update',
+        className: styles.view_update_button,
+        onClick: viewReleaseNotes,
+      },
+    ]
+  }
+
   return (
-    <AlertModal
+    <ScrollableAlertModal
       heading={HEADING}
-      buttons={[
-        notNowButton,
-        {
-          children: 'view robot update',
-          className: styles.view_update_button,
-        },
-      ]}
+      buttons={buttons}
       alertOverlay
       contentsClassName={styles.system_update_modal}
     >
-      <p className={styles.system_update_warning}>
-        This update is a little different than previous updates.{' '}
-      </p>
+      {showReleaseNotes ? (
+        <h2>TODO: get release notes from buildroot</h2>
+      ) : (
+        <>
+          <p className={styles.system_update_warning}>
+            This update is a little different than previous updates.{' '}
+          </p>
 
-      <p>
-        In addition to delivering new features, this update changes the robot’s
-        operating system to improve robot stabillity and support.
-      </p>
+          <p>
+            In addition to delivering new features, this update changes the
+            robot’s operating system to improve robot stabillity and support.
+          </p>
 
-      <p>
-        Please note that this update will take an estimated 10-15 minutes, will
-        reboot your robot two times, and requires your OT-2 to remain
-        discoverable via USB or Wifi throughout the entire migration process.
-      </p>
-    </AlertModal>
+          <p>
+            Please note that this update will take an estimated 10-15 minutes,
+            will reboot your robot two times, and requires your OT-2 to remain
+            discoverable via USB or Wifi throughout the entire migration
+            process.
+          </p>
+        </>
+      )}
+    </ScrollableAlertModal>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/SystemUpdateModal.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+import { AlertModal } from '@opentrons/components'
+import styles from './styles.css'
+
+type Props = {
+  parentUrl: string,
+  ignoreUpdate: () => mixed,
+}
+const HEADING = 'Robot System Update Available'
+export default function UpdateBuildroot(props: Props) {
+  const { parentUrl, ignoreUpdate } = props
+  const notNowButton = {
+    Component: Link,
+    to: parentUrl,
+    children: 'not now',
+    onClick: ignoreUpdate,
+  }
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        notNowButton,
+        {
+          children: 'view robot update',
+          className: styles.view_update_button,
+        },
+      ]}
+      alertOverlay
+      contentsClassName={styles.system_update_modal}
+    >
+      <p className={styles.system_update_warning}>
+        This update is a little different than previous updates.{' '}
+      </p>
+
+      <p>
+        In addition to delivering new features, this update changes the robot’s
+        operating system to improve robot stabillity and support.
+      </p>
+
+      <p>
+        Please note that this update will take an estimated 10-15 minutes, will
+        reboot your robot two times, and requires your OT-2 to remain
+        discoverable via USB or Wifi throughout the entire migration process.
+      </p>
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppMessage.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppMessage.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import semver from 'semver'
+import styles from './styles.css'
+import type { VersionProps } from './types.js'
+
+const NEWER_VERSION = (
+  <strong>A newer version of the robot server is available.</strong>
+)
+const RECOMMEND_UPDATE_APP_FIRST = (
+  <React.Fragment>
+    We recommend you update your app first <em>before</em> updating your robot
+    server to ensure you have received all the latest improvements.
+  </React.Fragment>
+)
+const UPDATE_APP = (
+  <React.Fragment>
+    Please update your app to receive all the latest improvements and robot
+    server update.
+  </React.Fragment>
+)
+
+export default function UpdateAppMessage(props: VersionProps) {
+  const { appVersion, robotVersion } = props
+  const versionsMatch = semver.eq(appVersion, robotVersion)
+
+  return (
+    <p className={styles.sync_message}>
+      {NEWER_VERSION}
+      <br />
+      {!versionsMatch ? RECOMMEND_UPDATE_APP_FIRST : UPDATE_APP}
+    </p>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
@@ -1,0 +1,54 @@
+// @flow
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+
+import { AlertModal } from '@opentrons/components'
+import UpdateAppMessage from './UpdateAppMessage'
+import VersionList from './VersionList'
+import SkipAppUpdateMessage from './SkipAppUpdateMessage'
+
+import type { RobotUpdateInfo } from '../../../http-api-client'
+import type { VersionProps } from './types'
+
+type Props = {
+  updateInfo: RobotUpdateInfo,
+  parentUrl: string,
+  versionProps: VersionProps,
+  ignoreUpdate: () => mixed,
+  onClick: () => mixed,
+}
+
+export default function UpdateAppModal(props: Props) {
+  const { updateInfo, parentUrl, versionProps, onClick, ignoreUpdate } = props
+  const HEADING = `Robot Server Version ${
+    versionProps.availableUpdate
+  } Available`
+  const isUpgrade = updateInfo.type === 'upgrade'
+  let notNowButton
+  if (isUpgrade) {
+    notNowButton = {
+      onClick: ignoreUpdate,
+      children: 'not now',
+    }
+  } else {
+    notNowButton = { Component: Link, to: parentUrl, children: 'not now' }
+  }
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        notNowButton,
+        {
+          Component: Link,
+          to: '/menu/app/update',
+          children: 'View App Update',
+        },
+      ]}
+      alertOverlay
+    >
+      <UpdateAppMessage {...versionProps} />
+      <VersionList {...versionProps} />
+      <SkipAppUpdateMessage onClick={onClick} />
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
@@ -19,20 +19,17 @@ type Props = {
 }
 
 export default function UpdateAppModal(props: Props) {
-  const { updateInfo, parentUrl, versionProps, onClick, ignoreUpdate } = props
+  const { parentUrl, versionProps, onClick, ignoreUpdate } = props
   const HEADING = `Robot Server Version ${
     versionProps.availableUpdate
   } Available`
-  const isUpgrade = updateInfo.type === 'upgrade'
-  let notNowButton
-  if (isUpgrade) {
-    notNowButton = {
-      onClick: ignoreUpdate,
-      children: 'not now',
-    }
-  } else {
-    notNowButton = { Component: Link, to: parentUrl, children: 'not now' }
+  const notNowButton = {
+    Component: Link,
+    to: parentUrl,
+    children: 'not now',
+    onClick: ignoreUpdate,
   }
+
   return (
     <AlertModal
       heading={HEADING}

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateAppModal.js
@@ -20,9 +20,7 @@ type Props = {
 
 export default function UpdateAppModal(props: Props) {
   const { parentUrl, versionProps, onClick, ignoreUpdate } = props
-  const HEADING = `Robot Server Version ${
-    versionProps.availableUpdate
-  } Available`
+  const HEADING = `Robot Version ${versionProps.availableUpdate} Available`
   const notNowButton = {
     Component: Link,
     to: parentUrl,

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
@@ -41,9 +41,6 @@ type Props = {
 }
 
 function UpdateRobotModal(props: Props) {
-  const [ignoreAppUpdate, setIgnoreAppUpdate] = React.useState<boolean>(false)
-  const setAppUpdateIgnored = () => setIgnoreAppUpdate(true)
-
   const {
     parentUrl,
     appVersion,
@@ -56,16 +53,14 @@ function UpdateRobotModal(props: Props) {
   const robotUpdateVersion = robotUpdateInfo.version
   const availableUpdate = appUpdateVersion || robotUpdateVersion
   const versionProps = { appVersion, robotVersion, availableUpdate }
-  const isUpgrade = robotUpdateInfo.type === 'upgrade'
   const proceed = () => setCurrentStep('viewUpdateInfo')
-  const onClick = isUpgrade ? setAppUpdateIgnored : proceed
 
-  if (appUpdateAvailable && !ignoreAppUpdate) {
+  if (appUpdateAvailable) {
     return (
       <UpdateAppModal
         updateInfo={robotUpdateInfo}
         parentUrl={parentUrl}
-        onClick={onClick}
+        onClick={proceed}
         versionProps={versionProps}
         ignoreUpdate={props.ignoreUpdate}
       />

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
@@ -82,7 +82,11 @@ function UpdateRobotModal(props: Props) {
     )
   } else {
     return (
-      <ReinstallModal {...props} update={proceed} versionProps={versionProps} />
+      <ReinstallModal
+        {...props}
+        proceed={proceed}
+        versionProps={versionProps}
+      />
     )
   }
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
@@ -1,0 +1,133 @@
+// @flow
+import * as React from 'react'
+import { connect } from 'react-redux'
+
+import { push } from 'connected-react-router'
+
+import {
+  updateRobotServer,
+  makeGetRobotUpdateInfo,
+} from '../../../http-api-client'
+
+import { getRobotApiVersion } from '../../../discovery'
+
+import { CURRENT_VERSION, setBuildrootUpdateSeen } from '../../../shell'
+
+import UpdateAppModal from './UpdateAppModal'
+import SyncRobotModal from './SyncRobotModal'
+import ReinstallModal from './ReinstallModal'
+
+import type { State, Dispatch } from '../../../types'
+import type { ShellUpdateState } from '../../../shell'
+import type { ViewableRobot } from '../../../discovery'
+import type { RobotUpdateInfo } from '../../../http-api-client'
+
+type OP = {| robot: ViewableRobot, appUpdate: ShellUpdateState |}
+
+type SP = {|
+  appVersion: string,
+  robotVersion: string,
+  robotUpdateInfo: RobotUpdateInfo,
+|}
+
+type DP = {| dispatch: Dispatch |}
+
+type Props = {
+  ...OP,
+  ...SP,
+  parentUrl: string,
+  ignoreUpdate: () => mixed,
+  update: () => mixed,
+}
+
+type UpdateRobotState = {
+  ignoreAppUpdate: boolean,
+}
+
+class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { ignoreAppUpdate: false }
+  }
+
+  setIgnoreAppUpdate = () => {
+    this.setState({ ignoreAppUpdate: true })
+  }
+
+  render() {
+    const {
+      parentUrl,
+      appVersion,
+      robotVersion,
+      robotUpdateInfo,
+      appUpdate: { available: appUpdateAvailable, info: appUpdateInfo },
+    } = this.props
+    const { ignoreAppUpdate } = this.state
+    const appUpdateVersion = appUpdateInfo && appUpdateInfo.version
+    const robotUpdateVersion = robotUpdateInfo.version
+    const availableUpdate = appUpdateVersion || robotUpdateVersion
+    const versionProps = { appVersion, robotVersion, availableUpdate }
+    const isUpgrade = robotUpdateInfo.type === 'upgrade'
+    const onClick = isUpgrade ? this.setIgnoreAppUpdate : this.props.update
+
+    if (appUpdateAvailable && !ignoreAppUpdate) {
+      return (
+        <UpdateAppModal
+          updateInfo={robotUpdateInfo}
+          parentUrl={parentUrl}
+          onClick={onClick}
+          versionProps={versionProps}
+          ignoreUpdate={this.props.ignoreUpdate}
+        />
+      )
+    } else if (robotUpdateInfo.type) {
+      return (
+        <SyncRobotModal
+          updateInfo={robotUpdateInfo}
+          parentUrl={parentUrl}
+          versionProps={versionProps}
+          update={this.props.update}
+          ignoreUpdate={this.props.ignoreUpdate}
+          showReleaseNotes={isUpgrade && ignoreAppUpdate}
+        />
+      )
+    } else {
+      return <ReinstallModal {...this.props} versionProps={versionProps} />
+    }
+  }
+}
+
+function makeMapStateToProps(): (State, OP) => SP {
+  const getRobotUpdateInfo = makeGetRobotUpdateInfo()
+
+  return (state, ownProps) => ({
+    appVersion: CURRENT_VERSION,
+    robotVersion: getRobotApiVersion(ownProps.robot) || 'Unknown',
+    robotUpdateInfo: getRobotUpdateInfo(state, ownProps.robot),
+  })
+}
+
+function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
+  const { robot } = ownProps
+  const { robotUpdateInfo } = stateProps
+  const { dispatch } = dispatchProps
+  const parentUrl = `/robots/${robot.name}`
+  const close = () => dispatch(push(parentUrl))
+  let ignoreUpdate = robotUpdateInfo.type
+    ? () => dispatch(setBuildrootUpdateSeen())
+    : close
+
+  return {
+    ...ownProps,
+    ...stateProps,
+    parentUrl,
+    ignoreUpdate,
+    update: () => dispatch(updateRobotServer(robot)),
+  }
+}
+
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
+  makeMapStateToProps,
+  null,
+  mergeProps
+)(UpdateRobotModal)

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
@@ -4,10 +4,7 @@ import { connect } from 'react-redux'
 
 import { push } from 'connected-react-router'
 
-import {
-  updateRobotServer,
-  makeGetRobotUpdateInfo,
-} from '../../../http-api-client'
+import { makeGetRobotUpdateInfo } from '../../../http-api-client'
 
 import { getRobotApiVersion } from '../../../discovery'
 
@@ -26,7 +23,7 @@ type OP = {|
   robot: ViewableRobot,
   parentUrl: string,
   appUpdate: ShellUpdateState,
-  buildrootUpdateAvailable: boolean,
+  setCurrentStep: (step: string) => mixed,
 |}
 
 type SP = {|
@@ -41,65 +38,52 @@ type Props = {
   ...OP,
   ...SP,
   ignoreUpdate: () => mixed,
-  update: () => mixed,
 }
 
-type UpdateRobotState = {
-  ignoreAppUpdate: boolean,
-}
+function UpdateRobotModal(props: Props) {
+  const [ignoreAppUpdate, setIgnoreAppUpdate] = React.useState<boolean>(false)
+  const setAppUpdateIgnored = () => setIgnoreAppUpdate(true)
 
-class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
-  constructor(props: Props) {
-    super(props)
-    this.state = { ignoreAppUpdate: false }
-  }
+  const {
+    parentUrl,
+    appVersion,
+    robotVersion,
+    robotUpdateInfo,
+    appUpdate: { available: appUpdateAvailable, info: appUpdateInfo },
+    setCurrentStep,
+  } = props
+  const appUpdateVersion = appUpdateInfo && appUpdateInfo.version
+  const robotUpdateVersion = robotUpdateInfo.version
+  const availableUpdate = appUpdateVersion || robotUpdateVersion
+  const versionProps = { appVersion, robotVersion, availableUpdate }
+  const isUpgrade = robotUpdateInfo.type === 'upgrade'
+  const proceed = () => setCurrentStep('viewUpdateInfo')
+  const onClick = isUpgrade ? setAppUpdateIgnored : proceed
 
-  setIgnoreAppUpdate = () => {
-    this.setState({ ignoreAppUpdate: true })
-  }
-
-  render() {
-    const {
-      parentUrl,
-      appVersion,
-      robotVersion,
-      robotUpdateInfo,
-      buildrootUpdateAvailable,
-      appUpdate: { available: appUpdateAvailable, info: appUpdateInfo },
-    } = this.props
-    const { ignoreAppUpdate } = this.state
-    const appUpdateVersion = appUpdateInfo && appUpdateInfo.version
-    const robotUpdateVersion = robotUpdateInfo.version
-    const availableUpdate = appUpdateVersion || robotUpdateVersion
-    const versionProps = { appVersion, robotVersion, availableUpdate }
-    const isUpgrade = robotUpdateInfo.type === 'upgrade'
-    const onClick = isUpgrade ? this.setIgnoreAppUpdate : this.props.update
-
-    if (appUpdateAvailable && !ignoreAppUpdate) {
-      return (
-        <UpdateAppModal
-          updateInfo={robotUpdateInfo}
-          parentUrl={parentUrl}
-          onClick={onClick}
-          versionProps={versionProps}
-          ignoreUpdate={this.props.ignoreUpdate}
-        />
-      )
-    } else if (robotUpdateInfo.type) {
-      return (
-        <SyncRobotModal
-          updateInfo={robotUpdateInfo}
-          parentUrl={parentUrl}
-          versionProps={versionProps}
-          update={this.props.update}
-          ignoreUpdate={this.props.ignoreUpdate}
-          showReleaseNotes={isUpgrade && ignoreAppUpdate}
-          buildrootUpdateAvailable={buildrootUpdateAvailable}
-        />
-      )
-    } else {
-      return <ReinstallModal {...this.props} versionProps={versionProps} />
-    }
+  if (appUpdateAvailable && !ignoreAppUpdate) {
+    return (
+      <UpdateAppModal
+        updateInfo={robotUpdateInfo}
+        parentUrl={parentUrl}
+        onClick={onClick}
+        versionProps={versionProps}
+        ignoreUpdate={props.ignoreUpdate}
+      />
+    )
+  } else if (robotUpdateInfo.type) {
+    return (
+      <SyncRobotModal
+        updateInfo={robotUpdateInfo}
+        parentUrl={parentUrl}
+        versionProps={versionProps}
+        proceed={proceed}
+        ignoreUpdate={props.ignoreUpdate}
+      />
+    )
+  } else {
+    return (
+      <ReinstallModal {...props} update={proceed} versionProps={versionProps} />
+    )
   }
 }
 
@@ -114,21 +98,21 @@ function makeMapStateToProps(): (State, OP) => SP {
 }
 
 function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
-  const { robot } = ownProps
+  const { parentUrl } = ownProps
   const { robotUpdateInfo } = stateProps
   const { dispatch } = dispatchProps
-  const parentUrl = `/robots/${robot.name}`
   const close = () => dispatch(push(parentUrl))
   let ignoreUpdate = robotUpdateInfo.type
-    ? () => dispatch(setBuildrootUpdateSeen())
+    ? () => {
+        dispatch(setBuildrootUpdateSeen())
+        close()
+      }
     : close
 
   return {
     ...ownProps,
     ...stateProps,
-    parentUrl,
     ignoreUpdate,
-    update: () => dispatch(updateRobotServer(robot)),
   }
 }
 

--- a/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/UpdateRobotModal.js
@@ -22,7 +22,12 @@ import type { ShellUpdateState } from '../../../shell'
 import type { ViewableRobot } from '../../../discovery'
 import type { RobotUpdateInfo } from '../../../http-api-client'
 
-type OP = {| robot: ViewableRobot, appUpdate: ShellUpdateState |}
+type OP = {|
+  robot: ViewableRobot,
+  parentUrl: string,
+  appUpdate: ShellUpdateState,
+  buildrootUpdateAvailable: boolean,
+|}
 
 type SP = {|
   appVersion: string,
@@ -35,7 +40,6 @@ type DP = {| dispatch: Dispatch |}
 type Props = {
   ...OP,
   ...SP,
-  parentUrl: string,
   ignoreUpdate: () => mixed,
   update: () => mixed,
 }
@@ -60,6 +64,7 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
       appVersion,
       robotVersion,
       robotUpdateInfo,
+      buildrootUpdateAvailable,
       appUpdate: { available: appUpdateAvailable, info: appUpdateInfo },
     } = this.props
     const { ignoreAppUpdate } = this.state
@@ -89,6 +94,7 @@ class UpdateRobotModal extends React.Component<Props, UpdateRobotState> {
           update={this.props.update}
           ignoreUpdate={this.props.ignoreUpdate}
           showReleaseNotes={isUpgrade && ignoreAppUpdate}
+          buildrootUpdateAvailable={buildrootUpdateAvailable}
         />
       )
     } else {

--- a/app/src/components/RobotSettings/UpdateBuildroot/VersionList.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/VersionList.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+import type { VersionProps } from './types.js'
+
+type Props = {
+  ...$Exact<VersionProps>,
+  ignoreAppUpdate?: boolean,
+}
+export default function VersionList(props: Props) {
+  return (
+    <ol className={styles.version_list}>
+      <li>Your current app version: {props.appVersion}</li>
+      <li>Your current robot server version: {props.robotVersion}</li>
+      {!props.ignoreAppUpdate && (
+        <li>Available update: {props.availableUpdate}</li>
+      )}
+    </ol>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -74,6 +74,7 @@ function ViewUpdateModal(props: Props) {
       <ReleaseNotesModal
         notNowButton={notNowButton}
         releaseNotes={buildrootUpdateInfo?.releaseNotes}
+        buildrootStatus={buildrootStatus}
       />
     )
   }

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -4,10 +4,16 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 
 import { getRobotBuildrootStatus } from '../../../discovery'
-import { getBuildrootUpdateInfo, setBuildrootUpdateSeen } from '../../../shell'
+import {
+  getBuildrootUpdateInfo,
+  getBuildrootDownloadProgress,
+  getBuildrootDownloadError,
+  setBuildrootUpdateSeen,
+} from '../../../shell'
 import { makeGetRobotUpdateInfo } from '../../../http-api-client'
 
 import SystemUpdateModal from './SystemUpdateModal'
+import DownloadUpdateModal from './DownloadUpdateModal'
 import ReleaseNotesModal from './ReleaseNotesModal'
 
 import type { State, Dispatch } from '../../../types'
@@ -23,6 +29,8 @@ type OP = {|
 type SP = {|
   buildrootStatus: BuildrootStatus | null,
   buildrootUpdateInfo: BuildrootUpdateInfo | null,
+  buildrootDownloadProgress: number | null,
+  buildrootDownloadError: string | null,
   robotUpdateInfo: RobotUpdateInfo,
 |}
 
@@ -38,8 +46,9 @@ function ViewUpdateModal(props: Props) {
     ignoreUpdate,
     robotUpdateInfo,
     buildrootUpdateInfo,
+    buildrootDownloadError,
+    buildrootDownloadProgress,
   } = props
-  // TODO (ka 2019-7-10): This does not need to be a link or remove merge props
   const notNowButton = {
     onClick: ignoreUpdate,
     children: 'not now',
@@ -50,6 +59,14 @@ function ViewUpdateModal(props: Props) {
       <SystemUpdateModal
         notNowButton={notNowButton}
         viewReleaseNotes={viewReleaseNotes}
+      />
+    )
+  } else if (!buildrootUpdateInfo) {
+    return (
+      <DownloadUpdateModal
+        notNowButton={notNowButton}
+        error={buildrootDownloadError}
+        progress={buildrootDownloadProgress}
       />
     )
   } else if (showReleaseNotes && robotUpdateInfo.type === 'upgrade') {
@@ -69,6 +86,8 @@ function mapStateToProps(): (state: State, ownProps: OP) => SP {
   return (state, ownProps) => ({
     buildrootStatus: getRobotBuildrootStatus(ownProps.robot),
     buildrootUpdateInfo: getBuildrootUpdateInfo(state),
+    buildrootDownloadProgress: getBuildrootDownloadProgress(state),
+    buildrootDownloadError: getBuildrootDownloadError(state),
     robotUpdateInfo: getRobotUpdateInfo(state, ownProps.robot),
   })
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -1,0 +1,101 @@
+// @flow
+import * as React from 'react'
+import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
+
+import { getRobotBuildrootStatus } from '../../../discovery'
+import { getBuildrootUpdateInfo, setBuildrootUpdateSeen } from '../../../shell'
+import { makeGetRobotUpdateInfo } from '../../../http-api-client'
+
+import SystemUpdateModal from './SystemUpdateModal'
+import ReleaseNotesModal from './ReleaseNotesModal'
+
+import type { State, Dispatch } from '../../../types'
+import type { ViewableRobot, BuildrootStatus } from '../../../discovery'
+import type { BuildrootUpdateInfo } from '../../../shell'
+import type { RobotUpdateInfo } from '../../../http-api-client'
+
+type OP = {|
+  robot: ViewableRobot,
+  parentUrl: string,
+|}
+
+type SP = {|
+  buildrootStatus: BuildrootStatus | null,
+  buildrootUpdateInfo: BuildrootUpdateInfo | null,
+  robotUpdateInfo: RobotUpdateInfo,
+|}
+
+type DP = {| dispatch: Dispatch |}
+
+type Props = { ...OP, ...SP, ignoreUpdate: () => mixed }
+
+function ViewUpdateModal(props: Props) {
+  const [showReleaseNotes, setShowReleaseNotes] = React.useState<boolean>(false)
+  const viewReleaseNotes = () => setShowReleaseNotes(true)
+  const {
+    buildrootStatus,
+    ignoreUpdate,
+    robotUpdateInfo,
+    buildrootUpdateInfo,
+  } = props
+  // TODO (ka 2019-7-10): This does not need to be a link or remove merge props
+  const notNowButton = {
+    onClick: ignoreUpdate,
+    children: 'not now',
+  }
+
+  if (buildrootStatus === 'balena' && !showReleaseNotes) {
+    return (
+      <SystemUpdateModal
+        notNowButton={notNowButton}
+        viewReleaseNotes={viewReleaseNotes}
+      />
+    )
+  } else if (showReleaseNotes && robotUpdateInfo.type === 'upgrade') {
+    return (
+      <ReleaseNotesModal
+        notNowButton={notNowButton}
+        releaseNotes={buildrootUpdateInfo?.releaseNotes}
+      />
+    )
+  }
+
+  return null
+}
+
+function mapStateToProps(): (state: State, ownProps: OP) => SP {
+  const getRobotUpdateInfo = makeGetRobotUpdateInfo()
+  return (state, ownProps) => ({
+    buildrootStatus: getRobotBuildrootStatus(ownProps.robot),
+    buildrootUpdateInfo: getBuildrootUpdateInfo(state),
+    robotUpdateInfo: getRobotUpdateInfo(state, ownProps.robot),
+  })
+}
+
+// TODO (ka 2019-7-10): This is identical to UpdateRobotModal,
+// consider moving this up to index
+function mergeProps(stateProps: SP, dispatchProps: DP, ownProps: OP): Props {
+  const { parentUrl } = ownProps
+  const { robotUpdateInfo } = stateProps
+  const { dispatch } = dispatchProps
+  const close = () => dispatch(push(parentUrl))
+  let ignoreUpdate = robotUpdateInfo.type
+    ? () => {
+        dispatch(setBuildrootUpdateSeen())
+        close()
+      }
+    : close
+
+  return {
+    ...ownProps,
+    ...stateProps,
+    ignoreUpdate,
+  }
+}
+
+export default connect<Props, OP, SP, {||}, State, Dispatch>(
+  mapStateToProps,
+  null,
+  mergeProps
+)(ViewUpdateModal)

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -60,13 +60,12 @@ function ViewUpdateModal(props: Props) {
   }
 
   React.useEffect(() => {
-    const proceedToInstall = () => setCurrentStep('installUpdate')
     if (robotUpdateInfo.type !== 'upgrade' && buildrootUpdateInfo) {
       if (
         (buildrootStatus === 'balena' && migrationWarningSeen) ||
         buildrootStatus !== 'balena'
       ) {
-        proceedToInstall()
+        setCurrentStep('installUpdate')
       }
     }
   }, [

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -1,48 +1,34 @@
 // @flow
 import * as React from 'react'
 
-import SystemUpdateModal from './SystemUpdateModal'
 import UpdateRobotModal from './UpdateRobotModal'
+import ViewUpdateModal from './ViewUpdateModal'
 
-import type { BuildrootStatus, ViewableRobot } from '../../../discovery'
+import type { ViewableRobot } from '../../../discovery'
 import type { ShellUpdateState } from '../../../shell'
 
 type Props = {
   robot: ViewableRobot,
   appUpdate: ShellUpdateState,
   parentUrl: string,
-  buildrootStatus: BuildrootStatus | null,
-  buildrootUpdateAvailable: boolean,
-  ignoreBuildrootUpdate: () => mixed,
 }
 
 export default function UpdateBuildroot(props: Props) {
-  const {
-    robot,
-    parentUrl,
-    appUpdate,
-    buildrootStatus,
-    buildrootUpdateAvailable,
-    ignoreBuildrootUpdate,
-  } = props
-  if (buildrootStatus === 'balena') {
-    return (
-      <SystemUpdateModal
-        robot={robot}
-        parentUrl={parentUrl}
-        ignoreUpdate={ignoreBuildrootUpdate}
-        buildrootUpdateAvailable={buildrootUpdateAvailable}
-      />
-    )
-  } else if (buildrootStatus === 'buildroot') {
+  const [currentStep, setCurrentStep] = React.useState<string>(
+    'versionMismatch'
+  )
+  const { robot, parentUrl, appUpdate } = props
+  if (currentStep === 'versionMismatch') {
     return (
       <UpdateRobotModal
         robot={robot}
         parentUrl={parentUrl}
         appUpdate={appUpdate}
-        buildrootUpdateAvailable={buildrootUpdateAvailable}
+        setCurrentStep={setCurrentStep}
       />
     )
+  } else if (currentStep === 'viewUpdateInfo') {
+    return <ViewUpdateModal robot={robot} parentUrl={parentUrl} />
   }
   return null
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 
 import UpdateRobotModal from './UpdateRobotModal'
 import ViewUpdateModal from './ViewUpdateModal'
+import InstallModal from './InstallModal'
 
 import type { ViewableRobot } from '../../../discovery'
 import type { ShellUpdateState } from '../../../shell'
@@ -11,13 +12,14 @@ type Props = {
   robot: ViewableRobot,
   appUpdate: ShellUpdateState,
   parentUrl: string,
+  ignoreBuildrootUpdate: () => mixed,
 }
 
 export default function UpdateBuildroot(props: Props) {
   const [currentStep, setCurrentStep] = React.useState<string>(
     'versionMismatch'
   )
-  const { robot, parentUrl, appUpdate } = props
+  const { robot, parentUrl, appUpdate, ignoreBuildrootUpdate } = props
   if (currentStep === 'versionMismatch') {
     return (
       <UpdateRobotModal
@@ -28,7 +30,20 @@ export default function UpdateBuildroot(props: Props) {
       />
     )
   } else if (currentStep === 'viewUpdateInfo') {
-    return <ViewUpdateModal robot={robot} parentUrl={parentUrl} />
+    return (
+      <ViewUpdateModal
+        robot={robot}
+        parentUrl={parentUrl}
+        setCurrentStep={setCurrentStep}
+      />
+    )
+  } else if (currentStep === 'installUpdate') {
+    return (
+      <InstallModal
+        parentUrl={parentUrl}
+        ignoreUpdate={ignoreBuildrootUpdate}
+      />
+    )
   }
   return null
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -1,15 +1,28 @@
 // @flow
 import * as React from 'react'
+
 import SystemUpdateModal from './SystemUpdateModal'
-import type { BuildrootStatus } from '../../../discovery'
+import UpdateRobotModal from './UpdateRobotModal'
+
+import type { BuildrootStatus, ViewableRobot } from '../../../discovery'
+import type { ShellUpdateState } from '../../../shell'
 
 type Props = {
+  robot: ViewableRobot,
+  appUpdate: ShellUpdateState,
   parentUrl: string,
   buildrootStatus: BuildrootStatus | null,
   ignoreBuildrootUpdate: () => mixed,
 }
+
 export default function UpdateBuildroot(props: Props) {
-  const { buildrootStatus, parentUrl, ignoreBuildrootUpdate } = props
+  const {
+    robot,
+    appUpdate,
+    buildrootStatus,
+    parentUrl,
+    ignoreBuildrootUpdate,
+  } = props
   if (buildrootStatus === 'balena') {
     return (
       <SystemUpdateModal
@@ -17,6 +30,8 @@ export default function UpdateBuildroot(props: Props) {
         parentUrl={parentUrl}
       />
     )
+  } else if (buildrootStatus === 'buildroot') {
+    return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
   }
   return null
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -12,26 +12,37 @@ type Props = {
   appUpdate: ShellUpdateState,
   parentUrl: string,
   buildrootStatus: BuildrootStatus | null,
+  buildrootUpdateAvailable: boolean,
   ignoreBuildrootUpdate: () => mixed,
 }
 
 export default function UpdateBuildroot(props: Props) {
   const {
     robot,
+    parentUrl,
     appUpdate,
     buildrootStatus,
-    parentUrl,
+    buildrootUpdateAvailable,
     ignoreBuildrootUpdate,
   } = props
   if (buildrootStatus === 'balena') {
     return (
       <SystemUpdateModal
-        ignoreUpdate={ignoreBuildrootUpdate}
+        robot={robot}
         parentUrl={parentUrl}
+        ignoreUpdate={ignoreBuildrootUpdate}
+        buildrootUpdateAvailable={buildrootUpdateAvailable}
       />
     )
   } else if (buildrootStatus === 'buildroot') {
-    return <UpdateRobotModal robot={robot} appUpdate={appUpdate} />
+    return (
+      <UpdateRobotModal
+        robot={robot}
+        parentUrl={parentUrl}
+        appUpdate={appUpdate}
+        buildrootUpdateAvailable={buildrootUpdateAvailable}
+      />
+    )
   }
   return null
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -1,49 +1,22 @@
 // @flow
 import * as React from 'react'
-import { Link } from 'react-router-dom'
-import { AlertModal } from '@opentrons/components'
-import styles from './styles.css'
+import SystemUpdateModal from './SystemUpdateModal'
+import type { BuildrootStatus } from '../../../discovery'
 
 type Props = {
   parentUrl: string,
+  buildrootStatus: BuildrootStatus | null,
   ignoreBuildrootUpdate: () => mixed,
 }
-const HEADING = 'Robot System Update Available'
 export default function UpdateBuildroot(props: Props) {
-  const { parentUrl, ignoreBuildrootUpdate } = props
-  const notNowButton = {
-    Component: Link,
-    to: parentUrl,
-    children: 'not now',
-    onClick: ignoreBuildrootUpdate,
+  const { buildrootStatus, parentUrl, ignoreBuildrootUpdate } = props
+  if (buildrootStatus === 'balena') {
+    return (
+      <SystemUpdateModal
+        ignoreUpdate={ignoreBuildrootUpdate}
+        parentUrl={parentUrl}
+      />
+    )
   }
-  return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[
-        notNowButton,
-        {
-          children: 'view robot update',
-          className: styles.view_update_button,
-        },
-      ]}
-      alertOverlay
-      contentsClassName={styles.system_update_modal}
-    >
-      <p className={styles.system_update_warning}>
-        This update is a little different than previous updates.{' '}
-      </p>
-
-      <p>
-        In addition to delivering new features, this update changes the robot’s
-        operating system to improve robot stabillity and support.
-      </p>
-
-      <p>
-        Please note that this update will take an estimated 10-15 minutes, will
-        reboot your robot two times, and requires your OT-2 to remain
-        discoverable via USB or Wifi throughout the entire migration process.
-      </p>
-    </AlertModal>
-  )
+  return null
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/styles.css
+++ b/app/src/components/RobotSettings/UpdateBuildroot/styles.css
@@ -1,7 +1,11 @@
 @import '@opentrons/components';
 
 .system_update_modal {
-  padding: 4rem 2rem 1rem;
+  padding: 0 1rem;
+
+  & > p {
+    margin-bottom: 1rem;
+  }
 }
 
 .system_update_warning {
@@ -10,4 +14,25 @@
 
 .view_update_button {
   width: auto;
+}
+
+.version_list {
+  @apply --font-body-1-dark;
+
+  margin: 0 0 1.5rem 2rem;
+}
+
+.sync_link {
+  color: var(--c-blue);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.sync_message {
+  margin-left: 1rem;
+  padding-bottom: 1rem;
+}
+
+.reinstall_message {
+  margin-left: 1rem;
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/types.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/types.js
@@ -1,0 +1,7 @@
+// @flow
+
+export type VersionProps = {
+  appVersion: string,
+  robotVersion: string,
+  availableUpdate: string,
+}

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -27,6 +27,7 @@ import type {
   ConnectableStatus,
   ReachableStatus,
   UnreachableStatus,
+  BuildrootStatus,
 } from './types'
 
 type GroupedRobotsMap = {
@@ -148,3 +149,29 @@ export const getRobotApiVersion = (robot: AnyRobot): ?string =>
 export const getRobotFirmwareVersion = (robot: AnyRobot): ?string =>
   (robot.health && robot.health.fw_version) ||
   (robot.serverHealth && robot.serverHealth.smoothieVersion)
+
+export const getRobotBuildrootStatus = (
+  robot: AnyRobot
+): BuildrootStatus | null => {
+  if (robot.serverHealth) {
+    // no capabilities object present, robot is on balena and not migration capable
+    if (!robot.serverHealth.capabilities) {
+      return 'balena'
+    }
+    // migration capable proceed to step 2 automatically
+    if (
+      robot.serverHealth.capabilities &&
+      robot.serverHealth.capabilities['buildroot-migration']
+    ) {
+      return 'migrating'
+    }
+    // robot is already on buildroot and capable of receiving normal buildroot updates
+    if (
+      robot.serverHealth.capabilities &&
+      robot.serverHealth.capabilities['buildroot-update']
+    ) {
+      return 'buildroot'
+    }
+  }
+  return null
+}

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -45,3 +45,5 @@ export type UnreachableRobot = {
 export type ViewableRobot = Robot | ReachableRobot
 
 export type AnyRobot = Robot | ReachableRobot | UnreachableRobot
+
+export type BuildrootStatus = 'balena' | 'migrating' | 'buildroot'

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -132,7 +132,7 @@ function RobotSettingsPage(props: Props) {
         <Route
           path={`${path}/${UPDATE_FRAGMENT}`}
           render={() => {
-            if (props.__buildRootEnabled && !props.buildrootUpdateSeen) {
+            if (props.__buildRootEnabled) {
               return (
                 <UpdateBuildroot
                   robot={robot}

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -15,11 +15,7 @@ import {
   getRobotApiVersion,
   getRobotBuildrootStatus,
 } from '../../discovery'
-import {
-  getBuildrootUpdateAvailable,
-  getBuildrootUpdateSeen,
-  setBuildrootUpdateSeen,
-} from '../../shell'
+import { getBuildrootUpdateSeen, setBuildrootUpdateSeen } from '../../shell'
 
 import {
   makeGetRobotHome,
@@ -62,7 +58,6 @@ type SP = {|
   showConnectAlert: boolean,
   homeInProgress: ?boolean,
   homeError: ?Error,
-  buildrootUpdateAvailable: boolean,
   __buildRootEnabled: boolean,
   buildrootUpdateSeen: boolean,
   buildrootStatus: BuildrootStatus | null,
@@ -101,7 +96,6 @@ function RobotSettingsPage(props: Props) {
     closeConnectAlert,
     showUpdateModal,
     buildrootStatus,
-    buildrootUpdateAvailable,
     ignoreBuildrootUpdate,
     match: { path, url },
   } = props
@@ -140,7 +134,6 @@ function RobotSettingsPage(props: Props) {
                   appUpdate={appUpdate}
                   parentUrl={url}
                   buildrootStatus={buildrootStatus}
-                  buildrootUpdateAvailable={buildrootUpdateAvailable}
                   ignoreBuildrootUpdate={ignoreBuildrootUpdate}
                 />
               )
@@ -211,9 +204,6 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     const ignoredRequest = getUpdateIgnoredRequest(state, robot)
     const restartRequest = getRestartRequest(state, robot)
     const updateInfo = getRobotUpdateInfo(state, robot)
-
-    const buildrootUpdateAvailable =
-      !!robotVersion && getBuildrootUpdateAvailable(state, robotVersion)
     const buildrootStatus = getRobotBuildrootStatus(robot)
     const buildrootUpdateSeen = getBuildrootUpdateSeen(state)
     const __buildRootEnabled = Boolean(
@@ -221,13 +211,8 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     )
     let showUpdateModal: ?boolean
     if (__buildRootEnabled) {
-      if (!buildrootUpdateSeen) {
-        showUpdateModal =
-          // version mismatch or robot is still on balena
-          robotVersion !== updateInfo.version || buildrootStatus === 'balena'
-      } else {
-        showUpdateModal = false
-      }
+      showUpdateModal =
+        !buildrootUpdateSeen && robotVersion !== updateInfo.version
     } else {
       showUpdateModal =
         // only show the alert modal if there's an upgrade available
@@ -246,7 +231,6 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     return {
       __buildRootEnabled,
       buildrootStatus,
-      buildrootUpdateAvailable,
       buildrootUpdateSeen,
       showUpdateModal: !!showUpdateModal,
       homeInProgress: homeRequest && homeRequest.inProgress,

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -132,10 +132,11 @@ function RobotSettingsPage(props: Props) {
         <Route
           path={`${path}/${UPDATE_FRAGMENT}`}
           render={() => {
-            if (props.__buildRootEnabled) {
+            if (props.__buildRootEnabled && !props.buildrootUpdateSeen) {
               return (
                 <UpdateBuildroot
                   robot={robot}
+                  appUpdate={appUpdate}
                   parentUrl={url}
                   buildrootStatus={buildrootStatus}
                   ignoreBuildrootUpdate={ignoreBuildrootUpdate}
@@ -218,11 +219,13 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     )
     let showUpdateModal: ?boolean
     if (__buildRootEnabled) {
-      showUpdateModal =
-        // buidlroot update not seen
-        !buildrootUpdateSeen &&
-        // version mismatch or robot is still on balena
-        (robotVersion !== updateInfo.version || buildrootStatus === 'balena')
+      if (!buildrootUpdateSeen) {
+        showUpdateModal =
+          // version mismatch or robot is still on balena
+          robotVersion !== updateInfo.version || buildrootStatus === 'balena'
+      } else {
+        showUpdateModal = false
+      }
     } else {
       showUpdateModal =
         // only show the alert modal if there's an upgrade available

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -101,6 +101,7 @@ function RobotSettingsPage(props: Props) {
     closeConnectAlert,
     showUpdateModal,
     buildrootStatus,
+    buildrootUpdateAvailable,
     ignoreBuildrootUpdate,
     match: { path, url },
   } = props
@@ -139,6 +140,7 @@ function RobotSettingsPage(props: Props) {
                   appUpdate={appUpdate}
                   parentUrl={url}
                   buildrootStatus={buildrootStatus}
+                  buildrootUpdateAvailable={buildrootUpdateAvailable}
                   ignoreBuildrootUpdate={ignoreBuildrootUpdate}
                 />
               )

--- a/app/src/shell/__tests__/api-update.test.js
+++ b/app/src/shell/__tests__/api-update.test.js
@@ -44,7 +44,10 @@ describe('shell/api-update', () => {
       {
         name: 'getApiUpdateVersion',
         selector: apiUpdate.getApiUpdateVersion,
-        state: { shell: { apiUpdate: { version: '1.0.0' } } },
+        state: {
+          shell: { apiUpdate: { version: '1.0.0' } },
+          config: { devInternal: { enableBuildRoot: false } },
+        },
         expected: '1.0.0',
       },
       {

--- a/app/src/shell/__tests__/buildroot.test.js
+++ b/app/src/shell/__tests__/buildroot.test.js
@@ -66,17 +66,15 @@ describe('shell/buildroot', () => {
           shell: {
             buildroot: {
               info: {
-                filename: 'foobar.zip',
-                apiVersion: '1.0.0',
-                serverVersion: '1.0.0',
+                releaseNotes: 'some release notes',
+                version: '1.0.0',
               },
             },
           },
         },
         expected: {
-          filename: 'foobar.zip',
-          apiVersion: '1.0.0',
-          serverVersion: '1.0.0',
+          releaseNotes: 'some release notes',
+          version: '1.0.0',
         },
       },
       {

--- a/app/src/shell/__tests__/buildroot.test.js
+++ b/app/src/shell/__tests__/buildroot.test.js
@@ -80,6 +80,30 @@ describe('shell/buildroot', () => {
         },
       },
       {
+        name: 'getBuildrootDownloadError',
+        selector: buildroot.getBuildrootDownloadError,
+        state: {
+          shell: {
+            buildroot: {
+              downloadError: 'error with download',
+            },
+          },
+        },
+        expected: 'error with download',
+      },
+      {
+        name: 'getBuildrootDownloadProgress',
+        selector: buildroot.getBuildrootDownloadProgress,
+        state: {
+          shell: {
+            buildroot: {
+              downloadProgress: 10,
+            },
+          },
+        },
+        expected: 10,
+      },
+      {
         name: 'getBuildrootUpdateSeen',
         selector: buildroot.getBuildrootUpdateSeen,
         state: {

--- a/app/src/shell/api-update.js
+++ b/app/src/shell/api-update.js
@@ -9,6 +9,7 @@ export type ApiUpdateInfo = {
 
 const {
   apiUpdate: { getUpdateInfo, getUpdateFileContents },
+  update: { CURRENT_VERSION },
 } = remote
 
 export function apiUpdateReducer(state: ?ApiUpdateInfo) {
@@ -21,6 +22,9 @@ export function getApiUpdateFilename(state: State): string {
 }
 
 export function getApiUpdateVersion(state: State): string {
+  if (state.config?.devInternal?.enableBuildRoot) {
+    return CURRENT_VERSION
+  }
   return state.shell.apiUpdate.version
 }
 

--- a/app/src/shell/buildroot.js
+++ b/app/src/shell/buildroot.js
@@ -59,6 +59,14 @@ export function getBuildrootUpdateSeen(state: State): boolean {
   return state.shell.buildroot?.seen || false
 }
 
+export function getBuildrootDownloadProgress(state: State): number | null {
+  return state.shell.buildroot.downloadProgress || null
+}
+
+export function getBuildrootDownloadError(state: State): string | null {
+  return state.shell.buildroot.downloadError || null
+}
+
 // TODO(mc, 2019-07-08): because of the size of this file, we should have
 // update request streamed directly from the main process. Remove this
 // commented out function when we have that in place

--- a/app/src/shell/buildroot.js
+++ b/app/src/shell/buildroot.js
@@ -60,11 +60,11 @@ export function getBuildrootUpdateSeen(state: State): boolean {
 }
 
 export function getBuildrootDownloadProgress(state: State): number | null {
-  return state.shell.buildroot.downloadProgress || null
+  return state.shell.buildroot.downloadProgress
 }
 
 export function getBuildrootDownloadError(state: State): string | null {
-  return state.shell.buildroot.downloadError || null
+  return state.shell.buildroot.downloadError
 }
 
 // TODO(mc, 2019-07-08): because of the size of this file, we should have

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -9,12 +9,19 @@ export type HealthResponse = {
   logs?: Array<string>,
 }
 
+export type Capability = 'buildroot-migration' | 'buildroot-update' | 'restart'
+
+export type CapabilityMap = {
+  [capabilityName: Capability]: string,
+}
+
 export type ServerHealthResponse = {
   name: string,
   apiServerVersion: string,
   updateServerVersion: string,
   smoothieVersion: string,
   systemVersion: string,
+  capabilities?: CapabilityMap,
 }
 
 export type Candidate = {


### PR DESCRIPTION
## overview

This PR 
- pops up sync robot modal when FF enabled and appVersion !== robotApiVersion
- clicking view robot update when robot is on balena then shows migration warning modal
- if buildroot files are not present, show placeholder download in progress/error modal
- gets new release notes from buildroot state

closes #3562 
closes #3561 

TODO in follow up PR:
- Format download progress/error screens and messages

Flow implemented based on discussion with @sfoster1 and @mcous 
<img width="1042" alt="Screen Shot 2019-07-02 at 10 38 11 AM" src="https://user-images.githubusercontent.com/3430313/60521625-9687b300-9cb5-11e9-9a50-d655788e55bc.png">


## changelog

- refactor(app): Show robot system update modal
- refactor(app): Add getBuildrootStaus selector
- refactor(app): Get BUILDROOT_RELEASE_NOTES from buildroot files

## review requests
**Old flow**
`make -C app dev`
- [ ] Old upgrade/downgrade/reinstall functionality unaffected


**Enable FF and point to manifest with release notes for testing**
```
make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1 OT_APP_BUILDROOT__MANIFEST_URL="https://ot-test-bucket.s3.amazonaws.com/releases.json"
```

- [ ] Pop up sync robot modal if appVersion !== robotApiVersion
- [ ] Not Now sets update seen in shell/buildroot state
- [ ] Robots on Balena show migration warning modal before release notes/download progress/error
- [ ] View Robot Update shows release notes from buildroot if fully downloaded without error
- [ ] View Robot Update shows placeholder download in progress modal if buildroot files not present
- [ ] All install buttons disabled 
- [ ] App update available shows before sync robot when applicable

- please run all version mismatch + reinstall scenarios to ground on a buildroot robot. I think i got them all, but this one's a doozy!
- note: Its easier to test this by changing the robot version, if you change the app version it will look for the matching buildroot version (which wont exist)
- This PR does not address styling or formatting of progress bar or error messages, that will be a separate PR

