### PR TITLE
fix(api): unrestrict thermocycler lid at api level for testing

### DIFF
--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -2,7 +2,7 @@ import asyncio
 from . import mod_abc
 from typing import Union, Optional
 from opentrons.drivers.thermocycler.driver import (
-    Thermocycler as ThermocyclerDriver, ThermocyclerError)
+    Thermocycler as ThermocyclerDriver)
 
 
 class SimulatingDriver:
@@ -17,8 +17,8 @@ class SimulatingDriver:
         self._lid_heating_active = False
 
     async def open(self):
-        # TODO: BC 2019-07-11 once safe threshold is established in firmware, handle
-        # UI level warning responsibly here
+        # TODO: BC 2019-07-11 once safe threshold is established in
+        # firmware, handle UI level warning responsibly here
 
         # if self._active:
         #     raise ThermocyclerError(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -17,9 +17,12 @@ class SimulatingDriver:
         self._lid_heating_active = False
 
     async def open(self):
-        if self._active:
-            raise ThermocyclerError(
-                'Cannot open Thermocycler while it is active')
+        # TODO: BC 2019-07-11 once safe threshold is established in firmware, handle
+        # UI level warning responsibly here
+
+        # if self._active:
+        #     raise ThermocyclerError(
+        #         'Cannot open Thermocycler while it is active')
         self._lid_status = 'open'
         return self._lid_status
 


### PR DESCRIPTION
There was a remnant safety to prevent opening the lid of the thermocycler from the python api when
it has set target temperature for the block. Let's remove this for now given that some of this is to
be handled in firmware and we need to limit opening more responsibly.  More immediately, this is to
unblock science testing.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
