### PR TITLE
fix(app): Disable run start button if missing modules

### DIFF
--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -51,7 +51,6 @@ export default function LabwareListItem(props: LabwareListItemProps) {
       activeClassName={styles.active}
     >
       <HoverTooltip
-        placement="bottom-end"
         tooltipComponent={
           <LabwareNameTooltip
             name={name}

--- a/app/src/components/ConnectModules/index.js
+++ b/app/src/components/ConnectModules/index.js
@@ -8,7 +8,6 @@ import {
   actions as robotActions,
 } from '../../robot'
 
-import { RefreshWrapper } from '../Page'
 import DeckMap from '../DeckMap'
 import Prompt from './Prompt'
 import styles from './styles.css'
@@ -36,14 +35,12 @@ function ConnectModules(props: Props) {
   const onPromptClick = modulesMissing ? fetchModules : setReviewed
 
   return (
-    <RefreshWrapper refresh={fetchModules}>
-      <div className={styles.page_content_dark}>
-        <Prompt modulesMissing={modulesMissing} onClick={onPromptClick} />
-        <div className={styles.deck_map_wrapper}>
-          <DeckMap className={styles.deck_map} modulesRequired />
-        </div>
+    <div className={styles.page_content_dark}>
+      <Prompt modulesMissing={modulesMissing} onClick={onPromptClick} />
+      <div className={styles.deck_map_wrapper}>
+        <DeckMap className={styles.deck_map} modulesRequired />
       </div>
-    </RefreshWrapper>
+    </div>
   )
 }
 

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -5,9 +5,8 @@ import { connect } from 'react-redux'
 
 import { getModuleDisplayName } from '@opentrons/shared-data'
 import { selectors as robotSelectors } from '../../robot'
-import { getModulesState, fetchModules } from '../../robot-api'
+import { getModulesState } from '../../robot-api'
 
-import { RefreshWrapper } from '../Page'
 import InfoSection from './InfoSection'
 import { SectionContentHalf } from '../layout'
 import InstrumentItem from './InstrumentItem'
@@ -26,19 +25,18 @@ type SP = {|
   attachModulesUrl: string,
 |}
 
-type DP = {| fetchModules: () => mixed |}
+type DP = {| dispatch: Dispatch |}
 
-type Props = { ...OP, ...SP, ...DP }
+type Props = {| ...OP, ...SP, ...DP |}
 
 const TITLE = 'Required Modules'
 
-export default connect<Props, OP, SP, DP, _, _>(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProtocolModulesCard)
+export default connect<Props, OP, SP, DP, _, _>(mapStateToProps)(
+  ProtocolModulesCard
+)
 
 function ProtocolModulesCard(props: Props) {
-  const { modules, actualModules, fetchModules, attachModulesUrl } = props
+  const { modules, actualModules, attachModulesUrl } = props
 
   if (modules.length < 1) return null
 
@@ -52,20 +50,18 @@ function ProtocolModulesCard(props: Props) {
   const modulesMatch = moduleInfo.every(m => m.modulesMatch)
 
   return (
-    <RefreshWrapper refresh={fetchModules}>
-      <InfoSection title={TITLE}>
-        <SectionContentHalf>
-          {moduleInfo.map(m => (
-            <InstrumentItem key={m.slot} match={m.modulesMatch}>
-              {m.displayName}{' '}
-            </InstrumentItem>
-          ))}
-        </SectionContentHalf>
-        {!modulesMatch && (
-          <InstrumentWarning instrumentType="module" url={attachModulesUrl} />
-        )}
-      </InfoSection>
-    </RefreshWrapper>
+    <InfoSection title={TITLE}>
+      <SectionContentHalf>
+        {moduleInfo.map(m => (
+          <InstrumentItem key={m.slot} match={m.modulesMatch}>
+            {m.displayName}{' '}
+          </InstrumentItem>
+        ))}
+      </SectionContentHalf>
+      {!modulesMatch && (
+        <InstrumentWarning instrumentType="module" url={attachModulesUrl} />
+      )}
+    </InfoSection>
   )
 }
 
@@ -78,11 +74,5 @@ function mapStateToProps(state: State, ownProps: OP): SP {
     modules: robotSelectors.getModules(state),
     // TODO(mc, 2018-10-10): pass this prop down from page
     attachModulesUrl: `/robots/${robot.name}/instruments`,
-  }
-}
-
-function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  return {
-    fetchModules: () => dispatch(fetchModules(ownProps.robot)),
   }
 }

--- a/app/src/components/InstrumentSettings/AttachedModulesCard.js
+++ b/app/src/components/InstrumentSettings/AttachedModulesCard.js
@@ -3,8 +3,8 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 
-import { Card, IntervalWrapper } from '@opentrons/components'
-import { fetchModules, getModulesState } from '../../robot-api'
+import { Card } from '@opentrons/components'
+import { getModulesState } from '../../robot-api'
 import ModulesCardContents from './ModulesCardContents'
 import { getConfig } from '../../config'
 
@@ -19,32 +19,23 @@ type SP = {|
   __tempControlsEnabled: boolean,
 |}
 
-type DP = {| fetchModules: () => mixed |}
-
-type Props = { ...OP, ...SP, ...DP }
+type Props = {| ...OP, ...SP, dispatch: Dispatch |}
 
 const TITLE = 'Modules'
-const POLL_MODULE_INTERVAL_MS = 5000
 
-export default connect<Props, OP, SP, DP, State, Dispatch>(
-  mapStateToProps,
-  mapDispatchToProps
-)(AttachedModulesCard)
+export default connect<Props, OP, SP, {||}, State, Dispatch>(mapStateToProps)(
+  AttachedModulesCard
+)
 
 function AttachedModulesCard(props: Props) {
   return (
-    <IntervalWrapper
-      interval={POLL_MODULE_INTERVAL_MS}
-      refresh={props.fetchModules}
-    >
-      <Card title={TITLE} column>
-        <ModulesCardContents
-          modules={props.modules}
-          robot={props.robot}
-          showControls={props.__tempControlsEnabled}
-        />
-      </Card>
-    </IntervalWrapper>
+    <Card title={TITLE} column>
+      <ModulesCardContents
+        modules={props.modules}
+        robot={props.robot}
+        showControls={props.__tempControlsEnabled}
+      />
+    </Card>
   )
 }
 
@@ -54,11 +45,5 @@ function mapStateToProps(state: State, ownProps: OP): SP {
     __tempControlsEnabled: Boolean(
       getConfig(state).devInternal?.tempdeckControls
     ),
-  }
-}
-
-function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  return {
-    fetchModules: () => dispatch(fetchModules(ownProps.robot)),
   }
 }

--- a/app/src/components/InstrumentSettings/index.js
+++ b/app/src/components/InstrumentSettings/index.js
@@ -8,9 +8,7 @@ import { CardContainer, CardRow } from '../layout'
 
 import type { Robot } from '../../discovery'
 
-type Props = {
-  robot: Robot,
-}
+type Props = {| robot: Robot |}
 
 export default function InstrumentSettings(props: Props) {
   return (

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 
 import { getConnectedRobot } from '../../discovery'
 import {
-  fetchModules,
   getModulesState,
   sendModuleCommand,
   type ModuleCommandRequest,
@@ -13,8 +12,6 @@ import {
 import { selectors as robotSelectors } from '../../robot'
 import { getConfig } from '../../config'
 
-import { IntervalWrapper } from '@opentrons/components'
-
 import type { State, Dispatch } from '../../types'
 import type { Robot } from '../../discovery'
 
@@ -22,7 +19,6 @@ import TempDeckCard from './TempDeckCard'
 import MagDeckCard from './MagDeckCard'
 import ThermocyclerCard from './ThermocyclerCard'
 
-const POLL_MODULES_INTERVAL_MS = 1000
 const LIVE_STATUS_MODULES = ['magdeck', 'tempdeck', 'thermocycler']
 
 type SP = {|
@@ -33,7 +29,6 @@ type SP = {|
 |}
 
 type DP = {|
-  _fetchModules: (_robot: Robot) => mixed,
   _sendModuleCommand: (
     _robot: Robot,
     serial: string,
@@ -44,7 +39,6 @@ type DP = {|
 type Props = {|
   liveStatusModules: Array<Module>,
   isProtocolActive: boolean,
-  fetchModules: () => mixed,
   sendModuleCommand: (serial: string, request: ModuleCommandRequest) => mixed,
   __tempdeckControlsEnabled: boolean,
 |}
@@ -53,14 +47,14 @@ const ModuleLiveStatusCards = (props: Props) => {
   const {
     liveStatusModules,
     isProtocolActive,
-    fetchModules,
     sendModuleCommand,
     __tempdeckControlsEnabled,
   } = props
+
   if (liveStatusModules.length === 0) return null
 
   return (
-    <IntervalWrapper refresh={fetchModules} interval={POLL_MODULES_INTERVAL_MS}>
+    <>
       {liveStatusModules.map(module => {
         switch (module.name) {
           case 'tempdeck':
@@ -88,7 +82,7 @@ const ModuleLiveStatusCards = (props: Props) => {
             return null
         }
       })}
-    </IntervalWrapper>
+    </>
   )
 }
 
@@ -112,14 +106,13 @@ function mapStateToProps(state: State): SP {
 
 function mapDispatchToProps(dispatch: Dispatch): DP {
   return {
-    _fetchModules: _robot => dispatch(fetchModules(_robot)),
     _sendModuleCommand: (_robot, serial, request) =>
       dispatch(sendModuleCommand(_robot, serial, request)),
   }
 }
 
 function mergeProps(stateProps: SP, dispatchProps: DP): Props {
-  const { _fetchModules, _sendModuleCommand } = dispatchProps
+  const { _sendModuleCommand } = dispatchProps
   const {
     _robot,
     liveStatusModules,
@@ -130,7 +123,6 @@ function mergeProps(stateProps: SP, dispatchProps: DP): Props {
   return {
     liveStatusModules,
     isProtocolActive,
-    fetchModules: () => _robot && _fetchModules(_robot),
     sendModuleCommand: (serial, request) =>
       _robot && _sendModuleCommand(_robot, serial, request),
     __tempdeckControlsEnabled,

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -2,38 +2,19 @@
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
 import some from 'lodash/some'
-import {
-  useInterval,
-  PrimaryButton,
-  AlertModal,
-  Icon,
-} from '@opentrons/components'
+import { PrimaryButton, AlertModal, Icon } from '@opentrons/components'
 
-import {
-  fetchModules,
-  sendModuleCommand,
-  type Module,
-  type RobotHost,
-} from '../../robot-api'
+import { sendModuleCommand, type Module, type RobotHost } from '../../robot-api'
 import type { Dispatch } from '../../types'
 import DeckMap from '../DeckMap'
 import styles from './styles.css'
 import { Portal } from '../portal'
 
-const FETCH_MODULES_POLL_INTERVAL_MS = 1000
-
 type Props = {| robot: RobotHost, modules: Array<Module> |}
 
 function PrepareModules(props: Props) {
   const { modules, robot } = props
-
   const dispatch = useDispatch<Dispatch>()
-
-  // update on interval to respond to prepared modules
-  useInterval(
-    () => robot && dispatch(fetchModules(robot)),
-    FETCH_MODULES_POLL_INTERVAL_MS
-  )
 
   const handleOpenLidClick = () => {
     modules

--- a/app/src/components/RunPanel/RunControls.js
+++ b/app/src/components/RunPanel/RunControls.js
@@ -2,12 +2,16 @@
 // play pause run buttons for sidepanel
 import * as React from 'react'
 import { Link } from 'react-router-dom'
-import { OutlineButton } from '@opentrons/components'
+import { OutlineButton, HoverTooltip } from '@opentrons/components'
 
 import styles from './styles.css'
 
-type RunProps = {
+const MISSING_MODULES =
+  'Please attach all required modules before running this protocol'
+
+type RunProps = {|
   disabled: boolean,
+  modulesReady: boolean,
   isReadyToRun: boolean,
   isPaused: boolean,
   isRunning: boolean,
@@ -15,10 +19,12 @@ type RunProps = {
   onPauseClick: () => mixed,
   onResumeClick: () => mixed,
   onResetClick: () => mixed,
-}
+|}
+
 export default function RunControls(props: RunProps) {
   const {
     disabled,
+    modulesReady,
     isReadyToRun,
     isPaused,
     isRunning,
@@ -38,14 +44,24 @@ export default function RunControls(props: RunProps) {
   let resetButton
 
   if (isReadyToRun && !isRunning) {
+    // TODO(mc, 2019-09-03): add same check for pipettes
+    const runDisabled = disabled || !modulesReady
+    let tooltip = modulesReady ? null : MISSING_MODULES
+
     runButton = (
-      <OutlineButton
-        onClick={onRunClick}
-        className={styles.run_button}
-        disabled={disabled}
-      >
-        Start Run
-      </OutlineButton>
+      <HoverTooltip tooltipComponent={tooltip}>
+        {hoverTooltipHandlers => (
+          <div {...hoverTooltipHandlers}>
+            <OutlineButton
+              onClick={onRunClick}
+              className={styles.run_button}
+              disabled={runDisabled}
+            >
+              Start Run
+            </OutlineButton>
+          </div>
+        )}
+      </HoverTooltip>
     )
   } else if (isRunning) {
     pauseResumeButton = (
@@ -81,11 +97,11 @@ export default function RunControls(props: RunProps) {
   }
 
   return (
-    <div>
+    <>
       {runButton}
       {pauseResumeButton}
       {cancelButton}
       {resetButton}
-    </div>
+    </>
   )
 }

--- a/app/src/components/RunPanel/index.js
+++ b/app/src/components/RunPanel/index.js
@@ -6,6 +6,7 @@ import {
   actions as robotActions,
   selectors as robotSelectors,
 } from '../../robot'
+import { getMissingModules } from '../../robot-api'
 
 import { SidePanel, SidePanelGroup } from '@opentrons/components'
 import RunTimer from './RunTimer'
@@ -19,6 +20,7 @@ type SP = {|
   isPaused: boolean,
   startTime: ?number,
   isReadyToRun: boolean,
+  modulesReady: boolean,
   runTime: string,
   disabled: boolean,
 |}
@@ -30,13 +32,14 @@ type DP = {|
   onResetClick: () => mixed,
 |}
 
-type Props = { ...SP, ...DP }
+type Props = {| ...SP, ...DP |}
 
 const mapStateToProps = (state: State): SP => ({
   isRunning: robotSelectors.getIsRunning(state),
   isPaused: robotSelectors.getIsPaused(state),
   startTime: robotSelectors.getStartTime(state),
   isReadyToRun: robotSelectors.getIsReadyToRun(state),
+  modulesReady: getMissingModules(state).length === 0,
   runTime: robotSelectors.getRunTime(state),
   disabled:
     !robotSelectors.getSessionIsLoaded(state) ||
@@ -59,7 +62,17 @@ function RunPanel(props: Props) {
     <SidePanel title="Execute Run">
       <SidePanelGroup>
         <RunTimer startTime={props.startTime} runTime={props.runTime} />
-        <RunControls {...props} />
+        <RunControls
+          disabled={props.disabled}
+          modulesReady={props.modulesReady}
+          isReadyToRun={props.isReadyToRun}
+          isPaused={props.isPaused}
+          isRunning={props.isRunning}
+          onRunClick={props.onRunClick}
+          onPauseClick={props.onPauseClick}
+          onResumeClick={props.onResumeClick}
+          onResetClick={props.onResetClick}
+        />
       </SidePanelGroup>
       <ModuleLiveStatusCards />
     </SidePanel>

--- a/app/src/components/calibrate-pipettes/styles.css
+++ b/app/src/components/calibrate-pipettes/styles.css
@@ -17,5 +17,6 @@
 .alert {
   @apply --absolute-fill;
 
+  z-index: 1;
   bottom: auto;
 }

--- a/app/src/robot-api/resources/modules.js
+++ b/app/src/robot-api/resources/modules.js
@@ -134,6 +134,11 @@ export function getModulesState(
   return robotState?.resources.modules || []
 }
 
+const isModulePrepared = (module: Module): boolean => {
+  if (module.name === 'thermocycler') return module.data.lid === 'open'
+  return false
+}
+
 export function getUnpreparedModules(state: AppState): Array<Module> {
   const robot = getConnectedRobot(state)
   const sessionModules = robotSelectors.getModules(state)
@@ -142,10 +147,11 @@ export function getUnpreparedModules(state: AppState): Array<Module> {
     .map(m => m.name)
     .filter(name => PREPARABLE_MODULES.includes(name))
 
+  // return actual modules that are both
+  // a) required to be prepared by the session
+  // b) not prepared according to isModulePrepared
   return actualModules.filter(
-    m =>
-      preparableSessionModules.includes(m.name) &&
-      (m.name !== 'thermocycler' || m.data.lid !== 'open')
+    m => preparableSessionModules.includes(m.name) && isModulePrepared(m)
   )
 }
 

--- a/components/src/hooks/useInterval.js
+++ b/components/src/hooks/useInterval.js
@@ -7,10 +7,15 @@ import { useEffect, useRef } from 'react'
  *
  * @template T (type of the input value)
  * @param {() => mixed} callback (function to call on an interval)
- * @param {number | null} callback (interval delay, or null to stop interval)
+ * @param {number | null} delay (interval delay, or null to stop interval)
+ * @param {boolean} [immediate=false] (trigger the callback immediately before starting the interval)
  * @returns {void}
  */
-export function useInterval(callback: () => mixed, delay: number | null): void {
+export function useInterval(
+  callback: () => mixed,
+  delay: number | null,
+  immediate: boolean = false
+): void {
   const savedCallback = useRef()
 
   // remember the latest callback
@@ -21,9 +26,10 @@ export function useInterval(callback: () => mixed, delay: number | null): void {
   // set up the interval
   useEffect(() => {
     const tick = () => savedCallback.current && savedCallback.current()
-    if (delay !== null) {
+    if (delay !== null && delay > 0) {
+      if (immediate) tick()
       const id = setInterval(tick, delay)
       return () => clearInterval(id)
     }
-  }, [delay])
+  }, [delay, immediate])
 }

--- a/components/src/nav/SidePanel.css
+++ b/components/src/nav/SidePanel.css
@@ -6,7 +6,7 @@
 
 .panel {
   flex-shrink: 0;
-  overflow: hidden;
+  overflow: visible;
   border-right: var(--bd-light);
   background-color: var(--c-bg-light);
   position: relative;


### PR DESCRIPTION
## overview

This PR closes #2676 by disabling the "Start Run" button in the run page the robot is missing any required modules

## changelog

- fix(app): Disable run start button if missing modules
   - Due to the need to be polling modules on almost every page, I reconfigured the modules API client epic to simply poll GET /modules while connected to a robot
   - I think this should replace all most of out reactive module state needs until the notifications WS can be put in place
    - The only exception to this is the Modules card in Instrument Settings, which still needs to poll regardless of connection status (because user can view this card without clicking "Connect")

## review requests

I refactored some common code to a `getMissingModules` selector. This touched the following flows:

- [ ] Modules card in Instrument Settings
- [ ] Labware calibration with no modules
- [ ] Protocol run with no modules
- [ ] Labware calibration with missing modules
- [ ] Labware calibration with present modules
- [ ] Labware calibration with missing thermocycler
- [ ] Labware calibration with unprepared (lid closed) thermocycler
- [ ] Labware calibration with ready (lid open) thermocycler
