### PR TITLE
refactor(api): Rename model keys to be agnostic to hw model version

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import json
-import re
 from collections import namedtuple
 from typing import Any, Dict, List, Union, Tuple, Sequence, Optional
 import pkgutil
@@ -35,7 +34,9 @@ pipette_config = namedtuple(
         'ul_per_mm',
         'quirks',
         'tip_length',  # TODO (andy): remove from pipette, move to tip-rack
-        'display_name'
+        'display_name',
+        'name',
+        'backcompat_name'
     ]
 )
 
@@ -59,9 +60,6 @@ Z_OFFSET_P10 = -13  # longest single-channel pipette
 Z_OFFSET_P50 = 0
 Z_OFFSET_P300 = 0
 Z_OFFSET_P1000 = 20  # shortest single-channel pipette
-
-HAS_MODEL_RE = re.compile('^p.+_v.+$')
-#: If a prospective model string matches this, it has a full model number
 
 
 def model_config() -> Dict[str, Any]:
@@ -188,7 +186,9 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         ul_per_mm=ul_per_mm,
         quirks=validate_quirks(ensure_value(cfg, 'quirks', MUTABLE_CONFIGS)),
         tip_length=ensure_value(cfg, 'tipLength', MUTABLE_CONFIGS),
-        display_name=ensure_value(cfg, 'displayName', MUTABLE_CONFIGS)
+        display_name=ensure_value(cfg, 'displayName', MUTABLE_CONFIGS),
+        name=cfg.get('name'),
+        backcompat_name=cfg.get('backcompatName')
     )
 
     return res

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -132,10 +132,10 @@ def get_pipettes(sess):
         left = attached_pipettes.get('left')
         right = attached_pipettes.get('right')
         if left['model'] in pipette_config.config_models:
-            left_pipette = instruments.pipette_by_name('left', left['model'])
+            left_pipette = instruments.pipette_by_name('left', left['name'])
         if right['model'] in pipette_config.config_models:
             right_pipette = instruments.pipette_by_name(
-                'right', right['model'])
+                'right', right['name'])
     else:
         attached_pipettes = sess.adapter.attached_instruments
         left_pipette = attached_pipettes.get(Mount.LEFT)

--- a/api/src/opentrons/tools/write_pipette_memory.py
+++ b/api/src/opentrons/tools/write_pipette_memory.py
@@ -43,9 +43,11 @@ MODELS = {
         'P1KSV15': 'p1000_single_v1.5'
     },
     'v2': {
-        'P3HSV20': 'p+300_single_v2.0',
-        'P1KSV20': 'p+1000_single_v2.0',
-        'P20SV20': 'p+20_single_v2.0',
+        'P3HSV20': 'p300_single_v2.0',
+        'P3HMV20': 'p300_multi_v2.0',
+        'P1KSV20': 'p1000_single_v2.0',
+        'P20SV20': 'p20_single_v2.0',
+        'P20MV20': 'p20_multi_v2.0',
     }
 }
 

--- a/api/tests/opentrons/labware/test_pipette_constructors.py
+++ b/api/tests/opentrons/labware/test_pipette_constructors.py
@@ -5,28 +5,28 @@ from opentrons.config import pipette_config
 from opentrons.legacy_api.instruments import Pipette
 
 factories = [
-    ('p10_single', instruments.P10_Single),
-    ('p10_multi', instruments.P10_Multi),
-    ('p+20_single', instruments.P20_Plus_Single),
-    ('p50_single', instruments.P50_Single),
-    ('p50_multi', instruments.P50_Multi),
-    ('p300_single', instruments.P300_Single),
-    ('p+300_single', instruments.P300_Plus_Single),
-    ('p300_multi', instruments.P300_Multi),
-    ('p1000_single', instruments.P1000_Single),
-    ('p+1000_single', instruments.P1000_Plus_Single),
+    ('p10_single_v1.3', 'p10_single', instruments.P10_Single),
+    ('p10_multi_v1.5', 'p10_multi', instruments.P10_Multi),
+    ('p20_single_v2.0', 'p20_single_GEN2', instruments.P20_Single_GEN2),
+    ('p50_single_v1.3', 'p50_single', instruments.P50_Single),
+    ('p50_multi_v1.5', 'p50_multi', instruments.P50_Multi),
+    ('p300_single_v1.3', 'p300_single', instruments.P300_Single),
+    ('p300_single_v2.0', 'p300_single_GEN2', instruments.P300_Single_GEN2),
+    ('p300_multi_v1.5', 'p300_multi', instruments.P300_Multi),
+    ('p1000_single_v1.3', 'p1000_single', instruments.P1000_Single),
+    ('p1000_single_v2.0', 'p1000_single_GEN2', instruments.P1000_Single_GEN2),
 ]
 
 backcompat_pips = [
-    ('p+20_single', 'p10_single', instruments.P10_Single),
-    ('p+300_single', 'p300_single', instruments.P300_Single),
-    ('p+1000_single', 'p1000_single', instruments.P1000_Single),
+    ('p20_single_GEN2', 'p10_single', instruments.P10_Single),
+    ('p300_single_GEN2', 'p300_single', instruments.P300_Single),
+    ('p1000_single_GEN2', 'p1000_single', instruments.P1000_Single),
 ]
 
 
 @pytest.mark.parametrize('factory', factories)
 def test_pipette_contructors(factory, monkeypatch):
-    expected_name, make_pipette = factory
+    model_name, expected_name, make_pipette = factory
 
     aspirate_flow_rate = None
     dispense_flow_rate = None
@@ -40,10 +40,16 @@ def test_pipette_contructors(factory, monkeypatch):
     monkeypatch.setattr(Pipette, 'set_flow_rate', mock_set_flow_rate)
     robot.reset()
 
+    fake_pip = {'left': {'model': None, 'id': None, 'name': None},
+                'right': {
+                    'model': model_name,
+                    'id': 'FakePip',
+                    'name': expected_name}}
+    monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
     # note: not using named parameters here to catch any breakage due to
     # argument reordering
     pipette = make_pipette(
-        'left',  # mount
+        'right',  # mount
         '',      # trash_container
         [],      # tip_racks
         21,      # aspirate_flow_rate
@@ -53,7 +59,7 @@ def test_pipette_contructors(factory, monkeypatch):
     )
 
     assert pipette.name.startswith(expected_name) is True
-    assert pipette.mount == 'left'
+    assert pipette.mount == 'right'
     assert pipette.trash_container == robot.fixed_trash[0]
     assert pipette.tip_racks == []
     assert aspirate_flow_rate == 21
@@ -70,7 +76,7 @@ def test_backwards_compatibility(backcompat, monkeypatch):
 
     fake_pip = {'left': {'model': None, 'id': None, 'name': None},
                 'right': {
-                    'model': expected_name + '_v2.0',
+                    'model': expected_name.split('_GEN2')[0] + '_v2.0',
                     'id': 'FakePip',
                     'name': expected_name}}
     monkeypatch.setattr(robot, 'model_by_mount', fake_pip)

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -929,8 +929,9 @@
       },
       "quirks": ["dropTipShake", "doubleDropTip"]
     },
-    "p+20_single_v2.0": {
-      "name": "p+20_single",
+    "p20_single_v2.0": {
+      "name": "p20_single_GEN2",
+      "backcompatName": "p10_single",
       "top": {
         "value": 19.5,
         "min": -45,
@@ -2313,8 +2314,9 @@
       },
       "quirks": ["dropTipShake"]
     },
-    "p+300_single_v2.0": {
-      "name": "p+300_single",
+    "p300_single_v2.0": {
+      "name": "p300_single_GEN2",
+      "backcompatName": "p300_single",
       "top": {
         "value": 19.5,
         "min": 5,
@@ -3294,8 +3296,9 @@
         "max": 100
       }
     },
-    "p+1000_single_v2.0": {
-      "name": "p+1000_single",
+    "p1000_single_v2.0": {
+      "name": "p1000_single_GEN2",
+      "backcompatName": "p1000_single",
       "top": {
         "value": 19.5,
         "min": 5,

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -31,8 +31,8 @@
     },
     "channels": 8
   },
-  "p+20_single": {
-    "displayName": "P20+ Single-Channel",
+  "p20_single_GEN2": {
+    "displayName": "P20 Single-Channel GEN2",
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
@@ -95,8 +95,8 @@
     "minVolume": 30,
     "maxVolume": 300
   },
-  "p+300_single": {
-    "displayName": "P300+ Single-Channel",
+  "p300_single_GEN2": {
+    "displayName": "P300 Single-Channel GEN2",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -143,8 +143,8 @@
     "minVolume": 100,
     "maxVolume": 1000
   },
-  "p+1000_single": {
-    "displayName": "P1000+ Single-Channel",
+  "p1000_single_GEN2": {
+    "displayName": "P1000 Single-Channel GEN2",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -82,6 +82,10 @@
               "description": "reference to name of this version, should match a key in corresponding pipetteNameSpecs.json file",
               "type": "string"
             },
+            "backcompatName": {
+              "description": "Optional reference for name of backcompat pipette corresponding to a key in pipetteNameSpecs.json, only relevant to gen2 pipettes",
+              "type": "string"
+            },
             "top": { "$ref": "#/definitions/editConfigurations" },
             "bottom": { "$ref": "#/definitions/editConfigurations" },
             "blowout": { "$ref": "#/definitions/editConfigurations" },


### PR DESCRIPTION
## overview
Closes #3631 and closes #3484. This PR changes pipette model names such that they do not rely on a hw model version (i.e. GEN2 vs GEN1) to load the correct configs.

## changelog

- Modify pipette Gen2 model names to volume_type_v2.0
- Modify display names for Gen2 pipettes to volume type GEN2
- Add a backCompat key on Gen2 pipettes to find name key of the older generation config to use

## review requests

Make sure nothing snuck in from other PR. Check that code looks good and schema changes make sense.
