### PR TITLE
chore(api): fix outdated .PHONY targets in API Makefile

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -104,7 +104,7 @@ lint: $(ot_py_sources)
 	$(python) -m mypy src/opentrons
 	$(python) -m pylama src/opentrons tests
 
-.PHONY: docs docs-html docs-doctest docs-pdf-local docs-pdf-ci
+.PHONY: docs-html docs-doctest docs-pdf-prep docs-pdf-local docs-pdf-ci docs-pdf docs
 
 docs-html: local-install
 	$(SHX) rm -rf docs/build/html
@@ -168,14 +168,14 @@ deploy: wheel
 	$(python) -m twine upload $(twine_auth_args)\
                             $(wheel_file)
 
-.PHONY: push
+.PHONY: push-balena
 push-balena: wheel
 	curl -X POST \
 		-H "Content-Type: multipart/form-data" \
 		-F "whl=@$(wildcard dist/opentrons-*.whl)" \
 		http://$(host):31950/server/update
 
-.PHONY: push-buildroot
+.PHONY: push
 push: wheel
 	scp -i $(br_ssh_key) $(ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \


### PR DESCRIPTION
Many of the Makefile targets have corresponding .PHONY declarations.  A few of these were slightly out of sync, either using old names, or leaving targets out.

# Reviewing

Please make sure:

  - I didn't miss anything. i.e., all targets that should be `.PHONY` actually are, now.
  - I didn't mistakenly make something `.PHONY` that shouldn't have been.
