### PR TITLE
fix(api): fix format string in module slot assertion

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -222,7 +222,7 @@ class Deck(UserDict):
             else:
                 raise AssertionError(
                     f'module {module_name} cannot be loaded'
-                    ' into slot {location}')
+                    f' into slot {location}')
         else:
             valid_slots = [slot['id'] for slot in self.slots if module_name
                            in slot['compatibleModules']]


### PR DESCRIPTION
Module slot assertion error improperly included the string literal "{location}" instead of the template string representing the invalid slot.