### PR TITLE
feat(app): prompt to open TC lid before labware calibration

### DIFF
--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -12,8 +12,6 @@ import {
   type Labware,
   type LabwareType,
 } from '../../robot'
-import { getConnectedRobot } from '../../discovery'
-import { getModulesState } from '../../robot-api'
 
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { Icon, PrimaryButton } from '@opentrons/components'
@@ -113,13 +111,6 @@ function mapStateToProps(state: State, ownProps: OP): SP {
 
   if (_buttonTarget && _buttonTarget.calibratorMount) {
     _calibratorMount = _buttonTarget.calibratorMount
-  }
-
-  const robot = getConnectedRobot(state)
-  const sessionModules = robotSelectors.getModules(state)
-  const actualModules = getModulesState(state, robot.name)
-  if (some(sessionModules, (module) => module.name === 'thermocycler') {
-
   }
 
   return {

--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -5,17 +5,17 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 import capitalize from 'lodash/capitalize'
 
-import { getLabwareDisplayName } from '@opentrons/shared-data'
-import { Icon, PrimaryButton } from '@opentrons/components'
 import {
   selectors as robotSelectors,
   actions as robotActions,
-  type Mount,
-  type Labware,
-  type LabwareType,
 } from '../../robot'
-import type { State, Dispatch } from '../../types'
+
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+import { Icon, PrimaryButton } from '@opentrons/components'
 import styles from './styles.css'
+
+import type { Mount, Labware, LabwareType } from '../../robot'
+import type { State, Dispatch } from '../../types'
 
 type OP = {| labware: ?Labware |}
 
@@ -77,25 +77,23 @@ function InfoBox(props: Props) {
   const iconName = confirmed ? 'check-circle' : 'checkbox-blank-circle-outline'
 
   return (
-    <>
-      <div className={styles.info_box}>
-        <div className={styles.info_box_left}>
-          <h2 className={styles.info_box_title}>
-            <Icon name={iconName} className={styles.info_box_icon} />
-            {title}
-          </h2>
-          <div className={styles.info_box_description}>{description}</div>
-        </div>
-        {button && showButton && (
-          <PrimaryButton
-            className={styles.info_box_button}
-            onClick={button.onClick}
-          >
-            {buttonText}
-          </PrimaryButton>
-        )}
+    <div className={styles.info_box}>
+      <div className={styles.info_box_left}>
+        <h2 className={styles.info_box_title}>
+          <Icon name={iconName} className={styles.info_box_icon} />
+          {title}
+        </h2>
+        <div className={styles.info_box_description}>{description}</div>
       </div>
-    </>
+      {button && showButton && (
+        <PrimaryButton
+          className={styles.info_box_button}
+          onClick={button.onClick}
+        >
+          {buttonText}
+        </PrimaryButton>
+      )}
+    </div>
   )
 }
 

--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -8,13 +8,17 @@ import capitalize from 'lodash/capitalize'
 import {
   selectors as robotSelectors,
   actions as robotActions,
+  type Mount,
+  type Labware,
+  type LabwareType,
 } from '../../robot'
+import { getConnectedRobot } from '../../discovery'
+import { getModulesState } from '../../robot-api'
 
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { Icon, PrimaryButton } from '@opentrons/components'
 import styles from './styles.css'
 
-import type { Mount, Labware, LabwareType } from '../../robot'
 import type { State, Dispatch } from '../../types'
 
 type OP = {| labware: ?Labware |}
@@ -109,6 +113,13 @@ function mapStateToProps(state: State, ownProps: OP): SP {
 
   if (_buttonTarget && _buttonTarget.calibratorMount) {
     _calibratorMount = _buttonTarget.calibratorMount
+  }
+
+  const robot = getConnectedRobot(state)
+  const sessionModules = robotSelectors.getModules(state)
+  const actualModules = getModulesState(state, robot.name)
+  if (some(sessionModules, (module) => module.name === 'thermocycler') {
+
   }
 
   return {

--- a/app/src/components/CalibrateLabware/InfoBox.js
+++ b/app/src/components/CalibrateLabware/InfoBox.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 import capitalize from 'lodash/capitalize'
 
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+import { Icon, PrimaryButton } from '@opentrons/components'
 import {
   selectors as robotSelectors,
   actions as robotActions,
@@ -12,12 +14,8 @@ import {
   type Labware,
   type LabwareType,
 } from '../../robot'
-
-import { getLabwareDisplayName } from '@opentrons/shared-data'
-import { Icon, PrimaryButton } from '@opentrons/components'
-import styles from './styles.css'
-
 import type { State, Dispatch } from '../../types'
+import styles from './styles.css'
 
 type OP = {| labware: ?Labware |}
 
@@ -79,23 +77,25 @@ function InfoBox(props: Props) {
   const iconName = confirmed ? 'check-circle' : 'checkbox-blank-circle-outline'
 
   return (
-    <div className={styles.info_box}>
-      <div className={styles.info_box_left}>
-        <h2 className={styles.info_box_title}>
-          <Icon name={iconName} className={styles.info_box_icon} />
-          {title}
-        </h2>
-        <div className={styles.info_box_description}>{description}</div>
+    <>
+      <div className={styles.info_box}>
+        <div className={styles.info_box_left}>
+          <h2 className={styles.info_box_title}>
+            <Icon name={iconName} className={styles.info_box_icon} />
+            {title}
+          </h2>
+          <div className={styles.info_box_description}>{description}</div>
+        </div>
+        {button && showButton && (
+          <PrimaryButton
+            className={styles.info_box_button}
+            onClick={button.onClick}
+          >
+            {buttonText}
+          </PrimaryButton>
+        )}
       </div>
-      {button && showButton && (
-        <PrimaryButton
-          className={styles.info_box_button}
-          onClick={button.onClick}
-        >
-          {buttonText}
-        </PrimaryButton>
-      )}
-    </div>
+    </>
   )
 }
 

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import ModuleData from './ModuleData'
 import TemperatureControls from './TemperatureControls'
 
-import { setTargetTemp } from '../../robot-api'
+import { sendModuleCommand } from '../../robot-api'
 
 import type { State, Dispatch } from '../../types'
 import type { TempDeckModule, ModuleCommandRequest } from '../../robot-api'
@@ -16,7 +16,7 @@ type OP = {|
 |}
 
 type DP = {|
-  setTargetTemp: (request: ModuleCommandRequest) => mixed,
+  sendModuleCommand: (request: ModuleCommandRequest) => mixed,
 |}
 
 type Props = { ...OP, ...DP }
@@ -27,13 +27,13 @@ export default connect<Props, OP, {||}, DP, State, Dispatch>(
 )(ModuleControls)
 
 function ModuleControls(props: Props) {
-  const { module, setTargetTemp } = props
+  const { module, sendModuleCommand } = props
   const { currentTemp, targetTemp } = module.data
 
   return (
     <>
       <ModuleData currentTemp={currentTemp} targetTemp={targetTemp} />
-      <TemperatureControls setTemp={setTargetTemp} />
+      <TemperatureControls setTemp={sendModuleCommand} />
     </>
   )
 }
@@ -43,6 +43,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   const { serial } = module
 
   return {
-    setTargetTemp: request => dispatch(setTargetTemp(robot, serial, request)),
+    sendModuleCommand: request =>
+      dispatch(sendModuleCommand(robot, serial, request)),
   }
 }

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -6,7 +6,7 @@ import { getConnectedRobot } from '../../discovery'
 import {
   fetchModules,
   getModulesState,
-  setTargetTemp,
+  sendModuleCommand,
   type ModuleCommandRequest,
   type Module,
 } from '../../robot-api'
@@ -115,7 +115,7 @@ function mapDispatchToProps(dispatch: Dispatch): DP {
   return {
     _fetchModules: _robot => dispatch(fetchModules(_robot)),
     _sendModuleCommand: (_robot, serial, request) =>
-      dispatch(setTargetTemp(_robot, serial, request)),
+      dispatch(sendModuleCommand(_robot, serial, request)),
   }
 }
 

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -22,7 +22,7 @@ import { Portal } from '../portal'
 
 const FETCH_MODULES_POLL_INTERVAL_MS = 1000
 
-type Props = {| robot: ?RobotHost, modules: Array<Module> |}
+type Props = {| robot: RobotHost, modules: Array<Module> |}
 
 function PrepareModules(props: Props) {
   const { modules, robot } = props

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -1,0 +1,88 @@
+// @flow
+import * as React from 'react'
+import { connect } from 'react-redux'
+import some from 'lodash/some'
+import {
+  useInterval,
+  PrimaryButton,
+  AlertModal,
+  Icon,
+} from '@opentrons/components'
+
+import { fetchModules, sendModuleCommand, type Module } from '../../robot-api'
+
+import type { State, Dispatch } from '../../types'
+import DeckMap from '../DeckMap'
+import styles from './styles.css'
+import { Portal } from '../portal'
+
+const FETCH_MODULES_POLL_INTERVAL_MS = 1000
+
+type OP = {| modules: Array<Module> |}
+
+type DP = {| setReviewed: () => mixed, fetchModules: () => mixed |}
+
+type Props = { ...OP, ...DP }
+
+function PrepareModules(props: Props) {
+  const { modules, sendModuleCommand, fetchModules } = props
+
+  // update on interval to respond to prepared modules
+  useInterval(fetchModules, FETCH_MODULES_POLL_INTERVAL_MS)
+
+  const handleOpenLidClick = () => {
+    modules
+      .filter(mod => mod.name === 'thermocycler')
+      .forEach(mod => sendModuleCommand(mod.serial, { command_type: 'open' }))
+  }
+
+  const isHandling = some(modules, mod => mod.data?.lid === 'in_between')
+  return (
+    <div className={styles.page_content_dark}>
+      <div className={styles.deck_map_wrapper}>
+        <DeckMap className={styles.deck_map} modulesRequired />
+      </div>
+      <Portal>
+        <AlertModal
+          iconName={null}
+          heading="Open Thermocycler Module lid for calibration"
+        >
+          <p>
+            The Thermocycler Module&apos;s lid is closed. Please open the lid in
+            order to proceed with calibration.
+          </p>
+          <PrimaryButton
+            className={styles.open_lid_button}
+            onClick={handleOpenLidClick}
+            // disabled={isHandling}  TODO: uncomment when optical latches report 'closed'
+          >
+            {isHandling ? (
+              <>
+                <Icon
+                  name="ot-spinner"
+                  className={styles.in_progress_spinner}
+                  spin
+                />
+              </>
+            ) : (
+              'Open Lid'
+            )}
+          </PrimaryButton>
+        </AlertModal>
+      </Portal>
+    </div>
+  )
+}
+
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
+  return {
+    fetchModules: () => dispatch(fetchModules(ownProps.robot)),
+    sendModuleCommand: (serial, request) =>
+      dispatch(sendModuleCommand(ownProps.robot, serial, request)),
+  }
+}
+
+export default connect<Props, OP, {||}, DP, State, Dispatch>(
+  null,
+  mapDispatchToProps
+)(PrepareModules)

--- a/app/src/components/PrepareModules/styles.css
+++ b/app/src/components/PrepareModules/styles.css
@@ -1,0 +1,62 @@
+@import '@opentrons/components';
+
+.alert {
+  position: absolute;
+  top: 3rem;
+  left: 0;
+  right: 0;
+}
+
+.prompt {
+  padding-top: 2rem;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.prompt_text {
+  @apply --font-header-light;
+
+  font-weight: normal;
+  margin: 0.5rem 0;
+  text-align: center;
+}
+
+.prompt_button {
+  display: block;
+  width: auto;
+  margin: 0.5rem 0 1rem 0;
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.page_content_dark {
+  display: flex;
+  padding: 1rem;
+  flex-direction: column;
+  align-items: center;
+  background-color: color(var(--c-black) alpha(0.99));
+  height: 100%;
+}
+
+.deck_map_wrapper {
+  flex: 1 1 0;
+  align-self: stretch;
+  display: flex;
+  background-color: var(--c-bg-light);
+  border-radius: 6px;
+}
+
+.deck_map {
+  flex: 1;
+}
+
+.in_progress_spinner {
+  height: 1rem;
+}
+
+.open_lid_button {
+  margin: 2rem 0 0.5rem 0;
+}

--- a/app/src/pages/Calibrate/Labware.js
+++ b/app/src/pages/Calibrate/Labware.js
@@ -60,8 +60,12 @@ function SetupDeckPage(props: Props) {
     },
   } = props
 
+  if (!robot) {
+    return <Redirect to="/" />
+  }
+
   const renderPage = () => {
-    if (hasModulesLeftToReview && robot) {
+    if (hasModulesLeftToReview) {
       return <ConnectModules robot={robot} />
     } else if (unpreparedModules.length > 0) {
       return <PrepareModules robot={robot} modules={unpreparedModules} />

--- a/app/src/robot-api/resources/modules.js
+++ b/app/src/robot-api/resources/modules.js
@@ -121,7 +121,7 @@ export const getUnpreparedModules = (state: AppState): Array<Module> => {
   if (!robot) return []
 
   const sessionModules = robotSelectors.getModules(state)
-  const actualModules = getModulesState(state, robot.name)
+  const actualModules = getModulesState(state, robot.name) || []
 
   const preparableModules = sessionModules.reduce(
     (acc, mod) =>
@@ -133,9 +133,10 @@ export const getUnpreparedModules = (state: AppState): Array<Module> => {
       preparableModules.includes(mod.name)
     )
     return actualPreparableModules.reduce((acc, mod) => {
-      if (mod.name === 'thermocycler') {
-        return mod.data.lid !== 'open' ? [...acc, mod] : acc
+      if (mod.name === 'thermocycler' && mod.data.lid !== 'open') {
+        return [...acc, mod]
       }
+      return acc
     }, [])
   } else {
     return []

--- a/app/src/robot-api/resources/modules.js
+++ b/app/src/robot-api/resources/modules.js
@@ -2,6 +2,7 @@
 // modules endpoints
 import { combineEpics } from 'redux-observable'
 import pathToRegexp from 'path-to-regexp'
+import some from 'lodash/some'
 
 import {
   getRobotApiState,
@@ -10,6 +11,9 @@ import {
   GET,
   POST,
 } from '../utils'
+
+import { getConnectedRobot } from '../../discovery'
+import { selectors as robotSelectors } from '../../robot'
 
 import type { State as AppState, ActionLike } from '../../types'
 import type { RobotHost, RobotApiAction } from '../types'
@@ -109,4 +113,18 @@ export function getModulesState(
 
   // TODO: remove this filter when feature flag removed
   return modules.filter(m => tcEnabled || m.name !== 'thermocycler')
+}
+
+export function getAreModulesReadyForLabwareCalibration(
+  state: AppState
+): boolean {
+  const robot = getConnectedRobot(state)
+  const sessionModules = robotSelectors.getModules(state)
+  const actualModules = getModulesState(state, robot.name)
+  if (some(sessionModules, module => module.name === 'thermocycler')) {
+    // actualModules
+    return true
+  } else {
+    return true
+  }
 }

--- a/app/src/robot-api/resources/types.js
+++ b/app/src/robot-api/resources/types.js
@@ -47,7 +47,7 @@ export type MagDeckData = {|
 |}
 
 export type ThermocyclerData = {|
-  lid: 'open' | 'closed',
+  lid: 'open' | 'closed' | 'in_between',
   lidTarget: ?number,
   lidTemp: number,
   currentTemp: number,
@@ -68,7 +68,7 @@ export type ThermocyclerModule = {|
 |}
 
 export type ModuleCommandRequest = {|
-  command_type: 'set_temperature' | 'deactivate',
+  command_type: 'set_temperature' | 'deactivate' | 'open',
   args?: Array<number>,
 |}
 

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -48,7 +48,7 @@ export type RobotApiAction =
       meta: {| id: string |},
     |}
   | {|
-      type: 'robotApi:SET_MODULE_TARGET_TEMP',
+      type: 'robotApi:SEND_MODULE_COMMAND',
       payload: RobotApiRequest,
       meta: {| id: string |},
     |}


### PR DESCRIPTION
## Overview

Provide a mechanism to open the lid of the Thermocycler Module during pre-run calibration, so that the contained labware can be calibrated.

Closes #3066

## Review Requests

- with a closed thermocycler on deck, upload a thermocycler protocol to the robot and proceed to labware calibration
- after you've confirmed the module is connected, you should be prompted to open the lid before proceeding
- try again with the lid already open, you shouldn't see the blocking modal at all.

# NOTE

The firmware/hardware combination will not report 'closed' because of latch complications, until new units are in, the behavior of the "Open Lid" button will be either behave as if it's in progress. In order to allow testing, we keep the button enabled for now, despite the loading state. There is a TODO