### PR TITLE
feat(api): Allow python simulation without feature flag

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -146,7 +146,7 @@ def simulate(protocol_file: TextIO,
     contents = protocol_file.read()
     protocol = parse.parse(contents, protocol_file.name)
 
-    if opentrons.config.feature_flags.use_protocol_api_v2():
+    if protocol.api_level == 2:
         context = opentrons.protocol_api.contexts.ProtocolContext()
         context.home()
         scraper = CommandScraper(stack_logger, log_level, context.broker)


### PR DESCRIPTION
## overview

Implicitly determine whether a protocol is api v1 or v2 for simulation purposes. Closes #3753.

## changelog

- Use `api_level` returned from protocol parse to determine protocol version. 

## review requests

Use `opentrons_simulate` on a v1/v2 protocol. Notice that you should be able to successfully simulate either of them without changes the feature flag file in `.opentrons/`
