### PR TITLE
chore(api): Add tags to differentiate serial log sources

### DIFF
--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -293,7 +293,8 @@ class MagDeck:
                 cmd,
                 MAG_DECK_ACK,
                 self._connection,
-                timeout)
+                timeout,
+                tag=f'magdeck {id(self)}')
         except SerialNoResponse as e:
             retries -= 1
             if retries <= 0:

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -955,7 +955,8 @@ class SmoothieDriver_3_0_0:
         self._handle_return(cmd_ret)
         wait_ret = serial_communication.write_and_return(
             GCODES['WAIT'] + SMOOTHIE_COMMAND_TERMINATOR,
-            SMOOTHIE_ACK, self._connection, timeout=12000)
+            SMOOTHIE_ACK, self._connection, timeout=12000,
+            tag='smoothie')
         wait_ret = self._remove_unwanted_characters(
             GCODES['WAIT'], wait_ret)
         self._handle_return(wait_ret)
@@ -1015,7 +1016,8 @@ class SmoothieDriver_3_0_0:
                     cmd,
                     SMOOTHIE_ACK,
                     self._connection,
-                    timeout=timeout)
+                    timeout=timeout,
+                    tag='smoothie')
                 if attempt != 0:
                     log.warning(
                         f"required {attempt} retries for {cmd.strip()}")

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -178,7 +178,8 @@ class TCPoller(threading.Thread):
     def _recursive_write_and_return(self, cmd, timeout, retries):
         try:
             return serial_communication.write_and_return(
-                cmd, TC_ACK, self._connection, timeout)
+                cmd, TC_ACK, self._connection, timeout,
+                tag=f'thermocycler {id(self)}')
         except SerialNoResponse as e:
             retries -= 1
             if retries <= 0:

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1176,11 +1176,13 @@ class API(HardwareAPILike):
         gone = known - these
         for mod in gone:
             self._attached_modules.pop(mod)
+            self._log.info(f"Module {mod} disconnected")
         for mod in new:
             self._attached_modules[mod]\
                 = await self._backend.build_module(discovered[mod][0],
                                                    discovered[mod][1],
                                                    self.pause_with_message)
+            self._log.info(f"Module {mod} discovered and attached")
         return list(self._attached_modules.values())
 
     @_log_call

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -59,7 +59,7 @@ def discover() -> List[Tuple[str, str]]:
                 continue
             absolute_port = '/dev/modules/{}'.format(port)
             discovered_modules.append((absolute_port, name))
-    log.info('Discovered modules: {}'.format(discovered_modules))
+    log.debug('Discovered modules: {}'.format(discovered_modules))
 
     return discovered_modules
 

--- a/api/src/opentrons/legacy_api/modules/__init__.py
+++ b/api/src/opentrons/legacy_api/modules/__init__.py
@@ -100,7 +100,7 @@ def discover() -> List[Tuple[str, Any]]:
                             .format(name, port))
                 continue
             discovered_modules.append((port, name))
-    log.info('Discovered modules: {}'.format(discovered_modules))
+    log.debug('Discovered modules: {}'.format(discovered_modules))
 
     return discovered_modules
 

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -62,8 +62,8 @@ def _load_container_by_name(container_name):
                 container.properties['type'] = container_name
             log.info(f"Loaded {container_name} from {meth.__name__}")
             break
-        except (ValueError, KeyError):
-            log.exception(f"{container_name} not in {meth.__name__}")
+        except (ValueError, KeyError) as e:
+            log.info(f"{container_name} not in {meth.__name__} ({repr(e)})")
     else:
         raise KeyError(f"Unknown labware {container_name}")
     return container
@@ -1113,6 +1113,7 @@ class Robot(CommandPublisher):
         new = these - known
         gone = known - these
         for mod in gone:
+            log.info(f"Module {mod} disconnected")
             self._attached_modules.pop(mod)
         for mod in new:
             module_class = modules.SUPPORTED_MODULES[discovered[mod][1]]
@@ -1124,3 +1125,5 @@ class Robot(CommandPublisher):
                 self._attached_modules[mod].connect()
             except AttributeError:
                 log.exception('Failed to connect module')
+            else:
+                log.info(f"Module {mod} discovered and connected")

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -23,7 +23,7 @@ def test_get_temp_deck_temperature():
     command_log = []
     return_string = 'T:none C:90'
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log, return_string
         command_log += [command]
         return return_string
@@ -56,7 +56,7 @@ def test_fail_get_temp_deck_temperature():
 
     done = False
 
-    def _mock_send_command1(self, command, timeout=None):
+    def _mock_send_command1(self, command, timeout=None, tag=None):
         nonlocal done
         done = True
         return 'T:none C:90'
@@ -70,7 +70,7 @@ def test_fail_get_temp_deck_temperature():
 
     assert temp_deck._temperature == {'current': 90, 'target': None}
 
-    def _mock_send_command2(self, command, timeout=None):
+    def _mock_send_command2(self, command, timeout=None, tag=None):
         nonlocal done
         done = True
         return 'Tx:none C:1'    # Failure premise
@@ -93,7 +93,7 @@ def test_set_temp_deck_temperature(monkeypatch):
     temp_deck.simulating = False
     command_log = []
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log
         command_log += [command]
         return ''
@@ -113,7 +113,8 @@ def test_fail_set_temp_deck_temperature(monkeypatch):
 
     error_msg = 'ERROR: some error here'
 
-    def _raise_error(self, command, ack, serial_connection, timeout=None):
+    def _raise_error(
+            self, command, ack, serial_connection, timeout=None, tag=None):
         nonlocal error_msg
         return error_msg
 
@@ -129,7 +130,8 @@ def test_fail_set_temp_deck_temperature(monkeypatch):
 
     error_msg = 'Alarm: something alarming happened here'
 
-    def _raise_error(self, command, ack, serial_connection, timeout=None):
+    def _raise_error(
+            self, command, ack, serial_connection, timeout=None, tag=None):
         nonlocal error_msg
         return error_msg
 
@@ -148,7 +150,7 @@ def test_turn_off_temp_deck(monkeypatch):
     temp_deck.simulating = False
     command_log = []
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log
         command_log += [command]
         return ''
@@ -172,7 +174,7 @@ def test_get_device_info(monkeypatch):
     firmware_version = 'edge-1a2b345'
     serial = 'td20180102A01'
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log
         command_log += [command]
         return 'model:' + model \
@@ -202,7 +204,7 @@ def test_fail_get_device_info(monkeypatch):
     firmware_version = 'edge-1a2b345'
     serial = 'td20180102A01'
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log
         command_log += [command]
         return 'modelXX:' + model \
@@ -223,7 +225,7 @@ def test_dfu_command(monkeypatch):
     temp_deck.simulating = False
     command_log = []
 
-    def _mock_send_command(self, command, timeout=None):
+    def _mock_send_command(self, command, timeout=None, tag=None):
         nonlocal command_log
         command_log += [command]
         return ''

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -67,7 +67,7 @@ def test_remove_serial_echo(smoothie, monkeypatch):
     from opentrons.drivers.smoothie_drivers import driver_3_0
     smoothie.simulating = False
 
-    def return_echo_response(command, ack, connection, timeout):
+    def return_echo_response(command, ack, connection, timeout, tag=None):
         if 'some-data' in command:
             return command + 'TESTS-RULE'
         return command
@@ -88,7 +88,7 @@ def test_remove_serial_echo(smoothie, monkeypatch):
         driver_3_0.SMOOTHIE_ACK)
     assert res == 'TESTS-RULE'
 
-    def return_echo_response(command, ack, connection, timeout):
+    def return_echo_response(command, ack, connection, timeout, tag=None):
         if 'some-data' in command:
             return command.strip() + '\r\nT\r\nESTS-RULE'
         return command
@@ -127,7 +127,7 @@ def test_dwell_and_activate_axes(smoothie, monkeypatch):
     smoothie._setup()
     smoothie.simulating = False
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
 
@@ -172,7 +172,7 @@ def test_disable_motor(smoothie, monkeypatch):
     command_log = []
     smoothie.simulating = False
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
 
@@ -208,7 +208,7 @@ def test_plunger_commands(smoothie, monkeypatch):
     smoothie.home()
     smoothie.simulating = False
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
 
@@ -312,7 +312,7 @@ def test_set_active_current(smoothie, monkeypatch):
     smoothie.home()
     smoothie.simulating = False
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
 
@@ -382,7 +382,7 @@ def test_set_acceleration(smoothie, monkeypatch):
     smoothie.home()
     smoothie.simulating = False
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
 
@@ -719,7 +719,7 @@ def test_clear_limit_switch(smoothie, monkeypatch):
     driver.home('xyza')
     cmd_list = []
 
-    def write_mock(command, ack, serial_connection, timeout):
+    def write_mock(command, ack, serial_connection, timeout, tag=None):
         nonlocal cmd_list
         cmd_list.append(command)
         if GCODES['MOVE'] in command:
@@ -814,7 +814,7 @@ def test_speed_change(model, monkeypatch):
     from opentrons.drivers.smoothie_drivers import driver_3_0
     command_log = []
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         if 'G0F' in command:
             command_log.append(command.strip())
         elif 'M114' in command:
@@ -850,7 +850,7 @@ def test_max_speed_change(model, monkeypatch):
     from opentrons.drivers.smoothie_drivers import driver_3_0
     command_log = []
 
-    def write_with_log(command, ack, connection, timeout):
+    def write_with_log(command, ack, connection, timeout, tag=None):
         if 'M203.1' in command or 'G0F' in command:
             command_log.append(command.strip())
         return driver_3_0.SMOOTHIE_ACK
@@ -893,7 +893,7 @@ def test_send_command_with_retry(model, monkeypatch):
 
     count = 0
 
-    def _no_response(command, ack, connection, timeout):
+    def _no_response(command, ack, connection, timeout, tag=None):
         nonlocal count
         count += 1
         if count < 3:
@@ -1030,7 +1030,7 @@ def test_alarm_unhandled(model, monkeypatch):
     driver.simulating = False
     killmsg = 'ALARM: Kill button pressed - reset or M999 to continue\r\n'
 
-    def fake_write_and_return(cmdstr, ack, conn, timeout=None):
+    def fake_write_and_return(cmdstr, ack, conn, timeout=None, tag=None):
 
         return cmdstr + killmsg
 


### PR DESCRIPTION
Our serial logs track all data to and from the smoothie and the modules on an
equal footing. Since the smoothie and the modules all use gcode, when a robot is
connected to a smoothie and several modules it can be quite difficult to figure
out which serial traffic is for which source.

Instead, add a tag to serial logging that will differentiate between traffic to
the smoothie and to modules.

In addition, remove some very chatty error logs.

## Testing
 Just run with some modules attached and make sure nothing crashes