### PR TITLE
ci(travis): Ignore lerna file for linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,3 +17,4 @@ discovery-client/lib/**
 # prettier
 **/package.json
 **/CHANGELOG.md
+lerna.json

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ format:
 
 .PHONY: lint-py
 lint-py:
-	c -C $(API_DIR) lint
+	$(MAKE) -C $(API_DIR) lint
 	$(MAKE) -C $(UPDATE_SERVER_DIR) lint
 
 .PHONY: lint-js
@@ -148,4 +148,3 @@ coverage:
 bump:
 	@echo "Bumping versions"
 	lerna version $(or $(version),prerelease)
-	$(MAKE) format

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ format:
 
 .PHONY: lint-py
 lint-py:
-	$(MAKE) -C $(API_DIR) lint
+	c -C $(API_DIR) lint
 	$(MAKE) -C $(UPDATE_SERVER_DIR) lint
 
 .PHONY: lint-js
@@ -148,3 +148,4 @@ coverage:
 bump:
 	@echo "Bumping versions"
 	lerna version $(or $(version),prerelease)
+	$(MAKE) format


### PR DESCRIPTION
## overview
[New changes](https://github.com/Opentrons/opentrons/pull/4059) to the `format` command in the Makefile for CI caused a release branch to fail. Sometimes lerna will randomly change some file formats that might fail this check on `make format`, so ignore `prettier` check on the `lerna.json` file.  