### PR TITLE
refactor(update-server): fix capabilities and migration filename

### DIFF
--- a/update-server/buildroot_upload.py
+++ b/update-server/buildroot_upload.py
@@ -32,10 +32,9 @@ async def do_update(update_file: str, host: str, kind: UPDATE_KIND):
     async with aiohttp.ClientSession() as session:
         if kind == UPDATE_KIND.MIGRATE:
             root = host + '/server/update/migration'
-            filename = 'ot2-migration.zip'
         else:
             root = host + '/server/update'
-            filename = 'ot2-system.zip'
+        filename = 'ot2-system.zip'
         print(f"Starting update of {update_file.name} to {host}")
         begin_resp = await session.post(root + '/begin')
         if begin_resp.status == 409:

--- a/update-server/otupdate/balena/endpoints.py
+++ b/update-server/otupdate/balena/endpoints.py
@@ -23,8 +23,8 @@ def build_health_endpoint(
             'restart': '/server/update/restart'}
     }
     if with_migration:
-        health_dict.update({'buildroot-migration':
-                            '/server/update/migration/begin'})
+        health_dict['capabilities']['buildroot-migration']\
+            = '/server/update/migration/begin'
 
     async def health(request: web.Request) -> web.Response:
         return web.json_response(

--- a/update-server/otupdate/balena/endpoints.py
+++ b/update-server/otupdate/balena/endpoints.py
@@ -19,11 +19,11 @@ def build_health_endpoint(
         'systemVersion': system_version,
         'capabilities': {
             'bootstrap': '/server/update/bootstrap',
-            'balena-update': '/server/update',
+            'balenaUpdate': '/server/update',
             'restart': '/server/update/restart'}
     }
     if with_migration:
-        health_dict['capabilities']['buildroot-migration']\
+        health_dict['capabilities']['buildrootMigration']\
             = '/server/update/migration/begin'
 
     async def health(request: web.Request) -> web.Response:

--- a/update-server/otupdate/buildroot/control.py
+++ b/update-server/otupdate/buildroot/control.py
@@ -48,7 +48,7 @@ def build_health_endpoint(
                 'smoothieVersion': 'unimplemented',
                 'systemVersion': version_dict.get(
                     'buildroot_version', 'unknown'),
-                'capabilities': {'buildroot-update': '/server/update/begin',
+                'capabilities': {'buildrootUpdate': '/server/update/begin',
                                  'restart': '/server/restart'}
             },
             headers={'Access-Control-Allow-Origin': '*'}

--- a/update-server/otupdate/buildroot/update_session.py
+++ b/update-server/otupdate/buildroot/update_session.py
@@ -26,7 +26,8 @@ class UpdateSession:
     State machine for update sessions
     """
     def __init__(self, storage_path: str) -> None:
-        self._token = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode()
+        self._token = base64.urlsafe_b64encode(uuid.uuid4().bytes)\
+                            .decode().strip('=')
         self._stage = Stages.AWAITING_FILE
         self._progress = 0.0
         self._message = ''

--- a/update-server/otupdate/migration/endpoints.py
+++ b/update-server/otupdate/migration/endpoints.py
@@ -150,7 +150,7 @@ async def file_upload(
     """ Serves /update/:session/file
 
     Requires multipart (encoding doesn't matter) with a file field in the
-    body called 'ot2-migration.zip'.
+    body called 'ot2-system.zip'.
     """
     if session.stage != Stages.AWAITING_FILE:
         return web.json_response(
@@ -159,7 +159,7 @@ async def file_upload(
             status=409)
     reader = await request.multipart()
     async for part in reader:
-        if part.name != 'ot2-migration.zip':
+        if part.name != 'ot2-system.zip':
             LOG.warning(
                 f"Unknown field name {part.name} in file_upload, ignoring")
             await part.release()
@@ -169,7 +169,7 @@ async def file_upload(
     _begin_validation(
         session,
         asyncio.get_event_loop(),
-        os.path.join(session.download_path, 'ot2-migration.zip'),
+        os.path.join(session.download_path, 'ot2-system.zip'),
         request.app.get(constants.ROBOT_NAME_VARNAME, 'opentrons'))
 
     return web.json_response(data=session.state,

--- a/update-server/tests/balena/test_server_boot.py
+++ b/update-server/tests/balena/test_server_boot.py
@@ -36,7 +36,7 @@ async def test_server_boot(loop, test_client):
         'systemVersion': 'unknown',
         'capabilities': {
             'bootstrap': '/server/update/bootstrap',
-            'balena-update': '/server/update',
+            'balenaUpdate': '/server/update',
             'restart': '/server/update/restart'
         }
     }
@@ -61,7 +61,7 @@ async def test_server_boot(loop, test_client):
     resp = await cli.get('/server/update/health')
     res = await resp.json()
     assert resp.status == 200
-    assert res['capabilities']['buildroot-migration']\
+    assert res['capabilities']['buildrootMigration']\
         == '/server/update/migration/begin'
 
 

--- a/update-server/tests/balena/test_server_boot.py
+++ b/update-server/tests/balena/test_server_boot.py
@@ -61,7 +61,8 @@ async def test_server_boot(loop, test_client):
     resp = await cli.get('/server/update/health')
     res = await resp.json()
     assert resp.status == 200
-    assert res['buildroot-migration'] == '/server/update/migration/begin'
+    assert res['capabilities']['buildroot-migration']\
+        == '/server/update/migration/begin'
 
 
 async def test_bootstrap_fail(monkeypatch, loop, test_client):

--- a/update-server/tests/migration/conftest.py
+++ b/update-server/tests/migration/conftest.py
@@ -96,7 +96,7 @@ def downloaded_update_file(request, extracted_update_file):
     rootfs_hash_path = os.path.join(extracted_update_file, 'rootfs.ext4.hash')
     bootfs_path = os.path.join(extracted_update_file, 'boot.vfat')
     bootfs_hash_path = os.path.join(extracted_update_file, 'boot.vfat.hash')
-    zip_path = os.path.join(extracted_update_file, 'ot2-migration.zip')
+    zip_path = os.path.join(extracted_update_file, 'ot2-system.zip')
     with zipfile.ZipFile(zip_path, 'w') as zf:
         for marker, filepath in [('exclude_rootfs_ext4', rootfs_path),
                                  ('exclude_rootfs_ext4_hash',

--- a/update-server/tests/migration/test_migration_api.py
+++ b/update-server/tests/migration/test_migration_api.py
@@ -173,7 +173,7 @@ async def test_migration_happypath(otupdate_test_client, update_session,
     # Upload
     resp = await otupdate_test_client.post(
         session_endpoint(update_session, 'file'),
-        data={'ot2-migration.zip': open(downloaded_update_file, 'rb')})
+        data={'ot2-system.zip': open(downloaded_update_file, 'rb')})
     assert resp.status == 201
     body = await resp.json()
     assert body['stage'] == 'validating'
@@ -227,7 +227,7 @@ async def test_update_catches_validation_fail(otupdate_test_client,
     # Upload
     resp = await otupdate_test_client.post(
         session_endpoint(update_session, 'file'),
-        data={'ot2-migration.zip': open(downloaded_update_file, 'rb')})
+        data={'ot2-system.zip': open(downloaded_update_file, 'rb')})
     assert resp.status == 201
     body = await resp.json()
     assert body['stage'] == 'validating'


### PR DESCRIPTION
- buildroot-migration should have always been in the capabilities subdict of the
  health response
- given that it's now the same file as the update, make the migration system
  accept ot2-system.zip
