### PR TITLE
fix(api): dont parse the smoothie response to update_pipette_config

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -500,11 +500,7 @@ class SmoothieDriver_3_0_0:
             if res is None:
                 raise ValueError(
                     f'{key} was not updated to {value} on {axis} axis')
-            # ensure smoothie received code and changed value through
-            # return message. Format of return message:
-            # <Axis> (or E for endstop) updated <Value>
-            arr_result = res.strip().split(' ')
-            res_msg[axis][str(arr_result[0])] = float(arr_result[2])
+            res_msg[axis][key] = value
 
         return res_msg
 


### PR DESCRIPTION
This parsing is unreliable because we have the smoothie's echo mode on and our
multiple new lines sometimes stomp the actual response from the smoothie. This
raises an IndexError and breaks pipette config updating and makes the system
unreliable.

This should remove cases where sometimes you'd get mysterious homes during other actions and then errors during homing.