### PR TITLE
fix(app): make shell remote check lazier to avoid spurious assertions

### DIFF
--- a/app/src/shell/index.js
+++ b/app/src/shell/index.js
@@ -24,7 +24,7 @@ import type {
 import type { ViewableRobot } from '../discovery'
 import type { ShellState } from './types'
 
-const { ipcRenderer } = remote
+const { ipcRenderer, CURRENT_VERSION, CURRENT_RELEASE_NOTES } = remote
 
 const log = createLogger(__filename)
 
@@ -32,14 +32,7 @@ export * from './update'
 export * from './buildroot'
 export * from './types'
 
-const CURRENT_VERSION: string = remote.CURRENT_VERSION
-const CURRENT_RELEASE_NOTES: string = remote.CURRENT_RELEASE_NOTES
-const API_RELEASE_NOTES = CURRENT_RELEASE_NOTES.replace(
-  /<!-- start:@opentrons\/app -->([\S\s]*?)<!-- end:@opentrons\/app -->/,
-  ''
-)
-
-export { CURRENT_VERSION, CURRENT_RELEASE_NOTES, API_RELEASE_NOTES }
+export { CURRENT_VERSION, CURRENT_RELEASE_NOTES }
 
 export const shellReducer: Reducer<ShellState, Action> = combineReducers<
   _,

--- a/app/src/shell/remote.js
+++ b/app/src/shell/remote.js
@@ -2,20 +2,23 @@
 // access main process remote modules via attachments to `global`
 import assert from 'assert'
 
-assert(
-  global.APP_SHELL_REMOTE,
-  'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
+const remote = new Proxy(
+  {},
+  {
+    get(target, propName) {
+      assert(
+        global.APP_SHELL_REMOTE,
+        'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
+      )
+
+      assert(
+        propName in global.APP_SHELL_REMOTE,
+        `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.js properly configured?`
+      )
+
+      return global.APP_SHELL_REMOTE[propName]
+    },
+  }
 )
-
-const remote = new Proxy(global.APP_SHELL_REMOTE, {
-  get(target, propName) {
-    assert(
-      propName in target,
-      `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.js properly configured?`
-    )
-
-    return target[propName]
-  },
-})
 
 export default remote

--- a/app/src/shell/remote.js
+++ b/app/src/shell/remote.js
@@ -2,23 +2,22 @@
 // access main process remote modules via attachments to `global`
 import assert from 'assert'
 
-const remote = new Proxy(
-  {},
-  {
-    get(target, propName) {
-      assert(
-        global.APP_SHELL_REMOTE,
-        'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
-      )
+import type { Remote } from './types'
 
-      assert(
-        propName in global.APP_SHELL_REMOTE,
-        `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.js properly configured?`
-      )
+const remote = new Proxy((({}: any): Remote), {
+  get(target, propName) {
+    assert(
+      global.APP_SHELL_REMOTE,
+      'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.js properly configured?'
+    )
 
-      return global.APP_SHELL_REMOTE[propName]
-    },
-  }
-)
+    assert(
+      propName in global.APP_SHELL_REMOTE,
+      `Expected APP_SHELL_REMOTE.${propName} to exist, is app-shell/src/preload.js properly configured?`
+    )
+
+    return global.APP_SHELL_REMOTE[propName]
+  },
+})
 
 export default remote

--- a/app/src/shell/types.js
+++ b/app/src/shell/types.js
@@ -1,6 +1,16 @@
 // @flow
+import type { Service } from '@opentrons/discovery-client'
+import type { Config } from '../config/types'
 import type { BuildrootState, BuildrootAction } from './buildroot/types'
 import type { ShellUpdateState, ShellUpdateAction } from './update'
+
+export type Remote = {|
+  ipcRenderer: {| send: (string, ...args: Array<mixed>) => void |},
+  CURRENT_VERSION: string,
+  CURRENT_RELEASE_NOTES: string,
+  INITIAL_CONFIG: Config,
+  INITIAL_ROBOTS: Array<Service>,
+|}
 
 export type ShellState = {|
   update: ShellUpdateState,


### PR DESCRIPTION
## overview

In investigating @IanLondon's reports of a circular-dependency based assertion, I found that the root of the problem was an assertion firing for a missing remote during import (i.e. before the code was actually running).

I'm not 100% sure of the Electron and/or webpack mechanics that are allowing that assertion to be hit, but moving the assertion to property access time fixes the issue.

@IanLondon: `app/src/protocol/selectors.js` creates a logger (via `app/src/protocol/protocol-data.js`), which relies on the `remote` module to send logs over to the desktop shell to save to a file. Rebasing #3891 over this branch fixed the issues for me.

## changelog

- fix(app): make shell remote check lazier to avoid spurious assertions

## review requests

- [ ] No `AssertionError`s in the console in normal operation
- [ ] No `AssertionError`s in the console when #3891 is layered over this branch
