### PR TITLE
feat(app, api): Key calibration by parent-type/labware-type combo

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -178,19 +178,19 @@ def _load_new_well(well_data, saved_offset, lw_format):
     if lw_format == 'trough':
         well_tuple = (
             well_data['x'] + saved_offset.x,
-            well_data['y'] + 7*well_data['yDimension']/16 + saved_offset.y,
+            well_data['y'] + 7 * well_data['yDimension'] / 16 + saved_offset.y,
             well_data['z'] + saved_offset.z)
     else:
         well_tuple = (
-            well_data['x'] - well.x_size()/2 + saved_offset.x,
-            well_data['y'] - well.y_size()/2 + saved_offset.y,
+            well_data['x'] - well.x_size() / 2 + saved_offset.x,
+            well_data['y'] - well.y_size() / 2 + saved_offset.y,
             well_data['z'] + saved_offset.z)
     return (well, well_tuple)
 
 
 def _look_up_offsets(labware_hash):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v4']
-    labware_offset_path = calibration_path/'{}.json'.format(labware_hash)
+    labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     if labware_offset_path.exists():
         calibration_data = new_labware._read_file(str(labware_offset_path))
         offset_array = calibration_data['default']['offset']
@@ -205,7 +205,7 @@ def save_new_offsets(labware_hash, delta):
         calibration_path.mkdir(parents=True, exist_ok=True)
     old_delta = _look_up_offsets(labware_hash)
     new_delta = old_delta + Point(x=delta[0], y=delta[1], z=delta[2])
-    labware_offset_path = calibration_path/'{}.json'.format(labware_hash)
+    labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     calibration_data = new_labware._helper_offset_data_format(
         str(labware_offset_path), new_delta)
     with labware_offset_path.open('w') as f:

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -981,7 +981,7 @@ class Robot(CommandPublisher):
                                             instrument,
                                             save: bool
                                             ):
-        '''Calibrates a container using the bottom of the first well'''
+        '''Calibrates a container using the top or bottom of the first well'''
         well = container[0]
 
         # Get the relative position of well with respect to instrument

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1775,9 +1775,21 @@ class ThermocyclerContext(ModuleContext):
     def status(self):
         return self._module.status
 
+    def _prepare_for_lid_move(self):
+        loaded_instrument = next(value for key, value in list(
+            self._ctx.loaded_instruments.items()), None)
+        if loaded_instrument is not None:
+            loaded_instrument.move_to(self._ctx.fixed_trash.top())
+        else:
+            MODULE_LOG.warning(
+                "There are no loaded instruments, so the gantry"
+                " cannot assure a safe position to avoid colliding"
+                " with the lid of the Thermocycler Module.")
+
     @cmds.publish.both(command=cmds.thermocycler_open)
     def open(self):
         """ Opens the lid"""
+        self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.open()
         self._ctx.deck.recalculate_high_z()
         return self._geometry.lid_status
@@ -1785,6 +1797,7 @@ class ThermocyclerContext(ModuleContext):
     @cmds.publish.both(command=cmds.thermocycler_close)
     def close(self):
         """ Closes the lid"""
+        self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.close()
         self._ctx.deck.recalculate_high_z()
         return self._geometry.lid_status

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1775,22 +1775,9 @@ class ThermocyclerContext(ModuleContext):
     def status(self):
         return self._module.status
 
-    def _prepare_for_lid_move(self):
-        loaded_instrument = next((value for key, value in
-                                 self._ctx.loaded_instruments.items()),
-                                 None)
-        if loaded_instrument is not None:
-            loaded_instrument.move_to(self._ctx.fixed_trash.top())
-        else:
-            MODULE_LOG.warning(
-                "There are no loaded instruments, so the gantry"
-                " cannot assure a safe position to avoid colliding"
-                " with the lid of the Thermocycler Module.")
-
     @cmds.publish.both(command=cmds.thermocycler_open)
     def open(self):
         """ Opens the lid"""
-        self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.open()
         self._ctx.deck.recalculate_high_z()
         return self._geometry.lid_status
@@ -1798,7 +1785,6 @@ class ThermocyclerContext(ModuleContext):
     @cmds.publish.both(command=cmds.thermocycler_close)
     def close(self):
         """ Closes the lid"""
-        self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.close()
         self._ctx.deck.recalculate_high_z()
         return self._geometry.lid_status

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1776,8 +1776,9 @@ class ThermocyclerContext(ModuleContext):
         return self._module.status
 
     def _prepare_for_lid_move(self):
-        loaded_instrument = next(value for key, value in list(
-            self._ctx.loaded_instruments.items()), None)
+        loaded_instrument = next((value for key, value in
+                                 self._ctx.loaded_instruments.items()),
+                                 None)
         if loaded_instrument is not None:
             loaded_instrument.move_to(self._ctx.fixed_trash.top())
         else:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -743,8 +743,7 @@ def _hash_labware_def(labware_def: Dict[str, Any]) -> str:
 
 def _get_labware_offset_path(labware: Labware):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v4']
-    if not calibration_path.exists():
-        calibration_path.mkdir(parents=True, exist_ok=True)
+    calibration_path.mkdir(parents=True, exist_ok=True)
 
     parent_id = _get_parent_identifier(labware.parent)
     labware_hash = _hash_labware_def(labware._definition)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -726,20 +726,25 @@ class ThermocyclerGeometry(ModuleGeometry):
         self._labware = labware
         return self._labware
 
-def _get_parent_identifier(parent: [Labware, Well, str, ModuleGeometry, None]):
+
+def _get_parent_identifier(
+        parent: Union[Labware, Well, str, ModuleGeometry, None]):
     if isinstance(parent, ModuleGeometry):
         # treat a given labware on a given module type as same
         return parent.load_name
     else:
-        return '' # treat all slots as same
+        return ''  # treat all slots as same
+
 
 def _hash_labware_def(labware_def: Dict[str, Any]) -> str:
     # remove keys that do not affect run
     blacklist = ['metadata', 'brand', 'groups']
-    def_no_metadata = {k: v for k, v in labware_def.items() if k not in blacklist}
+    def_no_metadata = {
+        k: v for k, v in labware_def.items() if k not in blacklist}
     sorted_def_str = json.dumps(
         def_no_metadata, sort_keys=True, separators=(',', ':'))
     return sha256(sorted_def_str.encode('utf-8')).hexdigest()
+
 
 def _get_labware_offset_path(labware: Labware):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v4']

--- a/app/src/components/CalibratePanel/styles.css
+++ b/app/src/components/CalibratePanel/styles.css
@@ -9,6 +9,7 @@
 .item_info {
   flex: 1;
   display: flex;
+  align-items: center;
   overflow: hidden;
 }
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -321,8 +321,15 @@ export const getLabware: OutputSelector<
   getPipettesByMount,
   getLabwareBySlot,
   (state: State) => calibration(state).confirmedBySlot,
+  getModulesBySlot,
   getCalibrationRequest,
-  (instByMount, lwBySlot, confirmedBySlot, calibrationRequest): Labware[] => {
+  (
+    instByMount,
+    lwBySlot,
+    confirmedBySlot,
+    modulesBySlot,
+    calibrationRequest
+  ): Labware[] => {
     return Object.keys(lwBySlot)
       .filter(isSlot)
       .map<Labware>((slot: Slot) => {
@@ -333,12 +340,16 @@ export const getLabware: OutputSelector<
 
         // labware is confirmed if:
         //   - tiprack: labware in slot is confirmed
-        //   - non-tiprack: labware in slot or any of same type is confirmed
+        //   - non-tiprack: labware in slot or any of same type in same
+        // type of parent (e.g. slot, tempdeck, thermocycler) is confirmed
         const confirmed = some(
           confirmedBySlot,
           (value: boolean, key: Slot) =>
             value === true &&
-            (key === slot || (!isTiprack && type === lwBySlot[key].type))
+            (key === slot ||
+              (!isTiprack &&
+                type === lwBySlot[key].type &&
+                modulesBySlot[key]?.name === modulesBySlot[slot]?.name))
         )
 
         let calibration: LabwareCalibrationStatus = 'unconfirmed'

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -510,6 +510,13 @@ describe('robot selectors', () => {
             7: { slot: '7', type: 'a', isTiprack: false },
             9: { slot: '9', type: 'b', isTiprack: false },
           },
+          modulesBySlot: {
+            1: {
+              _id: 1,
+              slot: '1',
+              name: 'tempdeck',
+            },
+          },
           pipettesByMount: {
             left: { name: 'p200', mount: 'left', channels: 8, volume: 200 },
             right: { name: 'p50', mount: 'right', channels: 1, volume: 50 },


### PR DESCRIPTION
Separate calibration will now be required for instances of the same labware that exist in a given
protocol with a different direct parent type (e.g. slot, Thermocycler Module, Magnetic Module...)

Closes #3775