### PR TITLE
fix(protocol-designer): show form error state in StepItems

### DIFF
--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -61,11 +61,9 @@ const makeMapStateToProps: () => (BaseState, OP) => SP = () => {
     const argsAndErrors = getArgsAndErrors(state, { stepId })
     const step = getStep(state, { stepId })
 
-    const formAndFieldErrors =
-      argsAndErrors[stepId] && argsAndErrors[stepId].errors
     const hasError =
       fileDataSelectors.getErrorStepId(state) === stepId ||
-      !isEmpty(formAndFieldErrors)
+      argsAndErrors.errors !== undefined
 
     const hasWarnings =
       dismissSelectors.getHasTimelineWarningsPerStep(state)[stepId] ||

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import isEmpty from 'lodash/isEmpty'
 import mapValues from 'lodash/mapValues'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import type { BaseState, ThunkDispatch } from '../types'


### PR DESCRIPTION
## overview

Closes #3678 and more generally, fixes bug where form errors didn't make StepItem show an error icon.

## changelog


## review requests

- Deleting labware (the problem specified in #3678) will now make all StepItems for steps using that labware show the red error icon
- Play around with other ways to make form errors (mess with pipettes?? You can't save erroring forms, so I can only think of labware & pipettes being ways to make forms error out. Running out of tips is a timeline error, not a form error.) Behavior should be as expected - StepItem in sidebar shows red error icon, only by selecting the step and opening the form do you see error banners