### PR TITLE
fix(api): reflect protocol text over rpc

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -135,6 +135,7 @@ class Session(object):
         self.modules = None
         self.metadata = {}
         self.api_level = None
+        self.protocol_text = protocol.text
 
         self.startTime = None
         self._motion_lock = motion_lock

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -138,6 +138,7 @@ async def test_load_and_run_v2(
     session.run()
     assert len(session.command_log) == 4, \
         "Clears command log on the next run"
+    assert session.protocol_text == protocol.text
 
 
 @pytest.mark.api1_only
@@ -183,6 +184,7 @@ async def test_load_and_run(
     session.run()
     assert len(session.command_log) == 6, \
         "Clears command log on the next run"
+    assert session.protocol_text == protocol.text
 
 
 def test_init(run_session):


### PR DESCRIPTION
The session needs a protocol text member exposed via rpc to let apps that aren't
the one that uploaded the protocol see what the protocol was. The app also
relies on it (perhaps incorrectly) in a couple ways, for instance the creation
method, and without this exposed it can't decide what it is.

In addition, add a test to catch the regression in the future.

This issue was introduced in 1c503ed37cc1bbba0f4cf5b09c93811e08abc704

## Testing
- Push this to a robot
- Upload a python protocol and note that Creation Method says "Protocol API"
- Upload a json protocol and note that Creation Method says the PD version used to create it
- Connect to the robot from a different runapp and note that it has the protocol details as well