### PR TITLE
fix(api): always ensure labware db is up to date

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -5,9 +5,13 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 from opentrons import config  # noqa(E402)
 from opentrons.data_storage import database_migration  # noqa(E402)
 
+
 if os.environ.get('OT_UPDATE_SERVER') != 'true'\
    and not config.feature_flags.use_protocol_api_v2():
-    database_migration.check_version_and_perform_necessary_migrations()
+    database_migration.check_version_and_perform_full_migration()
+else:
+    database_migration.check_version_and_perform_minimal_migrations()
+
 
 import opentrons.hardware_control.adapters as adapters  # noqa(E402)
 from .protocol_api.back_compat import (build_globals as bcbuild,  # noqa(E402)

--- a/api/src/opentrons/data_storage/database_migration.py
+++ b/api/src/opentrons/data_storage/database_migration.py
@@ -1,3 +1,4 @@
+import logging
 import sqlite3
 from opentrons.data_storage import database
 from opentrons.data_storage.old_container_loading import \
@@ -8,6 +9,9 @@ from opentrons.config import CONFIG
 from opentrons.data_storage.schema_changes import \
     create_table_ContainerWells, create_table_Containers
 from opentrons.util.vector import Vector
+
+# TODO (SF 7/11/2019): Once we're off balena remove all these prints
+log = logging.getLogger(__name__)
 
 
 def transpose_coordinates(wells):
@@ -44,30 +48,61 @@ def rotate_container_for_alpha(container):
     return container
 
 
-def ensure_containers_and_wells():
+def _migrate_container(container_name):
+    print('migrating {} from json to database'.format(container_name))
+    container = get_persisted_container(container_name)
+    container = rotate_container_for_alpha(container)
+    print(
+        "CONTAINER: {}, {}".format(
+            container_name,
+            container._coordinates))
+
+    database.save_new_container(container, container_name)
+
+
+def _ensure_containers_and_wells():
+    """ Load all persisted containers in to the labware database
+    """
+
     print("Loading json containers...")
     load_all_containers_from_disk()
     json_containers = list_container_names()
+    log.debug("_ensure_containers_and_wells: file load complete")
     print("Json container file load complete, listing database")
     current_containers = database.list_all_containers()
     to_update = set(json_containers) - set(current_containers)
-    print(f"Found {len(to_update)} containers to add. Starting migration...")
+    msg = f"Found {len(to_update)} containers to add. Starting migration..."
+    print(msg)
+    log.info(msg)
     for container_name in to_update:
-        print('migrating {} from json to database'.format(container_name))
-        container = get_persisted_container(container_name)
-        container = rotate_container_for_alpha(container)
-        print(
-            "CONTAINER: {}, {}".format(
-                container_name,
-                container._coordinates))
-
-        database.save_new_container(container, container_name)
+        _migrate_container(container_name)
     current_containers = database.list_all_containers()
     missing = set(json_containers) - set(current_containers)
     if missing:
-        print(f"MIGRATION FAILED: MISSING {missing}")
+        msg = f"MIGRATION FAILED: MISSING {missing}"
+        log.error(msg)
+        print(msg)
     else:
+        log.info("Database migration complete")
         print("Database migration complete!")
+
+
+def _ensure_trash():
+    """ Ensure that the tall and short fixed trash containers are present
+
+    This is a separate step because the robot singleton needs them, so
+    they need to be present whenever the singleton is constructed on import.
+    The rest of the containers are not necessarily needed, and so are handled
+    elsewhere.
+    """
+    load_all_containers_from_disk()
+
+    to_load = set(['fixed-trash', 'tall-fixed-trash'])
+    present = set(database.list_all_containers())
+    to_update = to_load - present
+    log.info(f"_ensure_trash: loading {to_update}")
+    for container_name in to_update:
+        _migrate_container(container_name)
 
 
 def execute_schema_change(conn, sql_command):
@@ -75,15 +110,34 @@ def execute_schema_change(conn, sql_command):
     c.execute(sql_command)
 
 
-# FIXME: (JG 9/20/17) just for temporary migrations,
-# should have a more thought out structure for migrations
-# and schema changes
-def check_version_and_perform_necessary_migrations():
+def _do_schema_changes():
     db_path = str(CONFIG['labware_database_file'])
     conn = sqlite3.connect(db_path)
     db_version = database.get_version()
     if db_version == 0:
+        log.info("doing database schema migration")
         execute_schema_change(conn, create_table_ContainerWells)
         execute_schema_change(conn, create_table_Containers)
         database.set_version(1)
-    ensure_containers_and_wells()
+    return conn
+
+
+def check_version_and_perform_full_migration():
+    """
+    Migrate all labware to the database (if necessary). Only needs to be
+    performed if protocols will run using the labware database.
+    """
+    log.info("full database migration requested")
+    _do_schema_changes()
+    _ensure_containers_and_wells()
+
+
+def check_version_and_perform_minimal_migrations():
+    """
+    Perform the minimal set of migrations to make sure import-constructed
+    objects work. Should be performed in early import regardless of feature
+    flags
+    """
+    log.info("minimal database migration requested")
+    _do_schema_changes()
+    _ensure_trash()


### PR DESCRIPTION
When the robot boots, it checks to see if the labware database is the right
version, creating it if necessary. If the version detected is incorrect, the
software ensures that it is up to date, then adds all containers from
default-containers.json. If this process gets interrupted (it takes a while, and
the robot can look like it is failing to boot, leading customers to interrupt
it) then the version is still set to be up to date, but the database will be
missing containers. This leads to customers unexpectedly failing to load
labware.

This change splits the detection of required database changes:
- migrations, which change the structure of the database, are gated behind the
user version. If the user version is out of date, the structure is changed.
- independent of the above, at boot (and whenever the opentrons module is
imported) the software scans the database and adds any containers that _are_ in
default-containers.json but _are not_ in the database to the database. This way,
even if the migration of data was interrupted, it will get picked up again next
time the software boots.

It also introduces the concept of the minimal database migration, which changes the database shape and adds the trash labware, and the full migration, which changes the shape and adds all the labware. This is necessary because the robot singleton requires the trash labware when constructed at import, regardless of the situation in which the package is imported. However, we don't want to do a full migration if we're imported from the update server or while using apiv2; so we only do the minimal migration in those cases.

## Testing

This is actually pretty easy and can be accomplished on either a robot (buildroot or balena) or a local install.

- on both apiv1 and apiv2:
  - Delete the labware db
  - Open a python shell and `import opentrons`
  - Watch the database migration and ctrl-c before it finishes
  - Open a python shell and `import opentrons`
  - Note that the migration continues where it left off
