### PR TITLE
fix(api): fix tip probing not fully self-centering

### DIFF
--- a/api/src/opentrons/util/calibration_functions.py
+++ b/api/src/opentrons/util/calibration_functions.py
@@ -35,8 +35,8 @@ def probe_instrument(instrument, robot, tip_length=None) -> Point:
     robot.poses = instrument._move(robot.poses, z=safe_height)
 
     for hs in hot_spots:
-        x0 = tp.center[0] + hs.x_start_offs
-        y0 = tp.center[1] + hs.y_start_offs
+        x0 = center[0] + hs.x_start_offs
+        y0 = center[1] + hs.y_start_offs
         z0 = hs.z_start_abs
 
         log.info("Moving to {}".format((x0, y0, z0)))


### PR DESCRIPTION
Fix #3983. The bug was simply reading from a similarly named (but wrong) variable.

# Reviewing

During CLI tip probe calibration, assuming the tip correctly hits the west and east switches, it should also correctly hit the south and north switches.

CLI tip probe calibration should also be immediately responsive to hitting the east or west switches unexpectedly early or late. Use your finger to tap the east or west switch well before the pipette tip hits it. Then, when the pipette moves to touch the south and north switches, its x-position should be off-center in that direction.