### PR TITLE
feat(api): apiv1: load magdeck engage height from labware definitions

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -232,6 +232,11 @@ def load_new_labware_def(definition):
     container.properties['labware_hash'] = labware_hash
     container.properties['type'] = container_name
     lw_format = definition['parameters']['format']
+    if definition['parameters']['isMagneticModuleCompatible']:
+        engage_height = definition['parameters']['magneticModuleEngageHeight']
+    else:
+        engage_height = None
+    container.properties['magdeck_engage_height'] = engage_height
 
     container._coordinates = Vector(definition['cornerOffsetFromSlot'])
     for well_name in itertools.chain(*definition['ordering']):

--- a/api/src/opentrons/legacy_api/containers/placeable.py
+++ b/api/src/opentrons/legacy_api/containers/placeable.py
@@ -336,6 +336,12 @@ class Placeable(object):
             self.z_size()
         )
 
+    def magdeck_engage_height(self):
+        """
+        Returns magnetic module engage height
+        """
+        return self.properties['magdeck_engage_height']
+
     def max_volume(self):
         """
         Returns placeable's maximum liquid volume in uL

--- a/api/src/opentrons/legacy_api/modules/magdeck.py
+++ b/api/src/opentrons/legacy_api/modules/magdeck.py
@@ -2,9 +2,7 @@ from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons import commands
 
 LABWARE_ENGAGE_HEIGHT = {
-    'biorad-hardshell-96-PCR': 18,
-    'biorad_96_wellplate_200ul_pcr': 18,
-    'nest_96_wellplate_100ul_pcr_full_skirt': 20}    # mm
+    'biorad-hardshell-96-PCR': 18}  # mm
 MAX_ENGAGE_HEIGHT = 45  # mm from home position
 
 
@@ -51,8 +49,12 @@ class MagDeck(commands.CommandPublisher):
         if 'height' in kwargs:
             height = kwargs.get('height')
         else:
-            height = LABWARE_ENGAGE_HEIGHT.get(
-                self.labware.get_children_list()[1].get_name())
+            try:
+                height = self.labware.get_children_list()[1].\
+                    magdeck_engage_height()
+            except KeyError:
+                height = LABWARE_ENGAGE_HEIGHT.get(
+                    self.labware.get_children_list()[1].get_name())
             if not height:
                 raise ValueError(
                     'No engage height definition found for {}. Provide a'

--- a/api/tests/opentrons/labware/test_modules.py
+++ b/api/tests/opentrons/labware/test_modules.py
@@ -100,6 +100,16 @@ def test_run_tempdeck_connected(
     tempdeck.disconnect()  # Necessary to kill the thread started by connect()
 
 
+def test_load_correct_engage_height():
+    robot.reset()
+    md = modules.load('magdeck', '1')
+    test_container = labware.load('biorad_96_wellplate_200ul_pcr',
+                                  '1', share=True)
+    assert test_container.magdeck_engage_height() == 18
+    assert md.labware.get_children_list()[1].magdeck_engage_height() == \
+        test_container.magdeck_engage_height()
+
+
 @pytest.fixture
 def old_bootloader_module():
     module = modules.TempDeck(port='/dev/modules/tty0_tempdeck')


### PR DESCRIPTION
## overview
APIv1 magdeck does not check the labware definition for the engage height. This means that any custom labware that is not in the `LABWARE_ENGAGE_HEIGHT` list would not work with the magdeck even if they are compatible.

https://github.com/Opentrons/opentrons/blob/7fe710955745f7fd76f1ebfc4c0534ab949dbd92/api/src/opentrons/legacy_api/modules/magdeck.py#L4-L6

closes #3832

## changelog
- add `magdeck_engage_height` as one of the properties of `Placeable`
    - which would return `magneticModuleEngageHeight` from the definition if it is magdeck compatible and return `None` if not


## review requests
Test on robot