### PR TITLE
fix(api): Fix sim and exec entrypoints for bundled protocols

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -147,7 +147,9 @@ def simulate(protocol_file: TextIO,
     protocol = parse.parse(contents, protocol_file.name)
 
     if opentrons.config.feature_flags.use_protocol_api_v2():
-        context = opentrons.protocol_api.contexts.ProtocolContext()
+        context = opentrons.protocol_api.contexts.ProtocolContext(
+            bundled_labware=getattr(protocol, 'bundled_labware', None),
+            bundled_data=getattr(protocol, 'bundled_data', None))
         context.home()
         scraper = CommandScraper(stack_logger, log_level, context.broker)
         opentrons.protocol_api.execute.run_protocol(protocol,


### PR DESCRIPTION
Functionality for bundled protocols wasn't added to opentrons_simulate and
opentrons_execute entrypoints.

## Testing

On Windows and either OSX or Linux:
- simulate a bundle in apiv2 and make sure it works
- simulate a non-bundle in apiv2 and apiv1 and make sure they still work
- simulate json protocols in apiv2 and apiv1 and make sure they still work

On a robot (for opentrons_execute):
Note: since the behavior we're testing happens at parse and labware creation time, you don't have to wait for the protocol to finish
- use opentrons_execute in apiv2 on a bundle
- use opentrons_execute in apiv2 and apiv1 on a non-bundle
- use opentrons_execute in apiv1 and apiv2 on a json protocol