### PR TITLE
refactor(api): apiv2: raise error on api version mismatch

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -286,6 +286,15 @@ class Session(object):
             self._protocol = compile(parsed, filename=self.name, mode='exec')
             version = infer_version(self.metadata, parsed)
 
+        if ff.use_protocol_api_v2() and version == '1':
+            raise RuntimeError(
+                'This protocol targets Protocol API V1, but the robot is set '
+                'to Protocol API V2. If this is actually a V2 protocol, '
+                'please set the \'apiLevel\' to \'2\' in the metadata. If you '
+                'do not want to be on API V2, please disable the \'Use '
+                'Protocol API version 2\' toggle in the robot\'s Advanced '
+                'Settings and restart the robot.')
+
         log.info(f"Protocol API version: {version}")
 
         try:


### PR DESCRIPTION
Raise an error if we're on apiv2 and the user tries to upload a protocol
targeting APIv1.

Closes #3750
