### PR TITLE
fix(components): add remove scroll override prop to Modal

### DIFF
--- a/components/src/__tests__/__snapshots__/modals.test.js.snap
+++ b/components/src/__tests__/__snapshots__/modals.test.js.snap
@@ -63,45 +63,39 @@ exports[`modals AlertModal renders correctly 1`] = `
 
 exports[`modals ContinueModal renders correctly 1`] = `
 <div
-  onScrollCapture={[Function]}
-  onTouchMoveCapture={[Function]}
-  onWheelCapture={[Function]}
+  className="modal"
 >
   <div
-    className="modal"
+    className="overlay clickable"
+    onClick={[Function]}
+  />
+  <div
+    className="modal_contents alert_modal_wrapper no_alert_header"
   >
     <div
-      className="overlay clickable"
-      onClick={[Function]}
-    />
-    <div
-      className="modal_contents alert_modal_wrapper no_alert_header"
+      className="alert_modal_contents"
     >
-      <div
-        className="alert_modal_contents"
+      children
+    </div>
+    <div
+      className="alert_modal_buttons"
+    >
+      <button
+        className="button_outline alert_button"
+        onClick={[Function]}
+        title="Cancel"
+        type="button"
       >
-        children
-      </div>
-      <div
-        className="alert_modal_buttons"
+        Cancel
+      </button>
+      <button
+        className="button_outline alert_button"
+        onClick={[Function]}
+        title="Continue"
+        type="button"
       >
-        <button
-          className="button_outline alert_button"
-          onClick={[Function]}
-          title="Cancel"
-          type="button"
-        >
-          Cancel
-        </button>
-        <button
-          className="button_outline alert_button"
-          onClick={[Function]}
-          title="Continue"
-          type="button"
-        >
-          Continue
-        </button>
-      </div>
+        Continue
+      </button>
     </div>
   </div>
 </div>

--- a/components/src/modals/AlertModal.js
+++ b/components/src/modals/AlertModal.js
@@ -24,13 +24,22 @@ type Props = {
   alertOverlay?: boolean,
   /** override default alert icon */
   iconName?: IconName,
+  /** restricts scroll outside of Modal when open, true by default */
+  restrictOuterScroll?: boolean,
 }
 
 /**
  * Generic alert modal with a heading and a set of buttons at the bottom
  */
 export default function AlertModal(props: Props) {
-  const { heading, buttons, className, onCloseClick, alertOverlay } = props
+  const {
+    heading,
+    buttons,
+    className,
+    onCloseClick,
+    alertOverlay,
+    restrictOuterScroll,
+  } = props
   const iconName = props.iconName || 'alert'
   const wrapperStyle = cx(
     styles.alert_modal_wrapper,
@@ -46,6 +55,7 @@ export default function AlertModal(props: Props) {
       contentsClassName={wrapperStyle}
       onCloseClick={onCloseClick}
       alertOverlay={alertOverlay}
+      restrictOuterScroll={restrictOuterScroll}
     >
       {heading && (
         <div className={styles.alert_modal_heading}>

--- a/components/src/modals/AlertModal.md
+++ b/components/src/modals/AlertModal.md
@@ -20,6 +20,7 @@ const alertContents = {
         { children: 'bar', onClick: () => setState({ alert: 'bar' }) },
         { children: 'close', onClick: () => setState({ alert: '' }) },
       ]}
+      restrictOuterScroll={false}
     >
       {alertContents[state.alert]}
     </AlertModal>
@@ -50,6 +51,7 @@ const alertContents = {
         { children: 'bar', onClick: () => setState({ alert: 'bar' }) },
         { children: 'close', onClick: () => setState({ alert: '' }) },
       ]}
+      restrictOuterScroll={false}
     >
       {alertContents[state.alert]}
     </AlertModal>
@@ -80,6 +82,7 @@ const alertContents = {
         { children: 'close', onClick: () => setState({ alert: '' }) },
       ]}
       alertOverlay
+      restrictOuterScroll={false}
     >
       {alertContents[state.alert]}
     </AlertModal>
@@ -108,6 +111,7 @@ const alertContents = {
         { children: 'bar', onClick: () => setState({ alert: 'bar' }) },
         { children: 'close', onClick: () => setState({ alert: '' }) },
       ]}
+      restrictOuterScroll={false}
     >
       {alertContents[state.alert]}
     </AlertModal>

--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -32,6 +32,7 @@ export default function ContinueModal(props: ContinueModalProps) {
       className={className}
       buttons={buttons}
       onCloseClick={onCancelClick}
+      restrictOuterScroll={false}
     >
       {props.children}
     </AlertModal>

--- a/components/src/modals/Modal.js
+++ b/components/src/modals/Modal.js
@@ -16,8 +16,10 @@ type ModalProps = {
   className?: string,
   /** classes to apply to the contents box */
   contentsClassName?: string,
-  /** lightens overlay (alert modal over existing modal)**/
+  /** lightens overlay (alert modal over existing modal) */
   alertOverlay?: boolean,
+  /** restricts scroll outside of Modal when open, true by default */
+  restrictOuterScroll?: boolean,
   innerRef?: React.Ref<*>,
 }
 
@@ -32,9 +34,11 @@ export default function Modal(props: ModalProps) {
     onCloseClick,
     heading,
     innerRef,
+    restrictOuterScroll = true,
   } = props
+  const Wrapper = restrictOuterScroll ? RemoveScroll : React.Fragment
   return (
-    <RemoveScroll>
+    <Wrapper>
       <div
         className={cx(styles.modal, props.className, {
           [styles.alert_modal]: alertOverlay,
@@ -49,6 +53,6 @@ export default function Modal(props: ModalProps) {
           {props.children}
         </div>
       </div>
-    </RemoveScroll>
+    </Wrapper>
   )
 }

--- a/components/src/modals/Modal.md
+++ b/components/src/modals/Modal.md
@@ -4,7 +4,10 @@ Basic usage (click overlay to close):
 initialState = { isOpen: true }
 ;<div style={{ position: 'relative', width: '32em', height: '16rem' }}>
   {state.isOpen && (
-    <Modal onCloseClick={() => setState({ isOpen: false })}>
+    <Modal
+      onCloseClick={() => setState({ isOpen: false })}
+      restrictOuterScroll={false}
+    >
       <span>Modal contents</span>
     </Modal>
   )}
@@ -19,6 +22,7 @@ initialState = { isOpen: true }
 ;<div style={{ position: 'relative', width: '32em', height: '16rem' }}>
   {state.isOpen && (
     <Modal
+      restrictOuterScroll={false}
       onCloseClick={() => setState({ isOpen: false })}
       heading={'Optional styled heading'}
     >


### PR DESCRIPTION
Add a prop to allow overriding default external scroll restriction on modal components in CL. This
should clear up the scrolling problems in CL as it is the only place that more than one modal
component is rendered simultaneously and out of view.