### PR TITLE
refactor(docs): Allow warnings locally but suppress on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       script:
         - make test-py
         - make lint-py
-        - make -C api docs docs-pdf
+        - make -C api docs
       after_success:
         - make coverage
         - aws s3 sync ./api/dist $OT_CI_TEMP_S3_PATH/api/dist

--- a/api/Makefile
+++ b/api/Makefile
@@ -50,6 +50,8 @@ ssh_opts ?= -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 
+# PDF builds must succeed on ci, not necessary for local builds
+which_pdf := $(if $(CI),docs-pdf-ci,docs-pdf-local)
 
 # Source discovery
 # For the python sources
@@ -99,7 +101,7 @@ lint: $(ot_py_sources)
 	$(python) -m mypy src/opentrons
 	$(python) -m pylama src/opentrons tests
 
-.PHONY: docs docs-html docs-doctest docs-pdf
+.PHONY: docs docs-html docs-doctest docs-pdf-local docs-pdf-ci
 
 docs-html: local-install
 	$(SHX) rm -rf docs/build/html
@@ -109,16 +111,22 @@ docs-doctest: local-install
 	$(SHX) rm -rf docs/build/doctest
 	pipenv run sphinx-build -b doctest -d docs/build/doctrees docs/source docs/build/doctest
 
-docs-pdf: local-install
+docs-pdf-local: local-install
+	echo "Local pdf install"
 	-$(SHX) rm -rf docs/build/pdf
 	-pipenv run sphinx-build -b latex -d docs/build/doctrees docs/source docs/build/pdf
-	-$(MAKE) -C docs/build/pdf all-pdf > /dev/null
+	-$(MAKE) -C docs/build/pdf all-pdf
 
-.PHONY: docs
-docs: docs-pdf docs-html
+docs-pdf-ci: local-install
+	echo "CI pdf install"
+	$(SHX) rm -rf docs/build/pdf
+	pipenv run sphinx-build -b latex -d docs/build/doctrees docs/source docs/build/pdf
+	$(MAKE) -C docs/build/pdf all-pdf >/dev/null
+	$(SHX) ls docs/build/pdf/*.pdf
+
+docs: docs-html $(which_pdf)
 	$(SHX) mkdir -p docs/dist
 	$(SHX) cp -R docs/build/html/. docs/public/. docs/dist
-	-$(SHX) cp docs/build/pdf/OpentronsAPI.pdf docs/dist/_static
 
 .PHONY: publish
 publish:


### PR DESCRIPTION
## overview

In #3846, latex warnings were causing CI to fail. As a workaround, the warnings were sent to /dev/null/ instead of the commandline. This PR is a refactor to that workaround so that local pdf builds can still print out warnings/not require a pdf build whereas a pdf build is required on CI.

## changelog
- Require a pdf build if running on CI
- Add a local build option to allow for warnings


