### PR TITLE
feat(labware-creator): Add main navigation to labware creator page

### DIFF
--- a/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
+++ b/labware-library/src/components/App/__tests__/__snapshots__/App.test.js.snap
@@ -5,18 +5,7 @@ exports[`App component renders with definition 1`] = `
   className="app is_detail_page"
 >
   <Nav />
-  <Breadcrumbs
-    definition={
-      Object {
-        "brand": Object {
-          "brand": "generic",
-        },
-        "metadata": Object {
-          "displayCategory": "wellPlate",
-        },
-      }
-    }
-  />
+  <Breadcrumbs />
   <Page
     content={
       <LabwareDetails

--- a/labware-library/src/components/App/index.js
+++ b/labware-library/src/components/App/index.js
@@ -34,7 +34,7 @@ export function App(props: DefinitionRouteRenderProps) {
       })}
     >
       <Nav />
-      {detailPage && <Breadcrumbs definition={definition} />}
+      {detailPage && <Breadcrumbs />}
       <Page
         scrollRef={scrollRef}
         detailPage={detailPage}

--- a/labware-library/src/components/Nav/Breadcrumbs.js
+++ b/labware-library/src/components/Nav/Breadcrumbs.js
@@ -7,17 +7,7 @@ import { Link } from '../ui'
 
 import styles from './styles.css'
 
-import type { LabwareDefinition } from '../../types'
-
-export type BreadcrumbsProps = {|
-  definition: LabwareDefinition | null,
-  creator?: boolean,
-|}
-
-export default function Breadcrumbs(props: BreadcrumbsProps) {
-  const { definition, creator } = props
-  if (!definition && !creator) return null
-
+export default function Breadcrumbs() {
   return (
     <div className={styles.breadcrumbs}>
       <div className={styles.breadcrumbs_contents}>

--- a/labware-library/src/components/Nav/Breadcrumbs.js
+++ b/labware-library/src/components/Nav/Breadcrumbs.js
@@ -11,11 +11,12 @@ import type { LabwareDefinition } from '../../types'
 
 export type BreadcrumbsProps = {|
   definition: LabwareDefinition | null,
+  creator?: boolean,
 |}
 
 export default function Breadcrumbs(props: BreadcrumbsProps) {
-  const { definition } = props
-  if (!definition) return null
+  const { definition, creator } = props
+  if (!definition && !creator) return null
 
   return (
     <div className={styles.breadcrumbs}>

--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import LinkOut from './LinkOut'
 import { LINK_CUSTOM_LABWARE_FORM } from '../fields'
+import styles from '../styles.css'
 
 const IntroCopy = () => (
   <>
@@ -27,17 +28,21 @@ const IntroCopy = () => (
           Opentrons aluminum block
         </LinkOut>
       </li>
-      <p>
-        For all other custom labware, please use this{' '}
-        <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>request form</LinkOut>
-      </p>
     </ul>
-
     <p>
-      <strong>Please note:</strong> We strongly recommend you reference
-      mechanical drawing to ensure accurate measurements for defining labware,
-      only relying on manual measurements to supplement missing information.
+      For all other custom labware, please use this{' '}
+      <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>request form</LinkOut>
     </p>
+
+    <div className={styles.callout}>
+      <p>
+        <strong>Please note:</strong> We strongly recommend you reference
+        mechanical drawings to ensure accurate measurements for defining
+        labware, only relying on manual measurements to supplement missing
+        information. To learn more about ways to access mechanical drawings from
+        manufacturerers, please refer to this guide.
+      </p>
+    </div>
   </>
 )
 

--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -40,7 +40,7 @@ const IntroCopy = () => (
         mechanical drawings to ensure accurate measurements for defining
         labware, only relying on manual measurements to supplement missing
         information. To learn more about ways to access mechanical drawings from
-        manufacturerers, please refer to this guide.
+        manufacturers, please refer to this guide.
       </p>
     </div>
   </>

--- a/labware-library/src/labware-creator/components/LabwareCreator.css
+++ b/labware-library/src/labware-creator/components/LabwareCreator.css
@@ -1,0 +1,22 @@
+@import '@opentrons/components';
+@import '../../styles/breakpoints.css';
+@import '../../styles/spacing.css';
+
+.page_wrapper {
+  height: 100%;
+
+  /* nav height plus breadcrumbs */
+  padding-top: calc(var(--size-mobile-nav) + var(--size-breadcrumb-nav));
+}
+
+@media (--medium) {
+  .page_wrapper {
+    padding-top: calc(var(--size-main-nav) + var(--size-breadcrumb-nav));
+  }
+}
+
+@media (--large) {
+  .page_wrapper {
+    padding-top: calc(var(--size-total-nav) + var(--size-breadcrumb-nav));
+  }
+}

--- a/labware-library/src/labware-creator/components/LabwareCreator.js
+++ b/labware-library/src/labware-creator/components/LabwareCreator.js
@@ -1,0 +1,18 @@
+// @flow
+import * as React from 'react'
+import Nav, { Breadcrumbs } from '../../components/Nav'
+import styles from './LabwareCreator.css'
+
+type Props = {|
+  children: React.Node,
+|}
+
+export default function LabwareCreator(props: Props) {
+  return (
+    <>
+      <Nav />
+      <Breadcrumbs creator definition={null} />
+      <div className={styles.page_wrapper}>{props.children}</div>
+    </>
+  )
+}

--- a/labware-library/src/labware-creator/components/LabwareCreator.js
+++ b/labware-library/src/labware-creator/components/LabwareCreator.js
@@ -11,7 +11,7 @@ export default function LabwareCreator(props: Props) {
   return (
     <>
       <Nav />
-      <Breadcrumbs creator definition={null} />
+      <Breadcrumbs />
       <div className={styles.page_wrapper}>{props.children}</div>
     </>
   )

--- a/labware-library/src/labware-creator/components/Section.js
+++ b/labware-library/src/labware-creator/components/Section.js
@@ -16,6 +16,7 @@ type Props = {|
   additionalAlerts?: React.Node,
   fieldList?: Array<$Keys<LabwareFields>>,
   children?: React.Node,
+  headingClassName?: string,
 |}
 const Section = connect((props: Props) => {
   const fieldList = props.fieldList || []
@@ -62,7 +63,9 @@ const Section = connect((props: Props) => {
 
   return (
     <div className={styles.section_wrapper}>
-      <h2 className={styles.section_header}>{props.label}</h2>
+      <h2 className={props.headingClassName || styles.section_header}>
+        {props.label}
+      </h2>
       <div>
         {allErrorAlerts}
         {props.additionalAlerts}

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -299,410 +299,398 @@ const App = () => {
 
   return (
     <LabwareCreator>
-      <div>
-        {showExportErrorModal && (
-          <AlertModal
-            className={styles.export_error_modal}
-            heading="Cannot export file"
-            onCloseClick={() => setShowExportErrorModal(false)}
-            buttons={[
-              {
-                onClick: () => setShowExportErrorModal(false),
-                children: 'close',
-              },
-            ]}
-          >
-            Please resolve all invalid fields in order to export the labware
-            definition
-          </AlertModal>
-        )}
-        <Formik
-          initialValues={getDefaultFormState()}
-          validationSchema={labwareFormSchema}
-          onSubmit={(values: LabwareFields) => {
-            const castValues: ProcessedLabwareFields = labwareFormSchema.cast(
-              values
-            )
-            const { pipetteName } = castValues
-            const def = fieldsToLabware(castValues)
-            const { displayName } = def.metadata
-
-            const zip = new JSZip()
-            zip.file(`${displayName}.json`, JSON.stringify(def, null, 4))
-            zip.file(
-              `calibrate_${displayName}.py`,
-              labwareTestProtocol({ pipetteName, definition: def })
-            )
-            zip
-              .generateAsync({ type: 'blob' })
-              .then(blob => saveAs(blob, `${displayName}.zip`))
-          }}
+      {showExportErrorModal && (
+        <AlertModal
+          className={styles.export_error_modal}
+          heading="Cannot export file"
+          onCloseClick={() => setShowExportErrorModal(false)}
+          buttons={[
+            {
+              onClick: () => setShowExportErrorModal(false),
+              children: 'close',
+            },
+          ]}
         >
-          {({
-            handleSubmit,
-            values,
-            isValid,
-            errors,
-            touched,
-            setTouched,
-            setValues,
-          }) => (
-            <div className={styles.labware_creator}>
-              <h2>Custom Labware Creator</h2>
-              <IntroCopy />
-              <div className={styles.flex_row}>
-                <div className={styles.new_definition_section}>
-                  <Section
-                    label="Create a new definition"
-                    fieldList={[
-                      'labwareType',
-                      'tubeRackInsertLoadName',
-                      'aluminumBlockType',
-                      'aluminumBlockChildType',
-                    ]}
-                    headingClassName={styles.setup_heading}
-                  >
-                    <div className={styles.new_definition_content}>
+          Please resolve all invalid fields in order to export the labware
+          definition
+        </AlertModal>
+      )}
+      <Formik
+        initialValues={getDefaultFormState()}
+        validationSchema={labwareFormSchema}
+        onSubmit={(values: LabwareFields) => {
+          const castValues: ProcessedLabwareFields = labwareFormSchema.cast(
+            values
+          )
+          const { pipetteName } = castValues
+          const def = fieldsToLabware(castValues)
+          const { displayName } = def.metadata
+
+          const zip = new JSZip()
+          zip.file(`${displayName}.json`, JSON.stringify(def, null, 4))
+          zip.file(
+            `calibrate_${displayName}.py`,
+            labwareTestProtocol({ pipetteName, definition: def })
+          )
+          zip
+            .generateAsync({ type: 'blob' })
+            .then(blob => saveAs(blob, `${displayName}.zip`))
+        }}
+      >
+        {({
+          handleSubmit,
+          values,
+          isValid,
+          errors,
+          touched,
+          setTouched,
+          setValues,
+        }) => (
+          <div className={styles.labware_creator}>
+            <h2>Custom Labware Creator</h2>
+            <IntroCopy />
+            <div className={styles.flex_row}>
+              <div className={styles.new_definition_section}>
+                <Section
+                  label="Create a new definition"
+                  fieldList={[
+                    'labwareType',
+                    'tubeRackInsertLoadName',
+                    'aluminumBlockType',
+                    'aluminumBlockChildType',
+                  ]}
+                  headingClassName={styles.setup_heading}
+                >
+                  <div className={styles.new_definition_content}>
+                    <Dropdown name="labwareType" options={labwareTypeOptions} />
+                    {values.labwareType === 'tubeRack' && (
                       <Dropdown
-                        name="labwareType"
-                        options={labwareTypeOptions}
+                        name="tubeRackInsertLoadName"
+                        options={tubeRackInsertOptions}
+                        onValueChange={makeAutofillOnChange({
+                          name: 'tubeRackInsertLoadName',
+                          autofills: tubeRackAutofills,
+                          values,
+                          touched,
+                          setTouched,
+                          setValues,
+                        })}
                       />
-                      {values.labwareType === 'tubeRack' && (
+                    )}
+                    {values.labwareType === 'aluminumBlock' && (
+                      <Dropdown
+                        name="aluminumBlockType"
+                        options={aluminumBlockTypeOptions}
+                        onValueChange={makeAutofillOnChange({
+                          name: 'aluminumBlockType',
+                          autofills: aluminumBlockAutofills,
+                          values,
+                          touched,
+                          setTouched,
+                          setValues,
+                        })}
+                      />
+                    )}
+                    {values.labwareType === 'aluminumBlock' &&
+                      values.aluminumBlockType === '96well' && (
+                        // Only show for '96well' aluminum block type
                         <Dropdown
-                          name="tubeRackInsertLoadName"
-                          options={tubeRackInsertOptions}
-                          onValueChange={makeAutofillOnChange({
-                            name: 'tubeRackInsertLoadName',
-                            autofills: tubeRackAutofills,
-                            values,
-                            touched,
-                            setTouched,
-                            setValues,
-                          })}
+                          name="aluminumBlockChildType"
+                          options={aluminumBlockChildTypeOptions}
                         />
                       )}
-                      {values.labwareType === 'aluminumBlock' && (
-                        <Dropdown
-                          name="aluminumBlockType"
-                          options={aluminumBlockTypeOptions}
-                          onValueChange={makeAutofillOnChange({
-                            name: 'aluminumBlockType',
-                            autofills: aluminumBlockAutofills,
-                            values,
-                            touched,
-                            setTouched,
-                            setValues,
-                          })}
-                        />
-                      )}
-                      {values.labwareType === 'aluminumBlock' &&
-                        values.aluminumBlockType === '96well' && (
-                          // Only show for '96well' aluminum block type
-                          <Dropdown
-                            name="aluminumBlockChildType"
-                            options={aluminumBlockChildTypeOptions}
-                          />
-                        )}
-                    </div>
-                  </Section>
-                </div>
-                <div className={styles.upload_exisiting_section}>
-                  <h2 className={styles.setup_heading}>
-                    Edit a file you’ve built with our labware creator.{' '}
-                  </h2>
-                </div>
+                  </div>
+                </Section>
               </div>
-              {/* PAGE 1 - Labware */}
-              <Section label="Regularity" fieldList={['homogeneousWells']}>
-                {/* tubeRackSides: Array<string> maybe?? */}
-                <RadioField name="homogeneousWells" options={yesNoOptions} />
-              </Section>
-              <Section
-                label="Footprint"
-                fieldList={['footprintXDimension', 'footprintYDimension']}
-                additionalAlerts={getXYDimensionAlerts(values, touched)}
-              >
-                <div>
-                  <p>
-                    Ensure measurement is taken from the{' '}
-                    <strong>very bottom</strong> of plate.
-                  </p>
-                  <p>
-                    The footprint measurement helps determine if the labware
-                    fits firmly into the slots on the OT-2 deck.
-                  </p>
-                </div>
-                <img src={require('./images/footprint.svg')} />
+              <div className={styles.upload_exisiting_section}>
+                <h2 className={styles.setup_heading}>
+                  Edit a file you’ve built with our labware creator.{' '}
+                </h2>
+              </div>
+            </div>
+            {/* PAGE 1 - Labware */}
+            <Section label="Regularity" fieldList={['homogeneousWells']}>
+              {/* tubeRackSides: Array<string> maybe?? */}
+              <RadioField name="homogeneousWells" options={yesNoOptions} />
+            </Section>
+            <Section
+              label="Footprint"
+              fieldList={['footprintXDimension', 'footprintYDimension']}
+              additionalAlerts={getXYDimensionAlerts(values, touched)}
+            >
+              <div>
+                <p>
+                  Ensure measurement is taken from the{' '}
+                  <strong>very bottom</strong> of plate.
+                </p>
+                <p>
+                  The footprint measurement helps determine if the labware fits
+                  firmly into the slots on the OT-2 deck.
+                </p>
+              </div>
+              <img src={require('./images/footprint.svg')} />
+              <TextField
+                name="footprintXDimension"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+              <TextField
+                name="footprintYDimension"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+            </Section>
+            <Section
+              label={
+                ['aluminumBlock', 'tubeRack'].includes(values.labwareType)
+                  ? 'Total Height'
+                  : 'Height'
+              }
+              fieldList={['labwareZDimension']}
+              additionalAlerts={getHeightAlerts(values, touched)}
+            >
+              <div>
+                <HeightGuidingText labwareType={values.labwareType} />
+              </div>
+              <HeightImg
+                labwareType={values.labwareType}
+                aluminumBlockChildType={values.aluminumBlockChildType}
+              />
+              <TextField
+                name="labwareZDimension"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+            </Section>
+            <Section
+              label="Grid"
+              fieldList={[
+                'gridRows',
+                'gridColumns',
+                'regularRowSpacing',
+                'regularColumnSpacing',
+              ]}
+            >
+              <div>
+                <p>
+                  The grid of wells on your labware is arranged in a number of
+                  rows (run horizontally across your labware, left to right) and
+                  columns (run top to bottom).
+                </p>
+              </div>
+              <TextField name="gridRows" inputMasks={[maskToInteger]} />
+              <RadioField name="regularRowSpacing" options={yesNoOptions} />
+              <TextField name="gridColumns" inputMasks={[maskToInteger]} />
+              <RadioField name="regularColumnSpacing" options={yesNoOptions} />
+            </Section>
+            {/* PAGE 2 */}
+            <Section label="Well/Tube Volume" fieldList={['wellVolume']}>
+              <div>
+                <p>Total maximum volume of each well.</p>
+              </div>
+              <TextField
+                name="wellVolume"
+                inputMasks={[maskTo2Decimal]}
+                units="μL"
+              />
+            </Section>
+            <Section
+              label="Well Shape & Sides"
+              fieldList={[
+                'wellShape',
+                'wellDiameter',
+                'wellXDimension',
+                'wellYDimension',
+              ]}
+            >
+              <div>
+                <p>
+                  Reference the <strong>inside</strong> of the well. Ignore any
+                  lip.
+                </p>
+                <p>Diameter helps the robot locate the sides of the wells.</p>
+              </div>
+              <WellXYImg wellShape={values.wellShape} />
+              <RadioField name="wellShape" options={wellShapeOptions} />
+              {values.wellShape === 'circular' && (
                 <TextField
-                  name="footprintXDimension"
+                  name="wellDiameter"
                   inputMasks={[maskTo2Decimal]}
                   units="mm"
                 />
-                <TextField
-                  name="footprintYDimension"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-              </Section>
-              <Section
-                label={
-                  ['aluminumBlock', 'tubeRack'].includes(values.labwareType)
-                    ? 'Total Height'
-                    : 'Height'
-                }
-                fieldList={['labwareZDimension']}
-                additionalAlerts={getHeightAlerts(values, touched)}
-              >
-                <div>
-                  <HeightGuidingText labwareType={values.labwareType} />
-                </div>
-                <HeightImg
-                  labwareType={values.labwareType}
-                  aluminumBlockChildType={values.aluminumBlockChildType}
-                />
-                <TextField
-                  name="labwareZDimension"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-              </Section>
-              <Section
-                label="Grid"
-                fieldList={[
-                  'gridRows',
-                  'gridColumns',
-                  'regularRowSpacing',
-                  'regularColumnSpacing',
-                ]}
-              >
-                <div>
-                  <p>
-                    The grid of wells on your labware is arranged in a number of
-                    rows (run horizontally across your labware, left to right)
-                    and columns (run top to bottom).
-                  </p>
-                </div>
-                <TextField name="gridRows" inputMasks={[maskToInteger]} />
-                <RadioField name="regularRowSpacing" options={yesNoOptions} />
-                <TextField name="gridColumns" inputMasks={[maskToInteger]} />
-                <RadioField
-                  name="regularColumnSpacing"
-                  options={yesNoOptions}
-                />
-              </Section>
-              {/* PAGE 2 */}
-              <Section label="Well/Tube Volume" fieldList={['wellVolume']}>
-                <div>
-                  <p>Total maximum volume of each well.</p>
-                </div>
-                <TextField
-                  name="wellVolume"
-                  inputMasks={[maskTo2Decimal]}
-                  units="μL"
-                />
-              </Section>
-              <Section
-                label="Well Shape & Sides"
-                fieldList={[
-                  'wellShape',
-                  'wellDiameter',
-                  'wellXDimension',
-                  'wellYDimension',
-                ]}
-              >
-                <div>
-                  <p>
-                    Reference the <strong>inside</strong> of the well. Ignore
-                    any lip.
-                  </p>
-                  <p>Diameter helps the robot locate the sides of the wells.</p>
-                </div>
-                <WellXYImg wellShape={values.wellShape} />
-                <RadioField name="wellShape" options={wellShapeOptions} />
-                {values.wellShape === 'circular' && (
+              )}
+              {values.wellShape === 'rectangular' && (
+                <>
                   <TextField
-                    name="wellDiameter"
+                    name="wellXDimension"
                     inputMasks={[maskTo2Decimal]}
                     units="mm"
                   />
-                )}
-                {values.wellShape === 'rectangular' && (
-                  <>
-                    <TextField
-                      name="wellXDimension"
-                      inputMasks={[maskTo2Decimal]}
-                      units="mm"
-                    />
-                    <TextField
-                      name="wellYDimension"
-                      inputMasks={[maskTo2Decimal]}
-                      units="mm"
-                    />
-                  </>
-                )}
-              </Section>
-              <Section
-                label="Well Bottom & Depth"
-                fieldList={['wellBottomShape', 'wellDepth']}
-              >
-                <div>
-                  <p>
-                    Reference the measurement from the top of the well (include
-                    any lip but exclude any cap) to the bottom of the{' '}
-                    <strong>inside</strong> of the{' '}
-                    {displayAsTube(values) ? 'tube' : 'well'}.
-                  </p>
-
-                  <p>
-                    Depth informs the robot how far down it can go inside a
-                    well.
-                  </p>
-                </div>
-                <DepthImg
-                  labwareType={values.labwareType}
-                  wellBottomShape={values.wellBottomShape}
-                />
-                <Dropdown
-                  name="wellBottomShape"
-                  options={wellBottomShapeOptions}
-                />
-                <TextField
-                  name="wellDepth"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-              </Section>
-              <Section
-                label="Well Spacing"
-                fieldList={['gridSpacingX', 'gridSpacingY']}
-              >
-                <div>
-                  <p>
-                    Spacing is between the <strong>center</strong> of wells.
-                  </p>
-                  <p>
-                    Well spacing measurements inform the robot how far away rows
-                    and columns are from each other.
-                  </p>
-                </div>
-                <XYSpacingImg
-                  labwareType={values.labwareType}
-                  wellShape={values.wellShape}
-                  gridRows={values.gridRows}
-                />
-                <TextField
-                  name="gridSpacingX"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-                <TextField
-                  name="gridSpacingY"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-              </Section>
-              <Section
-                label="Grid Offset"
-                fieldList={['gridOffsetX', 'gridOffsetY']}
-              >
-                <div>
-                  <p>
-                    Find the measurement from the center of{' '}
-                    <strong>
-                      {values.labwareType === 'reservoir'
-                        ? 'the top left-most well'
-                        : 'well A1'}
-                    </strong>{' '}
-                    to the edge of the labware{"'"}s footprint.
-                  </p>
-                  <p>
-                    Corner offset informs the robot how far the grid of wells is
-                    from the slot{"'"}s top left corner.
-                  </p>
-                  <div>
-                    <img src={require('./images/offset_helpText.svg')} />
-                  </div>
-                  <div>
-                    <XYOffsetImg
-                      labwareType={values.labwareType}
-                      wellShape={values.wellShape}
-                    />
-                  </div>
-                </div>
-                <TextField
-                  name="gridOffsetX"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-                <TextField
-                  name="gridOffsetY"
-                  inputMasks={[maskTo2Decimal]}
-                  units="mm"
-                />
-              </Section>
-              <Section label="Check your work">
-                <p>
-                  Check that the size, spacing, and shape of your wells looks
-                  correct.
-                </p>
-                <ConditionalLabwareRender values={values} />
-              </Section>
-
-              {/* PAGE 3 */}
-              <Section label="Description" fieldList={['brand', 'brandId']}>
-                <TextField name="brand" />
-                <TextField
-                  name="brandId"
-                  caption="Separate multiple by comma"
-                />
-              </Section>
-              {/* PAGE 4 */}
-              <Section
-                label="File"
-                fieldList={['loadName', 'displayName', 'pipetteName']}
-              >
-                <TextField
-                  name="displayName"
-                  placeholder={getDefaultDisplayName(values)}
-                />
-                <TextField
-                  name="loadName"
-                  placeholder={getDefaultLoadName(values)}
-                  caption="Only lower case letters, numbers, periods, and underscores may be used"
-                  inputMasks={[maskLoadName]}
-                />
-                <Dropdown
-                  name="pipetteName"
-                  options={pipetteNameOptions}
-                  caption="Files are exported with a protocol that will use a single channel pipette to test whether a pipette can hit key points on your labware"
-                />
-              </Section>
-              <div className={styles.double_check_before_exporting}>
-                <p>DOUBLE CHECK YOUR WORK BEFORE EXPORTING!</p>
-                <p>
-                  If you are not comfortable reading a JSON labware definition
-                  then consider noting down the values you put in these fields.
-                  You will not be able to re-import your file back into the
-                  labware creator to read or edit it.
-                </p>
-              </div>
+                  <TextField
+                    name="wellYDimension"
+                    inputMasks={[maskTo2Decimal]}
+                    units="mm"
+                  />
+                </>
+              )}
+            </Section>
+            <Section
+              label="Well Bottom & Depth"
+              fieldList={['wellBottomShape', 'wellDepth']}
+            >
               <div>
-                <PrimaryButton
-                  className={styles.export_button}
-                  onClick={() => {
-                    if (!isValid && !showExportErrorModal) {
-                      setShowExportErrorModal(true)
-                    }
-                    handleSubmit()
-                  }}
-                >
-                  EXPORT FILE
-                </PrimaryButton>
+                <p>
+                  Reference the measurement from the top of the well (include
+                  any lip but exclude any cap) to the bottom of the{' '}
+                  <strong>inside</strong> of the{' '}
+                  {displayAsTube(values) ? 'tube' : 'well'}.
+                </p>
+
+                <p>
+                  Depth informs the robot how far down it can go inside a well.
+                </p>
               </div>
+              <DepthImg
+                labwareType={values.labwareType}
+                wellBottomShape={values.wellBottomShape}
+              />
+              <Dropdown
+                name="wellBottomShape"
+                options={wellBottomShapeOptions}
+              />
+              <TextField
+                name="wellDepth"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+            </Section>
+            <Section
+              label="Well Spacing"
+              fieldList={['gridSpacingX', 'gridSpacingY']}
+            >
+              <div>
+                <p>
+                  Spacing is between the <strong>center</strong> of wells.
+                </p>
+                <p>
+                  Well spacing measurements inform the robot how far away rows
+                  and columns are from each other.
+                </p>
+              </div>
+              <XYSpacingImg
+                labwareType={values.labwareType}
+                wellShape={values.wellShape}
+                gridRows={values.gridRows}
+              />
+              <TextField
+                name="gridSpacingX"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+              <TextField
+                name="gridSpacingY"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+            </Section>
+            <Section
+              label="Grid Offset"
+              fieldList={['gridOffsetX', 'gridOffsetY']}
+            >
+              <div>
+                <p>
+                  Find the measurement from the center of{' '}
+                  <strong>
+                    {values.labwareType === 'reservoir'
+                      ? 'the top left-most well'
+                      : 'well A1'}
+                  </strong>{' '}
+                  to the edge of the labware{"'"}s footprint.
+                </p>
+                <p>
+                  Corner offset informs the robot how far the grid of wells is
+                  from the slot{"'"}s top left corner.
+                </p>
+                <div>
+                  <img src={require('./images/offset_helpText.svg')} />
+                </div>
+                <div>
+                  <XYOffsetImg
+                    labwareType={values.labwareType}
+                    wellShape={values.wellShape}
+                  />
+                </div>
+              </div>
+              <TextField
+                name="gridOffsetX"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+              <TextField
+                name="gridOffsetY"
+                inputMasks={[maskTo2Decimal]}
+                units="mm"
+              />
+            </Section>
+            <Section label="Check your work">
+              <p>
+                Check that the size, spacing, and shape of your wells looks
+                correct.
+              </p>
+              <ConditionalLabwareRender values={values} />
+            </Section>
+
+            {/* PAGE 3 */}
+            <Section label="Description" fieldList={['brand', 'brandId']}>
+              <TextField name="brand" />
+              <TextField name="brandId" caption="Separate multiple by comma" />
+            </Section>
+            {/* PAGE 4 */}
+            <Section
+              label="File"
+              fieldList={['loadName', 'displayName', 'pipetteName']}
+            >
+              <TextField
+                name="displayName"
+                placeholder={getDefaultDisplayName(values)}
+              />
+              <TextField
+                name="loadName"
+                placeholder={getDefaultLoadName(values)}
+                caption="Only lower case letters, numbers, periods, and underscores may be used"
+                inputMasks={[maskLoadName]}
+              />
+              <Dropdown
+                name="pipetteName"
+                options={pipetteNameOptions}
+                caption="Files are exported with a protocol that will use a single channel pipette to test whether a pipette can hit key points on your labware"
+              />
+            </Section>
+            <div className={styles.double_check_before_exporting}>
+              <p>DOUBLE CHECK YOUR WORK BEFORE EXPORTING!</p>
+              <p>
+                If you are not comfortable reading a JSON labware definition
+                then consider noting down the values you put in these fields.
+                You will not be able to re-import your file back into the
+                labware creator to read or edit it.
+              </p>
             </div>
-          )}
-        </Formik>
-      </div>
+            <div>
+              <PrimaryButton
+                className={styles.export_button}
+                onClick={() => {
+                  if (!isValid && !showExportErrorModal) {
+                    setShowExportErrorModal(true)
+                  }
+                  handleSubmit()
+                }}
+              >
+                EXPORT FILE
+              </PrimaryButton>
+            </div>
+          </div>
+        )}
+      </Formik>
     </LabwareCreator>
   )
 }

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -1,27 +1,42 @@
 @import '@opentrons/components';
+@import '../styles/breakpoints.css';
 
 .labware_creator {
   @apply --font-body-2-dark;
 
-  max-width: 60rem;
+  max-width: 50rem;
   margin: 1rem auto;
+  padding: 1rem;
 
   & p {
     margin: 1rem 0;
     line-height: var(--lh-copy);
   }
 
+  & a,
+  & a:visited {
+    color: var(--c-blue);
+  }
+
   & ul {
-    list-style: disc inside;
+    list-style: disc;
+    padding-left: 1.25rem;
+    line-height: var(--lh-copy);
+  }
+
+  & li {
+    line-height: var(--lh-copy);
+    padding-bottom: 0.5rem;
   }
 
   & strong {
     font-weight: var(--fw-semibold);
   }
+}
 
-  & h2 {
-    @apply --font-header-dark;
-  }
+/* TODO (ka 2019-8-23): Removed nesting here to allow for easier style overrides/reduce specificity */
+h2 {
+  @apply --font-header-dark;
 }
 
 .double_check_before_exporting {
@@ -40,4 +55,52 @@
 
 .export_button {
   max-width: 20rem;
+}
+
+.callout {
+  padding: 0 0.75rem;
+  border-radius: 0.5rem;
+  border: var(--bd-light);
+  margin-bottom: 2rem;
+}
+
+.setup_heading {
+  border: none;
+  font-weight: var(--fw-regular);
+}
+
+.flex_row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 1rem 0;
+}
+
+.new_definition_section,
+.upload_exisiting_section {
+  flex-basis: 100%;
+  flex-shrink: 0;
+}
+
+.new_definition_content {
+  padding-top: 1rem;
+}
+
+.upload_exisiting_section {
+  min-height: 19rem;
+}
+
+@media (--medium) {
+  .new_definition_section {
+    flex-basis: 45%;
+    flex-shrink: 1;
+    padding-right: 2rem;
+    border-right: var(--bd-light);
+  }
+
+  .upload_exisiting_section {
+    padding: 1rem;
+    flex-shrink: 1;
+    padding-right: 0;
+    flex-basis: 55%;
+  }
 }

--- a/labware-library/src/styles/spacing.css
+++ b/labware-library/src/styles/spacing.css
@@ -34,6 +34,7 @@
 
   /* main navigation specific width and height sizes */
   --size-subdomain-nav: 2rem; /* 32px */
+  --size-breadcrumb-nav: 3rem; /* 48px */
   --size-main-nav: 5rem; /* 80px */
   --size-mobile-nav: 4rem; /* 64px */
   --size-total-nav: calc(var(--size-subdomain-nav) + var(--size-main-nav));


### PR DESCRIPTION
## overview

addresses #3910

This PR 
- Adds the website main nav from LL to LC page
- Adds breadcrumb nav to LC page
- Adds some initial responsive styling to the 'landing page' content with a placeholder for upload section 

## changelog

- feat: Add main navigation to labware creator page
- refactor: Update breadcrumbs to accept a creator boolean (to render on LC page)
- refactor: Initial responsive styling for LC landing content
- refactor: Placeholder div for upload

## review requests

- [ ] Breadcrumb in LL is not affected
- [ ] Main nav renders in LC
- [ ] Breadcrumbs render in LC

Happy to have a convo now before we get to far about what styles live where!
