### PR TITLE
fix(api): remove protocol file size limit and ack immediately

### DIFF
--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -84,7 +84,7 @@ class RPCServer(object):
 
         def task_done(future):
             try:
-                result = future.result()
+                future.result()
             except Exception:
                 log.exception("send_task for socket {} threw:".format(_id))
 
@@ -250,7 +250,7 @@ class RPCServer(object):
                     'WebSocket connection closed unexpectedly: {0}'.format(
                         message))
             else:
-                log.warning('Unhanled WSMsgType: {0}'.format(message.type))
+                log.warning('Unhandled WSMsgType: {0}'.format(message.type))
         except Exception:
             log.exception('Error while processing request')
 

--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -87,10 +87,6 @@ class RPCServer(object):
                 result = future.result()
             except Exception:
                 log.exception("send_task for socket {} threw:".format(_id))
-            else:
-                log.info('send_task for socket {} result: {}'.format(
-                    _id, result))
-            log.debug('Send task for {} finished'.format(_id))
 
         async def send_task(socket, queue):
             while True:
@@ -140,24 +136,20 @@ class RPCServer(object):
                         traceback.format_exc())
                 )
 
-        client = web.WebSocketResponse()
+        client = web.WebSocketResponse(max_msg_size=0)
         client_id = id(client)
 
         # upgrade to Websockets
         await client.prepare(request)
 
         log.info('Opening Websocket {0}'.format(id(client)))
-        log.debug('Tasks: {0}'.format(self.tasks))
-        log.debug('Clients: {0}'.format(self.clients))
 
         try:
-            log.debug('Sending root info to {0}'.format(client_id))
             await client.send_json({
                 '$': {'type': CONTROL_MESSAGE, 'monitor': True},
                 'root': self.call_and_serialize(lambda: self.root),
                 'type': self.call_and_serialize(lambda: type(self.root))
             })
-            log.debug('Root info sent to {0}'.format(client_id))
         except Exception:
             log.exception('While sending root info to {0}'.format(client_id))
 
@@ -241,11 +233,11 @@ class RPCServer(object):
                     _id = id(self.system)
 
                 try:
+                    self.send_ack(token)
                     func = self.build_call(
                         _id=_id,
                         name=data.get('name'),
                         args=data.get('args', []))
-                    self.send_ack(token)
                 except Exception as e:
                     log.exception("Exception during rpc.Server.process:")
                     error = '{0}: {1}'.format(e.__class__.__name__, e)
@@ -274,7 +266,6 @@ class RPCServer(object):
     async def make_call(self, func, token):
         response = {'$': {'type': CALL_RESULT_MESSAGE, 'token': token}}
         try:
-            log.info(f"RPC call: {func} begins")
             call_result = await self.loop.run_in_executor(
                 self.executor, self.call_and_serialize, func)
             response['$']['status'] = 'success'
@@ -306,7 +297,6 @@ class RPCServer(object):
                     'traceback': trace
                 }
         finally:
-            log.info(f"RPC call: {func} ends")
             response['data'] = call_result
         return response
 

--- a/api/tests/opentrons/server/test_server.py
+++ b/api/tests/opentrons/server/test_server.py
@@ -122,6 +122,11 @@ async def test_exception_during_call(session):
     await session.call()
     res = await session.socket.receive_json()
     assert res.pop('$') == {
+        'type': rpc.CALL_ACK_MESSAGE,
+        'token': session.token
+    }
+    res = await session.socket.receive_json()
+    assert res.pop('$') == {
         'type': rpc.CALL_NACK_MESSAGE,
         'token': session.token
     }

--- a/app/src/robot/api-client/index.js
+++ b/app/src/robot/api-client/index.js
@@ -23,7 +23,7 @@ export default function apiClientMiddleware() {
           action.error === true ? action.payload : action.payload.error
 
         if (error) {
-          log.warn('Error response from robot', { action })
+          log.warn('Error response from robot', { actionType: action.type })
           if (error.traceback) log.warn(error.traceback)
         }
       }

--- a/app/src/rpc/client.js
+++ b/app/src/rpc/client.js
@@ -156,7 +156,7 @@ class RpcContext extends EventEmitter {
   }
 
   // cache required metadata from call results
-  // filter type field from type object to avoid getting unecessary types
+  // filter type field from type object to avoid getting unnecessary types
   _cacheCallResultMetadata(resultData) {
     if (!resultData || !resultData.i) {
       return


### PR DESCRIPTION
Fixes #3998

An arbitrary (default) file size limit in the API made it impossible to upload protocol files larger than 4Mb. After removing that limit, we discovered that:

1. The API simulates the protocol before sending an 'ack' back to the client, causing the client request to time out
2. The API had log statments that would crash the API server when receiving large files

This PR removes the log statements from the API (and a log statement from the App with the same problem), and removes the file size limit. It also moves the 'ack' response to before simulation, as expected by the App.