### PR TITLE
fix(api): Make BCRobot fw_version sync again

### DIFF
--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -4,6 +4,7 @@ This should not be imported directly; it is used to provide backwards
 compatible singletons in opentrons/__init__.py.
 """
 
+import asyncio
 import importlib.util
 from typing import Any, List
 
@@ -37,9 +38,11 @@ class BCRobot:
 
     def __init__(self,
                  hardware: hc.adapters.SingletonAdapter,
-                 protocol_ctx: ProtocolContext) -> None:
+                 protocol_ctx: ProtocolContext,
+                 loop: asyncio.AbstractEventLoop = None) -> None:
         self._hardware = hardware
         self._ctx = protocol_ctx
+        self._loop = loop or asyncio.get_event_loop()
 
     def connect(self, port: str = None,
                 options: Any = None):
@@ -64,7 +67,11 @@ class BCRobot:
 
     @property
     def fw_version(self):
-        return self._hardware.fw_version
+        try:
+            return self._loop.run_until_complete(self._hardware.fw_version)
+        except RuntimeError:  # If this was called from an async context
+            return 'unknown'  # return a default
+
 
     def __getattr__(self, name):
         """ Provide transparent access to the protocol context """
@@ -289,7 +296,7 @@ class BCModules:
 def build_globals(hardware=None, loop=None):
     hw = hardware or hc.adapters.SingletonAdapter(loop)
     ctx = ProtocolContext(loop)
-    rob = BCRobot(hw, ctx)
+    rob = BCRobot(hw, ctx, loop)
     instr = BCInstruments(ctx)
     lw = BCLabware(ctx)
     mod = BCModules(ctx)

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -72,7 +72,6 @@ class BCRobot:
         except RuntimeError:  # If this was called from an async context
             return 'unknown'  # return a default
 
-
     def __getattr__(self, name):
         """ Provide transparent access to the protocol context """
         return getattr(self._ctx, name)


### PR DESCRIPTION
This is a regression report and a fix.

#3637 made a lot of hardware control API elements async, including `fw_version`. Unfortunately, the update server imports the wheel and tries to check `fw_version` and send it back on requests to `/server/update/health`, and those requests then 500 because coroutines are not json serializable.

Luckily, the update server is doing this through `opentrons.robot`, which is a `BCRobot`, and already has an override for `fw_version`; so we can just change that to be synchronous. Also luckily the app now prefers `/health` (from the api server) for information like the smoothie version.
