### PR TITLE
refactor(api): Remove smoothie run time values from source code

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -39,6 +39,9 @@ pipette_config = namedtuple(
         'backcompat_name',
         'return_tip_height',
         'blow_out_flow_rate',
+        'max_travel',
+        'home_position',
+        'steps_per_mm'
     ]
 )
 
@@ -194,6 +197,9 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         return_tip_height=cfg.get('returnTipHeight'),
         blow_out_flow_rate=ensure_value(
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
+        max_travel=cfg.get('travelDistance'),
+        home_position=cfg.get('homePosition'),
+        steps_per_mm=cfg.get('stepsPerMM')
     )
 
     return res

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -131,7 +131,6 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
 
     # Load the model config and update with the name config
     cfg = copy.deepcopy(configs[pipette_model])
-    print(name_config()[cfg['name']])
     cfg.update(copy.deepcopy(name_config()[cfg['name']]))
     # Load overrides if we have a pipette id
     if pipette_id:
@@ -163,7 +162,7 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         log.info("Using new aspiration functions")
         ul_per_mm = cfg['ulPerMm'][-1]
 
-    smoothie_configs = cfg.get('smoothieConfigs')
+    smoothie_configs = cfg['smoothieConfigs']
     res = pipette_config(
         top=ensure_value(
             cfg, 'top', MUTABLE_CONFIGS),
@@ -199,9 +198,9 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         return_tip_height=cfg.get('returnTipHeight'),
         blow_out_flow_rate=ensure_value(
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
-        max_travel=smoothie_configs.get('travelDistance'),
-        home_position=smoothie_configs.get('homePosition'),
-        steps_per_mm=smoothie_configs.get('stepsPerMM')
+        max_travel=smoothie_configs['travelDistance'],
+        home_position=smoothie_configs['homePosition'],
+        steps_per_mm=smoothie_configs['stepsPerMM']
     )
 
     return res

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -131,6 +131,7 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
 
     # Load the model config and update with the name config
     cfg = copy.deepcopy(configs[pipette_model])
+    print(name_config()[cfg['name']])
     cfg.update(copy.deepcopy(name_config()[cfg['name']]))
     # Load overrides if we have a pipette id
     if pipette_id:
@@ -162,6 +163,7 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         log.info("Using new aspiration functions")
         ul_per_mm = cfg['ulPerMm'][-1]
 
+    smoothie_configs = cfg.get('smoothieConfigs')
     res = pipette_config(
         top=ensure_value(
             cfg, 'top', MUTABLE_CONFIGS),
@@ -197,9 +199,9 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         return_tip_height=cfg.get('returnTipHeight'),
         blow_out_flow_rate=ensure_value(
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
-        max_travel=cfg.get('travelDistance'),
-        home_position=cfg.get('homePosition'),
-        steps_per_mm=cfg.get('stepsPerMM')
+        max_travel=smoothie_configs.get('travelDistance'),
+        home_position=smoothie_configs.get('homePosition'),
+        steps_per_mm=smoothie_configs.get('stepsPerMM')
     )
 
     return res

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -110,6 +110,12 @@ DEFAULT_ACCELERATION: Dict[str, float] = {
     'C': C_ACCELERATION
 }
 
+DEFAULT_PIPETTE_CONFIGS: Dict[str, float] = {
+    'homePosition': 220,
+    'stepsPerMM': 768,
+    'maxTravel': 30
+}
+
 DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
     'X': 80.00,
     'Y': 80.00,

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -176,7 +176,8 @@ robot_config = namedtuple(
         'default_max_speed',
         'mount_offset',
         'log_level',
-        'tip_probe'
+        'tip_probe',
+        'default_pipette_configs'
     ]
 )
 
@@ -287,7 +288,9 @@ def build_config(deck_cal: List[List[float]],
             'default_max_speed', DEFAULT_MAX_SPEEDS),
         log_level=robot_settings.get('log_level', DEFAULT_LOG_LEVEL),
         tip_probe=_build_tip_probe(
-            _tip_probe_settings_with_migration(robot_settings))
+            _tip_probe_settings_with_migration(robot_settings)),
+        default_pipette_configs=robot_settings.get(
+            'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS)
     )
     return cfg
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -34,15 +34,6 @@ HOMED_POSITION = {
     'C': 19
 }
 
-EEPROM_DEFAULT = {
-    'X': 0.0,
-    'Y': 0.0,
-    'Z': 0.0,
-    'A': 0.0,
-    'B': 0.0,
-    'C': 0.0
-}
-
 PLUNGER_BACKLASH_MM = 0.3
 LOW_CURRENT_Z_SPEED = 30
 CURRENT_CHANGE_DELAY = 0.005
@@ -287,7 +278,6 @@ class SmoothieDriver_3_0_0:
     def __init__(self, config, handle_locks=True):
         self.run_flag = Event()
         self.run_flag.set()
-        self.dist_from_eeprom = EEPROM_DEFAULT.copy()
 
         self._position = HOMED_POSITION.copy()
         self.log = []

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -282,27 +282,16 @@ class API(HardwareAPILike):
                 self._attached_instruments[mount] = p
                 mount_axis = Axis.by_mount(mount)
                 plunger_axis = Axis.of_plunger(mount)
-                if 'v2' in model:
-                    # Check if new model of pipettes, load smoothie configs
-                    # for this particular model
-                    self._backend._smoothie_driver.update_steps_per_mm(
-                        {plunger_axis.name: 3200})
-                    # TODO(LC25-4-2019): Modify configs to update to as
-                    # testing informs better values
-                    self._backend._smoothie_driver.update_pipette_config(
-                        mount_axis.name, {'home': 172.15})
-                    self._backend._smoothie_driver.update_pipette_config(
-                        plunger_axis.name, {'max_travel': 60})
-                else:
-                    self._backend._smoothie_driver.update_steps_per_mm(
-                        {plunger_axis.name: 768})
 
-                    self._backend._smoothie_driver.update_pipette_config(
-                        mount_axis.name, {'home': 220})
-                    self._backend._smoothie_driver.update_pipette_config(
-                        plunger_axis.name, {'max_travel': 30})
             else:
                 self._attached_instruments[mount] = None
+            self._backend._smoothie_driver.update_steps_per_mm(
+                {plunger_axis.name: 768})
+
+            self._backend._smoothie_driver.update_pipette_config(
+                mount_axis.name, {'home': 220})
+            self._backend._smoothie_driver.update_pipette_config(
+                plunger_axis.name, {'max_travel': 30})
         mod_log.info("Instruments found: {}".format(
             self._attached_instruments))
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Union, List, Optional, Tuple
 from opentrons import types as top_types
 from opentrons.util import linal
 from .simulator import Simulator
-from opentrons.config import robot_configs, pipette_config
+from opentrons.config import robot_configs
 from .pipette import Pipette
 try:
     from .controller import Controller
@@ -280,10 +280,9 @@ class API(HardwareAPILike):
                     self._config.instrument_offset[mount.name.lower()],
                     instrument_data['id'])
                 self._attached_instruments[mount] = p
-                cfg = pipette_config.load(model)
-                home_pos = cfg.home_position
-                max_travel = cfg.max_travel
-                steps_mm = cfg.steps_per_mm
+                home_pos = p.config.home_position
+                max_travel = p.config.max_travel
+                steps_mm = p.config.steps_per_mm
             else:
                 self._attached_instruments[mount] = None
                 home_pos = self._config.default_pipette_configs['homePosition']

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -292,11 +292,11 @@ class Robot(CommandPublisher):
                 cfg = pipette_config.load(model_value)
                 home_pos = cfg.home_position
                 max_travel = cfg.max_travel
-                steps_per_mm = cfg.steps_per_mm
+                steps_mm = cfg.steps_per_mm
             else:
-                home_pos = self.config.DEFAULT_PIPETTE_CONFIGS['homePosition']
-                max_travel = self.config.DEFAULT_PIPETTE_CONFIGS['maxTravel']
-                steps_mm = self.config.DEFAULT_PIPETTE_CONFIGS['stepsPerMM']
+                home_pos = self.config.default_pipette_configs['homePosition']
+                max_travel = self.config.default_pipette_configs['maxTravel']
+                steps_mm = self.config.default_pipette_configs['stepsPerMM']
 
             self._driver.update_steps_per_mm({plunger_axis: steps_mm})
             self._driver.update_pipette_config(mount_axis, {'home': home_pos})

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -288,25 +288,20 @@ class Robot(CommandPublisher):
                 name_value = None
             plunger_axis = 'B' if mount == 'left' else 'C'
             mount_axis = 'Z' if mount == 'left' else 'A'
-            if model_value and 'v2' in model_value:
-                # Check if new model of pipettes, load smoothie configs
-                # for this particular model
-                self._driver.update_steps_per_mm({plunger_axis: 3200})
-                # TODO(LC25-4-2019): Modify configs to update to as
-                # testing informs better values
-                self._driver.update_pipette_config(
-                    mount_axis, {'home': 172.15})
-                self._driver.update_pipette_config(
-                    plunger_axis, {'max_travel': 60})
-                self._driver.dist_from_eeprom[mount_axis] = 47.8
+            if model_value:
+                cfg = pipette_config.load(model_value)
+                home_pos = cfg.home_position
+                max_travel = cfg.max_travel
+                steps_per_mm = cfg.steps_per_mm
             else:
-                self._driver.dist_from_eeprom[mount_axis] = 0.0
-                self._driver.update_steps_per_mm(
-                    {plunger_axis: 768})
+                home_pos = self.config.DEFAULT_PIPETTE_CONFIGS['homePosition']
+                max_travel = self.config.DEFAULT_PIPETTE_CONFIGS['maxTravel']
+                steps_mm = self.config.DEFAULT_PIPETTE_CONFIGS['stepsPerMM']
 
-                self._driver.update_pipette_config(mount_axis, {'home': 220})
-                self._driver.update_pipette_config(
-                    plunger_axis, {'max_travel': 30})
+            self._driver.update_steps_per_mm({plunger_axis: steps_mm})
+            self._driver.update_pipette_config(mount_axis, {'home': home_pos})
+            self._driver.update_pipette_config(
+                plunger_axis, {'max_travel': max_travel})
 
             if model_value:
                 id_response = self._driver.read_pipette_id(mount)

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -35,7 +35,7 @@ dummy_settings = {
     'high_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
     'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
     'default_pipette_configs': {
-        'homePosition': 220, 'maxTravel': 30,'stepsPerMM': 768},
+        'homePosition': 220, 'maxTravel': 30, 'stepsPerMM': 768},
     'log_level': 'NADA',
     'tip_probe': {
         'bounce_distance': 5.0,

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -34,6 +34,8 @@ dummy_settings = {
     'low_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
     'high_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
     'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    'default_pipette_configs': {
+        'homePosition': 220, 'maxTravel': 30,'stepsPerMM': 768},
     'log_level': 'NADA',
     'tip_probe': {
         'bounce_distance': 5.0,

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -224,3 +224,42 @@ def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
     new_pose = pose_tracker.absolute(robot.poses, plate[0])
 
     assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
+
+
+def test_cache_instruments(monkeypatch):
+    # Test that smoothie runtime configs are set at run when
+    # cache_instrument_models is called
+    robot.reset()
+    fake_pip = {'left': {
+                    'model': 'p10_single_v1.3',
+                    'id': 'FakePip2',
+                    'name': 'p10_single'},
+                'right': {
+                    'model': 'p300_single_v2.0',
+                    'id': 'FakePip',
+                    'name': 'p300_single_gen2'}}
+    monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
+
+    def fake_func1(value):
+        return value
+
+    def fake_func2(mount, value):
+        return mount, value
+
+    def fake_read(mount):
+        return robot.model_by_mount[mount]['model']
+    # With nothing specified at init or expected, we should have nothing
+    robot._driver.update_steps_per_mm = mock.Mock(fake_func1)
+    robot._driver.update_pipette_config = mock.Mock(fake_func2)
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', fake_read)
+    robot.cache_instrument_models()
+    steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
+    pip_config_calls = [
+        mock.call('Z', {'home': 220}),
+        mock.call('A', {'home': 172.15}),
+        mock.call('B', {'max_travel': 30}),
+        mock.call('C', {'max_travel': 60})]
+    robot._driver.update_steps_per_mm.assert_has_calls(
+        steps_mm_calls, any_order=True)
+    robot._driver.update_pipette_config.assert_has_calls(
+        pip_config_calls, any_order=True)

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -108,6 +108,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -302,6 +307,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -496,6 +506,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -691,6 +706,11 @@ Object {
     "dropTipShake",
     "doubleDropTip",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -854,6 +874,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1053,6 +1078,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1252,6 +1282,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1451,6 +1486,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1614,6 +1654,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1798,6 +1843,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -1982,6 +2032,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -2167,6 +2222,11 @@ Object {
     "dropTipShake",
     "doubleDropTip",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -2330,6 +2390,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -2514,6 +2579,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -2698,6 +2768,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -2882,6 +2957,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3030,6 +3110,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3178,6 +3263,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3327,6 +3417,11 @@ Object {
     "dropTipShake",
     "doubleDropTip",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3475,6 +3570,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3679,6 +3779,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -3883,6 +3988,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4087,6 +4197,11 @@ Object {
   "quirks": Array [
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4256,6 +4371,11 @@ Object {
     "pickupTipShake",
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4425,6 +4545,11 @@ Object {
     "pickupTipShake",
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4594,6 +4719,11 @@ Object {
     "pickupTipShake",
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4763,6 +4893,11 @@ Object {
     "pickupTipShake",
     "dropTipShake",
   ],
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
   "tipLength": Object {
     "max": 100,
     "min": 0,
@@ -4846,6 +4981,11 @@ Object {
   "maxVolume": 10,
   "minVolume": 1,
   "name": "p10_multi",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -4872,6 +5012,11 @@ Object {
   "maxVolume": 10,
   "minVolume": 1,
   "name": "p10_single",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -4898,6 +5043,11 @@ Object {
   "maxVolume": 50,
   "minVolume": 5,
   "name": "p50_multi",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -4924,6 +5074,11 @@ Object {
   "maxVolume": 50,
   "minVolume": 5,
   "name": "p50_single",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -4950,6 +5105,11 @@ Object {
   "maxVolume": 300,
   "minVolume": 30,
   "name": "p300_multi",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -4976,6 +5136,11 @@ Object {
   "maxVolume": 300,
   "minVolume": 30,
   "name": "p300_single",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;
 
@@ -5002,5 +5167,10 @@ Object {
   "maxVolume": 1000,
   "minVolume": 100,
   "name": "p1000_single",
+  "smoothieConfigs": Object {
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "travelDistance": 30,
+  },
 }
 `;

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -19,6 +19,11 @@
       "value": 1000,
       "min": 5,
       "max": 1000
+    },
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
     }
   },
   "p10_multi": {
@@ -41,7 +46,12 @@
       "min": 5,
       "max": 1000
     },
-    "channels": 8
+    "channels": 8,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p20_single_gen2": {
     "displayName": "P20 Single-Channel GEN2",
@@ -63,7 +73,12 @@
     },
     "minVolume": 1,
     "maxVolume": 20,
-    "channels": 1
+    "channels": 1,
+    "smoothieConfigs": {
+      "stepsPerMM": 3200,
+      "homePosition": 172.15,
+      "travelDistance": 60
+    }
   },
   "p20_multi_gen2": {
     "displayName": "P20 8-Channel GEN2",
@@ -85,7 +100,12 @@
     },
     "minVolume": 1,
     "maxVolume": 20,
-    "channels": 8
+    "channels": 8,
+    "smoothieConfigs": {
+      "stepsPerMM": 3200,
+      "homePosition": 152.25,
+      "travelDistance": 60
+    }
   },
   "p50_single": {
     "displayName": "P50 Single-Channel",
@@ -107,7 +127,12 @@
     },
     "channels": 1,
     "minVolume": 5,
-    "maxVolume": 50
+    "maxVolume": 50,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p50_multi": {
     "displayName": "P50 8-Channel",
@@ -129,7 +154,12 @@
     },
     "channels": 8,
     "minVolume": 5,
-    "maxVolume": 50
+    "maxVolume": 50,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p300_single": {
     "displayName": "P300 Single-Channel",
@@ -151,7 +181,12 @@
     },
     "channels": 1,
     "minVolume": 30,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p300_single_gen2": {
     "displayName": "P300 Single-Channel GEN2",
@@ -173,7 +208,12 @@
     },
     "channels": 1,
     "minVolume": 20,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "smoothieConfigs": {
+      "stepsPerMM": 3200,
+      "homePosition": 172.15,
+      "travelDistance": 60
+    }
   },
   "p300_multi_gen2": {
     "displayName": "P300 8-Channel GEN2",
@@ -195,7 +235,12 @@
     },
     "channels": 8,
     "minVolume": 20,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "smoothieConfigs": {
+      "stepsPerMM": 3200,
+      "homePosition": 152.25,
+      "travelDistance": 60
+    }
   },
   "p300_multi": {
     "displayName": "P300 8-Channel",
@@ -217,7 +262,12 @@
     },
     "channels": 8,
     "minVolume": 30,
-    "maxVolume": 300
+    "maxVolume": 300,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel",
@@ -239,7 +289,12 @@
     },
     "channels": 1,
     "minVolume": 100,
-    "maxVolume": 1000
+    "maxVolume": 1000,
+    "smoothieConfigs": {
+      "stepsPerMM": 768,
+      "homePosition": 220,
+      "travelDistance": 30
+    }
   },
   "p1000_single_gen2": {
     "displayName": "P1000 Single-Channel GEN2",
@@ -261,6 +316,11 @@
     },
     "channels": 1,
     "minVolume": 100,
-    "maxVolume": 1000
+    "maxVolume": 1000,
+    "smoothieConfigs": {
+      "stepsPerMM": 3200,
+      "homePosition": 172.15,
+      "travelDistance": 60
+    }
   }
 }

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -51,7 +51,16 @@
         "displayName": { "type": "string" },
         "displayCategory": { "$ref": "#/definitions/displayCategory" },
         "maxVolume": { "$ref": "#/definitions/positiveNumber" },
-        "minVolume": { "$ref": "#/definitions/positiveNumber" }
+        "minVolume": { "$ref": "#/definitions/positiveNumber" },
+        "smoothieConfigs": {
+          "type": "object",
+          "description": "Runtime smoothie configs per pipette type",
+          "properties": {
+            "stepsPerMM": { "type": "number" },
+            "homePosition": { "type": "number" },
+            "travelDistance": { "type": "number" }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## overview

Closes #3694. Turns out multi-channel gen2's have a different homing position requirement because they are longer :o. This forced our hands to refactor how smoothie run-time configs are handled.

## changelog

- Add smoothie run time configs into pipette name specs as it is a per pipette type value
- Add a few more tests for smoothie runtime configs
- Add default smoothie configs into robot_settings

## review requests

Test on a robot, see that the configs are correctly set from a gen1 pipette to a gen2 pipette.
