### PR TITLE
fix(api): Do not publish commands for RPC pause/resume in APIv1

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -324,12 +324,24 @@ class Session(object):
         return self
 
     def pause(self):
-        self._hardware.pause()
+        if ff.use_protocol_api_v2():
+            self._hardware.pause()
+        # robot.pause in the legacy API will publish commands to the broker
+        # use the broker-less execute_pause instead
+        else:
+            self._hardware.execute_pause()
+
         self.set_state('paused')
         return self
 
     def resume(self):
-        self._hardware.resume()
+        if ff.use_protocol_api_v2():
+            self._hardware.resume()
+        # robot.resume in the legacy API will publish commands to the broker
+        # use the broker-less execute_resume instead
+        else:
+            self._hardware.execute_resume()
+
         self.set_state('running')
         return self
 

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -873,7 +873,30 @@ class Robot(CommandPublisher):
         """
         Pauses execution of the protocol. Use :meth:`resume` to resume
         """
+        self.execute_pause()
+
+    def execute_pause(self):
+        """ Pause the driver
+
+        This method should not be called inside a protocol. Use
+        :py:meth:`pause` instead
+        """
         self._driver.pause()
+
+    @commands.publish.both(command=commands.resume)
+    def resume(self):
+        """
+        Resume execution of the protocol after :meth:`pause`
+        """
+        self.execute_resume()
+
+    def execute_resume(self):
+        """ Resume the driver after :meth:`execute_pause`
+
+        This method should not be called inside a protocol. Use
+        :py:meth:`resume` instead
+        """
+        self._driver.resume()
 
     def stop(self):
         """
@@ -882,13 +905,6 @@ class Robot(CommandPublisher):
         self._driver.kill()
         self.reset()
         self.home()
-
-    @commands.publish.both(command=commands.resume)
-    def resume(self):
-        """
-        Resume execution of the protocol after :meth:`pause`
-        """
-        self._driver.resume()
 
     def halt(self):
         """

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -162,7 +162,7 @@ async def test_load_and_run(
 
     await loop.run_in_executor(executor=None,
                                func=run)
-    assert len(session.command_log) == 7
+    assert len(session.command_log) == 6
 
     res = []
     index = 0
@@ -182,7 +182,7 @@ async def test_load_and_run(
     assert main_router.notifications.queue.qsize() == 0,\
         'Notification should be empty after receiving "finished" state change'
     session.run()
-    assert len(session.command_log) == 7, \
+    assert len(session.command_log) == 6, \
         "Clears command log on the next run"
 
 

--- a/api/tests/opentrons/integration/test_server.py
+++ b/api/tests/opentrons/integration/test_server.py
@@ -59,7 +59,7 @@ async def test_notifications(session, session_manager, protocol, root, connect, 
     await socket.receive_json()  # Skip ack
     res = await socket.receive_json()
 
-    assert len(res['data']['v']['command_log']['v']) == 76
+    assert len(res['data']['v']['command_log']['v']) == 75
 
     states = [
         response['data']['v']['payload']['v']['state']


### PR DESCRIPTION
## overview

This ticket alleviates #2047. Due to fundamental architectural problems with the RPC API's session state, it does not fix the issue completely. It should, however, make the run log less wrong than it was before

## changelog

- fix(api): Do not publish commands for RPC pause/resume in APIv1

## review requests

- [ ] Run log in APIv2 is not affected (APIv2 does not appear to have the same problem with pauses and resumes)
- [ ] Clicking "pause" or "resume" in an APIv1 protocol does not cause the run log to increment
- [ ] This is a valid way to make this problem less bad
