### PR TITLE
refactor(shared-data): remove DropTipShake from all Gen2 models

### DIFF
--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -324,7 +324,7 @@ async def test_shake_during_drop(hardware_api, monkeypatch):
     await hardware_api.home()
     hardware_api._backend._attached_instruments\
         = {types.Mount.LEFT: {'model': None, 'id': None},
-           types.Mount.RIGHT: {'model': 'p1000_single_v2.0',
+           types.Mount.RIGHT: {'model': 'p1000_single_v1.5',
                                'id': 'testyness'}}
     await hardware_api.cache_instruments()
     await hardware_api.add_tip(types.Mount.RIGHT, 50.0)

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -79,7 +79,7 @@ def test_shake_during_pick_up(monkeypatch):
 def test_shake_during_drop(monkeypatch):
     robot.reset()
     pip = instruments._create_pipette_from_config(
-            config=pipette_config.load('p1000_single_v2.0'),
+            config=pipette_config.load('p1000_single_v1.5'),
             mount='left',
             name='p1000_single_v2.0')
     tiprack = containers_load(robot, 'opentrons_96_tiprack_1000ul', '1')

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1116,7 +1116,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": []
     },
     "p20_multi_v2.0": {
       "name": "p20_multi_gen2",
@@ -1253,7 +1253,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": []
     },
     "p50_single_v1": {
       "name": "p50_single",
@@ -2833,7 +2833,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": []
     },
     "p300_multi_v1": {
       "name": "p300_multi",
@@ -3404,7 +3404,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake"]
+      "quirks": []
     },
     "p1000_single_v1": {
       "name": "p1000_single",
@@ -3997,7 +3997,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["dropTipShake", "pickupTipShake"],
+      "quirks": ["pickupTipShake"],
       "returnTipHeight": 0.83
     }
   },


### PR DESCRIPTION
## overview
Gen2 models no longer need the `DropTipShake`.

## changelog
- remove quirks from pipetteModelSepcs.json
- update appropriate tests

## review requests
Test on robot