### PR TITLE
fix(api): Fix usage of return tip height v1

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -339,6 +339,7 @@ class InstrumentsWrapper(object):
             pick_up_increment=config.pick_up_increment,
             pick_up_presses=config.pick_up_presses,
             pick_up_speed=config.pick_up_speed,
+            return_tip_height=config.return_tip_height,
             quirks=config.quirks,
             fallback_tip_length=config.tip_length,  # TODO move to labware
             blow_out_flow_rate=config.blow_out_flow_rate)


### PR DESCRIPTION
## overview

Return tip height config value was never being passed into the pipette constructor in api v1, and so the p1000 gen2 was never actually going to the correct height.

## changelog
- Pass in return tip height to `Pipette` constructor

## review requests

- See that the return tip value is actually 0.83 for a gen2 pipette instead of 0.5
