### PR TITLE
fix(app): Do not swallow protocol run errors

### DIFF
--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -12,42 +12,60 @@ type Props = {
 export default function SessionAlert(props: Props) {
   const { sessionStatus, className, onResetClick } = props
 
-  const completeMessage = (
-    <p>
-      Run complete! <a onClick={onResetClick}>Reset run</a> to run protocol
-      again.
-    </p>
-  )
-  const pauseMessage = 'Run paused'
-  const cancelMessage = (
-    <p>
-      Run canceled. <a onClick={onResetClick}>Reset run</a> to run protocol
-      again.
-    </p>
-  )
-
   switch (sessionStatus) {
     case 'finished':
       return (
         <AlertItem
-          type="success"
-          title={completeMessage}
           className={className}
+          type="success"
+          title={
+            <p>
+              Run complete! <a onClick={onResetClick}>Reset run</a> to run
+              protocol again.
+            </p>
+          }
         />
       )
+
     case 'paused':
       return (
         <AlertItem
-          type="info"
-          title={pauseMessage}
           className={className}
+          type="info"
           icon={{ name: 'pause-circle' }}
+          title="Run paused"
         />
       )
+
     case 'stopped':
       return (
-        <AlertItem type="warning" title={cancelMessage} className={className} />
+        <AlertItem
+          className={className}
+          type="warning"
+          title={
+            <p>
+              Run canceled. <a onClick={onResetClick}>Reset run</a> to run
+              protocol again.
+            </p>
+          }
+        />
       )
+
+    case 'error':
+      return (
+        <AlertItem
+          className={className}
+          type="error"
+          title={
+            <p>
+              Run encountered an error. <a onClick={onResetClick}>Reset run</a>{' '}
+              to run protocol again. Please contact support if you need help
+              resolving this issue.
+            </p>
+          }
+        />
+      )
+
     default:
       return null
   }

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -128,7 +128,7 @@ export default function sessionReducer(
 
 function handleSessionUpdate(state: State, action: SessionUpdateAction): State {
   const {
-    payload: { state: sessionState, startTime, lastCommand },
+    payload: { state: sessionStateUpdate, startTime, lastCommand },
   } = action
   let { protocolCommandsById } = state
 
@@ -143,6 +143,13 @@ function handleSessionUpdate(state: State, action: SessionUpdateAction): State {
       [lastCommand.id]: command,
     }
   }
+
+  // TODO(mc, 2019-07-15): remove this workaround when API issue is resolved
+  // https://github.com/Opentrons/opentrons/issues/2994
+  const sessionState =
+    state.state === 'stopped' && sessionStateUpdate === 'error'
+      ? 'stopped'
+      : sessionStateUpdate
 
   return { ...state, state: sessionState, startTime, protocolCommandsById }
 }
@@ -182,8 +189,9 @@ function handleRun(state: State, action: any): State {
 function handleRunResponse(state: State, action: any): State {
   const { error, payload } = action
 
-  if (error)
+  if (error) {
     return { ...state, runRequest: { inProgress: false, error: payload } }
+  }
 
   return { ...state, runRequest: { inProgress: false, error: null } }
 }


### PR DESCRIPTION
## overview

In conjunction with #3721, this PR adds a very minimal amount of app-side logic to avoid swallowing protocol run errors that are _not_ the result of protocol cancellation.

Due to technical limitations with RPC, the run error alert does not display the error that API raises. But the fact that any sort of error banner is displayed is a significant improvement from ending the run without any success or failure indication.

**Note**: the app will still swallow some run errors after this PR. Specifically, it will swallow any error status that is emitted after a "stopped" (cancelled) status is emitted. This seems safe to me until the underlying API issue (#2994) is fixed

Fixes #1828

## changelog

- fix(app): Do now swallow protocol run errors

## review requests

- [ ] Cancelled protocol run shows "run cancelled" banner
- [ ] Errored protocol run shows "run encountered an error" banner
    - An error can be induced by telling the robot to go somewhere it can't
    - `pipette.move_to((robot.deck, (0, 0, 400)))`
