### PR TITLE
fix(api): Do not run out of memory when dumping large logs

### DIFF
--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -44,19 +44,14 @@ def _get_options(params: Mapping[str, str],
 
 async def _get_log_response(syslog_selector: str, record_count: int,
                             record_format: str) -> web.Response:
-    if record_format == 'json':
-        records = []
-        async for ser_record in log_control.get_records_serializable(
-                syslog_selector, record_count):
-            records.append(ser_record)
-        response = web.json_response(data=records)
-    else:
-        text = ''
-        async for text_record in log_control.get_records_text(
-                syslog_selector, record_count):
-            text += text_record + '\n'
-        response = web.Response(text=text)
-    return response
+    modes = {
+        'json': 'json',
+        'text': 'short'
+    }
+    output = await log_control.get_records_dumb(syslog_selector,
+                                                record_count,
+                                                modes[record_format])
+    return web.Response(text=output.decode('utf-8'))
 
 
 async def get_logs_by_id(request: web.Request) -> web.Response:

--- a/api/src/opentrons/server/endpoints/logs.py
+++ b/api/src/opentrons/server/endpoints/logs.py
@@ -44,15 +44,19 @@ def _get_options(params: Mapping[str, str],
 
 async def _get_log_response(syslog_selector: str, record_count: int,
                             record_format: str) -> web.Response:
-
     if record_format == 'json':
-        records = await log_control.get_records_serializable(
-            syslog_selector, record_count)
-        return web.json_response(data=records)
+        records = []
+        async for ser_record in log_control.get_records_serializable(
+                syslog_selector, record_count):
+            records.append(ser_record)
+        response = web.json_response(data=records)
     else:
-        text = await log_control.get_records_text(
-            syslog_selector, record_count)
-        return web.Response(text=text)
+        text = ''
+        async for text_record in log_control.get_records_text(
+                syslog_selector, record_count):
+            text += text_record + '\n'
+        response = web.Response(text=text)
+    return response
 
 
 async def get_logs_by_id(request: web.Request) -> web.Response:

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -5,14 +5,10 @@ This is the implementation of the endpoints in
 :py:mod:`opentrons.server.endpoints.logs` and friends.
 """
 import asyncio
-import collections
-import datetime
 import logging
+import subprocess
 import syslog
-import time
-from typing import Any, AsyncGenerator, Deque, Dict, Tuple
-
-import systemd.journal as journal  # type: ignore
+from typing import Tuple
 
 
 LOG = logging.getLogger(__name__)
@@ -31,87 +27,23 @@ _SYSLOG_PRIORITY_TO_NAME = {
 }
 
 
-async def get_records(selector: str, record_count: int)\
-          -> AsyncGenerator[Deque[Dict[str, Any]], None]:
+async def get_records_dumb(selector: str, records: int,
+                           mode: str) -> bytes:
+    """ Dump the log files.
+
+    :param selector: The syslog selector to limit responses to
+    :param records: The maximum number of records to print
+    :param mode: A journalctl dump mode. Should be either "short" or "json".
     """
-    Generate log records up to record count.
-
-    The records are dicts from string keys to the arbitrary data provided
-    by journald's interface (see
-    https://www.freedesktop.org/software/systemd/python-systemd/journal.html ).
-
-    :return: deque[dict[str, Any]]: A deque of records
-    """
-    log_deque: Deque[Dict[str, Any]] = collections.deque(maxlen=record_count)
-    with journal.Reader(journal.SYSTEM_ONLY) as r:
-        r.add_match(SYSLOG_IDENTIFIER=selector)
-        then = time.monotonic()
-        for record in r:
-            log_deque.append(record)
-            now = time.monotonic()
-            if (now-then) > 0.1:
-                yield log_deque
-                log_deque.clear()
-                await asyncio.sleep(0.001)
-                then = time.monotonic()
-        yield log_deque
-
-
-def _format_record_text(record: Dict[str, Any]) -> str:
-    dict_rec = _format_record_dict(record)
-    return f'{dict_rec["time"]} {dict_rec["logger"]} '\
-        f'[{dict_rec["level_name"]}]: {dict_rec["message"]}'
-
-
-async def get_records_text(selector: str, record_count: int)\
-          -> AsyncGenerator[str, None]:
-    """ Get log records as a newline-separated string of log records.
-
-    Each record is a string of
-
-    ``isotime logger [levelname]: message``
-    """
-    async for record_deque in get_records(selector, record_count):
-        for record in record_deque:
-            yield _format_record_text(record)
-
-
-def _format_record_dict(record: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        'logger': record.get('LOGGER', '<unknown>'),
-        'level': record.get('PRIORITY'),
-        'level_name': _SYSLOG_PRIORITY_TO_NAME.get(  # type: ignore
-            record.get('PRIORITY'), '<unknown>'),
-        'file': record.get('CODE_FILE', '<unknown>'),
-        'line': record.get('CODE_LINE', '<unknown>'),
-        'func': record.get('CODE_FUNC', '<unknown>'),
-        'time': record.get(
-            '__REALTIME_TIMESTAMP',
-            datetime.datetime.fromtimestamp(0)).isoformat(),
-        'boot': str(record.get('_BOOT_ID', '<unknown>')),
-        'message': record.get('MESSAGE', '<unknown>')
-    }
-
-
-async def get_records_serializable(
-        selector: str, record_count: int)\
-        -> AsyncGenerator[Dict[str, Any], None]:
-    """ Get log records in a structured format that is json serializable.
-
-    Retains the syslog fields
-    - 'logger': logger name
-    - 'level': syslog priority, as an int
-    - 'level_name': the name of the priority
-    - 'file': the file from which the record was sourced
-    - 'line': the line from which the record was sourced
-    - 'func': the function from which the record was sourecd
-    - 'time': the time in iso at which the record was sourced
-    - 'boot': the boot id, an opaque string different per boot
-    - 'message': the actual message
-    """
-    async for record_deque in get_records(selector, record_count):
-        for record in record_deque:
-            yield _format_record_dict(record)
+    proc = await asyncio.create_subprocess_exec(
+        'journalctl', '--no-pager',
+        '-t', selector,
+        '-n', str(records),
+        '-o', mode,
+        '-a',
+        stdout=subprocess.PIPE)
+    stdout, _ = await proc.communicate()
+    return stdout
 
 
 async def set_syslog_level(level: str) -> Tuple[int, str, str]:

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -52,6 +52,7 @@ async def get_records(selector: str, record_count: int)\
             if (now-then) > 0.1:
                 yield log_deque
                 log_deque.clear()
+                await asyncio.sleep(0.001)
                 then = time.monotonic()
         yield log_deque
 


### PR DESCRIPTION
Previously we coalesced logs twice: once as a list of journald reports, and then
again in the destination format. This was really slow and let us run out of
memory. We also use the python-journald reader, which is _unbelievably slow_ and unsuited to the task of streaming out logs. It took ~2ms per log record.

Instead, just call `journalctl --no-pager` and dump them to a pipe. It's so much faster.

## Testing
- Get logs. Nothing should crash and it shouldn't take literally 5 minutes on some robots.