### PR TITLE
feat(shared-data): add displayCategory to pipetteNameSpecs and schema

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -95,7 +95,7 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-        return self.pipette_by_name(mount, 'p20_single_GEN2',
+        return self.pipette_by_name(mount, 'p20_single_gen2',
                                     trash_container, tip_racks,
                                     aspirate_flow_rate, dispense_flow_rate,
                                     min_volume, max_volume)
@@ -109,7 +109,7 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-        return self.pipette_by_name(mount, 'p20_multi_GEN2',
+        return self.pipette_by_name(mount, 'p20_multi_gen2',
                                     trash_container, tip_racks,
                                     aspirate_flow_rate, dispense_flow_rate,
                                     min_volume, max_volume)
@@ -165,7 +165,7 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-        return self.pipette_by_name(mount, 'p300_single_GEN2',
+        return self.pipette_by_name(mount, 'p300_single_gen2',
                                     trash_container, tip_racks,
                                     aspirate_flow_rate, dispense_flow_rate,
                                     min_volume, max_volume)
@@ -179,7 +179,7 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-        return self.pipette_by_name(mount, 'p300_multi_GEN2',
+        return self.pipette_by_name(mount, 'p300_multi_gen2',
                                     trash_container, tip_racks,
                                     aspirate_flow_rate, dispense_flow_rate,
                                     min_volume, max_volume)
@@ -221,7 +221,7 @@ class InstrumentsWrapper(object):
             dispense_flow_rate=None,
             min_volume=None,
             max_volume=None):
-        return self.pipette_by_name(mount, 'p1000_single_GEN2',
+        return self.pipette_by_name(mount, 'p1000_single_gen2',
                                     trash_container, tip_racks,
                                     aspirate_flow_rate, dispense_flow_rate,
                                     min_volume, max_volume)
@@ -333,8 +333,8 @@ class InstrumentsWrapper(object):
             # In the case that the expected model substring does not equal
             # attached model name or backcompat name, then take the expected
             # model substring and create a fallback model name.
-            if 'GEN2' in expected_model_substring:
-                return expected_model_substring.split('_GEN2')[0] + '_v2.0'
+            if 'gen2' in expected_model_substring:
+                return expected_model_substring.split('_gen2')[0] + '_v2.0'
             return expected_model_substring.split('_v')[0] + '_v1'
 
 

--- a/api/tests/opentrons/labware/test_pipette_constructors.py
+++ b/api/tests/opentrons/labware/test_pipette_constructors.py
@@ -7,24 +7,24 @@ from opentrons.legacy_api.instruments import Pipette
 factories = [
     ('p10_single_v1.3', 'p10_single', instruments.P10_Single),
     ('p10_multi_v1.5', 'p10_multi', instruments.P10_Multi),
-    ('p20_single_v2.0', 'p20_single_GEN2', instruments.P20_Single_GEN2),
-    ('p20_multi_v2.0', 'p20_multi_GEN2', instruments.P20_Multi_GEN2),
+    ('p20_single_v2.0', 'p20_single_gen2', instruments.P20_Single_GEN2),
+    ('p20_multi_v2.0', 'p20_multi_gen2', instruments.P20_Multi_GEN2),
     ('p50_single_v1.3', 'p50_single', instruments.P50_Single),
     ('p50_multi_v1.5', 'p50_multi', instruments.P50_Multi),
     ('p300_single_v1.3', 'p300_single', instruments.P300_Single),
-    ('p300_single_v2.0', 'p300_single_GEN2', instruments.P300_Single_GEN2),
-    ('p300_multi_v2.0', 'p300_multi_GEN2', instruments.P300_Multi_GEN2),
+    ('p300_single_v2.0', 'p300_single_gen2', instruments.P300_Single_GEN2),
+    ('p300_multi_v2.0', 'p300_multi_gen2', instruments.P300_Multi_GEN2),
     ('p300_multi_v1.5', 'p300_multi', instruments.P300_Multi),
     ('p1000_single_v1.3', 'p1000_single', instruments.P1000_Single),
-    ('p1000_single_v2.0', 'p1000_single_GEN2', instruments.P1000_Single_GEN2),
+    ('p1000_single_v2.0', 'p1000_single_gen2', instruments.P1000_Single_GEN2),
 ]
 
 backcompat_pips = [
-    ('p20_single_GEN2', 'p10_single', instruments.P10_Single),
-    ('p300_single_GEN2', 'p300_single', instruments.P300_Single),
-    ('p20_multi_GEN2', 'p10_multi', instruments.P10_Multi),
-    ('p300_multi_GEN2', 'p300_multi', instruments.P300_Multi),
-    ('p1000_single_GEN2', 'p1000_single', instruments.P1000_Single),
+    ('p20_single_gen2', 'p10_single', instruments.P10_Single),
+    ('p300_single_gen2', 'p300_single', instruments.P300_Single),
+    ('p20_multi_gen2', 'p10_multi', instruments.P10_Multi),
+    ('p300_multi_gen2', 'p300_multi', instruments.P300_Multi),
+    ('p1000_single_gen2', 'p1000_single', instruments.P1000_Single),
 ]
 
 
@@ -80,7 +80,7 @@ def test_backwards_compatibility(backcompat, monkeypatch):
 
     fake_pip = {'left': {'model': None, 'id': None, 'name': None},
                 'right': {
-                    'model': expected_name.split('_GEN2')[0] + '_v2.0',
+                    'model': expected_name.split('_gen2')[0] + '_v2.0',
                     'id': 'FakePip',
                     'name': expected_name}}
     monkeypatch.setattr(robot, 'model_by_mount', fake_pip)

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -27,6 +27,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -215,6 +216,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -403,6 +405,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -591,6 +594,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -749,6 +753,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -942,6 +947,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1135,6 +1141,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1328,6 +1335,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1485,6 +1493,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1663,6 +1672,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -1841,6 +1851,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2019,6 +2030,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2177,6 +2189,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2355,6 +2368,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2533,6 +2547,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2711,6 +2726,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2853,6 +2869,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -2995,6 +3012,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3137,6 +3155,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 8-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3280,6 +3299,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3478,6 +3498,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3676,6 +3697,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -3874,6 +3896,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4036,6 +4059,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
+  "displayCategory": "OG",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4199,6 +4223,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
+  "displayCategory": "OG",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4362,6 +4387,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
+  "displayCategory": "OG",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4525,6 +4551,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
+  "displayCategory": "OG",
   "displayName": "P1000 Single-Channel",
   "dropTip": Object {
     "max": 2,
@@ -4674,6 +4701,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 8-Channel",
   "maxVolume": 10,
   "minVolume": 1,
@@ -4694,6 +4722,7 @@ Object {
     "min": 0.001,
     "value": 10,
   },
+  "displayCategory": "OG",
   "displayName": "P10 Single-Channel",
   "maxVolume": 10,
   "minVolume": 1,
@@ -4714,6 +4743,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 8-Channel",
   "maxVolume": 50,
   "minVolume": 5,
@@ -4734,6 +4764,7 @@ Object {
     "min": 0.001,
     "value": 50,
   },
+  "displayCategory": "OG",
   "displayName": "P50 Single-Channel",
   "maxVolume": 50,
   "minVolume": 5,
@@ -4754,6 +4785,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 8-Channel",
   "maxVolume": 300,
   "minVolume": 30,
@@ -4774,6 +4806,7 @@ Object {
     "min": 0.001,
     "value": 300,
   },
+  "displayCategory": "OG",
   "displayName": "P300 Single-Channel",
   "maxVolume": 300,
   "minVolume": 30,
@@ -4794,6 +4827,7 @@ Object {
     "min": 50,
     "value": 1000,
   },
+  "displayCategory": "OG",
   "displayName": "P1000 Single-Channel",
   "maxVolume": 1000,
   "minVolume": 100,

--- a/shared-data/js/pipettes.js
+++ b/shared-data/js/pipettes.js
@@ -7,6 +7,7 @@ export type PipetteChannels = 1 | 8
 export type PipetteNameSpecs = {
   name: string,
   displayName: string,
+  displayCategory: ?string,
   minVolume: number,
   maxVolume: number,
   defaultAspirateFlowRate: { value: number },

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -930,7 +930,7 @@
       "quirks": ["dropTipShake", "doubleDropTip"]
     },
     "p20_single_v2.0": {
-      "name": "p20_single_GEN2",
+      "name": "p20_single_gen2",
       "backcompatName": "p10_single",
       "top": {
         "value": 19.5,
@@ -1040,7 +1040,7 @@
       "quirks": ["dropTipShake"]
     },
     "p20_multi_v2.0": {
-      "name": "p20_multi_GEN2",
+      "name": "p20_multi_gen2",
       "backcompatName": "p10_multi",
       "top": {
         "value": 19.5,
@@ -2554,7 +2554,7 @@
       "quirks": ["dropTipShake"]
     },
     "p300_single_v2.0": {
-      "name": "p300_single_GEN2",
+      "name": "p300_single_gen2",
       "backcompatName": "p300_single",
       "top": {
         "value": 19.5,
@@ -3100,7 +3100,7 @@
       "quirks": ["dropTipShake", "doubleDropTip"]
     },
     "p300_multi_v2.0": {
-      "name": "p300_multi_GEN2",
+      "name": "p300_multi_gen2",
       "backcompatName": "p300_multi",
       "top": {
         "value": 19.5,
@@ -3657,7 +3657,7 @@
       }
     },
     "p1000_single_v2.0": {
-      "name": "p1000_single_GEN2",
+      "name": "p1000_single_gen2",
       "backcompatName": "p1000_single",
       "top": {
         "value": 19.5,

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -1,6 +1,7 @@
 {
   "p10_single": {
     "displayName": "P10 Single-Channel",
+    "displayCategory": "OG",
     "minVolume": 1,
     "maxVolume": 10,
     "channels": 1,
@@ -17,6 +18,7 @@
   },
   "p10_multi": {
     "displayName": "P10 8-Channel",
+    "displayCategory": "OG",
     "minVolume": 1,
     "maxVolume": 10,
     "defaultAspirateFlowRate": {
@@ -33,6 +35,7 @@
   },
   "p20_single_GEN2": {
     "displayName": "P20 Single-Channel GEN2",
+    "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
@@ -49,6 +52,7 @@
   },
   "p20_multi_GEN2": {
     "displayName": "P20 8-Channel GEN2",
+    "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
@@ -65,6 +69,7 @@
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
+    "displayCategory": "OG",
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
@@ -81,6 +86,7 @@
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
+    "displayCategory": "OG",
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
@@ -97,6 +103,7 @@
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
+    "displayCategory": "OG",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -113,6 +120,7 @@
   },
   "p300_single_GEN2": {
     "displayName": "P300 Single-Channel GEN2",
+    "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -129,6 +137,7 @@
   },
   "p300_multi_GEN2": {
     "displayName": "P300 8-Channel GEN2",
+    "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -145,6 +154,7 @@
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
+    "displayCategory": "OG",
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
@@ -161,6 +171,7 @@
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
+    "displayCategory": "OG",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,
@@ -177,6 +188,7 @@
   },
   "p1000_single_GEN2": {
     "displayName": "P1000 Single-Channel GEN2",
+    "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -33,7 +33,7 @@
     },
     "channels": 8
   },
-  "p20_single_GEN2": {
+  "p20_single_gen2": {
     "displayName": "P20 Single-Channel GEN2",
     "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
@@ -50,7 +50,7 @@
     "maxVolume": 20,
     "channels": 1
   },
-  "p20_multi_GEN2": {
+  "p20_multi_gen2": {
     "displayName": "P20 8-Channel GEN2",
     "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
@@ -118,7 +118,7 @@
     "minVolume": 30,
     "maxVolume": 300
   },
-  "p300_single_GEN2": {
+  "p300_single_gen2": {
     "displayName": "P300 Single-Channel GEN2",
     "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
@@ -135,7 +135,7 @@
     "minVolume": 20,
     "maxVolume": 300
   },
-  "p300_multi_GEN2": {
+  "p300_multi_gen2": {
     "displayName": "P300 8-Channel GEN2",
     "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {
@@ -186,7 +186,7 @@
     "minVolume": 100,
     "maxVolume": 1000
   },
-  "p1000_single_GEN2": {
+  "p1000_single_gen2": {
     "displayName": "P1000 Single-Channel GEN2",
     "displayCategory": "GEN2",
     "defaultAspirateFlowRate": {

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -8,6 +8,10 @@
     },
     "channels": {
       "enum": [1, 8]
+    },
+    "displayCategory": {
+      "type": "string",
+      "enum": ["OG", "GEN2"]
     }
   },
 
@@ -39,7 +43,7 @@
           "max": { "$ref": "#/definitions/positiveNumber" }
         },
         "displayName": { "type": "string" },
-        "displayCategory": { "type": "string" },
+        "displayCategory": { "$ref": "#/definitions/displayCategory" },
         "maxVolume": { "$ref": "#/definitions/positiveNumber" },
         "minVolume": { "$ref": "#/definitions/positiveNumber" }
       }

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -39,6 +39,7 @@
           "max": { "$ref": "#/definitions/positiveNumber" }
         },
         "displayName": { "type": "string" },
+        "displayCategory": { "type": "string" },
         "maxVolume": { "$ref": "#/definitions/positiveNumber" },
         "minVolume": { "$ref": "#/definitions/positiveNumber" }
       }


### PR DESCRIPTION
For a number of FE use cases, it is helpful to be able to distinguish "categories" of pipette names.
This adds a 'displayCategory' key and value to the pipetteNameSpecs and schema.