### PR TITLE
refactor(labware-library): Add actual links to labware guide

### DIFF
--- a/labware-library/src/components/Sidebar/LabwareGuide.js
+++ b/labware-library/src/components/Sidebar/LabwareGuide.js
@@ -5,14 +5,29 @@ import * as React from 'react'
 import { Icon } from '@opentrons/components'
 import styles from './styles.css'
 
-// TODO(mc, 2019-03-14): i18n
-const EN_LABWARE_GUIDE = 'Labware Guide'
-const EN_HOW_TO_CHOOSE_LABWARE = 'How to choose labware'
-const EN_MAKING_CUSTOM_DEFINITIONS = 'Making custom definitions'
+import {
+  LABWARE_GUIDE,
+  WHAT_IS_A_LABWARE_DEFINITION,
+  USING_THE_LABWARE_LIBRARY,
+  CREATING_CUSTOM_LABWARE_DEFINITIONS,
+} from '../../localization'
 
 const LINKS = [
-  { label: EN_HOW_TO_CHOOSE_LABWARE, href: '#' },
-  { label: EN_MAKING_CUSTOM_DEFINITIONS, href: '#' },
+  {
+    label: WHAT_IS_A_LABWARE_DEFINITION,
+    href:
+      'https://support.opentrons.com/en/articles/3136501-what-is-a-labware-definition',
+  },
+  {
+    label: USING_THE_LABWARE_LIBRARY,
+    href:
+      'https://support.opentrons.com/en/articles/3136507-using-the-labware-library',
+  },
+  {
+    label: CREATING_CUSTOM_LABWARE_DEFINITIONS,
+    href:
+      'https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions',
+  },
 ]
 
 export default function LabwareGuide() {
@@ -24,7 +39,7 @@ export default function LabwareGuide() {
             className={styles.labware_guide_icon}
             name="book-open-page-variant"
           />
-          {EN_LABWARE_GUIDE}
+          {LABWARE_GUIDE}
         </h2>
         <ul className={styles.labware_guide_list}>
           {LINKS.map((a, i) => (

--- a/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
+++ b/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
@@ -24,11 +24,11 @@ exports[`LabwareGuide component renders 1`] = `
       >
         <a
           className="labware_guide_link"
-          href="#"
+          href="https://support.opentrons.com/en/articles/3136501-what-is-a-labware-definition"
           rel="noopener noreferrer"
           target="_blank"
         >
-          How to choose labware
+          What is a labware definition?
         </a>
       </li>
       <li
@@ -36,11 +36,23 @@ exports[`LabwareGuide component renders 1`] = `
       >
         <a
           className="labware_guide_link"
-          href="#"
+          href="https://support.opentrons.com/en/articles/3136507-using-the-labware-library"
           rel="noopener noreferrer"
           target="_blank"
         >
-          Making custom definitions
+          Using the labware library
+        </a>
+      </li>
+      <li
+        key="2"
+      >
+        <a
+          className="labware_guide_link"
+          href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Creating custom labware definitions
         </a>
       </li>
     </ul>

--- a/labware-library/src/components/Sidebar/styles.css
+++ b/labware-library/src/components/Sidebar/styles.css
@@ -16,7 +16,7 @@
 .labware_guide_container {
   border: var(--bd-light);
   border-radius: 3px;
-  padding: var(--spacing-4) var(--spacing-6);
+  padding: var(--spacing-5);
 }
 
 .labware_guide_title {
@@ -24,6 +24,7 @@
 
   display: flex;
   align-items: center;
+  margin-bottom: var(--spacing-5);
   font-weight: var(--fw-semibold);
 }
 
@@ -35,9 +36,9 @@
 
 .labware_guide_link {
   display: block;
-  line-height: var(--lh-title);
+  line-height: var(--lh-copy);
   font-size: var(--fs-body-1);
-  margin-top: var(--spacing-3);
+  margin-top: var(--spacing-2);
   color: var(--c-blue);
 }
 

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -69,3 +69,9 @@ export const API_NAME = 'api name'
 export const COPIED_TO_CLIPBOARD = 'Copied to clipboard!'
 export const VARIOUS = 'Various'
 export const NA = 'N/A'
+
+export const LABWARE_GUIDE = 'Labware Guide'
+export const WHAT_IS_A_LABWARE_DEFINITION = 'What is a labware definition?'
+export const USING_THE_LABWARE_LIBRARY = 'Using the labware library'
+export const CREATING_CUSTOM_LABWARE_DEFINITIONS =
+  'Creating custom labware definitions'


### PR DESCRIPTION
## overview

This PR serving as a ticket and implementation. The "Labware Guide" links in the top-left of the labware library were placeholders. This PR adds the actual Intercom links.

## changelog

- refactor(labware-library): Add actual links to labware guide

## review requests

<http://sandbox.labware.opentrons.com/ll_guide-links>

Please note that the Intercom articles themselves are not live yet!
