### PR TITLE
refactor(api): Change log readout default to text for reability

### DIFF
--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -18,7 +18,7 @@ def _get_options(params: Mapping[str, str],
     requests will just use defaults.
     """
     response = {
-        'format': 'json',
+        'format': 'text',
         'records': default_length
     }
 


### PR DESCRIPTION
## overview

Make logs readable again! For buildroot, default was set to machine readable logs which is great for computers but not for humans.

## changelog

- Change default for logs to be text instead of JSON.

## review requests

Check that when you download logs, you can now read the files instead of having JSON blobs.
