### PR TITLE
fix(api): Put camera images in tempdirs

### DIFF
--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -531,7 +531,8 @@ async def set_rail_lights(request):
 
 
 async def take_picture(request):
-    filename = './picture.jpg'
+    filename = os.path.join(
+        request.app['com.opentrons.response_file_tempdir'], 'picture.jpg')
     if os.path.exists(filename):
         try:
             os.remove(filename)


### PR DESCRIPTION
And not in the cwd of the server.

Closes #4122


Testing: Put this on a robot and get a picture with `curl -X POST $(robot ip):31950/camera/picture > image.jpg; open image.jpg`