### PR TITLE
fix(api): Use proper currents for plunger home

### DIFF
--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -31,6 +31,15 @@ class Axis(enum.Enum):
               opentrons.types.Mount.RIGHT: cls.C}
         return pm[mount]
 
+    @classmethod
+    def to_mount(cls, inst: 'Axis'):
+        return {
+            cls.Z: opentrons.types.Mount.LEFT,
+            cls.A: opentrons.types.Mount.RIGHT,
+            cls.B: opentrons.types.Mount.LEFT,
+            cls.C: opentrons.types.Mount.RIGHT
+        }[inst]
+
     def __str__(self):
         return self.name
 

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -32,8 +32,16 @@ def hardware(monkeypatch, async_server, model1, model2):
     hardware = async_server['com.opentrons.hardware']
     if model1:
         monkeypatch.setattr(hardware, 'model_by_mount', {
-            'left': {'model': model1[0], 'id': 'fakeid', 'name': model1[1]},
-            'right': {'model': model1[0], 'id': 'fakeid2', 'name': model1[1]}})
+            'left': {
+                'model': model1[0],
+                'id': 'fakeid',
+                'name': model1[1],
+                'home_current': 0.1},
+            'right': {
+                'model': model1[0],
+                'id': 'fakeid2',
+                'name': model1[1],
+                'home_current': 0.1}})
     elif model2:
         monkeypatch.setattr(hardware, 'model_by_mount', {
             'left': {'model': model2[0], 'id': 'fakeid', 'name': model2[1]},


### PR DESCRIPTION
We set the plunger currents to the values in the pipette config for most
actions, but do not do it when homing those axes. As a consequence, they home at
the robot config current values, which are 0.05A regardless of the kind of
pipettes. We've been mostly getting away with this, but there are positive
reports of skipping axes on gen2 pipettes.

Closes #3572

## Testing

Home pipette plungers. Look at the smoothie logs and make sure that it's setting the current specified in the smoothie configs. Do this in both apiv1 and apiv2. You're looking for a line like this:

`Oct 02 20:54:01 OT2BK111111111 opentrons-api-serial[6395]: smoothie: Write -> b'M907 A0.1 B1.0 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G28.2B\r\n\r\n'`
This is the line that commands a B-axis home (note the `G28.2B`) and the current (`M907... B1.0`). This was with a gen2. Only the current for the specific pipette doing the home should be set.
