### PR TITLE
fix(app): fix zip mimetype bug

### DIFF
--- a/app/src/protocol/__tests__/actions.test.js
+++ b/app/src/protocol/__tests__/actions.test.js
@@ -28,19 +28,19 @@ describe('protocol actions', () => {
   describe('openProtocol with python protocol', () => {
     const pythonFile = {
       name: 'foobar.py',
-      type: 'application/x-python-code',
+      type: 'python',
       lastModified: 123,
     }
 
     const bundleFile = {
       name: 'foobar.zip',
-      type: 'application/zip',
+      type: 'zip',
       lastModified: 111,
     }
 
     const jsonFile = {
       name: 'foobar.json',
-      type: 'application/json',
+      type: 'json',
       lastModified: 456,
     }
 

--- a/app/src/protocol/__tests__/reducer.test.js
+++ b/app/src/protocol/__tests__/reducer.test.js
@@ -53,7 +53,7 @@ describe('protocolReducer', () => {
       expectedState: {
         file: {
           name: 'foo.json',
-          type: 'application/json',
+          type: 'json',
           lastModified: null,
         },
         contents: '{"metadata": {}}',
@@ -74,7 +74,7 @@ describe('protocolReducer', () => {
       expectedState: {
         file: {
           name: 'foo.py',
-          type: 'text/x-python-script',
+          type: 'python',
           lastModified: null,
         },
         contents: '# foo.py',

--- a/app/src/protocol/__tests__/selectors.test.js
+++ b/app/src/protocol/__tests__/selectors.test.js
@@ -200,7 +200,7 @@ const SPECS = [
     selector: protocol.getProtocolMethod,
     state: {
       protocol: {
-        file: { name: 'proto.json', type: 'application/json' },
+        file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
         data: null,
       },
@@ -212,7 +212,7 @@ const SPECS = [
     selector: protocol.getProtocolMethod,
     state: {
       protocol: {
-        file: { name: 'proto.py', type: 'application/json' },
+        file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
         data: { metadata: {} },
       },
@@ -224,7 +224,7 @@ const SPECS = [
     selector: protocol.getProtocolMethod,
     state: {
       protocol: {
-        file: { name: 'proto.py', type: 'application/json' },
+        file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
         data: {
           metadata: {},
@@ -241,7 +241,7 @@ const SPECS = [
     selector: protocol.getProtocolMethod,
     state: {
       protocol: {
-        file: { name: 'proto.py', type: 'application/json' },
+        file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
         data: {
           metadata: {},

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -3,7 +3,7 @@
 import {
   fileToProtocolFile,
   parseProtocolData,
-  filenameToMimeType,
+  filenameToType,
   fileIsBinary,
 } from './protocol-data'
 
@@ -88,7 +88,7 @@ export function protocolReducer(
       const { name, metadata, protocolText: contents } = action.payload
       const file =
         !state.file || name !== state.file.name
-          ? { name, type: filenameToMimeType(name), lastModified: null }
+          ? { name, type: filenameToType(name), lastModified: null }
           : state.file
       const data =
         !state.data || contents !== state.contents

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -91,7 +91,8 @@ export function protocolReducer(
           ? { name, type: filenameToType(name), lastModified: null }
           : state.file
       const data =
-        !state.data || contents !== state.contents
+        !state.data ||
+        (typeof contents === 'string' && contents !== state.contents)
           ? parseProtocolData(file, contents, metadata)
           : state.data
 

--- a/app/src/protocol/protocol-data.js
+++ b/app/src/protocol/protocol-data.js
@@ -1,21 +1,22 @@
 // @flow
 // functions for parsing protocol files
-// import path from 'path'
-// import {getter} from '@thi.ng/paths'
 import createLogger from '../logger'
 
 import type { ProtocolFile, ProtocolData, ProtocolType } from './types'
 
 const log = createLogger(__filename)
 
-export const MIME_TYPE_JSON = 'application/json'
-export const MIME_TYPE_PYTHON = 'text/x-python-script'
-export const MIME_TYPE_ZIP = 'application/zip'
+export function filenameToType(filename: string): ProtocolType | null {
+  if (filename.endsWith('.json')) return 'json'
+  if (filename.endsWith('.py')) return 'python'
+  if (filename.endsWith('.zip')) return 'zip'
+  return null
+}
 
 export function fileToProtocolFile(file: File): ProtocolFile {
   return {
     name: file.name,
-    type: file.type,
+    type: filenameToType(file.name),
     lastModified: file.lastModified,
   }
 }
@@ -42,26 +43,12 @@ export function parseProtocolData(
   return null
 }
 
-export function filenameToMimeType(name: string): string | null {
-  if (name.endsWith('.json')) return MIME_TYPE_JSON
-  if (name.endsWith('.py')) return MIME_TYPE_PYTHON
-  if (name.endsWith('.zip')) return MIME_TYPE_ZIP
-  return null
-}
-
-export function fileToType(file: ?ProtocolFile): ProtocolType | null {
-  if (file?.type === MIME_TYPE_JSON) return 'json'
-  if (file?.type === MIME_TYPE_PYTHON) return 'python'
-  if (file?.type === MIME_TYPE_ZIP) return 'zip'
-  return null
-}
-
 export function fileIsJson(file: ProtocolFile): boolean {
-  return file.type === MIME_TYPE_JSON
+  return file.type === 'json'
 }
 
 export function fileIsBundle(file: ProtocolFile): boolean {
-  return file.type === MIME_TYPE_ZIP
+  return file.type === 'zip'
 }
 
 export function fileIsBinary(file: ProtocolFile): boolean {

--- a/app/src/protocol/selectors.js
+++ b/app/src/protocol/selectors.js
@@ -4,7 +4,7 @@ import startCase from 'lodash/startCase'
 import { createSelector } from 'reselect'
 import { getter } from '@thi.ng/paths'
 import { getProtocolSchemaVersion } from '@opentrons/shared-data'
-import { fileIsJson, fileToType } from './protocol-data'
+import { fileIsJson } from './protocol-data'
 import createLogger from '../logger'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -166,7 +166,7 @@ export const getProtocolLastUpdated: NumberSelector = createSelector(
 
 export const getProtocolType: ProtocolTypeSelector = createSelector(
   getProtocolFile,
-  fileToType
+  file => file?.type || null
 )
 
 export const getProtocolCreatorApp: CreatorAppSelector = createSelector(

--- a/app/src/protocol/types.js
+++ b/app/src/protocol/types.js
@@ -10,9 +10,11 @@ export type ProtocolData =
   | { metadata: $PropertyType<SchemaV1ProtocolFile<{}>, 'metadata'> }
 // NOTE: add union of additional versions after schema is bumped
 
+export type ProtocolType = 'json' | 'python' | 'zip'
+
 export type ProtocolFile = {
   name: string,
-  type: ?string,
+  type: ?ProtocolType,
   lastModified: ?number,
 }
 
@@ -21,5 +23,3 @@ export type ProtocolState = {
   contents: ?string,
   data: ?ProtocolData,
 }
-
-export type ProtocolType = 'json' | 'python' | 'zip'


### PR DESCRIPTION
## overview

On Windows, Run App was sending bytes instead of base64-encoded bytes when uploading a zip, because Windows Electron does different mime types for zips?

This drops the mime typing and just uses file suffixes, which are more straightforward.

## review requests

- .json & .py uploads still work as before
- .zip upload works (esp on Windows)

NOTE: there's a bug with "Creation Method" that will be fixed in a separate ticket