### PR TITLE
fix(api): apiv1: cli-dc: fix tip pickup with left mount

### DIFF
--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -325,10 +325,8 @@ class CLITool:
             p.instrument_mover.set_active_current(p._pick_up_current)
             p.instrument_mover.set_speed(p._pick_up_speed)
             dist = (-1 * p._pick_up_distance) + (-1 * p._pick_up_increment * i)
-            location_pickup = Vector(top[0], top[1], dist + top[2])
-            self.hardware.move_to(
-                (self.hardware.deck, location_pickup), p, 'direct')
-            self.hardware.move_to((self.hardware.deck, top), p, 'direct')
+            self.hardware._driver.move({self._current_mount: dist + top[2]})
+            self.hardware._driver.move({self._current_mount: top[2]})
             # move nozzle back up
             p.instrument_mover.pop_active_current()
             p.instrument_mover.pop_speed()

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -21,7 +21,6 @@ from opentrons.config import (robot_configs, feature_flags,
 from opentrons.util.calibration_functions import probe_instrument
 from opentrons.util.linal import (solve, add_z, apply_transform,
                                   identity_deck_transform)
-from opentrons.util.vector import Vector
 from opentrons.util import logging_config
 
 from . import (


### PR DESCRIPTION
We were getting a little complex with motion commands in _helper_pickup. Relying
on the smoothie driver to move only in z is ugly, but in line with how we do it
elsewhere in the module, and doesn't have this issue.

Closes #3980

## Testing

This is luckily a limited change so we can just test picking up tips with left and right mounts in apiv1.