### PR TITLE
feat(labware-creator): upload labware definitions to LC

### DIFF
--- a/labware-library/package.json
+++ b/labware-library/package.json
@@ -16,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentrons/components": "3.10.2",
+    "ajv": "^6.2.1",
     "classnames": "^2.2.5",
     "file-saver": "^2.0.1",
     "formik": "^1.5.8",

--- a/labware-library/src/__mocks__/definitions.js
+++ b/labware-library/src/__mocks__/definitions.js
@@ -28,6 +28,22 @@ export const getAllLoadNames = jest.fn<Array<void>, Array<string>>(
   () => allLoadNames
 )
 
+const allDisplayNames = uniq(
+  glob
+    .sync(LABWARE_FIXTURE_PATTERN)
+    .map(require)
+    .map(def => def.metadata.displayName)
+)
+
+assert(
+  allDisplayNames.length > 0,
+  `no labware displayNames found, something broke. ${LABWARE_FIXTURE_PATTERN}`
+)
+
+export const getAllDisplayNames = jest.fn<Array<void>, Array<string>>(
+  () => allDisplayNames
+)
+
 const allLabware = glob
   .sync(LABWARE_FIXTURE_PATTERN)
   .map(require)

--- a/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
+++ b/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
@@ -57,7 +57,7 @@ Array [
     "xOffsetFromLeft": 15,
     "xSpacing": 10,
     "yOffsetFromTop": 70.48,
-    "ySpacing": null,
+    "ySpacing": 0,
   },
 ]
 `;

--- a/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
+++ b/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getUniqueWellProperties fixture_96_plate 1`] = `
+Array [
+  Object {
+    "brand": Object {
+      "brand": "generic",
+      "brandId": Array [],
+    },
+    "depth": 10.54,
+    "metadata": Object {
+      "displayCategory": "wellPlate",
+      "displayName": "ANSI 96 Standard Microplate",
+      "wellBottomShape": "flat",
+    },
+    "shape": Object {
+      "diameter": 6.4,
+      "shape": "circular",
+    },
+    "totalLiquidVolume": 380,
+    "wellCount": 96,
+    "xOffsetFromLeft": 14.38,
+    "xSpacing": 9,
+    "yOffsetFromTop": 11.240000000000009,
+    "ySpacing": 9,
+  },
+]
+`;
+
+exports[`getUniqueWellProperties fixture_irregular_example_1 1`] = `
+Array [
+  Object {
+    "brand": null,
+    "depth": 10.54,
+    "metadata": Object {},
+    "shape": Object {
+      "diameter": 10,
+      "shape": "circular",
+    },
+    "totalLiquidVolume": 3000,
+    "wellCount": 50,
+    "xOffsetFromLeft": 10,
+    "xSpacing": 10,
+    "yOffsetFromTop": 55.480000000000004,
+    "ySpacing": 5,
+  },
+  Object {
+    "brand": null,
+    "depth": 20.54,
+    "metadata": Object {},
+    "shape": Object {
+      "diameter": 15,
+      "shape": "circular",
+    },
+    "totalLiquidVolume": 10000,
+    "wellCount": 5,
+    "xOffsetFromLeft": 15,
+    "xSpacing": 10,
+    "yOffsetFromTop": 70.48,
+    "ySpacing": null,
+  },
+]
+`;

--- a/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
+++ b/labware-library/src/__tests__/__snapshots__/labwareInference.test.js.snap
@@ -21,7 +21,7 @@ Array [
     "wellCount": 96,
     "xOffsetFromLeft": 14.38,
     "xSpacing": 9,
-    "yOffsetFromTop": 11.240000000000009,
+    "yOffsetFromTop": 11.24,
     "ySpacing": 9,
   },
 ]
@@ -41,7 +41,7 @@ Array [
     "wellCount": 50,
     "xOffsetFromLeft": 10,
     "xSpacing": 10,
-    "yOffsetFromTop": 55.480000000000004,
+    "yOffsetFromTop": 55.48,
     "ySpacing": 5,
   },
   Object {

--- a/labware-library/src/__tests__/labwareInference.test.js
+++ b/labware-library/src/__tests__/labwareInference.test.js
@@ -1,0 +1,98 @@
+// @flow
+import fixture96Plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate'
+import fixtureIrregular from '@opentrons/shared-data/labware/fixtures/2/fixture_irregular_example_1'
+import {
+  getIfConsistent,
+  getSpacingIfUniform,
+  getUniqueWellProperties,
+} from '../labwareInference'
+
+describe('getSpacingIfUniform', () => {
+  const testCases = [
+    {
+      testLabel: '2 well case',
+      wells: [{ x: 10 }, { x: 20 }],
+      expected: 10,
+    },
+    {
+      testLabel: '2 well case: 0 spacing',
+      wells: [{ x: 10 }, { x: 10 }],
+      expected: null,
+    },
+    {
+      testLabel: '3 well case',
+      wells: [{ x: 0 }, { x: 25 }, { x: 50 }],
+      expected: 25,
+    },
+    {
+      testLabel: '3 well case: out of order is non-uniform, return null',
+      wells: [{ x: 50 }, { x: 0 }, { x: 25 }],
+      expected: null,
+    },
+    {
+      testLabel: '3 well case: zero spacing, return null',
+      wells: [{ x: 25 }, { x: 25 }, { x: 25 }],
+      expected: null,
+    },
+    {
+      testLabel: '3 well case: non-uniform with some duplicate values',
+      wells: [
+        { x: 0 },
+        { x: 25 },
+        { x: 25, spam: 'spam' },
+        { x: 50 },
+        { x: 50, foo: 'foo' },
+      ],
+      expected: 25,
+    },
+    {
+      testLabel: 'returns null if wells have irregular spacing',
+      wells: [{ x: 10 }, { x: 20 }, { x: 21 }],
+      expected: null,
+    },
+    {
+      testLabel: 'returns null if only 1 well across axis',
+      wells: [{ x: 10 }],
+      expected: null,
+    },
+    {
+      testLabel: 'returns null with no wells',
+      wells: [],
+      expected: null,
+    },
+  ]
+  testCases.forEach(({ wells, expected, testLabel }) =>
+    test(testLabel, () =>
+      expect(getSpacingIfUniform((wells: Array<any>), 'x')).toBe(expected)
+    )
+  )
+})
+
+describe('getIfConsistent', () => {
+  test('deep equal', () => {
+    const items = [
+      { a: 123, b: [1, 2, [3]] },
+      { a: 123, b: [1, 2, [3]] },
+      { a: 123, b: [1, 2, [3]] },
+    ]
+    expect(getIfConsistent(items)).toEqual(items[0])
+  })
+
+  test('deep difference', () => {
+    const items = [
+      { a: 123, b: [1, 2, [3]] },
+      { a: 123, b: [1, 2, [999999]] },
+      { a: 123, b: [1, 2, [3]] },
+    ]
+    expect(getIfConsistent(items)).toBe(null)
+  })
+})
+
+describe('getUniqueWellProperties', () => {
+  const defs = [fixture96Plate, fixtureIrregular]
+  defs.forEach(def =>
+    test(def.parameters.loadName, () => {
+      expect(getUniqueWellProperties(def)).toMatchSnapshot()
+    })
+  )
+})

--- a/labware-library/src/__tests__/labwareInference.test.js
+++ b/labware-library/src/__tests__/labwareInference.test.js
@@ -10,14 +10,20 @@ import {
 describe('getSpacingIfUniform', () => {
   const testCases = [
     {
+      testLabel: '1 well case: return 0',
+      wells: [{ x: 10 }],
+      expected: 0,
+    },
+    {
       testLabel: '2 well case',
       wells: [{ x: 10 }, { x: 20 }],
       expected: 10,
     },
     {
-      testLabel: '2 well case: 0 spacing',
+      testLabel:
+        '2 well case with overlapping wells (eg, single-column labware): return 0',
       wells: [{ x: 10 }, { x: 10 }],
-      expected: null,
+      expected: 0,
     },
     {
       testLabel: '3 well case',
@@ -25,13 +31,14 @@ describe('getSpacingIfUniform', () => {
       expected: 25,
     },
     {
-      testLabel: '3 well case: out of order is non-uniform, return null',
-      wells: [{ x: 50 }, { x: 0 }, { x: 25 }],
-      expected: null,
+      testLabel:
+        '3 well case with overlapping wells (eg, single-column labware): return 0',
+      wells: [{ x: 10 }, { x: 10 }, { x: 10 }],
+      expected: 0,
     },
     {
-      testLabel: '3 well case: zero spacing, return null',
-      wells: [{ x: 25 }, { x: 25 }, { x: 25 }],
+      testLabel: '3 well case: out of order is non-uniform, return null',
+      wells: [{ x: 50 }, { x: 0 }, { x: 25 }],
       expected: null,
     },
     {
@@ -51,14 +58,9 @@ describe('getSpacingIfUniform', () => {
       expected: null,
     },
     {
-      testLabel: 'returns null if only 1 well across axis',
-      wells: [{ x: 10 }],
-      expected: null,
-    },
-    {
-      testLabel: 'returns null with no wells',
+      testLabel: 'returns 0 with no wells',
       wells: [],
-      expected: null,
+      expected: 0,
     },
   ]
   testCases.forEach(({ wells, expected, testLabel }) =>

--- a/labware-library/src/components/LabwareDetails/InsertDetails.js
+++ b/labware-library/src/components/LabwareDetails/InsertDetails.js
@@ -2,7 +2,7 @@
 // full-width labware details
 import * as React from 'react'
 
-import { getUniqueWellProperties } from '../../definitions'
+import { getUniqueWellProperties } from '../../labwareInference'
 import { getWellLabel, WellProperties, ManufacturerStats } from '../labware-ui'
 import { DetailsBox } from '../ui'
 import WellDimensions from './WellDimensions'

--- a/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
+++ b/labware-library/src/components/LabwareDetails/LabwareDetailsBox.js
@@ -2,7 +2,7 @@
 // full-width labware details
 import * as React from 'react'
 
-import { getUniqueWellProperties } from '../../definitions'
+import { getUniqueWellProperties } from '../../labwareInference'
 import {
   getWellLabel,
   WellCount,

--- a/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
+++ b/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.js.snap
@@ -25,7 +25,15 @@ exports[`LabwareList component renders 1`] = `
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "USA Scientific",
+              "brandId": Array [
+                "1061-8150",
+              ],
+            },
             "metadata": Object {
+              "displayCategory": "reservoir",
+              "displayName": "12 Channel Trough",
               "wellBottomShape": "v",
             },
             "wells": Array [
@@ -4909,7 +4917,13 @@ exports[`LabwareList component renders 1`] = `
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "generic",
+              "brandId": Array [],
+            },
             "metadata": Object {
+              "displayCategory": "wellPlate",
+              "displayName": "ANSI 96 Standard Microplate",
               "wellBottomShape": "flat",
             },
             "wells": Array [

--- a/labware-library/src/components/labware-ui/WellProperties.js
+++ b/labware-library/src/components/labware-ui/WellProperties.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { Icon } from '@opentrons/components'
 import { getDisplayVolume } from '@opentrons/shared-data'
-import { getUniqueWellProperties } from '../../definitions'
+import { getUniqueWellProperties } from '../../labwareInference'
 import {
   MAX_VOLUME,
   SHAPE,

--- a/labware-library/src/definitions.js
+++ b/labware-library/src/definitions.js
@@ -3,13 +3,8 @@
 // TODO(mc, 2019-03-18): move to shared-data?
 import * as React from 'react'
 import { Route } from 'react-router-dom'
-import isEqual from 'lodash/isEqual'
 import groupBy from 'lodash/groupBy'
 import uniq from 'lodash/uniq'
-import uniqBy from 'lodash/uniqBy'
-import uniqWith from 'lodash/uniqWith'
-import round from 'lodash/round'
-import orderBy from 'lodash/orderBy'
 import {
   LABWAREV2_DO_NOT_LIST,
   type LabwareDefinition2,
@@ -17,13 +12,7 @@ import {
 import { getPublicPath } from './public-path'
 
 import type { ContextRouter } from 'react-router-dom'
-import type {
-  LabwareList,
-  LabwareWell,
-  LabwareWellShapeProperties,
-  LabwareWellGroupProperties,
-  LabwareDefinition,
-} from './types'
+import type { LabwareList, LabwareDefinition } from './types'
 
 // require all definitions in the labware/definitions/2 directory
 // require.context is webpack-specific method
@@ -88,69 +77,6 @@ export function getAllDefinitions(): LabwareList {
 export function getDefinition(loadName: ?string): LabwareDefinition | null {
   const def = getAllDefinitions().find(d => d.parameters.loadName === loadName)
   return def || null
-}
-
-export function getUniqueWellProperties(
-  definition: LabwareDefinition
-): Array<LabwareWellGroupProperties> {
-  const { groups, wells, dimensions } = definition
-
-  return groups.map(group => {
-    const wellProps = orderBy(
-      group.wells.map(n => wells[n]),
-      ['x', 'y'],
-      ['asc', 'desc']
-    )
-    const wellDepths = wellProps.map<number>(w => w.depth)
-    const wellVolumes = wellProps.map<number>(w => w.totalLiquidVolume)
-    const wellShapes = wellProps.map<LabwareWellShapeProperties>(
-      (well: LabwareWell) =>
-        well.shape === 'circular'
-          ? { shape: well.shape, diameter: well.diameter }
-          : {
-              shape: well.shape,
-              xDimension: well.xDimension,
-              yDimension: well.yDimension,
-            }
-    )
-
-    const xStart = wellProps[0].x
-    const yStart = wellProps[0].y
-
-    return {
-      metadata: group.metadata,
-      brand: group.brand || null,
-      xSpacing: getSpacing(wellProps, 'x'),
-      ySpacing: getSpacing(wellProps, 'y'),
-      xOffsetFromLeft: xStart,
-      yOffsetFromTop: dimensions.yDimension - yStart,
-      wellCount: wellProps.length,
-      depth: getIfConsistent(wellDepths),
-      totalLiquidVolume: getIfConsistent(wellVolumes),
-      shape: getIfConsistent(wellShapes),
-    }
-  })
-}
-
-function getIfConsistent<T>(items: Array<T>): T | null {
-  return uniqWith(items, isEqual).length === 1 ? items[0] : null
-}
-
-function getSpacing(wells: Array<LabwareWell>, axis: 'x' | 'y'): number | null {
-  return uniqBy<LabwareWell>(wells, axis).reduce<number | null>(
-    (spacing, well, index, uniqueWells) => {
-      if (index > 0) {
-        const prev = uniqueWells[index - 1]
-        const currentSpacing = Math.abs(round(well[axis] - prev[axis], 2))
-
-        return spacing === 0 || spacing === currentSpacing
-          ? currentSpacing
-          : null
-      }
-      return spacing
-    },
-    0
-  )
 }
 
 export type DefinitionRouteRenderProps = {|

--- a/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.js.snap
+++ b/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.js.snap
@@ -16,7 +16,7 @@ Object {
   "gridSpacingX": "9.09",
   "gridSpacingY": null,
   "homogeneousWells": "true",
-  "labwareType": null,
+  "labwareType": "reservoir",
   "labwareZDimension": "44.45",
   "loadName": "fixture_12_trough",
   "pipetteName": null,

--- a/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.js.snap
+++ b/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`labwareDefToFields fixture_12_trough 1`] = `
+Object {
+  "aluminumBlockChildType": null,
+  "aluminumBlockType": null,
+  "brand": "USA Scientific",
+  "brandId": "1061-8150",
+  "displayName": "12 Channel Trough",
+  "footprintXDimension": "127.76",
+  "footprintYDimension": "85.8",
+  "gridColumns": "12",
+  "gridOffsetX": "13.94",
+  "gridOffsetY": "42.9",
+  "gridRows": "1",
+  "gridSpacingX": "9.09",
+  "gridSpacingY": null,
+  "homogeneousWells": "true",
+  "labwareType": null,
+  "labwareZDimension": "44.45",
+  "loadName": "fixture_12_trough",
+  "pipetteName": null,
+  "regularColumnSpacing": "true",
+  "regularRowSpacing": "true",
+  "tubeRackInsertLoadName": null,
+  "wellBottomShape": "v",
+  "wellDepth": "42.16",
+  "wellDiameter": null,
+  "wellShape": "rectangular",
+  "wellVolume": "22000",
+  "wellXDimension": "8.33",
+  "wellYDimension": "71.88",
+}
+`;

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
@@ -1,0 +1,59 @@
+// @flow
+import labwareDefToFields from '../labwareDefToFields'
+import fixtureRegularExample1 from '@opentrons/shared-data/labware/fixtures/2/fixture_regular_example_1'
+import fixtureIrregularExample1 from '@opentrons/shared-data/labware/fixtures/2/fixture_irregular_example_1'
+
+jest.mock('../../definitions')
+
+describe('labwareDefToFields', () => {
+  test('fixture_regular_example_1', () => {
+    const def = fixtureRegularExample1
+    const result = labwareDefToFields(def)
+    expect(result).toEqual({
+      labwareType: null,
+      tubeRackInsertLoadName: null,
+      aluminumBlockType: null,
+      aluminumBlockChildType: null,
+
+      footprintXDimension: String(def.dimensions.xDimension),
+      footprintYDimension: String(def.dimensions.yDimension),
+      labwareZDimension: String(def.dimensions.zDimension),
+
+      gridRows: '1',
+      gridColumns: '2',
+      gridSpacingX: '10',
+      gridSpacingY: null, // only single row, no Y spacing
+      gridOffsetX: '10',
+      gridOffsetY: '75.48',
+
+      homogeneousWells: 'true',
+      regularRowSpacing: 'true',
+      regularColumnSpacing: 'true',
+
+      wellVolume: '100',
+      wellBottomShape: null, // TODO IMMEDIATELY: rethink this field?
+      wellDepth: '40',
+      wellShape: 'circular',
+
+      wellDiameter: '30',
+
+      // used with rectangular well shape only
+      wellXDimension: null,
+      wellYDimension: null,
+
+      brand: 'opentrons',
+      brandId: 't40u9sernisofsea',
+
+      loadName: def.parameters.loadName,
+      displayName: def.metadata.displayName,
+
+      pipetteName: null,
+    })
+  })
+
+  test('fixture_irregular_example_1 should return null (not yet supported)', () => {
+    const def = fixtureIrregularExample1
+    const result = labwareDefToFields(def)
+    expect(result).toEqual(null)
+  })
+})

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
@@ -11,7 +11,7 @@ describe('labwareDefToFields', () => {
     const def = fixture96Plate
     const result = labwareDefToFields(def)
     expect(result).toEqual({
-      labwareType: null,
+      labwareType: 'wellPlate',
       tubeRackInsertLoadName: null,
       aluminumBlockType: null,
       aluminumBlockChildType: null,
@@ -57,6 +57,7 @@ describe('labwareDefToFields', () => {
     const def = fixture12Trough
     const result = labwareDefToFields(def)
 
+    expect(result?.labwareType).toEqual('reservoir')
     expect(result?.gridSpacingY).toBe(null) // single row -> null Y-spacing
     expect(result?.wellDiameter).toBe(null)
     expect(result).toMatchSnapshot()

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
@@ -1,13 +1,14 @@
 // @flow
 import labwareDefToFields from '../labwareDefToFields'
-import fixtureRegularExample1 from '@opentrons/shared-data/labware/fixtures/2/fixture_regular_example_1'
+import fixture96Plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate'
+import fixture12Trough from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough'
 import fixtureIrregularExample1 from '@opentrons/shared-data/labware/fixtures/2/fixture_irregular_example_1'
 
 jest.mock('../../definitions')
 
 describe('labwareDefToFields', () => {
-  test('fixture_regular_example_1', () => {
-    const def = fixtureRegularExample1
+  test('fixture_96_plate', () => {
+    const def = fixture96Plate
     const result = labwareDefToFields(def)
     expect(result).toEqual({
       labwareType: null,
@@ -19,30 +20,30 @@ describe('labwareDefToFields', () => {
       footprintYDimension: String(def.dimensions.yDimension),
       labwareZDimension: String(def.dimensions.zDimension),
 
-      gridRows: '1',
-      gridColumns: '2',
-      gridSpacingX: '10',
-      gridSpacingY: null, // only single row, no Y spacing
-      gridOffsetX: '10',
-      gridOffsetY: '75.48',
+      gridRows: '8',
+      gridColumns: '12',
+      gridSpacingX: '9',
+      gridSpacingY: '9',
+      gridOffsetX: String(def.wells.A1.x),
+      gridOffsetY: '11.24',
 
       homogeneousWells: 'true',
       regularRowSpacing: 'true',
       regularColumnSpacing: 'true',
 
-      wellVolume: '100',
-      wellBottomShape: null, // TODO IMMEDIATELY: rethink this field?
-      wellDepth: '40',
+      wellVolume: '380',
+      wellBottomShape: 'flat',
+      wellDepth: '10.54',
       wellShape: 'circular',
 
-      wellDiameter: '30',
+      wellDiameter: String(def.wells.A1.diameter),
 
       // used with rectangular well shape only
       wellXDimension: null,
       wellYDimension: null,
 
-      brand: 'opentrons',
-      brandId: 't40u9sernisofsea',
+      brand: 'generic',
+      brandId: null,
 
       loadName: def.parameters.loadName,
       displayName: def.metadata.displayName,
@@ -51,7 +52,17 @@ describe('labwareDefToFields', () => {
     })
   })
 
-  test('fixture_irregular_example_1 should return null (not yet supported)', () => {
+  test('fixture_12_trough', () => {
+    // make sure rectangular wells + single row works as expected
+    const def = fixture12Trough
+    const result = labwareDefToFields(def)
+
+    expect(result.gridSpacingY).toBe(null) // single row -> null Y-spacing
+    expect(result.wellDiameter).toBe(null)
+    expect(result).toMatchSnapshot()
+  })
+
+  test('fixture_irregular_example_1 should return null (until multi-grid labware is supported in LC)', () => {
     const def = fixtureIrregularExample1
     const result = labwareDefToFields(def)
     expect(result).toEqual(null)

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.js
@@ -57,8 +57,8 @@ describe('labwareDefToFields', () => {
     const def = fixture12Trough
     const result = labwareDefToFields(def)
 
-    expect(result.gridSpacingY).toBe(null) // single row -> null Y-spacing
-    expect(result.wellDiameter).toBe(null)
+    expect(result?.gridSpacingY).toBe(null) // single row -> null Y-spacing
+    expect(result?.wellDiameter).toBe(null)
     expect(result).toMatchSnapshot()
   })
 

--- a/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
+++ b/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
@@ -15,11 +15,11 @@ describe('load and immediately save integrity test', () => {
   const testCases = [
     {
       inputDef: fixture96Plate,
-      extraFields: { pipetteName, labwareType: 'wellPlate' },
+      extraFields: { pipetteName },
     },
     {
       inputDef: fixture12Trough,
-      extraFields: { pipetteName, labwareType: 'reservoir' },
+      extraFields: { pipetteName },
     },
   ]
   testCases.forEach(({ inputDef, extraFields }) => {

--- a/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
+++ b/labware-library/src/labware-creator/__tests__/loadAndSaveIntegration.test.js
@@ -1,0 +1,62 @@
+// @flow
+import labwareDefToFields from '../labwareDefToFields'
+import fieldsToLabware from '../fieldsToLabware'
+import labwareFormSchema from '../labwareFormSchema'
+import { DEFAULT_CUSTOM_NAMESPACE } from '@opentrons/shared-data'
+import fixture96Plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate'
+import fixture12Trough from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough'
+
+jest.mock('../../definitions')
+
+describe('load and immediately save integrity test', () => {
+  const pipetteName = 'P10_Single'
+  // include "extraFields" that the user would have to set before being able to save a freshly-loaded definition
+  // (without these fields, Yup schema cast would fail)
+  const testCases = [
+    {
+      inputDef: fixture96Plate,
+      extraFields: { pipetteName, labwareType: 'wellPlate' },
+    },
+    {
+      inputDef: fixture12Trough,
+      extraFields: { pipetteName, labwareType: 'reservoir' },
+    },
+  ]
+  testCases.forEach(({ inputDef, extraFields }) => {
+    test(inputDef.parameters.loadName, () => {
+      const rawFieldValues = {
+        ...labwareDefToFields(inputDef),
+        ...extraFields,
+      }
+      const processedFieldValues = labwareFormSchema.cast(rawFieldValues)
+      const outputDef = fieldsToLabware(processedFieldValues)
+
+      // We need to compensate for acceptable differences btw input def & output def.
+      // Labware Creator...
+      //   - does not save all original metadata fields, eg `metadata.tags`,
+      //   - may set some fields to a fixed default value, eg namespace and displayVolumeUnits
+      //   - may save empty arrays where original def had `undefined`s (brandId, quirks)
+      //   - will include all possible `groups` properties, which input does not always have (fixtures should, though)
+      const tweakedInputDef = {
+        ...inputDef,
+        brand: {
+          ...inputDef.brand,
+          brandId: inputDef.brand.brandId || [],
+        },
+        parameters: {
+          ...inputDef.parameters,
+          format: 'irregular', // 'format' use is deprecated, LC always uses 'irregular'
+          quirks: inputDef.parameters.quirks || [],
+        },
+        metadata: {
+          ...inputDef.metadata,
+          tags: [], // specifying this is not yet supported
+          displayVolumeUnits: 'µL', // specifying this is not yet supported
+        },
+        namespace: DEFAULT_CUSTOM_NAMESPACE, // specifying this is not yet supported
+      }
+
+      expect(outputDef).toEqual(tweakedInputDef)
+    })
+  })
+})

--- a/labware-library/src/labware-creator/components/ImportErrorModal.js
+++ b/labware-library/src/labware-creator/components/ImportErrorModal.js
@@ -35,8 +35,14 @@ const ImportErrorModal = (props: {|
       buttons={[{ onClick: onClose, children: 'close' }]}
     >
       {ERROR_MAP[importError.key]}
-      {props.importError.message != null && (
-        <div className={styles.error_message}>{importError.message}</div>
+      {importError.messages != null && importError.messages.length > 0 && (
+        <div>
+          {importError.messages.map((message, i) => (
+            <p key={i} className={styles.error_message}>
+              {message}
+            </p>
+          ))}
+        </div>
       )}
     </AlertModal>
   )

--- a/labware-library/src/labware-creator/components/ImportErrorModal.js
+++ b/labware-library/src/labware-creator/components/ImportErrorModal.js
@@ -1,0 +1,45 @@
+// @flow
+import * as React from 'react'
+import { AlertModal } from '@opentrons/components'
+import styles from '../styles.css'
+import type { ImportError, ImportErrorKey } from '../fields'
+
+const ERROR_MAP: { [ImportErrorKey]: React.Node } = {
+  NOT_JSON: 'This is not a .json file',
+  INVALID_JSON_FILE: 'This is not valid JSON file',
+  INVALID_LABWARE_DEF: 'This is not a valid labware definition',
+  UNSUPPORTED_LABWARE_PROPERTIES: (
+    <>
+      <p>
+        This labware definition appears valid, but is not yet supported in
+        Labware Creator.
+      </p>
+      <p>
+        Labware Creator currently only supports labware with a single regular
+        grid. Also, it does not support tipracks or trash boxes.
+      </p>
+    </>
+  ),
+}
+
+const ImportErrorModal = (props: {|
+  onClose: () => mixed,
+  importError: ImportError,
+|}) => {
+  const { importError, onClose } = props
+  return (
+    <AlertModal
+      className={styles.error_modal}
+      heading="Cannot import file"
+      onCloseClick={onClose}
+      buttons={[{ onClick: onClose, children: 'close' }]}
+    >
+      {ERROR_MAP[importError.key]}
+      {props.importError.message != null && (
+        <div className={styles.error_message}>{importError.message}</div>
+      )}
+    </AlertModal>
+  )
+}
+
+export default ImportErrorModal

--- a/labware-library/src/labware-creator/components/ImportErrorModal.js
+++ b/labware-library/src/labware-creator/components/ImportErrorModal.js
@@ -5,7 +5,7 @@ import styles from '../styles.css'
 import type { ImportError, ImportErrorKey } from '../fields'
 
 const ERROR_MAP: { [ImportErrorKey]: React.Node } = {
-  NOT_JSON: 'This is not a .json file',
+  INVALID_FILE_TYPE: 'This is not a .json file',
   INVALID_JSON_FILE: 'This is not valid JSON file',
   INVALID_LABWARE_DEF: 'This is not a valid labware definition',
   UNSUPPORTED_LABWARE_PROPERTIES: (

--- a/labware-library/src/labware-creator/components/ImportLabware.js
+++ b/labware-library/src/labware-creator/components/ImportLabware.js
@@ -23,6 +23,8 @@ export default function ImportLabware(props: Props) {
   )
 }
 
+const stopEvent = (e: SyntheticEvent<>) => e.preventDefault()
+
 function UploadInput(props: UploadInputProps) {
   const { isButton, onUpload } = props
 
@@ -40,7 +42,7 @@ function UploadInput(props: UploadInputProps) {
     : { onDrop: onUpload, className: styles.file_drop }
 
   return (
-    <div className={styles.upload}>
+    <div className={styles.upload} onDragOver={stopEvent} onDrop={stopEvent}>
       <Label {...labelProps}>
         {!isButton && <Icon name="upload" className={styles.file_drop_icon} />}
         {labelText}

--- a/labware-library/src/labware-creator/components/ImportLabware.js
+++ b/labware-library/src/labware-creator/components/ImportLabware.js
@@ -3,23 +3,27 @@ import * as React from 'react'
 import { PrimaryButton, Icon } from '@opentrons/components'
 import styles from './importLabware.css'
 
-type Props = {
+type Props = {|
   onUpload: (
     SyntheticInputEvent<HTMLInputElement> | SyntheticDragEvent<*>
   ) => void,
-  isButton?: boolean,
-}
+|}
 
-export default function ImportLabware() {
+type UploadInputProps = {|
+  onUpload: $PropertyType<Props, 'onUpload'>,
+  isButton?: boolean,
+|}
+
+export default function ImportLabware(props: Props) {
   return (
     <div className={styles.upload_group}>
-      <UploadInput onUpload={() => console.log('uploading')} />
-      <UploadInput onUpload={() => console.log('uploading')} isButton />
+      <UploadInput onUpload={props.onUpload} />
+      <UploadInput onUpload={props.onUpload} isButton />
     </div>
   )
 }
 
-function UploadInput(props: Props) {
+function UploadInput(props: UploadInputProps) {
   const { isButton, onUpload } = props
 
   const Label = isButton ? PrimaryButton : 'label'

--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -22,6 +22,17 @@ export const IRREGULAR_LABWARE_ERROR = 'IRREGULAR_LABWARE_ERROR'
 export const LINK_CUSTOM_LABWARE_FORM =
   'https://opentrons-ux.typeform.com/to/xi8h0W'
 
+// TODO IMMEDIATELY: make keys consistent with PD/App
+export type ImportErrorKey =
+  | 'NOT_JSON'
+  | 'INVALID_JSON_FILE'
+  | 'INVALID_LABWARE_DEF'
+  | 'UNSUPPORTED_LABWARE_PROPERTIES'
+export type ImportError = {|
+  key: ImportErrorKey,
+  message?: string,
+|}
+
 export type Options = Array<{|
   name: string,
   value: string,

--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -30,7 +30,7 @@ export type ImportErrorKey =
   | 'UNSUPPORTED_LABWARE_PROPERTIES'
 export type ImportError = {|
   key: ImportErrorKey,
-  message?: string,
+  messages?: Array<string>,
 |}
 
 export type Options = Array<{|

--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -22,9 +22,8 @@ export const IRREGULAR_LABWARE_ERROR = 'IRREGULAR_LABWARE_ERROR'
 export const LINK_CUSTOM_LABWARE_FORM =
   'https://opentrons-ux.typeform.com/to/xi8h0W'
 
-// TODO IMMEDIATELY: make keys consistent with PD/App
 export type ImportErrorKey =
-  | 'NOT_JSON'
+  | 'INVALID_FILE_TYPE'
   | 'INVALID_JSON_FILE'
   | 'INVALID_LABWARE_DEF'
   | 'UNSUPPORTED_LABWARE_PROPERTIES'

--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -1,4 +1,6 @@
 // @flow
+import type { WellBottomShape } from '@opentrons/shared-data'
+
 export const MAX_X_DIMENSION = 129
 export const MIN_X_DIMENSION = 127
 export const SUGGESTED_X = 127.76
@@ -45,10 +47,9 @@ export const wellShapeOptions: Options = [
   { name: 'Rectangular', value: 'rectangular' },
 ]
 
-export type WellBottomShape = 'flat' | 'round' | 'v'
 export const wellBottomShapeOptions: Options = [
   { name: 'Flat', value: 'flat' },
-  { name: 'Round', value: 'round' },
+  { name: 'Round', value: 'u' },
   { name: 'V-Bottom', value: 'v' },
 ]
 

--- a/labware-library/src/labware-creator/fieldsToLabware.js
+++ b/labware-library/src/labware-creator/fieldsToLabware.js
@@ -16,6 +16,7 @@ export default function fieldsToLabware(
   // NOTE Ian 2019-07-27: only the 15-50-esque tube rack has multiple grids,
   // and it is not supported in labware creator. So all are regular.
   const isRegularLabware = true
+  const { displayName } = fields
   const displayCategory = fields.labwareType
 
   if (isRegularLabware) {
@@ -60,12 +61,19 @@ export default function fieldsToLabware(
       // format = 'trough' // Uncomment to break test protocol but allow multichannel use in APIv1
     }
 
+    const brand = {
+      brand: fields.brand,
+      brandId: fields.brandId,
+      //   links: []
+    }
+
     const def = createRegularLabware({
       strict: false,
       metadata: {
-        displayName: fields.displayName,
+        displayName,
         displayCategory,
         displayVolumeUnits: DISPLAY_VOLUME_UNITS,
+        tags: [], // specifying tags is not yet supported
       },
       parameters: {
         format,
@@ -83,11 +91,7 @@ export default function fieldsToLabware(
         yDimension: fields.footprintYDimension,
         zDimension: fields.labwareZDimension,
       },
-      brand: {
-        brand: fields.brand,
-        brandId: fields.brandId,
-        //   links: []
-      },
+      brand,
       version: 1,
       offset: {
         x: fields.gridOffsetX,
@@ -106,6 +110,14 @@ export default function fieldsToLabware(
         row: fields.gridSpacingY,
       },
       well: wellProperties,
+      group: {
+        metadata: {
+          displayName,
+          displayCategory,
+          wellBottomShape: fields.wellBottomShape,
+        },
+        brand,
+      },
     })
 
     // overwrite loadName from createRegularLabware with ours

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -38,12 +38,14 @@ import RadioField from './components/RadioField'
 import Section from './components/Section'
 import TextField from './components/TextField'
 import ImportLabware from './components/ImportLabware'
+import ImportErrorModal from './components/ImportErrorModal'
 import styles from './styles.css'
 import type {
   LabwareDefinition2,
   WellBottomShape,
 } from '@opentrons/shared-data'
 import type {
+  ImportError,
   LabwareFields,
   LabwareType,
   ProcessedLabwareFields,
@@ -291,33 +293,6 @@ const getXYDimensionAlerts = (
   ) : null
 }
 
-// TODO IMMEDIATELY: make keys consistent with PD/App
-type ImportError = {|
-  key:
-    | 'NOT_JSON'
-    | 'INVALID_JSON_FILE'
-    | 'INVALID_LABWARE_DEF'
-    | 'UNSUPPORTED_LABWARE_PROPERTIES',
-  message?: string,
-|}
-
-const ImportErrorModal = (props: {|
-  onClose: () => mixed,
-  importError: ImportError,
-|}) => (
-  <AlertModal
-    // TODO IMMEDIATELY rename class, or new class?
-    className={styles.export_error_modal}
-    heading="Cannot import file"
-    // TODO IMMEDIATELY is there a 'shortcut' set of props for single-button?
-    onCloseClick={props.onClose}
-    buttons={[{ onClick: props.onClose, children: 'close' }]}
-  >
-    <strong>{props.importError.key}</strong>
-    {props.importError.message}
-  </AlertModal>
-)
-
 const App = () => {
   const [
     showExportErrorModal,
@@ -394,7 +369,7 @@ const App = () => {
       )}
       {showExportErrorModal && (
         <AlertModal
-          className={styles.export_error_modal}
+          className={styles.error_modal}
           heading="Cannot export file"
           onCloseClick={() => setShowExportErrorModal(false)}
           buttons={[

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -327,7 +327,7 @@ const App = () => {
       event.currentTarget.value = ''
 
       if (!file.name.endsWith('.json')) {
-        setImportError({ key: 'NOT_JSON' })
+        setImportError({ key: 'INVALID_FILE_TYPE' })
       } else {
         reader.onload = readEvent => {
           const result = readEvent.currentTarget.result

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -38,12 +38,12 @@ import Section from './components/Section'
 import TextField from './components/TextField'
 import ImportLabware from './components/ImportLabware'
 import styles from './styles.css'
+import type { WellBottomShape } from '@opentrons/shared-data'
 import type {
   LabwareFields,
   LabwareType,
   ProcessedLabwareFields,
   WellShape,
-  WellBottomShape,
 } from './fields'
 
 const maskTo2Decimal = makeMaskToDecimal(2)
@@ -164,14 +164,14 @@ const DepthImg = (props: DepthImgProps) => {
     const imgMap = {
       v: require('./images/depth_reservoir-and-tubes_v.svg'),
       flat: require('./images/depth_reservoir-and-tubes_flat.svg'),
-      round: require('./images/depth_reservoir-and-tubes_round.svg'),
+      u: require('./images/depth_reservoir-and-tubes_round.svg'),
     }
     src = imgMap[wellBottomShape]
   } else {
     const imgMap = {
       v: require('./images/depth_plate_v.svg'),
       flat: require('./images/depth_plate_flat.svg'),
-      round: require('./images/depth_plate_round.svg'),
+      u: require('./images/depth_plate_round.svg'),
     }
     src = imgMap[wellBottomShape]
   }

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -41,8 +41,8 @@ export default function labwareDefToFields(
   const gridRowsNum = def.ordering[0].length
   const gridColumnsNum = def.ordering.length
 
-  const regularColumnSpacing = xSpacing !== null || gridColumnsNum === 1
-  const regularRowSpacing = ySpacing !== null || gridRowsNum === 1
+  const regularColumnSpacing = xSpacing !== null
+  const regularRowSpacing = ySpacing !== null
 
   let labwareType: $PropertyType<LabwareFields, 'labwareType'> | null = null
 

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -1,36 +1,48 @@
 // @flow
-import flatten from 'lodash/flatten'
-import isEqual from 'lodash/isEqual'
-import round from 'lodash/round'
-import omit from 'lodash/omit'
-import { getSpacingIfUniform } from '../labwareInference'
+import { getUniqueWellProperties } from '../labwareInference'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareFields, BooleanString } from './fields'
 
 // NOTE: this is just String() with some typing for flow
 const boolToBoolString = (b: boolean): BooleanString => (b ? 'true' : 'false')
 
-// NOTE: this fn should always be passed an object valid under JSON schema for LabwareDefinition2
-// TODO: Ian 2019-08-26 this shares functionality with getUniqueWellProperties fn in labware-library/src/definitions.js
 export default function labwareDefToFields(
   def: LabwareDefinition2
 ): ?LabwareFields {
-  const groups = def.groups || []
-  const allWells = flatten(def.ordering).map(wellName => def.wells[wellName])
-  // single well we'll use to represent the entire labware if homogeneousWell is true
-  const commonWell = def.wells.A1
+  const allUniqueWellGroupProps = getUniqueWellProperties(def)
 
-  const wellDimKeys = ['x', 'y', 'z']
-  const commonWellNoDims = omit(commonWell, wellDimKeys)
-  const homogeneousWells = allWells.every(well =>
-    isEqual(omit(well, wellDimKeys), commonWellNoDims)
-  )
+  if (allUniqueWellGroupProps.length === 0) {
+    console.warn(
+      'cannot get unique well props for definition, maybe it has missing/incomplete "groups" data?',
+      def
+    )
+    return null
+  }
 
-  // don't bother trying to infer row/col regularity, assume `groups` is correct. If `groups` is missing, assume irregular
-  const gridSpacingX = getSpacingIfUniform(allWells, 'x')
-  const gridSpacingY = getSpacingIfUniform(allWells, 'y')
-  const regularColumnSpacing = gridSpacingX !== null
-  const regularRowSpacing = gridSpacingY !== null
+  const {
+    xSpacing,
+    ySpacing,
+    shape,
+    depth,
+    metadata,
+    totalLiquidVolume,
+    xOffsetFromLeft,
+    yOffsetFromTop,
+  } = allUniqueWellGroupProps[0]
+
+  const homogeneousWells =
+    allUniqueWellGroupProps.length === 1 &&
+    shape !== null &&
+    depth !== null &&
+    totalLiquidVolume !== null
+
+  // TODO: Ian 2019-08-28 once LC supports multiple groupds, num of rows / num of columns should
+  // come from getUniqueWellProperties. Using `ordering` won't extend to multiple groups
+  const gridRowsNum = def.ordering[0].length
+  const gridColumnsNum = def.ordering.length
+
+  const regularColumnSpacing = xSpacing !== null || gridColumnsNum === 1
+  const regularRowSpacing = ySpacing !== null || gridRowsNum === 1
 
   let labwareType: $PropertyType<LabwareFields, 'labwareType'> | null = null
 
@@ -47,32 +59,29 @@ export default function labwareDefToFields(
     !homogeneousWells ||
     !regularRowSpacing ||
     !regularColumnSpacing ||
-    labwareType === null
+    labwareType === null ||
+    !(shape !== null && depth !== null && totalLiquidVolume !== null)
   ) {
-    // TODO IMMEDIATELY: somehow handle uploading "irregular" (multi-grid) labware, error messaging
-    console.warn('TODO! unhandled labware def', {
-      homogeneousWells,
-      regularColumnSpacing,
-      regularRowSpacing,
-      labwareType,
-    })
+    console.warn(
+      'this labware def is more heterogeneous than LC can currently support',
+      {
+        homogeneousWells,
+        regularColumnSpacing,
+        regularRowSpacing,
+        labwareType,
+        allUniqueWellGroupProps,
+      }
+    )
     return null
   }
 
-  // use first group, if it exists
-  const group = groups[0] || null
-
-  const gridRowsNum = def.ordering[0].length
-  const gridColumnsNum = def.ordering.length
-
   return {
-    // NOTE: Ian 2019-08-26 these fields cannot be inferred
+    // NOTE: Ian 2019-08-26 these LC-specific fields cannot easily/reliably be inferred
     tubeRackInsertLoadName: null,
     aluminumBlockType: null,
     aluminumBlockChildType: null,
 
     labwareType,
-
     footprintXDimension: String(def.dimensions.xDimension),
     footprintYDimension: String(def.dimensions.yDimension),
     labwareZDimension: String(def.dimensions.zDimension),
@@ -80,33 +89,29 @@ export default function labwareDefToFields(
     // Missing values or zeroes for these fields should be translated to null
     gridRows: gridRowsNum > 0 ? String(gridRowsNum) : null,
     gridColumns: gridColumnsNum > 0 ? String(gridColumnsNum) : null,
-    gridSpacingX:
-      gridSpacingX == null || gridSpacingX === 0 ? null : String(gridSpacingX),
-    gridSpacingY:
-      gridSpacingY == null || gridSpacingY === 0 ? null : String(gridSpacingY),
+    gridSpacingX: xSpacing == null || xSpacing === 0 ? null : String(xSpacing),
+    gridSpacingY: ySpacing == null || ySpacing === 0 ? null : String(ySpacing),
 
-    gridOffsetX: String(commonWell.x),
-    // y offset is dist btw labware 'top' (furthest in y) and first well y
-    gridOffsetY: String(round(def.dimensions.yDimension - commonWell.y, 2)),
+    gridOffsetX: String(xOffsetFromLeft),
+    gridOffsetY: String(yOffsetFromTop),
 
     homogeneousWells: boolToBoolString(homogeneousWells),
     regularRowSpacing: boolToBoolString(regularRowSpacing),
     regularColumnSpacing: boolToBoolString(regularColumnSpacing),
 
-    wellVolume: String(commonWell.totalLiquidVolume),
-    wellBottomShape: group?.metadata.wellBottomShape || null,
-    wellDepth: String(commonWell.depth),
-    wellShape: commonWell.shape,
+    wellVolume: String(totalLiquidVolume),
+    wellBottomShape: metadata.wellBottomShape || null,
+    wellDepth: String(depth),
+    wellShape: shape.shape,
 
     // used with circular well shape only
-    wellDiameter:
-      commonWell.shape === 'circular' ? String(commonWell.diameter) : null,
+    wellDiameter: shape.shape === 'circular' ? String(shape.diameter) : null,
 
     // used with rectangular well shape only
     wellXDimension:
-      commonWell.shape === 'rectangular' ? String(commonWell.xDimension) : null,
+      shape.shape === 'rectangular' ? String(shape.xDimension) : null,
     wellYDimension:
-      commonWell.shape === 'rectangular' ? String(commonWell.yDimension) : null,
+      shape.shape === 'rectangular' ? String(shape.yDimension) : null,
 
     brand: def.brand.brand,
     brandId: def.brand.brandId ? def.brand.brandId.join(',') : null, // comma-separated values

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -31,12 +31,29 @@ export default function labwareDefToFields(
   const regularColumnSpacing = gridSpacingX !== null
   const regularRowSpacing = gridSpacingY !== null
 
-  if (!homogeneousWells || !regularRowSpacing || !regularColumnSpacing) {
+  let labwareType: $PropertyType<LabwareFields, 'labwareType'> | null = null
+
+  if (
+    def.metadata.displayCategory === 'wellPlate' ||
+    def.metadata.displayCategory === 'tubeRack' ||
+    def.metadata.displayCategory === 'aluminumBlock' ||
+    def.metadata.displayCategory === 'reservoir'
+  ) {
+    labwareType = def.metadata.displayCategory
+  }
+
+  if (
+    !homogeneousWells ||
+    !regularRowSpacing ||
+    !regularColumnSpacing ||
+    labwareType === null
+  ) {
     // TODO IMMEDIATELY: somehow handle uploading "irregular" (multi-grid) labware, error messaging
     console.warn('TODO! unhandled labware def', {
       homogeneousWells,
       regularColumnSpacing,
       regularRowSpacing,
+      labwareType,
     })
     return null
   }
@@ -49,10 +66,11 @@ export default function labwareDefToFields(
 
   return {
     // NOTE: Ian 2019-08-26 these fields cannot be inferred
-    labwareType: null,
     tubeRackInsertLoadName: null,
     aluminumBlockType: null,
     aluminumBlockChildType: null,
+
+    labwareType,
 
     footprintXDimension: String(def.dimensions.xDimension),
     footprintYDimension: String(def.dimensions.yDimension),

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -1,0 +1,82 @@
+// @flow
+import { getSpacing } from '../labwareInference'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareFields, BooleanString } from './fields'
+
+const boolToBoolString = (b: boolean): BooleanString => (b ? 'true' : 'false') // TODO IMMEDIATELY revisit, is this duplicated elsewhere?
+
+// NOTE: this fn should always be passed an object valid under JSON schema for LabwareDefinition2
+// TODO: Ian 2019-08-26 this shares functionality with getUniqueWellProperties fn in labware-library/src/definitions.js
+export default function labwareDefToFields(
+  def: LabwareDefinition2
+): ?LabwareFields {
+  // TODO IMMEDIATELY: use fns from labware-library/definitions.js ???
+  const homogeneousWells = true
+  const regularRowSpacing = true
+  const regularColumnSpacing = true
+
+  if (!homogeneousWells || !regularRowSpacing || !regularColumnSpacing) {
+    // TODO IMMEDIATELY: somehow handle uploading "irregular" (multi-grid) labware, error messaging
+    return null
+  }
+
+  // single well to use to represent the grid
+  const well = def.wells.A1
+  const allWells = Object.keys(def.wells).map(wellName => def.wells[wellName])
+
+  const gridSpacingX = getSpacing(allWells, 'x')
+  const gridSpacingY = getSpacing(allWells, 'y')
+
+  const gridRowsNum = def.ordering[0].length
+  const gridColumnsNum = def.ordering.length
+
+  return {
+    // NOTE: Ian 2019-08-26 these fields cannot be inferred
+    labwareType: null,
+    tubeRackInsertLoadName: null,
+    aluminumBlockType: null,
+    aluminumBlockChildType: null,
+
+    footprintXDimension: String(def.dimensions.xDimension),
+    footprintYDimension: String(def.dimensions.yDimension),
+    labwareZDimension: String(def.dimensions.zDimension),
+
+    // Missing values or zeroes for these fields should be translated to null
+    gridRows: gridRowsNum > 0 ? String(gridRowsNum) : null,
+    gridColumns: gridColumnsNum > 0 ? String(gridColumnsNum) : null,
+    gridSpacingX:
+      gridSpacingX == null || gridSpacingX <= 0 ? null : String(gridSpacingX),
+    gridSpacingY:
+      gridSpacingY == null || gridSpacingY <= 0 ? null : String(gridSpacingY),
+
+    gridOffsetX: String(well.x),
+    gridOffsetY: String(well.y),
+
+    homogeneousWells: boolToBoolString(homogeneousWells),
+    regularRowSpacing: boolToBoolString(regularRowSpacing),
+    regularColumnSpacing: boolToBoolString(regularColumnSpacing),
+
+    wellVolume: String(well.totalLiquidVolume),
+    wellBottomShape: null, // TODO IMMEDIATELY how does LL infer this?
+    wellDepth: String(well.depth),
+    wellShape: well.shape,
+
+    // used with circular well shape only
+    wellDiameter: well.shape === 'circular' ? String(well.diameter) : null,
+
+    // used with rectangular well shape only
+    wellXDimension:
+      well.shape === 'rectangular' ? String(well.xDimension) : null,
+    wellYDimension:
+      well.shape === 'rectangular' ? String(well.yDimension) : null,
+
+    brand: def.brand.brand,
+    brandId: (def.brand.brandId || []).join(','), // comma-separated values
+
+    loadName: def.parameters.loadName,
+    displayName: def.metadata.displayName,
+
+    // fields for test protocol
+    pipetteName: null,
+  }
+}

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -75,7 +75,7 @@ export default function labwareDefToFields(
     regularColumnSpacing: boolToBoolString(regularColumnSpacing),
 
     wellVolume: String(commonWell.totalLiquidVolume),
-    wellBottomShape: group?.metadata?.wellBottomShape || null,
+    wellBottomShape: group?.metadata.wellBottomShape || null,
     wellDepth: String(commonWell.depth),
     wellShape: commonWell.shape,
 

--- a/labware-library/src/labware-creator/labwareDefToFields.js
+++ b/labware-library/src/labware-creator/labwareDefToFields.js
@@ -3,11 +3,12 @@ import flatten from 'lodash/flatten'
 import isEqual from 'lodash/isEqual'
 import round from 'lodash/round'
 import omit from 'lodash/omit'
-import { getSpacing } from '../labwareInference'
+import { getSpacingIfUniform } from '../labwareInference'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareFields, BooleanString } from './fields'
 
-const boolToBoolString = (b: boolean): BooleanString => (b ? 'true' : 'false') // TODO IMMEDIATELY revisit, is this duplicated elsewhere?
+// NOTE: this is just String() with some typing for flow
+const boolToBoolString = (b: boolean): BooleanString => (b ? 'true' : 'false')
 
 // NOTE: this fn should always be passed an object valid under JSON schema for LabwareDefinition2
 // TODO: Ian 2019-08-26 this shares functionality with getUniqueWellProperties fn in labware-library/src/definitions.js
@@ -26,8 +27,8 @@ export default function labwareDefToFields(
   )
 
   // don't bother trying to infer row/col regularity, assume `groups` is correct. If `groups` is missing, assume irregular
-  const gridSpacingX = getSpacing(allWells, 'x')
-  const gridSpacingY = getSpacing(allWells, 'y')
+  const gridSpacingX = getSpacingIfUniform(allWells, 'x')
+  const gridSpacingY = getSpacingIfUniform(allWells, 'y')
   const regularColumnSpacing = gridSpacingX !== null
   const regularRowSpacing = gridSpacingY !== null
 

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -49,13 +49,18 @@ h2 {
   font-weight: var(--fw-semibold);
 }
 
-.export_error_modal {
+.error_modal {
   position: fixed;
   x: 0;
   y: 0;
   width: 100%;
   height: 100%;
   z-index: 999;
+}
+
+.error_message {
+  color: var(--c-red);
+  font-style: italic;
 }
 
 .callout {

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -61,6 +61,7 @@ h2 {
 .error_message {
   color: var(--c-red);
   font-style: italic;
+  padding: 0.5rem 0;
 }
 
 .callout {

--- a/labware-library/src/labwareInference.js
+++ b/labware-library/src/labwareInference.js
@@ -1,0 +1,78 @@
+// @flow
+import isEqual from 'lodash/isEqual'
+import uniqBy from 'lodash/uniqBy'
+import uniqWith from 'lodash/uniqWith'
+import round from 'lodash/round'
+import orderBy from 'lodash/orderBy'
+import type {
+  LabwareWell,
+  LabwareWellShapeProperties,
+  LabwareWellGroupProperties,
+  LabwareDefinition,
+} from './types'
+
+export function getUniqueWellProperties(
+  definition: LabwareDefinition
+): Array<LabwareWellGroupProperties> {
+  const { groups, wells, dimensions } = definition
+
+  return groups.map(group => {
+    const wellProps = orderBy(
+      group.wells.map(n => wells[n]),
+      ['x', 'y'],
+      ['asc', 'desc']
+    )
+    const wellDepths = wellProps.map<number>(w => w.depth)
+    const wellVolumes = wellProps.map<number>(w => w.totalLiquidVolume)
+    const wellShapes = wellProps.map<LabwareWellShapeProperties>(
+      (well: LabwareWell) =>
+        well.shape === 'circular'
+          ? { shape: well.shape, diameter: well.diameter }
+          : {
+              shape: well.shape,
+              xDimension: well.xDimension,
+              yDimension: well.yDimension,
+            }
+    )
+
+    const xStart = wellProps[0].x
+    const yStart = wellProps[0].y
+
+    return {
+      metadata: group.metadata,
+      brand: group.brand || null,
+      xSpacing: getSpacing(wellProps, 'x'),
+      ySpacing: getSpacing(wellProps, 'y'),
+      xOffsetFromLeft: xStart,
+      yOffsetFromTop: dimensions.yDimension - yStart,
+      wellCount: wellProps.length,
+      depth: getIfConsistent(wellDepths),
+      totalLiquidVolume: getIfConsistent(wellVolumes),
+      shape: getIfConsistent(wellShapes),
+    }
+  })
+}
+
+function getIfConsistent<T>(items: Array<T>): T | null {
+  return uniqWith(items, isEqual).length === 1 ? items[0] : null
+}
+
+export function getSpacing(
+  wells: Array<LabwareWell>,
+  axis: 'x' | 'y'
+): number | null {
+  return uniqBy<LabwareWell>(wells, axis).reduce<number | null>(
+    (spacing, well, index, uniqueWells) => {
+      if (index > 0) {
+        const prev = uniqueWells[index - 1]
+        const currentSpacing = Math.abs(round(well[axis] - prev[axis], 2))
+
+        return spacing === 0 || spacing === currentSpacing
+          ? currentSpacing
+          : null
+      }
+      return spacing
+    },
+    0
+  )
+}

--- a/labware-library/src/labwareInference.js
+++ b/labware-library/src/labwareInference.js
@@ -56,19 +56,18 @@ export function getIfConsistent<T>(items: Array<T>): T | null {
   return uniqWith(items, isEqual).length === 1 ? items[0] : null
 }
 
+// returning null means "spacing is irregular"; returning 0 means "there is only 1 well along the given axis"
 export function getSpacingIfUniform(
   wells: Array<LabwareWell>,
   axis: 'x' | 'y'
 ): number | null {
   const wellPositions = sortedUniq(uniq(wells.map(well => well[axis])))
-  if (wellPositions.length < 2) return null
+  if (wellPositions.length < 2) return 0
 
   const initialSpacing = round(
     wellPositions[1] - wellPositions[0],
     ROUNDING_PRECISION
   )
-
-  if (initialSpacing === 0) return null
 
   for (var i = 2; i < wellPositions.length; i++) {
     const pos = wellPositions[i]

--- a/labware-library/src/labwareInference.js
+++ b/labware-library/src/labwareInference.js
@@ -57,6 +57,7 @@ function getIfConsistent<T>(items: Array<T>): T | null {
   return uniqWith(items, isEqual).length === 1 ? items[0] : null
 }
 
+// TODO IMMEDIATELY write test
 export function getSpacing(
   wells: Array<LabwareWell>,
   axis: 'x' | 'y'

--- a/labware-library/src/labwareInference.js
+++ b/labware-library/src/labwareInference.js
@@ -11,6 +11,8 @@ import type {
   LabwareDefinition,
 } from './types'
 
+const ROUNDING_PRECISION = 2
+
 export function getUniqueWellProperties(
   definition: LabwareDefinition
 ): Array<LabwareWellGroupProperties> {
@@ -41,7 +43,7 @@ export function getUniqueWellProperties(
       xSpacing: getSpacingIfUniform(wellProps, 'x'),
       ySpacing: getSpacingIfUniform(wellProps, 'y'),
       xOffsetFromLeft: xStart,
-      yOffsetFromTop: dimensions.yDimension - yStart,
+      yOffsetFromTop: round(dimensions.yDimension - yStart, ROUNDING_PRECISION),
       wellCount: wellProps.length,
       depth: getIfConsistent(wellDepths),
       totalLiquidVolume: getIfConsistent(wellVolumes),
@@ -54,7 +56,6 @@ export function getIfConsistent<T>(items: Array<T>): T | null {
   return uniqWith(items, isEqual).length === 1 ? items[0] : null
 }
 
-const SPACING_PRECISION = 2
 export function getSpacingIfUniform(
   wells: Array<LabwareWell>,
   axis: 'x' | 'y'
@@ -64,7 +65,7 @@ export function getSpacingIfUniform(
 
   const initialSpacing = round(
     wellPositions[1] - wellPositions[0],
-    SPACING_PRECISION
+    ROUNDING_PRECISION
   )
 
   if (initialSpacing === 0) return null
@@ -72,7 +73,7 @@ export function getSpacingIfUniform(
   for (var i = 2; i < wellPositions.length; i++) {
     const pos = wellPositions[i]
     const prevWellPos = wellPositions[i - 1]
-    const spacing = round(pos - prevWellPos, SPACING_PRECISION)
+    const spacing = round(pos - prevWellPos, ROUNDING_PRECISION)
     if (spacing !== initialSpacing) return null
   }
 

--- a/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
+++ b/protocol-designer/src/step-generation/test-with-flow/__snapshots__/fixtureGeneration.test.js.snap
@@ -562,7 +562,13 @@ Object {
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "generic",
+              "brandId": Array [],
+            },
             "metadata": Object {
+              "displayCategory": "wellPlate",
+              "displayName": "ANSI 96 Standard Microplate",
               "wellBottomShape": "flat",
             },
             "wells": Array [
@@ -1695,7 +1701,13 @@ Object {
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "generic",
+              "brandId": Array [],
+            },
             "metadata": Object {
+              "displayCategory": "wellPlate",
+              "displayName": "ANSI 96 Standard Microplate",
               "wellBottomShape": "flat",
             },
             "wells": Array [
@@ -6300,7 +6312,15 @@ Object {
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "USA Scientific",
+              "brandId": Array [
+                "1061-8150",
+              ],
+            },
             "metadata": Object {
+              "displayCategory": "reservoir",
+              "displayName": "12 Channel Trough",
               "wellBottomShape": "v",
             },
             "wells": Array [

--- a/shared-data/js/labwareTools/index.js
+++ b/shared-data/js/labwareTools/index.js
@@ -29,7 +29,7 @@ import type {
 } from '../types'
 
 // NOTE: leaving this 'beta' to reduce conflicts with future labware cloud namespaces
-const DEFAULT_CUSTOM_NAMESPACE = 'custom_beta'
+export const DEFAULT_CUSTOM_NAMESPACE = 'custom_beta'
 const SCHEMA_VERSION = 2
 const DEFAULT_BRAND_NAME = 'generic'
 

--- a/shared-data/labware/fixtures/2/fixture_12_trough.json
+++ b/shared-data/labware/fixtures/2/fixture_12_trough.json
@@ -175,7 +175,13 @@
         "A11",
         "A12"
       ],
+      "brand": {
+        "brand": "USA Scientific",
+        "brandId": ["1061-8150"]
+      },
       "metadata": {
+        "displayName": "12 Channel Trough",
+        "displayCategory": "reservoir",
         "wellBottomShape": "v"
       }
     }

--- a/shared-data/labware/fixtures/2/fixture_96_plate.json
+++ b/shared-data/labware/fixtures/2/fixture_96_plate.json
@@ -1003,7 +1003,13 @@
         "H12"
       ],
       "metadata": {
+        "displayCategory": "wellPlate",
+        "displayName": "ANSI 96 Standard Microplate",
         "wellBottomShape": "flat"
+      },
+      "brand": {
+        "brand": "generic",
+        "brandId": []
       }
     }
   ],


### PR DESCRIPTION
## overview

Closes #3842 

## changelog

- make `ImportLabware` trigger an upload attempt, on either click or drag-and-drop-file
- save `groups` metadata into saved defs
- use `groups` metadata to populate the form fields from an uploaded def

## review requests

- [x] Clicking the import button should let you import a file
- [x] Dragging and droping a file should let you import a file
- [x] Valid labware definition from LC (saved from **THIS BRANCH** of LC, earlier LC commits will not work properly), or from shared-data, should load successfully and populate all appropriate fields correctly.
- [x] EXCEPTION: labware defs that have heterogeneous wells, multiple grids, irregular spacing, or are trash/tiprack labware will not be supported by LC until a later redesign. In this PR, uploading a definition that has any of those traits will give an error message explaining that. For example, the 15-50 tube rack def in shared-data is too complex for LC to handle, and you should get an error on upload.

ERROR MESSAGE MODAL
- [x] Non-`.json` files should say something like "this file is not .json"
- [x] Invalid JSON, eg a file just containing an open bracket, should say something like "this file is not valid JSON"
- [x] Valid JSON that is does not conform to labware v2 schema should say something like "this is not a valid labware definition" and give the reason that the JSON schema is invalid in italic red (like RA does for a bad JSON protocol)
- (See "EXCEPTION" in section above for the 4th possible error message case)

- [ ] Code review, especially around new test coverage. Please examine the shorter snapshots eg for `getUniqueWellProperties`

LABWARE LIBRARY
- [ ] This PR touches the util functions that LL uses to derive info from groups. Please double-check that LL in this branch is still working correctly, especially for the footprint/well measurements/spacing sidebar of the labware detail page, for both single-group and multi-group labware.

NOTE: I imagine we'll have **copy changes** around the file import errors. I'd like to not evaluate them in this PR, unless I'm going totally in the wrong direction with the 4 error cases of have. I'm down to modify the copy and the details of the import error message modal in a follow-up.