### PR TITLE
build(app-shell): Only publish app release if tag matches ^v.+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,9 +138,7 @@ jobs:
       name: 'Build/deploy Opentrons App for POSIX (unsigned dev builds)'
       os: linux
       script: make -C app-shell dist-posix
-      # TODO(mc, 2019-03-07): app-shell makefile still looks for presense of
-      # tag rather than correct tag format. For now, skip app builds entirely if
-      # tag is present but does not match ^v
+      # skip app builds entirely if tag is present but does not match ^v
       if: tag IS blank AND (NOT branch =~ ^(edge|release_.+)$)
 
     - # build the Opentrons App for Linux (tagged / edge / RC builds)

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -31,18 +31,14 @@ update_files := "dist/@(alpha|beta|latest)*.@(yml|json)"
 publish_dir := dist/publish
 
 # TODO(mc, 2018-03-27): move all this to some sort of envfile
-# TODO(mc, 2018-03-07): tag logic here is too naive since PD will tag its
-#   releases independently. See TODO in .travis.yml and revisit this logic
 # build id suffix to add to artifacts
 # if no build number -> dev
-# if tagged build (branch == tag) -> b$(BUILD_NUMBER)
+# if tagged build (tag ~= ^v.+) -> b$(BUILD_NUMBER)
 # if branch exists -> b$(BUILD_NUMBER)-$(BRANCH_NAME)
-branch := $(filter-out $(OT_TAG),$(OT_BRANCH))
-branch_suffix := $(and $(branch),-$(branch))
-build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
-
 # only copy update files publish directory on tagged builds
-publish_update := $(OT_TAG)
+publish_update := $(filter v%,$(OT_TAG))
+branch_suffix := $(if $(publish_update),,-$(OT_BRANCH))
+build_id := $(or $(and $(OT_BUILD),b$(OT_BUILD)$(branch_suffix)),dev)
 
 builder := electron-builder -p never
 


### PR DESCRIPTION
## overview

Our Windows build configuration was not set up to properly ignore tags that don't match `^v.+`, which resulted in bogus Windows publish(es) for other tags (like PD and LL releases).

I couldn't exactly figure out AppVeyor's filtering logic for builds / deploys, so this PR modifies the Makefile in `app-shell` to ensure the release manifest files are not set to publish unless the tag matches `^v.+`

## changelog

- build(app-shell): Only publish app release if tag matches ^v.+

## review requests

You can try this out locally by setting the env vars that CI sets. Note that none of this will actually push anything to s3:

```shell
# dist-osx, dist-linux, or dist-win depending on your OS
make -C app-shell dist-osx \
  OT_APP_DEPLOY_BUCKET=opentrons-app \
  OT_APP_DEPLOY_FOLDER=builds \
  OT_BUILD=42 \
  OT_BRANCH=foobar \
  OT_TAG=v3.10.2
```

To test tagged or non-tagged builds, edit or omit `OT_TAG` as necessary

Then, to see what's gonna get published:

```shell
# regular non-release
ls app-shell/dist/publish
# > Opentrons-v3.10.2-mac-b42-foobar.zip

# release
ls app-shell/dist/publish
# > Opentrons-v3.10.2-mac-b42.zip beta-mac.yml
# > alpha-mac.yml                 latest-mac.yml
```