### PR TITLE
refactor(app): toggle dev feature flags from settings

### DIFF
--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -3,8 +3,17 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { withRouter, Route, Link } from 'react-router-dom'
+import startCase from 'lodash/startCase'
 
-import { getConfig, updateConfig, toggleDevTools } from '../../config'
+import {
+  getConfig,
+  updateConfig,
+  toggleDevTools,
+  toggleDevInternalFlag,
+  DEV_INTERNAL_FLAGS,
+  type Config,
+  type DevInternalFlag,
+} from '../../config'
 import { Card } from '@opentrons/components'
 import { LabeledToggle, LabeledSelect, LabeledButton } from '../controls'
 import AddManualIp from './AddManualIp'
@@ -20,11 +29,13 @@ type OP = {
 
 type SP = {|
   devToolsOn: boolean,
+  devInternal: $PropertyType<Config, 'devInternal'>,
   channel: UpdateChannel,
 |}
 
 type DP = {|
   toggleDevTools: () => mixed,
+  toggleDevInternalFlag: DevInternalFlag => mixed,
   handleChannel: (event: SyntheticInputEvent<HTMLSelectElement>) => mixed,
 |}
 
@@ -86,6 +97,15 @@ function AdvancedSettingsCard(props: Props) {
             manually add its IP address or hostname here
           </p>
         </LabeledButton>
+        {props.devToolsOn &&
+          DEV_INTERNAL_FLAGS.map(flag => (
+            <LabeledToggle
+              key={flag}
+              label={`__DEV__ ${startCase(flag)}`}
+              toggledOn={props.devInternal ? props.devInternal[flag] : false}
+              onClick={() => props.toggleDevInternalFlag(flag)}
+            />
+          ))}
       </Card>
       <Route
         path={`${props.match.path}/add-ip`}
@@ -100,6 +120,7 @@ function mapStateToProps(state: State): SP {
 
   return {
     devToolsOn: config.devtools,
+    devInternal: config.devInternal,
     channel: config.update.channel,
   }
 }
@@ -107,6 +128,8 @@ function mapStateToProps(state: State): SP {
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OP) {
   return {
     toggleDevTools: () => dispatch(toggleDevTools()),
+    toggleDevInternalFlag: (flag: DevInternalFlag) =>
+      dispatch(toggleDevInternalFlag(flag)),
     handleChannel: event => {
       dispatch(updateConfig('update.channel', event.target.value))
 

--- a/app/src/components/controls/LabeledToggle.js
+++ b/app/src/components/controls/LabeledToggle.js
@@ -8,7 +8,7 @@ import styles from './styles.css'
 type Props = {
   label: string,
   toggledOn: boolean,
-  children: React.Node,
+  children?: React.Node,
   onClick: () => mixed,
 }
 
@@ -26,7 +26,7 @@ export default function LabeledToggle(props: Props) {
         />
       }
     >
-      {props.children}
+      {props.children ? props.children : null}
     </LabeledControl>
   )
 }

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -6,9 +6,17 @@ import remove from 'lodash/remove'
 import remote from '../shell/remote'
 
 import type { State, Action, ThunkAction } from '../types'
-import type { Config, UpdateConfigAction } from './types'
+import type { Config, UpdateConfigAction, DevInternalFlag } from './types'
 
 export * from './types'
+
+export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
+  'allPipetteConfig',
+  'tempdeckControls',
+  'enableThermocycler',
+  'enablePipettePlus',
+  'enableBuildRoot',
+]
 
 // trigger a config value update to the app-shell via shell middleware
 export function updateConfig(path: string, value: any): UpdateConfigAction {
@@ -40,6 +48,14 @@ export function toggleDevTools(): ThunkAction {
   return (dispatch, getState) => {
     const devToolsOn = getConfig(getState()).devtools
     return dispatch(updateConfig('devtools', !devToolsOn))
+  }
+}
+
+export function toggleDevInternalFlag(flag: DevInternalFlag): ThunkAction {
+  return (dispatch, getState) => {
+    const devInternal = getConfig(getState()).devInternal
+    const isFlagOn = devInternal ? devInternal[flag] : false
+    return dispatch(updateConfig(`devInternal.${flag}`, !isFlagOn))
   }
 }
 

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -7,6 +7,13 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string | Array<string>
 
+export type DevInternalFlag =
+  | 'allPipetteConfig'
+  | 'tempdeckControls'
+  | 'enableThermocycler'
+  | 'enablePipettePlus'
+  | 'enableBuildRoot'
+
 export type Config = {
   devtools: boolean,
 
@@ -65,11 +72,7 @@ export type Config = {
 
   // internal development flags
   devInternal?: {
-    allPipetteConfig?: boolean,
-    tempdeckControls?: boolean,
-    enableThermocycler?: boolean,
-    enablePipettePlus?: boolean,
-    enableBuildRoot?: boolean,
+    [DevInternalFlag]: boolean,
   },
 }
 


### PR DESCRIPTION
Make it easier to test and configure unreleased code by exposing toggles for dev feature flags when devTools are enabled.

Now, when devTools are enabled in the Advanced Settings, devInternal settings are exposed as toggles at the bottom of the Advanced Settings section.