### PR TITLE
fix(api): apiv2: allow transfer with uneven sources and targets 

### DIFF
--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -484,7 +484,7 @@ class TransferPlan:
     @staticmethod
     def _extend_source_target_lists(
             sources: List[Well],
-            targets: List[Well]) -> (List[Well], List[Well]):
+            targets: List[Well]):
         """Extend source or target list to match the length of the other
         """
         if len(sources) < len(targets):

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -499,7 +499,6 @@ class TransferPlan:
                     'Source and destination lists must be divisible')
             targets = [target for target in targets
                        for i in range(int(len(sources)/len(targets)))]
-        print(sources, targets)
         return sources, targets
 
     def _plan_distribute(self):

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -458,8 +458,11 @@ class TransferPlan:
             -> Touch tip -> Dispense air gap -> Dispense -> Mix if empty ->
             -> Blow out -> Touch tip -> Drop tip*
         """
+        # reform source target lists
+        sources, dests = self._extend_source_target_lists(
+            self._sources, self._dests)
         plan_iter = self._expand_for_volume_constraints(
-            self._volumes, zip(self._sources, self._dests),
+            self._volumes, zip(sources, dests),
             self._instr.max_volume
             - self._strategy.disposal_volume
             - self._strategy.air_gap)
@@ -477,6 +480,27 @@ class TransferPlan:
                 yield from self._dispense_actions(vol, dest)
                 xferred_vol += vol
             yield from self._new_tip_action()
+
+    @staticmethod
+    def _extend_source_target_lists(
+            sources: List[Well],
+            targets: List[Well]) -> (List[Well], List[Well]):
+        """Extend source or target list to match the length of the other
+        """
+        if len(sources) < len(targets):
+            if len(targets) % len(sources) != 0:
+                raise ValueError(
+                    'Source and destination lists must be divisible')
+            sources = [source for source in sources
+                       for i in range(int(len(targets)/len(sources)))]
+        elif len(sources) > len(targets):
+            if len(sources) % len(targets) != 0:
+                raise ValueError(
+                    'Source and destination lists must be divisible')
+            targets = [target for target in targets
+                       for i in range(int(len(sources)/len(targets)))]
+        print(sources, targets)
+        return sources, targets
 
     def _plan_distribute(self):
         """

--- a/api/tests/opentrons/protocol_api/test_transfers.py
+++ b/api/tests/opentrons/protocol_api/test_transfers.py
@@ -134,6 +134,98 @@ def test_default_transfers(_instr_labware):
     assert consd_plan_list == exp3
 
 
+def test_uneven_transfers(_instr_labware):
+    _instr_labware['ctx'].home()
+    lw1 = _instr_labware['lw1']
+    lw2 = _instr_labware['lw2']
+
+    options = tx.TransferOptions()
+    options = options._replace(
+        transfer=options.transfer._replace(
+            new_tip=TransferTipPolicy.NEVER))
+
+    # ========== One-to-Many ==========
+    xfer_plan = tx.TransferPlan(
+        100, lw1.columns()[0][0], lw2.columns()[1][:4],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        mode='transfer', options=options)
+    one_to_many_plan_list = []
+    for step in xfer_plan:
+        one_to_many_plan_list.append(step)
+    exp1 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][1], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][2], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][3], 1.0],
+            'kwargs': {}}]
+    assert one_to_many_plan_list == exp1
+
+    # ========== Few-to-Many ==========
+    xfer_plan = tx.TransferPlan(
+        [100, 90, 80, 70], lw1.columns()[0][:2], lw2.columns()[1][:4],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        mode='transfer', options=options)
+    few_to_many_plan_list = []
+    for step in xfer_plan:
+        few_to_many_plan_list.append(step)
+    exp2 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [90, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [90, lw2.columns()[1][1], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [80, lw1.columns()[0][1], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [80, lw2.columns()[1][2], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [70, lw1.columns()[0][1], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [70, lw2.columns()[1][3], 1.0],
+            'kwargs': {}}]
+    assert few_to_many_plan_list == exp2
+
+    # ========== Many-to-One ==========
+    xfer_plan = tx.TransferPlan(
+        [100, 90, 80, 70], lw1.columns()[0][:4], lw2.columns()[1][0],
+        _instr_labware['instr'],
+        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        mode='transfer', options=options)
+    many_to_one_plan_list = []
+    for step in xfer_plan:
+        many_to_one_plan_list.append(step)
+    exp3 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [90, lw1.columns()[0][1], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [90, lw2.columns()[1][0], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [80, lw1.columns()[0][2], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [80, lw2.columns()[1][0], 1.0],
+            'kwargs': {}},
+            {'method': 'aspirate', 'args': [70, lw1.columns()[0][3], 1.0],
+            'kwargs': {}},
+            {'method': 'dispense', 'args': [70, lw2.columns()[1][0], 1.0],
+            'kwargs': {}}]
+    assert many_to_one_plan_list == exp3
+
+
 def test_no_new_tip(_instr_labware):
     _instr_labware['ctx'].home()
     lw1 = _instr_labware['lw1']


### PR DESCRIPTION
## overview

Transfers with uneven lists of sources and targets were previously cut short, with the number of transfers determined by the length of the shorter list. For example, a one-to-many transfer would turn into a one-to-one.

This PR primes the source and target lists to make their lengths match before generating aspirate and dispense actions, mimicking the behavior of apiv1. This allows apiv2 to handle one-to-many, few-to-many transfers as described in the documentation.

closes #4081 


## changelog
- add `extend_source_target_lists()` to update the source or target list if they are of uneven lengths

## review requests
Simulate the following protocol:
```
def run(ctx):
    from opentrons.protocol_api import transfers as tx

    tiprack = ctx.load_labware('opentrons_96_tiprack_10uL', 1)
    pip = ctx.load_instrument('p20_single_gen2',
                              mount='right', tip_racks=[tiprack])
    plate = ctx.load_labware('nest_96_wellplate_200ul_flat', 2)

    pip.transfer(4.5, plate.wells_by_name()['A1'], plate.columns_by_name()['2'])
```