### PR TITLE
refactor(api): add compatible modules to slot definitions and load by default slot

### DIFF
--- a/api/docs/source/v2/new_modules.rst
+++ b/api/docs/source/v2/new_modules.rst
@@ -229,9 +229,11 @@ For the purposes of this section, assume we have the following already:
         tc_mod = protocol.load_module('thermocycler module')
         plate = tc_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
 
-**NOTE** When loading the Thermocycler Module, it is not necessary to specify a slot.
-This is because the Thermocycler Module has a default position that covers Slots 7, 8, 10, and 11.
-This is the only valid location for the Thermocycler Module on the OT2 deck.
+.. note::
+
+    When loading the Thermocycler Module, it is not necessary to specify a slot.
+    This is because the Thermocycler Module has a default position that covers Slots 7, 8, 10, and 11.
+    This is the only valid location for the Thermocycler Module on the OT2 deck.
 
 Set Temperature
 ^^^^^^^^^^^^^^^

--- a/api/docs/source/v2/new_modules.rst
+++ b/api/docs/source/v2/new_modules.rst
@@ -226,9 +226,12 @@ For the purposes of this section, assume we have the following already:
     from opentrons import protocol_api
 
     def run(protocol: protocol_api.ProtocolContext):
-        tc_mod = protocol.load_module('thermocycler module', '1')
+        tc_mod = protocol.load_module('thermocycler module')
         plate = tc_mod.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
 
+**NOTE** When loading the Thermocycler Module, it is not necessary to specify a slot.
+This is because the Thermocycler Module has a default position that covers Slots 7, 8, 10, and 11.
+This is the only valid location for the Thermocycler Module on the OT2 deck.
 
 Set Temperature
 ^^^^^^^^^^^^^^^

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -8,7 +8,8 @@ from . import back_compat, labware
 from .contexts import (ProtocolContext,
                        InstrumentContext,
                        TemperatureModuleContext,
-                       MagneticModuleContext)
+                       MagneticModuleContext,
+                       ThermocyclerContext)
 from .execute import run_protocol
 
 

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -18,5 +18,6 @@ __all__ = ['run_protocol',
            'InstrumentContext',
            'TemperatureModuleContext',
            'MagneticModuleContext',
+           'ThermocyclerContext',
            'back_compat',
            'labware']

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import json
 import pkgutil
-from pprint import pprint
 from typing import Any, Dict, List, Optional, Union, Tuple, Sequence
 from opentrons import types, hardware_control as hc, commands as cmds
 from opentrons.commands import CommandPublisher
@@ -287,8 +286,6 @@ class ProtocolContext(CommandPublisher):
             valid_slots = [slot['id'] for slot in slots if module_name
                            in slot['compatibleModules']]
             if len(valid_slots) == 1:
-                pprint(valid_slots)
-                pprint(valid_slots[0])
                 return valid_slots[0]
             else:
                 raise AssertionError(
@@ -304,7 +301,6 @@ class ProtocolContext(CommandPublisher):
             resolved_location = self._resolve_module_location(
                     resolved_name, location)
             location_pos = self._deck_layout.position_for(resolved_location)
-            pprint(location_pos)
             geometry = load_module(resolved_name, location_pos)
         except KeyError:
             self._log.error(f'Unsupported Module: {resolved_name}')

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import json
 import pkgutil
+from pprint import pprint
 from typing import Any, Dict, List, Optional, Union, Tuple, Sequence
 from opentrons import types, hardware_control as hc, commands as cmds
 from opentrons.commands import CommandPublisher
@@ -271,9 +272,11 @@ class ProtocolContext(CommandPublisher):
                     ' into slot {location}')
         else:
             valid_slots = [slot['id'] for slot in slots
-                    if slot['compatibleModules'] == module_name]
+                    if module_name in slot['compatibleModules']]
             if len(valid_slots) == 1:
-                return valid_slot[0]
+                pprint(valid_slots)
+                pprint(valid_slots[0])
+                return valid_slots[0]
             else:
                 raise AssertionError(
                     f'module {module_name} does not have a default' \
@@ -291,6 +294,7 @@ class ProtocolContext(CommandPublisher):
         try:
             resolved_location = self._resolve_module_location(module_name, location)
             location_pos = self._deck_layout.position_for(resolved_location)
+            pprint(location_pos)
             geometry = load_module(mod_id, location_pos)
         except KeyError:
             self._log.error(f'Unsupported Module: {mod_id}')
@@ -321,7 +325,7 @@ class ProtocolContext(CommandPublisher):
         else:
             raise RuntimeError(
                 f'Could not find specified module: {mod_id}')
-        self._deck_layout[location] = geometry
+        self._deck_layout[resolved_location] = geometry
         return mod_ctx
 
     @property

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -650,11 +650,28 @@ class Labware:
 
 class ModuleGeometry:
     """
-    This class represents an active peripheral, such as an Opentrons MagBead
-    Module or Temperature Module. It defines the physical geometry of the
-    device (primarily the offset that modifies the position of the labware
-    mounted on top of it).
+    This class represents an active peripheral, such as an Opentrons Magnetic
+    Module, Temperature Module or Thermocycler Module. It defines the physical
+    geometry of the device (primarily the offset that modifies the position of
+    the labware mounted on top of it).
     """
+
+    @classmethod
+    def resolve_module_name(cls, module_name: str):
+        alias_map = {
+            'magdeck': 'magdeck',
+            'magnetic module': 'magdeck',
+            'tempdeck': 'tempdeck',
+            'temperature module': 'tempdeck',
+            'thermocycler': 'thermocycler',
+            'thermocycler module': 'thermocycler'
+        }
+        lower_name = module_name.lower()
+        resolved_name = alias_map.get(lower_name, None)
+        if not resolved_name:
+            raise ValueError(f'{module_name} is not a valid module load name')
+        return resolved_name
+
     def __init__(self,
                  definition: dict,
                  parent: Location) -> None:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1054,8 +1054,7 @@ def clear_calibrations():
 
 
 def load_module_from_definition(
-        definition: dict, parent: Location) -> \
-            Union[ModuleGeometry, ThermocyclerGeometry]:
+        definition: dict, parent: Location) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a specified definition
 
@@ -1067,7 +1066,7 @@ def load_module_from_definition(
     """
     mod_name = definition['loadName']
     if mod_name == 'thermocycler':
-        mod: Union[ModuleGeometry, ThermocyclerGeometry] = \
+        mod: ModuleGeometry = \
                 ThermocyclerGeometry(definition, parent)
     else:
         mod = ModuleGeometry(definition, parent)
@@ -1075,7 +1074,8 @@ def load_module_from_definition(
     return mod
 
 
-def load_module(name: str, parent: Location) -> ModuleGeometry:
+
+def load_module(name: str, parent: Optional[Location]) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a definition looked up
     by name.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1074,8 +1074,7 @@ def load_module_from_definition(
     return mod
 
 
-
-def load_module(name: str, parent: Optional[Location]) -> ModuleGeometry:
+def load_module(name: str, parent: Location) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a definition looked up
     by name.

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -34,7 +34,7 @@ def test_no_slot_module_error(loop):
         assert ctx.load_module('magdeck')
 
 
-def test_bad_slot_module_error(loop):
+def test_invalid_slot_module_error(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [
         ('mod0', 'tempdeck')]
@@ -43,12 +43,21 @@ def test_bad_slot_module_error(loop):
         assert ctx.load_module('thermocycler', 1)
 
 
+def test_bad_slot_module_error(loop):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    ctx.home()
+    with pytest.raises(ValueError):
+        assert ctx.load_module('thermocycler', 42)
+
+
 def test_incorrect_module_error(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [
         ('mod0', 'tempdeck')]
     ctx.home()
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         assert ctx.load_module('the cool module', 1)
 
 

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -16,12 +16,39 @@ def test_load_module(loop):
     assert isinstance(mod, papi.TemperatureModuleContext)
 
 
+def test_load_module_default_slot(loop):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    ctx.home()
+    mod = ctx.load_module('thermocycler')
+    assert isinstance(mod, papi.ThermocyclerContext)
+
+
+def test_no_slot_module_error(loop):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    ctx.home()
+    with pytest.raises(AssertionError):
+        assert ctx.load_module('magdeck')
+
+
+def test_bad_slot_module_error(loop):
+    ctx = papi.ProtocolContext(loop)
+    ctx._hw_manager.hardware._backend._attached_modules = [
+        ('mod0', 'tempdeck')]
+    ctx.home()
+    with pytest.raises(AssertionError):
+        assert ctx.load_module('thermocycler', 1)
+
+
 def test_incorrect_module_error(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [
         ('mod0', 'tempdeck')]
     ctx.home()
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         assert ctx.load_module('the cool module', 1)
 
 
@@ -81,8 +108,8 @@ def test_thermocycler_lid(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [
         ('mod0', 'thermocycler')]
-    mod = ctx.load_module('thermocycler', 1)
-    assert ctx.deck[1] == mod._geometry
+    mod = ctx.load_module('thermocycler')
+    assert ctx.deck[7] == mod._geometry
 
     assert mod.lid_status == 'open'
 
@@ -115,7 +142,7 @@ def test_thermocycler_temp(loop):
     ctx = papi.ProtocolContext(loop)
     ctx._hw_manager.hardware._backend._attached_modules = [
         ('mod0', 'thermocycler')]
-    mod = ctx.load_module('Thermocycler', 1)
+    mod = ctx.load_module('thermocycler')
 
     assert mod.target is None
 

--- a/shared-data/deck/definitions/1/ot2_short_trash.json
+++ b/shared-data/deck/definitions/1/ot2_short_trash.json
@@ -21,7 +21,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 1"
+        "displayName": "Slot 1",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "2",
@@ -32,7 +33,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 2"
+        "displayName": "Slot 2",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "3",
@@ -43,7 +45,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 3"
+        "displayName": "Slot 3",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "4",
@@ -54,7 +57,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 4"
+        "displayName": "Slot 4",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "5",
@@ -65,7 +69,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 5"
+        "displayName": "Slot 5",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "6",
@@ -76,7 +81,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 6"
+        "displayName": "Slot 6",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "7",
@@ -87,7 +93,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 7"
+        "displayName": "Slot 7",
+        "compatibleModules": ["magdeck", "tempdeck", "thermocycler"]
       },
       {
         "id": "8",
@@ -98,7 +105,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 8"
+        "displayName": "Slot 8",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "9",
@@ -109,7 +117,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 9"
+        "displayName": "Slot 9",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "10",
@@ -120,7 +129,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 10"
+        "displayName": "Slot 10",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "11",
@@ -131,7 +141,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 11"
+        "displayName": "Slot 11",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "12",
@@ -141,7 +152,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 12"
+        "displayName": "Slot 12",
+        "compatibleModules": []
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/1/ot2_standard.json
+++ b/shared-data/deck/definitions/1/ot2_standard.json
@@ -21,7 +21,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 1"
+        "displayName": "Slot 1",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "2",
@@ -32,7 +33,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 2"
+        "displayName": "Slot 2",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "3",
@@ -43,7 +45,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 3"
+        "displayName": "Slot 3",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "4",
@@ -54,7 +57,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 4"
+        "displayName": "Slot 4",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "5",
@@ -65,7 +69,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 5"
+        "displayName": "Slot 5",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "6",
@@ -76,7 +81,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 6"
+        "displayName": "Slot 6",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "7",
@@ -87,7 +93,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 7"
+        "displayName": "Slot 7",
+        "compatibleModules": ["magdeck", "tempdeck", "thermocycler"]
       },
       {
         "id": "8",
@@ -98,7 +105,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 8"
+        "displayName": "Slot 8",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "9",
@@ -109,7 +117,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 9"
+        "displayName": "Slot 9",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "10",
@@ -120,7 +129,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 10"
+        "displayName": "Slot 10",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "11",
@@ -131,7 +141,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 11"
+        "displayName": "Slot 11",
+        "compatibleModules": ["magdeck", "tempdeck"]
       },
       {
         "id": "12",
@@ -141,7 +152,8 @@
           "yDimension": 86.0,
           "zDimension": 0
         },
-        "displayName": "Slot 12"
+        "displayName": "Slot 12",
+        "compatibleModules": []
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/schemas/1.json
+++ b/shared-data/deck/schemas/1.json
@@ -122,7 +122,13 @@
           "description": "Ordered slots available for placing labware",
           "items": {
             "type": "object",
-            "required": ["id", "position", "boundingBox", "displayName"],
+            "required": [
+              "id",
+              "position",
+              "boundingBox",
+              "displayName",
+              "compatibleModules"
+            ],
             "properties": {
               "id": {
                 "description": "Unique identifier for slot",
@@ -137,6 +143,14 @@
               "displayName": {
                 "description": "An optional human-readable nickname for this slot Eg \"Slot 1\" or \"Fixed Trash\"",
                 "type": "string"
+              },
+              "compatibleModules": {
+                "description": "An array of module loadNames that can be placed in this slot.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["magdeck", "tempdeck", "thermocycler"]
+                }
               }
             }
           }


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

This adds `compatibleModules` to the slots within the deck schema and definitions within shared-data. The addition will allow us to be programmatic about slot/module compatibility as the robot server grows and changes.

The behavior of `protocol.load_module` in PAPIv2 is now slightly augmented.  It will behave the same as it has in the past for TD and MD (e.g. `protocol.load_module('Magnetic Module', 4)`).
Though the Thermocycler Module should now be loaded using `protocol.load_module('Thermocycler Module')` or `protocol.load_module('thermocycler')` with *no specified slot location*. Because the Thermocycler Module has a single compatible slot in the OT2 standard deck definition ('Slot 7'), this will load it into it's position unambiguously.

Similarly, you can load the TC explicitly using `protocol.load_module('thermocycler', 7)`, but it is preferred to use the implicit load for modules with a single compatible slot.

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

- Add listing of compatible modules to deck definitions and schema.
- Allow modules with only one valid slot to be implicitly loaded.

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

- try uploading a TC protocol using the implicit load (`protocol.load_module('thermocycler')`)
- try uploading other modules using explicit slot param (unchanged from before)
<!--
  Describe any requests for your reviewers here.
-->
