### PR TITLE
feat(api): Always remove v2 calibration

### DIFF
--- a/api/src/opentrons/server/endpoints/settings.py
+++ b/api/src/opentrons/server/endpoints/settings.py
@@ -121,9 +121,8 @@ async def reset(request: web.Request) -> web.Response:  # noqa(C901)
             config.tip_length.clear()
         rc.save_robot_settings(config)
     if data.get('labwareCalibration'):
-        if ff.use_protocol_api_v2():
-            labware.clear_calibrations()
-        else:
+        labware.clear_calibrations()
+        if not ff.use_protocol_api_v2():
             db.reset()
 
     if data.get('customLabware'):


### PR DESCRIPTION
Since we're letting users load v2 labware in v1, we always need to delete v2
labware calibration in factory reset. However, we only delete the database if
apiv1 is selected.

Closes #3700

## Test
- [ ] check that on apiv1, the database and v2 cal is deleted
- [ ] check that on apiv2, only the v2 cal is deleted