### PR TITLE
fix(protocol-designer): mend and extend scroll to top, fix reorder crash

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/BrowseLabware.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/BrowseLabware.js
@@ -3,10 +3,12 @@ import React from 'react'
 import cx from 'classnames'
 import { connect } from 'react-redux'
 import { Icon } from '@opentrons/components'
+import forEach from 'lodash/forEach'
 import i18n from '../../../localization'
 import type { ThunkDispatch } from '../../../types'
 import type { LabwareOnDeck } from '../../../step-forms'
 import { drillDownOnLabware } from '../../../labware-ingred/actions'
+import { MAIN_CONTENT_FORCED_SCROLL_CLASSNAME } from '../../../ui/steps/actions'
 import styles from './LabwareOverlays.css'
 
 type OP = {|
@@ -32,7 +34,18 @@ function BrowseLabwareOverlay(props: Props) {
 }
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<*>, ownProps: OP): DP => ({
-  drillDown: () => dispatch(drillDownOnLabware(ownProps.labwareOnDeck.id)),
+  drillDown: () => {
+    // scroll to top of all elements with the special class
+    forEach(
+      global.document.getElementsByClassName(
+        MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
+      ),
+      elem => {
+        elem.scrollTop = 0
+      }
+    )
+    dispatch(drillDownOnLabware(ownProps.labwareOnDeck.id))
+  },
 })
 
 export default connect<Props, OP, _, DP, _, _>(

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.js
@@ -64,7 +64,9 @@ const EditLabware = (props: Props) => {
     )
   } else {
     const isBeingDragged =
-      draggedItem && draggedItem.labwareOnDeck.slot === labwareOnDeck.slot
+      draggedItem &&
+      draggedItem.labwareOnDeck &&
+      draggedItem.labwareOnDeck.slot === labwareOnDeck.slot
 
     const contents = draggedItem ? (
       <div

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -12,7 +12,7 @@ import FileUploadMessageModal from './modals/FileUploadMessageModal'
 import GateModal from './modals/GateModal'
 import { PortalRoot as MainPageModalPortalRoot } from '../components/portals/MainPageModalPortal'
 import { PortalRoot as TopPortalRoot } from './portals/TopPortal'
-import { SCROLL_ON_SELECT_STEP_CLASSNAME } from '../steplist/actions'
+import { MAIN_CONTENT_FORCED_SCROLL_CLASSNAME } from '../ui/steps/actions'
 import styles from './ProtocolEditor.css'
 
 const showGateModal =
@@ -26,15 +26,15 @@ function ProtocolEditor() {
       <div className={styles.wrapper}>
         <ConnectedNav />
         <ConnectedSidebar />
-        <div
-          className={cx(
-            styles.main_page_wrapper,
-            SCROLL_ON_SELECT_STEP_CLASSNAME
-          )}
-        >
+        <div className={styles.main_page_wrapper}>
           <ConnectedTitleBar />
 
-          <div className={styles.main_page_content}>
+          <div
+            className={cx(
+              styles.main_page_content,
+              MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
+            )}
+          >
             <NewFileModal useProtocolFields />
             <FileUploadMessageModal />
             {/* TODO: Ian 2018-06-28 All main page modals will go here */}

--- a/protocol-designer/src/steplist/actions/thunks.js
+++ b/protocol-designer/src/steplist/actions/thunks.js
@@ -9,8 +9,6 @@ import { actions as tutorialActions } from '../../tutorial'
 import type { StepType, StepIdType } from '../../form-types'
 import type { GetState, ThunkDispatch } from '../../types'
 
-export const SCROLL_ON_SELECT_STEP_CLASSNAME = 'scroll_on_select_step'
-
 export type SelectStepAction = {
   type: 'SELECT_STEP',
   payload: StepIdType,

--- a/protocol-designer/src/ui/steps/actions.js
+++ b/protocol-designer/src/ui/steps/actions.js
@@ -92,7 +92,7 @@ export const clearWellSelectionLabwareKey = (): ClearWellSelectionLabwareKeyActi
   payload: null,
 })
 
-export const SCROLL_ON_SELECT_STEP_CLASSNAME = 'scroll_on_select_step'
+export const MAIN_CONTENT_FORCED_SCROLL_CLASSNAME = 'main_content_forced_scroll'
 
 export type SelectStepAction = { type: 'SELECT_STEP', payload: StepIdType }
 // NOTE: 'newStepType' arg is only used when generating a new step
@@ -144,7 +144,9 @@ export const selectStep = (
 
   // scroll to top of all elements with the special class
   forEach(
-    global.document.getElementsByClassName(SCROLL_ON_SELECT_STEP_CLASSNAME),
+    global.document.getElementsByClassName(
+      MAIN_CONTENT_FORCED_SCROLL_CLASSNAME
+    ),
     elem => {
       elem.scrollTop = 0
     }


### PR DESCRIPTION
Fix regression of scroll to top of step form on step select and extend similar functionality to the
BrowseLabware modal on drillDown. Fix intermittent reorder steps crash that occurs after moving a
labware at least once.

Closes #3679
