### PR TITLE
ci(travis): Pipe stylelint to tee in CI to paper over stdout problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,11 @@ lint-js:
 lint-json:
 	eslint --max-warnings 0 --ext .json .
 
+# stylelint seems to close stdout before make can, causing spurious failures
+# with `write error: stdout`; pipe to tee which will hopefully paper over it
 .PHONY: lint-css
 lint-css:
-	stylelint '**/*.css'
+	stylelint '**/*.css' $(and $(CI),| tee /dev/null)
 
 .PHONY: check-js
 check-js:


### PR DESCRIPTION
## overview

We've been getting flaky CI failures all the time where `make lint-css` fails with an [obscure make error about stdout already being closed](https://lists.gnu.org/archive/html/bug-make/2014-07/msg00035.html)

In a blind attempt to fix these issues (and without any obvious errors in the [stylelint CLI](https://github.com/stylelint/stylelint/blob/master/lib/cli.js)) this PR pipes the stylelint into `tee` to paper over whatever is causing this

🤷‍♂ 

## changelog

- ci(travis): Pipe stylelint to tee in CI to paper over stdout problems

## review requests

Thanks to @sfoster1 for this idea. Open to others if anyone has them
