### PR TITLE
fix(api): force nmcli to actively check for connectivity

### DIFF
--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -292,7 +292,7 @@ async def available_ssids() -> List[Dict[str, Any]]:
 
 async def is_connected() -> str:
     """ Return nmcli's connection measure: none/portal/limited/full/unknown"""
-    res, _ = await _call(['networking', 'connectivity'])
+    res, _ = await _call(['networking', 'connectivity', 'check'])
     return res
 
 


### PR DESCRIPTION
On buildroot, nmcli networking connectivity always returns unknown, probably
because of a file caching issue on a read-only rootfs. Changing the call to
nmcli networking connectivity check avoids the cache.

Closes #3768

## Testing
Put this on both a balena and buildroot robot on a couple different kinds of connection (USB, wifi, etc) and check that it does the right thing still.
