### PR TITLE
feat(labware-creator): default well shape & bottom field values

### DIFF
--- a/labware-library/src/labware-creator/fields.js
+++ b/labware-library/src/labware-creator/fields.js
@@ -327,9 +327,9 @@ export const getDefaultFormState = (): LabwareFields => ({
   regularColumnSpacing: null,
 
   wellVolume: null,
-  wellBottomShape: null,
+  wellBottomShape: 'flat',
   wellDepth: null,
-  wellShape: null,
+  wellShape: 'circular',
 
   // used with circular well shape only
   wellDiameter: null,

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -136,13 +136,18 @@ const GridImg = () => {
   return <img src={src} />
 }
 
-const WellXYImg = (props: {| wellShape: WellShape |}) => {
+const WellXYImg = (props: {| wellShape: ?WellShape |}) => {
   const { wellShape } = props
-  let src = require('./images/wellXY_circular.svg')
-  if (wellShape === 'rectangular') {
-    src = require('./images/wellXY_rectangular.svg')
+  const wellShapeToImg: { [WellShape]: string } = {
+    circular: require('./images/wellXY_circular.svg'),
+    rectangular: require('./images/wellXY_rectangular.svg'),
   }
-  return <img src={src} />
+
+  if (wellShape != null && wellShape in wellShapeToImg) {
+    return <img src={wellShapeToImg[wellShape]} />
+  }
+
+  return null
 }
 
 const XYSpacingImg = (props: {|
@@ -174,10 +179,9 @@ type DepthImgProps = {|
 |}
 const DepthImg = (props: DepthImgProps) => {
   const { labwareType, wellBottomShape } = props
-  const defaultSrc = require('./images/depth_plate_flat.svg')
   let src
 
-  if (!wellBottomShape) return <img src={defaultSrc} />
+  if (!wellBottomShape) return null
 
   if (labwareType === 'reservoir' || labwareType === 'tubeRack') {
     const imgMap = {
@@ -195,7 +199,7 @@ const DepthImg = (props: DepthImgProps) => {
     src = imgMap[wellBottomShape]
   }
 
-  return <img src={src != null ? src : defaultSrc} />
+  return <img src={src} />
 }
 
 const XYOffsetImg = (props: {|


### PR DESCRIPTION
## overview

Serves as its own ticket!

Default the well shape to "circular" and default the well bottom shape to "flat".

Get rid of the image fallback stuff now that neither of those fields should ever become `null`.

## changelog


## review requests

👁‍🗨 