### PR TITLE
refactor(app): Add install modals for buildroot updates

### DIFF
--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -3,6 +3,7 @@
 
 import * as React from 'react'
 import { AlertModal } from '@opentrons/components'
+import { ProgressBar } from './progress'
 import styles from './styles.css'
 import type { ButtonProps } from '@opentrons/components'
 
@@ -49,21 +50,5 @@ export default function DownloadUpdateModal(props: Props) {
         )}
       </div>
     </AlertModal>
-  )
-}
-
-type ProgressBarProps = {
-  progress: number | null,
-}
-
-function ProgressBar(props: ProgressBarProps) {
-  const progress = props.progress || 0
-  const width = `${progress}%`
-
-  return (
-    <div className={styles.progress_bar_container}>
-      <span className={styles.progress_text}>{progress}%</span>
-      <div style={{ width: width }} className={styles.progress_bar} />
-    </div>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/InstallModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/InstallModal.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useDispatch } from 'react-redux'
 
 import { AlertModal } from '@opentrons/components'
+import InstallModalContents from './InstallModalContents'
 import { clearBuildrootSession } from '../../../shell'
 
 import type { Dispatch } from '../../../types'
@@ -17,7 +18,7 @@ type Props = {|
 |}
 
 export default function InstallModal(props: Props) {
-  const { session, close } = props
+  const { session, close, robotSystemType } = props
   const dispatch = useDispatch<Dispatch>()
   const buttons = []
 
@@ -31,14 +32,28 @@ export default function InstallModal(props: Props) {
     })
   }
 
+  let heading: string
+  if (robotSystemType === 'balena') {
+    if (
+      session.step === 'premigration' ||
+      session.step === 'premigrationRestart'
+    ) {
+      heading = 'Robot Update: Step 1 of 2'
+    } else {
+      heading = 'Robot Update: Step 2 of 2'
+    }
+  } else if (robotSystemType === 'buildroot') {
+    heading = 'Robot Update'
+  }
+
   return (
     <AlertModal
-      heading="Modal not implemented"
+      heading={heading}
       buttons={buttons}
       restrictOuterScroll={false}
       alertOverlay
     >
-      <p>{JSON.stringify(session, null, 2)}</p>
+      <InstallModalContents {...props} />
     </AlertModal>
   )
 }

--- a/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
@@ -1,0 +1,103 @@
+// @flow
+import * as React from 'react'
+import { ProgressSpinner, ProgressBar } from './progress'
+import styles from './styles.css'
+import type { BuildrootUpdateSession, RobotSystemType } from '../../../shell'
+type Props = {
+  robotSystemType: RobotSystemType | null,
+  session: BuildrootUpdateSession,
+}
+export default function InstallModalContents(props: Props) {
+  const {
+    robotSystemType,
+    session: { step: updateStep, progress, error },
+  } = props
+  const prevStep = usePrevious(updateStep)
+  const step = updateStep || prevStep
+
+  let title: string
+  let restartMessage: string
+
+  if (robotSystemType === 'balena') {
+    if (step === 'premigration') {
+      title = 'Robot server update in progress…'
+      restartMessage =
+        'Your OT-2 will reboot once robot server update is complete.'
+    } else if (
+      step === 'premigrationRestart' ||
+      step === 'restart' ||
+      step === 'restarting'
+    ) {
+      title = 'Robot is restarting...'
+      restartMessage =
+        'Robot update process will continue once robot restart is complete.'
+    } else {
+      title = 'Robot system update in progress…'
+      restartMessage =
+        'Your OT-2 will reboot once robot system update is complete.'
+    }
+  } else if (robotSystemType === 'buildroot') {
+    if (step === 'restart' || step === 'restarting') {
+      title = 'Robot is restarting...'
+      restartMessage =
+        'Robot update process will continue once robot restart is complete.'
+    } else {
+      title = 'Robot update in progress…'
+      restartMessage = 'Your OT-2 will reboot once robot update is complete.'
+    }
+  }
+
+  const progressComponent =
+    step === 'processFile' || step === 'commitUpdate' ? (
+      <ProgressBar progress={progress} />
+    ) : (
+      <ProgressSpinner />
+    )
+
+  if (error !== null) {
+    return (
+      <div className={styles.system_update_modal}>
+        <p className={styles.update_title}>
+          An error occured while updating your robot:
+        </p>
+        <p className={styles.update_message}>{error}</p>
+      </div>
+    )
+  }
+  return (
+    <div className={styles.system_update_modal}>
+      {step === 'finished' ? (
+        <p>Your robot is now succesfully updated.</p>
+      ) : (
+        <>
+          <p className={styles.update_title}>{title}</p>
+          {progressComponent}
+          <p className={styles.update_message}>
+            {step && UPDATE_MESSAGE[step]}
+          </p>
+          <p>{restartMessage}</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+function usePrevious(value) {
+  const ref = React.useRef()
+  React.useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}
+
+const UPDATE_MESSAGE = {
+  premigration: 'Hang tight! This may take about 3-5 minutes.',
+  premigrationRestart: 'Hang tight! This may take about 3-5 minutes.',
+  getToken: 'Sending update file to robot',
+  uploadFile: 'Sending update file to robot',
+  processFile: 'Applying update to robot',
+  commitUpdate: 'Applying update to robot',
+  restart: 'Hang tight! This may take about 3-5 minutes.',
+  restarting: 'Hang tight! This may take about 3-5 minutes.',
+  finished: null,
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/MigrationWarningModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/MigrationWarningModal.js
@@ -1,0 +1,55 @@
+// @flow
+import * as React from 'react'
+
+import { ScrollableAlertModal } from '../../modals'
+import styles from './styles.css'
+
+import type { ButtonProps } from '@opentrons/components'
+import type { BuildrootUpdateType } from '../../../shell'
+
+type Props = {|
+  notNowButton: ButtonProps,
+  updateType: BuildrootUpdateType,
+  proceed: () => mixed,
+|}
+
+const HEADING = 'Robot System Update Available'
+
+export default function MigrationWarningModal(props: Props) {
+  const { notNowButton, updateType, proceed } = props
+
+  const buttons: Array<?ButtonProps> = [
+    notNowButton,
+    {
+      children: updateType === 'upgrade' ? 'view robot update' : 'update robot',
+      className: styles.view_update_button,
+      onClick: proceed,
+    },
+  ]
+
+  return (
+    <ScrollableAlertModal
+      heading={HEADING}
+      buttons={buttons}
+      restrictOuterScroll={false}
+      alertOverlay
+    >
+      <div className={styles.system_update_modal}>
+        <p className={styles.system_update_warning}>
+          This update is a little different than previous updates.
+        </p>
+
+        <p>
+          In addition to delivering new features, this update changes the
+          robot’s operating system to improve robot stability and support.
+        </p>
+
+        <p>
+          Please note that this update will take an estimated 10-15 minutes,
+          will reboot your robot two times, and requires your OT-2 to remain
+          discoverable via USB or Wi-Fi throughout the entire migration process.
+        </p>
+      </div>
+    </ScrollableAlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -8,7 +8,7 @@ import {
   getBuildrootDownloadError,
 } from '../../../shell'
 
-import SystemMigrationModal from './SystemMigrationModal'
+import MigrationWarningModal from './MigrationWarningModal'
 import DownloadUpdateModal from './DownloadUpdateModal'
 import ReleaseNotesModal from './ReleaseNotesModal'
 
@@ -42,7 +42,7 @@ export default function ViewUpdateModal(props: Props) {
 
   if (showMigrationWarning) {
     return (
-      <SystemMigrationModal
+      <MigrationWarningModal
         notNowButton={notNowButton}
         updateType={robotUpdateType}
         proceed={() => setShowMigrationWarning(false)}

--- a/app/src/components/RobotSettings/UpdateBuildroot/progress.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/progress.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import styles from './styles.css'
+
+export function ProgressSpinner() {
+  return (
+    <div className={styles.progress_spinner}>
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+      <span />
+    </div>
+  )
+}
+
+export type ProgressBarProps = {
+  progress: number | null,
+}
+
+export function ProgressBar(props: ProgressBarProps) {
+  const progress = props.progress || 0
+  const width = `${progress}%`
+
+  return (
+    <div className={styles.progress_bar_container}>
+      <span className={styles.progress_text}>{progress}%</span>
+      <div style={{ width: width }} className={styles.progress_bar} />
+    </div>
+  )
+}

--- a/app/src/components/RobotSettings/UpdateBuildroot/styles.css
+++ b/app/src/components/RobotSettings/UpdateBuildroot/styles.css
@@ -37,11 +37,13 @@
   margin-left: 1rem;
 }
 
-.download_message {
+.download_message,
+.update_title {
   font-weight: var(--fw-semibold);
 }
 
-.download_error {
+.download_error,
+.update_message {
   font-style: italic;
 }
 
@@ -66,4 +68,67 @@
 .progress_text {
   line-height: 1.75;
   padding: 0.5rem 0.25rem;
+  position: relative;
+  z-index: 99;
+  color: var(--c-med-gray);
+}
+
+.progress_spinner {
+  height: 2rem;
+  margin-bottom: -0.5rem;
+}
+
+.progress_spinner span {
+  transition: all 500ms ease;
+  background: #006fff;
+  height: 0.5rem;
+  width: 0.5rem;
+  display: inline-block;
+  border-radius: 0.5rem;
+  animation: wave 2s ease infinite;
+  margin-right: 0.5rem;
+}
+
+.progress_spinner span:nth-child(1) {
+  animation-delay: 0;
+}
+
+.progress_spinner span:nth-child(2) {
+  animation-delay: 100ms;
+}
+
+.progress_spinner span:nth-child(3) {
+  animation-delay: 200ms;
+}
+
+.progress_spinner span:nth-child(4) {
+  animation-delay: 300ms;
+}
+
+.progress_spinner span:nth-child(5) {
+  animation-delay: 400ms;
+}
+
+.progress_spinner span:nth-child(6) {
+  animation-delay: 500ms;
+}
+
+.progress_spinner span:nth-child(7) {
+  animation-delay: 600ms;
+}
+
+.progress_spinner span:nth-child(8) {
+  animation-delay: 700ms;
+}
+
+@keyframes wave {
+  0%,
+  40%,
+  100% {
+    transform: translate(0, 0);
+  }
+
+  10% {
+    transform: translate(0, -1rem);
+  }
 }


### PR DESCRIPTION
## overview
This PR takes @mcous lovely session/state work and displays install modals accordingly for:
- Server Update (balena only)
- Restart
- System Update
- Restart (again)
- Update Error (might need some copy suggestions after UI final pass)
- Update Complete

closes #3565 closes #3567 closes #3568

## changelog

- refactor(app): Add install modals for buildroot updates

## review requests

Note: I am planning a follow up cleanup PR for CSS and possible logic simplification, but for now this PR is big enough. I think we should do a follow up UI pass since some screens have been improvised.

Please test the entire flow for both Balena and Buildroot robots/raspis

```
make -C app dev OT_APP_DEV_INTERNAL__ENABLE_BUILD_ROOT=1
```

**Balena**
- [ ] premigration (Robot Update: Step 1 of 2)
- [ ] premigrationRestart
- [ ] update (Robot Update: Step 2 of 2)
     - sending file to robot (bouncing spinner)
     - applying update to robot (progress bar)
- [ ] restart
- [ ] finished + exit

**Buildroot**
- [ ] update (Robot Update)
     - sending file to robot (bouncing spinner)
     - applying update to robot (progress bar)
- [ ] restart
- [ ] finished + exit

If you can force an error you should see an error modal with the error message and close button.

