### PR TITLE
chore(docs): Update make install docs for systemd-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,7 @@ Your computer will need the following tools installed to be able to develop with
 - GNU Make - we use [Makefiles][] to manage our builds
 
 - cURL - used to push development updates to robots
+- On Linux, you will need libsystemd and headers. On Ubuntu, install `systemd-dev` and `python3-dev` before running `make install`.
 
 Once you're set up, clone the repository and install all project dependencies:
 


### PR DESCRIPTION
On linux, we need libsystemd-dev to interact with logs.
