### PR TITLE
feat(shared-data): labwareV2: add filter tip racks

### DIFF
--- a/labware-library/src/components/labware-ui/labware-images.js
+++ b/labware-library/src/components/labware-ui/labware-images.js
@@ -102,6 +102,15 @@ export default {
   opentrons_96_tiprack_300ul: [
     require('../../images/opentrons_96_tiprack_300ul_side_view.jpg'),
   ],
+  opentrons_96_filtertiprack_1000ul: [
+    require('../../images/opentrons_96_tiprack_1000ul_side_view.jpg'),
+  ],
+  opentrons_96_filtertiprack_10ul: [
+    require('../../images/opentrons_96_tiprack_10ul_side_view.jpg'),
+  ],
+  opentrons_96_filtertiprack_200ul: [
+    require('../../images/opentrons_96_tiprack_300ul_side_view.jpg'),
+  ],
   tipone_96_tiprack_200ul: [
     require('../../images/tipone_96_tiprack_200ul_side_view.jpg'),
     require('../../images/tipone_200ul_tip_side_view.jpg'),

--- a/shared-data/labware/definitions/2/opentrons_96_filtertiprack_1000ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_filtertiprack_1000ul/1.json
@@ -1,0 +1,1017 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons 96 Filter Tip Rack 1000 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 97.47
+  },
+  "wells": {
+    "A1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H1": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 14.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H2": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 23.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H3": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 32.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H4": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 41.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H5": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 50.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H6": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 59.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H7": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 68.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H8": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 77.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H9": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 86.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H10": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 95.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H11": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 104.36,
+      "y": 11.26,
+      "z": 9.47
+    },
+    "A12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 74.26,
+      "z": 9.47
+    },
+    "B12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 65.26,
+      "z": 9.47
+    },
+    "C12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 56.26,
+      "z": 9.47
+    },
+    "D12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 47.26,
+      "z": 9.47
+    },
+    "E12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 38.26,
+      "z": 9.47
+    },
+    "F12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 29.26,
+      "z": 9.47
+    },
+    "G12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 20.26,
+      "z": 9.47
+    },
+    "H12": {
+      "depth": 88,
+      "shape": "circular",
+      "diameter": 7.23,
+      "totalLiquidVolume": 1000,
+      "x": 113.36,
+      "y": 11.26,
+      "z": 9.47
+    }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": true,
+    "tipLength": 88,
+    "tipOverlap": 7.95,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_filtertiprack_1000ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_96_filtertiprack_10ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_filtertiprack_10ul/1.json
@@ -1,0 +1,1017 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons 96 Filter Tip Rack 10 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 64.69
+  },
+  "wells": {
+    "A1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H1": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 14.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H2": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 23.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H3": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 32.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H4": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 41.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H5": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 50.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H6": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 59.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H7": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 68.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H8": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 77.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H9": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 86.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H10": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 95.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H11": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 104.36,
+      "y": 11.26,
+      "z": 25.49
+    },
+    "A12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 74.26,
+      "z": 25.49
+    },
+    "B12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 65.26,
+      "z": 25.49
+    },
+    "C12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 56.26,
+      "z": 25.49
+    },
+    "D12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 47.26,
+      "z": 25.49
+    },
+    "E12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 38.26,
+      "z": 25.49
+    },
+    "F12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 29.26,
+      "z": 25.49
+    },
+    "G12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 20.26,
+      "z": 25.49
+    },
+    "H12": {
+      "depth": 39.2,
+      "shape": "circular",
+      "diameter": 3.27,
+      "totalLiquidVolume": 10,
+      "x": 113.36,
+      "y": 11.26,
+      "z": 25.49
+    }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": true,
+    "tipLength": 39.2,
+    "tipOverlap": 3.29,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_filtertiprack_10ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_96_filtertiprack_200ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_filtertiprack_200ul/1.json
@@ -1,0 +1,1017 @@
+{
+  "ordering": [
+    ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+    ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+    ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+    ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+    ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+    ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+    ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+    ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+    ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+    ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+    ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+    ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons 96 Filter Tip Rack 200 µL",
+    "displayCategory": "tipRack",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 64.49
+  },
+  "wells": {
+    "A1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H1": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 14.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H2": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 23.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H3": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 32.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H4": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 41.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H5": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 50.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H6": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 59.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H7": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 68.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H8": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 77.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H9": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 86.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H10": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 95.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H11": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 104.38,
+      "y": 11.24,
+      "z": 5.39
+    },
+    "A12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 74.24,
+      "z": 5.39
+    },
+    "B12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 65.24,
+      "z": 5.39
+    },
+    "C12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 56.24,
+      "z": 5.39
+    },
+    "D12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 47.24,
+      "z": 5.39
+    },
+    "E12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 38.24,
+      "z": 5.39
+    },
+    "F12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 29.24,
+      "z": 5.39
+    },
+    "G12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 20.24,
+      "z": 5.39
+    },
+    "H12": {
+      "depth": 59.3,
+      "shape": "circular",
+      "diameter": 5.23,
+      "totalLiquidVolume": 200,
+      "x": 113.38,
+      "y": 11.24,
+      "z": 5.39
+    }
+  },
+  "groups": [
+    {
+      "metadata": {},
+      "wells": [
+        "A1",
+        "B1",
+        "C1",
+        "D1",
+        "E1",
+        "F1",
+        "G1",
+        "H1",
+        "A2",
+        "B2",
+        "C2",
+        "D2",
+        "E2",
+        "F2",
+        "G2",
+        "H2",
+        "A3",
+        "B3",
+        "C3",
+        "D3",
+        "E3",
+        "F3",
+        "G3",
+        "H3",
+        "A4",
+        "B4",
+        "C4",
+        "D4",
+        "E4",
+        "F4",
+        "G4",
+        "H4",
+        "A5",
+        "B5",
+        "C5",
+        "D5",
+        "E5",
+        "F5",
+        "G5",
+        "H5",
+        "A6",
+        "B6",
+        "C6",
+        "D6",
+        "E6",
+        "F6",
+        "G6",
+        "H6",
+        "A7",
+        "B7",
+        "C7",
+        "D7",
+        "E7",
+        "F7",
+        "G7",
+        "H7",
+        "A8",
+        "B8",
+        "C8",
+        "D8",
+        "E8",
+        "F8",
+        "G8",
+        "H8",
+        "A9",
+        "B9",
+        "C9",
+        "D9",
+        "E9",
+        "F9",
+        "G9",
+        "H9",
+        "A10",
+        "B10",
+        "C10",
+        "D10",
+        "E10",
+        "F10",
+        "G10",
+        "H10",
+        "A11",
+        "B11",
+        "C11",
+        "D11",
+        "E11",
+        "F11",
+        "G11",
+        "H11",
+        "A12",
+        "B12",
+        "C12",
+        "D12",
+        "E12",
+        "F12",
+        "G12",
+        "H12"
+      ]
+    }
+  ],
+  "parameters": {
+    "format": "96Standard",
+    "isTiprack": true,
+    "tipLength": 59.3,
+    "tipOverlap": 7.47,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_96_filtertiprack_200ul"
+  },
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}


### PR DESCRIPTION
## overview
Closes #3762.  This PR adds the definitions for `10`, `200` and `1000 uL` filter tip racks.
Technical drawings can be found [here](https://drive.google.com/drive/u/1/folders/1EJGJAV8y1d6G_v9vTakb09CecYWmMULM).
Tip rack images are the same as the non filter tip racks.

**Display Names**: 

- Opentrons 96 Filter Tip Rack 10 µL
- Opentrons 96 Filter Tip Rack 200 µL
- Opentrons 96 Filter Tip Rack 1000 µL

**API Names**: 

- opentrons_96_filtertiprack_10ul
- opentrons_96_filtertiprack_200ul
- opentrons_96_filtertiprack_100ul


## review requests

- [ ]   Labware definition should match manufacturer's technical diagram
- [ ]   Labware should be browseable with images in Labware Library.
- [ ]   Labware should be browseable in Protocol Designer