### PR TITLE
fix(api): do not handle smoothie alarms from halt()

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -985,7 +985,6 @@ class SmoothieDriver_3_0_0:
             if is_alarm or is_error:
                 raise SmoothieError(ret_code)
 
-
     def _remove_unwanted_characters(self, command, response):
         # smoothieware can enter a weird state, where it repeats back
         # the sent command at the beginning of its response.


### PR DESCRIPTION
When changing the smoothie driver in 628c6c47c79a656f9babd552784a96d99deb4852 to
be more robust and have better locking, the changes to the main comms sequence
around write_with_retries and handle_return started trying to handle and recover
from _all_ smoothie alarms, including the one generated by a call to
robot.halt() toggling the estop gpios. This interferes with (read: breaks
catastrophically) protocol cancel, which relies on this sequence:

```
run() rpc call         smoothie      stop rpc call
  |                       |                |
  smoothie cmd start -> executing          |
  |                       | (estop) <-   halt
  smoothie cmd raises <- ALARM             |
  |                       |                |
  exc raised, call done   |                |
  (cancel)                |                |
                         recover     <-   M999
                         executing   <-  home...
```

and if the smoothie cmd in run handles the alarm and tries to recover, then it
never cancels the protocol.

To fix this, raise a different exception that the normal error handling
machinery doesn't catch and therefore propagates all the way up.
