### PR TITLE
fix(api): apiv2: Correctly handle flow rates and plunger speeds

### DIFF
--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -145,7 +145,7 @@ class Pipette:
         Add a tip to the pipette for position tracking and validation
         (effectively updates the pipette's critical point)
 
-        :param tip_length: a positive, non-zero float representing the distance
+        :param tip_length: a positive, non-zero float presenting the distance
             in Z from the end of the pipette nozzle to the end of the tip
         :return:
         """

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1369,25 +1369,33 @@ class InstrumentContext(CommandPublisher):
         return self._mount.name.lower()
 
     @property
-    def speeds(self) -> Dict[str, float]:
-        """ The speeds (in mm/s) configured for the pipette, as a dict.
+    def speed(self) -> Dict[str, float]:
+        """ The speeds (in mm/s) configured for the pipette plunger, as a dict.
 
-        The keys will be 'aspirate' and 'dispense' (e.g. the keys of
-        :py:class:`MODE`)
+        The keys will be ``'aspirate'``, ``'dispense'``, and ``'blow_out'``
 
-        :note: This property is equivalent to :py:attr:`speeds`; the only
-        difference is the units in which this property is specified.
+        :note: This property is equivalent to :py:attr:`flow_rate`; the only
+        difference is the units in which this property is specified. Specifying
+        this attribute uses the units of the linear speed of the plunger inside
+        the pipette, while :py:attr:`flow_rate` uses the units of the
+        volumetric flow rate of liquid into or out of the tip.
+
+        :note: When setting this attribute, make sure to assign values to it
+        rather than modifying the entries. For example, always do
+
+        .. code-block:: python
+
+          instrument.speed = {'aspirate': 30}
         """
-        raise NotImplementedError
+        return {
+            'aspirate': self.hw_pipette['aspirate_speed'],
+            'dispense': self.hw_pipette['dispense_speed'],
+            'blow_out': self.hw_pipette['blow_out_speed']}
 
-    @speeds.setter
-    def speeds(self, new_speeds: Dict[str, float]) -> None:
-        """ Update the speeds (in mm/s) set for the pipette.
-
-        :param new_speeds: A dict containing at least one of 'aspirate'
-                           and 'dispense',  mapping to new speeds in mm/s.
-        """
-        raise NotImplementedError
+    @speed.setter
+    def speed(self, new_speeds: Dict[str, float]) -> None:
+        self._hw_manager.hardware.set_pipette_speed(self._mount,
+                                                    **new_speeds)
 
     @property
     def flow_rate(self) -> Dict[str, float]:
@@ -1396,8 +1404,18 @@ class InstrumentContext(CommandPublisher):
         Returns a dict with the keys 'aspirate' and 'dispense' and correspoding
         values are the flow rates for each operation.
 
-        :note: This property is equivalent to :py:attr:`speeds`; the only
-        difference is the units in which this property is specified.
+        :note: This property is equivalent to :py:attr:`speed`; the only
+        difference is the units in which this property is specified. Specifying
+        this property uses the units of the volumetric flow rate of liquid into
+        or out of the tip, while :py:attr:`speed` uses the units of the linear
+        speed of the plunger inside the pipette.
+
+        :note: When setting this attribute, make sure to assign values to it
+        rather than modifying the entries. For example, always do
+
+        .. code-block:: python
+
+          instrument.flow_rate = {'aspirate': 50}
         """
         return {'aspirate': self.hw_pipette['aspirate_flow_rate'],
                 'dispense': self.hw_pipette['dispense_flow_rate'],
@@ -1405,18 +1423,6 @@ class InstrumentContext(CommandPublisher):
 
     @flow_rate.setter
     def flow_rate(self, new_flow_rate: Dict[str, float]) -> None:
-        """ Update the speeds (in uL/s) for the pipette.
-
-        :param new_flow_rate: A dict containing at least one of ``'aspirate'``,
-                              ``'dispense'``, or ``'blow_out'``, mapping to
-                              new speeds in uL/s.
-
-        For instance:
-
-        .. code-block:: python
-
-          instrument.flow_rate = {'aspirate': 50}
-        """
         self._hw_manager.hardware.set_flow_rate(self._mount, **new_flow_rate)
 
     @property

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -2,6 +2,7 @@
 
 import json
 import pkgutil
+from unittest import mock
 
 import opentrons.protocol_api as papi
 from opentrons.types import Mount, Point, Location, TransferTipPolicy
@@ -524,3 +525,45 @@ def test_transfer_options(loop, monkeypatch):
         dispense=tf.DispenseOpts()
     )
     assert transfer_options == expected_xfer_options2
+
+
+def test_flow_rate(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    old_sfm = ctx._hw_manager.hardware
+
+    def pass_on(aspirate=None, dispense=None, blow_out=None):
+        old_sfm(aspirate=None, dispense=None, blow_out=None)
+
+    set_flow_rate = mock.Mock(side_effect=pass_on)
+    monkeypatch.setattr(ctx._hw_manager.hardware, 'set_flow_rate',
+                        set_flow_rate)
+    instr = ctx.load_instrument('p300_single', Mount.RIGHT)
+
+    ctx.home()
+    instr.flow_rate = {'aspirate': 1}
+    assert set_flow_rate.called_with(aspirate=1)
+    set_flow_rate.reset_mock()
+    instr.flow_rate = {'dispense': 10, 'blow_out': 2}
+    assert set_flow_rate.called_with(dispense=10, blow_out=2)
+    assert instr.flow_rate == {'aspirate': 1, 'dispense': 10, 'blow_out': 2}
+
+
+def test_pipette_speed(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop)
+    old_sfm = ctx._hw_manager.hardware
+
+    def pass_on(aspirate=None, dispense=None, blow_out=None):
+        old_sfm(aspirate=None, dispense=None, blow_out=None)
+
+    set_speed = mock.Mock(side_effect=pass_on)
+    monkeypatch.setattr(ctx._hw_manager.hardware, 'set_pipette_speed',
+                        set_speed)
+    instr = ctx.load_instrument('p300_single', Mount.RIGHT)
+
+    ctx.home()
+    instr.speed = {'aspirate': 1}
+    assert set_speed.called_with(aspirate=1)
+    set_speed.reset_mock()
+    instr.speed = {'dispense': 10, 'blow_out': 2}
+    assert set_speed.called_with(dispense=10, blow_out=2)
+    assert instr.speed == {'aspirate': 1, 'dispense': 10, 'blow_out': 2}


### PR DESCRIPTION
We didn't have InstrumentContext.speed implemented at all, and the rest of the
apiv2 stack was treating flow rates as if they were linear speeds. This
implements speed, and treats flowrates correctly.

Closes #3737
Closes #3270

Test:

Run the below protocols (apiv1 and apiv2). They have a fast blowout and a slow blowout. The blowouts should be the same speed in each api version, and in particular the slow blowout should have a `G0F31` command sent to the smoothie before the move (if you're using a p300 single; other pipettes will have different numbers for this one since it passes through `ul_per_mm`)

apiv2:
```python
def run(ctx):
  tr = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 2)
  trough = ctx.load_labware_by_name('usascientific_12_reservoir_22ml', 1)
  pip = ctx.load_instrument('p300_single', 'right', tip_racks=[tr])
  pip.pick_up_tip()
  pip.aspirate(200, trough.wells()[0])
  pip.blow_out(trough.wells()[-1])
  pip.flow_rate = {'blow_out': 10}
  pip.aspirate(200, trough.wells()[-1])
  pip.blow_out(trough.wells()[0])
  pip.return_tip()
```

apiv1
```python
from opentrons import instruments, labware

tr = labware.load('opentrons_96_tiprack_300ul', 2)
trough = labware.load('usascientific_12_reservoir_22ml', 1)
p300 = instruments.P300_Single('right', tip_racks=[tr])

p300.pick_up_tip()
p300.aspirate(200, trough.well('A1'))
p300.blow_out(trough.well('A12'))
p300.set_flow_rate(blow_out=10)
p300.aspirate(200, trough.well('A2'))
p300.blow_out(trough.well('A12'))
p300.return_tip()
```