### PR TITLE
feat(labware-creator): Guide user to labware test

### DIFF
--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -6,12 +6,7 @@ import { Formik } from 'formik'
 import mapValues from 'lodash/mapValues'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
-import {
-  AlertItem,
-  AlertModal,
-  PrimaryButton,
-  Icon,
-} from '@opentrons/components'
+import { AlertItem, AlertModal, PrimaryButton } from '@opentrons/components'
 import labwareSchema from '@opentrons/shared-data/labware/schemas/2.json'
 import { makeMaskToDecimal, maskToInteger, maskLoadName } from './fieldMasks'
 import {
@@ -945,7 +940,6 @@ const App = () => {
                         className={cx(styles.callout, styles.export_callout)}
                       >
                         <h4 className={styles.test_labware_heading}>
-                          <Icon name="flask-outline" className={styles.icon} />
                           Please test your definition file!
                         </h4>
 

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -6,7 +6,12 @@ import { Formik } from 'formik'
 import mapValues from 'lodash/mapValues'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
-import { AlertItem, AlertModal, PrimaryButton } from '@opentrons/components'
+import {
+  AlertItem,
+  AlertModal,
+  PrimaryButton,
+  Icon,
+} from '@opentrons/components'
 import labwareSchema from '@opentrons/shared-data/labware/schemas/2.json'
 import { makeMaskToDecimal, maskToInteger, maskLoadName } from './fieldMasks'
 import {
@@ -888,32 +893,8 @@ const App = () => {
                   </Section>
                   {/* PAGE 4 */}
 
-                  <Section
-                    label="File"
-                    fieldList={['loadName', 'displayName', 'pipetteName']}
-                  >
+                  <Section label="File" fieldList={['loadName', 'displayName']}>
                     <div className={styles.flex_row}>
-                      <div className={styles.instructions_column}>
-                        <p>
-                          Files are exported as a zipped file containing 1) the
-                          labware definition as a JSON file, and 2) a test
-                          python protocol referencing the labware to help
-                          troubleshoot the accuracy of the definition on your
-                          robot. The test protocol will require a single channel
-                          pipette on the
-                          <strong> right mount</strong> of your robot.{' '}
-                          <LinkOut href={PDF_URL}>Click here</LinkOut> for
-                          instructions on running the test protocol.
-                        </p>
-                        <p>
-                          Please Note: It’s important to create a labware
-                          definition that is precise, and does not rely on
-                          excessive calibration prior to each run to achieve
-                          accuracy. In this way you&apos;ll generate labware
-                          definitions that are reusable and shareable with
-                          others inside or outside your lab.
-                        </p>
-                      </div>
                       <div className={styles.export_form_fields}>
                         <TextField
                           name="displayName"
@@ -925,23 +906,65 @@ const App = () => {
                           caption="Only lower case letters, numbers, periods, and underscores may be used"
                           inputMasks={[maskLoadName]}
                         />
-                        <div className={styles.pipette_field_wrapper}>
-                          <Dropdown
-                            name="pipetteName"
-                            options={pipetteNameOptions}
-                          />
-                        </div>
-                        <PrimaryButton
-                          className={styles.export_button}
-                          onClick={() => {
-                            if (!isValid && !showExportErrorModal) {
-                              setShowExportErrorModal(true)
-                            }
-                            handleSubmit()
-                          }}
+                      </div>
+                    </div>
+                  </Section>
+                  <Section
+                    label="Labware Test Protocol"
+                    fieldList={['pipetteName']}
+                  >
+                    <div className={cx(styles.flex_row, styles.flex_row_start)}>
+                      <div className={styles.instructions_column}>
+                        <p>
+                          Your file will be exported with a protocol that will
+                          help you test and troubleshoot your labware definition
+                          on the robot. The protocol requires a Single Channel
+                          pipette on the right mount of your robot.
+                        </p>
+                      </div>
+                      <div className={styles.pipette_field_wrapper}>
+                        <Dropdown
+                          name="pipetteName"
+                          options={pipetteNameOptions}
+                        />
+                      </div>
+                    </div>
+                    <div className={styles.export_section}>
+                      <PrimaryButton
+                        className={styles.export_button}
+                        onClick={() => {
+                          if (!isValid && !showExportErrorModal) {
+                            setShowExportErrorModal(true)
+                          }
+                          handleSubmit()
+                        }}
+                      >
+                        EXPORT FILE
+                      </PrimaryButton>
+                      <div
+                        className={cx(styles.callout, styles.export_callout)}
+                      >
+                        <h4 className={styles.test_labware_heading}>
+                          <Icon name="flask-outline" className={styles.icon} />
+                          Please test your definition file!
+                        </h4>
+
+                        <p>
+                          Use the labware test protocol contained in the
+                          downloaded file to check the accuracy of your
+                          definition. It’s important to create definitions that
+                          are precise and do not rely on excessive calibration
+                          prior to each run to achieve accuracy.
+                        </p>
+                        <p>
+                          Use the test guide to troubleshoot your definition.
+                        </p>
+                        <LinkOut
+                          href={PDF_URL}
+                          className={styles.test_guide_button}
                         >
-                          EXPORT FILE
-                        </PrimaryButton>
+                          view test guide
+                        </LinkOut>
                       </div>
                     </div>
                   </Section>

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -2,6 +2,29 @@
 @import '../styles/breakpoints.css';
 @import '../styles/spacing.css';
 
+:root {
+  --link-btn-blue: {
+    display: inline-block;
+    width: auto;
+    margin: 1.5rem 0 0.5rem;
+    padding: 1rem 2rem;
+    border-radius: 3px;
+    background-color: var(--c-blue);
+    font-size: var(--fs-body-2);
+    color: white;
+    font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
+    text-transform: uppercase;
+
+    &:hover {
+      background-color: #00f;
+    }
+
+    &:visited {
+      color: white;
+    }
+  }
+}
+
 .labware_creator {
   @apply --font-body-2-dark;
 
@@ -31,8 +54,8 @@
   }
 }
 
-.labware_creator a,
-.labware_creator a:visited {
+a,
+a:visited {
   color: var(--c-blue);
 }
 
@@ -42,24 +65,7 @@ h2 {
 }
 
 .labware_creator .labware_guide_button {
-  display: inline-block;
-  width: auto;
-  margin: 1.5rem 0 0.5rem;
-  padding: 1rem 2rem;
-  border-radius: 3px;
-  background-color: var(--c-blue);
-  font-size: var(--fs-body-2);
-  color: white;
-  font-family: 'AkkoPro-Regular', 'Ropa Sans', 'Open Sans', sans-serif;
-  text-transform: uppercase;
-
-  &:hover {
-    background-color: #00f;
-  }
-
-  &:visited {
-    color: white;
-  }
+  @apply --link-btn-blue;
 }
 
 .start_creating_btn:focus {
@@ -103,10 +109,18 @@ h2 {
   margin: 1rem 0 3rem;
 }
 
+.flex_row_start {
+  justify-content: flex-start;
+}
+
 .new_definition_section,
 .upload_existing_section {
   flex-basis: 100%;
   flex-shrink: 0;
+}
+
+.new_definition_section {
+  border-bottom: var(--bd-light);
 }
 
 .labware_type_fields {
@@ -140,11 +154,16 @@ h2 {
   display: none;
 }
 
+.pipette_field_wrapper {
+  width: 13rem;
+}
+
 @media (--medium) {
   .new_definition_section {
     flex-basis: 45%;
     flex-shrink: 1;
     padding-right: 2rem;
+    border-bottom: none;
     border-right: var(--bd-light);
   }
 
@@ -187,10 +206,6 @@ h2 {
   .help_text {
     max-width: var(--size-50p);
   }
-
-  .pipette_field_wrapper {
-    max-width: 13rem;
-  }
 }
 
 @media (--large) {
@@ -215,4 +230,40 @@ h2 {
 
 .disabled_section {
   color: var(--c-font-disabled);
+}
+
+.export_section {
+  margin: 2rem auto;
+
+  @media (--large) {
+    max-width: var(--size-75p);
+  }
+}
+
+.export_button {
+  margin-bottom: 2rem;
+}
+
+.export_callout {
+  padding: 2rem;
+  text-align: center;
+  font-size: var(--fs-body-1);
+}
+
+.test_labware_heading {
+  @apply --center-children;
+
+  font-size: var(--fs-body-2);
+
+  & .icon {
+    height: 1.5rem;
+    margin-right: 0.5rem;
+  }
+}
+
+.test_guide_button {
+  @apply --link-btn-blue;
+
+  margin-top: 0;
+  padding: 1rem 4rem;
 }

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -251,14 +251,7 @@ h2 {
 }
 
 .test_labware_heading {
-  @apply --center-children;
-
   font-size: var(--fs-body-2);
-
-  & .icon {
-    height: 1.5rem;
-    margin-right: 0.5rem;
-  }
 }
 
 .test_guide_button {


### PR DESCRIPTION
## overview

This PR separates the File and Labware Test Protocol sections and adds a callout to the bottom that guides the user to the labware test guide PDF.

While I was in there, I refactored the CSS a little so that when we have a LinkOut that we want to look like a button (occurs 2x now) we can `@apply --link-btn-blue` (note: the blue button style uses akko pro as per website style-guide)

closes #4118 

## changelog

- feat(labware-creator): Guide user to labware test

## review requests

http://sandbox.labware.opentrons.com/lc_labware-test-callout/create/

Since this splits up an existing section please double check validation/generation is unaffected.