### PR TITLE
build(app-shell): Use Digicert's timestamp server for code-signing

### DIFF
--- a/app-shell/electron-builder.json
+++ b/app-shell/electron-builder.json
@@ -26,7 +26,8 @@
   },
   "win": {
     "target": ["nsis"],
-    "publisherName": "Opentrons Labworks Inc."
+    "publisherName": "Opentrons Labworks Inc.",
+    "timeStampServer": "http://timestamp.digicert.com"
   },
   "linux": {
     "target": ["AppImage"],


### PR DESCRIPTION
## overview

Window's code-signing has been broken today due to an unresponsive timestamp server. According to electron-userland/electron-builder#3965, the old default server may heve been deprecated by Verisign. This PR switches our timestamp server to electron-builder's latest default (which we will pick up when we eventually update it).

The new server is Digicert's, who also happens to be the issuer of our Windows code-signing cert. This doesn't make any technical difference whatsoever, but is emotionally calming for me.

## changelog

- build(app-shell): Use Digicert's timestamp server for code-signing

## review requests

- [x] AppVeyor CI goes green
