### PR TITLE
feat(labware-creator): show diameter field by default

### DIFF
--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -586,14 +586,7 @@ const App = () => {
                     </div>
                     <div className={styles.form_fields_column}>
                       <RadioField name="wellShape" options={wellShapeOptions} />
-                      {values.wellShape === 'circular' && (
-                        <TextField
-                          name="wellDiameter"
-                          inputMasks={[maskTo2Decimal]}
-                          units="mm"
-                        />
-                      )}
-                      {values.wellShape === 'rectangular' && (
+                      {values.wellShape === 'rectangular' ? (
                         <>
                           <TextField
                             name="wellXDimension"
@@ -606,6 +599,12 @@ const App = () => {
                             units="mm"
                           />
                         </>
+                      ) : (
+                        <TextField
+                          name="wellDiameter"
+                          inputMasks={[maskTo2Decimal]}
+                          units="mm"
+                        />
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
Closes #3970

## review requests

- show diameter field when well shape's radio group is unselected
- nothing weird?