### PR TITLE
fix(api): apiv2: allow pipette name or model in cache_instruments

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -86,6 +86,7 @@ def name_config() -> Dict[str, Any]:
 
 
 config_models = list(model_config()['config'].keys())
+config_names = list(name_config().keys())
 configs = model_config()['config']
 #: A list of pipette model names for which we have config entries
 MUTABLE_CONFIGS = model_config()['mutableConfigs']

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -5,7 +5,9 @@ from threading import Event
 from typing import Dict, Optional, List, Tuple
 from contextlib import contextmanager
 from opentrons import types
-from opentrons.config.pipette_config import config_models, configs
+from opentrons.config.pipette_config import (config_models,
+                                             config_names,
+                                             configs)
 from opentrons.drivers.smoothie_drivers import SimulatingDriver
 from . import modules
 
@@ -149,6 +151,11 @@ class Simulator:
         to_return: Dict[types.Mount, Dict[str, Optional[str]]] = {}
         for mount in types.Mount:
             expected_instr = expected.get(mount, None)
+            if expected_instr and expected_instr not in\
+               config_models + config_names:
+                raise RuntimeError(
+                    f'mount {mount.name}: invalid pipette type'
+                    f' {expected_instr}')
             init_instr = self._attached_instruments.get(mount, {})
             found_model = init_instr.get('model', '')
             if expected_instr and found_model\

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -165,6 +165,13 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
         loop=loop, strict_attached_instruments=False)
     await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
 
+    with pytest.raises(RuntimeError):
+        # When we say prefixes we really mean names or models should
+        # equally work with some special casing for gen2; if you do
+        # just some arbitrary stuff that happens to be a prefix, that
+        # absolutely should not work
+        await sim.cache_instruments({types.Mount.LEFT: 'p10_sing'})
+
 
 async def test_prep_aspirate(dummy_instruments, loop):
     hw_api = hc.API.build_hardware_simulator(


### PR DESCRIPTION
Previously, the hardware controller would accept only the name, model, or
appropriate back compat patches for the attached pipettes while the simulator
would accept anything that was a valid prefix of a pipette. Well, it turns out
'p' is a valid prefix for just about anything that the hardware controller will
choke on. Stop just allowing prefixes and make the user put in something that's
a valid pipette identifier.

Closes #4062
