### PR TITLE
fix(api): apiv1: handle partial db schema changes

### DIFF
--- a/api/src/opentrons/data_storage/database_migration.py
+++ b/api/src/opentrons/data_storage/database_migration.py
@@ -116,8 +116,18 @@ def _do_schema_changes():
     db_version = database.get_version()
     if db_version == 0:
         log.info("doing database schema migration")
-        execute_schema_change(conn, create_table_ContainerWells)
-        execute_schema_change(conn, create_table_Containers)
+        try:
+            execute_schema_change(conn, create_table_ContainerWells)
+        except sqlite3.OperationalError:
+            log.warning(
+                "Creation of container wells failed, robot may have been "
+                "interrupted during last boot")
+        try:
+            execute_schema_change(conn, create_table_Containers)
+        except sqlite3.OperationalError:
+            log.warning(
+                "Creation of containers failed, robot may have been "
+                "interrupted during last boot")
         database.set_version(1)
     return conn
 


### PR DESCRIPTION
This is a bug report and a fix.

If the labware database has been partially migrated - one or both of the schema
changes creating tables have occurred, but the sqlite user version has not yet
been set - then the next time the robot boots, it will try to recreate the
tables and die from an unhandled exception. This commit handles these exceptions
and moves to the next migration.

To test, run this python snippet on a robot running apiv1 then restart the api server. If you do this without the fix, the api server will crash on boot; with the fix, you'll get some messages in stdout but everything will be fine.

```python
import sqlite3
conn = sqlite3.connect('/data/opentrons.db')
conn.execute('PRAGMA user_version=0')
```
