### PR TITLE
fix(api): Correct labwarev2 reservoirs on apiv1

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -233,11 +233,7 @@ def load_new_labware_def(definition):
 
     container._coordinates = Vector(definition['cornerOffsetFromSlot'])
     for well_name in itertools.chain(*definition['ordering']):
-        try:
-            well_obj, well_pos = _load_new_well(
-                definition['wells'][well_name], saved_offset, lw_format)
-        except Exception:
-            log.exception("couldn't add well ")
-            raise
+        well_obj, well_pos = _load_new_well(
+            definition['wells'][well_name], saved_offset, lw_format)
         container.add(well_obj, well_name, well_pos)
     return container

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -153,6 +153,13 @@ def save_custom_container(data):
 
 
 def _load_new_well(well_data, saved_offset, lw_format):
+    # There are two key hacks in here to make troughs work:
+    # - do not specify the size of the well
+    # - specify the center without subtracting the size (since
+    #   the size is 0) in x, and _add_ 7/16 of the size in y
+    #   so that the nominal center leaves the nozzle centered in
+    #   an imaginary well instead of centering itself over the
+    #   top wall of the trough.
     props = {
         'depth': well_data['depth'],
         'total-liquid-volume': well_data['totalLiquidVolume'],
@@ -160,7 +167,9 @@ def _load_new_well(well_data, saved_offset, lw_format):
     if well_data['shape'] == 'circular':
         props['diameter'] = well_data['diameter']
     elif well_data['shape'] == 'rectangular':
-        pass
+        if lw_format != 'trough':
+            props['length'] = well_data['yDimension']
+            props['width'] = well_data['xDimension']
     else:
         raise ValueError(
             f"Bad definition for well shape: {well_data['shape']}")
@@ -168,8 +177,8 @@ def _load_new_well(well_data, saved_offset, lw_format):
 
     if lw_format == 'trough':
         well_tuple = (
-            well_data['x'] - well_data['xDimension']/2 + saved_offset.x,
-            well_data['y'] + well_data['yDimension']/2 + saved_offset.y,
+            well_data['x'] + saved_offset.x,
+            well_data['y'] + 7*well_data['yDimension']/16 + saved_offset.y,
             well_data['z'] + saved_offset.z)
     else:
         well_tuple = (
@@ -224,7 +233,11 @@ def load_new_labware_def(definition):
 
     container._coordinates = Vector(definition['cornerOffsetFromSlot'])
     for well_name in itertools.chain(*definition['ordering']):
-        well_obj, well_pos = _load_new_well(
-            definition['wells'][well_name], saved_offset, lw_format)
+        try:
+            well_obj, well_pos = _load_new_well(
+                definition['wells'][well_name], saved_offset, lw_format)
+        except Exception:
+            log.exception("couldn't add well ")
+            raise
         container.add(well_obj, well_name, well_pos)
     return container

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -63,7 +63,7 @@ def _load_container_by_name(container_name):
             log.info(f"Loaded {container_name} from {meth.__name__}")
             break
         except (ValueError, KeyError):
-            log.info(f"{container_name} not in {meth.__name__}")
+            log.exception(f"{container_name} not in {meth.__name__}")
     else:
         raise KeyError(f"Unknown labware {container_name}")
     return container

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -97,7 +97,7 @@ def test_load_new_trough(robot):
     cont = new_load(trough)
     assert cont.size() == (0, 0, 0)
     assert cont.wells('A1')._coordinates \
-        == (13.94 - 4.165, 42.9 + 35.94, 2.29)
+        == (13.94, 42.9 + 31.4475, 2.29)
 
 
 def test_containers_list(robot):


### PR DESCRIPTION
This serves as a bug report and fix for incorrect behaviors of labware v2 reservoirs and rectangular well labwares on apiv1.

Reservoirs (previously troughs) need special handling on apiv1 to interact
properly with multichannels. We keep the well size as 0 and manipulate the
center directly to land both single pipettes and the backmost nozzle of
multichannel pipettes at the back of the well, to minimize the surface area of
the hack and make both pipettes work.

Additionally, we need to _not_ do this for wells which are rectangular but are
not part of reservoirs.

To test, interact with a reservoir (such as `usascientific_12_reservoir_22ml`) and rectangular well plate (such as 'usascientific_96_wellplate_2.4ml_deep'`) and see that the pipette goes in the right place.

Note that as with labware v1 troughs, the xy well size on reservoirs is 0 so offsets from center do not work.