### PR TITLE
refactor(api): apiv2 name changes

### DIFF
--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -56,8 +56,8 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
     def run(protocol_context):
 
         # labware
-        plate = protocol_context.load_labware_by_name('corning_96_wellplate_360ul_flat', '2')
-        tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300ul', '1')
+        plate = protocol_context.load_labware('corning_96_wellplate_360ul_flat', '2')
+        tiprack = protocol_context.load_labware('opentrons_96_tiprack_300ul', '1')
 
         # pipettes
         pipette = protocol_context.load_instrument('p300_single', 'left', tip_racks=[tiprack])
@@ -111,8 +111,8 @@ From the example above, the "labware" section looked like:
 
 .. code-block:: python
 
-    plate = protocol_context.load_labware_by_name('corning_96_wellplate_360ul_flat', '2')
-    tiprack = protocol_context.load_labware_by_name('opentrons_96_tiprack_300ul', '1')
+    plate = protocol_context.load_labware('corning_96_wellplate_360ul_flat', '2')
+    tiprack = protocol_context.load_labware('opentrons_96_tiprack_300ul', '1')
 
 
 and informed the protocol context that the deck contains a 300 µL tiprack in slot 1 and a 96 well plate in slot 2.
@@ -122,7 +122,7 @@ More complete documentation on labware methods (such as the ``.wells()`` method)
 .. _protocol-api-valid-labware:
 
 To see the labware names that can be loaded with
-:py:meth:`.ProtocolContext.load_labware_by_name`, please see the
+:py:meth:`.ProtocolContext.load_labware`, please see the
 `Opentrons Labware Library`__
 
 __ https://labware.opentrons.com

--- a/api/docs/source/new_protocol_api.rst
+++ b/api/docs/source/new_protocol_api.rst
@@ -63,8 +63,8 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
         pipette = protocol_context.load_instrument('p300_single', 'left', tip_racks=[tiprack])
 
         # commands
-        pipette.aspirate(100, plate.wells_by_index()['A1'])
-        pipette.dispense(100, plate.wells_by_index()['B2'])
+        pipette.aspirate(100, plate['A1'])
+        pipette.dispense(100, plate['B2'])
 
 
 **********************
@@ -150,8 +150,8 @@ From the example above, the "commands" section looked like:
 
 .. code-block:: python
 
-    pipette.aspirate(100, plate.wells_by_index()['A1'])
-    pipette.dispense(100, plate.wells_by_index()['B2'])
+    pipette.aspirate(100, plate['A1'])
+    pipette.dispense(100, plate['B2'])
 
 which does exactly what it says - aspirate 100 µL from A1 and dispense it all in B2.
 
@@ -173,7 +173,7 @@ A Temperature Module, for example, can be loaded and used in a protocol like thi
         master_mix = labware.load('opentrons_6_tuberack_falcon_50ml_conical')
 
         for target_well in temp_plate.wells():
-            pipette.transfer(50, master_mix.wells_by_index()['A1'], target_well)
+            pipette.transfer(50, master_mix['A1'], target_well)
 
         target_temp = 80.0  # degrees Celcius
         temp_mod.set_temp(target_temp)

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -251,10 +251,10 @@ class BCLabware:
     def load(self, container_name, slot, label=None, share=False):
         """ Load a piece of labware by specifying its name and position.
 
-        This method calls :py:meth:`.ProtocolContext.load_labware_by_name`;
+        This method calls :py:meth:`.ProtocolContext.load_labware`;
         see that documentation for more information on arguments and return
         values. Calls to this function should be replaced with calls to
-        :py:meth:`.Protocolcontext.load_labware_by_name`.
+        :py:meth:`.Protocolcontext.load_labware`.
 
         In addition, this function contains translations between old
         labware names and new labware names.
@@ -275,7 +275,7 @@ class BCLabware:
             else:
                 name = container_name
 
-        return self._ctx.load_labware_by_name(name, slot, label)
+        return self._ctx.load_labware(name, slot, label)
 
     def create(self, *args, **kwargs):
         raise NotImplementedError

--- a/api/src/opentrons/protocol_api/execute_v1.py
+++ b/api/src/opentrons/protocol_api/execute_v1.py
@@ -41,7 +41,7 @@ def _get_well(loaded_labware: Dict[str, labware.Labware],
         raise ValueError(
             'Command tried to use labware "{}", but that ID does not exist '
             'in protocol\'s "labware" section'.format(labwareId))
-    return plate.wells_by_index()[well]
+    return plate[well]
 
 
 # TODO (Ian 2018-08-22) once Pipette has more sensible way of managing

--- a/api/src/opentrons/protocol_api/execute_v1.py
+++ b/api/src/opentrons/protocol_api/execute_v1.py
@@ -60,24 +60,15 @@ def _set_flow_rate(
 
     flow_rate_param = params.get('flow-rate')
 
-    if flow_rate_param is not None:
-        if command_type == 'aspirate':
-            pipette.flow_rate = {
-                'aspirate': flow_rate_param,
-                'dispense': default_dispense
-            }
-            return
-        if command_type == 'dispense':
-            pipette.flow_rate = {
-                'aspirate': default_aspirate,
-                'dispense': flow_rate_param
-            }
-            return
-
-    pipette.flow_rate = {
-        'aspirate': default_aspirate,
-        'dispense': default_dispense
-    }
+    if flow_rate_param is not None and command_type == 'aspirate':
+        pipette.flow_rate.aspirate = flow_rate_param
+        pipette.flow_rate.dispense = default_dispense
+    elif flow_rate_param is not None and command_type == 'dispense':
+        pipette.flow_rate.aspirate = default_aspirate
+        pipette.flow_rate.dispense = flow_rate_param
+    else:
+        pipette.flow_rate.aspirate = default_aspirate
+        pipette.flow_rate.dispense = default_dispense
 
 
 def load_labware_from_json_loadnames(

--- a/api/src/opentrons/protocol_api/execute_v3.py
+++ b/api/src/opentrons/protocol_api/execute_v3.py
@@ -27,7 +27,7 @@ def _get_well(loaded_labware: Dict[str, labware.Labware],
     labwareId = params['labware']
     well = params['well']
     plate = loaded_labware[labwareId]
-    return plate.wells_by_index()[well]
+    return plate[well]
 
 
 # TODO (Ian 2019-04-05) once Pipette commands allow flow rate as an

--- a/api/src/opentrons/protocol_api/execute_v3.py
+++ b/api/src/opentrons/protocol_api/execute_v3.py
@@ -42,11 +42,9 @@ def _set_flow_rate(pipette, params) -> None:
     if not (flow_rate_param > 0):
         raise RuntimeError('Positive flowRate param required')
 
-    pipette.flow_rate = {
-        'aspirate': flow_rate_param,
-        'dispense': flow_rate_param,
-        'blow_out': flow_rate_param,
-    }
+    pipette.flow_rate.aspirate = flow_rate_param
+    pipette.flow_rate.dispense = flow_rate_param
+    pipette.flow_rate.blow_out = flow_rate_param
 
 
 def load_labware_from_json_defs(

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -407,7 +407,7 @@ def model(robot, hardware, loop, request):
         loop.run_until_complete(hardware.cache_instruments(
             {Mount.RIGHT: 'p300_single'}))
         instrument = models.Instrument(pip, context=ctx)
-        plate = ctx.load_labware_by_name(
+        plate = ctx.load_labware(
             lw_name or 'corning_96_wellplate_360ul_flat', 1)
         rob = hardware
         container = models.Container(plate, context=ctx)

--- a/api/tests/opentrons/data/testosaur_v2.py
+++ b/api/tests/opentrons/data/testosaur_v2.py
@@ -3,9 +3,9 @@ from opentrons import types
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 1)
+    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
     right = ctx.load_instrument('p300_single', types.Mount.RIGHT, [tr])
-    lw = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 2)
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -149,7 +149,7 @@ def test_wells_accessor():
     assert fake_labware.wells()[1]._position == a2
 
 
-def test_wells_index_accessor():
+def test_wells_name_accessor():
     deck = Location(Point(0, 0, 0), 'deck')
     fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
@@ -159,8 +159,30 @@ def test_wells_index_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.wells_by_index()['A1']._position == a1
-    assert fake_labware.wells_by_index()['A2']._position == a2
+    assert fake_labware.wells_by_name()['A1']._position == a1
+    assert fake_labware.wells_by_name()['A2']._position == a2
+
+
+def test_deprecated_index_accessors():
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
+    assert fake_labware.wells_by_name() == fake_labware.wells_by_index()
+    assert fake_labware.rows_by_name() == fake_labware.rows_by_index()
+    assert fake_labware.columns_by_name() == fake_labware.columns_by_index()
+
+
+def test_dict_accessor():
+    deck = Location(Point(0, 0, 0), 'deck')
+    fake_labware = labware.Labware(minimalLabwareDef, deck)
+    depth1 = minimalLabwareDef['wells']['A1']['depth']
+    depth2 = minimalLabwareDef['wells']['A2']['depth']
+    x = minimalLabwareDef['wells']['A2']['x']
+    y = minimalLabwareDef['wells']['A2']['y']
+    offset = fake_labware._offset
+    a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
+    a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
+    assert fake_labware['A1']._position == a1
+    assert fake_labware['A2']._position == a2
 
 
 def test_rows_accessor():
@@ -179,7 +201,7 @@ def test_rows_accessor():
     assert fake_labware.rows()[1][1]._position == b2
 
 
-def test_row_index_accessor():
+def test_row_name_accessor():
     deck = Location(Point(0, 0, 0), 'deck')
     fake_labware = labware.Labware(minimalLabwareDef2, deck)
     depth1 = minimalLabwareDef2['wells']['A1']['depth']
@@ -191,8 +213,8 @@ def test_row_index_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0] + x1, y=offset[1] + y1, z=offset[2] + depth1)
     b2 = Point(x=offset[0] + x2, y=offset[1] + y2, z=offset[2] + depth2)
-    assert fake_labware.rows_by_index()['A'][0]._position == a1
-    assert fake_labware.rows_by_index()['B'][1]._position == b2
+    assert fake_labware.rows_by_name()['A'][0]._position == a1
+    assert fake_labware.rows_by_name()['B'][1]._position == b2
 
 
 def test_cols_accessor():
@@ -209,7 +231,7 @@ def test_cols_accessor():
     assert fake_labware.columns()[1][0]._position == a2
 
 
-def test_col_index_accessor():
+def test_col_name_accessor():
     deck = Location(Point(0, 0, 0), 'deck')
     fake_labware = labware.Labware(minimalLabwareDef, deck)
     depth1 = minimalLabwareDef['wells']['A1']['depth']
@@ -219,5 +241,5 @@ def test_col_index_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.columns_by_index()['1'][0]._position == a1
-    assert fake_labware.columns_by_index()['2'][0]._position == a2
+    assert fake_labware.columns_by_name()['1'][0]._position == a1
+    assert fake_labware.columns_by_name()['2'][0]._position == a2

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -54,7 +54,7 @@ def test_labware_mappings(loop, monkeypatch):
 
     ctx = ProtocolContext(loop)
     bc = back_compat.BCLabware(ctx)
-    monkeypatch.setattr(ctx, 'load_labware_by_name', fake_ctx_load)
+    monkeypatch.setattr(ctx, 'load_labware', fake_ctx_load)
     obj = bc.load('384-plate', 2, 'hey there')
     assert obj == 'heres a fake labware'
     assert lw_name == 'corning_384_wellplate_112ul_flat'

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -139,7 +139,7 @@ def test_pick_up_and_drop_tip(loop, get_labware_def):
     pipette: Pipette = ctx._hw_manager.hardware._attached_instruments[mount]
     model_offset = Point(*pipette.config.model_offset)
     assert pipette.critical_point() == model_offset
-    target_location = tiprack.wells_by_index()['A1'].top()
+    target_location = tiprack['A1'].top()
 
     instr.pick_up_tip(target_location)
     assert not tiprack.wells()[0].has_tip
@@ -166,7 +166,7 @@ def test_return_tip(loop, get_labware_def):
     pipette: Pipette\
         = ctx._hw_manager.hardware._attached_instruments[mount]
 
-    target_location = tiprack.wells_by_index()['A1'].top()
+    target_location = tiprack['A1'].top()
     instr.pick_up_tip(target_location)
     assert not tiprack.wells()[0].has_tip
     assert pipette.has_tip

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -58,7 +58,7 @@ def test_location_cache(loop, monkeypatch, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.connect(hardware)
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
-    lw = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 1)
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     ctx.home()
 
     test_args = None
@@ -95,7 +95,7 @@ def test_move_uses_arc(loop, monkeypatch, get_labware_def):
     ctx.connect(hardware)
     ctx.home()
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
-    lw = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 1)
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     ctx.home()
 
     targets = []
@@ -130,7 +130,7 @@ def test_pipette_info(loop):
 def test_pick_up_and_drop_tip(loop, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
     tip_length = tiprack.tip_length
     mount = Mount.LEFT
 
@@ -155,7 +155,7 @@ def test_pick_up_and_drop_tip(loop, get_labware_def):
 def test_return_tip(loop, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
     mount = Mount.LEFT
 
     instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
@@ -180,10 +180,10 @@ def test_pick_up_tip_no_location(loop, get_labware_def):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
 
-    tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 1)
+    tiprack1 = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
     tip_length1 = tiprack1.tip_length
 
-    tiprack2 = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 2)
+    tiprack2 = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
     tip_length2 = tip_length1 + 1.0
     tiprack2.tip_length = tip_length2
 
@@ -231,7 +231,7 @@ def test_instrument_trash(loop, get_labware_def):
 
     assert instr.trash_container.name == 'opentrons_1_trash_1100ml_fixed'
 
-    new_trash = ctx.load_labware_by_name('usascientific_12_reservoir_22ml', 2)
+    new_trash = ctx.load_labware('usascientific_12_reservoir_22ml', 2)
     instr.trash_container = new_trash
 
     assert instr.trash_container.name == 'usascientific_12_reservoir_22ml'
@@ -240,7 +240,7 @@ def test_instrument_trash(loop, get_labware_def):
 def test_aspirate(loop, get_labware_def, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    lw = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 1)
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     instr = ctx.load_instrument('p10_single', Mount.RIGHT)
 
     fake_hw_aspirate = mock.Mock()
@@ -283,7 +283,7 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
 def test_dispense(loop, get_labware_def, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    lw = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 1)
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     instr = ctx.load_instrument('p10_single', Mount.RIGHT)
 
     disp_called_with = None
@@ -361,9 +361,9 @@ def test_hw_manager(loop):
 def test_mix(loop, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    lw = ctx.load_labware_by_name(
+    lw = ctx.load_labware(
         'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 3)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr = ctx.load_instrument('p300_single', Mount.RIGHT,
                                 tip_racks=[tiprack])
 
@@ -403,9 +403,9 @@ def test_mix(loop, monkeypatch):
 def test_touch_tip_default_args(loop, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    lw = ctx.load_labware_by_name(
+    lw = ctx.load_labware(
         'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 3)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr = ctx.load_instrument('p300_single', Mount.RIGHT,
                                 tip_racks=[tiprack])
 
@@ -433,9 +433,9 @@ def test_touch_tip_default_args(loop, monkeypatch):
 def test_blow_out(loop, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
-    lw = ctx.load_labware_by_name(
+    lw = ctx.load_labware(
         'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 3)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr = ctx.load_instrument('p300_single', Mount.RIGHT,
                                 tip_racks=[tiprack])
 
@@ -466,9 +466,9 @@ def test_blow_out(loop, monkeypatch):
 
 def test_transfer_options(loop, monkeypatch):
     ctx = papi.ProtocolContext(loop)
-    lw1 = ctx.load_labware_by_name('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 2)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 3)
+    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
+    lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr = ctx.load_instrument('p300_single', Mount.RIGHT,
                                 tip_racks=[tiprack])
 

--- a/api/tests/opentrons/protocol_api/test_execute_v1.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v1.py
@@ -67,9 +67,9 @@ def test_get_location_with_offset(loop, command_type):
         assert offs == offset
         result = execute_v1._get_location_with_offset(
             loaded_labware, command_type, command_params, default_values)
-        assert result.labware == plate.wells_by_index()[well]
+        assert result.labware == plate[well]
         assert result.point\
-            == plate.wells_by_index()[well].bottom().point + Point(z=offset)
+            == plate[well].bottom().point + Point(z=offset)
 
     command_params = {
         "labware": "someLabwareId",
@@ -83,7 +83,7 @@ def test_get_location_with_offset(loop, command_type):
     assert execute_v1._get_bottom_offset(
         command_type, command_params, default_values) == default
     assert result.point\
-        == plate.wells_by_index()[well].bottom().point + Point(z=default)
+        == plate[well].bottom().point + Point(z=default)
 
 
 def test_load_labware(loop):
@@ -176,9 +176,9 @@ def test_dispatch_commands(monkeypatch, loop):
         ctx, protocol_data, insts, loaded_labware)
 
     assert cmd == [
-        ("aspirate", 5, source_plate.wells_by_index()['A1'].bottom()),
+        ("aspirate", 5, source_plate['A1'].bottom()),
         ("sleep", 42),
-        ("dispense", 4.5, dest_plate.wells_by_index()['B1'].bottom())
+        ("dispense", 4.5, dest_plate['B1'].bottom())
     ]
 
     assert flow_rates == [

--- a/api/tests/opentrons/protocol_api/test_execute_v1.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v1.py
@@ -43,7 +43,7 @@ async def test_load_pipettes(loop, protocol_data):
 @pytest.mark.parametrize('command_type', ['aspirate', 'dispense'])
 def test_get_location_with_offset(loop, command_type):
     ctx = ProtocolContext(loop=loop)
-    plate = ctx.load_labware_by_name("corning_96_wellplate_360ul_flat", 1)
+    plate = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
     well = "B2"
 
     default_values = {
@@ -156,9 +156,9 @@ def test_dispatch_commands(monkeypatch, loop):
 
     insts = execute_v1.load_pipettes_from_json(ctx, protocol_data)
 
-    source_plate = ctx.load_labware_by_name(
+    source_plate = ctx.load_labware(
         'corning_96_wellplate_360ul_flat', '1')
-    dest_plate = ctx.load_labware_by_name(
+    dest_plate = ctx.load_labware(
         'corning_96_wellplate_360ul_flat', '2')
 
     loaded_labware = {

--- a/api/tests/opentrons/protocol_api/test_execute_v1.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v1.py
@@ -182,6 +182,8 @@ def test_dispatch_commands(monkeypatch, loop):
     ]
 
     assert flow_rates == [
-        (123, 102),
-        (101, 102)
+        (123, None),
+        (None, 102),
+        (101, None),
+        (None, 102),
     ]

--- a/api/tests/opentrons/protocol_api/test_execute_v3.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v3.py
@@ -115,11 +115,11 @@ def test_dispatch_commands(monkeypatch, loop):
 
     monkeypatch.setattr(ctx, 'delay', mock_delay)
 
-    source_plate = ctx.load_labware_by_name(
+    source_plate = ctx.load_labware(
         'corning_96_wellplate_360ul_flat', '1')
-    dest_plate = ctx.load_labware_by_name(
+    dest_plate = ctx.load_labware(
         'corning_96_wellplate_360ul_flat', '2')
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_10ul', '3')
+    tiprack = ctx.load_labware('opentrons_96_tiprack_10ul', '3')
 
     loaded_labware = {
         'sourcePlateId': source_plate,

--- a/api/tests/opentrons/protocol_api/test_execute_v3.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v3.py
@@ -132,23 +132,23 @@ def test_dispatch_commands(monkeypatch, loop):
         ctx, protocol_data, insts, loaded_labware)
 
     assert command_log == [
-        ("pick_up_tip", (tiprack.wells_by_index()['B1'],)),
+        ("pick_up_tip", (tiprack['B1'],)),
         ("set: flow_rate.aspirate", (3,)),
         ("set: flow_rate.dispense", (3,)),
         ("set: flow_rate.blow_out", (3,)),
-        ("aspirate", (5, source_plate.wells_by_index()['A1'].bottom(2),)),
+        ("aspirate", (5, source_plate['A1'].bottom(2),)),
         ("delay", 42),
         ("set: flow_rate.aspirate", (2.5,)),
         ("set: flow_rate.dispense", (2.5,)),
         ("set: flow_rate.blow_out", (2.5,)),
-        ("dispense", (4.5, dest_plate.wells_by_index()['B1'].bottom(1),)),
-        ("touch_tip", (dest_plate.wells_by_index()['B1'],),
+        ("dispense", (4.5, dest_plate['B1'].bottom(1),)),
+        ("touch_tip", (dest_plate['B1'],),
             {"v_offset": 0.33000000000000007}),
         ("set: flow_rate.aspirate", (2,)),
         ("set: flow_rate.dispense", (2,)),
         ("set: flow_rate.blow_out", (2,)),
-        ("blow_out", (dest_plate.wells_by_index()['B1'],)),
+        ("blow_out", (dest_plate['B1'],)),
         ("move_to", (ctx.deck.position_for('5').move(Point(1, 2, 3)),),
             {"force_direct": None, "minimum_z_height": None}),
-        ("drop_tip", (ctx.fixed_trash.wells_by_index()['A1'],))
+        ("drop_tip", (ctx.fixed_trash['A1'],))
     ]

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -123,9 +123,9 @@ def test_backcompat():
     # because dimensional parameters could be subject to modification through
     # calibration, whereas here we are testing for "identity" in a way that is
     # related to the combination of well name, labware name, and slot name
-    well_a1_name = repr(lw.wells_by_index()['A1'])
-    well_b2_name = repr(lw.wells_by_index()['B2'])
-    well_c3_name = repr(lw.wells_by_index()['C3'])
+    well_a1_name = repr(lw.wells_by_name()['A1'])
+    well_b2_name = repr(lw.wells_by_name()['B2'])
+    well_c3_name = repr(lw.wells_by_name()['C3'])
 
     w2 = lw.well(0)
     assert repr(w2) == well_a1_name

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -7,15 +7,15 @@ labware_name = 'corning_96_wellplate_360ul_flat'
 
 def test_load_to_slot(loop):
     ctx = papi.ProtocolContext(loop=loop)
-    labware = ctx.load_labware_by_name(labware_name, '1')
+    labware = ctx.load_labware(labware_name, '1')
     assert labware._offset == types.Point(0, 0, 0)
-    other = ctx.load_labware_by_name(labware_name, 2)
+    other = ctx.load_labware(labware_name, 2)
     assert other._offset == types.Point(132.5, 0, 0)
 
 
 def test_loaded(loop):
     ctx = papi.ProtocolContext(loop=loop)
-    labware = ctx.load_labware_by_name(labware_name, '1')
+    labware = ctx.load_labware(labware_name, '1')
     assert ctx.loaded_labwares[1] == labware
 
 
@@ -31,6 +31,12 @@ def test_get_mixed_case_labware_def():
 
 
 def test_load_label(loop):
+    ctx = papi.ProtocolContext(loop=loop)
+    labware = ctx.load_labware(labware_name, '1', 'my cool labware')
+    assert 'my cool labware' in str(labware)
+
+
+def test_deprecated_load(loop):
     ctx = papi.ProtocolContext(loop=loop)
     labware = ctx.load_labware_by_name(labware_name, '1', 'my cool labware')
     assert 'my cool labware' in str(labware)

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -8,9 +8,9 @@ from opentrons.protocol_api import transfers as tx
 @pytest.fixture
 def _instr_labware(loop):
     ctx = papi.ProtocolContext(loop)
-    lw1 = ctx.load_labware_by_name('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', 2)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 3)
+    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
+    lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
     instr = ctx.load_instrument('p300_single', Mount.RIGHT,
                                 tip_racks=[tiprack])
 


### PR DESCRIPTION
## overview

This PR encapsulates a number of small changes to the names of apiv2 functions and objects as described in the linked ticket. There's no real functionality or behavior differences, just a bunch of namechanges.

Most of the simple name changes have the old versions stick around with warning level logs about using them; the flow rate, speed, and clearance don't because the structure of them changed. This makes this a breaking change for APIv2, but APIv2 is also not publicly released.

## changelog

- s/load_labware_by_name/load_labware/
- s/(wells,columns,rows)_by_index/(\1)_by_name/
- make flow rate, speed, and well bottom clearance accessed by attribute instead of as weird fake dicts that you have to assign over rather than modifying keys

## review requests

Make sure it all makes sense, run or simulate some protocols. Check out the docs (attached).
[html.zip](https://github.com/Opentrons/opentrons/files/3453602/html.zip)


Closes #3785 