### PR TITLE
fix(api): apiv1: fix transfer volume

### DIFF
--- a/api/src/opentrons/legacy_api/containers/placeable.py
+++ b/api/src/opentrons/legacy_api/containers/placeable.py
@@ -340,7 +340,10 @@ class Placeable(object):
         """
         Returns placeable's maximum liquid volume in uL
         """
-        return self.properties['total-liquid-volume']
+        try:
+            return self.properties['total-liquid-volume']
+        except KeyError:
+            return None
 
     def x_size(self):
         """

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1596,11 +1596,9 @@ class Pipette(CommandPublisher):
                 'dispense': {'location': t[i], 'volume': v[i]}
             })
 
-        if not self.tip_attached:
-            try:
-                max_vol = self.get_next_tip().max_volume()
-            except KeyError:
-                max_vol = self._working_volume
+        if not self.tip_attached and self.tip_racks:
+            max_vol = min(
+                self.tip_racks[0][0].max_volume(), self._working_volume)
         else:
             max_vol = self._working_volume
         max_vol -= kwargs.get('air_gap', 0)  # air

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1047,10 +1047,10 @@ class Pipette(CommandPublisher):
                    'after', self, None, self, location, presses, increment)
 
         # update working volume
-        try:
+        if location.max_volume():
             self._working_volume = float(
                 min(self.max_volume, location.max_volume()))
-        except KeyError:
+        else:
             log.info('No tip liquid volume, defaulting to max volume.')
             self._working_volume = float(self.max_volume)
         return self
@@ -1596,7 +1596,8 @@ class Pipette(CommandPublisher):
                 'dispense': {'location': t[i], 'volume': v[i]}
             })
 
-        if not self.tip_attached and self.tip_racks:
+        if not self.tip_attached and self.tip_racks and \
+                self.tip_racks[0][0].max_volume():
             max_vol = min(
                 self.tip_racks[0][0].max_volume(), self._working_volume)
         else:


### PR DESCRIPTION
## overview
A P50 pipette with a 300 uL tip attached would attempt to incorrectly aspirate 300 uL as its maximum volume during transfer/consolidate/distribute. This is because during `_create_transfer_plan`, the pipette's max volume is set to be the next tip's maximum volume. It should actually be the lesser of the tip's and pipette's max volumes. Rather than using `get_next_tip` to get the volume of the tip, it nows calls the very first tip of the pipette's available tip racks. 

closes #3789

## changelog
- set max volume in _create_transfer_plan to be the lesser of the pipette's max volume and the volume of the very first tip of that pipette, if a tip rack is present

## review requests
To test, simulate the protocol below and it should no longer fail:
```
from opentrons import instruments, labware

tipracks = [labware.load('opentrons_96_tiprack_300ul', slot)
            for slot in [1, 2, 3, 4]]
wells = labware.load('corning_96_wellplate_360ul_flat', 11)
wells2 = labware.load('corning_96_wellplate_360ul_flat', 10)

right = instruments.P50_Single('left', tip_racks=tipracks)

right.distribute(60, wells2.wells(0),
                 [wells.well(w) for w in range(30)],
                 mix_before=(2, 10),
                 mix_after=(3, 15),
                 new_tip='always')
```

