### PR TITLE
refactor(app): update older pipette calibrations ff text

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -69,7 +69,8 @@ settings = [
         description='Use the older pipette calibrations for P10S, P10M, P50S,'
                     ' P50M, and P300S pipettes. Note this will cause the '
                     ' default aspirate behavior (ul to mm conversion) to '
-                    ' function as it did prior to version 3.7.0.'
+                    ' function as it did prior to version 3.7.0. '
+                    ' NOTE: this does not impact GEN2 pipettes'
     ),
 ]
 


### PR DESCRIPTION
For the "use older pipette calibrations" feature flag, emphasize that this doesn't impact GEN2
pipettes

Closes #3596