### PR TITLE
refactor(labware-library): Update landing content and instructions copy

### DIFF
--- a/labware-library/src/labware-creator/components/ImportLabware.js
+++ b/labware-library/src/labware-creator/components/ImportLabware.js
@@ -39,7 +39,7 @@ function UploadInput(props: Props) {
     <div className={styles.upload}>
       <Label {...labelProps}>
         {!isButton && <Icon name="upload" className={styles.file_drop_icon} />}
-        {labelText}
+        <span className={styles.label_text}>{labelText}</span>
         <input className={styles.file_input} type="file" onChange={onUpload} />
       </Label>
     </div>

--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -1,31 +1,23 @@
 // @flow
 import * as React from 'react'
-import { PrimaryButton } from '@opentrons/components'
 import LinkOut from './LinkOut'
 import { LINK_CUSTOM_LABWARE_FORM } from '../fields'
 import styles from '../styles.css'
 
+const LINK_CUSTOM_LABWARE_GUIDE =
+  'https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions'
 const IntroCopy = () => (
   <>
-    <PrimaryButton
-      Component="LinkOut"
-      href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions"
+    <LinkOut
+      href={LINK_CUSTOM_LABWARE_GUIDE}
       className={styles.labware_guide_button}
     >
       read the custom labware guide
-    </PrimaryButton>
+    </LinkOut>
     <p>
-      The BETA version of this tool will allow you to create definitions for
-      well plates, reservoirs, tubes in Opentrons tube racks, and plates/tubes
-      in Opentrons aluminum blocks.
-    </p>
-    <p>
-      The basic restrictions on the type of labware this tool can create are
-      listed below. For more details read the{' '}
-      <LinkOut href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions">
-        custom labware guide
-      </LinkOut>
-      .
+      This tool will allow you to create definitions for well plates,
+      reservoirs, tubes in Opentrons tube racks, and plates/tubes in Opentrons
+      aluminum blocks.
     </p>
     <ol>
       <li>All your wells/tubes must be the same size and volume.</li>
@@ -40,32 +32,14 @@ const IntroCopy = () => (
       <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>request form</LinkOut>
     </p>
 
-    <p>
-      Upon completing the form you’ll be able to export the labware definition
-      for use on the OT-2. The zipped file you download will contain 1) the
-      labware definition as a JSON file, and 2) a python protocol referencing
-      the labware to help you test and troubleshoot the accuracy of the
-      definition on your robot.
-    </p>
-
-    <p>
-      It’s important to create a labware definition that is precise, and does
-      not rely on excessive calibration prior to each run to achieve accuracy.
-      In this way you’ll generate labware definitions that are reusable and
-      shareable with others inside or outside your lab.
-    </p>
-
     <div className={styles.callout}>
       <p>
         <strong>Please note:</strong> We strongly recommend you reference
-        mechanical drawings directly from your supplier or manufacturer and only
-        rely on manual measurements to supplement missing information. Refer to
-        the bottom of{' '}
-        <LinkOut href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions">
-          this guide
-        </LinkOut>{' '}
-        for some tips on how to get the most accuracy with your manual
-        measurements.
+        mechanical drawings directly from your supplier/manufacturer and only
+        rely on manual measurements (using callipers when possible) to
+        supplement missing information. Refer to the bottom of{' '}
+        <LinkOut href={LINK_CUSTOM_LABWARE_GUIDE}>this guide </LinkOut> for some
+        tips on how to get the most accuracy with your manual measurements.
       </p>
     </div>
   </>

--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -1,46 +1,71 @@
 // @flow
 import * as React from 'react'
+import { PrimaryButton } from '@opentrons/components'
 import LinkOut from './LinkOut'
 import { LINK_CUSTOM_LABWARE_FORM } from '../fields'
 import styles from '../styles.css'
 
 const IntroCopy = () => (
   <>
-    <p>Use this tool if you are creating one of the following:</p>
-    <ul>
+    <PrimaryButton
+      Component="LinkOut"
+      href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions"
+      className={styles.labware_guide_button}
+    >
+      read the custom labware guide
+    </PrimaryButton>
+    <p>
+      The BETA version of this tool will allow you to create definitions for
+      well plates, reservoirs, tubes in Opentrons tube racks, and plates/tubes
+      in Opentrons aluminum blocks.
+    </p>
+    <p>
+      The basic restrictions on the type of labware this tool can create are
+      listed below. For more details read the{' '}
+      <LinkOut href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions">
+        custom labware guide
+      </LinkOut>
+      .
+    </p>
+    <ol>
+      <li>All your wells/tubes must be the same size and volume.</li>
+      <li>All columns and rows must be evenly spaced.</li>
       <li>
-        Well plates and reservoirs which can be made via the labware creator
-        (refer to{' '}
-        <LinkOut href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions">
-          this guide
-        </LinkOut>{' '}
-        for more information)
+        The labware must fit snugly into a slot on the deck without the help of
+        an adapter.
       </li>
-      <li>
-        Tubes + the{' '}
-        <LinkOut href="https://shop.opentrons.com/collections/racks-and-adapters/products/tube-rack-set-1">
-          Opentrons tube rack
-        </LinkOut>
-      </li>
-      <li>
-        Tubes / plates + the{' '}
-        <LinkOut href="https://shop.opentrons.com/collections/racks-and-adapters/products/aluminum-block-set">
-          Opentrons aluminum block
-        </LinkOut>
-      </li>
-    </ul>
+    </ol>
     <p>
       For all other custom labware, please use this{' '}
       <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>request form</LinkOut>
     </p>
 
+    <p>
+      Upon completing the form you’ll be able to export the labware definition
+      for use on the OT-2. The zipped file you download will contain 1) the
+      labware definition as a JSON file, and 2) a python protocol referencing
+      the labware to help you test and troubleshoot the accuracy of the
+      definition on your robot.
+    </p>
+
+    <p>
+      It’s important to create a labware definition that is precise, and does
+      not rely on excessive calibration prior to each run to achieve accuracy.
+      In this way you’ll generate labware definitions that are reusable and
+      shareable with others inside or outside your lab.
+    </p>
+
     <div className={styles.callout}>
       <p>
         <strong>Please note:</strong> We strongly recommend you reference
-        mechanical drawings to ensure accurate measurements for defining
-        labware, only relying on manual measurements to supplement missing
-        information. To learn more about ways to access mechanical drawings from
-        manufacturers, please refer to this guide.
+        mechanical drawings directly from your supplier or manufacturer and only
+        rely on manual measurements to supplement missing information. Refer to
+        the bottom of{' '}
+        <LinkOut href="https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions">
+          this guide
+        </LinkOut>{' '}
+        for some tips on how to get the most accuracy with your manual
+        measurements.
       </p>
     </div>
   </>

--- a/labware-library/src/labware-creator/components/IntroCopy.js
+++ b/labware-library/src/labware-creator/components/IntroCopy.js
@@ -36,8 +36,8 @@ const IntroCopy = () => (
       <p>
         <strong>Please note:</strong> We strongly recommend you reference
         mechanical drawings directly from your supplier/manufacturer and only
-        rely on manual measurements (using callipers when possible) to
-        supplement missing information. Refer to the bottom of{' '}
+        rely on manual measurements (using calipers when possible) to supplement
+        missing information. Refer to the bottom of{' '}
         <LinkOut href={LINK_CUSTOM_LABWARE_GUIDE}>this guide </LinkOut> for some
         tips on how to get the most accuracy with your manual measurements.
       </p>

--- a/labware-library/src/labware-creator/components/importLabware.css
+++ b/labware-library/src/labware-creator/components/importLabware.css
@@ -24,10 +24,10 @@
 
 .file_drop {
   @apply --font-body-1-dark;
+  @apply --center-children;
 
-  display: block;
-  width: 11rem;
-  padding: 1rem 2rem 2rem;
+  width: 100%;
+  padding: 1rem 2rem;
   margin: 0 auto;
   border: 2px dashed silver;
   border-radius: 6px;
@@ -37,6 +37,6 @@
 
 .file_drop_icon {
   display: block;
-  margin: 2rem auto 1rem;
-  width: 2rem;
+  margin: 1rem;
+  width: 3rem;
 }

--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -35,8 +35,8 @@ export type LabwareType =
 export const labwareTypeOptions: Options = [
   { name: 'Well Plate', value: 'wellPlate' },
   { name: 'Reservoir', value: 'reservoir' },
-  { name: 'Tube Rack', value: 'tubeRack' },
-  { name: 'Aluminum Block', value: 'aluminumBlock' },
+  { name: 'Tubes + Opentrons Tube Rack', value: 'tubeRack' },
+  { name: 'Tubes / Plates + Opentrons Aluminum Block', value: 'aluminumBlock' },
 ]
 
 export type WellShape = 'circular' | 'rectangular'

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -596,9 +596,7 @@ const App = () => {
                 >
                   <div className={styles.flex_row}>
                     <div className={styles.instructions_column}>
-                      {values.labwareType === 'tubeRack' ||
-                      values.aluminumBlockChildType === 'tubes' ||
-                      values.aluminumBlockChildType === 'pcrTubeStrip' ? (
+                      {displayAsTube(values) ? (
                         <>
                           <p>
                             Reference the <strong>top</strong> of the{' '}

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -38,6 +38,7 @@ import Section from './components/Section'
 import TextField from './components/TextField'
 import ImportLabware from './components/ImportLabware'
 import styles from './styles.css'
+
 import type {
   LabwareFields,
   LabwareType,
@@ -56,6 +57,9 @@ type MakeAutofillOnChangeArgs = {|
   setTouched: ({ [$Keys<LabwareFields>]: boolean }) => void,
   setValues: ($Shape<LabwareFields>) => void,
 |}
+
+const PDF_URL =
+  'https://opentrons-publications.s3.us-east-2.amazonaws.com/TestGuide_labware.pdf'
 
 const makeAutofillOnChange = ({
   autofills,
@@ -373,7 +377,7 @@ const App = () => {
           setValues,
         }) => (
           <div className={styles.labware_creator}>
-            <h2>Custom Labware Creator</h2>
+            <h2>Custom Labware Creator BETA</h2>
             <IntroCopy />
             <div className={styles.flex_row}>
               <div className={styles.new_definition_section}>
@@ -540,9 +544,9 @@ const App = () => {
                   <div className={styles.flex_row}>
                     <div className={styles.instructions_column}>
                       <p>
-                        The grid of wells on your labware is arranged in a
-                        number of rows (run horizontally across your labware,
-                        left to right) and columns (run top to bottom).
+                        The grid of wells on your labware is arranged via rows
+                        and columns. Rows run horizontally across your labware
+                        (left to right). Columns run top to bottom.
                       </p>
                     </div>
                     <div className={styles.diagram_column}>
@@ -592,13 +596,32 @@ const App = () => {
                 >
                   <div className={styles.flex_row}>
                     <div className={styles.instructions_column}>
-                      <p>
-                        Reference the <strong>inside</strong> of the well.
-                        Ignore any lip.
-                      </p>
-                      <p>
-                        Diameter helps the robot locate the sides of the wells.
-                      </p>
+                      {values.labwareType === 'tubeRack' ||
+                      values.aluminumBlockChildType === 'tubes' ||
+                      values.aluminumBlockChildType === 'pcrTubeStrip' ? (
+                        <>
+                          <p>
+                            Reference the <strong>top</strong> of the{' '}
+                            <strong>inside</strong> of the tube. Ignore any lip.{' '}
+                          </p>
+                          <p>
+                            Diameter helps the robot locate the sides of the
+                            tubes. If there are multiple measurements for this
+                            dimension then use the smaller one.{' '}
+                          </p>
+                        </>
+                      ) : (
+                        <>
+                          <p>
+                            Reference the <strong>inside</strong> of the well.
+                            Ignore any lip.
+                          </p>
+                          <p>
+                            Diameter helps the robot locate the sides of the
+                            wells.
+                          </p>
+                        </>
+                      )}
                     </div>
                     <div className={styles.diagram_column}>
                       <WellXYImg wellShape={values.wellShape} />
@@ -776,10 +799,22 @@ const App = () => {
                   <div className={styles.flex_row}>
                     <div className={styles.instructions_column}>
                       <p>
-                        Your file will be exported with a protocol that will
-                        help you test and troubleshoot your labware definition
-                        on the robot. The protocol requires a Single Channel
-                        pipette on the right mount of your robot.
+                        Files are exported as a zipped file containing 1) the
+                        labware definition as a JSON file, and 2) a test python
+                        protocol referencing the labware to help troubleshoot
+                        the accuracy of the definition on your robot. The test
+                        protocol will require a single channel pipette on the
+                        <strong> right mount</strong> of your robot.{' '}
+                        <LinkOut href={PDF_URL}>Click here</LinkOut> for
+                        instructions on running the test protocol.
+                      </p>
+                      <p>
+                        Please Note: It’s important to create a labware
+                        definition that is precise, and does not rely on
+                        excessive calibration prior to each run to achieve
+                        accuracy. In this way you&apos;ll generate labware
+                        definitions that are reusable and shareable with others
+                        inside or outside your lab.
                       </p>
                     </div>
                     <div className={styles.export_form_fields}>
@@ -799,11 +834,6 @@ const App = () => {
                           options={pipetteNameOptions}
                         />
                       </div>
-                      <p className={styles.pipette_field_caption}>
-                        Files are exported with a protocol that will use a
-                        single channel pipette to test whether a pipette can hit
-                        key points on your labware
-                      </p>
                       <PrimaryButton
                         className={styles.export_button}
                         onClick={() => {

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -14,11 +14,6 @@
     line-height: var(--lh-copy);
   }
 
-  & a,
-  & a:visited {
-    color: var(--c-blue);
-  }
-
   & ul {
     list-style: disc;
     padding-left: 1.25rem;
@@ -35,15 +30,35 @@
   }
 }
 
+a,
+a:visited {
+  color: var(--c-blue);
+}
+
 /* TODO (ka 2019-8-23): Removed nesting here to allow for easier style overrides/reduce specificity */
 h2 {
   @apply --font-header-dark;
 }
 
 .labware_guide_button {
+  display: inline-block;
   width: auto;
   margin: 2rem 0 1rem;
-  padding: 0.5rem 2rem;
+  padding: 1rem 2rem;
+  border-radius: 3px;
+  background-color: var(--c-blue);
+  font-size: var(--fs-body-2);
+  color: white;
+  font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
+  text-transform: uppercase;
+
+  &:hover {
+    background-color: #00f;
+  }
+
+  &:visited {
+    color: white;
+  }
 }
 
 .start_creating_btn:focus {
@@ -72,7 +87,6 @@ h2 {
 
 .setup_heading {
   border: none;
-  font-weight: var(--fw-regular);
 }
 
 .flex_row {

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -40,6 +40,12 @@ h2 {
   @apply --font-header-dark;
 }
 
+.labware_guide_button {
+  width: auto;
+  margin: 2rem 0 1rem;
+  padding: 0.5rem 2rem;
+}
+
 .start_creating_btn:focus {
   outline: none;
 }


### PR DESCRIPTION
## overview

closes #3977

## changelog

- refactor(labware-library): Update landing content and instructions copy

## review requests

http://sandbox.labware.opentrons.com/lc_copy-edits/create/

**Note:** Punted on the subscript for XY offset and spacing since this text is driven by data strings and there is no subscript S unicode character.

- [ ] Layout looks good
- [ ] Copy/changes match doc
- [ ] Code is sane
