### PR TITLE
feat(api): implement deck item spanning first pass

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -176,11 +176,15 @@ class Deck(UserDict):
                 if 'fixedTrash' in labware.parameters.get('quirks', []):
                     pass
                 else:
-                    raise ValueError('Deck location {} is for fixed trash only'
-                                     .format(key))
+                    raise ValueError(f'Deck location {key} '
+                                     'is for fixed trash only')
             else:
-                raise ValueError('Deck location {} already has an item: {}'
-                                 .format(key, self.data[key_int]))
+                raise ValueError(f'Deck location {key} already'
+                                 f'  has an item: {self.data[key_int]}')
+        elif key_int not in self.open_slot_keys:
+            raise ValueError(f'Deck location {key} '
+                             'is obscured by another item,'
+                             'maybe a Thermocycler Module?')
         self.data[key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
 
@@ -244,7 +248,7 @@ class Deck(UserDict):
         return self._definition['locations']['orderedSlots']
 
     @property
-    def open_slots(self) -> List[Dict]:
+    def open_slot_keys(self) -> List[Dict]:
         """ The slot definitions of the currently unobscured
             lots on the loaded robot deck.
         """
@@ -255,6 +259,7 @@ class Deck(UserDict):
             else
                 obscured_slot_keys.append(slot_key)
 
-        self.slots
+        return [slot_key for slot_key in self.data
+                if slot_key not in obscured_slot_keys]
 
 

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -242,3 +242,19 @@ class Deck(UserDict):
     def slots(self) -> List[Dict]:
         """ Return the definition of the loaded robot deck. """
         return self._definition['locations']['orderedSlots']
+
+    @property
+    def open_slots(self) -> List[Dict]:
+        """ The slot definitions of the currently unobscured
+            lots on the loaded robot deck.
+        """
+        obscured_slot_keys = []
+        for slot_key, item in self.data:
+            if isinstance(item, ThermocyclerGeometry):
+                obscured_slot_keys.extend(['7', '8', '10', '11'])
+            else
+                obscured_slot_keys.append(slot_key)
+
+        self.slots
+
+

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -17,6 +17,7 @@ MODULE_LOG = logging.getLogger(__name__)
 def max_many(*args):
     return functools.reduce(max, args[1:], args[0])
 
+
 def plan_moves(
         from_loc: types.Location,
         to_loc: types.Location,
@@ -184,9 +185,11 @@ class Deck(UserDict):
                                  f'  has an item: {self.data[slot_key_int]}')
         elif overlapping_items:
             flattened_overlappers = [repr(item) for sublist in
-                    overlapping_items.values() for item in sublist]
+                                     overlapping_items.values()
+                                     for item in sublist]
             raise ValueError(f'Could not load {val} as deck location {key} '
-                             f'is obscured by {", ".join(flattened_overlappers)}')
+                             'is obscured by '
+                             f'{", ".join(flattened_overlappers)}')
         self.data[slot_key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
 
@@ -239,7 +242,6 @@ class Deck(UserDict):
                     f'module {module_name} does not have a default'
                     ' location, you must specify a slot')
 
-
     @property
     def highest_z(self) -> float:
         """ Return the tallest known point on the deck. """
@@ -250,7 +252,10 @@ class Deck(UserDict):
         """ Return the definition of the loaded robot deck. """
         return self._definition['locations']['orderedSlots']
 
-    def get_collisions_for_item(self, slot_key, item: DeckItem) -> Dict:
+    def get_collisions_for_item(self,
+                                slot_key: types.DeckLocation,
+                                item: DeckItem) -> Dict[types.DeckLocation,
+                                                        List[DeckItem]]:
         """ Return the loaded deck items that collide
             with the given item.
         """
@@ -264,12 +269,9 @@ class Deck(UserDict):
 
         item_slot_keys = get_item_covered_slot_keys(slot_key, item)
 
-        colliding_items = {}
+        colliding_items: Dict[types.DeckLocation, List[DeckItem]] = {}
         for sk, i in self.data.items():
             covered_sks = get_item_covered_slot_keys(sk, i)
             if item_slot_keys.issubset(covered_sks):
                 colliding_items.setdefault(sk, []).append(i)
         return colliding_items
-
-
-

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -17,14 +17,6 @@ MODULE_LOG = logging.getLogger(__name__)
 def max_many(*args):
     return functools.reduce(max, args[1:], args[0])
 
-def get_item_covered_slot_keys(slot_key, item):
-    if isinstance(item, ThermocyclerGeometry):
-        return([7, 8, 10, 11])
-    elif item is not None:
-        return [slot_key]
-    else:
-        return []
-
 def plan_moves(
         from_loc: types.Location,
         to_loc: types.Location,
@@ -179,7 +171,6 @@ class Deck(UserDict):
         slot_key_int = self._check_name(key)
         item = self.data.get(slot_key_int)
 
-        print(f'\n\nkeyval: {slot_key_int} .  {val}\n\n')
         overlapping_items = self.get_collisions_for_item(slot_key_int, val)
         if item is not None:
             if slot_key_int == 12:
@@ -259,18 +250,25 @@ class Deck(UserDict):
         """ Return the definition of the loaded robot deck. """
         return self._definition['locations']['orderedSlots']
 
-    def get_collisions_for_item(self, slot_key, item: DeckItem) -> List[int]:
+    def get_collisions_for_item(self, slot_key, item: DeckItem) -> Dict:
         """ Return the loaded deck items that collide
             with the given item.
         """
-        item_slot_keys = set(get_item_covered_slot_keys(slot_key, item))
+        def get_item_covered_slot_keys(sk, i):
+            if isinstance(i, ThermocyclerGeometry):
+                return(set([7, 8, 10, 11]))
+            elif i is not None:
+                return set([sk])
+            else:
+                return set([])
+
+        item_slot_keys = get_item_covered_slot_keys(slot_key, item)
 
         colliding_items = {}
         for sk, i in self.data.items():
-            covered_sks = set(get_item_covered_slot_keys(sk, i))
+            covered_sks = get_item_covered_slot_keys(sk, i)
             if item_slot_keys.issubset(covered_sks):
                 colliding_items.setdefault(sk, []).append(i)
-        print(f'\n\nCOL: {colliding_items}\n\n')
         return colliding_items
 
 

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -31,6 +31,7 @@ def test_slot_names():
     with pytest.raises(ValueError):
         d['ahgoasia'] = 'nope'
 
+
 def test_slot_collisions():
     d = Deck()
     mod_slot = '7'
@@ -50,7 +51,6 @@ def test_slot_collisions():
     d[lw_slot] = lw
 
     assert lw_slot in d
-
 
 
 def test_highest_z():

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -31,6 +31,27 @@ def test_slot_names():
     with pytest.raises(ValueError):
         d['ahgoasia'] = 'nope'
 
+def test_slot_collisions():
+    d = Deck()
+    mod_slot = '7'
+    mod = labware.load_module('thermocycler', d.position_for(mod_slot))
+    d[mod_slot] = mod
+    with pytest.raises(ValueError):
+        d['7'] = 'not this time boyo'
+    with pytest.raises(ValueError):
+        d['8'] = 'nor this time boyo'
+    with pytest.raises(ValueError):
+        d['10'] = 'or even this time boyo'
+    with pytest.raises(ValueError):
+        d['11'] = 'def not this time though'
+
+    lw_slot = '4'
+    lw = labware.load(labware_name, d.position_for(lw_slot))
+    d[lw_slot] = lw
+
+    assert lw_slot in d
+
+
 
 def test_highest_z():
     deck = Deck()


### PR DESCRIPTION
## Overview

During simulation, prevent deck items from being loaded into slots obscured by other deck items,
including the thermocycler, which spans multiple slots.

Closes #3107

## Review Requests

 - [ ] upload a protocol with thermocycler and other non-overlapping deck items, should simulate
- [ ] upload a protocol with thermocycler and deck items in 7, 8, 10 or 11, should raise exception
- [ ] upload a protocol without modules with two items in same slot, should still raise exception
- [ ] upload a protocol without modules and other non-overlapping deck items, should still simulate