### PR TITLE
feat(api): apiv2: prevent over-aspiration with filter tips

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1118,7 +1118,7 @@ class API(HardwareAPILike):
         self._log.info(
             "Updating working volume on pipette mount: {}, tip volume: {} ul"
             .format(mount, tip_volume))
-        instr.set_working_volume(tip_volume)
+        instr.working_volume = tip_volume
 
     @_log_call
     async def drop_tip(self, mount, home_after=True):

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -318,7 +318,8 @@ class API(HardwareAPILike):
         configs = ['name', 'min_volume', 'max_volume', 'channels',
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
-                   'tip_length', 'model', 'blow_out_flow_rate']
+                   'tip_length', 'model', 'blow_out_flow_rate',
+                   'working_volume']
         instruments: Dict[top_types.Mount, Pipette.DictType] = {
             top_types.Mount.LEFT: {},
             top_types.Mount.RIGHT: {}

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1112,6 +1112,12 @@ class API(HardwareAPILike):
 
         await self.retract(mount, instr.config.pick_up_distance)
 
+    def set_working_volume(self, mount, tip_volume):
+        instr = self._attached_instruments[mount]
+        assert instr
+        self._log.info("Updating working volume based on tip total volume")
+        instr.set_working_volume(tip_volume)
+
     @_log_call
     async def drop_tip(self, mount, home_after=True):
         """

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1115,7 +1115,9 @@ class API(HardwareAPILike):
     def set_working_volume(self, mount, tip_volume):
         instr = self._attached_instruments[mount]
         assert instr
-        self._log.info("Updating working volume based on tip total volume")
+        self._log.info(
+            "Updating working volume on pipette mount: {}, tip volume: {} ul"
+            .format(mount, tip_volume))
         instr.set_working_volume(tip_volume)
 
     @_log_call

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -208,5 +208,6 @@ class Pipette:
                             'name': self.name,
                             'model': self.model,
                             'pipette_id': self.pipette_id,
-                            'has_tip': self.has_tip})
+                            'has_tip': self.has_tip,
+                            'working_volume': self.working_volume})
         return config_dict

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -29,6 +29,7 @@ class Pipette:
         self._model = model
         self._model_offset = self._config.model_offset
         self._current_volume = 0.0
+        self._working_volume = self._config.max_volume
         self._current_tip_length = 0.0
         self._fallback_tip_length = self._config.tip_length
         self._has_tip = False
@@ -127,14 +128,23 @@ class Pipette:
         return (self._current_tip_length
                 - self._instrument_offset.z)
 
+    def set_working_volume(self, tip_volume: float):
+        """ The working volume is the current tip max volume """
+        self._working_volume = min(self.config.max_volume, tip_volume)
+
+    @property
+    def working_volume(self) -> float:
+        """ The working volume of the pipette """
+        return self._working_volume
+
     @property
     def available_volume(self) -> float:
         """ The amount of liquid possible to aspirate """
-        return self.config.max_volume - self.current_volume
+        return self.working_volume - self.current_volume
 
     def set_current_volume(self, new_volume: float):
         assert new_volume >= 0
-        assert new_volume <= self.config.max_volume
+        assert new_volume <= self.working_volume
         self._current_volume = new_volume
 
     def add_current_volume(self, volume_incr: float):
@@ -146,7 +156,7 @@ class Pipette:
         self._current_volume -= volume_incr
 
     def ok_to_add_volume(self, volume_incr: float) -> bool:
-        return self.current_volume + volume_incr <= self.config.max_volume
+        return self.current_volume + volume_incr <= self.working_volume
 
     def add_tip(self, tip_length: float) -> None:
         """

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -128,14 +128,15 @@ class Pipette:
         return (self._current_tip_length
                 - self._instrument_offset.z)
 
-    def set_working_volume(self, tip_volume: float):
-        """ The working volume is the current tip max volume """
-        self._working_volume = min(self.config.max_volume, tip_volume)
-
     @property
     def working_volume(self) -> float:
         """ The working volume of the pipette """
         return self._working_volume
+
+    @working_volume.setter
+    def working_volume(self, tip_volume: float):
+        """ The working volume is the current tip max volume """
+        self._working_volume = min(self.config.max_volume, tip_volume)
 
     @property
     def available_volume(self) -> float:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1414,11 +1414,12 @@ class InstrumentContext(CommandPublisher):
         if kwargs.get('blow_out'):
             blow_out = transfers.BlowOutStrategy.TRASH
 
-        max_volume = None
         if new_tip != types.TransferTipPolicy.NEVER:
             tr, next_tip = self._select_tiprack_from_list(
                     self.tip_racks, self.channels)
             max_volume = min(next_tip.max_volume, self.max_volume)
+        else:
+            max_volume = self.hw_pipette['working_volume']
 
         touch_tip = None
         if kwargs.get('touch_tip'):
@@ -1441,12 +1442,11 @@ class InstrumentContext(CommandPublisher):
             drop_tip_strategy=drop_tip,
             blow_out_strategy=blow_out or default_args.blow_out_strategy,
             touch_tip_strategy=(touch_tip or
-                                default_args.touch_tip_strategy),
-            max_volume=max_volume
+                                default_args.touch_tip_strategy)
         )
         transfer_options = transfers.TransferOptions(transfer=transfer_args,
                                                      mix=mix_opts)
-        plan = transfers.TransferPlan(volume, source, dest, self,
+        plan = transfers.TransferPlan(volume, source, dest, self, max_volume,
                                       kwargs['mode'], transfer_options)
         self._execute_transfer(plan)
         return self

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1134,7 +1134,7 @@ class InstrumentContext(CommandPublisher):
         cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
                         'after', self, None, instrument=self, location=target)
         self._hw_manager.hardware.set_working_volume(
-            self._mount, target._volume)
+            self._mount, target._max_volume)
         tiprack.use_tips(target, num_channels)
         self._last_tip_picked_up_from = target
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1133,6 +1133,8 @@ class InstrumentContext(CommandPublisher):
         # Note that the hardware API pick_up_tip action includes homing z after
         cmds.do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
                         'after', self, None, instrument=self, location=target)
+        self._hw_manager.hardware.set_working_volume(
+            self._mount, target._volume)
         tiprack.use_tips(target, num_channels)
         self._last_tip_picked_up_from = target
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -94,7 +94,7 @@ class Well:
             raise ValueError(
                 'Shape "{}" is not a supported well shape'.format(
                     well_props['shape']))
-        self._max_volume = well_props['totalLiquidVolume']
+        self.max_volume = well_props['totalLiquidVolume']
         self._depth = well_props['depth']
 
     @property

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -94,7 +94,7 @@ class Well:
             raise ValueError(
                 'Shape "{}" is not a supported well shape'.format(
                     well_props['shape']))
-        self._volume = well_props['totalLiquidVolume']
+        self._max_volume = well_props['totalLiquidVolume']
         self._depth = well_props['depth']
 
     @property

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -94,7 +94,7 @@ class Well:
             raise ValueError(
                 'Shape "{}" is not a supported well shape'.format(
                     well_props['shape']))
-
+        self._volume = well_props['totalLiquidVolume']
         self._depth = well_props['depth']
 
     @property

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -188,6 +188,7 @@ Transfer.max_volume.__doc__ = """
     tips. If ``None``, use default max volume of the pipette.
     """
 
+
 class PickUpTipOpts(NamedTuple):
     """
     Options to customize :py:attr:`.Transfer.new_tip`.
@@ -411,7 +412,8 @@ class TransferPlan:
         self._mix_after_opts = self._options.mix.mix_after
         if self._strategy.max_volume is None:
             self._strategy = self._strategy._replace(
-                max_volume=instr.working_volume)
+                max_volume=instr._hw_manager.hardware._attached_instruments[
+                    instr._mount].working_volume)
 
         if not mode:
             if len(sources) < len(dests):

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -33,7 +33,7 @@ instrument_keys = sorted([
     'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
-    'blow_out_speed', 'aspirate_speed', 'dispense_speed'])
+    'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -184,14 +184,18 @@ def test_use_filter_tips(loop, get_labware_def):
 
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount)
+    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
     pipette: Pipette = ctx._hw_manager.hardware._attached_instruments[mount]
 
     assert pipette.available_volume == pipette.config.max_volume
 
-    instr.pick_up_tip(tiprack.wells()[0])
+    instr.pick_up_tip()
     assert pipette.available_volume < pipette.config.max_volume
     instr.drop_tip()
+
+    plate = ctx.load_labware_by_name('biorad_96_wellplate_200ul_pcr', 1)
+    instr.pick_up_tip()
+    instr.transfer(30, plate.wells('A1'), plate.wells('A2'), new_tip='never')
 
 
 def test_pick_up_tip_no_location(loop, get_labware_def):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -516,7 +516,6 @@ def test_transfer_options(loop, monkeypatch):
             drop_tip_strategy=tf.DropTipStrategy.TRASH,
             blow_out_strategy=tf.BlowOutStrategy.TRASH,
             touch_tip_strategy=tf.TouchTipStrategy.NEVER,
-            max_volume=300
         ),
         pick_up_tip=tf.PickUpTipOpts(),
         mix=tf.Mix(

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -180,7 +180,7 @@ def test_use_filter_tips(loop, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
 
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_10ul', 2)
+    tiprack = ctx.load_labware_by_name('opentrons_96_filtertiprack_200ul', 2)
 
     mount = Mount.LEFT
 
@@ -191,11 +191,6 @@ def test_use_filter_tips(loop, get_labware_def):
 
     instr.pick_up_tip()
     assert pipette.available_volume < pipette.config.max_volume
-    instr.drop_tip()
-
-    plate = ctx.load_labware_by_name('biorad_96_wellplate_200ul_pcr', 1)
-    instr.pick_up_tip()
-    instr.transfer(30, plate.wells('A1'), plate.wells('A2'), new_tip='never')
 
 
 def test_pick_up_tip_no_location(loop, get_labware_def):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -176,6 +176,24 @@ def test_return_tip(loop, get_labware_def):
     assert tiprack.wells()[0].has_tip
 
 
+def test_use_filter_tips(loop, get_labware_def):
+    ctx = papi.ProtocolContext(loop)
+    ctx.home()
+
+    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_10ul', 2)
+
+    mount = Mount.LEFT
+
+    instr = ctx.load_instrument('p300_single', mount)
+    pipette: Pipette = ctx._hw_manager.hardware._attached_instruments[mount]
+
+    assert pipette.available_volume == pipette.config.max_volume
+
+    instr.pick_up_tip(tiprack.wells()[0])
+    assert pipette.available_volume < pipette.config.max_volume
+    instr.drop_tip()
+
+
 def test_pick_up_tip_no_location(loop, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.home()

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -515,7 +515,8 @@ def test_transfer_options(loop, monkeypatch):
             mix_strategy=tf.MixStrategy.BOTH,
             drop_tip_strategy=tf.DropTipStrategy.TRASH,
             blow_out_strategy=tf.BlowOutStrategy.TRASH,
-            touch_tip_strategy=tf.TouchTipStrategy.NEVER
+            touch_tip_strategy=tf.TouchTipStrategy.NEVER,
+            max_volume=300
         ),
         pick_up_tip=tf.PickUpTipOpts(),
         mix=tf.Mix(

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -453,9 +453,9 @@ def test_touchtip_mix(_instr_labware):
     # ========== Consolidate ==========
     consd_plan = tx.TransferPlan(
         60, lw1.columns()[1], lw2.rows()[1][1],
-         _instr_labware['instr'],
-         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-         options=options)
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -559,8 +559,10 @@ def test_oversized_distribute(_instr_labware):
     lw1 = _instr_labware['lw1']
     lw2 = _instr_labware['lw2']
 
-    xfer_plan = tx.TransferPlan(700, lw1.columns()[0][0], lw2.rows()[0][1:3],
-                                _instr_labware['instr'])
+    xfer_plan = tx.TransferPlan(
+        700, lw1.columns()[0][0], lw2.rows()[0][1:3],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -598,10 +600,11 @@ def test_oversized_consolidate(_instr_labware):
     lw1 = _instr_labware['lw1']
     lw2 = _instr_labware['lw2']
 
-    xfer_plan = tx.TransferPlan(700,
-                                lw2.rows()[0][1:3],
-                                lw1.wells_by_index()['A1'],
-                                _instr_labware['instr'])
+    xfer_plan = tx.TransferPlan(
+        700, lw2.rows()[0][1:3],
+        lw1.wells_by_index()['A1'],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -639,8 +642,10 @@ def test_oversized_transfer(_instr_labware):
     lw1 = _instr_labware['lw1']
     lw2 = _instr_labware['lw2']
 
-    xfer_plan = tx.TransferPlan(700, lw2.rows()[0][1:3], lw1.columns()[0][1:3],
-                                _instr_labware['instr'])
+    xfer_plan = tx.TransferPlan(
+        700, lw2.rows()[0][1:3], lw1.columns()[0][1:3],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -26,8 +26,10 @@ def test_default_transfers(_instr_labware):
     lw2 = _instr_labware['lw2']
 
     # ========== Transfer ===========
-    xfer_plan = tx.TransferPlan(100, lw1.columns()[0], lw2.columns()[0],
-                                _instr_labware['instr'])
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0], lw2.columns()[0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -68,8 +70,10 @@ def test_default_transfers(_instr_labware):
     assert xfer_plan_list == exp1
 
     # ========== Distribute ===========
-    dist_plan = tx.TransferPlan(50, lw1.columns()[0][0], lw2.columns()[0],
-                                _instr_labware['instr'])
+    dist_plan = tx.TransferPlan(
+        50, lw1.columns()[0][0], lw2.columns()[0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
@@ -98,8 +102,10 @@ def test_default_transfers(_instr_labware):
     assert dist_plan_list == exp2
 
     # ========== Consolidate ===========
-    consd_plan = tx.TransferPlan(50, lw1.columns()[0], lw2.columns()[0][0],
-                                 _instr_labware['instr'])
+    consd_plan = tx.TransferPlan(
+        50, lw1.columns()[0], lw2.columns()[0][0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'])
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -138,22 +144,31 @@ def test_no_new_tip(_instr_labware):
         transfer=options.transfer._replace(
             new_tip=TransferTipPolicy.NEVER))
     # ========== Transfer ==========
-    xfer_plan = tx.TransferPlan(100, lw1.columns()[0], lw2.columns()[0],
-                                _instr_labware['instr'], options=options)
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0], lw2.columns()[0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     for step in xfer_plan:
         assert step['method'] != 'pick_up_tip'
         assert step['method'] != 'drop_tip'
 
     # ========== Distribute ===========
-    dist_plan = tx.TransferPlan(30, lw1.columns()[0][0], lw2.columns()[0],
-                                _instr_labware['instr'], options=options)
+    dist_plan = tx.TransferPlan(
+        30, lw1.columns()[0][0], lw2.columns()[0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     for step in dist_plan:
         assert step['method'] != 'pick_up_tip'
         assert step['method'] != 'drop_tip'
 
     # ========== Consolidate ===========
-    consd_plan = tx.TransferPlan(40, lw1.columns()[0], lw2.rows()[0][1],
-                                 _instr_labware['instr'], options=options)
+    consd_plan = tx.TransferPlan(
+        40, lw1.columns()[0], lw2.rows()[0][1],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     for step in consd_plan:
         assert step['method'] != 'pick_up_tip'
         assert step['method'] != 'drop_tip'
@@ -172,9 +187,12 @@ def test_new_tip_always(_instr_labware, monkeypatch):
             new_tip=TransferTipPolicy.ALWAYS,
             drop_tip_strategy=tx.DropTipStrategy.TRASH))
 
-    xfer_plan = tx.TransferPlan(100,
-                                lw1.columns()[0][1:5], lw2.columns()[0][1:5],
-                                _instr_labware['instr'], options=options)
+    xfer_plan = tx.TransferPlan(
+        100,
+        lw1.columns()[0][1:5], lw2.columns()[0][1:5],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -220,8 +238,11 @@ def test_transfer_w_airgap_blowout(_instr_labware):
             new_tip=TransferTipPolicy.NEVER))
 
     # ========== Transfer ==========
-    xfer_plan = tx.TransferPlan(100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
-                                _instr_labware['instr'], options=options)
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -267,8 +288,11 @@ def test_transfer_w_airgap_blowout(_instr_labware):
     assert xfer_plan_list == exp1
 
     # ========== Distribute ==========
-    dist_plan = tx.TransferPlan(60, lw1.columns()[1][0], lw2.rows()[1][1:6],
-                                _instr_labware['instr'], options=options)
+    dist_plan = tx.TransferPlan(
+        60, lw1.columns()[1][0], lw2.rows()[1][1:6],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
@@ -301,8 +325,11 @@ def test_transfer_w_airgap_blowout(_instr_labware):
     assert dist_plan_list == exp2
 
     # ========== Consolidate ==========
-    consd_plan = tx.TransferPlan(60, lw1.columns()[1], lw2.rows()[1][1],
-                                 _instr_labware['instr'], options=options)
+    consd_plan = tx.TransferPlan(
+        60, lw1.columns()[1], lw2.rows()[1][1],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -354,8 +381,11 @@ def test_touchtip_mix(_instr_labware):
             mix_strategy=tx.MixStrategy.AFTER))
 
     # ========== Transfer ==========
-    xfer_plan = tx.TransferPlan(100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
-                                _instr_labware['instr'], options=options)
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -390,8 +420,11 @@ def test_touchtip_mix(_instr_labware):
     assert xfer_plan_list == exp1
 
     # ========== Distribute ==========
-    dist_plan = tx.TransferPlan(60, lw1.columns()[1][0], lw2.rows()[1][1:6],
-                                _instr_labware['instr'], options=options)
+    dist_plan = tx.TransferPlan(
+        60, lw1.columns()[1][0], lw2.rows()[1][1:6],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
@@ -418,8 +451,11 @@ def test_touchtip_mix(_instr_labware):
     assert dist_plan_list == exp2
 
     # ========== Consolidate ==========
-    consd_plan = tx.TransferPlan(60, lw1.columns()[1], lw2.rows()[1][1],
-                                 _instr_labware['instr'], options=options)
+    consd_plan = tx.TransferPlan(
+        60, lw1.columns()[1], lw2.rows()[1][1],
+         _instr_labware['instr'],
+         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+         options=options)
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -483,8 +519,11 @@ def test_all_options(_instr_labware):
         aspirate=options.aspirate._replace(
             rate=1.5))
 
-    xfer_plan = tx.TransferPlan(100, lw1.columns()[0][1:4], lw2.rows()[0][1:4],
-                                _instr_labware['instr'], options=options)
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0][1:4], lw2.rows()[0][1:4],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        options=options)
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)


### PR DESCRIPTION
## overview
This PR adds support for filter tips in apiv2 by introducing `_working_volume` as a pipette state property. The default working volume is always the max volume of the pipette. The new behavior is that when a pipette picks up a tip, the working volume gets updated to the lesser of the tip volume and the pipette max volume. Pipette `available_volume` will then be calculated using `working_volume` instead of `max_volume` to prevent over-aspiration. 

To retrieve the `totalLiquidVolume` from a well, `_max_volume` is added as a labware variable.

Closes #3674. See #3692 for the version for apiv1.

## changelog
- add working volume as a pipette state variable
- add function to set working volume during tip pick up
- use working volume to determine pipette available volume instead of pipette max volume
- add max volume as a labware variable
- add test function

## review requests
Test to make sure a P300 pipette cannot aspirate more than 200 uL at once with the 200 uL filter tip attached
