### PR TITLE
refactor(app): Disconnect RPC session on update start

### DIFF
--- a/app/src/shell/buildroot/update-epics.js
+++ b/app/src/shell/buildroot/update-epics.js
@@ -25,6 +25,8 @@ import {
   passRobotApiErrorAction,
 } from '../../robot-api'
 
+import { actions as robotActions } from '../../robot'
+
 import {
   getBuildrootTargetVersion,
   getBuildrootSession,
@@ -363,6 +365,12 @@ export const removeMigratedRobotsEpic: Epic = (_, state$) =>
     })
   )
 
+export const disconnectRpcOnStartEpic: Epic = action$ =>
+  action$.pipe(
+    ofType(BR_START_UPDATE),
+    switchMap<_, _, mixed>(() => of(robotActions.disconnect()))
+  )
+
 export const buildrootUpdateEpic = combineEpics(
   startUpdateEpic,
   cancelSessionOnConflictEpic,
@@ -375,5 +383,6 @@ export const buildrootUpdateEpic = combineEpics(
   restartAfterCommitEpic,
   watchForOfflineAfterRestartEpic,
   watchForOnlineAfterRestartEpic,
-  removeMigratedRobotsEpic
+  removeMigratedRobotsEpic,
+  disconnectRpcOnStartEpic
 )


### PR DESCRIPTION
## overview

This PR serves as a bug ticket and fix. 

**Issue:** 
When a robot is connected via RPC, RPC unexpected robot disconnect modal would show during buildroot update restarts

<img width="1027" alt="Screen Shot 2019-08-19 at 12 14 38 PM" src="https://user-images.githubusercontent.com/3430313/63286187-715efc00-c285-11e9-86ee-2a7827dfc8fb.png">

Fix:
This PR disconnects any RPC session before starting any type of buildroot update.

## changelog

- refactor(app): Disconnect RPC session on update start

## review requests

Connect to a robot (RPC), then perform an update. 
- [ ] Unexpected disconnect modal does not show
- [ ] Buildroot update wizard flow behaves as expected
