### PR TITLE
fix(protocol-designer): fix tip position bug with zero

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPosition/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPosition/TipPositionModal.js
@@ -51,9 +51,10 @@ const roundValue = (value: number | string): number =>
 class TipPositionModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    const initialValue = props.mmFromBottom
-      ? roundValue(props.mmFromBottom)
-      : roundValue(this.getDefaultMmFromBottom())
+    const initialValue =
+      props.mmFromBottom != null
+        ? roundValue(props.mmFromBottom)
+        : roundValue(this.getDefaultMmFromBottom())
     this.state = { value: initialValue }
   }
   componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
## overview

Closes #4057

## changelog


## review requests

- Set tip position to `0`. Save the modal. Open the modal again. Modal field should be `0`. The bug was that when you open the modal again, the modal field would "default" to `1`.