### PR TITLE
fix(protocol-designer): fix labware nickname µL capitalization

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.js
@@ -19,7 +19,8 @@ type Props = { ...OP, ...SP }
 const NameOverlay = (props: Props) => {
   const { labwareOnDeck, nickname } = props
   const title = nickname || getLabwareDisplayName(labwareOnDeck.def)
-  return <LabwareNameOverlay title={title} />
+  // TODO(mc, 2019-06-27): µL to uL replacement needed to handle CSS capitalization
+  return <LabwareNameOverlay title={title.replace('µL', 'uL')} />
 }
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -73,8 +73,11 @@ function mapStateToProps(state: BaseState): SP {
     state
   )
 
+  // TODO(mc, 2019-06-27): µL to uL replacement needed to handle CSS capitalization
   const labwareNickname =
-    selectedLabwareId != null ? labwareNames[selectedLabwareId] : null
+    selectedLabwareId != null
+      ? labwareNames[selectedLabwareId].replace('µL', 'uL')
+      : null
   const labwareEntity =
     selectedLabwareId != null
       ? stepFormSelectors.getLabwareEntities(state)[selectedLabwareId]
@@ -133,8 +136,8 @@ function mapStateToProps(state: BaseState): SP {
           const nickname = uiLabwareSelectors.getLabwareNicknamesById(state)[
             drilledDownLabwareId
           ]
-          title = nickname
           // TODO(mc, 2019-06-27): µL to uL replacement needed to handle CSS capitalization
+          title = nickname.replace('µL', 'uL')
           subtitle =
             labwareDef && getLabwareDisplayName(labwareDef).replace('µL', 'uL')
         }


### PR DESCRIPTION
## overview

Mike fixed the behavior where capitalizing `µL` looks like "ML" in most places (because capital mu is M). But we missed one place (at least :upside_down_face: ) -- the labware nicknames, which often contain "µL", especially in protocols that migrated from labware v1.

## changelog

## review requests

All places that labware name/nickname is capitalized should have `µL` transform to `UL` and not to `ML`:

- Title bar of Add Liquids modal
- On the deck
- Title bar of View Details modal