### PR TITLE
fix(shared-data): fix labware display name; change python file

### DIFF
--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -328,7 +328,7 @@ const App = () => {
           const zip = new JSZip()
           zip.file(`${displayName}.json`, JSON.stringify(def, null, 4))
           zip.file(
-            `calibrate_${displayName}.py`,
+            `test_${displayName}.py`,
             labwareTestProtocol({ pipetteName, definition: def })
           )
           zip

--- a/shared-data/js/labwareTools/__tests__/createDefaultDisplayName.test.js
+++ b/shared-data/js/labwareTools/__tests__/createDefaultDisplayName.test.js
@@ -1,0 +1,103 @@
+import { createDefaultDisplayName } from '../index'
+
+describe('createDefaultDisplayName', () => {
+  const testCases = [
+    {
+      testName: 'minimal case',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+      },
+      expected: 'Generic 6 Well Plate 123 µL',
+    },
+    {
+      testName: 'decimal in volume',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 12.3,
+      },
+      expected: 'Generic 6 Well Plate 12.3 µL',
+    },
+    {
+      testName: 'calculate wells = rows x cols',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 8,
+        gridColumns: 10,
+        totalLiquidVolume: 123,
+      },
+      expected: 'Generic 80 Well Plate 123 µL',
+    },
+    {
+      testName: 'tube rack (example of a different displayCategory)',
+      args: {
+        displayCategory: 'tubeRack',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+      },
+      expected: 'Generic 6 Tube Rack 123 µL',
+    },
+    {
+      testName: 'should append loadNamePostfix',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+        loadNamePostfix: ['spam  ', ' blah', 'PCR'],
+      },
+      expected: 'Generic 6 Well Plate 123 µL Spam Blah PCR',
+    },
+    {
+      testName: 'support brand name when specified (ignore extra whitespace)',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+        brandName: ' cool  brand ',
+      },
+      expected: 'Cool Brand 6 Well Plate 123 µL',
+    },
+    {
+      testName: 'support brand name when specified (capitalization)',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'µL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+        brandName: ' BIO tech',
+      },
+      expected: 'BIO Tech 6 Well Plate 123 µL',
+    },
+    {
+      testName: 'support mL when specified (volume number always in µL!)',
+      args: {
+        displayCategory: 'wellPlate',
+        displayVolumeUnits: 'mL',
+        gridRows: 2,
+        gridColumns: 3,
+        totalLiquidVolume: 123,
+      },
+      expected: 'Generic 6 Well Plate 0.123 mL',
+    },
+  ]
+
+  testCases.forEach(({ testName, args, expected }) => {
+    test(testName, () => {
+      expect(createDefaultDisplayName(args)).toEqual(expected)
+    })
+  })
+})

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -280,10 +280,7 @@ type RegularNameProps = {
   loadNamePostfix?: Array<string>,
 }
 
-function _createNameWithJoin(
-  args: RegularNameProps,
-  joinFn: (Array<string | number | Array<string | number>>) => string
-): string {
+export function createRegularLoadName(args: RegularNameProps): string {
   const {
     gridRows,
     gridColumns,
@@ -294,7 +291,7 @@ function _createNameWithJoin(
     loadNamePostfix = [],
   } = args
   const numWells = gridRows * gridColumns
-  return joinFn([
+  return joinLoadName([
     brandName,
     numWells,
     displayCategory,
@@ -306,20 +303,35 @@ function _createNameWithJoin(
   ])
 }
 
-export function createRegularLoadName(args: RegularNameProps): string {
-  return _createNameWithJoin(args, joinLoadName)
+const capitalize = (_s: string): string => {
+  const s = _s.trim()
+  return `${s.slice(0, 1).toUpperCase()}${s.slice(1)}`
 }
 
+// TODO: Ian 2019-08-23 consider using this in the labware creation functions instead of manually entering displayName
 export function createDefaultDisplayName(args: RegularNameProps): string {
-  return _createNameWithJoin(args, arr =>
-    flatten(arr)
-      .map(i => {
-        const subs = String(i)
-        return `${subs.slice(0, 1).toUpperCase()}${subs.slice(1)}`.trim()
-      })
-      .filter(s => s !== '')
-      .join(' ')
-  )
+  const {
+    gridRows,
+    gridColumns,
+    displayCategory,
+    totalLiquidVolume,
+    displayVolumeUnits,
+    brandName = DEFAULT_BRAND_NAME,
+    loadNamePostfix = [],
+  } = args
+  const numWells = gridRows * gridColumns
+  return [
+    ...brandName.split(' ').map(capitalize),
+    numWells,
+    capitalize(displayCategory.replace(/([a-z])([A-Z])/g, '$1 $2')),
+    getDisplayVolume(totalLiquidVolume, displayVolumeUnits),
+    displayVolumeUnits,
+    ...loadNamePostfix.map(capitalize),
+  ]
+    .filter(s => s !== '')
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 // Generator function for labware definitions within a regular grid format


### PR DESCRIPTION
## overview

## changelog

- name the Python file saved in the zip test_{displayName}.py instead of calibrate_{displayName}.py
- fix displayName generation and add tests

## review requests

- python file starts with test_ instead of calibrate_?
- auto-generated display name correctly matches our conventions (fill in fields to see the value) 

Our display name convention is: `[brand]_[num_wells]_[format]_[total_volume]_[volume_units]_[optional modifiers]`

NOTE: we have a variant for tube rack / aluminum block, but since we don't have a place in LC to enter 2 different brands, I'm ignoring it for now. OK with you all? The variant would be `[brand]_[num_wells]_[format]_[tube_brand]_[total_volume]_[volume_units]_[optional modifiers]`