### PR TITLE
build(jest): print coverage summary rather than every single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ lint-json:
 # with `write error: stdout`; pipe to tee which will hopefully paper over it
 .PHONY: lint-css
 lint-css:
-	stylelint '**/*.css' $(and $(CI),| tee /dev/null)
+	stylelint '**/*.css'
 
 .PHONY: check-js
 check-js:

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,6 +37,6 @@ module.exports = {
     '!**/test-with-flow/**',
     '!**/flow-typed/**',
   ],
-  coverageReporters: ['lcov', 'text'],
+  coverageReporters: ['lcov', 'text-summary'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
 }


### PR DESCRIPTION
## overview

I think I figure out the `make: write error` bug that we're seeing in CI:

- Our `make test-js` task prints coverage
- Our coverage reporter was set to `text`, which prints out the coverage of **every single JS file in the repo**
- This log takes a long time on Travis, which can lead to a race condition where Jest doesn't exit cleanly because jest is waiting for the log to finish logging

## changelog

- build(jest): print coverage summary rather than every single file

## review requests

- Re-run the CI task if you feel like it
- Make sure test-js still behaves on your machine