### PR TITLE
chore(api): force pypi readme eols to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # These files are binary and line endings should be left untouched
 *.hex binary
 *.bat binary
+api/pypi-readme.rst text eol=lf


### PR DESCRIPTION
The tool we use to check that our long description doesn't break on pypi doesn't
handle crlf, so at least in some cases (presumably depending on git settings) on
windows the check would always fail.
