### PR TITLE
feat(labware-creator): separate create vs upload fields; scroll upon upload

### DIFF
--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -499,7 +499,7 @@ const App = () => {
                       [styles.disabled_section]: lastUploaded !== null,
                     })}
                   >
-                    <div className={styles.new_definition_content}>
+                    <div className={styles.labware_type_fields}>
                       {lastUploaded === null ? (
                         <>
                           <Dropdown
@@ -527,16 +527,16 @@ const App = () => {
                   {lastUploaded === null ? (
                     <ImportLabware onUpload={onUpload} />
                   ) : (
-                    <>
+                    <div className={styles.labware_type_fields}>
                       {labwareTypeChildFields}
                       <PrimaryButton
-                        className={styles.start_editing_labware_button}
+                        className={styles.start_creating_btn}
                         onClick={scrollToForm}
                         disabled={!canProceedToForm}
                       >
                         start editing labware
                       </PrimaryButton>
-                    </>
+                    </div>
                   )}
                 </div>
               </div>

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -103,7 +103,7 @@ h2 {
 }
 
 .new_definition_section,
-.upload_exisiting_section {
+.upload_existing_section {
   flex-basis: 100%;
   flex-shrink: 0;
 }
@@ -147,7 +147,7 @@ h2 {
     border-right: var(--bd-light);
   }
 
-  .upload_exisiting_section {
+  .upload_existing_section {
     padding: 1rem;
     flex-shrink: 1;
     padding-right: 0;
@@ -210,4 +210,8 @@ h2 {
   .help_text {
     max-width: 90%;
   }
+}
+
+.disabled_section {
+  color: var(--c-font-disabled);
 }

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -108,7 +108,7 @@ h2 {
   flex-shrink: 0;
 }
 
-.new_definition_content {
+.labware_type_fields {
   padding-top: 1rem;
 }
 


### PR DESCRIPTION
## overview

Closes #3971

## changelog


## review requests

- [ ] uploading a file disables the "Create New Definition" section & hides its fields
- [ ] for wellPlate/reservoir, uploading reveals & scrolls down to the form content right away
- [ ] for aluminum block / tube rack, filling out the remaining fields and clicking "start editing labware" reveals & scrolls down to the form content
