### PR TITLE
feat(protocol-designer): disallow standard labware def upload

### DIFF
--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
@@ -33,6 +33,13 @@ const MessageBody = (props: {| message: LabwareUploadMessage |}) => {
     )
   } else if (message.messageType === 'EXACT_LABWARE_MATCH') {
     return <p>This labware is identical to one you have already uploaded.</p>
+  } else if (message.messageType === 'USES_STANDARD_NAMESPACE') {
+    return (
+      <p>
+        This labware definition appears to be an Opentrons standard labware.
+        Please upload only custom labware.
+      </p>
+    )
   } else if (
     message.messageType === 'ASK_FOR_LABWARE_OVERWRITE' ||
     message.messageType === 'LABWARE_NAME_CONFLICT'

--- a/protocol-designer/src/labware-defs/actions.js
+++ b/protocol-designer/src/labware-defs/actions.js
@@ -6,7 +6,10 @@ import flatten from 'lodash/flatten'
 import values from 'lodash/values'
 import uniqBy from 'lodash/uniqBy'
 import labwareSchema from '@opentrons/shared-data/labware/schemas/2.json'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  getLabwareDefURI,
+  OPENTRONS_LABWARE_NAMESPACE,
+} from '@opentrons/shared-data'
 import * as labwareDefSelectors from './selectors'
 import { getAllWellSetsForLabware } from '../well-selection/utils'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -142,6 +145,12 @@ export const createCustomLabwareDef = (
       return dispatch(
         labwareUploadMessage({
           messageType: 'INVALID_JSON_FILE',
+        })
+      )
+    } else if (parsedLabwareDef?.namespace === OPENTRONS_LABWARE_NAMESPACE) {
+      return dispatch(
+        labwareUploadMessage({
+          messageType: 'USES_STANDARD_NAMESPACE',
         })
       )
     } else if (allLabwareDefs.some(def => isEqual(def, parsedLabwareDef))) {

--- a/protocol-designer/src/labware-defs/types.js
+++ b/protocol-designer/src/labware-defs/types.js
@@ -11,6 +11,7 @@ export type LabwareUploadMessageType =
   | 'EXACT_LABWARE_MATCH'
   | 'LABWARE_NAME_CONFLICT'
   | 'ASK_FOR_LABWARE_OVERWRITE'
+  | 'USES_STANDARD_NAMESPACE'
 
 type NameConflictFields = {|
   defsMatchingLoadName: Array<LabwareDefinition2>,
@@ -24,7 +25,7 @@ export type LabwareUploadMessage =
       errorText?: string,
     |}
   | {|
-      messageType: 'EXACT_LABWARE_MATCH',
+      messageType: 'EXACT_LABWARE_MATCH' | 'USES_STANDARD_NAMESPACE',
     |}
   | {|
       ...NameConflictFields,

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -28,7 +28,8 @@
       "NOT_JSON": "Incompatible file type",
       "EXACT_LABWARE_MATCH": "Duplicate labware definition",
       "LABWARE_NAME_CONFLICT": "Duplicate labware name",
-      "ASK_FOR_LABWARE_OVERWRITE": "Duplicate labware name"
+      "ASK_FOR_LABWARE_OVERWRITE": "Duplicate labware name",
+      "USES_STANDARD_NAMESPACE": "Standard (non-custom) Opentrons labware"
     }
   },
   "new_protocol": {


### PR DESCRIPTION
## overview

Closes #4009

## changelog


## review requests

- Uploading custom labware (non-Opentrons) should still work
- If you upload a labware with `"namespace": "opentrons"`, PD will now give you an error modal and block the upload