### PR TITLE
fix(api): duplicate mix with blowout during transfer

### DIFF
--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1702,10 +1702,6 @@ class Pipette(CommandPublisher):
                 if self.current_volume == 0:
                     blow_out = None
             self.blow_out(blow_out)
-            self._mix_during_transfer(
-                kwargs.get('mix_after', (0, 0)),
-                loc,
-                **kwargs)
 
     def _drop_tip_during_transfer(self, tips, i, total, **kwargs):
         """


### PR DESCRIPTION
Transfers with blowout and mix after set were mixing before the blowout and once again after. We
should only be mixing before the blowout.

Close #2607

## Review Requests
- this should be tested on robot
