### PR TITLE
feat(api): move gantry to safe spot while TC lid moves

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -790,7 +790,7 @@ class API(HardwareAPILike):
         self._backend.disengage_axes([ax.name for ax in which])
 
     @_log_call
-    async def retract(self, mount: top_types.Mount, margin: float):
+    async def retract(self, mount: top_types.Mount, margin: float = 10):
         """ Pull the specified mount up to its home position.
 
         Works regardless of critical point or home status.

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1781,16 +1781,17 @@ class ThermocyclerContext(ModuleContext):
                               if instr is not None]
         try:
             instrument = loaded_instruments[0]
-            trash_top = self._ctx.fixed_trash.wells()[0].top()
-            high_z = self._ctx.deck.highest_z
-            safe_point = types.Point(x=trash_top.point.x, y=trash_top.point.y,
-                                     z=high_z)
-            safe_loc = types.Location(safe_point, None)
-            instrument.move_to(safe_loc, minimum_z_height=high_z)
         except IndexError:
             MODULE_LOG.warning(
                 "Cannot assure a safe gantry position to avoid colliding"
                 " with the lid of the Thermocycler Module.")
+        else:
+            trash_top = self._ctx.fixed_trash.wells()[0].top()
+            high_z = self._ctx.deck.highest_z
+            safe_point = types.Point(x=trash_top.point.x, y=trash_top.point.y,
+                                        z=high_z)
+            safe_loc = types.Location(safe_point, None)
+            instrument.move_to(safe_loc, minimum_z_height=high_z)
 
     @cmds.publish.both(command=cmds.thermocycler_open)
     def open(self):

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1788,8 +1788,8 @@ class ThermocyclerContext(ModuleContext):
         else:
             trash_top = self._ctx.fixed_trash.wells()[0].top()
             high_z = self._ctx.deck.highest_z
-            safe_point = types.Point(x=trash_top.point.x, y=trash_top.point.y,
-                                        z=high_z)
+            safe_point = types.Point(x=trash_top.point.x,
+                                     y=trash_top.point.y, z=high_z)
             safe_loc = types.Location(safe_point, None)
             instrument.move_to(safe_loc, minimum_z_height=high_z)
 

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1790,7 +1790,8 @@ class ThermocyclerContext(ModuleContext):
             high_point = self._ctx._hw_manager.hardware.current_position(
                     instr._mount)
             trash_top = self._ctx.fixed_trash.wells()[0].top()
-            safe_point = trash_top.point._replace(z=high_point[Axis.by_mount(instr._mount)])
+            safe_point = trash_top.point._replace(
+                    z=high_point[Axis.by_mount(instr._mount)])
             instr.move_to(types.Location(safe_point, None), force_direct=True)
 
     @cmds.publish.both(command=cmds.thermocycler_open)


### PR DESCRIPTION
Provide a protection for calles to thermocycler.open() and .close() that prevents the possibility of
the lid colliding with the gantry. Before either command is sent to the module, the gantry will move
to a "safe" spot at the highest z above the fixed trash.
