### PR TITLE
fix(api): Modify delay and motors which are disengaged

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -46,6 +46,7 @@ EEPROM_DEFAULT = {
 PLUNGER_BACKLASH_MM = 0.3
 LOW_CURRENT_Z_SPEED = 30
 CURRENT_CHANGE_DELAY = 0.005
+PIPETTE_READ_DELAY = 0.1
 
 Y_SWITCH_BACK_OFF_MM = 28
 Y_SWITCH_REVERSE_BACK_OFF_MM = 10
@@ -1168,8 +1169,8 @@ class SmoothieDriver_3_0_0:
             # EMI interference from both plunger motors has been found to
             # prevent the I2C lines from communicating between Smoothieware and
             # pipette's onboard EEPROM. To avoid, turn off both plunger motors
-            self.disengage_axis('BC')
-            self.delay(CURRENT_CHANGE_DELAY)
+            self.disengage_axis('ZABC')
+            self.delay(PIPETTE_READ_DELAY)
             # request from Smoothieware the information from that pipette
             res = self._send_command(gcode + mount)
             if res:


### PR DESCRIPTION
## overview

The driver was having issues fully reading the pipette model from the new GEN2 pipette PCBs EEPROM. To mitigate this, we have modified the delay after changing motor currents to 0.1 seconds and we have also disengaged the Z and A axes.

## review requests

Test with pipette gen1 and pipette gen2s.
