### PR TITLE
fix(api): Allow gen2 reference in protocol without pipette attached

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -351,7 +351,7 @@ class InstrumentsWrapper(object):
             attached_model_config = pipette_config.configs[attached_model]
         except KeyError:
             return list(filter(
-                lambda m: expected_model_substring == m.split('_v')[0],
+                lambda m: m.split('_v')[0] in expected_model_substring,
                 pipette_config.config_models))[0]
 
         if attached_model_config.get('name') == expected_model_substring:


### PR DESCRIPTION
## overview
This PR serves as an issue and a fix. When API v1 loading of pipettes was refactored, one piece of logic was missed. If a pipette gen2 was _referenced_ in a protocol, but no pipette was attached at all, then there would be a indexing error on the filtering of pipettes. That is due to the fact that pipette names for gen2 now have no indicator in the model names. i.e. `p20_single_gen2` expected substring would never have matched `p20_single_v2.0`.

## changelog

- Change filter to check if the first half of the model key is found in the expected substring.

## review requests

Test on a robot. On edge, call a pipette gen2 in a protocol without attaching any pipette. Notice that you get a list index error. Do the same on this PR and see that you do not get this error anymore.
