### PR TITLE
refactor(api): Differentiate shake off tips for pick up tip and drop tip

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1136,12 +1136,8 @@ class API(HardwareAPILike):
         # the volume chamber and the drop-tip sleeve on p1000.
         # This extra shake ensures those tips are removed
         if 'pickupTipShake' in instr.config.quirks:
-            await self._shake_off_tips(mount, instr.current_tip_diameter)
-            await self._shake_off_tips(mount, instr.current_tip_diameter)
-
-        if 'pickupTipShakeXY' in instr.config.quirks:
-            await self._shake_off_tips_xy(mount, instr.current_tip_diameter)
-            await self._shake_off_tips_xy(mount, instr.current_tip_diameter)
+            await self._shake_off_tips_pick_up(mount, 0.3)
+            await self._shake_off_tips_pick_up(mount, 0.3)
 
         await self.retract(mount, instr.config.pick_up_distance)
 
@@ -1201,14 +1197,14 @@ class API(HardwareAPILike):
             await _drop_tip()
         await _drop_tip()
         if 'dropTipShake' in instr.config.quirks:
-            await self._shake_off_tips(mount, instr.current_tip_diameter)
+            await self._shake_off_tips_drop(mount, instr.current_tip_diameter)
         self._backend.set_active_current(plunger_ax,
                                          instr.config.plunger_current)
         instr.set_current_volume(0)
         instr.current_tip_diameter = 0.0
         instr.remove_tip()
 
-    async def _shake_off_tips(self, mount, tip_diameter):
+    async def _shake_off_tips_drop(self, mount, tip_diameter):
         # tips don't always fall off, especially if resting against
         # tiprack or other tips below it. To ensure the tip has fallen
         # first, shake the pipette to dislodge partially-sealed tips,
@@ -1228,16 +1224,11 @@ class API(HardwareAPILike):
         up_pos = top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE)
         await self.move_rel(mount, up_pos)
 
-    async def _shake_off_tips_xy(self, mount, tip_diameter):
+    async def _shake_off_tips_pick_up(self, mount, shake_off_dist):
         # tips don't always fall off, especially if resting against
         # tiprack or other tips below it. To ensure the tip has fallen
         # first, shake the pipette to dislodge partially-sealed tips,
         # then second, raise the pipette so loosened tips have room to fall
-        shake_off_dist = SHAKE_OFF_TIPS_DISTANCE
-        if tip_diameter > 0.0:
-            shake_off_dist = min(shake_off_dist, tip_diameter / 4)
-        shake_off_dist = max(shake_off_dist, 1.0)
-
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # move left
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(2*shake_off_dist, 0, 0)    # move right

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -31,6 +31,7 @@ class Pipette:
         self._current_volume = 0.0
         self._working_volume = self._config.max_volume
         self._current_tip_length = 0.0
+        self._current_tip_diameter = 0.0
         self._fallback_tip_length = self._config.tip_length
         self._has_tip = False
         self._pipette_id = pipette_id
@@ -127,6 +128,15 @@ class Pipette:
         """ The length of the current tip attached (0.0 if no tip) """
         return (self._current_tip_length
                 - self._instrument_offset.z)
+
+    @property
+    def current_tip_diameter(self) -> float:
+        """ The diameter of the current tip attached (0.0 if no tip) """
+        return self._current_tip_diameter
+
+    @current_tip_diameter.setter
+    def current_tip_diameter(self, diameter: float):
+        self._current_tip_diameter = diameter
 
     @property
     def working_volume(self) -> float:

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1185,6 +1185,8 @@ class InstrumentContext(CommandPublisher):
                         'before', None, None, instrument=self, location=target)
         self.move_to(target.top())
 
+        self._hw_manager.hardware.set_current_tip_diameter(
+            self._mount, target.diameter)
         self._hw_manager.hardware.pick_up_tip(
             self._mount, tiprack.tip_length, presses, increment)
         # Note that the hardware API pick_up_tip action includes homing z after

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -113,6 +113,10 @@ class Well:
     def has_tip(self, value: bool):
         self._has_tip = value
 
+    @property
+    def diameter(self) -> Optional[float]:
+        return self._diameter
+
     def top(self, z: float = 0.0) -> Location:
         """
         :param z: the z distance in mm

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -299,8 +299,8 @@ async def test_shake_during_pick_up(hardware_api, monkeypatch):
 
     # Test double shake for after pick up tips
     await hardware_api.pick_up_tip(types.Mount.RIGHT, 50)
-    shake_tip_calls = [mock.call(types.Mount.RIGHT, 0.3),
-                       mock.call(types.Mount.RIGHT, 0.3)]
+    shake_tip_calls = [mock.call(types.Mount.RIGHT),
+                       mock.call(types.Mount.RIGHT)]
     shake_tips_pick_up.assert_has_calls(shake_tip_calls)
 
     move_rel = mock.Mock(side_effect=hardware_api.move_rel)
@@ -308,7 +308,7 @@ async def test_shake_during_pick_up(hardware_api, monkeypatch):
 
     # Test shakes in X and Y direction with 0.3 mm shake tip distance
     shake_tips_pick_up.reset_mock()
-    await shake_tips_pick_up(types.Mount.RIGHT, 0.3)
+    await shake_tips_pick_up(types.Mount.RIGHT)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-0.3, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0.6, 0, 0), speed=50),
@@ -356,7 +356,7 @@ async def test_shake_during_drop(hardware_api, monkeypatch):
     # Test drop tip shake with 25% of tiprack well diameter
     # over upper (2.25 mm) limit
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 9.0*4)
+    await shake_tips_drop(types.Mount.RIGHT, 2.3*4)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4.5, 0, 0), speed=50),
@@ -367,7 +367,7 @@ async def test_shake_during_drop(hardware_api, monkeypatch):
     # Test drop tip shake with 25% of tiprack well diameter
     # below lower (1.0 mm) limit
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 0.5*4)
+    await shake_tips_drop(types.Mount.RIGHT, 0.9*4)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(2, 0, 0), speed=50),

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -3798,7 +3798,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake", "pickupTipShakeXY"],
+      "quirks": ["dropTipShake", "pickupTipShake"],
       "returnTipHeight": 0.83
     }
   },
@@ -3821,6 +3821,5 @@
     "defaultBlowOutFlowRate",
     "quirks"
   ],
-  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip",
-                  "pickupTipShakeXY"]
+  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip"]
 }

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -3798,7 +3798,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake", "pickupTipShake"],
+      "quirks": ["dropTipShake", "pickupTipShakeXY"],
       "returnTipHeight": 0.83
     }
   },
@@ -3821,5 +3821,6 @@
     "defaultBlowOutFlowRate",
     "quirks"
   ],
-  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip"]
+  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip",
+                  "pickupTipShakeXY"]
 }


### PR DESCRIPTION
## overview
This PR separates the shake tip function for pick up and drop tip, as they require different shake behaviors.

#### pick_up_tip
- Shake distance: 0.3 mm
- Shake direction: X, then Y

#### drop_tip
- Shake distance: 25% of the well/tip diameter (MAX=`2.25 mm`, MIN=`1.00 mm`)
- Shake direction: X only

## changelog

#### APIv1 & APIv2
- transform `shake_off_tips` to `shake_off_tips_pick_up` and `shake_off_tips_drop`

#### APIv2
- add current tip diameter setter to `pick_up_tip` so the tip diameter is saved
- add shake off distance logic to `shake_off_tips`, which was missing previously

## review requests
@ChrisYarka @Laura-Danielle Do the shake behaviors above make sense?