### PR TITLE
fix(shared-data): fix "strict" arg for labware creation

### DIFF
--- a/shared-data/js/labwareTools/__tests__/__snapshots__/createIrregularLabware.test.js.snap
+++ b/shared-data/js/labwareTools/__tests__/__snapshots__/createIrregularLabware.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test createIrregularLabware function failing to validate against labware schema throws w/o "strict" 1`] = `"Generated labware failed to validate, please check your inputs"`;

--- a/shared-data/js/labwareTools/__tests__/__snapshots__/createLabware.test.js.snap
+++ b/shared-data/js/labwareTools/__tests__/__snapshots__/createLabware.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createLabware failing to validate against labware schema throws w/o "strict" 1`] = `"Generated labware failed to validate, please check your inputs"`;

--- a/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createIrregularLabware.test.js
@@ -84,9 +84,9 @@ describe('test helper functions', () => {
 
 describe('test createIrregularLabware function', () => {
   let labware1
-
+  let labware1Args
   beforeEach(() => {
-    labware1 = createIrregularLabware({
+    labware1Args = {
       namespace: 'fixture',
       metadata: {
         displayName: 'Fake Irregular Container',
@@ -125,7 +125,8 @@ describe('test createIrregularLabware function', () => {
         { rowStart: 'A', colStart: '1', rowStride: 2, colStride: 1 },
         { rowStart: 'B', colStart: '1', rowStride: 1, colStride: 1 },
       ],
-    })
+    }
+    labware1 = createIrregularLabware(labware1Args)
   })
 
   test('irregular ordering generates as expected', () => {
@@ -173,5 +174,18 @@ describe('test createIrregularLabware function', () => {
     })
 
     expect(loadName).toEqual('somebrand_6_wellplate_6x4ml')
+  })
+
+  test('failing to validate against labware schema throws w/o "strict"', () => {
+    const args = {
+      ...labware1Args,
+      // negative y offset should fail schema validation by making well `y` negative
+      offset: [{ x: 10, y: -9999, z: 69.48 }, { x: 15, y: -9999, z: 69.48 }],
+    }
+
+    expect(() => createIrregularLabware(args)).toThrowErrorMatchingSnapshot()
+    expect(() =>
+      createIrregularLabware({ ...args, strict: false })
+    ).not.toThrow()
   })
 })

--- a/shared-data/js/labwareTools/__tests__/createLabware.test.js
+++ b/shared-data/js/labwareTools/__tests__/createLabware.test.js
@@ -26,6 +26,7 @@ const exampleLabware2 = {
 describe('createLabware', () => {
   let labware1
   let labware2
+  let labware2Args
   let well1
   let well2
   let offset1
@@ -49,7 +50,7 @@ describe('createLabware', () => {
       namespace: 'fixture',
     })
 
-    labware2 = createRegularLabware({
+    labware2Args = {
       metadata: exampleLabware2.metadata,
       parameters: exampleLabware2.parameters,
       dimensions: exampleLabware2.dimensions,
@@ -58,7 +59,8 @@ describe('createLabware', () => {
       spacing: { row: 10, column: 10 },
       well: well2,
       namespace: 'fixture',
-    })
+    }
+    labware2 = createRegularLabware(labware2Args)
   })
 
   afterEach(() => {
@@ -109,5 +111,16 @@ describe('createLabware', () => {
         expect(well.z).toBeCloseTo(offset2.z - well.depth, 2)
       })
     })
+  })
+
+  test('failing to validate against labware schema throws w/o "strict"', () => {
+    const args = {
+      ...labware2Args,
+      // this spacing should make negative well `y` value and fail schema validation
+      spacing: { row: 999, column: 999 },
+    }
+
+    expect(() => createRegularLabware(args)).toThrowErrorMatchingSnapshot()
+    expect(() => createRegularLabware({ ...args, strict: false })).not.toThrow()
   })
 })

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -87,7 +87,7 @@ const validate = ajv.compile(labwareSchema)
 
 function validateDefinition(
   definition: Definition,
-  strict: boolean = true
+  strict: ?boolean = true
 ): Definition {
   const valid = validate(definition)
 
@@ -328,7 +328,7 @@ export function createDefaultDisplayName(args: RegularNameProps): string {
 // or the labware definition schema in labware/schemas/
 export function createRegularLabware(args: RegularLabwareProps): Definition {
   const { offset, dimensions, grid, spacing, well, loadNamePostfix } = args
-  const strict = args.strict || true
+  const strict = args.strict
   const version = args.version || 1
   const namespace = args.namespace || DEFAULT_CUSTOM_NAMESPACE
   const ordering = determineOrdering(grid)
@@ -372,7 +372,7 @@ export function createIrregularLabware(
   args: IrregularLabwareProps
 ): Definition {
   const { offset, dimensions, grid, spacing, well, gridStart, group } = args
-  const strict = args.strict || true
+  const strict = args.strict
   const namespace = args.namespace || DEFAULT_CUSTOM_NAMESPACE
   const version = args.version || 1
   const { wells, groups } = determineIrregularLayout(


### PR DESCRIPTION
## overview

I messed up #3804, if strict was false it would "default" to true because of the `||`, oops!

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Code review, see unit tests.