### PR TITLE
fix(api): apiv2: Display locs for drop/pickup from implicit locs

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -916,10 +916,11 @@ class InstrumentContext(CommandPublisher):
 
         return self
 
-    @cmds.publish.both(command=cmds.pick_up_tip)  # noqa(C901)
-    def pick_up_tip(self, location: Union[types.Location, Well] = None,
-                    presses: int = 3,
-                    increment: float = 1.0) -> 'InstrumentContext':
+    def pick_up_tip(  # noqa(C901)
+            self,
+            location: Union[types.Location, Well] = None,
+            presses: int = 3,
+            increment: float = 1.0) -> 'InstrumentContext':
         """
         Pick up a tip for the pipette to run liquid-handling commands with
 
@@ -995,19 +996,21 @@ class InstrumentContext(CommandPublisher):
                 " However, it is a {}".format(location))
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
-
+        cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
+                        'before', None, None, instrument=self, location=target)
         self.move_to(target.top())
 
         self._hw_manager.hardware.pick_up_tip(
             self._mount, tiprack.tip_length, presses, increment)
         # Note that the hardware API pick_up_tip action includes homing z after
-
+        cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
+                        'after', self, None, instrument=self, location=target)
         tiprack.use_tips(target, num_channels)
         self._last_tip_picked_up_from = target
+
         return self
 
-    @cmds.publish.both(command=cmds.drop_tip)
-    def drop_tip(
+    def drop_tip(  # noqa(C901)
             self,
             location: Union[types.Location, Well] = None)\
             -> 'InstrumentContext':
@@ -1074,8 +1077,12 @@ class InstrumentContext(CommandPublisher):
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
                 " However, it is a {}".format(location))
+        cmds.do_publish(self.broker, cmds.drop_tip, self.drop_tip,
+                        'before', None, None, instrument=self, location=target)
         self.move_to(target)
         self._hw_manager.hardware.drop_tip(self._mount)
+        cmds.do_publish(self.broker, cmds.drop_tip, self.drop_tip,
+                        'after', self, None, instrument=self, location=target)
         if isinstance(target.labware, Well)\
            and target.labware.parent.is_tiprack:
             # If this is a tiprack we can try and add the tip back to the


### PR DESCRIPTION
In APIV2, we hadn’t yet changed pick_up_tip and drop_tip to call
commands.publish instead of using a decorator, and thus the decorators wouldn’t
pick up arguments that were deduced after the call, like picking up tips from
the tip racks
specified when creating an instrument, or dropping tips in the trash.

Closes #3364

## Testing

Use a protocol like this:
```python
from opentrons.protocol_api import contexts

def run(ctx: contexts.ProtocolContext):
    tr = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 1)
    pip = ctx.load_instrument('p300_single', 'left', tip_racks=[tr])
    pip.pick_up_tip()
    pip.drop_tip()
```

and check that the runapp properly displays the location from which the tip is picked up and the location into which the tip is dropped.