### PR TITLE
refactor(app): Add download progress bar and error content

### DIFF
--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -3,7 +3,7 @@
 
 import * as React from 'react'
 import { AlertModal } from '@opentrons/components'
-
+import styles from './styles.css'
 import type { ButtonProps } from '@opentrons/components'
 
 type Props = {|
@@ -12,26 +12,58 @@ type Props = {|
   progress: number | null,
 |}
 
-const HEADING = 'Robot System Update Downloading'
+const HEADING = 'Robot System Update'
 export default function DownloadUpdate(props: Props) {
   const { notNowButton, error, progress } = props
+
   let message
+
+  const progressMessage = (
+    <div className={styles.system_update_modal}>
+      <p className={styles.download_message}>
+        Robot update download in progress...
+      </p>
+      <ProgressBar progress={progress} />
+      <p>
+        Please keep app connected to the internet until the download is
+        complete.
+      </p>
+    </div>
+  )
+
   if (progress) {
-    message = <p>Download progress: {progress}%</p>
+    message = progressMessage
   } else if (error) {
     message = (
-      <>
-        <p>{error}</p>
-        <p>Some informative text about connecting to the internet</p>
-      </>
+      <div className={styles.system_update_modal}>
+        <p className={styles.download_message}>
+          There was an error downloading robot update files:
+        </p>
+        <p className={styles.download_error}>{error}</p>
+        <p>To download this update you must be connected to the internet.</p>
+      </div>
     )
   } else {
-    message = <p>Download progress: 0%</p>
+    message = progressMessage
   }
   return (
     <AlertModal heading={HEADING} buttons={[notNowButton]} alertOverlay>
-      <h2>Screens not fully implemented!</h2>
       {message}
     </AlertModal>
+  )
+}
+
+type ProgressBarProps = {
+  progress: number | null,
+}
+
+function ProgressBar(props: ProgressBarProps) {
+  const { progress } = props
+  const width = progress && `${progress}%`
+  return (
+    <div className={styles.progress_bar_container}>
+      <span className={styles.progress_text}>{progress}%</span>
+      <div style={{ width: width }} className={styles.progress_bar} />
+    </div>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/styles.css
+++ b/app/src/components/RobotSettings/UpdateBuildroot/styles.css
@@ -36,3 +36,34 @@
 .reinstall_message {
   margin-left: 1rem;
 }
+
+.download_message {
+  font-weight: var(--fw-semibold);
+}
+
+.download_error {
+  font-style: italic;
+}
+
+.progress_bar_container {
+  position: relative;
+  height: 1.75rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+  border: solid 2px var(--c-dark-gray);
+  text-align: right;
+}
+
+.progress_bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border: solid 2px var(--c-white);
+  border-radius: 3px;
+  background-color: #006fff;
+}
+
+.progress_text {
+  line-height: 1.75;
+  padding: 0.5rem 0.25rem;
+}


### PR DESCRIPTION
## overview

This PR closes #3740 by adding download error/progress screens 

(Copy + Design pass needed)

<img width="1021" alt="Screen Shot 2019-07-18 at 4 55 29 PM" src="https://user-images.githubusercontent.com/3430313/61492308-0ddc6880-a97f-11e9-831d-96a7261595fc.png">
<img width="1030" alt="Screen Shot 2019-07-18 at 5 09 58 PM" src="https://user-images.githubusercontent.com/3430313/61492309-0ddc6880-a97f-11e9-83a5-c6cac3c4426b.png">
<img width="1023" alt="Screen Shot 2019-07-18 at 5 10 24 PM" src="https://user-images.githubusercontent.com/3430313/61492310-0ddc6880-a97f-11e9-8ee5-360ebad146c5.png">

## changelog

- refactor(app): Add download progress bar and error content

## review requests

Would appreciate feedback on titles/copy!

Enable FF 
```
make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1 OT_APP_BUILDROOT__MANIFEST_URL="https://ot-test-bucket.s3.amazonaws.com/releases.json"
```

**Update File download error** (default since 3.10.0 is not in releases.json yet). 
*Be sure to delete __ot-buildroot_ folder!*

**Balena**
- [ ] Download error shows after viewing Migration Warning Modal

**Buildroot**
- [ ] Download error shows after viewing Sync Robot Modal

**Update File download progress**
*Fake app version 3.9.0 *  (3.10.0 is not in releases.json yet)

**Balena**
- [ ] Download progress shows after viewing Migration Warning Modal

**Buildroot**
- [ ] Download progress shows after viewing Sync Robot Modal

`downloadProgress: null` && `downloadError: null` (really slow internet but no error)

**Balena**
- [ ] Download progress shows after viewing Migration Warning Modal

**Buildroot**
- [ ] Download progress shows after viewing Sync Robot Modal