### PR TITLE
refactor(app): Allow "alpha" update channel with devtools enabled

### DIFF
--- a/app/src/components/AppSettings/AdvancedSettingsCard.js
+++ b/app/src/components/AppSettings/AdvancedSettingsCard.js
@@ -7,6 +7,7 @@ import startCase from 'lodash/startCase'
 
 import {
   getConfig,
+  getUpdateChannelOptions,
   updateConfig,
   toggleDevTools,
   toggleDevInternalFlag,
@@ -19,18 +20,20 @@ import { LabeledToggle, LabeledSelect, LabeledButton } from '../controls'
 import AddManualIp from './AddManualIp'
 
 import type { ContextRouter } from 'react-router'
+import type { DropdownOption } from '@opentrons/components'
 import type { State, Dispatch } from '../../types'
-import type { UpdateChannel } from '../../config'
+import type { UpdateChannel } from '../../config/types'
 
-type OP = {
+type OP = {|
   ...ContextRouter,
   checkUpdate: () => mixed,
-}
+|}
 
 type SP = {|
   devToolsOn: boolean,
   devInternal: $PropertyType<Config, 'devInternal'>,
   channel: UpdateChannel,
+  channelOptions: Array<DropdownOption>,
 |}
 
 type DP = {|
@@ -39,15 +42,9 @@ type DP = {|
   handleChannel: (event: SyntheticInputEvent<HTMLSelectElement>) => mixed,
 |}
 
-type Props = { ...$Exact<OP>, ...SP, ...DP }
+type Props = {| ...OP, ...SP, ...DP |}
 
 const TITLE = 'Advanced Settings'
-
-// TODO(mc, 2018-08-03): enable "alpha" option
-const CHANNEL_OPTIONS = [
-  { name: 'Stable', value: (('latest': UpdateChannel): string) },
-  { name: 'Beta', value: (('beta': UpdateChannel): string) },
-]
 
 export default withRouter(
   connect(
@@ -63,7 +60,7 @@ function AdvancedSettingsCard(props: Props) {
         <LabeledSelect
           label="Update Channel"
           value={props.channel}
-          options={CHANNEL_OPTIONS}
+          options={props.channelOptions}
           onChange={props.handleChannel}
         >
           <p>
@@ -122,6 +119,7 @@ function mapStateToProps(state: State): SP {
     devToolsOn: config.devtools,
     devInternal: config.devInternal,
     channel: config.update.channel,
+    channelOptions: getUpdateChannelOptions(state),
   }
 }
 

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -4,10 +4,12 @@ import { setIn } from '@thi.ng/paths'
 import remove from 'lodash/remove'
 
 import remote from '../shell/remote'
+import { getConfig } from './selectors'
 
-import type { State, Action, ThunkAction } from '../types'
+import type { Action, ThunkAction } from '../types'
 import type { Config, UpdateConfigAction, DevInternalFlag } from './types'
 
+export * from './selectors'
 export * from './types'
 
 export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
@@ -37,10 +39,6 @@ export function configReducer(state: ?Config, action: Action): Config {
   }
 
   return state
-}
-
-export function getConfig(state: State): Config {
-  return state.config
 }
 
 export function toggleDevTools(): ThunkAction {

--- a/app/src/config/selectors.js
+++ b/app/src/config/selectors.js
@@ -18,7 +18,8 @@ const UPDATE_CHANNEL_OPTS_WITH_ALPHA = [
 export const getUpdateChannelOptions = (
   state: State
 ): Array<DropdownOption> => {
-  return getConfig(state).devtools
+  const config = getConfig(state)
+  return config.devtools || config.update.channel === 'alpha'
     ? UPDATE_CHANNEL_OPTS_WITH_ALPHA
     : UPDATE_CHANNEL_OPTS
 }

--- a/app/src/config/selectors.js
+++ b/app/src/config/selectors.js
@@ -1,0 +1,24 @@
+// @flow
+import type { DropdownOption } from '@opentrons/components'
+import type { State } from '../types'
+import type { Config, UpdateChannel } from './types'
+
+export const getConfig = (state: State): Config => state.config
+
+const UPDATE_CHANNEL_OPTS = [
+  { name: 'Stable', value: (('latest': UpdateChannel): string) },
+  { name: 'Beta', value: (('beta': UpdateChannel): string) },
+]
+
+const UPDATE_CHANNEL_OPTS_WITH_ALPHA = [
+  ...UPDATE_CHANNEL_OPTS,
+  { name: 'Alpha', value: (('alpha': UpdateChannel): string) },
+]
+
+export const getUpdateChannelOptions = (
+  state: State
+): Array<DropdownOption> => {
+  return getConfig(state).devtools
+    ? UPDATE_CHANNEL_OPTS_WITH_ALPHA
+    : UPDATE_CHANNEL_OPTS
+}


### PR DESCRIPTION
## overview

Versions of the app ending in `-alpha.N` get published to the "alpha" update channel. While the update channel is configurable for a given app installation, setting the channel to "alpha" has not been available in the UI.

Following up on #3848, this PR enables "alpha" as an update channel setting in the app's "Advanced Settings" page if the devtools are enabled.

## changelog

- refactor(app): Allow "alpha" update channel with devtools enabled

## review requests

- [ ] Launching the app without devtools (you'll need a #builds branch build for this) gives "Stable" and "Beta" as update channel options
- [ ] If devtools are toggled on, "Alpha" is a selectable option
- [ ] If you select "Alpha", the latest available version should be (at the time of writing this PR) `...-alpha.6`
- [ ] If you select "Alpha" and turn the devtools off, "Alpha" will still be an option until you select something else (at which point "Alpha" will no longer be an option)
