### PR TITLE
fix(factory_scripts): Remove old func name and refactor IP look-up

### DIFF
--- a/api/src/opentrons/tools/factory_test.py
+++ b/api/src/opentrons/tools/factory_test.py
@@ -2,6 +2,7 @@ import atexit
 import logging
 import optparse
 import os
+import re
 import socket
 import subprocess
 
@@ -12,7 +13,7 @@ from opentrons.drivers import serial_communication
 
 log = logging.getLogger(__name__)
 
-
+IP_ADDRESS_SEARCH = re.compile(r'^(\d+\.\d+){3}')
 RESULT_SPACE = '\t- {}'
 FAIL = 'FAIL\t*** !!! ***'
 PASS = 'PASS'
@@ -45,9 +46,10 @@ def _find_storage_device():
 
 
 def _this_wifi_ip_address():
-    gw = os.popen('ip -4 route show default').read().split()
+    gw = os.popen('ip -f inet addr show eth0').read().split()
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect((gw[2], 0))
+    list_ips = [ip for ip in gw if IP_ADDRESS_SEARCH.match(ip)]
+    s.connect((list_ips[0], 0))
     return s.getsockname()[0]
 
 

--- a/api/src/opentrons/tools/factory_test.py
+++ b/api/src/opentrons/tools/factory_test.py
@@ -160,7 +160,7 @@ def test_smoothie_gpio(port_name=''):
     print('HALT')
     d._connection.reset_input_buffer()
     # drop the HALT line LOW, and make sure there is an error state
-    d._smoothie_hard_halt()
+    d.hard_halt()
 
     old_timeout = int(d._connection.timeout)
     d._connection.timeout = 1  # 1 second


### PR DESCRIPTION
## overview
This PR serves as a bug report and fix. While running the factory tests on new buildroot robots, we noticed that one of the functions used to call smoothie halt had a name change.

While fixing this, we ran into another problem with the command used to open a socket and find the IP address of the robot. I'm not sure why this was working before as when I tried to use the old command it returned an empty string.

## changelog

- Fix smoothie halt function name
- Fix IP look up

## review requests

Test on both balena and buildroot robots to make sure the script does not error.