### PR TITLE
feat(protocol-designer): put custom labware upload under feature flag

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -24,6 +24,7 @@ type Props = {
   customLabwareDefs: LabwareDefByDefURI,
   slot: ?DeckSlotId,
   permittedTipracks: Array<string>,
+  showUploadCustomLabwareButton: ?boolean,
 }
 
 const CUSTOM_CATEGORY = 'custom'
@@ -137,16 +138,18 @@ const LabwareDropdown = (props: Props) => {
             </PDTitledList>
           ))}
         </ul>
-        <OutlineButton Component="label" className={styles.upload_button}>
-          {i18n.t('button.upload_custom_labware')}
-          <input
-            type="file"
-            onChange={e => {
-              onUploadLabware(e)
-              selectCategory(CUSTOM_CATEGORY)
-            }}
-          />
-        </OutlineButton>
+        {props.showUploadCustomLabwareButton && (
+          <OutlineButton Component="label" className={styles.upload_button}>
+            {i18n.t('button.upload_custom_labware')}
+            <input
+              type="file"
+              onChange={e => {
+                onUploadLabware(e)
+                selectCategory(CUSTOM_CATEGORY)
+              }}
+            />
+          </OutlineButton>
+        )}
         <OutlineButton onClick={onClose}>
           {i18n.t('button.close')}
         </OutlineButton>

--- a/protocol-designer/src/components/LabwareSelectionModal/index.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import LabwareSelectionModal from './LabwareSelectionModal'
+import { selectors as featureFlagSelectors } from '../../feature-flags'
 import {
   closeLabwareSelector,
   createContainer,
@@ -20,6 +21,10 @@ type SP = {|
   customLabwareDefs: $PropertyType<Props, 'customLabwareDefs'>,
   slot: $PropertyType<Props, 'slot'>,
   permittedTipracks: $PropertyType<Props, 'permittedTipracks'>,
+  showUploadCustomLabwareButton: $PropertyType<
+    Props,
+    'showUploadCustomLabwareButton'
+  >,
 |}
 
 function mapStateToProps(state: BaseState): SP {
@@ -27,6 +32,9 @@ function mapStateToProps(state: BaseState): SP {
     customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),
     slot: labwareIngredSelectors.selectedAddLabwareSlot(state) || null,
     permittedTipracks: stepFormSelectors.getPermittedTipracks(state),
+    showUploadCustomLabwareButton: featureFlagSelectors.getShowUploadCustomLabwareButton(
+      state
+    ),
   }
 }
 

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react'
+import i18n from '../../../localization'
+import { Card, ToggleButton } from '@opentrons/components'
+import styles from '../SettingsPage.css'
+import type { Flags } from '../../../feature-flags'
+
+type Props = {
+  flags: Flags,
+  setFeatureFlags: (flags: Flags) => mixed,
+}
+
+const FeatureFlagCard = (props: Props) => {
+  const featureFlagRows = Object.keys(props.flags)
+    .sort()
+    .map(flagName => (
+      <div key={flagName}>
+        <div className={styles.setting_row}>
+          <p className={styles.toggle_label}>
+            {i18n.t(`feature_flags.${flagName}.title`)}
+          </p>
+          <ToggleButton
+            className={styles.toggle_button}
+            toggledOn={Boolean(props.flags[flagName])}
+            onClick={() =>
+              props.setFeatureFlags({
+                [flagName]: !props.flags[flagName],
+              })
+            }
+          />
+        </div>
+        <p className={styles.feature_flag_description}>
+          {i18n.t(`feature_flags.${flagName}.description`)}
+        </p>
+      </div>
+    ))
+  return (
+    <Card title={i18n.t('card.title.feature_flags')}>
+      <div>{featureFlagRows}</div>
+    </Card>
+  )
+}
+
+export default FeatureFlagCard

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/index.js
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/index.js
@@ -1,0 +1,29 @@
+// @flow
+import { connect } from 'react-redux'
+import FeatureFlagCard from './FeatureFlagCard'
+import {
+  actions as featureFlagActions,
+  selectors as featureFlagSelectors,
+} from '../../../feature-flags'
+
+import type { Dispatch } from 'redux'
+import type { ElementProps } from 'react'
+import type { BaseState } from '../../../types'
+
+type Props = ElementProps<typeof FeatureFlagCard>
+
+type SP = {| flags: $PropertyType<Props, 'flags'> |}
+type DP = {| setFeatureFlags: $PropertyType<Props, 'setFeatureFlags'> |}
+
+const mapStateToProps = (state: BaseState): SP => ({
+  flags: featureFlagSelectors.getFeatureFlagData(state),
+})
+
+const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
+  setFeatureFlags: flags => dispatch(featureFlagActions.setFeatureFlags(flags)),
+})
+
+export default connect<Props, {||}, SP, DP, BaseState, _>(
+  mapStateToProps,
+  mapDispatchToProps
+)(FeatureFlagCard)

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.js
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.js
@@ -8,7 +8,6 @@ import {
   ToggleButton,
   LabeledValue,
 } from '@opentrons/components'
-import styles from './SettingsPage.css'
 import {
   actions as analyticsActions,
   selectors as analyticsSelectors,
@@ -17,8 +16,10 @@ import {
   actions as tutorialActions,
   selectors as tutorialSelectors,
 } from '../../tutorial'
-import type { BaseState, ThunkDispatch } from '../../types'
 import { OLDEST_MIGRATEABLE_VERSION } from '../../load-file/migration'
+import FeatureFlagCard from './FeatureFlagCard'
+import styles from './SettingsPage.css'
+import type { BaseState, ThunkDispatch } from '../../types'
 
 type Props = {
   canClearHintDismissals: boolean,
@@ -87,6 +88,7 @@ function SettingsApp(props: Props) {
           </ul>
         </div>
       </Card>
+      <FeatureFlagCard />
     </div>
   )
 }

--- a/protocol-designer/src/components/SettingsPage/SettingsPage.css
+++ b/protocol-designer/src/components/SettingsPage/SettingsPage.css
@@ -36,6 +36,13 @@
   align-items: center;
 }
 
+.feature_flag_description {
+  @apply --font-body-1-dark;
+
+  padding: 0 1rem 1rem 1rem;
+  margin: -1rem 0 0 0;
+}
+
 .toggle_label {
   @apply --font-body-2-dark;
 

--- a/protocol-designer/src/components/SettingsPage/index.js
+++ b/protocol-designer/src/components/SettingsPage/index.js
@@ -12,10 +12,7 @@ type Props = { currentPage: Page }
 
 const SettingsPage = (props: Props) => {
   switch (props.currentPage) {
-    case 'settings-features': {
-      // TODO: BC 2018-09-01 when we have feature flags put them here
-      return <div>Feature Flags Coming Soon...</div>
-    }
+    // TODO: Ian 2019-08-21 when we have other pages, put them here
     case 'settings-app':
     default:
       return <SettingsApp />

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -13,6 +13,7 @@ function getRootReducer() {
   const rootReducer: any = combineReducers({
     analytics: require('./analytics').rootReducer,
     dismiss: require('./dismiss').rootReducer,
+    featureFlags: require('./feature-flags').rootReducer,
     fileData: require('./file-data').rootReducer,
     labwareIngred: require('./labware-ingred/reducers').default,
     loadFile: require('./load-file').rootReducer,
@@ -88,8 +89,9 @@ export default function configureStore() {
       [
         './analytics/reducers',
         './dismiss/reducers',
+        './feature-flags/reducers',
         './file-data/reducers',
-        './labware-defs/reducers',
+        './labware-defs/reducers', // NOTE: labware-defs is nested inside step-forms, so it doesn't need to go directly into getRootReducer fn above
         './labware-ingred/reducers',
         './load-file/reducers',
         './navigation/reducers',

--- a/protocol-designer/src/feature-flags/actions.js
+++ b/protocol-designer/src/feature-flags/actions.js
@@ -1,0 +1,12 @@
+// @flow
+import type { Flags } from './types'
+
+export type SetFeatureFlagAction = {|
+  type: 'SET_FEATURE_FLAGS',
+  payload: Flags,
+|}
+
+export const setFeatureFlags = (payload: Flags): SetFeatureFlagAction => ({
+  type: 'SET_FEATURE_FLAGS',
+  payload,
+})

--- a/protocol-designer/src/feature-flags/index.js
+++ b/protocol-designer/src/feature-flags/index.js
@@ -1,0 +1,9 @@
+// @flow
+import rootReducer, { type RootState } from './reducers'
+import * as actions from './actions'
+import * as selectors from './selectors'
+export * from './types'
+
+export { actions, rootReducer, selectors }
+
+export type { RootState }

--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -1,0 +1,41 @@
+// @flow
+import { combineReducers } from 'redux'
+import { handleActions } from 'redux-actions'
+import { rehydrate, type RehydratePersistedAction } from '../persist'
+import type { Flags } from './types'
+import type { SetFeatureFlagAction } from './actions'
+import type { Action } from '../types'
+
+// NOTE: these values will always be overridden by persisted values,
+// whenever the browser has seen the feature flag before and persisted it.
+// Only "never before seen" flags will take on the default values from `initialFlags`.
+const initialFlags: Flags = {
+  OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON: false,
+}
+
+const flags = handleActions<Flags, *>(
+  {
+    SET_FEATURE_FLAGS: (state, action: SetFeatureFlagAction) => ({
+      ...state,
+      ...action.payload,
+    }),
+    // feature flags that are new (to browser storage) should take on default values
+    REHYDRATE_PERSISTED: (state, action: RehydratePersistedAction) => ({
+      ...state,
+      ...rehydrate('featureFlags.flags', initialFlags),
+    }),
+  },
+  initialFlags
+)
+
+export const _allReducers = {
+  flags,
+}
+
+export type RootState = {
+  flags: Flags,
+}
+
+const rootReducer = combineReducers<_, Action>(_allReducers)
+
+export default rootReducer

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -1,0 +1,10 @@
+// @flow
+import { createSelector } from 'reselect'
+import type { BaseState, Selector } from '../types'
+
+export const getFeatureFlagData = (state: BaseState) => state.featureFlags.flags
+
+export const getShowUploadCustomLabwareButton: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -1,0 +1,14 @@
+// @flow
+
+// When flag types are removed from this list, the browser will hold on to that value indefinitely.
+// To avoid being surprised when/if we deprecate and then re-introduce a flag with the same type string,
+// let's keep this list here.
+// Deprecated types should never be reused (unless there's a really good reason).
+//
+// LIST OF DEPRECATED FLAG TYPES:
+// - (none yet)
+export type FlagTypes = 'OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON' // NOTE: any additional flag types should be added here with | (Union)
+
+export type Flags = {
+  [FlagTypes]: ?boolean,
+}

--- a/protocol-designer/src/localization/en/card.json
+++ b/protocol-designer/src/localization/en/card.json
@@ -7,9 +7,10 @@
     "restore_hints": "Restore all hints and tips notifications"
   },
   "title": {
-    "privacy": "Privacy",
+    "information": "Information",
+    "feature_flags": "Feature Flags",
     "hints": "Hints",
-    "information": "Information"
+    "privacy": "Privacy"
   },
   "toggle": {
     "share_session": "Share sessions with the Opentrons Product Team"

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -1,0 +1,6 @@
+{
+  "OT_PD_SHOW_UPLOAD_CUSTOM_LABWARE_BUTTON": {
+    "title": "Upload custom labware",
+    "description": "Show the \"Upload Custom Labware\" button to enable adding custom labware to protocol"
+  }
+}

--- a/protocol-designer/src/localization/en/index.js
+++ b/protocol-designer/src/localization/en/index.js
@@ -6,6 +6,7 @@ import button from './button.json'
 import card from './card.json'
 import context_menu from './context_menu.json'
 import deck from './deck.json'
+import feature_flags from './feature_flags.json'
 import form from './form.json'
 import modal from './modal.json'
 import nav from './nav.json'
@@ -20,6 +21,7 @@ export default {
     card,
     context_menu,
     deck,
+    feature_flags,
     form,
     modal,
     nav,

--- a/protocol-designer/src/persist.js
+++ b/protocol-designer/src/persist.js
@@ -4,7 +4,9 @@ import assert from 'assert'
 import type { Store } from 'redux'
 import { dismissedHintsPersist } from './tutorial/reducers'
 
-export function rehydratePersistedAction(): { type: 'REHYDRATE_PERSISTED' } {
+export type RehydratePersistedAction = {| type: 'REHYDRATE_PERSISTED' |}
+
+export function rehydratePersistedAction(): RehydratePersistedAction {
   return { type: 'REHYDRATE_PERSISTED' }
 }
 
@@ -13,7 +15,11 @@ function _addStoragePrefix(path: string): string {
 }
 
 // paths from Redux root to all persisted reducers
-const PERSISTED_PATHS = ['analytics.hasOptedIn', 'tutorial.dismissedHints']
+const PERSISTED_PATHS = [
+  'analytics.hasOptedIn',
+  'tutorial.dismissedHints',
+  'featureFlags.flags',
+]
 
 function transformBeforePersist(path: string, reducerState: any) {
   switch (path) {

--- a/protocol-designer/src/types.js
+++ b/protocol-designer/src/types.js
@@ -4,6 +4,7 @@ import type { OutputSelector } from 'reselect'
 import type { RootState as Analytics } from './analytics'
 import type { RootState as Dismiss } from './dismiss'
 import type { RootState as FileData } from './file-data'
+import type { RootState as FeatureFlags } from './feature-flags'
 import type { RootState as LabwareIngred } from './labware-ingred/reducers'
 import type { RootState as LoadFile } from './load-file'
 import type { RootState as Navigation } from './navigation'
@@ -16,6 +17,7 @@ export type BaseState = {
   analytics: Analytics,
   dismiss: Dismiss,
   fileData: FileData,
+  featureFlags: FeatureFlags,
   labwareIngred: LabwareIngred,
   loadFile: LoadFile,
   navigation: Navigation,


### PR DESCRIPTION
## overview

This PR serves as its own ticket.

It came up in the PD release planning meeting today that we want to be able to test the full custom labware flow (LC + PD + RA), so we want to make "upload custom labware" available to internal users and for user testing.

However, custom labware upload to PD is a highly desired feature and until it's fully supported (LC release), we don't want to mislead users by showing the button in PD.

This PR hides the "upload custom labware" button unless a user goes to Settings > Feature Flags > Upload custom labware and enabled that feature. It also establishes feature flags in PD (analytics opt-in/out is related, but not exactly the same domain). We plan to use more feature flags in the future with upcoming features in PD.

## changelog

- add feature flag "atom" to PD
- add feature flag card to settings page, where users can view & set feature flags
- put the "upload custom labware" button under a feature flag

## review requests

This will be easiest to test in an incognito tab. Refreshing the tab should persist the flag setting. Closing the tab and re-opening it will give you a clean slate for browser storage (as if it was your first time opening this version of PD).

- [ ] PD should load with the custom labware upload feature flag turned off. When it is turned off, the "custom labware upload" button should be hidden in the Labware Selection Modal.
- [ ] Going to the Settings page and toggling on the custom labware upload feature flag should make the "custom labware upload" button visible in the Labware Selection Modal (and it should work)
- [ ] Refreshing the page should keep the flag as you last left it (if you turned it on, it stays on). But opening a new incognito tab should start with the flag off.
- [ ] Nothing really horrible should happen when you have PD open in multiple tabs (normal, non-incognito for this one) - probably if you refresh, the most recent feature flag setting of any tab will be selected
- [ ] Code review. This leverages PD's existing persistence functionality, so it isn't a big paradigm change, but it is something new. Devs, please think of any gotchas with this implementation -- persistence can be tricky! Would you expect this will work for future feature flags in general?