### PR TITLE
fix(shared-data): patch v2 opentrons 15 and 50 mL tube racks

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1.json
+++ b/shared-data/labware/definitions/2/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical/1.json
@@ -17,7 +17,7 @@
   "dimensions": {
     "xDimension": 127.75,
     "yDimension": 85.5,
-    "zDimension": 123.76
+    "zDimension": 124.35
   },
   "parameters": {
     "format": "irregular",
@@ -30,91 +30,91 @@
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 13.88,
       "y": 67.75,
-      "z": 5.78
+      "z": 6.85
     },
     "B1": {
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 13.88,
       "y": 42.75,
-      "z": 5.78
+      "z": 6.85
     },
     "C1": {
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 13.88,
       "y": 17.75,
-      "z": 5.78
+      "z": 6.85
     },
     "A2": {
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 38.88,
       "y": 67.75,
-      "z": 5.78
+      "z": 6.85
     },
     "B2": {
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 38.88,
       "y": 42.75,
-      "z": 5.78
+      "z": 6.85
     },
     "C2": {
       "totalLiquidVolume": 15000,
       "diameter": 14.9,
       "shape": "circular",
-      "depth": 117.98,
+      "depth": 117.5,
       "x": 38.88,
       "y": 17.75,
-      "z": 5.78
+      "z": 6.85
     },
     "A3": {
       "totalLiquidVolume": 50000,
       "diameter": 27.81,
       "shape": "circular",
-      "depth": 113.85,
+      "depth": 113,
       "x": 71.38,
       "y": 60.25,
-      "z": 5.95
+      "z": 7.3
     },
     "B3": {
       "totalLiquidVolume": 50000,
       "diameter": 27.81,
       "shape": "circular",
-      "depth": 113.85,
+      "depth": 113,
       "x": 71.38,
       "y": 25.25,
-      "z": 5.95
+      "z": 7.3
     },
     "A4": {
       "totalLiquidVolume": 50000,
       "diameter": 27.81,
       "shape": "circular",
-      "depth": 113.85,
+      "depth": 113,
       "x": 106.38,
       "y": 60.25,
-      "z": 5.95
+      "z": 7.3
     },
     "B4": {
       "totalLiquidVolume": 50000,
       "diameter": 27.81,
       "shape": "circular",
-      "depth": 113.85,
+      "depth": 113,
       "x": 106.38,
       "y": 25.25,
-      "z": 5.95
+      "z": 7.3
     }
   },
   "brand": {

--- a/shared-data/labware/definitions/2/opentrons_15_tuberack_falcon_15ml_conical/1.json
+++ b/shared-data/labware/definitions/2/opentrons_15_tuberack_falcon_15ml_conical/1.json
@@ -22,146 +22,146 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 125.76
+    "zDimension": 124.35
   },
   "schemaVersion": 2,
   "version": 1,
   "namespace": "opentrons",
   "wells": {
     "C1": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 13.88,
       "y": 17.74,
-      "z": 7.78
+      "z": 6.85
     },
     "B1": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 13.88,
       "y": 42.74,
-      "z": 7.78
+      "z": 6.85
     },
     "A1": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 13.88,
       "y": 67.74,
-      "z": 7.78
+      "z": 6.85
     },
     "C2": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 38.88,
       "y": 17.74,
-      "z": 7.78
+      "z": 6.85
     },
     "B2": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 38.88,
       "y": 42.74,
-      "z": 7.78
+      "z": 6.85
     },
     "A2": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 38.88,
       "y": 67.74,
-      "z": 7.78
+      "z": 6.85
     },
     "C3": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 63.88,
       "y": 17.74,
-      "z": 7.78
+      "z": 6.85
     },
     "B3": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 63.88,
       "y": 42.74,
-      "z": 7.78
+      "z": 6.85
     },
     "A3": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 63.88,
       "y": 67.74,
-      "z": 7.78
+      "z": 6.85
     },
     "C4": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 88.88,
       "y": 17.74,
-      "z": 7.78
+      "z": 6.85
     },
     "B4": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 88.88,
       "y": 42.74,
-      "z": 7.78
+      "z": 6.85
     },
     "A4": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 88.88,
       "y": 67.74,
-      "z": 7.78
+      "z": 6.85
     },
     "C5": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 113.88,
       "y": 17.74,
-      "z": 7.78
+      "z": 6.85
     },
     "B5": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 113.88,
       "y": 42.74,
-      "z": 7.78
+      "z": 6.85
     },
     "A5": {
-      "depth": 117.98,
+      "depth": 117.5,
       "diameter": 14.9,
       "shape": "circular",
       "totalLiquidVolume": 15000,
       "x": 113.88,
       "y": 67.74,
-      "z": 7.78
+      "z": 6.85
     }
   },
   "parameters": {

--- a/shared-data/labware/definitions/2/opentrons_6_tuberack_falcon_50ml_conical/1.json
+++ b/shared-data/labware/definitions/2/opentrons_6_tuberack_falcon_50ml_conical/1.json
@@ -16,65 +16,65 @@
   "dimensions": {
     "xDimension": 127.76,
     "yDimension": 85.48,
-    "zDimension": 122
+    "zDimension": 120.3
   },
   "schemaVersion": 2,
   "version": 1,
   "namespace": "opentrons",
   "wells": {
     "B1": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 35.5,
       "y": 25.24,
-      "z": 8.22
+      "z": 7.3
     },
     "A1": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 35.5,
       "y": 60.24,
-      "z": 8.22
+      "z": 7.3
     },
     "B2": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 70.5,
       "y": 25.24,
-      "z": 8.22
+      "z": 7.3
     },
     "A2": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 70.5,
       "y": 60.24,
-      "z": 8.22
+      "z": 7.3
     },
     "B3": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 105.5,
       "y": 25.24,
-      "z": 8.22
+      "z": 7.3
     },
     "A3": {
-      "depth": 113.78,
+      "depth": 113,
       "diameter": 27.81,
       "shape": "circular",
       "totalLiquidVolume": 50000,
       "x": 105.5,
       "y": 60.24,
-      "z": 8.22
+      "z": 7.3
     }
   },
   "parameters": {


### PR DESCRIPTION
## overview
This updates the z-definitions for the following, based on [modified drawings](https://drive.google.com/drive/u/1/folders/16hWi78UoWiwCxQLq0gnYWOAtg0R5PEj4) provided by HW
* opentrons_6_tuberack_falcon_50ml_conical
* opentrons_15_tuberack_falcon_15ml_conical
* opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical

## review requests
To test in APIv2, upload this:
```
def run(ctx):

    TEST_INDEX = 0

    labware_list = ['opentrons_6_tuberack_falcon_50ml_conical',
                    'opentrons_15_tuberack_falcon_15ml_conical',
                    'opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical']
    wells_list = [[0, 1, 4, 5], [0, 2, 12, 14], [0, 2, 8, 9]]

    plate = ctx.load_labware_by_name(labware_list[TEST_INDEX], 1)
    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 11)

    pipette = ctx.load_instrument('p300_single', 'right', tip_racks=[tiprack])
    pipette.pick_up_tip(tiprack.wells()[0])

    ctx.comment(f'Here is the Well A1 Bottom: {plate.wells()[0].bottom()}')
    ctx.comment(f'Here is the well A1 Top: {plate.wells()[0].top()}')

    for well_index in wells_list[TEST_INDEX]:
        pipette.aspirate(100, plate.wells()[well_index].bottom())
        ctx.delay(seconds=3)
        pipette.dispense(100, plate.wells()[well_index].top())
        ctx.delay(seconds=3)

    pipette.return_tip()
```
Already tested on 🍀