### PR TITLE
feat(labware-creator): add analytics events skeleton

### DIFF
--- a/labware-library/src/analytics/index.js
+++ b/labware-library/src/analytics/index.js
@@ -1,0 +1,17 @@
+// @flow
+
+export type AnalyticsEvent = {|
+  name: string,
+  properties?: Object,
+  callback?: () => void,
+|}
+
+export const reportEvent = (event: AnalyticsEvent) => {
+  const { name, properties, callback } = event
+  // TODO IMMEDIATELY: hook up
+  console.log('FAKE ANALYTICS!', { name, properties })
+
+  if (callback) {
+    callback()
+  }
+}

--- a/labware-library/src/labware-creator/analyticsUtils/index.js
+++ b/labware-library/src/labware-creator/analyticsUtils/index.js
@@ -14,3 +14,42 @@ export const reportFieldEdit = (args: {| name: string, value: string |}) => {
   }
   _prevFieldValues[name] = value
 }
+
+let _prevErrors: { [string]: string } = {}
+export const reportErrors = (args: {|
+  values: Object,
+  errors: Object,
+  touched: Object,
+|}) => {
+  const { values, errors, touched } = args
+
+  // TODO Ian 2019-10-02: why is there an 'undefined' field in Formik `touched`?
+  const dirtyFieldNames = Object.keys(touched).filter(
+    name => touched[name] && name !== 'undefined'
+  )
+  const activeErrors = dirtyFieldNames.reduce(
+    (acc, name) => (errors[name] ? { ...acc, [name]: errors[name] } : acc),
+    {}
+  )
+
+  const newErrors = Object.keys(activeErrors).reduce((acc, name) => {
+    const prev = _prevErrors[name]
+    return prev === undefined || prev !== activeErrors[name]
+      ? { ...acc, [name]: activeErrors[name] }
+      : acc
+  }, {})
+  _prevErrors = newErrors
+
+  if (Object.keys(newErrors).length > 0) {
+    Object.keys(newErrors).forEach(name => {
+      reportEvent({
+        name: 'labwareCreatorAlertDisplay',
+        properties: {
+          alertContent: newErrors[name],
+          alertField: name,
+          alertValue: values[name],
+        },
+      })
+    })
+  }
+}

--- a/labware-library/src/labware-creator/analyticsUtils/index.js
+++ b/labware-library/src/labware-creator/analyticsUtils/index.js
@@ -1,0 +1,16 @@
+// @flow
+import { reportEvent } from '../../analytics'
+
+const _prevFieldValues = {}
+export const reportFieldEdit = (args: {| name: string, value: string |}) => {
+  // avoid reporting events on field blur unless there's a change
+  const { name, value } = args
+  const prevValue = _prevFieldValues[name]
+  if (prevValue === undefined || prevValue !== value) {
+    reportEvent({
+      name: 'labwareCreatorFieldEdit',
+      properties: { value, name },
+    })
+  }
+  _prevFieldValues[name] = value
+}

--- a/labware-library/src/labware-creator/components/Dropdown.js
+++ b/labware-library/src/labware-creator/components/Dropdown.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { SelectField } from '@opentrons/components'
 import { Field } from 'formik'
+import { reportFieldEdit } from '../analyticsUtils'
 import { LABELS } from '../fields'
 import type { LabwareFields, Options } from '../fields'
 import fieldStyles from './fieldStyles.css'
@@ -44,7 +45,10 @@ const Dropdown = (props: Props) => {
             name={field.name}
             caption={props.caption}
             value={field.value}
-            onLoseFocus={() => field.onBlur()}
+            onLoseFocus={() => {
+              reportFieldEdit({ value: field.value, name: field.name })
+              field.onBlur()
+            }}
             onValueChange={
               props.onValueChange ||
               ((name, value) => form.setFieldValue(name, value))

--- a/labware-library/src/labware-creator/components/LinkOut.js
+++ b/labware-library/src/labware-creator/components/LinkOut.js
@@ -6,9 +6,11 @@ type Props = {|
   href: string,
   className?: ?string,
   children?: React.Node,
+  onClick?: () => mixed,
 |}
 const LinkOut = (props: Props) => (
   <a
+    onClick={props.onClick}
     className={props.className}
     href={props.href}
     target="_blank"

--- a/labware-library/src/labware-creator/components/RadioField.js
+++ b/labware-library/src/labware-creator/components/RadioField.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { Field } from 'formik'
 import { RadioGroup } from '@opentrons/components'
+import { reportFieldEdit } from '../analyticsUtils'
 import { getIsHidden } from '../formSelectors'
 import { LABELS, type LabwareFields } from '../fields'
 import fieldStyles from './fieldStyles.css'
@@ -25,6 +26,7 @@ const RadioField = (props: Props) => (
               field.onChange(e)
               // do not wait until blur to make radio field 'dirty'
               field.onBlur(e)
+              reportFieldEdit({ value: field.value, name: field.name })
             }}
             options={props.options}
           />

--- a/labware-library/src/labware-creator/components/RadioField.js
+++ b/labware-library/src/labware-creator/components/RadioField.js
@@ -24,8 +24,15 @@ const RadioField = (props: Props) => (
             labelTextClassName={props.labelTextClassName}
             onChange={e => {
               field.onChange(e)
-              // do not wait until blur to make radio field 'dirty'
-              field.onBlur(e)
+              // do not wait until blur to make radio field 'dirty', so that alerts show up immediately.
+              // NOTE: Ian 2019-10-02 this setTimeout seems necessary to avoid a race condition where
+              // Formik blurs the field before setting its value, surfacing a transient error
+              // (eg "this field is required") which messes up error analytics
+              const blurTarget = e.currentTarget
+              setTimeout(() => {
+                blurTarget.blur()
+              }, 0)
+
               reportFieldEdit({ value: field.value, name: field.name })
             }}
             options={props.options}

--- a/labware-library/src/labware-creator/components/Section.js
+++ b/labware-library/src/labware-creator/components/Section.js
@@ -7,7 +7,11 @@ import { AlertItem } from '@opentrons/components'
 import { getIsHidden } from '../formSelectors'
 import LinkOut from './LinkOut'
 import styles from './Section.css'
-import { IRREGULAR_LABWARE_ERROR, type LabwareFields } from '../fields'
+import {
+  IRREGULAR_LABWARE_ERROR,
+  LINK_CUSTOM_LABWARE_FORM,
+  type LabwareFields,
+} from '../fields'
 
 // TODO: Make this DRY, don't require fields (in children) and also fieldList.
 type Props = {|
@@ -38,9 +42,9 @@ const Section = connect((props: Props) => {
   const allErrors: Array<string> = uniq(
     compact(dirtyFieldNames.map(name => props.formik.errors[name]))
   )
+
   const allErrorAlerts = allErrors.map(error => {
     if (error === IRREGULAR_LABWARE_ERROR) {
-      // TODO IMMEDIATELY get real link to labware request form
       return (
         <AlertItem
           key={error}
@@ -49,10 +53,8 @@ const Section = connect((props: Props) => {
             <>
               Your labware is not compatible with the Labware Creator. Please
               fill out{' '}
-              <LinkOut href="https://opentrons-ux.typeform.com/to/xi8h0W">
-                this form
-              </LinkOut>{' '}
-              to request a custom labware definition.
+              <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut> to
+              request a custom labware definition.
             </>
           }
         />

--- a/labware-library/src/labware-creator/components/TextField.js
+++ b/labware-library/src/labware-creator/components/TextField.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { Field } from 'formik'
 import { InputField } from '@opentrons/components'
+import { reportFieldEdit } from '../analyticsUtils'
 import { getIsHidden } from '../formSelectors'
 import { LABELS, type LabwareFields } from '../fields'
 import fieldStyles from './fieldStyles.css'
@@ -44,6 +45,10 @@ const TextField = (props: Props) => {
               caption={caption}
               placeholder={placeholder}
               onChange={makeHandleChange({ field, form })}
+              onBlur={(e: SyntheticEvent<HTMLInputElement>) => {
+                reportFieldEdit({ value: field.value, name: field.name })
+                field.onBlur(e)
+              }}
               units={units}
             />
           </div>

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -8,6 +8,7 @@ import mapValues from 'lodash/mapValues'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
 import { reportEvent } from '../analytics'
+import { reportErrors } from './analyticsUtils'
 import { AlertItem, AlertModal, PrimaryButton } from '@opentrons/components'
 import labwareSchema from '@opentrons/shared-data/labware/schemas/2.json'
 import { makeMaskToDecimal, maskToInteger, maskLoadName } from './fieldMasks'
@@ -509,6 +510,7 @@ const App = () => {
           setTouched,
           setValues,
         }) => {
+          reportErrors({ values, errors, touched })
           // TODO (ka 2019-8-27): factor out this as sub-schema from Yup schema and use it to validate instead of repeating the logic
           const canProceedToForm = Boolean(
             values.labwareType === 'wellPlate' ||

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -306,17 +306,20 @@ const App = () => {
     null
   )
   const setImportError = React.useMemo(
-    () => (value: ImportError | null) => {
-      if (value != null) {
+    () => (v: ImportError | null, def?: LabwareDefinition2) => {
+      if (v != null) {
         reportEvent({
           name: 'labwareCreatorFileImport',
           properties: {
+            labwareDisplayName: def?.metadata.displayName,
+            labwareAPIName: def?.parameters.loadName,
+            labwareBrand: def?.brand.brand,
             importSuccess: false,
-            importError: value,
+            importError: v.key,
           },
         })
       }
-      _setImportError(value)
+      _setImportError(v)
     },
     [_setImportError]
   )
@@ -325,22 +328,23 @@ const App = () => {
     null
   )
   const setLastUploaded = React.useMemo(
-    () => (value: LabwareFields | null) => {
-      if (value != null) {
+    () => (v: LabwareFields | null, def?: LabwareDefinition2) => {
+      if (v != null) {
+        assert(def, "setLastUploaded expected `def` if `v` isn't null")
         reportEvent({
           name: 'labwareCreatorFileImport',
           properties: {
-            labwareType: value.labwareType,
-            labwareDisplayName: value.displayName,
-            labwareAPIName: value.loadName,
-            labwareBrand: value.brand,
-            labwareManufacturerID: value.brandId,
+            labwareType: v.labwareType,
+            labwareDisplayName: def?.metadata.displayName,
+            labwareAPIName: def?.parameters.loadName,
+            labwareBrand: def?.brand.brand,
+            labwareManufacturerID: v.brandId,
             importSuccess: true,
             importError: null,
           },
         })
       }
-      _setLastUploaded(value)
+      _setLastUploaded(v)
     },
     [_setLastUploaded]
   )
@@ -412,10 +416,13 @@ const App = () => {
           }
           const fields = labwareDefToFields(parsedLabwareDef)
           if (!fields) {
-            setImportError({ key: 'UNSUPPORTED_LABWARE_PROPERTIES' })
+            setImportError(
+              { key: 'UNSUPPORTED_LABWARE_PROPERTIES' },
+              parsedLabwareDef
+            )
             return
           }
-          setLastUploaded(fields)
+          setLastUploaded(fields, parsedLabwareDef)
           if (
             fields.labwareType === 'wellPlate' ||
             fields.labwareType === 'reservoir'


### PR DESCRIPTION
## overview

This doesn't hook up the events, the stub function `reportEvent` will only `console.log` them. When we add the opt-in flow and connect MixPanel in upcoming PR(s), `reportEvent` would call `mixpanel.track`.

Part of #4115 

## changelog

## review requests

- Make sure all the events outlined in the spreadsheet linked in #4115 are logged. Make sure events always log when they should (no misses), and make sure there's no spamming of events that aren't really new (eg from re-rendering). See the sheet for full details (esp properties) but in summary:
  - [ ] labwareCreatorFileExport: on saving a file. Should emit on successful export, and when you get the export error modal (has success/error properties)
  - [ ] labwareCreatorFileImport: on importing a labware. Also should work both with success and with error. 
  - [ ] labwareCreatorAlertDisplay: whenever an alert appears that wasn't previously visible
  - [ ] labwareCreatorFieldEdit: on blur of any field, but only when the value has changed since last blur
  - [ ] labwareCreatorClickTestLabware: when you click the link for the testing PDF

- [ ] Code review: I could not get the Alerts/errors reporting to play nice with Formik and had to do a hacky "listener". If there's a better way, please LMK. I think this is revealing that LC needs a refactor, probably moving away from Formik and doing something similar to what Formik v2 (prerelease) is doing with `userReducer`, but with more options to subscribe and dispatch. Anyway, we're stuck with some nastiness here.