### PR TITLE
chore(api): update factory tests logging and smoothie handling

### DIFF
--- a/api/src/opentrons/tools/gantry_test.py
+++ b/api/src/opentrons/tools/gantry_test.py
@@ -7,6 +7,7 @@ with Max speed. This will result to a good assembly vs a bad assembly process.
 
 Author: Carlos Fernandez
 """
+import logging
 import optparse
 
 from opentrons import robot
@@ -130,7 +131,7 @@ if __name__ == '__main__':
     b_x_max = 417.2
     b_y_max = 320
     tolerance_mm = 0.5
-
+    logging.basicConfig(filename='gantry-test.log')
     try:
         connect_to_port()
         robot.home()

--- a/api/src/opentrons/tools/overnight_test.py
+++ b/api/src/opentrons/tools/overnight_test.py
@@ -94,6 +94,7 @@ def setup_logging():
     # add the handlers to the logger
     logger.addHandler(fh)
     logger.addHandler(ch)
+    logging.getLogger().handlers = [fh, ch]
     return logger
 
 

--- a/api/src/opentrons/tools/z_stage_test.py
+++ b/api/src/opentrons/tools/z_stage_test.py
@@ -13,6 +13,7 @@ QC Gantry Test
 """
 
 import atexit
+import logging
 import optparse
 
 from opentrons import robot
@@ -156,6 +157,7 @@ def run_z_stage():
 if __name__ == '__main__':
     atexit.register(_exit_test)
     options, args = get_options()
+    logging.basicConfig(filename='z-stage-test.log')
     try:
         robot.connect()
         print("In Progress.. ")


### PR DESCRIPTION
- The data loss factory test gets spoofed by sending two crnls to smoothie,
  which races with the smoothie's response and injects newlines into the data it
  returns, breaking the test. Don't do this anymore.
- Hide logging that confuses the line involving hard limits

Testing:
- Run the tests on some robots, buildroot and balena, with default deck calibrations (i.e. `rm /data/deck_calibration*` first)