### PR TITLE
feat(app): display custom labware on deckmap

### DIFF
--- a/app/src/protocol/__mocks__/selectors.js
+++ b/app/src/protocol/__mocks__/selectors.js
@@ -1,0 +1,6 @@
+// mocks for tests that don't deal with ProtocolState
+export const getProtocolFile = () => null
+export const getProtocolContents = () => null
+export const getProtocolFilename = () => null
+export const getProtocolData = () => null
+export const getLabwareDefBySlot = () => ({})

--- a/app/src/protocol/__mocks__/selectors.js
+++ b/app/src/protocol/__mocks__/selectors.js
@@ -1,6 +1,0 @@
-// mocks for tests that don't deal with ProtocolState
-export const getProtocolFile = () => null
-export const getProtocolContents = () => null
-export const getProtocolFilename = () => null
-export const getProtocolData = () => null
-export const getLabwareDefBySlot = () => ({})

--- a/app/src/protocol/selectors.js
+++ b/app/src/protocol/selectors.js
@@ -76,11 +76,9 @@ export const getProtocolFilename: StringSelector = createSelector(
 //   file => file && file.lastModified
 // )
 
-export const getLabwareDefBySlot: OutputSelector<
-  State,
-  void,
-  { [slot: string]: LabwareDefinition2 }
-> = createSelector(
+export const getLabwareDefBySlot: State => {
+  [slot: string]: LabwareDefinition2 | void,
+} = createSelector(
   getProtocolData,
   (_data: any) => {
     if (_data?.schemaVersion === 3) {

--- a/app/src/protocol/selectors.js
+++ b/app/src/protocol/selectors.js
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect'
 import { getter } from '@thi.ng/paths'
 import { getProtocolSchemaVersion } from '@opentrons/shared-data'
 import { fileIsJson, fileToType } from './protocol-data'
+import createLogger from '../logger'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { ProtocolFile as SchemaV3ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
@@ -33,6 +34,8 @@ type CreatorAppSelector = OutputSelector<
   { name: ?string, version: ?string }
 >
 
+const log = createLogger(__filename)
+
 const protocolV1V2GetterPaths = {
   name: 'metadata.protocol-name',
   lastModified: 'metadata.last-modified',
@@ -60,8 +63,7 @@ const stripDirAndExtension = f => path.basename(f, path.extname(f))
 
 export const getProtocolFile = (state: State) => state.protocol.file
 export const getProtocolContents = (state: State) => state.protocol.contents
-// NOTE: Ian 2019-08-15 protocol?.data safe get isn't necessary, but useful in unit tests with partial State
-export const getProtocolData = (state: State) => state.protocol?.data
+export const getProtocolData = (state: State) => state.protocol.data
 
 export const getProtocolFilename: StringSelector = createSelector(
   getProtocolFile,
@@ -74,7 +76,7 @@ export const getProtocolFilename: StringSelector = createSelector(
 //   file => file && file.lastModified
 // )
 
-export const getLabwareDefBySlotForJSONProtocol: OutputSelector<
+export const getLabwareDefBySlot: OutputSelector<
   State,
   void,
   { [slot: string]: LabwareDefinition2 }
@@ -88,7 +90,7 @@ export const getLabwareDefBySlotForJSONProtocol: OutputSelector<
         const labware = data.labware[labwareId]
         const slot = labware.slot
         if (slot in acc) {
-          console.warn(
+          log.warn(
             `expected 1 labware per slot, slot ${slot} contains multiple labware`
           )
         }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -7,7 +7,7 @@ import { createSelector } from 'reselect'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import { getLatestLabwareDef } from '../getLabware'
 import { PIPETTE_MOUNTS, DECK_SLOTS } from './constants'
-import { getLabwareDefBySlotForJSONProtocol } from '../protocol/selectors'
+import { getLabwareDefBySlot } from '../protocol/selectors'
 
 import type { OutputSelector } from 'reselect'
 import type { State } from '../types'
@@ -332,14 +332,14 @@ export const getLabware: OutputSelector<
   (state: State) => calibration(state).confirmedBySlot,
   getModulesBySlot,
   getCalibrationRequest,
-  getLabwareDefBySlotForJSONProtocol,
+  getLabwareDefBySlot,
   (
     instByMount,
     lwBySlot,
     confirmedBySlot,
     modulesBySlot,
     calibrationRequest,
-    labwareDefsBySlotForJSONProtocol
+    labwareDefsBySlot
   ): Labware[] => {
     return Object.keys(lwBySlot)
       .filter(isSlot)
@@ -349,8 +349,7 @@ export const getLabware: OutputSelector<
 
         let definition = null
         if (!isLegacy) {
-          definition =
-            labwareDefsBySlotForJSONProtocol[slot] || getLatestLabwareDef(type)
+          definition = labwareDefsBySlot[slot] || getLatestLabwareDef(type)
         }
 
         // labware is confirmed if:

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -16,6 +16,7 @@ import MockSession from './__mocks__/session'
 import MockCalibrationMangager from './__mocks__/calibration-manager'
 
 jest.mock('../../rpc/client')
+jest.mock('../../protocol/selectors')
 
 describe('api client', () => {
   let dispatch

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -15,6 +15,8 @@ import { NAME, actions, constants } from '../'
 import MockSession from './__mocks__/session'
 import MockCalibrationMangager from './__mocks__/calibration-manager'
 
+import { getLabwareDefBySlot } from '../../protocol/selectors'
+
 jest.mock('../../rpc/client')
 jest.mock('../../protocol/selectors')
 
@@ -63,6 +65,8 @@ describe('api client', () => {
     dispatch = jest.fn()
     mockResolvedValue(RpcClient, rpcClient)
 
+    getLabwareDefBySlot.mockReturnValue({})
+
     const _receive = client(dispatch)
 
     sendToClient = (state, action) => {
@@ -73,6 +77,7 @@ describe('api client', () => {
 
   afterEach(() => {
     RpcClient.mockReset()
+    jest.resetAllMocks()
   })
 
   const ROBOT_NAME = 'ot'

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -50,10 +50,6 @@ describe('robot selectors', () => {
       }
     })
 
-    afterEach(() => {
-      jest.resetAllMocks()
-    })
-
     test('getConnectedRobotName', () => {
       expect(getConnectedRobotName(state)).toEqual('bar')
       state = setIn(state, 'robot.connection.connectedTo', 'foo')

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -2,6 +2,8 @@
 import { setIn } from '@thi.ng/paths'
 import { NAME, selectors, constants } from '../'
 
+import { getLabwareDefBySlot } from '../../protocol/selectors'
+
 jest.mock('../../protocol/selectors')
 
 const makeState = state => ({ [NAME]: state })
@@ -32,6 +34,13 @@ const {
 } = selectors
 
 describe('robot selectors', () => {
+  beforeEach(() => {
+    getLabwareDefBySlot.mockReturnValue({})
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('robot list', () => {
     let state
 
@@ -39,6 +48,10 @@ describe('robot selectors', () => {
       state = {
         robot: { connection: { connectedTo: 'bar' } },
       }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
     })
 
     test('getConnectedRobotName', () => {

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -2,6 +2,8 @@
 import { setIn } from '@thi.ng/paths'
 import { NAME, selectors, constants } from '../'
 
+jest.mock('../../protocol/selectors')
+
 const makeState = state => ({ [NAME]: state })
 
 const {

--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -24,7 +24,7 @@ import type {
 import type { ViewableRobot } from '../discovery'
 import type { ShellState } from './types'
 
-const { ipcRenderer } = remote
+const { ipcRenderer, CURRENT_VERSION, CURRENT_RELEASE_NOTES } = remote
 
 const log = createLogger(__filename)
 
@@ -32,14 +32,7 @@ export * from './update'
 export * from './buildroot'
 export * from './types'
 
-const CURRENT_VERSION: string = remote.CURRENT_VERSION
-const CURRENT_RELEASE_NOTES: string = remote.CURRENT_RELEASE_NOTES
-const API_RELEASE_NOTES = CURRENT_RELEASE_NOTES.replace(
-  /<!-- start:@opentrons\/app -->([\S\s]*?)<!-- end:@opentrons\/app -->/,
-  ''
-)
-
-export { CURRENT_VERSION, CURRENT_RELEASE_NOTES, API_RELEASE_NOTES }
+export { CURRENT_VERSION, CURRENT_RELEASE_NOTES }
 
 export const shellReducer: Reducer<ShellState, Action> = combineReducers<
   _,

--- a/app/src/shell/remote.js
+++ b/app/src/shell/remote.js
@@ -2,19 +2,21 @@
 // access main process remote modules via attachments to `global`
 import assert from 'assert'
 
-assert(
-  global.APP_SHELL_REMOTE,
-  'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
-)
+import type { Remote } from './types'
 
-const remote = new Proxy(global.APP_SHELL_REMOTE, {
+const remote = new Proxy((({}: any): Remote), {
   get(target, propName) {
     assert(
-      propName in target,
+      global.APP_SHELL_REMOTE,
+      'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
+    )
+
+    assert(
+      propName in global.APP_SHELL_REMOTE,
       `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.js properly configured?`
     )
 
-    return target[propName]
+    return global.APP_SHELL_REMOTE[propName]
   },
 })
 

--- a/app/src/shell/types.js
+++ b/app/src/shell/types.js
@@ -1,6 +1,16 @@
 // @flow
+import type { Service } from '@opentrons/discovery-client'
+import type { Config } from '../config/types'
 import type { BuildrootState, BuildrootAction } from './buildroot/types'
 import type { ShellUpdateState, ShellUpdateAction } from './update'
+
+export type Remote = {|
+  ipcRenderer: {| send: (string, ...args: Array<mixed>) => void |},
+  CURRENT_VERSION: string,
+  CURRENT_RELEASE_NOTES: string,
+  INITIAL_CONFIG: Config,
+  INITIAL_ROBOTS: Array<Service>,
+|}
 
 export type ShellState = {|
   update: ShellUpdateState,


### PR DESCRIPTION
## overview

Closes #3826 

## changelog

- display labware on deckmap for JSON v3 protocols
- factor out protocol selectors into a selectors.js file

## review requests

This only works with JSON v3 protocols, not Python. Earlier JSON versions didn't have embedded labware, so there's no way to have it work with them.

For JSON v3 protocols, Run App should display labware on the Deck Map from the JSON protocol's embedded labware definitions. (Not only custom labware, but all labware in the protocol is read from the protocol, including standard labware.)

It will show all labware that is in a slot on the deck in that JSON protocol. BUT- the existing behavior where labware are not shown unless "interacted" with is preserved.

~I factored out `protocol/index.js` into its own `protocol/selectors.js` file to try and fix a circular dependency-related bug, but it didn't fix it. Instead, I just duplicated the `getProtocolData` selector in `robot/selectors.js` to use in there. BTW the bug that came up when I tried to import protocol selectors into robot selectors is: `AssertionError: Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?`. The symptom is that you cannot connect to robots, clicking "connect" button or toggle has no effect.~

## Side notes

Aside: I think the APP_SHELL_REMOTE bug could be a result of the way that `app-shell/config.js` and `app-shell/log.js` each import the other. It's only a hunch but I think this circularity is fragile and makes webpack more sensitive to bugging out.

Using the bleeding-edge version of https://github.com/pahen/madge so that I can ignore Flow type imports (false positives for circular dependencies), I got the following for this PR. I got the same result when I imported protocol/selectors into robot/selectors.js (I pushed this alternative code to a branch `experiment-cause-circular-dep-app-shell-bug` - you should be able to `make -C app dev` on that other branch to recreate the bug)

```
✖ Found 2 circular dependencies!

1) app/src/components/CalibrateLabware/ConfirmPositionDiagram.js > components/CalibrateLabware/instructions-data.js
2) app/src/components/modals/index.js > components/modals/ScrollableAlertModal.js
```

These aren't related to selectors, so IDK why selector import would cause these to break

For `app-shell`:

```
✖ Found 2 circular dependencies!

1) lib/log.js > lib/config.js
2) src/config.js > src/log.js
```