### PR TITLE
feat(api): Add P50Sv1.5

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1387,6 +1387,116 @@
       },
       "quirks": ["dropTipShake"]
     },
+    "p50_single_v1.5": {
+      "name": "p50_single",
+      "top": {
+        "value": 19.5,
+        "min": 5,
+        "max": 19.5,
+        "units": "mm",
+        "type": "float"
+      },
+      "bottom": {
+        "value": 2,
+        "min": -2,
+        "max": 19.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "blowout": {
+        "value": 0.5,
+        "min": -4,
+        "max": 10,
+        "units": "mm",
+        "type": "float"
+      },
+      "dropTip": {
+        "value": -5,
+        "min": -6,
+        "max": 2,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpCurrent": {
+        "value": 0.1,
+        "min": 0.05,
+        "max": 2.0,
+        "units": "amps",
+        "type": "float"
+      },
+      "pickUpDistance": {
+        "value": 10,
+        "min": 1,
+        "max": 30,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpIncrement": {
+        "value": 1.0,
+        "min": 0.0,
+        "max": 10.0,
+        "units": "mm",
+        "type": "float"
+      },
+      "pickUpPresses": {
+        "value": 3,
+        "min": 0,
+        "max": 10,
+        "units": "presses",
+        "type": "int"
+      },
+      "pickUpSpeed": {
+        "value": 30,
+        "min": 1,
+        "max": 100,
+        "units": "mm/s",
+        "type": "float"
+      },
+      "modelOffset": [0.0, 0.0, 0.0],
+      "ulPerMm": [
+        {
+          "aspirate": [
+            [5.762111167 , 0.02912395377 , 2.7132],
+            [7.208999967 , 0.001758534127 , 2.8709],
+            [10.18300033 , 0.008684827443 , 2.8210],
+            [35.954444 , 0.003367098915 , 2.8751],
+            [42.075889 , 0.001505686352 , 2.9421],
+            [50 , 0.001091358226 , 2.9595]
+          ],
+          "dispense": [[50, 0, 2.931601299]]
+        }
+      ],
+      "plungerCurrent": {
+        "value": 0.3,
+        "min": 0.1,
+        "max": 0.5,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipCurrent": {
+        "value": 0.5,
+        "min": 0.1,
+        "max": 0.8,
+        "units": "amps",
+        "type": "float"
+      },
+      "dropTipSpeed": {
+        "value": 5,
+        "min": 0.001,
+        "max": 30,
+        "units": "mm/sec",
+        "type": "float"
+      },
+
+      "tipLength": {
+        "value": 51.7,
+        "units": "mm",
+        "type": "float",
+        "min": 0,
+        "max": 100
+      },
+      "quirks": ["dropTipShake"]
+    },
     "p50_multi_v1": {
       "name": "p50_multi",
       "top": {


### PR DESCRIPTION
Adds support for v1.5 rev of p50 single. Settings are identical to v1.4 except
for a new aspirate function (and removal of the "legacy" function).

Closes #3680
