### PR TITLE
refactor(app): drive BR update logic from releases.json manifest

### DIFF
--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -18,7 +18,7 @@ import {
 } from '../discovery'
 
 import {
-  getBuildrootUpdateInfo,
+  getBuildrootUpdateVersion,
   getBuildrootRobot,
   getBuildrootSession,
   getRobotSystemType,
@@ -100,14 +100,14 @@ export function getBuildrootAnalyticsData(
   state: State,
   robotName: string | null = null
 ): BuildrootAnalyticsData | null {
-  const info = getBuildrootUpdateInfo(state)
+  const updateVersion = getBuildrootUpdateVersion(state)
   const session = getBuildrootSession(state)
   const robot =
     robotName === null
       ? getBuildrootRobot(state)
       : getViewableRobots(state).find(r => r.name === robotName) || null
 
-  if (info === null || robot === null) return null
+  if (updateVersion === null || robot === null) return null
 
   const currentVersion = getRobotApiVersion(robot) || 'unknown'
   const currentSystem = getRobotSystemType(robot) || 'unknown'
@@ -115,7 +115,7 @@ export function getBuildrootAnalyticsData(
   return {
     currentVersion,
     currentSystem,
-    updateVersion: info.version,
+    updateVersion,
     error: session?.error || null,
   }
 }

--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { withRouter, type ContextRouter } from 'react-router'
 
 import { actions as robotActions } from '../../robot'
-import { compareRobotVersionToUpdate } from '../../shell'
+import { getBuildrootUpdateAvailable } from '../../shell'
 import { RobotListItem } from './RobotListItem.js'
 
 import type { State, Dispatch } from '../../types'
@@ -28,9 +28,12 @@ export default withRouter<WithRouterOP>(
 )
 
 function mapStateToProps(state: State, ownProps: OP): SP {
+  const { robot } = ownProps
+  const updateType = getBuildrootUpdateAvailable(state, robot)
+
   return {
-    upgradable: compareRobotVersionToUpdate(ownProps.robot) !== 'reinstall',
-    selected: ownProps.match.params.name === ownProps.robot.name,
+    upgradable: updateType === 'upgrade',
+    selected: ownProps.match.params.name === robot.name,
   }
 }
 

--- a/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/InstallModalContents.js
@@ -57,7 +57,7 @@ export default function InstallModalContents(props: Props) {
     step === 'restart' ||
     step === 'restarting'
   ) {
-    updateMessage = 'Hang tight! This may take about 3-5 minutes.'
+    updateMessage = 'Hang tight! This may take up to 3 minutes.'
   } else if (step === 'getToken' || step === 'uploadFile') {
     updateMessage = 'Sending update file to robot'
   } else if (

--- a/app/src/components/RobotSettings/UpdateBuildroot/MigrationWarningModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/MigrationWarningModal.js
@@ -9,7 +9,7 @@ import type { BuildrootUpdateType } from '../../../shell'
 
 type Props = {|
   notNowButton: ButtonProps,
-  updateType: BuildrootUpdateType,
+  updateType: BuildrootUpdateType | null,
   proceed: () => mixed,
 |}
 
@@ -45,7 +45,7 @@ export default function MigrationWarningModal(props: Props) {
         </p>
 
         <p>
-          Please note that this update will take an estimated 10-15 minutes,
+          Please note that this update will take an estimated 3 to 5 minutes,
           will reboot your robot two times, and requires your OT-2 to remain
           discoverable via USB or Wi-Fi throughout the entire migration process.
         </p>

--- a/app/src/components/RobotSettings/UpdateBuildroot/VersionInfoModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/VersionInfoModal.js
@@ -18,7 +18,7 @@ import type { ViewableRobot } from '../../../discovery'
 
 type Props = {|
   robot: ViewableRobot,
-  robotUpdateType: BuildrootUpdateType,
+  robotUpdateType: BuildrootUpdateType | null,
   close: () => mixed,
   proceed: () => mixed,
 |}
@@ -46,7 +46,7 @@ export default function VersionInfoModal(props: Props) {
   let secondaryMessage = null
 
   if (appUpdate.available) {
-    heading = `Robot Version ${versionProps.availableUpdate} Available`
+    heading = `App Version ${versionProps.availableUpdate} Available`
     message = <UpdateAppMessage {...versionProps} />
     secondaryMessage = <SkipAppUpdateMessage onClick={proceed} />
     primaryButton = {

--- a/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/ViewUpdateModal.js
@@ -16,7 +16,7 @@ import type { BuildrootUpdateType, RobotSystemType } from '../../../shell'
 
 type Props = {|
   robotName: string,
-  robotUpdateType: BuildrootUpdateType,
+  robotUpdateType: BuildrootUpdateType | null,
   robotSystemType: RobotSystemType | null,
   close: () => mixed,
   proceed: () => mixed,

--- a/app/src/components/RobotSettings/UpdateBuildroot/index.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/index.js
@@ -12,7 +12,7 @@ import {
   getBuildrootSession,
   clearBuildrootSession,
   getRobotSystemType,
-  compareRobotVersionToUpdate,
+  getBuildrootUpdateAvailable,
 } from '../../../shell'
 
 import type { Dispatch } from '../../../types'
@@ -28,6 +28,9 @@ export default function UpdateBuildroot(props: Props) {
   const robotName = robot.name
   const [viewUpdateInfo, setViewUpdateInfo] = React.useState(false)
   const session = useSelector(getBuildrootSession)
+  const robotUpdateType = useSelector(state =>
+    getBuildrootUpdateAvailable(state, robot)
+  )
   const dispatch = useDispatch<Dispatch>()
   const { step, error } = session || { step: null, error: null }
 
@@ -58,7 +61,6 @@ export default function UpdateBuildroot(props: Props) {
   )
 
   const robotSystemType = getRobotSystemType(robot)
-  const robotUpdateType = compareRobotVersionToUpdate(robot)
 
   if (session) {
     return (

--- a/app/src/components/nav-bar/NavButton.js
+++ b/app/src/components/nav-bar/NavButton.js
@@ -8,7 +8,7 @@ import { selectors as robotSelectors } from '../../robot'
 
 import {
   getAvailableShellUpdate,
-  compareRobotVersionToUpdate,
+  getBuildrootUpdateAvailable,
 } from '../../shell'
 import { getConnectedRobot } from '../../discovery'
 import { NavButton } from '@opentrons/components'
@@ -32,10 +32,9 @@ function mapStateToProps(state: State, ownProps: OP): $Exact<Props> {
   const isProtocolRunning = robotSelectors.getIsRunning(state)
   const isProtocolDone = robotSelectors.getIsDone(state)
   const connectedRobot = getConnectedRobot(state)
-  const robotNotification = Boolean(
-    connectedRobot &&
-      compareRobotVersionToUpdate(connectedRobot) !== 'reinstall'
-  )
+  const robotNotification =
+    connectedRobot != null &&
+    getBuildrootUpdateAvailable(state, connectedRobot) === 'upgrade'
   const moreNotification = getAvailableShellUpdate(state) != null
 
   switch (name) {

--- a/app/src/pages/Robots/RobotSettings.js
+++ b/app/src/pages/Robots/RobotSettings.js
@@ -13,7 +13,7 @@ import {
   getBuildrootUpdateSeen,
   getBuildrootRobot,
   getBuildrootUpdateInProgress,
-  compareRobotVersionToUpdate,
+  getBuildrootUpdateAvailable,
 } from '../../shell'
 
 import { makeGetRobotHome, clearHomeResponse } from '../../http-api-client'
@@ -181,13 +181,14 @@ function makeMapStateToProps(): (state: State, ownProps: OP) => SP {
     const connectRequest = robotSelectors.getConnectRequest(state)
     const homeRequest = getHomeRequest(state, robot)
     const buildrootUpdateSeen = getBuildrootUpdateSeen(state)
+    const buildrootUpdateType = getBuildrootUpdateAvailable(state, robot)
     const updateInProgress = getBuildrootUpdateInProgress(state, robot)
     const currentBrRobot = getBuildrootRobot(state)
 
     const showUpdateModal =
       updateInProgress ||
       (!buildrootUpdateSeen &&
-        compareRobotVersionToUpdate(robot) !== 'reinstall' &&
+        buildrootUpdateType === 'upgrade' &&
         currentBrRobot === null)
 
     return {

--- a/app/src/shell/buildroot/__tests__/selectors.test.js
+++ b/app/src/shell/buildroot/__tests__/selectors.test.js
@@ -1,5 +1,8 @@
 import * as selectors from '../selectors'
-import { getViewableRobots } from '../../../discovery/selectors'
+import {
+  getViewableRobots,
+  getRobotApiVersion,
+} from '../../../discovery/selectors'
 
 jest.mock('../../../discovery/selectors')
 
@@ -17,20 +20,18 @@ describe('app/shell/buildroot selectors', () => {
           buildroot: {
             info: {
               releaseNotes: 'some release notes',
-              version: '1.0.0',
             },
           },
         },
       },
       expected: {
         releaseNotes: 'some release notes',
-        version: '1.0.0',
       },
     },
     {
       name: 'getBuildrootTargetVersion with auto-downloaded file',
       selector: selectors.getBuildrootTargetVersion,
-      state: { shell: { buildroot: { info: { version: '1.0.0' } } } },
+      state: { shell: { buildroot: { version: '1.0.0' } } },
       expected: '1.0.0',
     },
     {
@@ -39,7 +40,7 @@ describe('app/shell/buildroot selectors', () => {
       state: {
         shell: {
           buildroot: {
-            info: { version: '1.0.0' },
+            version: '1.0.0',
             session: { userFileInfo: { version: '1.0.1' } },
           },
         },
@@ -88,12 +89,15 @@ describe('app/shell/buildroot selectors', () => {
       state: {
         shell: {
           buildroot: {
-            info: { version: '1.0.0' },
+            version: '1.0.0',
           },
         },
       },
-      args: ['0.9.9'],
-      expected: true,
+      args: [{ name: 'robot-name' }],
+      expected: 'upgrade',
+      setup: () => {
+        getRobotApiVersion.mockReturnValueOnce('0.9.9')
+      },
     },
     {
       name: 'getBuildrootUpdateAvailable with greater version',
@@ -101,12 +105,15 @@ describe('app/shell/buildroot selectors', () => {
       state: {
         shell: {
           buildroot: {
-            info: { version: '1.0.0' },
+            version: '1.0.0',
           },
         },
       },
-      args: ['1.0.1'],
-      expected: false,
+      args: [{ name: 'robot-name' }],
+      expected: 'downgrade',
+      setup: () => {
+        getRobotApiVersion.mockReturnValueOnce('1.0.1')
+      },
     },
     {
       name: 'getBuildrootUpdateAvailable with same version',
@@ -114,12 +121,31 @@ describe('app/shell/buildroot selectors', () => {
       state: {
         shell: {
           buildroot: {
-            info: { version: '1.0.0' },
+            version: '1.0.0',
           },
         },
       },
-      args: ['1.0.0'],
-      expected: false,
+      args: [{ name: 'robot-name' }],
+      expected: 'reinstall',
+      setup: () => {
+        getRobotApiVersion.mockReturnValueOnce('1.0.0')
+      },
+    },
+    {
+      name: 'getBuildrootUpdateAvailable with no update available',
+      selector: selectors.getBuildrootUpdateAvailable,
+      state: {
+        shell: {
+          buildroot: {
+            version: null,
+          },
+        },
+      },
+      args: [{ name: 'robot-name' }],
+      expected: null,
+      setup: () => {
+        getRobotApiVersion.mockReturnValueOnce('1.0.0')
+      },
     },
     {
       name: 'getBuildrootUpdateSession',

--- a/app/src/shell/buildroot/actions.js
+++ b/app/src/shell/buildroot/actions.js
@@ -2,6 +2,9 @@
 import type { RobotHost } from '../../robot-api/types'
 import type { BuildrootAction, UpdateSessionStep } from './types'
 
+export const BR_UPDATE_VERSION: 'buildroot:UPDATE_VERSION' =
+  'buildroot:UPDATE_VERSION'
+
 export const BR_UPDATE_INFO: 'buildroot:UPDATE_INFO' = 'buildroot:UPDATE_INFO'
 
 export const BR_USER_FILE_INFO: 'buildroot:USER_FILE_INFO' =

--- a/app/src/shell/buildroot/reducer.js
+++ b/app/src/shell/buildroot/reducer.js
@@ -11,6 +11,7 @@ import * as actions from './actions'
 
 export const INITIAL_STATE: BuildrootState = {
   seen: false,
+  version: null,
   info: null,
   downloadProgress: null,
   downloadError: null,
@@ -36,6 +37,9 @@ export function buildrootReducer(
   action: Action
 ): BuildrootState {
   switch (action.type) {
+    case actions.BR_UPDATE_VERSION:
+      return { ...state, version: action.payload }
+
     case actions.BR_UPDATE_INFO:
       return { ...state, info: action.payload }
 

--- a/app/src/shell/buildroot/selectors.js
+++ b/app/src/shell/buildroot/selectors.js
@@ -6,7 +6,6 @@ import {
   getViewableRobots,
   getRobotApiVersion,
 } from '../../discovery/selectors'
-import remote from '../remote'
 
 import type { State } from '../../types'
 import type { ViewableRobot } from '../../discovery'
@@ -17,6 +16,10 @@ import type {
   RobotSystemType,
 } from './types'
 
+export function getBuildrootUpdateVersion(state: State): string | null {
+  return state.shell.buildroot.version || null
+}
+
 export function getBuildrootUpdateInfo(
   state: State
 ): BuildrootUpdateInfo | null {
@@ -26,7 +29,7 @@ export function getBuildrootUpdateInfo(
 export function getBuildrootTargetVersion(state: State): string | null {
   return (
     state.shell.buildroot.session?.userFileInfo?.version ||
-    state.shell.buildroot.info?.version ||
+    state.shell.buildroot.version ||
     null
   )
 }
@@ -84,42 +87,19 @@ export const getBuildrootRobot: State => ViewableRobot | null = createSelector(
   }
 )
 
-const compareCurrentVersionToUpdate = (
-  currentVersion: string,
-  updateVersion: string
-): boolean => {
-  const validCurrent = semver.valid(currentVersion)
-  const validUpdate = semver.valid(updateVersion)
-
-  return validCurrent !== null && validUpdate !== null
-    ? semver.gt(validUpdate, validCurrent)
-    : false
-}
-
 export function getBuildrootUpdateAvailable(
   state: State,
-  currentVersion: string
-): boolean {
-  const updateVersion = getBuildrootUpdateInfo(state)?.version
-
-  return updateVersion != null
-    ? compareCurrentVersionToUpdate(currentVersion, updateVersion)
-    : false
-}
-
-export function compareRobotVersionToUpdate(
   robot: ViewableRobot
-): BuildrootUpdateType {
+): BuildrootUpdateType | null {
+  const updateVersion = getBuildrootUpdateVersion(state)
   const currentVersion = getRobotApiVersion(robot)
-  // TODO(mc, 2019-07-23): get this from state once BR state info can come in piecemeal
-  const updateVersion: string = remote.CURRENT_VERSION
 
   const validCurrent: string | null = semver.valid(currentVersion)
   const validUpdate: string | null = semver.valid(updateVersion)
-  let type = 'upgrade'
+  let type = null
 
-  if (validCurrent && validUpdate) {
-    if (semver.gt(validUpdate, validCurrent)) {
+  if (validUpdate) {
+    if (!validCurrent || semver.gt(validUpdate, validCurrent)) {
       type = 'upgrade'
     } else if (semver.lt(validUpdate, validCurrent)) {
       type = 'downgrade'

--- a/app/src/shell/buildroot/types.js
+++ b/app/src/shell/buildroot/types.js
@@ -6,7 +6,6 @@ export type BuildrootUpdateType = 'upgrade' | 'downgrade' | 'reinstall'
 export type RobotSystemType = 'balena' | 'buildroot'
 
 export type BuildrootUpdateInfo = {|
-  version: string,
   releaseNotes: string,
 |}
 
@@ -54,6 +53,7 @@ export type BuildrootState = {|
   seen: boolean,
   downloadProgress: number | null,
   downloadError: string | null,
+  version: string | null,
   info: BuildrootUpdateInfo | null,
   session: BuildrootUpdateSession | null,
 |}
@@ -73,7 +73,8 @@ export type BuildrootAction =
   | UnexpectedBuildrootError
   | {| type: 'buildroot:DOWNLOAD_PROGRESS', payload: number |}
   | {| type: 'buildroot:DOWNLOAD_ERROR', payload: string |}
-  | {| type: 'buildroot:UPDATE_INFO', payload: BuildrootUpdateInfo | null |}
+  | {| type: 'buildroot:UPDATE_VERSION', payload: string |}
+  | {| type: 'buildroot:UPDATE_INFO', payload: BuildrootUpdateInfo |}
   | {| type: 'buildroot:USER_FILE_INFO', payload: BuildrootUserFileInfo |}
   | {| type: 'buildroot:SET_UPDATE_SEEN', meta: {| robotName: string |} |}
   | {| type: 'buildroot:CHANGELOG_SEEN', meta: {| robotName: string |} |}


### PR DESCRIPTION
## overview

While developing the BR update front-end, we leaned on the assumption that the current app version is always going to represent the latest available BR update. Due to how real world software delivery works, this assumption **doesn't hold up** for about 30 min after the latest app version is deployed and before the BR update is built and deployed

This sort of problem can (and should) be solved by separating out our artifact generation and artifact deployment stages, but in the mean time, we need to make sure the app gracefully handles the current version not being present in the BR releases.json manifest.

This PR implements that change by having the update check routine inform the UI that it has found a version entry in the releases manifest _before_ it starts downloading the files. Additionally, the UI has been tweaked to gracefully handle the absence of a version entry in the manifest

## changelog

- refactor(app): drive BR update logic from releases.json manifest

## review requests

Messing with `app-shell/package.json` is the best way to spoof the version you're checking the manifest for.

- [ ] App doesn't blow up or show errors to the user if no BR release files are found for the current version
- [ ] Robot update buttons are disabled with an appropriate tooltip
- [ ] If there are BR files for a given version, everything behaves as it did before