### PR TITLE
fix(api): Only load labware for modules from bundles

### DIFF
--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1948,7 +1948,9 @@ class ModuleContext(CommandPublisher):
         :param name: The name of the labware object.
         :returns: The initialized and loaded labware object.
         """
-        lw = load(name, self._geometry.location)
+        lw = load(
+            name, self._geometry.location,
+            bundled_defs=self._ctx._bundled_labware)
         return self.load_labware_object(lw)
 
     def load_labware_by_name(self, name: str) -> Labware:

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -93,6 +93,10 @@ def _run_python(
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
+    if proto.filename.endswith('zip'):
+        filename = 'protocol.ot2.py'
+    else:
+        filename = proto.filename
     try:
         _runfunc_ok(new_locs.get('run'))
     except SyntaxError as se:
@@ -103,7 +107,7 @@ def _run_python(
     except Exception as e:
         exc_type, exc_value, tb = sys.exc_info()
         try:
-            frame = _find_protocol_error(tb, proto.filename)
+            frame = _find_protocol_error(tb, filename)
         except KeyError:
             # No pretty names, just raise it
             raise e

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -93,10 +93,10 @@ def _run_python(
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
-    if proto.filename.endswith('zip'):
+    if proto.filename and proto.filename.endswith('zip'):
         filename = 'protocol.ot2.py'
     else:
-        filename = proto.filename
+        filename = proto.filename or '<protocol>'
     try:
         _runfunc_ok(new_locs.get('run'))
     except SyntaxError as se:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1096,7 +1096,8 @@ def load(
     parent: Location,
     label: str = None,
     namespace: str = None,
-    version: int = 1
+    version: int = 1,
+    bundled_defs: Dict[str, Dict[str, Any]] = None,
 ) -> Labware:
     """
     Return a labware object constructed from a labware definition dict looked
@@ -1115,8 +1116,14 @@ def load(
         If unspecified, will search 'opentrons' then 'custom_beta'
     :param int version: The version of the labware definition. If unspecified,
         will use version 1.
+    :param bundled_defs: If specified, a mapping of labware names to labware
+        definitions. Only the bundle will be searched for definitions.
     """
-    definition = get_labware_definition(load_name, namespace, version)
+    if bundled_defs is not None:
+        definition = get_labware_definition_from_bundle(
+            bundled_defs, load_name, namespace, version)
+    else:
+        definition = get_labware_definition(load_name, namespace, version)
     return load_from_definition(definition, parent, label)
 
 

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -36,10 +36,15 @@ def _parse_python(
 ) -> PythonProtocol:
     """ Parse a protocol known or at least suspected to be python """
     filename_checked = filename or '<protocol>'
+    if filename_checked.endswith('.zip'):
+        ast_filename = 'protocol.ot2.py'
+    else:
+        ast_filename = filename_checked
+
     parsed = ast.parse(protocol_contents,
-                       filename=filename_checked)
+                       filename=ast_filename)
     metadata = extract_metadata(parsed)
-    protocol = compile(parsed, filename=filename_checked, mode='exec')
+    protocol = compile(parsed, filename=ast_filename, mode='exec')
     version = infer_version(metadata, parsed)
 
     result = PythonProtocol(

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -220,7 +220,7 @@ def test_parse_bundle_details(get_bundle_fixture, ensure_api2):
     parsed = parse(fixture['binary_zipfile'], filename)
 
     assert isinstance(parsed, PythonProtocol)
-    assert parsed.filename == filename
+    assert parsed.filename == 'protocol.ot2.py'
     assert parsed.bundled_labware == fixture['bundled_labware']
     assert parsed.bundled_python == fixture['bundled_python']
     assert parsed.bundled_data == fixture['bundled_data']


### PR DESCRIPTION
If we have a bundle, we need to only consider labware from that bundle when
labware is loaded into modules.

Also fix an issue that would lead to very ugly exceptions when simulating a
bundled protocol.

## Testing
- Upload a non-bundled protocol that loads labware in a module and check that it works
- Upload a non-bundled protocol that loads nonexistent labware in a module and check that the error is acceptable
- Upload a bundled protocol that loads labware in a module and check that it works
- Uploads a bundled protocol that loads a labware not in the bundle into a module and check that the error occurs and is acceptable