### PR TITLE
docs(ot1): Fix small typo in OT1 documentation

### DIFF
--- a/api/docs/public/ot1/_sources/index.txt
+++ b/api/docs/public/ot1/_sources/index.txt
@@ -59,7 +59,7 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
     pipette = instruments.Pipette(axis='b', max_volume=200, tip_racks=[tiprack])
 
     # commands
-    pipette.transfer(100, plate.wells('A1'), plate.wells('B1'))
+    pipette.transfer(100, plate.wells('A1'), plate.wells('A2'))
 
 **********************
 

--- a/api/docs/public/ot1/_sources/index.txt
+++ b/api/docs/public/ot1/_sources/index.txt
@@ -42,7 +42,7 @@ The design goal of the Opentrons API is to make code readable and easy to unders
 
     Add a 200uL pipette to axis 'b', and tell it to use that tip rack
 
-    Transfer 100uL from the plate's 'A1' well to it's 'A2' well
+    Transfer 100uL from the plate's 'A1' well to its 'A2' well
 
 If we were to rewrite this with the Opentrons API, it would look like the following:
 


### PR DESCRIPTION
The comment states "Transfer 100uL from the plate's 'A1' well to it's 'A2' well" but the code had B1 instead of A2.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Fix a small typo in documentation.
-->

## changelog

<!--
  Change example in documentation to state A2 instead of B1.
-->

## review requests

<!--
  None
-->
