### PR TITLE
feat(labware-library): Add link for LC to LL sidebar

### DIFF
--- a/labware-library/src/components/Sidebar/LabwareGuide.js
+++ b/labware-library/src/components/Sidebar/LabwareGuide.js
@@ -3,6 +3,7 @@
 import * as React from 'react'
 
 import { Icon } from '@opentrons/components'
+import { Link } from '../ui'
 import styles from './styles.css'
 
 import {
@@ -10,6 +11,7 @@ import {
   WHAT_IS_A_LABWARE_DEFINITION,
   USING_THE_LABWARE_LIBRARY,
   CREATING_CUSTOM_LABWARE_DEFINITIONS,
+  LABWARE_CREATOR,
 } from '../../localization'
 
 const LINKS = [
@@ -54,6 +56,11 @@ export default function LabwareGuide() {
               </a>
             </li>
           ))}
+          <li>
+            <Link to="/create" className={styles.labware_guide_link}>
+              {LABWARE_CREATOR}
+            </Link>
+          </li>
         </ul>
       </div>
     </section>

--- a/labware-library/src/components/Sidebar/LabwareGuide.js
+++ b/labware-library/src/components/Sidebar/LabwareGuide.js
@@ -2,8 +2,10 @@
 // labware filters
 import * as React from 'react'
 
+import { getPublicPath } from '../../public-path'
+
 import { Icon } from '@opentrons/components'
-import { Link } from '../ui'
+import { Link } from 'react-router-dom'
 import styles from './styles.css'
 
 import {
@@ -57,7 +59,10 @@ export default function LabwareGuide() {
             </li>
           ))}
           <li>
-            <Link to="/create" className={styles.labware_guide_link}>
+            <Link
+              to={`${getPublicPath()}create`}
+              className={styles.labware_guide_link}
+            >
               {LABWARE_CREATOR}
             </Link>
           </li>

--- a/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
+++ b/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
@@ -55,6 +55,14 @@ exports[`LabwareGuide component renders 1`] = `
           Creating custom labware definitions
         </a>
       </li>
+      <li>
+        <withRouter(WrappedLink)
+          className="labware_guide_link"
+          to="/create"
+        >
+          Custom Labware Creator
+        </withRouter(WrappedLink)>
+      </li>
     </ul>
   </div>
 </section>

--- a/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
+++ b/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
@@ -40,7 +40,7 @@ exports[`LabwareGuide component renders 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          Using the labware library
+          Using the Labware Library
         </a>
       </li>
       <li

--- a/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
+++ b/labware-library/src/components/Sidebar/__tests__/__snapshots__/LabwareGuide.test.js.snap
@@ -56,12 +56,12 @@ exports[`LabwareGuide component renders 1`] = `
         </a>
       </li>
       <li>
-        <withRouter(WrappedLink)
+        <Link
           className="labware_guide_link"
           to="/create"
         >
           Custom Labware Creator
-        </withRouter(WrappedLink)>
+        </Link>
       </li>
     </ul>
   </div>

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -72,7 +72,7 @@ export const NA = 'N/A'
 
 export const LABWARE_GUIDE = 'Labware Guide'
 export const WHAT_IS_A_LABWARE_DEFINITION = 'What is a labware definition?'
-export const USING_THE_LABWARE_LIBRARY = 'Using the labware library'
+export const USING_THE_LABWARE_LIBRARY = 'Using the Labware Library'
 export const CREATING_CUSTOM_LABWARE_DEFINITIONS =
   'Creating custom labware definitions'
 export const LABWARE_CREATOR = 'Custom Labware Creator'

--- a/labware-library/src/localization/en.js
+++ b/labware-library/src/localization/en.js
@@ -75,3 +75,4 @@ export const WHAT_IS_A_LABWARE_DEFINITION = 'What is a labware definition?'
 export const USING_THE_LABWARE_LIBRARY = 'Using the labware library'
 export const CREATING_CUSTOM_LABWARE_DEFINITIONS =
   'Creating custom labware definitions'
+export const LABWARE_CREATOR = 'Custom Labware Creator'


### PR DESCRIPTION
## overview

This PR closes #4147 by adding `Custom Labware Creator` link to Labware Library sidebar

## changelog

- feat(labware-library): Add link for LC to LL sidebar

## review requests

http://sandbox.labware.opentrons.com/ll_add-lc-link/

Question: Is this a DO NOT MERGE kind of thing? I doubt we are cutting a LL release before LC

- [ ] `Custom Labware Creator` link on labware homepage links to labware creator
- [ ] `Custom Labware Creator` link on individual labware page links to labware creator
