### PR TITLE
fix(api): apiv2: fix protocol cancel

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -306,6 +306,7 @@ class Session(object):
         return self
 
     def stop(self):
+        self._hardware.halt()
         self._hardware.stop()
         self.set_state('stopped')
         return self
@@ -343,13 +344,16 @@ class Session(object):
             self._pre_run_hooks()
             if ff.use_protocol_api_v2():
                 self._hardware.cache_instruments()
-                ctx = ProtocolContext(loop=self._loop, broker=self._broker)
+                ctx = ProtocolContext(
+                    loop=self._loop, broker=self._broker)
                 ctx.connect(self._hardware)
                 ctx.home()
                 if self._is_json_protocol:
-                    run_protocol(protocol_json=self._protocol, context=ctx)
+                    run_protocol(protocol_json=self._protocol,
+                                 context=ctx)
                 else:
-                    run_protocol(protocol_code=self._protocol, context=ctx)
+                    run_protocol(protocol_code=self._protocol,
+                                 context=ctx)
             else:
                 self._hardware.broker = self._broker
                 if self._is_json_protocol:

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1533,7 +1533,7 @@ class SmoothieDriver_3_0_0:
         any other state needed for the driver.
         """
         log.debug("kill")
-        self._smoothie_hard_halt()
+        self.hard_halt()
         self._reset_from_error()
         self._setup()
 
@@ -1579,7 +1579,7 @@ class SmoothieDriver_3_0_0:
             gpio.set_high(gpio.OUTPUT_PINS['ISP'])
             sleep(0.25)
 
-    def _smoothie_hard_halt(self):
+    def hard_halt(self):
         log.debug('Halting Smoothie (simulating: {})'.format(
             self.simulating))
         if self.simulating:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -400,14 +400,31 @@ class API(HardwareAPILike):
         self._backend.resume()
 
     @_log_call
-    async def halt(self):
-        """ Immediately stop motion, reset, and home.
+    def halt(self):
+        """ Immediately stop motion.
+
+        Calls to :py:meth:`stop` through the synch adapter while other calls
+        are ongoing will typically wait until those calls are done, since most
+        of the async calls here in fact block the loop while they talk to
+        smoothie. To provide actual immediate halting, call this method which
+        does not require use of the loop.
+
+        After this call, the smoothie will be in a bad state until a call to
+        :py:meth:`stop`.
+        """
+        self._log.info("Halting")
+        self._backend.hard_halt()
+
+    async def stop(self):
+        """
+        Stop motion as soon as possible, reset, and home.
 
         This will cancel motion (after the current call to :py:meth:`move`;
         see :py:meth:`pause` for more detail), then home and reset the
         robot.
         """
         self._backend.halt()
+        self._log.info("Recovering from halt")
         await self.reset()
         await self.home()
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -372,7 +372,7 @@ class API(HardwareAPILike):
 
     # Global actions API
     @_log_call
-    async def pause(self):
+    def pause(self):
         """
         Pause motion of the robot after a current motion concludes.
 
@@ -386,11 +386,11 @@ class API(HardwareAPILike):
         """
         self._backend.pause()
 
-    async def pause_with_message(self, message):
+    def pause_with_message(self, message):
         self._log.warning('Pause with message: {}'.format(message))
         for cb in self._callbacks:
             cb(message)
-        await self.pause()
+        self.pause()
 
     @_log_call
     def resume(self):

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -224,6 +224,3 @@ class SingletonAdapter(HardwareAPILike):
                     = data.get('tip_length', None)
 
         return instrs
-
-    def stop(self):
-        self._api._loop.run_until_complete(self._api.halt())

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -244,7 +244,9 @@ class Controller:
 
     def halt(self):
         self._smoothie_driver.kill()
-        self._smoothie_driver.resume()
+
+    def hard_halt(self):
+        self._smoothie_driver.hard_halt()
 
     def probe(self, axis: str, distance: float) -> Dict[str, float]:
         """ Run a probe and return the new position dict

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -242,6 +242,9 @@ class Simulator:
     def halt(self):
         self._run_flag.set()
 
+    def hard_halt(self):
+        self._run_flag.set()
+
     def probe(self, axis: str, distance: float) -> Dict[str, float]:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -884,7 +884,9 @@ class Robot(CommandPublisher):
         """
         Stops execution of the protocol. (alias for `halt`)
         """
-        self.halt()
+        self._driver.kill()
+        self.reset()
+        self.home()
 
     @commands.publish.both(command=commands.resume)
     def resume(self):
@@ -897,9 +899,7 @@ class Robot(CommandPublisher):
         """
         Stops execution of both the protocol and the Smoothie board immediately
         """
-        self._driver.kill()
-        self.reset()
-        self.home()
+        self._driver.hard_halt()
 
     def get_attached_pipettes(self):
         """

--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -274,6 +274,7 @@ class RPCServer(object):
     async def make_call(self, func, token):
         response = {'$': {'type': CALL_RESULT_MESSAGE, 'token': token}}
         try:
+            log.info(f"RPC call: {func} begins")
             call_result = await self.loop.run_in_executor(
                 self.executor, self.call_and_serialize, func)
             response['$']['status'] = 'success'
@@ -305,6 +306,7 @@ class RPCServer(object):
                     'traceback': trace
                 }
         finally:
+            log.info(f"RPC call: {func} ends")
             response['data'] = call_result
         return response
 


### PR DESCRIPTION
In apiv2, actions are more strongly serialized than in apiv1 because all the smoothie communication actually blocks the asyncio loop! We need to halt from outside the loop, and we also need to not talk to the smoothie and cause races from another thread.

To do this,
- Make `halt` actually ONLY toggle the smoothie e-stop gpios, not recover
- Make `stop` do the recovery
- Make session `stop` call `halt` then `stop` separately, giving time for ongoing smoothie commands to fail

And in the longer term, make a way to cancel protocols other than using a backdoor to get the smoothie to send an error.

## Testing
Since this hits both apiv1 and v2, test cancelling a protocol on both apiv1 and apiv2.