### PR TITLE
fix(api): check instrument name or type, allow gen2's

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -258,27 +258,53 @@ class API(HardwareAPILike):
 
     @_log_call
     async def cache_instruments(self,
-                                require: Dict[top_types.Mount, str] = None):
+                                require:
+                                Dict[top_types.Mount, str] = {}):
         """
          - Get the attached instrument on each mount and
          - Cache their pipette configs from pipette-config.json
 
-        If specified, the require element should be a dict of mounts to
-        instrument models describing the instruments expected to be present.
-        This can save a subsequent of :py:attr:`attached_instruments` and also
-        serves as the hook for the hardware simulator to decide what is
-        attached.
+        :param require: If specified, the
+                                        require should
+                                        be a dict of mounts to instrument
+                                        identifier describing the instruments
+                                        expected to be present. This identifier
+                                        can be either an instrument name or
+                                        the more specific instrument model
+                                        string (e.g. 'p10_single' or
+                                        'p10_single_v1.3') This can save a
+                                        subsequent of
+                                        :py:attr:`attached_instruments` and
+                                        also serves as the hook for the
+                                        hardware simulator to decide what is
+                                        attached.
+        :raises RuntimeError: If an instrument is expected but not found.
+
         """
-        checked_require = require or {}
         self._log.info("Updating instrument model cache")
-        found = self._backend.get_attached_instruments(checked_require)
+        found = self._backend.get_attached_instruments(require or {})
         for mount, instrument_data in found.items():
             model = instrument_data.get('model')
+
+            req_instr = require.get(mount, None)
+            if req_instr and not model and not self.is_simulator_sync:
+                raise RuntimeError(
+                    f'mount {mount}: instrument {req_instr} was'
+                    f' requested, but no instrument is present')
+
             if model is not None:
                 p = Pipette(
                     model,
                     self._config.instrument_offset[mount.name.lower()],
                     instrument_data['id'])
+
+                if req_instr and not (
+                        req_instr == p.config.name or req_instr == model) and (
+                        not self.is_simulator_sync):
+                    raise RuntimeError(f'mount {mount}: instrument'
+                                       f' {req_instr} was requested'
+                                       f' but {p.config.name} is present')
+
                 self._attached_instruments[mount] = p
                 home_pos = p.config.home_position
                 max_travel = p.config.max_travel
@@ -288,6 +314,7 @@ class API(HardwareAPILike):
                 home_pos = self._config.default_pipette_configs['homePosition']
                 max_travel = self._config.default_pipette_configs['maxTravel']
                 steps_mm = self._config.default_pipette_configs['stepsPerMM']
+
             mount_axis = Axis.by_mount(mount)
             plunger_axis = Axis.of_plunger(mount)
             self._backend._smoothie_driver.update_steps_per_mm(
@@ -665,6 +692,7 @@ class API(HardwareAPILike):
         else:
             offset = top_types.Point(0, 0, 0)
         cp = self._critical_point_for(mount, critical_point)
+
         target_position = OrderedDict(
             ((Axis.X, abs_position.x - offset.x - cp.x),
              (Axis.Y, abs_position.y - offset.y - cp.y),

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -20,6 +20,7 @@ class _Locker:
 
     There should be one instance of this per process.
     """
+
     def __init__(self, force=False):
         global _lock
 
@@ -107,20 +108,15 @@ class Controller:
         return self._smoothie_driver.fast_home(axis, margin)
 
     def get_attached_instruments(
-            self, expected: Dict[Mount, str])\
+            self, _expected: Dict[Mount, str])\
             -> Dict[Mount, Dict[str, Optional[str]]]:
         """ Find the instruments attached to our mounts.
+        :param _expected: is ignored, it is just meant to enforce
+                          the same interface as the simulator, where
+                          required instruments can be manipulated.
 
-        :param expected: A dict that may contain a mapping from mount to
-                         strings that should prefix instrument model names.
-                         When instruments are scanned, they are matched
-                         against the expectation (if present) and a
-                         :py:attr:`RuntimeError` is raised if there is no
-                         match.
-
-        :raises RuntimeError: If an instrument is expected but not found.
         :returns: A dict with mounts as the top-level keys. Each mount value is
-            a dict with keys 'mount' (containing an instrument model name or
+            a dict with keys 'model' (containing an instrument model name or
             `None`) and 'id' (containing the serial number of the pipette
             attached to that mount, or `None`).
         """
@@ -130,12 +126,6 @@ class Controller:
                 mount.name.lower())
             found_id = self._smoothie_driver.read_pipette_id(
                 mount.name.lower())
-            expected_instr = expected.get(mount, None)
-            if expected_instr and\
-               (not found_model or not found_model.startswith(expected_instr)):
-                raise RuntimeError(
-                    'mount {}: instrument {} was requested but {} is present'
-                    .format(mount.name, expected_instr, found_model))
             to_return[mount] = {
                 'model': found_model,
                 'id': found_id}
@@ -201,7 +191,7 @@ class Controller:
     @property
     def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos+.05) for ax, pos
+        return {ax: (0, pos + .05) for ax, pos
                 in self._smoothie_driver.homed_position.items()
                 if ax not in 'BC'}
 

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -82,6 +82,7 @@ class Pipette:
         we have a tip, or :py:attr:`CriticalPoint.XY_CENTER` - the specified
         critical point will be used.
         """
+
         if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE
             tip_length = 0.0

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -39,6 +39,7 @@ class Simulator:
     hardware actions. It is suitable for use on a dev machine or on
     a robot with no smoothie connected.
     """
+
     def __init__(
             self,
             attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
@@ -211,7 +212,7 @@ class Simulator:
     @property
     def axis_bounds(self) -> Dict[str, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {ax: (0, pos+0.5) for ax, pos in _HOME_POSITION.items()
+        return {ax: (0, pos + 0.5) for ax, pos in _HOME_POSITION.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -23,7 +23,7 @@ def plan_moves(
         to_loc: types.Location,
         deck: 'Deck',
         well_z_margin: float = 5.0,
-        lw_z_margin: float = 20.0,
+        lw_z_margin: float = 5.0,
         force_direct: bool = False,
         minimum_z_height: float = None)\
         -> List[Tuple[types.Point,

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -9,7 +9,7 @@ from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, adapters
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
-from opentrons.config.pipette_config import config_models
+from opentrons.config.pipette_config import config_models, name_for_model
 from opentrons.protocol_api import transfers as tf
 
 import pytest
@@ -29,12 +29,12 @@ def get_labware_def(monkeypatch):
 
 def test_load_instrument(loop):
     ctx = papi.ProtocolContext(loop=loop)
-    for config in config_models:
-        loaded = ctx.load_instrument(config, Mount.LEFT, replace=True)
-        assert loaded.model == config
-        prefix = config.split('_v')[0]
-        loaded = ctx.load_instrument(prefix, Mount.RIGHT, replace=True)
-        assert loaded.name.startswith(prefix)
+    for model in config_models:
+        loaded = ctx.load_instrument(model, Mount.LEFT, replace=True)
+        assert loaded.model == model
+        instr_name = name_for_model(model)
+        loaded = ctx.load_instrument(instr_name, Mount.RIGHT, replace=True)
+        assert loaded.name == instr_name
 
 
 async def test_motion(loop):


### PR DESCRIPTION
Move the pipette type matching logic into the hardware controller init for a run. Furthermore, check
that the specified instruments name or model matches the attached instrument instead of more flimsy string checking which was causing errors with gen2 pipettes.

## review requests

<!--
  Describe any requests for your reviewers here.
-->

- loading instruments by name (e.g. `protocol.load_instrument('p1000_single_gen2` or `protocol.load_instrument('p1000_single`)

- loading instruments by model on a robot (e.g. `protocol.load_instrument('p1000_single_v2.0` or `protocol.load_instrument('p1000_single_v1`)