### PR TITLE
refactor(update-server): preserve machine ID

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -75,7 +75,7 @@ restart:
 push: wheel
 	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/$(wheel_file) && mount -o remount,ro / && systemctl start opentrons-update-server; } ;\
+"function cleanup () { rm -f /data/otupdate*.whl && mount -o remount,ro / && systemctl start opentrons-update-server; } ;\
 systemctl stop opentrons-update-server &&\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\

--- a/update-server/otupdate/buildroot/update.py
+++ b/update-server/otupdate/buildroot/update.py
@@ -8,6 +8,7 @@ import asyncio
 import functools
 import logging
 import os
+from subprocess import CalledProcessError
 
 from typing import Optional
 
@@ -178,6 +179,11 @@ async def commit(
                   f'(currently {session.stage.value.short})'},
             status=409)
     async with request.app[RESTART_LOCK_NAME]:
+        try:
+            with file_actions.mount_update() as new_part:
+                file_actions.write_machine_id('/', new_part)
+        except (OSError, CalledProcessError):
+            LOG.exception('Failed to update machine-id')
         file_actions.commit_update()
         session.set_stage(Stages.READY_FOR_RESTART)
 


### PR DESCRIPTION
## overview
linux has a concept of machine id
(http://man7.org/linux/man-pages/man5/machine-id.5.html), which is a uuidlike
that identifies a machine - e.g., every computer, kvm, docker container, etc
should have a unique one. systemd will generate one if it sees that
/etc/machine-id is empty, but if /etc/machine-id is not writable (or really /etc
in general), it will bind-mount a tmpfs on /etc/machine-id, which will be lost
when the machine reboots. Given the things we do to the robot, this is usually
ok, but journald scopes journal files by machine-id to allow unified log
locations for things like multiple docker containers or kvms running on the same
host without stomping each other. That means that even if we change journald to
force fs backing for journals, the journals will be in a new place every time we
boot, and therefore only information from the last boot will be available
without jumping through some hoops (specifically, using journalctl's --merge
option (http://man7.org/linux/man-pages/man1/journalctl.1.html) which loses
functionality.

To make a persistent machine-id, we need to write it to /etc/machine-id in the
rootfs. We could do this by remounting the active root readwrite and changing
it, but various other systems may take advantage of that and have behaviors we
don't want, same with mounting the rootfs r/w at boot and remounting ro later in
the boot process. By mounting the _new_ rootfs in a generic mountpoint _during
the update_, we avoid any of these problems since to the rest of the system it
has no effect on what's currently running.

Unfortunately, this behavior also means that the machine id will only be
constant the next time the robot is updated _after_ it is updated to a system
with this commit.

## changelog
- the above change to write `/etc/machine-id` in the rootfs we're updating to during update
- fix an issue with the update-server `push` makefile target that would cause it to fail if there were old `otupdate` wheels in `/data` (e.g. from usage of `make push` on versions before the current)
- add a `-s` option to `buildroot_upload` that will make the script pause in between stages so you can check intermediate state on the robot

## testing
- update to a buildroot build with this version, and update out of it. check that the update has gone through, probably by sshing in and doing `mount | grep mmcblk0p[2,3]` and making sure that the active rootfs changed during the update
- when updating _from_ a robot with this update server commit present, check that `/etc/machine-id` is the same before and after the update
- after the update from the robot with this update server commit present, check that you don't have `tmpfs` mounted over `/etc/machine-id` (`mount | grep machine-id` returns no results)

## notes
journals won't be stored on disk without https://github.com/Opentrons/buildroot/pull/38 so you can't check `journalctl --list-boots` yet until that's merged)