### PR TITLE
feat(labware-creator): add images to well shape fields

### DIFF
--- a/labware-library/src/images/circularWell.svg
+++ b/labware-library/src/images/circularWell.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>Round well</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Round-well" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Oval-2" stroke="#979797" stroke-width="1.5" cx="12" cy="12" r="11"></circle>
+    </g>
+</svg>

--- a/labware-library/src/images/rectangularWell.svg
+++ b/labware-library/src/images/rectangularWell.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>Square well</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Square-well" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" stroke="#979797" stroke-width="1.5" x="1.75" y="1.75" width="20.5" height="20.5"></rect>
+    </g>
+</svg>

--- a/labware-library/src/images/wellShapeFlat.svg
+++ b/labware-library/src/images/wellShapeFlat.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>Flat</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Flat" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <polyline id="Line" stroke="#979797" stroke-width="1.5" points="1 1 1 23 23 23 23 1"></polyline>
+    </g>
+</svg>

--- a/labware-library/src/images/wellShapeU.svg
+++ b/labware-library/src/images/wellShapeU.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>Rounded</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Rounded" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <path d="M1,1 L1,13 C1,19.7556783 4.66666667,23.1335174 12,23.1335174 C19.3333333,23.1335174 23,19.7556783 23,13 L23,1" id="Line" stroke="#979797" stroke-width="1.5"></path>
+    </g>
+</svg>

--- a/labware-library/src/images/wellShapeV.svg
+++ b/labware-library/src/images/wellShapeV.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>V Bottom</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="V-Bottom" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <path d="M1,1 L1,13 C8.33333333,19.7556783 12,23.1335174 12,23.1335174 C12,23.1335174 15.6666667,19.7556783 23,13 L23,1" id="Line" stroke="#979797" stroke-width="1.5"></path>
+    </g>
+</svg>

--- a/labware-library/src/labware-creator/components/HeightGuidingText.js
+++ b/labware-library/src/labware-creator/components/HeightGuidingText.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import type { LabwareType } from '../fields'
+
+const HeightGuidingText = (props: {| labwareType: ?LabwareType |}) => {
+  const { labwareType } = props
+  const footer = (
+    <p>
+      The height measurement informs the robot of the top and bottom of your
+      labware.
+    </p>
+  )
+  if (labwareType === 'tubeRack') {
+    return (
+      <>
+        <p>Place your tubes inside the rack.</p>
+        <p>
+          Reference{' '}
+          <strong>from the top of the tube to bottom of the rack.</strong>{' '}
+          Include any well lip. Exclude any cover or cap.
+        </p>
+        {footer}
+      </>
+    )
+  }
+  if (labwareType === 'aluminumBlock') {
+    return (
+      <>
+        <p>Put your labware on top of the aluminum block.</p>
+        <p>
+          Reference{' '}
+          <strong>
+            from the top of your labware to the bottom of the block.
+          </strong>{' '}
+          Include any well or tube lip. Exclude any cover or cap.
+        </p>
+        {footer}
+      </>
+    )
+  }
+  return (
+    <>
+      <p>Include any well lip in the measurement. Exclude any cover or cap.</p>
+      {footer}
+    </>
+  )
+}
+
+export default HeightGuidingText

--- a/labware-library/src/labware-creator/components/RadioField.js
+++ b/labware-library/src/labware-creator/components/RadioField.js
@@ -3,12 +3,13 @@ import * as React from 'react'
 import { Field } from 'formik'
 import { RadioGroup } from '@opentrons/components'
 import { getIsHidden } from '../formSelectors'
-import { LABELS, type LabwareFields, type Options } from '../fields'
+import { LABELS, type LabwareFields } from '../fields'
 import fieldStyles from './fieldStyles.css'
 
 type Props = {|
   name: $Keys<LabwareFields>,
-  options: Options,
+  options: $PropertyType<React.ElementProps<typeof RadioGroup>, 'options'>,
+  labelTextClassName?: ?string,
 |}
 
 const RadioField = (props: Props) => (
@@ -19,13 +20,13 @@ const RadioField = (props: Props) => (
           <div className={fieldStyles.field_label}>{LABELS[props.name]}</div>
           <RadioGroup
             {...field}
+            labelTextClassName={props.labelTextClassName}
             onChange={e => {
               field.onChange(e)
               // do not wait until blur to make radio field 'dirty'
               field.onBlur(e)
             }}
             options={props.options}
-            inline
           />
         </div>
       )

--- a/labware-library/src/labware-creator/components/optionsWithImages/index.js
+++ b/labware-library/src/labware-creator/components/optionsWithImages/index.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react'
+import {
+  wellBottomShapeOptions,
+  wellShapeOptions,
+  type Options,
+} from '../../fields'
+import styles from './optionsWithImages.css'
+
+const WELL_SHAPE_IMAGES = {
+  rectangular: require('../../../images/rectangularWell.svg'),
+  circular: require('../../../images/circularWell.svg'),
+}
+
+const WELL_BOTTOM_IMAGES = {
+  flat: require('../../../images/wellShapeFlat.svg'),
+  u: require('../../../images/wellShapeU.svg'),
+  v: require('../../../images/wellShapeV.svg'),
+}
+
+const makeOptionsWithImages = (
+  options: Options,
+  imageMap: { [value: string]: string }
+): Array<{| name: string, value: string, children?: React.Node |}> =>
+  options.map(opt => ({
+    name: opt.name,
+    value: opt.value,
+    children: (
+      <div className={styles.radio_image_label}>
+        <img className={styles.radio_image} src={imageMap[opt.value]} />
+        <div>{opt.name}</div>
+      </div>
+    ),
+  }))
+
+export const wellShapeOptionsWithIcons = makeOptionsWithImages(
+  wellShapeOptions,
+  WELL_SHAPE_IMAGES
+)
+
+export const wellBottomShapeOptionsWithIcons = makeOptionsWithImages(
+  wellBottomShapeOptions,
+  WELL_BOTTOM_IMAGES
+)

--- a/labware-library/src/labware-creator/components/optionsWithImages/optionsWithImages.css
+++ b/labware-library/src/labware-creator/components/optionsWithImages/optionsWithImages.css
@@ -1,0 +1,17 @@
+@import '@opentrons/components';
+
+.hidden {
+  display: none;
+}
+
+.radio_image_label {
+  text-anchor: middle;
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.radio_image {
+  padding: 0 0.5rem;
+  height: 1.25rem;
+}

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -302,6 +302,41 @@ const getXYDimensionAlerts = (
   ) : null
 }
 
+// TODO IMMEDIATELY: factor out
+const WELL_SHAPE_IMAGES = {
+  rectangular: require('../images/rectangularWell.svg'),
+  circular: require('../images/circularWell.svg'),
+}
+
+const WELL_BOTTOM_IMAGES = {
+  flat: require('../images/wellShapeFlat.svg'),
+  u: require('../images/wellShapeU.svg'),
+  v: require('../images/wellShapeV.svg'),
+}
+
+// TODO IMMEDIATELY: DRY
+const wellShapeOptionsWithIcons = wellShapeOptions.map(opt => ({
+  name: opt.name,
+  value: opt.value,
+  children: (
+    <div className={styles.radio_image_label}>
+      <img className={styles.radio_image} src={WELL_SHAPE_IMAGES[opt.value]} />
+      <div>{opt.name}</div>
+    </div>
+  ),
+}))
+
+const wellBottomShapeOptionsWithIcons = wellBottomShapeOptions.map(opt => ({
+  name: opt.name,
+  value: opt.value,
+  children: (
+    <div className={styles.radio_image_label}>
+      <img className={styles.radio_image} src={WELL_BOTTOM_IMAGES[opt.value]} />
+      <div>{opt.name}</div>
+    </div>
+  ),
+}))
+
 const App = () => {
   const [
     showExportErrorModal,
@@ -708,7 +743,11 @@ const App = () => {
                       <WellXYImg wellShape={values.wellShape} />
                     </div>
                     <div className={styles.form_fields_column}>
-                      <RadioField name="wellShape" options={wellShapeOptions} />
+                      <RadioField
+                        name="wellShape"
+                        labelTextClassName={styles.hidden}
+                        options={wellShapeOptionsWithIcons}
+                      />
                       {values.wellShape === 'rectangular' ? (
                         <>
                           <TextField
@@ -757,9 +796,10 @@ const App = () => {
                       />
                     </div>
                     <div className={styles.form_fields_column}>
-                      <Dropdown
+                      <RadioField
                         name="wellBottomShape"
-                        options={wellBottomShapeOptions}
+                        labelTextClassName={styles.hidden}
+                        options={wellBottomShapeOptionsWithIcons}
                       />
                       <TextField
                         name="wellDepth"

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -16,8 +16,6 @@ import {
   aluminumBlockChildTypeOptions,
   getDefaultFormState,
   getImplicitAutofillValues,
-  wellBottomShapeOptions,
-  wellShapeOptions,
   yesNoOptions,
   tubeRackAutofills,
   SUGGESTED_X,
@@ -39,8 +37,13 @@ import LinkOut from './components/LinkOut'
 import RadioField from './components/RadioField'
 import Section from './components/Section'
 import TextField from './components/TextField'
+import HeightGuidingText from './components/HeightGuidingText'
 import ImportLabware from './components/ImportLabware'
 import ImportErrorModal from './components/ImportErrorModal'
+import {
+  wellShapeOptionsWithIcons,
+  wellBottomShapeOptionsWithIcons,
+} from './components/optionsWithImages'
 import styles from './styles.css'
 
 import type {
@@ -208,50 +211,6 @@ const XYOffsetImg = (props: {|
   return <img src={src} />
 }
 
-const HeightGuidingText = (props: {| labwareType: ?LabwareType |}) => {
-  const { labwareType } = props
-  const footer = (
-    <p>
-      The height measurement informs the robot of the top and bottom of your
-      labware.
-    </p>
-  )
-  if (labwareType === 'tubeRack') {
-    return (
-      <>
-        <p>Place your tubes inside the rack.</p>
-        <p>
-          Reference{' '}
-          <strong>from the top of the tube to bottom of the rack.</strong>{' '}
-          Include any well lip. Exclude any cover or cap.
-        </p>
-        {footer}
-      </>
-    )
-  }
-  if (labwareType === 'aluminumBlock') {
-    return (
-      <>
-        <p>Put your labware on top of the aluminum block.</p>
-        <p>
-          Reference{' '}
-          <strong>
-            from the top of your labware to the bottom of the block.
-          </strong>{' '}
-          Include any well or tube lip. Exclude any cover or cap.
-        </p>
-        {footer}
-      </>
-    )
-  }
-  return (
-    <>
-      <p>Include any well lip in the measurement. Exclude any cover or cap.</p>
-      {footer}
-    </>
-  )
-}
-
 const displayAsTube = (values: LabwareFields) =>
   values.labwareType === 'tubeRack' ||
   (values.labwareType === 'aluminumBlock' &&
@@ -301,41 +260,6 @@ const getXYDimensionAlerts = (
     <AlertItem type="info" title={xyMessage} />
   ) : null
 }
-
-// TODO IMMEDIATELY: factor out
-const WELL_SHAPE_IMAGES = {
-  rectangular: require('../images/rectangularWell.svg'),
-  circular: require('../images/circularWell.svg'),
-}
-
-const WELL_BOTTOM_IMAGES = {
-  flat: require('../images/wellShapeFlat.svg'),
-  u: require('../images/wellShapeU.svg'),
-  v: require('../images/wellShapeV.svg'),
-}
-
-// TODO IMMEDIATELY: DRY
-const wellShapeOptionsWithIcons = wellShapeOptions.map(opt => ({
-  name: opt.name,
-  value: opt.value,
-  children: (
-    <div className={styles.radio_image_label}>
-      <img className={styles.radio_image} src={WELL_SHAPE_IMAGES[opt.value]} />
-      <div>{opt.name}</div>
-    </div>
-  ),
-}))
-
-const wellBottomShapeOptionsWithIcons = wellBottomShapeOptions.map(opt => ({
-  name: opt.name,
-  value: opt.value,
-  children: (
-    <div className={styles.radio_image_label}>
-      <img className={styles.radio_image} src={WELL_BOTTOM_IMAGES[opt.value]} />
-      <div>{opt.name}</div>
-    </div>
-  ),
-}))
 
 const App = () => {
   const [

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -120,22 +120,6 @@ h2 {
   max-width: 16rem;
 }
 
-.hidden {
-  display: none;
-}
-
-.radio_image_label {
-  text-anchor: middle;
-  display: flex;
-  align-items: center;
-  padding: 0.25rem 0;
-}
-
-.radio_image {
-  padding: 0 0.5rem;
-  height: 1.25rem;
-}
-
 .instructions_column,
 .diagram_column,
 .form_fields_column,

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -120,6 +120,22 @@ h2 {
   max-width: 16rem;
 }
 
+.hidden {
+  display: none;
+}
+
+.radio_image_label {
+  text-anchor: middle;
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.radio_image {
+  padding: 0 0.5rem;
+  height: 1.25rem;
+}
+
 .instructions_column,
 .diagram_column,
 .form_fields_column,


### PR DESCRIPTION
## overview

Closes #3957 -- see ticket for illustration and details

## changelog

- also factored out `HeightGuidingText` to its own file

## review requests

- LC should still work, especially the well shape / well bottom shape fields