### PR TITLE
refactor(shared-data): remove ref to full plate in tc name

### DIFF
--- a/shared-data/module/definitions/1.json
+++ b/shared-data/module/definitions/1.json
@@ -50,7 +50,7 @@
       "x": 14.4,
       "y": 64.93
     },
-    "displayName": "Full Plate Thermocycler Module",
+    "displayName": "Thermocycler Module",
     "loadName": "thermocycler",
     "quirks": []
   }


### PR DESCRIPTION
The display name of the Thermocycler Module should be 'Thermocycler Module' and not carry an old
reference to 'full plate'

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
