### PR TITLE
feat(protocol-designer): add copy with custom labware button

### DIFF
--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -7,19 +7,26 @@ export const KNOWLEDGEBASE_ROOT_URL =
 export const links = {
   multiDispense: `${KNOWLEDGEBASE_ROOT_URL}/building-a-protocol/steps/paths`,
   protocolSteps: `${KNOWLEDGEBASE_ROOT_URL}/en/collections/1606688-building-a-protocol#steps`,
+  customLabware: `https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions`,
 }
 
 type Link = $Keys<typeof links>
 
-type Props = {
+type Props = {|
   to: Link,
   children: React.Node,
-}
+  className?: ?string,
+|}
 
 /** Link which opens a page on the knowledge base to a new tab/window */
 function KnowledgeBaseLink(props: Props) {
   return (
-    <a target="_blank" rel="noopener noreferrer" href={links[props.to]}>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href={links[props.to]}
+      className={props.className}
+    >
       {props.children}
     </a>
   )

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -10,6 +10,7 @@ import startCase from 'lodash/startCase'
 import reduce from 'lodash/reduce'
 import i18n from '../../localization'
 import { getOnlyLatestDefs } from '../../labware-defs/utils'
+import KnowledgeBaseLink from '../KnowledgeBaseLink'
 import { Portal } from '../portals/TopPortal'
 import { PDTitledList } from '../lists'
 import LabwareItem from './LabwareItem'
@@ -139,16 +140,25 @@ const LabwareDropdown = (props: Props) => {
           ))}
         </ul>
         {props.showUploadCustomLabwareButton && (
-          <OutlineButton Component="label" className={styles.upload_button}>
-            {i18n.t('button.upload_custom_labware')}
-            <input
-              type="file"
-              onChange={e => {
-                onUploadLabware(e)
-                selectCategory(CUSTOM_CATEGORY)
-              }}
-            />
-          </OutlineButton>
+          <>
+            <OutlineButton Component="label" className={styles.upload_button}>
+              {i18n.t('button.upload_custom_labware')}
+              <input
+                type="file"
+                onChange={e => {
+                  onUploadLabware(e)
+                  selectCategory(CUSTOM_CATEGORY)
+                }}
+              />
+            </OutlineButton>
+            <div className={styles.upload_helper_copy}>
+              {i18n.t('modal.labware_selection.creating_labware_defs')}{' '}
+              <KnowledgeBaseLink className={styles.link} to="customLabware">
+                here
+              </KnowledgeBaseLink>
+              .
+            </div>
+          </>
         )}
         <OutlineButton onClick={onClose}>
           {i18n.t('button.close')}

--- a/protocol-designer/src/components/LabwareSelectionModal/styles.css
+++ b/protocol-designer/src/components/LabwareSelectionModal/styles.css
@@ -120,3 +120,14 @@
   position: fixed;
   clip: rect(1px 1px 1px 1px);
 }
+
+.upload_helper_copy {
+  @apply --font-body-1-dark;
+}
+
+/* TODO: Ian 2019-09-03 similar styles for links exist in multiple projects */
+.link {
+  color: var(--c-blue);
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -7,7 +7,8 @@
     "well_count": "# of wells",
     "max_vol": "Max Volume",
     "see_details": "See detail page",
-    "view_measurements": "view measurements"
+    "view_measurements": "view measurements",
+    "creating_labware_defs": "Learn more about creating custom labware definitions"
   },
   "tip_position": {
     "title": "Tip Positioning",


### PR DESCRIPTION
## overview

closes #3924

## changelog


## review requests

Enable the custom labware feature flag (in Settings page) to see the custom labware button and new copy in the Add Labware Modal.
- Link should work
- If you disable the custom labware feature flag, both the button and the copy should disappear from the Add Labware Modal.