### PR TITLE
refactor(app): Remove migrated balena robots from discovery

### DIFF
--- a/app-shell/src/__tests__/discovery.test.js
+++ b/app-shell/src/__tests__/discovery.test.js
@@ -189,7 +189,7 @@ describe('app-shell/discovery', () => {
   })
 
   // ensures config override works with only one candidate specified
-  test('canidates in config can be single value', () => {
+  test('candidates in config can be single value', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: '1.2.3.4' })
     registerDiscovery(dispatch)
 
@@ -200,7 +200,7 @@ describe('app-shell/discovery', () => {
     )
   })
 
-  test('services from overridden canidates are not persisted', () => {
+  test('services from overridden candidates are not persisted', () => {
     getConfig.mockReturnValue({ enabled: true, candidates: 'localhost' })
     getOverrides.mockImplementation(key => {
       if (key === 'discovery.candidates') return ['1.2.3.4', '5.6.7.8']
@@ -230,5 +230,15 @@ describe('app-shell/discovery', () => {
     expect(Store.__store.set).toHaveBeenCalledWith('services', [
       { name: 'bar' },
     ])
+  })
+
+  test('calls client.remove on discovery:REMOVE', () => {
+    const handleAction = registerDiscovery(dispatch)
+    handleAction({
+      type: 'discovery:REMOVE',
+      payload: { robotName: 'robot-name' },
+    })
+
+    expect(mockClient.remove).toHaveBeenCalledWith('robot-name')
   })
 })

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -59,8 +59,12 @@ export function registerDiscovery(dispatch: Dispatch) {
       case 'discovery:START':
         handleServices()
         return client.setPollInterval(FAST_POLL_INTERVAL_MS).start()
+
       case 'discovery:FINISH':
         return client.setPollInterval(SLOW_POLL_INTERVAL_MS)
+
+      case 'discovery:REMOVE':
+        return client.remove(action.payload.robotName)
     }
   }
 

--- a/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
@@ -60,7 +60,10 @@ export default function InstallModalContents(props: Props) {
     updateMessage = 'Hang tight! This may take about 3-5 minutes.'
   } else if (step === 'getToken' || step === 'uploadFile') {
     updateMessage = 'Sending update file to robot'
-  } else if (step === 'processFile' && session.stage === 'validating') {
+  } else if (
+    step === 'processFile' &&
+    (session.stage === 'awaiting-file' || session.stage === 'validating')
+  ) {
     updateMessage = 'Validating update file'
   } else if (step === 'processFile' || step === 'commitUpdate') {
     updateMessage = 'Applying update to robot'
@@ -68,7 +71,7 @@ export default function InstallModalContents(props: Props) {
 
   const progressComponent =
     step === 'processFile' || step === 'commitUpdate' ? (
-      <ProgressBar progress={progress} />
+      <ProgressBar key={step} progress={progress} />
     ) : (
       <ProgressSpinner />
     )

--- a/app/src/discovery/__tests__/actions.test.js
+++ b/app/src/discovery/__tests__/actions.test.js
@@ -1,44 +1,49 @@
 // discovery actions test
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-
-import { startDiscovery } from '..'
-
-const middlewares = [thunk]
-const mockStore = configureMockStore(middlewares)
+import * as actions from '../actions'
 
 describe('discovery actions', () => {
-  let store
+  const SPECS = [
+    {
+      name: 'startDiscovery',
+      creator: actions.startDiscovery,
+      args: [],
+      expected: {
+        type: 'discovery:START',
+        payload: { timeout: null },
+        meta: { shell: true },
+      },
+    },
+    {
+      name: 'startDiscovery with timeout specified',
+      creator: actions.startDiscovery,
+      args: [30000],
+      expected: {
+        type: 'discovery:START',
+        payload: { timeout: 30000 },
+        meta: { shell: true },
+      },
+    },
+    {
+      name: 'finishDiscovery',
+      creator: actions.finishDiscovery,
+      args: [],
+      expected: { type: 'discovery:FINISH', meta: { shell: true } },
+    },
+    {
+      name: 'removeRobot',
+      creator: actions.removeRobot,
+      args: ['robot-name'],
+      expected: {
+        type: 'discovery:REMOVE',
+        payload: { robotName: 'robot-name' },
+        meta: { shell: true },
+      },
+    },
+  ]
 
-  beforeEach(() => {
-    jest.useFakeTimers()
-    store = mockStore({ config: { discovery: { enabled: true } } })
-  })
+  SPECS.forEach(spec => {
+    const { name, creator, args, expected } = spec
 
-  afterEach(() => {
-    jest.clearAllTimers()
-    jest.useRealTimers()
-  })
-
-  test('startDiscovery', () => {
-    const expectedTimeout = 30000
-    const expectedStart = { type: 'discovery:START', meta: { shell: true } }
-    const expectedFinish = { type: 'discovery:FINISH', meta: { shell: true } }
-
-    store.dispatch(startDiscovery())
-    expect(store.getActions()).toEqual([expectedStart])
-    jest.runTimersToTime(expectedTimeout)
-    expect(store.getActions()).toEqual([expectedStart, expectedFinish])
-  })
-
-  test('startDiscovery with timeout', () => {
-    const expectedTimeout = 60000
-    const expectedStart = { type: 'discovery:START', meta: { shell: true } }
-    const expectedFinish = { type: 'discovery:FINISH', meta: { shell: true } }
-
-    store.dispatch(startDiscovery(60000))
-    expect(store.getActions()).toEqual([expectedStart])
-    jest.runTimersToTime(expectedTimeout)
-    expect(store.getActions()).toEqual([expectedStart, expectedFinish])
+    test(name, () => expect(creator(...args)).toEqual(expected))
   })
 })

--- a/app/src/discovery/__tests__/epics.test.js
+++ b/app/src/discovery/__tests__/epics.test.js
@@ -1,0 +1,52 @@
+import { TestScheduler } from 'rxjs/testing'
+
+import * as actions from '../actions'
+import * as epics from '../epics'
+
+describe('discovery actions', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  test('startDiscoveryEpic with default timeout', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const action$ = hot('-a', { a: actions.startDiscovery() })
+      const output$ = epics.startDiscoveryEpic(action$)
+
+      expectObservable(output$).toBe('- 30000ms a ', {
+        a: actions.finishDiscovery(),
+      })
+    })
+  })
+
+  test('startDiscoveryEpic with specified timeout', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const action$ = hot('-a', { a: actions.startDiscovery(42) })
+      const output$ = epics.startDiscoveryEpic(action$)
+
+      expectObservable(output$).toBe('- 42ms a ', {
+        a: actions.finishDiscovery(),
+      })
+    })
+  })
+
+  test('startDiscoveryOnRestartEpic', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const serverSuccessAction = {
+        type: 'api:SERVER_SUCCESS',
+        payload: { path: 'restart' },
+      }
+
+      const action$ = hot('-a', { a: serverSuccessAction })
+      const output$ = epics.startDiscoveryOnRestartEpic(action$)
+
+      expectObservable(output$).toBe('-a ', {
+        a: actions.startDiscovery(60000),
+      })
+    })
+  })
+})

--- a/app/src/discovery/actions.js
+++ b/app/src/discovery/actions.js
@@ -1,0 +1,32 @@
+// @flow
+
+import type { DiscoveryAction } from './types'
+
+export const DISCOVERY_START: 'discovery:START' = 'discovery:START'
+
+export const DISCOVERY_FINISH: 'discovery:FINISH' = 'discovery:FINISH'
+
+export const DISCOVERY_UPDATE_LIST: 'discovery:UPDATE_LIST' =
+  'discovery:UPDATE_LIST'
+
+export const DISCOVERY_REMOVE: 'discovery:REMOVE' = 'discovery:REMOVE'
+
+export function startDiscovery(timeout: number | null = null): DiscoveryAction {
+  return {
+    type: DISCOVERY_START,
+    payload: { timeout },
+    meta: { shell: true },
+  }
+}
+
+export function finishDiscovery(): DiscoveryAction {
+  return { type: DISCOVERY_FINISH, meta: { shell: true } }
+}
+
+export function removeRobot(robotName: string): DiscoveryAction {
+  return {
+    type: DISCOVERY_REMOVE,
+    payload: { robotName },
+    meta: { shell: true },
+  }
+}

--- a/app/src/discovery/epics.js
+++ b/app/src/discovery/epics.js
@@ -1,0 +1,39 @@
+// @flow
+import { of } from 'rxjs'
+import { filter, switchMap, delay } from 'rxjs/operators'
+import { ofType, combineEpics } from 'redux-observable'
+
+import { DISCOVERY_START, startDiscovery, finishDiscovery } from './actions'
+
+import type { Epic } from '../types'
+import type { DiscoveryAction, StartDiscoveryAction } from './types'
+
+export const DISCOVERY_TIMEOUT_MS = 30000
+export const RESTART_DISCOVERY_TIMEOUT_MS = 60000
+
+export const startDiscoveryEpic: Epic = action$ =>
+  action$.pipe(
+    ofType(DISCOVERY_START),
+    switchMap<StartDiscoveryAction, _, DiscoveryAction>(startAction => {
+      const timeout = startAction.payload.timeout || DISCOVERY_TIMEOUT_MS
+      return of(finishDiscovery()).pipe(delay(timeout))
+    })
+  )
+
+// TODO(mc, 2019-08-01): handle restart requests using robot-api actions
+export const startDiscoveryOnRestartEpic: Epic = action$ =>
+  action$.pipe(
+    filter(
+      action =>
+        action.type === 'api:SERVER_SUCCESS' &&
+        action.payload.path === 'restart'
+    ),
+    switchMap<_, _, DiscoveryAction>(() =>
+      of(startDiscovery(RESTART_DISCOVERY_TIMEOUT_MS))
+    )
+  )
+
+export const discoveryEpic = combineEpics(
+  startDiscoveryEpic,
+  startDiscoveryOnRestartEpic
+)

--- a/app/src/discovery/index.js
+++ b/app/src/discovery/index.js
@@ -3,14 +3,18 @@
 import groupBy from 'lodash/groupBy'
 import mapValues from 'lodash/mapValues'
 import some from 'lodash/some'
+
 import { getShellRobots } from '../shell'
+import * as actions from './actions'
 
 import type { Service } from '@opentrons/discovery-client'
-import type { Action, ThunkAction, Middleware } from '../types'
+import type { Action } from '../types'
 import type { RestartStatus } from './types'
 
 export * from './types'
+export * from './actions'
 export * from './selectors'
+export { discoveryEpic } from './epics'
 
 type RobotsMap = { [name: string]: Array<Service> }
 
@@ -22,51 +26,8 @@ export type DiscoveryState = {|
   restartsByName: RestartsMap,
 |}
 
-type StartAction = {|
-  type: 'discovery:START',
-  meta: {| shell: true |},
-|}
-
-type FinishAction = {|
-  type: 'discovery:FINISH',
-  meta: {| shell: true |},
-|}
-
-type UpdateListAction = {|
-  type: 'discovery:UPDATE_LIST',
-  payload: {| robots: Array<Service> |},
-|}
-
-export type DiscoveryAction = StartAction | FinishAction | UpdateListAction
-
-const DISCOVERY_TIMEOUT_MS = 30000
-const RESTART_DISCOVERY_TIMEOUT_MS = 60000
-
 export const RESTART_PENDING: RestartStatus = 'pending'
 export const RESTART_DOWN: RestartStatus = 'down'
-
-export function startDiscovery(
-  timeout: number = DISCOVERY_TIMEOUT_MS
-): ThunkAction {
-  const start: StartAction = { type: 'discovery:START', meta: { shell: true } }
-  const finish: FinishAction = {
-    type: 'discovery:FINISH',
-    meta: { shell: true },
-  }
-
-  return dispatch => {
-    setTimeout(() => dispatch(finish), timeout)
-    return dispatch(start)
-  }
-}
-
-// TODO(mc, 2018-08-09): uncomment when we figure out how to get this
-// to the app shell
-// export function updateDiscoveryList (
-//   robots: Array<Service>
-// ): UpdateListAction {
-//   return {type: 'discovery:UPDATE_LIST', payload: {robots}}
-// }
 
 // getShellRobots makes a sync RPC call, so use sparingly
 const initialState: DiscoveryState = {
@@ -80,13 +41,13 @@ export function discoveryReducer(
   action: Action
 ): DiscoveryState {
   switch (action.type) {
-    case 'discovery:START':
+    case actions.DISCOVERY_START:
       return { ...state, scanning: true }
 
-    case 'discovery:FINISH':
+    case actions.DISCOVERY_FINISH:
       return { ...state, scanning: false }
 
-    case 'discovery:UPDATE_LIST': {
+    case actions.DISCOVERY_UPDATE_LIST: {
       const robotsByName = normalizeRobots(action.payload.robots)
       const restartsByName = mapValues(state.restartsByName, (status, name) => {
         // TODO(mc, 2018-11-07): once POST /restart sets the status to PENDING,
@@ -117,17 +78,6 @@ export function discoveryReducer(
   }
 
   return state
-}
-
-export const discoveryMiddleware: Middleware = store => next => action => {
-  switch (action.type) {
-    case 'api:SERVER_SUCCESS':
-      if (action.payload.path === 'restart') {
-        store.dispatch(startDiscovery(RESTART_DISCOVERY_TIMEOUT_MS))
-      }
-  }
-
-  return next(action)
 }
 
 export function normalizeRobots(robots: Array<Service> = []): RobotsMap {

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -45,3 +45,31 @@ export type UnreachableRobot = {
 export type ViewableRobot = Robot | ReachableRobot
 
 export type AnyRobot = Robot | ReachableRobot | UnreachableRobot
+
+export type StartDiscoveryAction = {|
+  type: 'discovery:START',
+  payload: {| timeout: number | null |},
+  meta: {| shell: true |},
+|}
+
+export type FinishDiscoveryAction = {|
+  type: 'discovery:FINISH',
+  meta: {| shell: true |},
+|}
+
+export type UpdateListAction = {|
+  type: 'discovery:UPDATE_LIST',
+  payload: {| robots: Array<Service> |},
+|}
+
+export type RemoveRobotAction = {|
+  type: 'discovery:REMOVE',
+  payload: {| robotName: string |},
+  meta: {| shell: true |},
+|}
+
+export type DiscoveryAction =
+  | StartDiscoveryAction
+  | FinishDiscoveryAction
+  | UpdateListAction
+  | RemoveRobotAction

--- a/app/src/epic.js
+++ b/app/src/epic.js
@@ -1,7 +1,9 @@
 // @flow
 // root application epic
 import { combineEpics } from 'redux-observable'
-import { robotApiEpic } from './robot-api'
-import { buildrootUpdateEpic } from './shell'
 
-export default combineEpics(robotApiEpic, buildrootUpdateEpic)
+import { buildrootUpdateEpic } from './shell'
+import { discoveryEpic } from './discovery'
+import { robotApiEpic } from './robot-api'
+
+export default combineEpics(buildrootUpdateEpic, discoveryEpic, robotApiEpic)

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -15,7 +15,7 @@ import { checkShellUpdate, shellMiddleware } from './shell'
 import { apiClientMiddleware as robotApiMiddleware } from './robot'
 import { initializeAnalytics, analyticsMiddleware } from './analytics'
 import { initializeSupport, supportMiddleware } from './support'
-import { startDiscovery, discoveryMiddleware } from './discovery'
+import { startDiscovery } from './discovery'
 
 import rootReducer, { history } from './reducer'
 import rootEpic from './epic'
@@ -34,7 +34,6 @@ const middleware = applyMiddleware(
   shellMiddleware,
   analyticsMiddleware,
   supportMiddleware,
-  discoveryMiddleware,
   routerMiddleware(history)
 )
 


### PR DESCRIPTION
## overview

Ticket + PR. When a robot migrates from Balena to buildroot, its advertised name changes from `opentrons-some-name` to `some-name`. The discovery client keys robots by name, so when a robot migrates we're left with two robots in discovery state.

This PR ensures the old robot is removed post-migration.

## changelog

- refactor(app): Remove migrated balena robots from discovery

## review requests

This PR also does some much needed cleanup in the app's `discovery` redux module:
- Action creators split out into `app/src/discovery/actions`
- Side-effects moved from thunks + custom middleware to epics

Testing:

- [x] Migrate a Balena robot; you should end up with only one "robot-name" in your list
- [x] Click the "Refresh List" button; spinner should deactivate after 30 seconds like usual
