### PR TITLE
fix(shared-data): fix tipOverlap value for P20 tiprack

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_96_tiprack_20ul/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_tiprack_20ul/1.json
@@ -1004,7 +1004,7 @@
     "format": "96Standard",
     "isTiprack": true,
     "tipLength": 39.2,
-    "tipOverlap": 3.29,
+    "tipOverlap": 8.25,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_96_tiprack_20ul"
   },


### PR DESCRIPTION
## overview
This PR updates the `tipOverlap` value for the Opentrons 20 uL tip rack. The original value is copied from the 10 uL tip rack definition. Since the P20 GEN2 pipette has a longer nozzle than the P10, this number should be larger. 

## Review
After robot factory reset and CLI deck calibration, do not tip probe and run this protocol. You should see that the pipette would not touch the deck because the tip length was supposed to be longer.
```
def run(ctx):
    from opentrons.types import Location, Point
    tiprack = ctx.load_labware('opentrons_96_tiprack_20uL', '6')
    pip = ctx.load_instrument('p20_single_v2.0',
                              mount='right', tip_racks=[tiprack])

    pip.pick_up_tip()
    location = Location(Point(380.87, 9.0, 0.0), ctx.deck)
    pip.move_to(location)
    pip.return_tip()
```
After updating the 20 uL tip rack definition, you should no longer see this problem.