### PR TITLE
fix(api): fix blow out logic

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -738,28 +738,28 @@ class InstrumentContext(CommandPublisher):
                               :py:meth:`dispense`)
         :returns: This instance
         """
-        if location is None:
-            if not self._ctx.location_cache:
-                raise RuntimeError('No valid current location cache present')
-            else:
-                location = self._ctx.location_cache.labware  # type: ignore
-                # type checked below
 
         if isinstance(location, Well):
             if location.parent.is_tiprack:
                 self._log.warning('Blow_out being performed on a tiprack. '
                                   'Please re-check your code')
-            target = location.top()
-        elif isinstance(location, types.Location) and not \
-                isinstance(location.labware, Well):
+            loc = location.top()
+            self.move_to(loc)
+        elif isinstance(location, types.Location):
+            loc = location
+            self.move_to(loc)
+        elif location is not None:
             raise TypeError(
-                'location should be a Well or None, but it is {}'
+                'location should be a Well or Location, but it is {}'
                 .format(location))
+        elif self._ctx.location_cache:
+            loc = self._ctx.location_cache
         else:
-            raise TypeError(
-                'location should be a Well or None, but it is {}'
-                .format(location))
-        self.move_to(target)
+            raise RuntimeError(
+                "If blow out is called without an explicit location, another"
+                " method that moves to a location (such as move_to or "
+                "dispense) must previously have been called so the robot "
+                "knows where it is.")
         self._hw_manager.hardware.blow_out(self._mount)
         return self
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -753,7 +753,9 @@ class InstrumentContext(CommandPublisher):
                 'location should be a Well or Location, but it is {}'
                 .format(location))
         elif self._ctx.location_cache:
-            loc = self._ctx.location_cache
+            # if location cache exists, pipette blows out immediately at
+            # current location, no movement is needed
+            pass
         else:
             raise RuntimeError(
                 "If blow out is called without an explicit location, another"

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -450,13 +450,18 @@ def test_blow_out(loop, monkeypatch):
     monkeypatch.setattr(instr, 'move_to', fake_move)
 
     instr.blow_out()
+    # pipette should not move, if no location is passed
     assert move_location is None
 
     instr.aspirate(10)
     instr.blow_out(lw.wells()[0])
-
+    # pipette should blow out at the top of the well as default
     assert move_location == lw.wells()[0].top()
 
+    instr.aspirate(10)
+    instr.blow_out(lw.wells()[0].bottom())
+    # pipette should blow out at the location defined
+    assert move_location == lw.wells()[0].bottom()
 
 
 def test_transfer_options(loop, monkeypatch):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -448,8 +448,15 @@ def test_blow_out(loop, monkeypatch):
         move_location = loc
 
     monkeypatch.setattr(instr, 'move_to', fake_move)
+
     instr.blow_out()
+    assert move_location is None
+
+    instr.aspirate(10)
+    instr.blow_out(lw.wells()[0])
+
     assert move_location == lw.wells()[0].top()
+
 
 
 def test_transfer_options(loop, monkeypatch):


### PR DESCRIPTION
## overview
This PR serves as an issue and a fix. When no blow_out location is passed, the pipette always blows out at the top of previous well, even if the previous location is `well.bottom()`. This is because `cache_location.labware`, rather than `cache_location`, is saved as the previous location. This PR updates the logic so that pipette would not longer deploys `move_to` if no location is passed, and blows out at the current position. Logic is copied from `aspirate` and `dispense`.

## changelog
* uses the same logic as `aspirate` and `dispense` to determine the blow_out location 
* update test script accordingly

## review requests
Test on robot. I will be testing this with the Science Team 