### PR TITLE
ci(travis): only sign the mac app on v* tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,14 +141,14 @@ jobs:
       os: linux
       script: make -C app-shell dist-posix
       # skip app builds entirely if tag is present but does not match ^v
-      if: tag IS blank AND (NOT branch =~ ^(edge|release_.+)$)
+      if: tag IS blank
 
     - # build the Opentrons App for Linux (tagged / edge / RC builds)
       <<: *app_stage_build
       name: 'Build/deploy Opentrons App for Linux'
       os: linux
       script: make -C app-shell dist-linux
-      if: tag =~ ^v OR branch =~ ^(edge|release_.+)$
+      if: tag =~ ^v
 
     - # build the Opentrons App for macOS (tagged / edge / RC builds)
       <<: *app_stage_build
@@ -156,7 +156,7 @@ jobs:
       os: osx
       osx_image: xcode10.3
       script: make -C app-shell dist-osx
-      if: tag =~ ^v OR branch =~ ^(edge|release_.+)$
+      if: tag =~ ^v
 
 env:
   global:


### PR DESCRIPTION
## overview

Given that our release process now includes tagging each RC build as an `alpha`, this PR removes the legacy signing of builds on `edge` and `release_*` branches, as that behavior was from earlier times where we attempted to use builds from those branches as release candidates.

## changelog

- ci(travis): only sign the mac app on v* tagged builds

## review requests

I checked `appveyor.yml` and `app-shell/Makefile` for additional changes, but it looks like the travis config is the only thing that needs updating

- [ ] Config changes make sense
