### PR TITLE
fix(docs): Fix OT 1 API link and PDF link

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -123,6 +123,8 @@ docs-pdf-prep: local-install
 docs-pdf-local: docs-pdf-prep
 	-$(sphinx_build) -b latex -d docs/build/doctrees docs/source docs/build/pdf
 	-$(MAKE) -C docs/build/pdf all-pdf
+	$(SHX) ls docs/build/pdf/*.pdf
+	$(SHX) cp docs/build/pdf/*.pdf docs/dist/
 
 docs-pdf-ci: docs-pdf-prep
 	$(sphinx_build) -b latex -d docs/build/doctrees docs/source docs/build/pdf

--- a/api/docs/source/conf.py
+++ b/api/docs/source/conf.py
@@ -158,7 +158,7 @@ html_theme_options = {
     'sidebar_list': '#05C1B3',
     'sidebar_link_underscore': '#DDDDDD',
     'extra_nav_links': {
-        'Download As PDF': '_static/OpentronsAPI.pdf',
+        'Download As PDF': 'OpentronsAPI.pdf',
         'OT 1 API': 'ot1/index.html'
     }
 }

--- a/api/docs/source/templates/toc-with-nav-force-no-hidden.html
+++ b/api/docs/source/templates/toc-with-nav-force-no-hidden.html
@@ -10,7 +10,7 @@
 <hr />
 <ul>
     {% for text, uri in theme_extra_nav_links.items() %}
-    <li class="toctree-l1"><a href="{{ uri }}">{{ text }}</a></li>
+    <li class="toctree-l1"><a href="https://docs.opentrons.com/{{uri}}">{{ text }}</a></li>
     {% endfor %}
 </ul>
 {% endif %}

--- a/api/docs/source/templates/toc-with-nav-force-show-hidden.html
+++ b/api/docs/source/templates/toc-with-nav-force-show-hidden.html
@@ -10,7 +10,7 @@
 <hr />
 <ul>
     {% for text, uri in theme_extra_nav_links.items() %}
-    <li class="toctree-l1"><a href="{{ uri }}">{{ text }}</a></li>
+    <li class="toctree-l1"><a href="https://docs.opentrons.com/{{uri}}">{{ text }}</a></li>
     {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
## overview

The new tree structure broke links for both the OT 1 API and the generated PDF of our documentation. Closes #3987.

## changelog

- Change link reference for OT 1 api and PDF to always point to parent link
- Modify location that PDF is placed
- Ensure that the PDF is copied to the correct place for local and CI builds

## review requests

Check links work when you're in API v1 docs, API v2 docs and the main page.
