### PR TITLE
feat(api): Add bundle creation to opentrons_simulate

### DIFF
--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f9f8941737cd60a0dd7f14169eae2c0449bb84bbf4dd1e2965248dde9200ed69"
+            "sha256": "da4c59db977479a007cacbc5d215b87676a7b68bc5509091c885368460cd4bb1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,9 +46,9 @@
         },
         "apply-defaults": {
             "hashes": [
-                "sha256:b8c1bc511a0368dabe1af4d80b97186296e25182d7e371d920a9633cf6a2a385"
+                "sha256:ce7eed01ab3830a701f5c5b7a0322061fbdb1639458350ec76ea27526b2373c8"
             ],
-            "version": "==0.1.1"
+            "version": "==0.1.3"
         },
         "async-timeout": {
             "hashes": [
@@ -59,10 +59,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
+                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
             ],
-            "version": "==19.1.0"
+            "version": "==19.2.0"
         },
         "chardet": {
             "hashes": [
@@ -101,12 +101,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:36673ac378feed3daa5956276a829699056523d7961027911f064b52255ead41",
-                "sha256:71e7b3bcf9fca408bcb65bb60892f375d3abdd2e4f296eeeb8fe0bbbfcde598e",
-                "sha256:9088494da4c74497a7a27842ae4ca9c3355b5f7754121edc440463eaf020f079"
+                "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
+                "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==3.0.2"
         },
         "multidict": {
             "hashes": [
@@ -176,6 +175,12 @@
             "index": "pypi",
             "version": "==1.15.1"
         },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
+            ],
+            "version": "==0.15.4"
+        },
         "pyserial": {
             "hashes": [
                 "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627",
@@ -183,6 +188,13 @@
             ],
             "index": "pypi",
             "version": "==3.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "systemd-python": {
             "hashes": [
@@ -274,10 +286,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
+                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
             ],
-            "version": "==19.1.0"
+            "version": "==19.2.0"
         },
         "babel": {
             "hashes": [
@@ -295,10 +307,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -398,11 +410,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
-                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.19"
+            "version": "==0.23"
         },
         "jinja2": {
             "hashes": [
@@ -494,20 +506,20 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0107bff4f46a289f0e4081d59b77cef1c48ea43da5a0dbf0005d54748b26df2a",
-                "sha256:07957f5471b3bb768c61f08690c96d8a09be0912185a27a68700f3ede99184e4",
-                "sha256:10af62f87b6921eac50271e667cc234162a194e742d8e02fc4ddc121e129a5b0",
-                "sha256:11fd60d2f69f0cefbe53ce551acf5b1cec1a89e7ce2d47b4e95a84eefb2899ae",
-                "sha256:15e43d3b1546813669bd1a6ec7e6a11d2888db938e0607f7b5eef6b976671339",
-                "sha256:352c24ba054a89bb9a35dd064ee95ab9b12903b56c72a8d3863d882e2632dc76",
-                "sha256:437020a39417e85e22ea8edcb709612903a9924209e10b3ec6d8c9f05b79f498",
-                "sha256:49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4",
-                "sha256:6724fcd5777aa6cebfa7e644c526888c9d639bd22edd26b2a8038c674a7c34bd",
-                "sha256:7a17613f7ea374ab64f39f03257f22b5755335b73251d0d253687a69029701ba",
-                "sha256:cdc1151ced496ca1496272da7fc356580e95f2682be1d32377c22ddebdf73c91"
+                "sha256:1d98fd818ad3128a5408148c9e4a5edce6ed6b58cc314283e631dd5d9216527b",
+                "sha256:22ee018e8fc212fe601aba65d3699689dd29a26410ef0d2cc1943de7bec7e3ac",
+                "sha256:3a24f80776edc706ec8d05329e854d5b9e464cd332e25cde10c8da2da0a0db6c",
+                "sha256:42a78944e80770f21609f504ca6c8173f7768043205b5ac51c9144e057dcf879",
+                "sha256:4b2b20106973548975f0c0b1112eceb4d77ed0cafe0a231a1318f3b3a22fc795",
+                "sha256:591a9625b4d285f3ba69f541c84c0ad9e7bffa7794da3fa0585ef13cf95cb021",
+                "sha256:5b4b70da3d8bae73b908a90bb2c387b977e59d484d22c604a2131f6f4397c1a3",
+                "sha256:84edda1ffeda0941b2ab38ecf49302326df79947fa33d98cdcfbf8ca9cf0bb23",
+                "sha256:b2b83d29babd61b876ae375786960a5374bba0e4aba3c293328ca6ca5dc448dd",
+                "sha256:cc4502f84c37223a1a5ab700649b5ab1b5e4d2bf2d426907161f20672a21930b",
+                "sha256:e29e24dd6e7f39f200a5bb55dcaa645d38a397dd5a6674f6042ef02df5795046"
             ],
             "index": "pypi",
-            "version": "==0.720"
+            "version": "==0.730"
         },
         "mypy-extensions": {
             "hashes": [
@@ -526,10 +538,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
-                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.1"
+            "version": "==19.2"
         },
         "pkginfo": {
             "hashes": [
@@ -540,10 +552,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -597,11 +609,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95b1f6db806e5b1b5b443efeb58984c24945508f93a866c1719e1a507a957d7c",
-                "sha256:c3d5020755f70c82eceda3feaf556af9a341334414a8eca521a18f463bcead88"
+                "sha256:13c1c9b22127a77fc684eee24791efafcef343335d855e3573791c68588fe1a5",
+                "sha256:d8ba7be9466f55ef96ba203fc0f90d0cf212f2f927e69186e1353e30bc7f62e5"
             ],
             "index": "pypi",
-            "version": "==5.1.1"
+            "version": "==5.2.0"
         },
         "pytest-aiohttp": {
             "hashes": [
@@ -656,9 +668,10 @@
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:9f3b9ffe0809d174f7047e121431acf99c89a7040f0ca84f94ba53a498e6d0c9"
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
-            "version": "==1.9.0"
+            "version": "==2.0.0"
         },
         "sphinx": {
             "hashes": [
@@ -670,18 +683,18 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:438d6a735167099d75e5fd9a55175c6727c4dbba345ae406b2886c2728fe3e80",
-                "sha256:ebc205051d79b49989140f5f6c73ec23fce5f590cbc4d9cd6e4c47f168fa0f10"
+                "sha256:abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d",
+                "sha256:dd3fcca8488bb1d416aa7469d2f277902f26260c45aa86b667b074cd44b3b115"
             ],
-            "version": "==4.34.0"
+            "version": "==4.36.1"
         },
         "twine": {
             "hashes": [
-                "sha256:0fb0bfa3df4f62076cab5def36b1a71a2e4acb4d1fa5c97475b048117b1a6446",
-                "sha256:d6c29c933ecfc74e9b1d9fa13aa1f87c5d5770e119f5a4ce032092f0ff5b14dc"
+                "sha256:5319dd3e02ac73fcddcd94f035b9631589ab5d23e1f4699d57365199d85261e1",
+                "sha256:9fe7091715c7576df166df8ef6654e61bada39571783f2fd415bdcba867c6993"
             ],
             "index": "pypi",
-            "version": "==1.13.0"
+            "version": "==2.0.0"
         },
         "typed-ast": {
             "hashes": [
@@ -714,10 +727,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.6"
         },
         "wcwidth": {
             "hashes": [
@@ -759,10 +772,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
-                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
+                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
             ],
-            "version": "==0.5.2"
+            "version": "==0.6.0"
         }
     }
 }

--- a/api/docs/source/v2/new_advanced_running.rst
+++ b/api/docs/source/v2/new_advanced_running.rst
@@ -60,3 +60,70 @@ The robot's command line is accessible either by creating a new terminal in Jupy
 
 
 You can access help on the usage of ``opentrons_execute`` by calling ``opentrons_execute --help``. This script has a couple options to let you customize what it prints out when you run it. By default, it will print out the same runlog you see in the Opentrons App when running a protocol, as it executes; it will also print out internal logs at level ``warning`` or above. Both of these behaviors can be changed.
+
+
+Bundling Protocols
+==================
+
+.. warning::
+
+    Bundled protocols are a beta feature. The only way to create them is with the ``opentrons_simulate`` script. The format of the bundle files themselves is subject to change. This is a feature you should use with care. Only very limited support from Opentrons is available for this beta feature.
+
+
+Bundled protocols are zip files containing
+
+1. an APIv2 protocol
+2. Definitions for all required labware for the protocol, including the fixed trash
+3. Additional data files that will be made available to the protocol
+
+Bundled protocols may be uploaded through the Opentrons App in their zipped form, just like normal protocols. They may be simulated with ``opentrons_simulate`` and executed from the robot command line with ``opentrons_execute`` just like normal protocols.
+
+The advantage to using bundled protocols is that you can pack in custom labware definitions and custom data files such as CSVs specifying aspiration amounts and locations.
+
+
+Writing A Bundled Protocol
+--------------------------
+
+When you write a bundled protocol, you write a normal APIv2 Python protocol. It may or may not include custom labware or data files. It is written in Python using the same API as any other APIv2 Python protocol.
+
+Bundled protocols have all their labware definitions available to them inside the bundle, including both standard and custom definitions. They are limited to loading labware defined in the bundle; for this reason, **if you change what labware you use in a bundled protocol you must rebundle it**.
+
+Bundled protocols also have any data files they may need available to them inside the bundle. Similarly to labware, if you change what data files you read inside the protocol you should rebundle it.
+
+Bundled protocols are created using ``opentrons_simulate``. The protocol must be an APIv2 protocol, and ``opentrons_simulate`` must be running in APIv2 mode. The easiest way to do this is to specify it with the environment variable ``OT_API_FF_useProtocolApi2=1``. You can specify this every time you run ``opentrons_simulate`` on Linux or Mac, or put it in your shell rc file; on Windows, you can set it in the environment variables dialog.
+
+To bundle, use the ``-b`` option to ``opentrons_simulate``. **If the ``-b`` option is not available, it is because you have not set the APIv2 feature flag**. This will simulate the protocol, then (if successful) bundle the protocol file, all required labware definitions, and any specified data file into a zip suitable for use with the Opentrons app or the ``opentrons_execute`` script. If you are using custom data files or custom labware definitions, you must ensure that these files and definitions are available to ``opentrons_simulate``.
+
+
+Accessing Custom Labware Definitions
+++++++++++++++++++++++++++++++++++++
+
+To access a labware definition inside a bundle, use :py:meth:`.ProtocolContext.load_labware` just like in a normal protocol. To make custom labware definitions available to ``opentrons_simulate``, use the ``-L`` option. By default, any labware definition in the current directory when you run ``opentrons_simulate`` is available to the protocol.
+
+
+Accessing Custom Data
++++++++++++++++++++++
+
+Custom data files are made available in :py:attr:`.ProtocolContext.bundled_data`. This is a dictionary mapping the names of data files (without any paths) to their contents, as bytes. If you need the contents of the files as strings, you must decode them with ``.decode('utf-8')`` (the files are presented in bytes in case they are not text, for instance if they are images or zip files). These can then be read in whatever format you need.
+
+For instance, if a CSV file called ``aspirations.csv`` is bundled, you can do:
+
+.. code-block::
+
+    import csv
+    def run(ctx):
+        aspirations_contents = ctx.bundled_data['aspirations.csv'].decode('utf-8')
+        print(aspirations_contents)  # prints contents when simulated
+
+
+To make a custom data file available to ``opentrons_simulate``, use the ``-d`` option to specify a file.
+
+
+Executing A Bundled Protocol
+----------------------------
+
+Once you have a bundled protocol file (by default, its file extension will be ``.ot2.zip``) you can use it without any further specification of labware or data files - they are all bundled inside the file. For instance,
+
+1. You can execute a bundled protocol through the Opentrons App by selecting it in the protocol pane
+2. You can execute a bundled protocol on the robot command line by doing ``opentrons_execute ./protocol.ot2.zip``
+3. You can simulate a bundled protocol on your computer by doing ``opentrons_simulate ./protocol.ot2.zip``.

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -233,17 +233,10 @@ class Session(object):
                      for mod in self._hardware.attached_modules.values()],
                     strict_attached_instruments=False)
                 sim.home()
-                bundled_data = None
-                bundled_labware = None
-                if isinstance(self._protocol, PythonProtocol):
-                    bundled_data = self._protocol.bundled_data
-                    bundled_labware = self._protocol.bundled_labware
                 self._simulating_ctx = ProtocolContext(
                     loop=self._loop,
                     hardware=sim,
-                    broker=self._broker,
-                    bundled_labware=bundled_labware,
-                    bundled_data=bundled_data)
+                    broker=self._broker)
                 run_protocol(self._protocol,
                              simulate=True,
                              context=self._simulating_ctx)

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -485,7 +485,7 @@ def thermocycler_close():
 
 
 def delay(seconds, minutes, msg=None):
-    text = "Delaying for {minutes}m {seconds}s"
+    text = f"Delaying for {minutes}m {seconds}s"
     if msg:
         text = f"{text}. {msg}"
     return make_command(

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -779,8 +779,8 @@ class API(HardwareAPILike):
         # target_position.items() is (rightly) Tuple[float, ...] with unbounded
         # size; unfortunately, mypy can’t quite figure out the length check
         # above that makes this OK
-        transformed = linal.apply_transform(  # type: ignore
-            self._config.gantry_calibration, to_transform)
+        transformed = linal.apply_transform(
+            self._config.gantry_calibration, to_transform)  # type: ignore
 
         # Since target_position is an OrderedDict with the axes ordered by
         # (x, y, z, a, b, c), and we’ll only have one of a or z (as checked

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -87,6 +87,8 @@ def _find_protocol_error(tb, proto_name):
 
 def _run_python(
         proto: PythonProtocol, context: ProtocolContext):
+    context.set_bundle_contents(
+        proto.bundled_labware, proto.bundled_data, proto.extra_labware)
     new_locs = locals()
     new_globs = globals()
     exec(proto.contents, new_globs, new_locs)
@@ -122,9 +124,15 @@ def run_protocol(protocol: Protocol,
 
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
     :param simulate: True to simulate; False to execute. If this is not an
-    OT2, ``simulate`` will be forced ``True``.
+                     OT2, ``simulate`` will be forced ``True``.
     :param context: The context to use. If ``None``, create a new
-    ProtocolContext.
+                    :py:class:`.ProtocolContext`.
+
+    .. note ::
+
+        The :py:class:`.ProtocolContext` has the bundle contents (if any)
+        inserted in it by this method.
+
     """
     if not config.IS_ROBOT:
         simulate = True  # noqa - will be used later

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -19,7 +19,9 @@ from collections import defaultdict
 from enum import Enum, auto
 from hashlib import sha256
 from itertools import takewhile, dropwhile
-from typing import Any, List, Dict, Optional, Union, Tuple
+from typing import Any, AnyStr, List, Dict, Optional, Union, Tuple
+
+import jsonschema  # type: ignore
 
 from opentrons.types import Location
 from opentrons.types import Point
@@ -32,6 +34,9 @@ OPENTRONS_NAMESPACE = 'opentrons'
 CUSTOM_NAMESPACE = 'custom_beta'
 STANDARD_DEFS_PATH = Path(sys.modules['opentrons'].__file__).parent /\
     'shared_data' / 'labware' / 'definitions' / '2'
+
+
+LabwareDefinition = Dict[str, Any]
 
 
 class OutOfTipsError(Exception):
@@ -848,7 +853,7 @@ def _get_parent_identifier(
         return ''  # treat all slots as same
 
 
-def _hash_labware_def(labware_def: Dict[str, Any]) -> str:
+def _hash_labware_def(labware_def: LabwareDefinition) -> str:
     # remove keys that do not affect run
     blacklist = ['metadata', 'brand', 'groups']
     def_no_metadata = {
@@ -959,7 +964,7 @@ def _get_path_to_labware(load_name: str, namespace: str, version: int) -> Path:
 
 
 def save_definition(
-    labware_def: Dict[str, Any],
+    labware_def: LabwareDefinition,
     force: bool = False
 ) -> None:
     """
@@ -1003,12 +1008,12 @@ def delete_all_custom_labware() -> None:
         shutil.rmtree(custom_def_dir)
 
 
-def get_labware_definition_from_bundle(
-    bundled_labware: Dict[str, Dict[str, Any]],
+def _get_labware_definition_from_bundle(
+    bundled_labware: Dict[str, LabwareDefinition],
     load_name: str,
     namespace: str = None,
     version: int = None,
-) -> Dict[str, Any]:
+) -> LabwareDefinition:
     """
     Look up and return a bundled definition by ``load_name`` + ``namespace``
     + ``version`` and return it or raise an exception. The``namespace`` and
@@ -1047,28 +1052,20 @@ def get_labware_definition_from_bundle(
             f'namespace {namespace}, and version {version}.')
 
 
-def get_labware_definition(
-    load_name: str,
-    namespace: str = None,
-    version: int = 1
-) -> Dict[str, Any]:
-    """
-    Look up and return a definition by load_name + namespace + version and
-        return it or raise an exception
+def _get_standard_labware_definition(
+        load_name: str, namespace: str = None, version: int = None)\
+        -> LabwareDefinition:
 
-    :param str load_name: corresponds to 'loadName' key in definition
-    :param str namespace: The namespace the labware definition belongs to.
-        If unspecified, will search 'opentrons' then 'custom_beta'
-    :param int version: The version of the labware definition. If unspecified,
-        will use version 1.
-    """
-    load_name = load_name.lower()
+    if version is None:
+        checked_version = 1
+    else:
+        checked_version = version
 
     if namespace is None:
         for fallback_namespace in [OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE]:
             try:
                 return get_labware_definition(
-                    load_name, fallback_namespace, version)
+                    load_name, fallback_namespace, checked_version)
             except (FileNotFoundError):
                 pass
         raise FileNotFoundError(
@@ -1077,7 +1074,7 @@ def get_labware_definition(
             f'{CUSTOM_NAMESPACE}, please specify it')
 
     namespace = namespace.lower()
-    def_path = _get_path_to_labware(load_name, namespace, version)
+    def_path = _get_path_to_labware(load_name, namespace, checked_version)
 
     try:
         with open(def_path, 'r') as f:
@@ -1091,13 +1088,69 @@ def get_labware_definition(
     return labware_def
 
 
+def verify_definition(contents: AnyStr) -> LabwareDefinition:
+    """ Verify that an input string is a labware definition and return it.
+
+    If the definition is invalid, an exception is raised; otherwise parse the
+    json and return the valid definition.
+
+    :raises json.JsonDecodeError: If the definition is not valid json
+    :raises jsonschema.ValidationError: If the definition is not valid.
+    :returns: The parsed definition
+    """
+    loaded = json.loads(contents)
+    schema_body = pkgutil.get_data(  # type: ignore
+        'opentrons',
+        'shared_data/labware/schemas/2.json').decode('utf-8')
+    labware_schema_v2 = json.loads(schema_body)
+    # do the validation
+    jsonschema.validate(loaded, labware_schema_v2)
+    return loaded
+
+
+def get_labware_definition(
+    load_name: str,
+    namespace: str = None,
+    version: int = None,
+    bundled_defs: Dict[str, LabwareDefinition] = None,
+    extra_defs: Dict[str, LabwareDefinition] = None
+) -> Dict[str, Any]:
+    """
+    Look up and return a definition by load_name + namespace + version and
+        return it or raise an exception
+
+    :param str load_name: corresponds to 'loadName' key in definition
+    :param str namespace: The namespace the labware definition belongs to.
+        If unspecified, will search 'opentrons' then 'custom_beta'
+    :param int version: The version of the labware definition. If unspecified,
+        will use version 1.
+    """
+    load_name = load_name.lower()
+
+    if bundled_defs is not None:
+        return _get_labware_definition_from_bundle(
+            bundled_defs, load_name, namespace, version)
+
+    checked_extras = extra_defs or {}
+
+    try:
+        return _get_labware_definition_from_bundle(
+            checked_extras, load_name, namespace, version)
+    except (FileNotFoundError, RuntimeError):
+        pass
+
+    return _get_standard_labware_definition(
+        load_name, namespace, version)
+
+
 def load(
     load_name: str,
     parent: Location,
     label: str = None,
     namespace: str = None,
     version: int = 1,
-    bundled_defs: Dict[str, Dict[str, Any]] = None,
+    bundled_defs: Dict[str, LabwareDefinition] = None,
+    extra_defs: Dict[str, LabwareDefinition] = None
 ) -> Labware:
     """
     Return a labware object constructed from a labware definition dict looked
@@ -1118,12 +1171,14 @@ def load(
         will use version 1.
     :param bundled_defs: If specified, a mapping of labware names to labware
         definitions. Only the bundle will be searched for definitions.
+    :param extra_defs: If specified, a mapping of labware names to labware
+        definitions. If no bundle is passed, these definitions will also be
+        searched.
     """
-    if bundled_defs is not None:
-        definition = get_labware_definition_from_bundle(
-            bundled_defs, load_name, namespace, version)
-    else:
-        definition = get_labware_definition(load_name, namespace, version)
+    definition = get_labware_definition(
+        load_name, namespace, version,
+        bundled_defs=bundled_defs,
+        extra_defs=extra_defs)
     return load_from_definition(definition, parent, label)
 
 
@@ -1253,33 +1308,24 @@ def filter_tipracks_to_start(
         lambda tr: starting_point.parent is not tr, tipracks))
 
 
-def uri_from_details(namespace: str, load_name: str, version: str) -> str:
+def uri_from_details(namespace: str, load_name: str, version: str,
+                     delimiter='/') -> str:
     """ Build a labware URI from its details.
 
     A labware URI is a string that uniquely specifies a labware definition.
 
     :returns str: The URI.
     """
-    return f'{namespace}/{load_name}/{version}'
+    return f'{namespace}{delimiter}{load_name}{delimiter}{version}'
 
 
-def details_from_uri(uri: str) -> Tuple[str, str, str]:
-    """ Parse a labware URI and return the details.
-
-    :returns: A tuple of (namespace, load name, version)
-    """
-    namespace, loadname, version = uri.split('/')
-    return namespace, loadname, version
-
-
-def uri_from_definition(definition: Dict[str, Any]) -> str:
+def uri_from_definition(definition: LabwareDefinition, delimiter='/') -> str:
     """ Build a labware URI from its definition.
 
     A labware URI is a string that uniquely specifies a labware definition.
 
     :returns str: The URI.
     """
-    return '{namespace}/{loadname}/{version}'.format(
-        namespace=definition['namespace'],
-        loadname=definition['parameters']['loadName'],
-        version=definition['version'])
+    return uri_from_details(definition['namespace'],
+                            definition['parameters']['loadName'],
+                            definition['version'])

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1064,7 +1064,7 @@ def _get_standard_labware_definition(
     if namespace is None:
         for fallback_namespace in [OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE]:
             try:
-                return get_labware_definition(
+                return _get_standard_labware_definition(
                     load_name, fallback_namespace, checked_version)
             except (FileNotFoundError):
                 pass
@@ -1077,8 +1077,8 @@ def _get_standard_labware_definition(
     def_path = _get_path_to_labware(load_name, namespace, checked_version)
 
     try:
-        with open(def_path, 'r') as f:
-            labware_def = json.load(f)
+        with open(def_path, 'rb') as f:
+            labware_def = json.loads(f.read().decode('utf-8'))
     except FileNotFoundError:
         raise FileNotFoundError(
             f'Labware "{load_name}" not found with version {version} ' +

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1253,8 +1253,8 @@ def load_module(name: str, parent: Location) -> ModuleGeometry:
                    is (often the front-left corner of a slot on the deck).
     """
     def_path = 'shared_data/module/definitions/1.json'
-    module_def = json.loads(  # type: ignore
-        pkgutil.get_data('opentrons', def_path))
+    module_def = json.loads(
+        pkgutil.get_data('opentrons', def_path))  # type: ignore
     return load_module_from_definition(module_def[name], parent)
 
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1254,7 +1254,8 @@ def load_module(name: str, parent: Location) -> ModuleGeometry:
     """
     def_path = 'shared_data/module/definitions/1.json'
     module_def = json.loads(
-        pkgutil.get_data('opentrons', def_path))  # type: ignore
+        pkgutil.get_data(  # type: ignore
+            'opentrons', def_path).decode('utf-8'))  # type: ignore
     return load_module_from_definition(module_def[name], parent)
 
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1124,6 +1124,10 @@ def get_labware_definition(
         If unspecified, will search 'opentrons' then 'custom_beta'
     :param int version: The version of the labware definition. If unspecified,
         will use version 1.
+    :param bundled_defs: A bundle of labware definitions to exlusively use for
+        finding labware definitions, if specified
+    :param extra_defs: An extra set of definitions (in addition to the system
+        definitions) in which to search
     """
     load_name = load_name.lower()
 

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -1,0 +1,88 @@
+"""
+functions and utilities for handling zipped protocol bundles
+"""
+from datetime import date
+import json
+from pathlib import PurePosixPath, PurePath
+from typing import Any, Dict, BinaryIO
+from zipfile import ZipFile
+
+from opentrons.protocol_api.labware import uri_from_definition
+
+from .types import BundleContents
+
+MAIN_PROTOCOL_FILENAME = 'protocol.ot2.py'
+LABWARE_DIR = 'labware'
+DATA_DIR = 'data'
+
+
+def _has_files_at_root(zipFile):
+    for zipInfo in zipFile.infolist():
+        if zipInfo.filename.count('/') == 0:
+            return True
+    return False
+
+
+def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa(C901)
+    """ Extract a bundle and verify its contents and structure. """
+    if not _has_files_at_root(bundle):
+        raise RuntimeError(
+            'No files found in ZIP file\'s root directory. When selecting '
+            'files to zip, make sure to directly select the files '
+            'themselves. Do not select their parent directory, which would '
+            'result in nesting all files inside that directory in the ZIP.')
+    try:
+        with bundle.open(MAIN_PROTOCOL_FILENAME, 'r') as protocol_file:
+            py_protocol = protocol_file.read().decode('utf-8')
+    except KeyError:
+        raise RuntimeError(
+            f'Bundled protocol should have a {MAIN_PROTOCOL_FILENAME} ' +
+            'file in the root directory')
+    bundled_labware: Dict[str, Dict[str, Any]] = {}
+    bundled_data = {}
+    bundled_python = {}
+    for zipInfo in bundle.infolist():
+        filepath = PurePosixPath(zipInfo.filename)
+        rootpath = filepath.parts[0]
+
+        # skip directories and weird OS-added directories
+        # (note: the __MACOSX dir would contain '__MACOSX/foo.py'
+        # and other files. This would break our inferences, so we need
+        # to exclude all contents of that directory)
+        if rootpath == '__MACOSX' or zipInfo.is_dir():
+            continue
+
+        with bundle.open(zipInfo) as f:
+            if rootpath == LABWARE_DIR and filepath.suffix == '.json':
+                labware_def = json.load(f)
+                labware_key = uri_from_definition(labware_def)
+                if labware_key in bundled_labware:
+                    raise RuntimeError(
+                        f'Conflicting labware in bundle: {labware_key}')
+                bundled_labware[labware_key] = labware_def
+            elif rootpath == DATA_DIR:
+                # note: data files are read as binary
+                bundled_data[str(filepath.relative_to(DATA_DIR))] = f.read()
+            elif (filepath.suffix == '.py' and
+                  str(filepath) != MAIN_PROTOCOL_FILENAME):
+                bundled_python[str(filepath)] = f.read().decode('utf-8')
+
+    if not bundled_labware:
+        raise RuntimeError('No labware definitions found in bundle.')
+
+    return BundleContents(py_protocol, bundled_labware,
+                          bundled_data, bundled_python)
+
+
+def create_bundle(contents: BundleContents,
+                  into_file: BinaryIO):
+    """ Create a bundle from assumed-good contents """
+    with ZipFile(into_file, mode='w') as zf:
+        zf.writestr(MAIN_PROTOCOL_FILENAME, contents.protocol)
+        for dataname, datafile in contents.bundled_data.items():
+            name = PurePath(dataname).name
+            zf.writestr(f'{DATA_DIR}/{name}', datafile)
+        for lwdef in contents.bundled_labware.values():
+            zipsafe = uri_from_definition(lwdef, '-')
+            zf.writestr(f'{LABWARE_DIR}/{zipsafe}.json', json.dumps(lwdef))
+        zf.writestr('.bundle_beta', str(date.today()))

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -54,7 +54,7 @@ def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa(C901)
 
         with bundle.open(zipInfo) as f:
             if rootpath == LABWARE_DIR and filepath.suffix == '.json':
-                labware_def = json.load(f)
+                labware_def = json.loads(f.read().decode('utf-8'))
                 labware_key = uri_from_definition(labware_def)
                 if labware_key in bundled_labware:
                     raise RuntimeError(

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -96,11 +96,11 @@ def parse(
     :param protocol_file: The protocol file, or for single-file protocols, a
                         string of the protocol contents.
     :param filename: The name of the protocol. Optional, but helps with
-                        deducing the kind of protocol (e.g. if it ends with
-                        '.json' we can treat it like json)
-    :param extra_defs: Any extra labware defs that should be given to the
-                       protocol. Ignored if the protocol is json or zipped
-                       python.
+                     deducing the kind of protocol (e.g. if it ends with
+                     '.json' we can treat it like json)
+    :param extra_labware: Any extra labware defs that should be given to the
+                          protocol. Ignored if the protocol is json or zipped
+                          python.
     :param extra_data: Any extra data files that should be provided to the
                        protocol. Ignored if the protocol is json or zipped
                        python.

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -7,7 +7,6 @@ import itertools
 import json
 import pkgutil
 from io import BytesIO
-from pathlib import PurePosixPath
 from zipfile import ZipFile
 from typing import Any, Dict, Union
 
@@ -15,6 +14,7 @@ import jsonschema  # type: ignore
 
 from opentrons.config import feature_flags as ff
 from .types import Protocol, PythonProtocol, JsonProtocol, Metadata
+from .bundle import extract_bundle
 
 
 def _parse_json(
@@ -32,7 +32,8 @@ def _parse_python(
     filename: str = None,
     bundled_labware: Dict[str, Dict[str, Any]] = None,
     bundled_data: Dict[str, bytes] = None,
-    bundled_python: Dict[str, str] = None
+    bundled_python: Dict[str, str] = None,
+    extra_labware: Dict[str, Dict[str, Any]] = None,
 ) -> PythonProtocol:
     """ Parse a protocol known or at least suspected to be python """
     filename_checked = filename or '<protocol>'
@@ -55,22 +56,10 @@ def _parse_python(
         api_level=version,
         bundled_labware=bundled_labware,
         bundled_data=bundled_data,
-        bundled_python=bundled_python)
+        bundled_python=bundled_python,
+        extra_labware=extra_labware)
 
     return result
-
-
-def _has_files_at_root(zipFile):
-    for zipInfo in zipFile.infolist():
-        if zipInfo.filename.count('/') == 0:
-            return True
-    return False
-
-
-def _get_labware_uri(labware_def: Dict[str, Any]) -> str:
-    return '/'.join([labware_def['namespace'],
-                     labware_def['parameters']['loadName'],
-                     str(labware_def['version'])])
 
 
 def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:  # noqa: C901
@@ -80,60 +69,14 @@ def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:  # n
             'Uploading a bundled protocol requires the robot to be set to '
             'Protocol API V2. Enable the \'Use Protocol API version 2\' '
             'toggle in the robot\'s Advanced Settings and restart the robot')
-    if not _has_files_at_root(bundle):
-        raise RuntimeError(
-            'No files found in ZIP file\'s root directory. When selecting '
-            'files to zip, make sure to directly select the files '
-            'themselves. Do not select their parent directory, which would '
-            'result in nesting all files inside that directory in the ZIP.')
 
-    MAIN_PROTOCOL_FILENAME = 'protocol.ot2.py'
-    LABWARE_DIR = 'labware'
-    DATA_DIR = 'data'
-    bundled_labware: Dict[str, Dict[str, Any]] = {}
-    bundled_data = {}
-    bundled_python = {}
-
-    try:
-        with bundle.open(MAIN_PROTOCOL_FILENAME, 'r') as protocol_file:
-            py_protocol = protocol_file.read().decode('utf-8')
-    except KeyError:
-        raise RuntimeError(
-            f'Bundled protocol should have a {MAIN_PROTOCOL_FILENAME} ' +
-            'file in the root directory')
-
-    for zipInfo in bundle.infolist():
-        filepath = PurePosixPath(zipInfo.filename)
-        rootpath = filepath.parts[0]
-
-        # skip directories and weird OS-added directories
-        # (note: the __MACOSX dir would contain '__MACOSX/foo.py'
-        # and other files. This would break our inferences, so we need
-        # to exclude all contents of that directory)
-        if rootpath == '__MACOSX' or zipInfo.is_dir():
-            continue
-
-        with bundle.open(zipInfo) as f:
-            if rootpath == LABWARE_DIR and filepath.suffix == '.json':
-                labware_def = json.load(f)
-                labware_key = _get_labware_uri(labware_def)
-                if labware_key in bundled_labware:
-                    raise RuntimeError(
-                        f'Conflicting labware in bundle. {labware_key}')
-                bundled_labware[labware_key] = labware_def
-            elif rootpath == DATA_DIR:
-                # note: data files are read as binary
-                bundled_data[str(filepath.relative_to(DATA_DIR))] = f.read()
-            elif (filepath.suffix == '.py' and
-                  str(filepath) != MAIN_PROTOCOL_FILENAME):
-                bundled_python[str(filepath)] = f.read().decode('utf-8')
-
-    if not bundled_labware:
-        raise RuntimeError('No labware definitions found in bundle.')
+    contents = extract_bundle(bundle)
 
     result = _parse_python(
-        py_protocol, filename, bundled_labware, bundled_data,
-        bundled_python)
+        contents.protocol, filename,
+        contents.bundled_labware,
+        contents.bundled_data,
+        contents.bundled_python)
 
     if result.api_level != '2':
         raise RuntimeError('Bundled protocols must use Protocol API V2, ' +
@@ -144,7 +87,9 @@ def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:  # n
 
 def parse(
     protocol_file: Union[str, bytes],
-    filename: str = None
+    filename: str = None,
+    extra_labware: Dict[str, Dict[str, Any]] = None,
+    extra_data: Dict[str, bytes] = None
 ) -> Protocol:
     """ Parse a protocol from text.
 
@@ -153,6 +98,12 @@ def parse(
     :param filename: The name of the protocol. Optional, but helps with
                         deducing the kind of protocol (e.g. if it ends with
                         '.json' we can treat it like json)
+    :param extra_defs: Any extra labware defs that should be given to the
+                       protocol. Ignored if the protocol is json or zipped
+                       python.
+    :param extra_data: Any extra data files that should be provided to the
+                       protocol. Ignored if the protocol is json or zipped
+                       python.
     :return types.Protocol: The protocol holder, a named tuple that stores the
                         data in the protocol for later simulation or
                         execution.
@@ -174,13 +125,17 @@ def parse(
         if filename and filename.endswith('.json'):
             return _parse_json(protocol_str, filename)
         elif filename and filename.endswith('.py'):
-            return _parse_python(protocol_str, filename)
+            return _parse_python(
+                protocol_str, filename, extra_labware=extra_labware,
+                bundled_data=extra_data)
 
         # our jsonschema says the top level json kind is object
         if protocol_str and protocol_str[0] in ('{', b'{'):
             return _parse_json(protocol_str, filename)
         else:
-            return _parse_python(protocol_str, filename)
+            return _parse_python(
+                protocol_str, filename, extra_labware=extra_labware,
+                bundled_data=extra_data)
 
 
 def extract_metadata(parsed: ast.Module) -> Metadata:

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -20,6 +20,15 @@ class PythonProtocol(NamedTuple):
     bundled_labware: Optional[Dict[str, Dict[str, Any]]]
     bundled_data: Optional[Dict[str, bytes]]
     bundled_python: Optional[Dict[str, str]]
+    # this should only be included when the protocol is not a zip
+    extra_labware: Optional[Dict[str, Dict[str, Any]]]
 
 
 Protocol = Union[JsonProtocol, PythonProtocol]
+
+
+class BundleContents(NamedTuple):
+    protocol: str
+    bundled_labware: Dict[str, Dict[str, Any]]
+    bundled_data: Dict[str, bytes]
+    bundled_python: Dict[str, str]

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -1,0 +1,62 @@
+""" opentrons.util.entrypoint_util: functions common to entrypoints
+"""
+
+import logging
+from json import JSONDecodeError
+import pathlib
+from typing import Any, Dict, List
+
+from jsonschema import ValidationError  # type: ignore
+
+from opentrons.protocol_api import labware
+log = logging.getLogger(__name__)
+
+
+def labware_from_paths(paths: List[str]) -> Dict[str, Dict[str, Any]]:
+    labware_defs: Dict[str, Dict[str, Any]] = {}
+
+    for strpath in paths:
+        log.info(f"local labware: checking path {strpath}")
+        purepath = pathlib.PurePath(strpath)
+        if purepath.is_absolute():
+            path = pathlib.Path(purepath)
+        else:
+            path = pathlib.Path.cwd() / purepath
+        if not path.is_dir():
+            raise RuntimeError(f'{path} is not a directory')
+        for child in path.iterdir():
+            if child.is_file() and child.suffix.endswith('json'):
+                try:
+                    defn = labware.verify_definition(child.read_bytes())
+                except (ValidationError, JSONDecodeError) as e:
+                    print(f'{child}: invalid ({str(e)})')
+                    log.info(f"{child}: invalid ({str(e)})")
+                else:
+                    uri = labware.uri_from_definition(defn)
+                    labware_defs[uri] = defn
+                    log.info(f'loaded labware {uri} from {child}')
+            else:
+                log.info(f'ignoring {child} in labware path')
+    return labware_defs
+
+
+def datafiles_from_paths(paths: List[str]) -> Dict[str, bytes]:
+    datafiles: Dict[str, bytes] = {}
+    for strpath in paths:
+        log.info(f"data files: checking path {strpath}")
+        purepath = pathlib.PurePath(strpath)
+        if purepath.is_absolute():
+            path = pathlib.Path(purepath)
+        else:
+            path = pathlib.Path.cwd() / purepath
+        if path.is_file():
+            datafiles[path.name] = path.read_bytes()
+            log.info(f'read {path} into custom data as {path.name}')
+        elif path.is_dir():
+            for child in path.iterdir():
+                if child.is_file():
+                    datafiles[child.name] = child.read_bytes()
+                    log.info(f'read {child} into data path as {child.name}')
+                else:
+                    log.info(f'ignoring {child} in data path')
+    return datafiles

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -541,9 +541,9 @@ def get_bundle_fixture():
         with open(
             pathlib.Path(__file__).parent / '..' / '..' / '..' /
             'shared-data' / 'labware' / 'definitions' / '2' /
-            loadName / f'{version}.json', 'r'
+            loadName / f'{version}.json', 'rb'
         ) as f:
-            labware_def = json.load(f)
+            labware_def = json.loads(f.read().decode('utf-8'))
         return labware_def
 
     def _get_bundle_protocol_fixture(fixture_name):

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -407,7 +407,6 @@ def test_uris():
     details = ('opentrons', 'opentrons_96_tiprack_300ul', '1')
     uri = 'opentrons/opentrons_96_tiprack_300ul/1'
     assert labware.uri_from_details(*details) == uri
-    assert labware.details_from_uri(uri) == details
     defn = labware.get_labware_definition(details[1], details[0], details[2])
     assert labware.uri_from_definition(defn) == uri
     lw = labware.Labware(defn, Location(Point(0, 0, 0), 'Test Slot'))

--- a/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
+++ b/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
@@ -13,4 +13,4 @@ def run(protocol_context):
 
     for volume in csv_data.split(','):
         v = float(volume.strip())
-        pipette.transfer(v, plate.wells('A1'), plate.wells('B1'))
+        pipette.transfer(v, plate.wells('A1'), plate.wells('A4'))

--- a/api/tests/opentrons/protocols/test_bundle.py
+++ b/api/tests/opentrons/protocols/test_bundle.py
@@ -1,0 +1,53 @@
+import io
+import zipfile
+
+import pytest
+
+from opentrons.protocols import bundle
+
+
+@pytest.mark.api2_only
+def test_parse_bundle_no_root_files(get_bundle_fixture, ensure_api2):
+    fixture = get_bundle_fixture('no_root_files_bundle')
+    with pytest.raises(RuntimeError,
+                       match='No files found in ZIP file\'s root directory'):
+        buf = io.BytesIO(fixture['binary_zipfile'])
+        buf.seek(0)
+        zf = zipfile.ZipFile(buf)
+        bundle.extract_bundle(zf)
+
+
+@pytest.mark.api2_only
+def test_parse_bundle_no_entrypoint_protocol(get_bundle_fixture, ensure_api2):
+    fixture = get_bundle_fixture('no_entrypoint_protocol_bundle')
+    with pytest.raises(RuntimeError,
+                       match='Bundled protocol should have a'):
+        buf = io.BytesIO(fixture['binary_zipfile'])
+        buf.seek(0)
+        zf = zipfile.ZipFile(buf)
+        bundle.extract_bundle(zf)
+
+
+@pytest.mark.api2_only
+def test_parse_bundle_conflicting_labware(get_bundle_fixture, ensure_api2):
+    fixture = get_bundle_fixture('conflicting_labware_bundle')
+    with pytest.raises(RuntimeError,
+                       match='Conflicting labware in bundle'):
+        buf = io.BytesIO(fixture['binary_zipfile'])
+        buf.seek(0)
+        zf = zipfile.ZipFile(buf)
+        bundle.extract_bundle(zf)
+
+
+@pytest.mark.api2_only
+def test_write_bundle(ensure_api2, get_bundle_fixture):
+    fixture = get_bundle_fixture('simple_bundle')
+    buf = io.BytesIO(fixture['binary_zipfile'])
+    buf.seek(0)
+    zf = zipfile.ZipFile(buf)
+    original_contents = bundle.extract_bundle(zf)
+    t = io.BytesIO()
+    bundle.create_bundle(original_contents, t)
+    zf2 = zipfile.ZipFile(t)
+    new_contents = bundle.extract_bundle(zf2)
+    assert new_contents == original_contents

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -226,28 +226,17 @@ def test_parse_bundle_details(get_bundle_fixture, ensure_api2):
     assert parsed.api_level == '2'
 
 
-@pytest.mark.api2_only
-def test_parse_bundle_no_root_files(get_bundle_fixture, ensure_api2):
-    fixture = get_bundle_fixture('no_root_files_bundle')
-    filename = fixture['filename']
-    with pytest.raises(RuntimeError,
-                       match='No files found in ZIP file\'s root directory'):
-        parse(fixture['binary_zipfile'], filename)
-
-
-@pytest.mark.api2_only
-def test_parse_bundle_no_entrypoint_protocol(get_bundle_fixture, ensure_api2):
-    fixture = get_bundle_fixture('no_entrypoint_protocol_bundle')
-    filename = fixture['filename']
-    with pytest.raises(RuntimeError,
-                       match='Bundled protocol should have a'):
-        parse(fixture['binary_zipfile'], filename)
-
-
-@pytest.mark.api2_only
-def test_parse_bundle_conflicting_labware(get_bundle_fixture, ensure_api2):
-    fixture = get_bundle_fixture('conflicting_labware_bundle')
-    filename = fixture['filename']
-    with pytest.raises(RuntimeError,
-                       match='Conflicting labware in bundle'):
-        parse(fixture['binary_zipfile'], filename)
+@pytest.mark.parametrize('protocol_file',
+                         ['testosaur.py'])
+def test_extra_contents(
+        get_labware_fixture, ensure_api2, protocol_file, protocol):
+    fixture_96_plate = get_labware_fixture('fixture_96_plate')
+    bundled_labware = {
+        'fixture/fixture_96_plate/1': fixture_96_plate
+    }
+    extra_data = {'hi': b'there'}
+    parsed = parse(protocol.text, 'testosaur.py',
+                   extra_labware=bundled_labware,
+                   extra_data=extra_data)
+    assert parsed.extra_labware == bundled_labware
+    assert parsed.bundled_data == extra_data

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -1,0 +1,93 @@
+import io
+
+import pytest
+
+from opentrons import simulate, protocols
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+def test_simulate_function_apiv2(ensure_api2,
+                                 protocol,
+                                 protocol_file):
+    runlog, bundle = simulate.simulate(
+        protocol.filelike, 'testosaur_v2.py')
+    assert isinstance(bundle, protocols.types.BundleContents)
+    assert [item['payload']['text'] for item in runlog] == [
+        'Picking up tip A1 of Opentrons 96 Tip Rack 300 µL on 1',
+        'Aspirating 10 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 1.0 speed',  # noqa(E501),
+        'Dispensing 10 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2',
+        'Dropping tip H12 of Opentrons 96 Tip Rack 300 µL on 1'
+        ]
+
+
+def test_simulate_function_json_apiv2(ensure_api2,
+                                      get_json_protocol_fixture):
+    jp = get_json_protocol_fixture('3', 'simple', False)
+    filelike = io.StringIO(jp)
+    runlog, bundle = simulate.simulate(filelike, 'simple.json')
+    assert bundle is None
+    assert [item['payload']['text'] for item in runlog] == [
+        'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 1',
+        'Aspirating 5 uL from A1 of Source Plate on 2 at 1.0 speed',
+        'Delaying for 0m 42s',
+        'Dispensing 4.5 uL into B1 of Dest Plate on 3',
+        'Touching tip',
+        'Blowing out at B1 of Dest Plate on 3',
+        'Dropping tip A1 of Trash on 12'
+    ]
+
+
+def test_simulate_function_bundle_apiv2(ensure_api2,
+                                        get_bundle_fixture):
+    bundle = get_bundle_fixture('simple_bundle')
+    runlog, bundle = simulate.simulate(
+        bundle['filelike'], 'simple_bundle.zip')
+    assert bundle is None
+    assert [item['payload']['text'] for item in runlog] == [
+        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip A1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 1.0 uL into A4 of FAKE example labware on 1',
+        'Dropping tip A1 of Opentrons Fixed Trash on 12',
+        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip B1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 2.0 uL into A4 of FAKE example labware on 1',
+        'Dropping tip A1 of Opentrons Fixed Trash on 12',
+        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Picking up tip C1 of Opentrons 96 Tip Rack 10 µL on 3',
+        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 1.0 speed',
+        'Dispensing 3.0 uL into A4 of FAKE example labware on 1',
+        'Dropping tip A1 of Opentrons Fixed Trash on 12'
+        ]
+
+
+@pytest.mark.parametrize('protocol_file', ['testosaur.py'])
+def test_simulate_function_apiv1(ensure_api1, protocol, protocol_file):
+    runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
+    assert bundle is None
+    assert [item['payload']['text'] for item in runlog] == [
+        'Picking up tip well A1 in "5"',
+        'Aspirating 10 uL from well A1 in "8" at 1.0 speed',
+        'Dispensing 10 uL into well H12 in "8"',
+        'Aspirating 10 uL from well A1 in "11" at 1.0 speed',
+        'Dispensing 10 uL into well H12 in "11"',
+        'Dropping tip well A1 in "12"'
+    ]
+
+
+def test_simulate_function_json_apiv1(ensure_api1,
+                                      get_json_protocol_fixture):
+    jp = get_json_protocol_fixture('3', 'simple', False)
+    filelike = io.StringIO(jp)
+    runlog, bundle = simulate.simulate(filelike, 'simple.json')
+    assert bundle is None
+    assert [item['payload']['text'] for item in runlog] == [
+        'Picking up tip well B1 in "1"',
+        'Aspirating 5 uL from well A1 in "2" at 1.0 speed',
+        'Delaying for 0:00:42',
+        'Dispensing 4.5 uL into well B1 in "3"',
+        'Touching tip',
+        'Blowing out at well B1 in "3"',
+        'Dropping tip well A1 in "12"'
+    ]

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import io
 
 import pytest

--- a/api/tests/opentrons/util/test_entrypoint_utils.py
+++ b/api/tests/opentrons/util/test_entrypoint_utils.py
@@ -1,0 +1,55 @@
+import json
+import os
+import pathlib
+
+from opentrons.util.entrypoint_util import (labware_from_paths,
+                                            datafiles_from_paths)
+
+
+def test_labware_from_paths(tmpdir, get_labware_fixture):
+    os.mkdir(os.path.join(tmpdir, 'path-1'))
+    os.mkdir(os.path.join(tmpdir, 'path-2'))
+    lw1 = get_labware_fixture('fixture_96_plate')
+    lw2 = get_labware_fixture('fixture_24_tuberack')
+    lw3 = get_labware_fixture('fixture_irregular_example_1')
+    with open(os.path.join(tmpdir, 'path-1', 'labware1.json'), 'w') as lwtemp:
+        json.dump(lw1, lwtemp)
+    with open(os.path.join(tmpdir, 'path-1', 'labware2.json'), 'w') as lwtemp:
+        json.dump(lw2, lwtemp)
+    with open(os.path.join(tmpdir, 'path-2', 'labware3.json'), 'w') as lwtemp:
+        json.dump(lw3, lwtemp)
+    with open(os.path.join(tmpdir, 'path-2', 'invalid.json'), 'w') as lwtemp:
+        lwtemp.write('asdjkashdkajvka')
+    with open(os.path.join(tmpdir, 'path-2', 'notevenjson'), 'w') as lwtemp:
+        lwtemp.write('bgbbabcba')
+
+    res = labware_from_paths([os.path.realpath(os.path.join(tmpdir, 'path-1')),
+                              pathlib.Path(os.path.join(tmpdir, 'path-2'))])
+    assert sorted(res) == sorted({
+        'fixture/fixture_96_plate/1': lw1,
+        'fixture/fixture_24_tuberack/1': lw2,
+        'fixture/fixture_irregular_example_1/1': lw2})
+
+
+def test_datafiles_from_paths(tmpdir):
+    os.mkdir(os.path.join(tmpdir, 'path-1'))
+    os.mkdir(os.path.join(tmpdir, 'path-2'))
+    with open(os.path.join(tmpdir, 'path-1', 'test3'), 'wb') as f:
+        f.write('oh hey there checkitout'.encode('utf-8'))
+    with open(os.path.join(tmpdir, 'path-2', 'test2'), 'wb') as f:
+        f.write('oh man this isnt even utf8'.encode('utf-16'))
+    with open(os.path.join(tmpdir, 'path-2', 'test1'), 'wb') as f:
+        f.write("wait theres a second file???".encode())
+    with open(os.path.join(tmpdir, 'test-file'), 'wb') as f:
+        f.write("this isnt even in a directory".encode())
+
+    res = datafiles_from_paths([
+        os.path.join(tmpdir, 'path-1'),
+        pathlib.Path(os.path.join(tmpdir, 'path-2')),
+        os.path.join(tmpdir, 'test-file')])
+    assert sorted(res) == sorted({
+        'test3': 'oh hey there checkitout'.encode('utf-8'),
+        'test2': 'oh man this isnt even utf8'.encode('utf-16'),
+        'test1': 'wait theres a second file???'.encode(),
+        'test-file': "this isnt even in a directory".encode()
+    })


### PR DESCRIPTION
## overview

Adds bundle handling and bundle creation to the simulate script.

You can now

- Specify directories to gather data files and labware defs from (python files are not yet supported)
- Specify a place to emit the bundle


## changelog
- In addition to adding these features to simulate, centralized bundle parsing further

## review requests
Look over the python code
Simulate some bundles
Create some bundles and simulate and/or run them
