### PR TITLE
fix(api): Use pip config presses by default

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -917,9 +917,8 @@ class InstrumentContext(CommandPublisher):
         return self
 
     def pick_up_tip(  # noqa(C901)
-            self,
-            location: Union[types.Location, Well] = None,
-            presses: int = 3,
+            self, location: Union[types.Location, Well] = None,
+            presses: int = None,
             increment: float = 1.0) -> 'InstrumentContext':
         """
         Pick up a tip for the pipette to run liquid-handling commands with


### PR DESCRIPTION
## overview

Happened to test Seth's tiprack PR with a gen2 pipette and noticed that it picked up tip 3x instead of once. This was happening because the protocol context `pick_up_tip` always defaulted to 3 presses and thus the hardware controller would never check the pipette config to use the correct number of presses.

## changelog

- Set default presses to `None`

## review requests

Test with a gen2 pipette in api v2 and see that it picks up the tip once.
