### PR TITLE
refactor(labware-creator): Add missing hidden class

### DIFF
--- a/labware-library/src/labware-creator/components/optionsWithImages/optionsWithImages.css
+++ b/labware-library/src/labware-creator/components/optionsWithImages/optionsWithImages.css
@@ -1,9 +1,5 @@
 @import '@opentrons/components';
 
-.hidden {
-  display: none;
-}
-
 .radio_image_label {
   text-anchor: middle;
   display: flex;

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -139,6 +139,10 @@ h2 {
   justify-content: center;
 }
 
+.hidden {
+  display: none;
+}
+
 @media (--medium) {
   .new_definition_section {
     flex-basis: 45%;


### PR DESCRIPTION
## overview

This PR hides the default options label for radio fields that have options with images. Nothing crazy here, the work was done, just the class was never added to CSS. Closes #3957

Before:
<img width="1406" alt="Screen Shot 2019-09-09 at 11 35 27 AM" src="https://user-images.githubusercontent.com/3430313/64545287-751af700-d2f6-11e9-9b81-0af718438104.png">

Now:
<img width="1406" alt="Screen Shot 2019-09-09 at 11 35 04 AM" src="https://user-images.githubusercontent.com/3430313/64545305-7fd58c00-d2f6-11e9-9e4e-1f490dc9b044.png">


## changelog

- refactor(labware-creator): Add missing hidden class

## review requests

- [ ] Well shape labels have image _then_ text
- [ ] Well bottom shape labels have image _then_ text
- [ ] Other radio fields are unaffected
