### PR TITLE
fix(api): Remove model name check for non-gen2 pipettes

### DIFF
--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -299,7 +299,7 @@ class Robot(CommandPublisher):
                 self._driver.update_pipette_config(
                     plunger_axis, {'max_travel': 60})
                 self._driver.dist_from_eeprom[mount_axis] = 47.8
-            elif model_value:
+            else:
                 self._driver.dist_from_eeprom[mount_axis] = 0.0
                 self._driver.update_steps_per_mm(
                     {plunger_axis: 768})

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -6,8 +6,8 @@ import pytest
 from opentrons import robot, types
 from opentrons.legacy_api import modules as legacy_modules
 
-from opentrons.hardware_control import modules
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
+from opentrons.hardware_control import modules
 from opentrons import instruments
 from opentrons.config import pipette_config
 
@@ -33,12 +33,26 @@ async def test_get_pipettes_uncommissioned(
     }
 
     if async_server['api_version'] == 1:
-        def mock_parse_fail(self, gcode, mount):
+        def mock_parse_fail(gcode, mount):
+            pass
+
+        def fake_update_config(axis, data):
+            pass
+
+        def fake_update_steps_per_mm(data):
             pass
 
         monkeypatch.setattr(
-            SmoothieDriver_3_0_0, '_read_from_pipette', mock_parse_fail)
+            async_server['com.opentrons.hardware']._driver,
+            '_read_from_pipette', mock_parse_fail)
+        monkeypatch.setattr(
+            async_server['com.opentrons.hardware']._driver,
+            'update_pipette_config', fake_update_config)
+        monkeypatch.setattr(
+            async_server['com.opentrons.hardware']._driver,
+            'update_steps_per_mm', fake_update_steps_per_mm)
         robot._driver.simulating = False
+
     else:
         hw = async_server['com.opentrons.hardware']._backend
         hw._attached_instruments[types.Mount.LEFT] = {


### PR DESCRIPTION
## overview

This PR closes #3722. Smoothie settings for pipettes such as home position and steps per mm should always be set back to default once it is detected that a non-gen2 pipette (or no pipette) is attached.

This behavior was only prevalent in API V1.

## changelog
- Do not check if a pipette is present to set smoothie settings to default, just always do it.

## review requests

On edge you should notice that the smoothie settings described above never get set back to default in V1. This PR fixes that.
