### PR TITLE
fix(api): Force the permanent mac address for wifi connections

### DIFF
--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -412,7 +412,8 @@ def _build_con_add_cmd(ssid: str, security_type: SECURITY_TYPES,
                      'ifname', 'wlan0',
                      'type', 'wifi',
                      'con-name', ssid,
-                     'wifi.ssid', ssid]
+                     'wifi.ssid', ssid,
+                     '802-11-wireless.cloned-mac-address', 'permanent']
     if hidden:
         configure_cmd += ['wifi.hidden', 'true']
     if security_type == SECURITY_TYPES.WPA_PSK:


### PR DESCRIPTION
This should prevent the macs from changing when the robot restarts, which plays
havoc with people using mac whitelisting in their wireless networks.

Testing:
- push this to your robot
- reconnect to wifi
- dump the mac addr
- restart the robot
- dump the mac addr
- they should be the same