### PR TITLE
fix(api): handled optional args for InstrumentContext commands

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -235,7 +235,7 @@ def comment(msg):
 
 
 def mix(instrument, repetitions, volume, location):
-    text = 'Mixing {repetitions} times with a volume of {volume}ul'.format(
+    text = 'Mixing {repetitions} times with a volume of {volume} ul'.format(
         repetitions=repetitions, volume=volume
     )
     return make_command(

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -209,5 +209,6 @@ class Pipette:
                             'model': self.model,
                             'pipette_id': self.pipette_id,
                             'has_tip': self.has_tip,
-                            'working_volume': self.working_volume})
+                            'working_volume': self.working_volume,
+                            'available_volume': self.available_volume})
         return config_dict

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -33,7 +33,8 @@ instrument_keys = sorted([
     'name', 'min_volume', 'max_volume', 'aspirate_flow_rate', 'channels',
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
-    'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume'])
+    'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume',
+    'available_volume'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):
@@ -226,7 +227,8 @@ async def test_dispense(dummy_instruments, loop):
     assert (await hw_api.current_position(types.Mount.LEFT))[Axis.B]\
         == plunger_pos_1
 
-    await hw_api.dispense(types.Mount.LEFT, rate=2)
+    disp_vol = aspirate_ul - dispense_1
+    await hw_api.dispense(types.Mount.LEFT, disp_vol, rate=2)
     plunger_pos_2 = 2
     assert (await hw_api.current_position(types.Mount.LEFT))[Axis.B]\
         == plunger_pos_2


### PR DESCRIPTION
## overview
This PR fixes the volume logic for liquid handling commands in contexts to handle optional arguments. This is accomplished through checking the arg types and determining which argument is the actual `volume` and/or `location`
* aspirate/mix/air gap
  * if no volume is passed, aspirate up to pipette's available volume
* dispense
  * if no volume is passed, dispense all of pipette current volume

This PR also moves the volume logic for liquid handling from `Hardware Control` to `InstrumentContext`, to (1) keep it more consistent with the location logic that is already in contexts and (2) allow the publisher to print the correct volume and location.

closes #3860

## changelog
- added `available_volume` as a InstrumentContext property
- removed all contexts-related volume logic from Hardware Control and move to InstrumentContext
- called `cmd.do_publish` directly in `mix`

## review requests
Simulate the following protocol and to see that it should print the correct volumes and mix locations rather than raising this `TypeError: unsupported operand type(s) for +: 'int' and 'list'`
```
def run(ctx):

    tiprack = ctx.load_labware('opentrons_96_filtertiprack_200ul', '4')
    plate = ctx.load_labware('biorad_96_wellplate_200ul_pcr', '5')
    pipL = ctx.load_instrument('p300_single', 'left', tip_racks=[tiprack])

    pipL.pick_up_tip()
    pipL.aspirate(plate.wells('A1'))
    pipL.dispense(plate.wells('A2'))

    mix_args = [{'volume': None, 'location': None},
                {'volume': 30, 'location': plate.wells('A3')},
                {'volume': plate.wells('A4')},
                {'volume': 30}]
    for index, arg in enumerate(mix_args):
        pipL.mix(repetitions=2, **arg)
    pipL.drop_tip()
