### PR TITLE
refactor(app): Ensure BR update is disabled if a diff robot is updating

### DIFF
--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -1,114 +1,123 @@
 // @flow
 // RobotSettings card for robot status
 import * as React from 'react'
-import { connect } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
 
-import {
-  fetchHealthAndIgnored,
-  makeGetRobotUpdateInfo,
-} from '../../http-api-client'
+import { makeGetRobotUpdateInfo } from '../../http-api-client'
 import { getConfig } from '../../config'
 import { getRobotApiVersion, getRobotFirmwareVersion } from '../../discovery'
-import { checkShellUpdate, getBuildrootUpdateAvailable } from '../../shell'
 
-import { RefreshCard, LabeledValue, OutlineButton } from '@opentrons/components'
+import {
+  getBuildrootRobot,
+  checkShellUpdate,
+  compareRobotVersionToUpdate,
+} from '../../shell'
+
+import {
+  Card,
+  LabeledValue,
+  OutlineButton,
+  HoverTooltip,
+  useInterval,
+} from '@opentrons/components'
+
 import { CardContentQuarter } from '../layout'
 
 import type { State, Dispatch } from '../../types'
-import type { RobotUpdateInfo } from '../../http-api-client'
 import type { ViewableRobot } from '../../discovery'
 
-type OP = {|
+type Props = {|
   robot: ViewableRobot,
   updateUrl: string,
 |}
-
-type SP = {|
-  version: string,
-  updateInfo: RobotUpdateInfo,
-  buildrootUpdateAvailable: boolean,
-  __buildRootEnabled: boolean,
-|}
-
-type DP = {|
-  fetchHealth: () => mixed,
-  checkAppUpdate: () => mixed,
-|}
-
-type Props = { ...OP, ...SP, ...DP }
 
 const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
 
-export default connect<Props, OP, SP, _, _, _>(
-  makeMapStateToProps,
-  mapDispatchToProps
-)(InformationCard)
+const UPDATE_SERVER_UNAVAILABLE =
+  "Unable to update because your robot's update server is not responding"
+const OTHER_ROBOT_UPDATING =
+  'Unable to update because your app is currently updating a different robot'
 
-function InformationCard(props: Props) {
-  const {
-    robot,
-    updateInfo,
-    fetchHealth,
-    updateUrl,
-    checkAppUpdate,
-    version,
-  } = props
-  const { name, displayName, serverOk } = robot
-  const firmwareVersion = getRobotFirmwareVersion(robot) || 'Unknown'
+const UPDATE_RECHECK_DELAY_MS = 60000
 
-  // NOTE: this logic still makes sense when buildroot is associated with a version bump
-  const updateText = updateInfo.type || 'Reinstall'
+export default function InformationCard(props: Props) {
+  const { robot, updateUrl } = props
+  const dispatch = useDispatch<Dispatch>()
+  const checkAppUpdate = React.useCallback(() => dispatch(checkShellUpdate()), [
+    dispatch,
+  ])
+
+  const { displayName, serverOk } = robot
+  const buildrootRobot = useSelector(getBuildrootRobot)
+
+  // TODO(mc, 2019-08-06): remove when we switch BR on by default
+  const __buildrootEnabled = useSelector(
+    state => getConfig(state).devInternal?.enableBuildRoot
+  )
+  const getUpdateInfo = React.useMemo(() => makeGetRobotUpdateInfo(), [])
+  const legacyUpdateInfo = useSelector<State, _>(state =>
+    getUpdateInfo(state, robot)
+  )
+
+  const version = getRobotApiVersion(robot)
+  const firmwareVersion = getRobotFirmwareVersion(robot)
+
+  const updateServerUnavailable = !serverOk
+  const otherRobotUpdating = Boolean(buildrootRobot && buildrootRobot !== robot)
+  const updateDisabled = updateServerUnavailable || otherRobotUpdating
+
+  const updateButtonText =
+    __buildrootEnabled === true
+      ? compareRobotVersionToUpdate(robot)
+      : legacyUpdateInfo.type || 'reinstall'
+
+  const updateButtonTooltip = updateDisabled ? (
+    <span>
+      {updateServerUnavailable
+        ? UPDATE_SERVER_UNAVAILABLE
+        : OTHER_ROBOT_UPDATING}
+    </span>
+  ) : null
+
+  // check for available updates on an interval
+  useInterval(checkAppUpdate, UPDATE_RECHECK_DELAY_MS)
 
   return (
-    <RefreshCard watch={name} refresh={fetchHealth} title={TITLE}>
+    <Card title={TITLE}>
       <CardContentQuarter>
         <LabeledValue label={NAME_LABEL} value={displayName} />
       </CardContentQuarter>
       <CardContentQuarter>
-        <LabeledValue label={SERVER_VERSION_LABEL} value={version} />
+        <LabeledValue
+          label={SERVER_VERSION_LABEL}
+          value={version || 'Unknown'}
+        />
       </CardContentQuarter>
       <CardContentQuarter>
-        <LabeledValue label={FIRMWARE_VERSION_LABEL} value={firmwareVersion} />
+        <LabeledValue
+          label={FIRMWARE_VERSION_LABEL}
+          value={firmwareVersion || 'Unknown'}
+        />
       </CardContentQuarter>
       <CardContentQuarter>
-        <OutlineButton
-          Component={Link}
-          to={updateUrl}
-          onClick={checkAppUpdate}
-          disabled={!serverOk}
-        >
-          {updateText}
-        </OutlineButton>
+        <HoverTooltip tooltipComponent={updateButtonTooltip}>
+          {hoverTooltipHandlers => (
+            <div {...hoverTooltipHandlers}>
+              <OutlineButton
+                Component={Link}
+                to={updateUrl}
+                disabled={updateDisabled}
+              >
+                {updateButtonText}
+              </OutlineButton>
+            </div>
+          )}
+        </HoverTooltip>
       </CardContentQuarter>
-    </RefreshCard>
+    </Card>
   )
-}
-
-function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
-  const getUpdateInfo = makeGetRobotUpdateInfo()
-
-  return (state, ownProps) => {
-    const version = getRobotApiVersion(ownProps.robot) || 'Unknown'
-
-    return {
-      version,
-      updateInfo: getUpdateInfo(state, ownProps.robot),
-      buildrootUpdateAvailable: getBuildrootUpdateAvailable(state, version),
-      __buildRootEnabled: Boolean(
-        getConfig(state).devInternal?.enableBuildRoot
-      ),
-    }
-  }
-}
-
-function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  return {
-    // TODO(mc, 2018-10-10): only need to fetch ignored
-    fetchHealth: () => dispatch(fetchHealthAndIgnored(ownProps.robot)),
-    checkAppUpdate: () => dispatch(checkShellUpdate()),
-  }
 }

--- a/app/src/components/layout/index.js
+++ b/app/src/components/layout/index.js
@@ -1,3 +1,4 @@
+// @flow
 import CardContainer from './CardContainer'
 import CardRow from './CardRow'
 import CardColumn from './CardColumn'

--- a/app/src/http-api-client/server.js
+++ b/app/src/http-api-client/server.js
@@ -268,11 +268,7 @@ const compareCurrentVersionToUpdate = (
 }
 
 export const makeGetRobotUpdateInfo = () => {
-  const selector: OutputSelector<
-    State,
-    AnyRobot,
-    RobotUpdateInfo
-  > = createSelector(
+  const selector: (State, AnyRobot) => RobotUpdateInfo = createSelector(
     (_, robot) => getRobotApiVersion(robot),
     getApiUpdateVersion,
     compareCurrentVersionToUpdate

--- a/components/src/buttons/Button.js
+++ b/components/src/buttons/Button.js
@@ -35,7 +35,13 @@ export type ButtonProps = {
 }
 
 // props to strip if using a custom component
-const STRIP_PROPS = ['inverted', 'iconName', 'children', 'Component']
+const STRIP_PROPS = [
+  'inverted',
+  'iconName',
+  'children',
+  'Component',
+  'hoverTooltipHandlers',
+]
 
 /**
  * Basic, un-styled button. You probably want to use a styled button

--- a/components/src/hooks/__tests__/useInterval.test.js
+++ b/components/src/hooks/__tests__/useInterval.test.js
@@ -1,0 +1,47 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+import { useInterval } from '..'
+
+describe('usePrevious hook', () => {
+  const callback = jest.fn()
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  const TestUseInterval = (props: { delay: number | null }) => {
+    useInterval(callback, props.delay)
+    return <span />
+  }
+
+  test('delay `null` results in no calls', () => {
+    mount(<TestUseInterval delay={null} />)
+    jest.runTimersToTime(10000)
+
+    expect(callback).toHaveBeenCalledTimes(0)
+  })
+
+  test('delay sets an interval', () => {
+    mount(<TestUseInterval delay={2} />)
+    jest.runTimersToTime(10)
+
+    expect(callback).toHaveBeenCalledTimes(5)
+  })
+
+  test('re-rendering with delay={null} clears the interval', () => {
+    const wrapper = mount(<TestUseInterval delay={2} />)
+
+    jest.runTimersToTime(6)
+    wrapper.setProps({ delay: null })
+    jest.runTimersToTime(4)
+
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+})

--- a/components/src/hooks/index.js
+++ b/components/src/hooks/index.js
@@ -2,3 +2,4 @@
 // generic react hooks that don't fit cleanly anywhere else
 
 export * from './usePrevious'
+export * from './useInterval'

--- a/components/src/hooks/useInterval.js
+++ b/components/src/hooks/useInterval.js
@@ -1,0 +1,29 @@
+// @flow
+import { useEffect, useRef } from 'react'
+
+/**
+ * React hook to call a function on an interval; copied from:
+ * https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+ *
+ * @template T (type of the input value)
+ * @param {() => mixed} callback (function to call on an interval)
+ * @param {number | null} callback (interval delay, or null to stop interval)
+ * @returns {void}
+ */
+export function useInterval(callback: () => mixed, delay: number | null): void {
+  const savedCallback = useRef()
+
+  // remember the latest callback
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  // set up the interval
+  useEffect(() => {
+    const tick = () => savedCallback.current && savedCallback.current()
+    if (delay !== null) {
+      const id = setInterval(tick, delay)
+      return () => clearInterval(id)
+    }
+  }, [delay])
+}


### PR DESCRIPTION
## overview

The new BR update flow is designed to update exactly one robot at a time because it drastically simplifies the state needed. This PR ensures the UI will not allow a user to try to kick off multiple BR updates to different robots

## changelog

- refactor(app): Ensure BR update is disabled if a diff robot is updating

## review requests

- [ ] Update button in RobotSettings is disabled if a different robot is updating
- [ ] Button displays tooltip
