### PR TITLE
refactor(app): remove thermocycler feature flag

### DIFF
--- a/app/src/components/ModuleLiveStatusCards/TempDeckCard.js
+++ b/app/src/components/ModuleLiveStatusCards/TempDeckCard.js
@@ -13,19 +13,19 @@ type Props = {|
   module: TempDeckModule,
   sendModuleCommand: (serial: string, request: ModuleCommandRequest) => mixed,
   isProtocolActive: boolean,
-  __tempControlsEnabled: boolean,
+  __tempdeckControlsEnabled: boolean,
 |}
 
 const TempDeckCard = ({
   module,
   sendModuleCommand,
   isProtocolActive,
-  __tempControlsEnabled,
+  __tempdeckControlsEnabled,
 }: Props) => (
   <StatusCard title={getModuleDisplayName(module.name)}>
     <CardContentRow>
       <StatusItem status={module.status} />
-      {__tempControlsEnabled && !isProtocolActive && (
+      {__tempdeckControlsEnabled && !isProtocolActive && (
         <TemperatureControl
           module={module}
           sendModuleCommand={sendModuleCommand}

--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -35,19 +35,17 @@ type Props = {|
   module: ThermocyclerModule,
   sendModuleCommand: (serial: string, request: ModuleCommandRequest) => mixed,
   isProtocolActive: boolean,
-  __tempControlsEnabled: boolean,
 |}
 
 const ThermocyclerCard = ({
   module,
   sendModuleCommand,
   isProtocolActive,
-  __tempControlsEnabled,
 }: Props) => (
   <StatusCard title={getModuleDisplayName(module.name)}>
     <CardContentRow>
       <StatusItem status={module.status} />
-      {__tempControlsEnabled && !isProtocolActive && (
+      {!isProtocolActive && (
         <TemperatureControl
           module={module}
           sendModuleCommand={sendModuleCommand}

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -29,7 +29,7 @@ type SP = {|
   _robot: ?Robot,
   liveStatusModules: Array<Module>,
   isProtocolActive: boolean,
-  __tempControlsEnabled: boolean,
+  __tempdeckControlsEnabled: boolean,
 |}
 
 type DP = {|
@@ -46,7 +46,7 @@ type Props = {|
   isProtocolActive: boolean,
   fetchModules: () => mixed,
   sendModuleCommand: (serial: string, request: ModuleCommandRequest) => mixed,
-  __tempControlsEnabled: boolean,
+  __tempdeckControlsEnabled: boolean,
 |}
 
 const ModuleLiveStatusCards = (props: Props) => {
@@ -55,7 +55,7 @@ const ModuleLiveStatusCards = (props: Props) => {
     isProtocolActive,
     fetchModules,
     sendModuleCommand,
-    __tempControlsEnabled,
+    __tempdeckControlsEnabled,
   } = props
   if (liveStatusModules.length === 0) return null
 
@@ -70,7 +70,7 @@ const ModuleLiveStatusCards = (props: Props) => {
                 module={module}
                 sendModuleCommand={sendModuleCommand}
                 isProtocolActive={isProtocolActive}
-                __tempControlsEnabled={__tempControlsEnabled}
+                __tempdeckControlsEnabled={__tempdeckControlsEnabled}
               />
             )
           case 'thermocycler':
@@ -80,7 +80,6 @@ const ModuleLiveStatusCards = (props: Props) => {
                 module={module}
                 sendModuleCommand={sendModuleCommand}
                 isProtocolActive={isProtocolActive}
-                __tempControlsEnabled={__tempControlsEnabled}
               />
             )
           case 'magdeck':
@@ -105,7 +104,7 @@ function mapStateToProps(state: State): SP {
     _robot,
     liveStatusModules,
     isProtocolActive: robotSelectors.getIsActive(state),
-    __tempControlsEnabled: Boolean(
+    __tempdeckControlsEnabled: Boolean(
       getConfig(state).devInternal?.tempdeckControls
     ),
   }
@@ -125,7 +124,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP): Props {
     _robot,
     liveStatusModules,
     isProtocolActive,
-    __tempControlsEnabled,
+    __tempdeckControlsEnabled,
   } = stateProps
 
   return {
@@ -134,7 +133,7 @@ function mergeProps(stateProps: SP, dispatchProps: DP): Props {
     fetchModules: () => _robot && _fetchModules(_robot),
     sendModuleCommand: (serial, request) =>
       _robot && _sendModuleCommand(_robot, serial, request),
-    __tempControlsEnabled,
+    __tempdeckControlsEnabled,
   }
 }
 

--- a/app/src/config/index.js
+++ b/app/src/config/index.js
@@ -15,7 +15,6 @@ export * from './types'
 export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'tempdeckControls',
-  'enableThermocycler',
   'enablePipettePlus',
 ]
 

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -10,7 +10,6 @@ export type DiscoveryCandidates = string | Array<string>
 export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'tempdeckControls'
-  | 'enableThermocycler'
   | 'enablePipettePlus'
 
 export type Config = {

--- a/app/src/robot-api/resources/modules.js
+++ b/app/src/robot-api/resources/modules.js
@@ -126,11 +126,8 @@ export function getModulesState(
   robotName: string
 ): Array<Module> {
   const robotState = getRobotApiState(state, robotName)
-  const modules = robotState?.resources.modules || []
-  const tcEnabled = Boolean(state.config.devInternal?.enableThermocycler)
 
-  // TODO: remove this filter when feature flag removed
-  return modules.filter(m => tcEnabled || m.name !== 'thermocycler')
+  return robotState?.resources.modules || []
 }
 
 const PREPARABLE_MODULES = ['thermocycler']

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -292,13 +292,8 @@ export const getModules: OutputSelector<
   getModulesBySlot,
   // TODO (ka 2019-3-26): can't import getConfig due to circular dependency
   state => state.config,
-  (modulesBySlot, config) => {
-    const tcEnabled = !!config.devInternal?.enableThermocycler
-
-    return Object.keys(modulesBySlot)
-      .map((slot: Slot) => modulesBySlot[slot])
-      .filter((m: SessionModule) => tcEnabled || m.name !== 'thermocycler')
-  }
+  (modulesBySlot, config) =>
+    Object.keys(modulesBySlot).map((slot: Slot) => modulesBySlot[slot])
 )
 
 export function getLabwareBySlot(state: State) {

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -31,7 +31,6 @@ const {
   getNextLabware,
   getTipracksByMount,
   getModulesBySlot,
-  getModules,
   getDeckPopulated,
 } = selectors
 

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -496,17 +496,6 @@ describe('robot selectors', () => {
         },
       })
     })
-
-    test('get modules', () => {
-      state = setIn(state, 'config.devInternal.enableThermocycler', 'true')
-      expect(getModules(state)).toEqual([
-        {
-          _id: 1,
-          slot: '1',
-          name: 'tempdeck',
-        },
-      ])
-    })
   })
 
   describe('labware selectors', () => {

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -31,6 +31,7 @@ const {
   getNextLabware,
   getTipracksByMount,
   getModulesBySlot,
+  getModules,
   getDeckPopulated,
 } = selectors
 
@@ -494,6 +495,16 @@ describe('robot selectors', () => {
           name: 'tempdeck',
         },
       })
+    })
+
+    test('get modules', () => {
+      expect(getModules(state)).toEqual([
+        {
+          _id: 1,
+          slot: '1',
+          name: 'tempdeck',
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
Remove flag that hides thermocycler cards and controls.

## Review Requests

- [ ] Thermocycler should appear in "Modules & Pipettes" if connected
- [ ] Thermocycler should appear in Run Tab Card if connected
- [ ] Thermocycler "Set Temp"/"Deactivate" control should appear Run Tab Card
- [ ] Temperature Module controls should not exist be present (without feature flag flipped) on either the "Modules & Pipettes" tab, or the Temperature Module Run Tab Card