### PR TITLE
fix(labware-library): Fix incorrect tree hydration with query params

### DIFF
--- a/labware-library/src/components/App/index.js
+++ b/labware-library/src/components/App/index.js
@@ -5,7 +5,7 @@ import { hot } from 'react-hot-loader/root'
 import cx from 'classnames'
 
 import { DefinitionRoute } from '../../definitions'
-import { getFilters } from '../../filters'
+import { useFilters } from '../../filters'
 import Nav, { Breadcrumbs } from '../Nav'
 import Sidebar from '../Sidebar'
 import Page from './Page'
@@ -18,7 +18,7 @@ import type { DefinitionRouteRenderProps } from '../../definitions'
 export function App(props: DefinitionRouteRenderProps) {
   const { definition, location } = props
   const scrollRef = React.useRef<HTMLDivElement | null>(null)
-  const filters = getFilters(location)
+  const filters = useFilters(location)
   const detailPage = Boolean(definition)
 
   React.useEffect(() => {

--- a/labware-library/src/filters.js
+++ b/labware-library/src/filters.js
@@ -1,5 +1,6 @@
 // @flow
 // filter helpers
+import { useState, useLayoutEffect } from 'react'
 import queryString from 'query-string'
 import flatMap from 'lodash/flatMap'
 import pickBy from 'lodash/pickBy'
@@ -31,12 +32,23 @@ export function getAllManufacturers(): Array<string> {
   return uniq([FILTER_OFF, ...brands, ...wellGroupBrands])
 }
 
-export function getFilters(location: Location): FilterParams {
-  const queryParams = queryString.parse(location.search)
-  const category = queryParams.category || FILTER_OFF
-  const manufacturer = queryParams.manufacturer || FILTER_OFF
+export function useFilters(location: Location): FilterParams {
+  const [params, setParams] = useState({
+    category: FILTER_OFF,
+    manufacturer: FILTER_OFF,
+  })
 
-  return { category, manufacturer }
+  // layout effect (rather than regular effect) to trigger a state change
+  // before paint if needed
+  useLayoutEffect(() => {
+    const queryParams = queryString.parse(location.search)
+    const category = queryParams.category || FILTER_OFF
+    const manufacturer = queryParams.manufacturer || FILTER_OFF
+
+    setParams({ category, manufacturer })
+  }, [location.search])
+
+  return params
 }
 
 export function buildFiltersUrl(filters: FilterParams): string {


### PR DESCRIPTION
## overview

When query parameters are present in the labware library URL, React hydrates the tree incorrectly because the prerendered tree includes definitions that the React rendered tree (with the query param filters included) does not.

This PR fixes this problem by mirroring the query params into component state, thereby ensuring the first React render includes all definitions and therefor matches the pre-rendered tree. There is a split second between HTML rendered on the screen and React taking over and applying the filters, but that is existing behavior in the 1.0.0 release.

This branch is branched off of the tag `labware-library@1.1.0`. Once this PR is approved, this commit should be tagged `1.1.1` and _then_ merged into `edge`.

## changelog

- fix(labware-library): Fix incorrect tree hydration with query params

## review requests

<http://sandbox.labware.opentrons.com/hotfix_labware-library-reconcilliation>

- [ ] Regular page navigation works
- [ ] Going directly to a query param URL renders properly
