### PR TITLE
fix(api): Allow apiv2 to find pipettes by name versus model

### DIFF
--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -15,16 +15,17 @@ MODULE_LOG = logging.getLogger(__name__)
 
 def find_config(prefix: str) -> str:
     """ Find the most recent config matching `prefix` """
-    matches = [prefix]
-    try:
-        configs[prefix]
-    except KeyError:
+    if prefix in config_models:
+        return prefix
+    else:
+        # We need to check for the nickname of pipettes if the prefix given
+        # is not the exact model. This is because gen2 nicknames are not
+        # subsets of gen2 pipette model strings.
         matches = [conf for conf in config_models
                    if configs[conf]['name'].startswith(prefix)]
     if not matches:
         raise KeyError('No match found for prefix {}'.format(prefix))
-    if prefix in matches:
-        return prefix
+
     else:
         return sorted(matches)[0]
 

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -5,7 +5,7 @@ from threading import Event
 from typing import Dict, Optional, List, Tuple
 from contextlib import contextmanager
 from opentrons import types
-from opentrons.config.pipette_config import config_models
+from opentrons.config.pipette_config import config_models, configs
 from opentrons.drivers.smoothie_drivers import SimulatingDriver
 from . import modules
 
@@ -15,7 +15,12 @@ MODULE_LOG = logging.getLogger(__name__)
 
 def find_config(prefix: str) -> str:
     """ Find the most recent config matching `prefix` """
-    matches = [conf for conf in config_models if conf.startswith(prefix)]
+    matches = [prefix]
+    try:
+        configs[prefix]
+    except KeyError:
+        matches = [conf for conf in config_models
+                   if configs[conf]['name'].startswith(prefix)]
     if not matches:
         raise KeyError('No match found for prefix {}'.format(prefix))
     if prefix in matches:

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -17,15 +17,15 @@ def find_config(prefix: str) -> str:
     """ Find the most recent config matching `prefix` """
     if prefix in config_models:
         return prefix
-    else:
-        # We need to check for the nickname of pipettes if the prefix given
-        # is not the exact model. This is because gen2 nicknames are not
-        # subsets of gen2 pipette model strings.
-        matches = [conf for conf in config_models
-                   if configs[conf]['name'].startswith(prefix)]
+
+    # We need to check for the nickname of pipettes if the prefix given
+    # is not the exact model. This is because gen2 nicknames are not
+    # subsets of gen2 pipette model strings.
+    matches = [conf for conf in config_models
+               if configs[conf]['name'].startswith(prefix)]
+
     if not matches:
         raise KeyError('No match found for prefix {}'.format(prefix))
-
     else:
         return sorted(matches)[0]
 


### PR DESCRIPTION
## overview

Also while testing seth's tiprack PR I found another bug in v2 haha... Due to the nickname not being a subset of the model name in gen2 anymore, the simulator for api v2 no longer recognized `p300_single_gen2` as a valid name to load a pipette into a protocol context.

## review requests

Check that you can load pipettes with the following string values:

`p300_single`
`p300_single_v1.4`
`p300_single_gen2`
`p300_single_v2.0`
