### PR TITLE
chore(protocol-designer): bump to 3.0.1

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '3.0.0'
+const OT_PD_VERSION = '3.0.1'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
Bump to 3.0.1 from unreleased 3.0.0

## CHANGELOG

relevant changes from 3.0.0 tag

* chore(protocol-designer): bump to 3.0.1
* feat(protocol-designer): update migration modal copy (#3709)
* fix(protocol-designer): update various styles to match designs (#3714)
* refactor(labware): Redo OT tiprack defs based on CAD data (#3699)
* fix(shared-data): patch v2 opentrons 15 and 50 mL tube racks (#3712)
* fix(labware): Fix generator well y calculation, update docs/schema (#3697)
* fix(api): change resume() back to sync fn (#3702)
* chore(js): update jest to v24; drop --runInBand (#3672)
* fix(protocol-designer): mend and extend scroll to top, fix reorder crash (#3681)
* fix(protocol-designer): inner mix in move liquid predictable tip height (#3418)
