### PR TITLE
fix(api): fix ignoring smoothie errors during non-home

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -931,11 +931,14 @@ class SmoothieDriver_3_0_0:
             # is locking at a higher level like in APIv2.
             self._reset_from_error()
             error_axis = se.ret_code.strip()[-1]
-            if GCODES['HOME'] not in command and error_axis in 'XYZABC':
-                log.warning(
-                    f"alarm/error in {se.ret_code}, homing {error_axis}")
+            log.warning(
+                    f"alarm/error: command={command}, resp={se.ret_code}")
+            if GCODES['MOVE'] in command or GCODES['PROBE'] in command:
+                if error_axis not in 'XYZABC':
+                    error_axis = AXES
+                log.info("Homing after alarm/error")
                 self.home(error_axis)
-                raise SmoothieError(se.ret_code, command)
+            raise SmoothieError(se.ret_code, command)
 
     def _send_command_unsynchronized(self,
                                      command,


### PR DESCRIPTION
This commit fixes incorrect indentation during a previous refactor that caused smoothie errors to be silently swallowed if they occured at any time but during home. Unlike the last fix, it doesn't make the system home after such an error unless the error occurred during move or probe, since homing after other errors would be pointless at best and actively harmful at worst (for instance, smoothie "returns an error" if it tries to read an instrument eeprom on a mount with no instrument attached).

## Testing

This is a change to a pretty fundamental part of the API, since this codepath is taken on every smoothie communication path. We should look at
- Tip probes without failures
- Tip probes with induced failures (aka probes with no tip attached)
- Attach pipette, especially removing pipette
- Induced errors during motion (pressing an endstop during a motion). BE CAREFUL WITH YOUR HANDS!
- Induced errors during home if possible, by either disconnecting an endstop or grabbing the gantry and preventing it from moving during home
- Good homes
