### PR TITLE
refactor(api): Implement an API v1 Executor

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -94,11 +94,15 @@ $(wheel_pattern): setup.py $(ot_sources)
 
 wheel: $(wheel_file)
 
-.PHONY: test
-test: local-install
+.PHONY: test, test-apiv1, test-apiv2
+test: local-install test-apiv2 test-apiv1
 	$(python)	-m twine check $(wheel_file)
-	OT_API_FF_useProtocolApi2=0 $(pytest) $(tests) $(test_opts) -m "not api2_only"
-	# OT_API_FF_useProtocolApi2=1 $(pytest) $(tests) $(test_opts) -m "not api1_only"
+
+test-apiv2: local-install
+	OT_API_FF_useProtocolApi2=1 $(pytest) $(tests) $(test_opts) -m "not apiv1 and not api1_only"
+
+test-apiv1: local-install
+	OT_API_FF_useProtocolApi2=0 $(pytest) $(tests) $(test_opts) -m "not apiv2 and not api2_only"
 
 .PHONY: lint
 lint: $(ot_py_sources)

--- a/api/Makefile
+++ b/api/Makefile
@@ -37,7 +37,7 @@ simfile ?=
 # make test tests=tests/opentrons/tools/test_qc_scripts.py would run only the
 # specified test
 tests ?= tests
-test_opts ?= --cov --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
+test_opts ?=  --cov --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi
@@ -97,7 +97,8 @@ wheel: $(wheel_file)
 .PHONY: test
 test: local-install
 	$(python)	-m twine check $(wheel_file)
-	$(pytest) $(tests) $(test_opts)
+	OT_API_FF_useProtocolApi2=0 $(pytest) $(tests) $(test_opts) -m "not api2_only"
+	# OT_API_FF_useProtocolApi2=1 $(pytest) $(tests) $(test_opts) -m "not api1_only"
 
 .PHONY: lint
 lint: $(ot_py_sources)

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -4,3 +4,5 @@ markers =
         api2_only: Test only functions using API version 2 (protocol API and hardware control)
         model1: Marks for functions using gen1 pipettes in deck cal cli tests
         model2: Marks for functions using gen2 pipettes in deck cal cli tests
+        apiv1: This test invocation requires apiv1
+        apiv2: This test invocation requires apiv2

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -14,12 +14,16 @@ elif not config.feature_flags.use_protocol_api_v2():
 
 
 if not config.feature_flags.use_protocol_api_v2():
-    from .legacy_api.api import (robot as robotv1,   # noqa(E402)
-                                 reset as resetv1,
-                                 instruments as instrumentsv1,
-                                 containers as containersv1,
-                                 labware as labwarev1,
-                                 modules as modulesv1)
+    from .legacy_api.api import (robot,   # noqa(E402)
+                                 reset,
+                                 instruments,
+                                 containers,
+                                 labware,
+                                 modules)
+    names_list = [
+        'containers', 'instruments', 'robot', 'reset', 'modules', 'labware']
+else:
+    names_list = []
 
 try:
     with open(os.path.join(HERE, 'package.json')) as pkg:
@@ -35,35 +39,4 @@ if version < (3, 5):
             version[0], version[1]))
 
 
-def build_globals():
-    if config.feature_flags.use_protocol_api_v2():
-        return None, None, None, None, None, None, None
-    else:
-        return robotv1, resetv1, instrumentsv1, containersv1,\
-            labwarev1, modulesv1, robotv1
-
-
-def reset_globals():
-    """ Reinitialize the global singletons with a given API version.
-
-    :param version: 1 or 2. If `None`, pulled from the `useProtocolApiV2`
-                    advanced setting.
-    """
-    global containers
-    global instruments
-    global labware
-    global robot
-    global reset
-    global modules
-    global hardware
-
-    robot, reset, instruments, containers, labware, modules, hardware\
-        = build_globals()
-
-
-robot, reset, instruments, containers, labware, modules, hardware\
-        = build_globals()
-
-
-__all__ = ['containers', 'instruments', 'labware', 'robot', 'reset',
-           '__version__', 'modules', 'hardware', 'HERE']
+__all__ = ['__version__', 'HERE'] + names_list

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -40,4 +40,3 @@ if version < (3, 5):
 
 
 __all__ = ['__version__', 'HERE'] + names_list
-print(f"THIS IS ALL {__all__}")

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -40,3 +40,4 @@ if version < (3, 5):
 
 
 __all__ = ['__version__', 'HERE'] + names_list
+print(f"THIS IS ALL {__all__}")

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -18,10 +18,11 @@ from opentrons.protocol_api.execute import run_protocol
 from opentrons.hardware_control import adapters, API
 from .models import Container, Instrument, Module
 
+from opentrons.legacy_api.containers.placeable import (
+    Module as ModulePlaceable, Placeable)
 if not ff.use_protocol_api_v2():
     from opentrons.legacy_api.containers import get_container, location_to_list
-    from opentrons.legacy_api.containers.placeable import (
-        Module as ModulePlaceable, Placeable)
+
     from opentrons.legacy_api.protocols import execute_protocol
 
 log = logging.getLogger(__name__)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -6,22 +6,23 @@ import logging
 from time import time
 from uuid import uuid4
 from opentrons.broker import Broker
-from opentrons.legacy_api.containers import get_container, location_to_list
-from opentrons.legacy_api.containers.placeable import (
-    Module as ModulePlaceable, Placeable)
 from opentrons.commands import tree, types as command_types
 from opentrons.commands.commands import is_new_loc, listify
-from opentrons.legacy_api.protocols import execute_protocol
 from opentrons.config import feature_flags as ff
 from opentrons.protocols.types import JsonProtocol, PythonProtocol
 from opentrons.protocols.parse import parse
+from opentrons.types import Location, Point
 from opentrons.protocol_api import (ProtocolContext,
                                     labware)
 from opentrons.protocol_api.execute import run_protocol
 from opentrons.hardware_control import adapters, API
-from opentrons.types import Location, Point
-
 from .models import Container, Instrument, Module
+
+if not ff.use_protocol_api_v2():
+    from opentrons.legacy_api.containers import get_container, location_to_list
+    from opentrons.legacy_api.containers.placeable import (
+        Module as ModulePlaceable, Placeable)
+    from opentrons.legacy_api.protocols import execute_protocol
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -239,17 +239,12 @@ def _load_with_overrides(base) -> Dict[str, str]:
     overrides = _get_environ_overrides()
     try:
         index = json.load((base/_CONFIG_FILENAME).open())
-    except (OSError, json.JSONDecodeError) as e:
-        sys.stderr.write("Error loading config from {}: {}\nRewriting...\n"
-                         .format(str(base), e))
+    except (OSError, json.JSONDecodeError):
         should_write = True
         index = generate_config_index(overrides)
 
     for key in CONFIG_ELEMENTS:
         if key.name not in index:
-            sys.stderr.write(
-                f"New config index key {key.name}={key.default}"
-                "\nRewriting...\n")
             if key.kind in (ConfigElementType.DIR, ConfigElementType.FILE):
                 index[key.name] = base/key.default
             else:

--- a/api/src/opentrons/data_storage/database.py
+++ b/api/src/opentrons/data_storage/database.py
@@ -13,8 +13,6 @@ import os
 SUPPORTED_MODULES = ['magdeck', 'tempdeck']
 
 log = logging.getLogger(__file__)
-database_path = str(CONFIG['labware_database_file'])
-log.debug("Database path: {}".format(database_path))
 
 # ======================== Private Functions ======================== #
 
@@ -147,14 +145,14 @@ def _get_db_version(db):
 
 # ======================== Public Functions ======================== #
 def save_new_container(container: Container, container_name: str) -> bool:
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     _create_container_obj_in_db(db_conn, container, container_name)
     res = True  # old create fn does not return anything
     return res
 
 
 def load_container(container_name: str) -> Container:
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     res = _load_container_object_from_db(db_conn, container_name)
     return res
 
@@ -162,53 +160,48 @@ def load_container(container_name: str) -> Container:
 def overwrite_container(container: Container) -> bool:
     log.debug("Overwriting container definition: {}".format(
         container.get_type()))
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     _update_container_object_in_db(db_conn, container)
     res = True  # old overwrite fn does not return anything
     return res
 
 
 def delete_container(container_name) -> bool:
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     _delete_container_object_in_db(db_conn, container_name)
     res = True  # old delete fn does not return anything
     return res
 
 
 def list_all_containers() -> List[str]:
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     res = _list_all_containers_by_name(db_conn)
     return res
 
 
 def load_module(module_name: str) -> Container:
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     res = _load_module_dict_from_db(db_conn, module_name)
     return res
 
 
-def change_database(db_path: str):
-    global database_path
-    database_path = db_path
-
-
 def get_version():
     '''Get the Opentrons-defined database version'''
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     return _get_db_version(db_conn)
 
 
 def set_version(version):
-    db_conn = sqlite3.connect(database_path)
+    db_conn = sqlite3.connect(str(CONFIG['labware_database_file']))
     db_queries.set_user_version(db_conn, version)
 
 
 def reset():
     """ Unmount and remove the sqlite database (used in robot reset) """
-    if os.path.exists(database_path):
-        os.remove(database_path)
+    if os.path.exists(str(CONFIG['labware_database_file'])):
+        os.remove(str(CONFIG['labware_database_file']))
     # Not an os.path.join because it is a suffix to the full filename
-    journal_path = database_path + '-journal'
+    journal_path = str(CONFIG['labware_database_file']) + '-journal'
     if os.path.exists(journal_path):
         os.remove(journal_path)
 

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -13,7 +13,7 @@ from typing import Tuple
 from numpy.linalg import inv  # type: ignore
 from numpy import dot, array  # type: ignore
 import opentrons
-from opentrons import robot, instruments, types
+from opentrons import types
 from opentrons.hardware_control import adapters
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.config import (robot_configs, feature_flags,
@@ -566,7 +566,7 @@ class CLITool:
         else:
             self.hardware.cache_instrument_models()
             cached = self.hardware.get_attached_pipettes()
-            pip_func = instruments.pipette_by_name
+            pip_func = opentrons.instruments.pipette_by_name
         for mount, attached in cached.items():
             if mount == 'left':
                 mount_key = left
@@ -726,7 +726,7 @@ def main(loop=None):
     args = parser.parse_args()
 
     if not feature_flags.use_protocol_api_v2():
-        hardware = robot
+        hardware = opentrons.robot
         hardware.connect()
         hardware.turn_on_rail_lights()
         atexit.register(hardware.turn_off_rail_lights)

--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -564,9 +564,10 @@ class CLITool:
             cached = self.hardware.get_attached_instruments()
             pip_func = None
         else:
+            from opentrons import instruments
             self.hardware.cache_instrument_models()
             cached = self.hardware.get_attached_pipettes()
-            pip_func = opentrons.instruments.pipette_by_name
+            pip_func = instruments.pipette_by_name
         for mount, attached in cached.items():
             if mount == 'left':
                 mount_key = left

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -5,8 +5,9 @@ from typing import Dict, Tuple
 
 import logging
 import json
+import opentrons
 from opentrons.config import pipette_config, robot_configs, feature_flags
-from opentrons import instruments, hardware_control
+from opentrons import hardware_control
 from opentrons.types import Mount, Point
 from opentrons.hardware_control.types import CriticalPoint
 from . import jog, position, dots_set, z_pos
@@ -132,9 +133,10 @@ def get_pipettes(sess):
         left = attached_pipettes.get('left')
         right = attached_pipettes.get('right')
         if left['model'] in pipette_config.config_models:
-            left_pipette = instruments.pipette_by_name('left', left['name'])
+            left_pipette = opentrons.instruments.pipette_by_name(
+                'left', left['name'])
         if right['model'] in pipette_config.config_models:
-            right_pipette = instruments.pipette_by_name(
+            right_pipette = opentrons.instruments.pipette_by_name(
                 'right', right['name'])
     else:
         attached_pipettes = sess.adapter.attached_instruments

--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -5,7 +5,10 @@ from typing import Dict, Tuple
 
 import logging
 import json
-import opentrons
+try:
+    from opentrons import instruments
+except ImportError:
+    pass
 from opentrons.config import pipette_config, robot_configs, feature_flags
 from opentrons import hardware_control
 from opentrons.types import Mount, Point
@@ -133,10 +136,10 @@ def get_pipettes(sess):
         left = attached_pipettes.get('left')
         right = attached_pipettes.get('right')
         if left['model'] in pipette_config.config_models:
-            left_pipette = opentrons.instruments.pipette_by_name(
+            left_pipette = instruments.pipette_by_name(
                 'left', left['name'])
         if right['model'] in pipette_config.config_models:
-            right_pipette = opentrons.instruments.pipette_by_name(
+            right_pipette = instruments.pipette_by_name(
                 'right', right['name'])
     else:
         attached_pipettes = sess.adapter.attached_instruments

--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -21,6 +21,21 @@ class SimulatingDriver:
     def _smoothie_reset(self):
         pass
 
+    def read_pipette_id(self, mount):
+        pass
+
+    def read_pipette_model(self, mount):
+        pass
+
+    def write_pipette_id(self, mount, id):
+        pass
+
+    def write_pipette_model(self, mount, model):
+        pass
+
+    def _send_command(self, command, timeout=None):
+        pass
+
     def turn_on_blue_button_light(self):
         pass
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -13,7 +13,7 @@ import sys
 import threading
 from typing import Any, Callable, Dict, Optional, TextIO
 
-from opentrons import protocol_api, robot, legacy_api, __version__
+from opentrons import protocol_api, __version__
 from opentrons.protocol_api import execute as execute_apiv2
 from opentrons import commands
 from opentrons.config import feature_flags as ff
@@ -190,6 +190,7 @@ def execute(protocol_file: TextIO,
                                    simulate=False,
                                    context=context)
     else:
+        from opentrons import robot, legacy_api
         robot.connect()
         robot.cache_instrument_models()
         robot.discover_modules()

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -190,7 +190,8 @@ def execute(protocol_file: TextIO,
                                    simulate=False,
                                    context=context)
     else:
-        from opentrons import robot, legacy_api
+        from opentrons import robot
+        from opentrons.legacy_api import protocols
         robot.connect()
         robot.cache_instrument_models()
         robot.discover_modules()
@@ -199,7 +200,7 @@ def execute(protocol_file: TextIO,
             robot.broker.subscribe(
                 commands.command_types.COMMAND, emit_runlog)
         if isinstance(protocol, JsonProtocol):
-            legacy_api.protocols.execute_protocol(protocol)
+            protocols.execute_protocol(protocol)
         else:
             exec(protocol.contents, {})
 

--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -190,7 +190,7 @@ def main():
     if ff.use_protocol_api_v2():
         checked_hardware = adapters.SingletonAdapter(asyncio.get_event_loop())
     else:
-        checked_hardware = opentrons.hardware
+        checked_hardware = opentrons.robot
     run(checked_hardware, **vars(args))
     arg_parser.exit(message="Stopped\n")
 

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -300,4 +300,4 @@ def build_globals(hardware=None, loop=None):
     lw = BCLabware(ctx)
     mod = BCModules(ctx)
 
-    return rob, instr, lw, lw, mod
+    return {'robot': rob, 'instruments': instr, 'labware': lw, 'modules': mod}

--- a/api/src/opentrons/protocol_api/back_compat.py
+++ b/api/src/opentrons/protocol_api/back_compat.py
@@ -301,32 +301,3 @@ def build_globals(hardware=None, loop=None):
     mod = BCModules(ctx)
 
     return rob, instr, lw, lw, mod
-
-
-def set_globals(rob, instr, lw, mod):
-    global robot
-    global instruments
-    global labware
-    global containers
-    global modules
-    robot = rob
-    instruments = instr
-    labware = lw
-    containers = lw
-    modules = mod
-
-
-def reset_globals(hardware=None, loop=None):
-    robot, instruments, containers, labware, modules = build_globals(hardware,
-                                                                     loop)
-    set_globals(robot, instruments, containers, modules)
-
-
-def reset():
-    global robot
-    robot.reset()
-
-
-robot, instruments, containers, labware, modules = build_globals()
-
-__all__ = ['robot', 'reset', 'instruments', 'containers', 'labware', 'modules']

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -6,7 +6,8 @@ from typing import Any, Callable
 
 import opentrons
 from .contexts import ProtocolContext
-from . import execute_v3
+from . import execute_v3, back_compat
+
 from opentrons import config
 from opentrons.protocols.types import PythonProtocol, Protocol
 

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -4,6 +4,7 @@ import traceback
 import sys
 from typing import Any, Callable
 
+import opentrons
 from .contexts import ProtocolContext
 from . import execute_v3
 from opentrons import config
@@ -119,6 +120,9 @@ def _run_python(
 def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
     new_locs = locals()
     new_globs = globals()
+    namespace_mapping = back_compat.build_globals()
+    for key, value in namespace_mapping.items():
+        setattr(opentrons, key, value)
     try:
         exec(proto.contents, new_globs, new_locs)
     except Exception as e:
@@ -129,6 +133,9 @@ def _run_python_legacy(proto: PythonProtocol, context: ProtocolContext):
             # No pretty names, just raise it
             raise e
         raise ExceptionInProtocolError(e, tb, str(e), frame.lineno)
+    finally:
+        for key in namespace_mapping.keys():
+            delattr(opentrons, key)
 
 
 def run_protocol(protocol: Protocol,

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -6,7 +6,7 @@ import logging
 from aiohttp import web
 from threading import Thread
 
-from opentrons import instruments
+import opentrons
 from opentrons.config import pipette_config
 from opentrons.trackers import pose_tracker
 from opentrons.config import feature_flags as ff
@@ -396,11 +396,11 @@ def _fetch_or_create_pipette(robot, mount, model=None):
             should_remove = False
     if pipette is None:
         if model is None:
-            pipette = instruments.Pipette(
+            pipette = opentrons.instruments.Pipette(
                 mount=mount, max_volume=1000, ul_per_mm=1000)
         else:
             config = pipette_config.load(model)
-            pipette = instruments._create_pipette_from_config(
+            pipette = opentrons.instruments._create_pipette_from_config(
                 config=config,
                 mount=mount,
                 name=model)

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -6,7 +6,10 @@ import logging
 from aiohttp import web
 from threading import Thread
 
-import opentrons
+try:
+    from opentrons import instruments
+except ImportError:
+    pass
 from opentrons.config import pipette_config
 from opentrons.trackers import pose_tracker
 from opentrons.config import feature_flags as ff
@@ -387,6 +390,8 @@ def _move_pipette(robot, mount, model, point):
 
 
 def _fetch_or_create_pipette(robot, mount, model=None):
+
+    print(f"GLOBALS IN FETCH/CREATE {globals()}")
     existing_pipettes = robot.get_instruments()
     pipette = None
     should_remove = True
@@ -396,11 +401,11 @@ def _fetch_or_create_pipette(robot, mount, model=None):
             should_remove = False
     if pipette is None:
         if model is None:
-            pipette = opentrons.instruments.Pipette(
+            pipette = instruments.Pipette(
                 mount=mount, max_volume=1000, ul_per_mm=1000)
         else:
             config = pipette_config.load(model)
-            pipette = opentrons.instruments._create_pipette_from_config(
+            pipette = instruments._create_pipette_from_config(
                 config=config,
                 mount=mount,
                 name=model)

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -390,8 +390,6 @@ def _move_pipette(robot, mount, model, point):
 
 
 def _fetch_or_create_pipette(robot, mount, model=None):
-
-    print(f"GLOBALS IN FETCH/CREATE {globals()}")
     existing_pipettes = robot.get_instruments()
     pipette = None
     should_remove = True

--- a/api/src/opentrons/server/endpoints/update.py
+++ b/api/src/opentrons/server/endpoints/update.py
@@ -2,7 +2,7 @@ import logging
 import asyncio
 import tempfile
 from aiohttp import web
-from opentrons import modules
+import opentrons
 
 log = logging.getLogger(__name__)
 UPDATE_TIMEOUT = 15
@@ -72,7 +72,7 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
     for module in hw_mods:
         if module.device_info.get('serial') == serialnum:
             log.info("Module with serial {} found".format(serialnum))
-            bootloader_port = await modules.enter_bootloader(module)
+            bootloader_port = await opentrons.modules.enter_bootloader(module)
             if bootloader_port:
                 module._port = bootloader_port
             # else assume old bootloader connection on existing module port
@@ -81,7 +81,7 @@ async def _upload_to_module(hw, serialnum, fw_filename, loop):
             log.info("Flashing firmware. This will take a few seconds")
             try:
                 res = await asyncio.wait_for(
-                    modules.update_firmware(
+                    opentrons.modules.update_firmware(
                         module, fw_filename, loop),
                     UPDATE_TIMEOUT)
             except asyncio.TimeoutError:

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -15,14 +15,13 @@ from typing import Any, Dict, List, Mapping, TextIO, Tuple, BinaryIO, Optional
 
 
 import opentrons
-import opentrons.legacy_api.protocols
 import opentrons.commands
 import opentrons.broker
 from opentrons.protocols import parse, bundle
-from opentrons.protocols.types import (
-    JsonProtocol, PythonProtocol, BundleContents)
 from opentrons.protocol_api import execute
 from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
+from opentrons.protocols.types import (
+    JsonProtocol, PythonProtocol, BundleContents)
 
 
 class AccumulatingHandler(logging.Handler):
@@ -222,6 +221,7 @@ def simulate(protocol_file: TextIO,
         else:
             bundle_contents = None
     else:
+        import opentrons.legacy_api.protocols
         opentrons.robot.disconnect()
         scraper = CommandScraper(stack_logger, log_level,
                                  opentrons.robot.broker)

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -19,10 +19,10 @@ import opentrons.commands
 import opentrons.broker
 import opentrons.config
 from opentrons.protocols import parse, bundle
-from opentrons.protocol_api import execute
-from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
 from opentrons.protocols.types import (
     JsonProtocol, PythonProtocol, BundleContents)
+from opentrons.protocol_api import execute
+from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
 
 
 class AccumulatingHandler(logging.Handler):

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Mapping, TextIO, Tuple, BinaryIO, Optional
 import opentrons
 import opentrons.commands
 import opentrons.broker
+import opentrons.config
 from opentrons.protocols import parse, bundle
 from opentrons.protocol_api import execute
 from .util.entrypoint_util import labware_from_paths, datafiles_from_paths
@@ -221,14 +222,19 @@ def simulate(protocol_file: TextIO,
         else:
             bundle_contents = None
     else:
-        import opentrons.legacy_api.protocols
-        opentrons.robot.disconnect()
-        scraper = CommandScraper(stack_logger, log_level,
-                                 opentrons.robot.broker)
-        if isinstance(protocol, JsonProtocol):
-            opentrons.legacy_api.protocols.execute_protocol(protocol)
-        else:
-            exec(protocol.contents, {})
+
+        def _simulate_v1():
+            import opentrons.legacy_api.protocols
+            opentrons.robot.disconnect()
+            scraper = CommandScraper(stack_logger, log_level,
+                                     opentrons.robot.broker)
+            if isinstance(protocol, JsonProtocol):
+                opentrons.legacy_api.protocols.execute_protocol(protocol)
+            else:
+                exec(protocol.contents, {})
+            return scraper
+
+        scraper = _simulate_v1()
         bundle_contents = None
 
     return scraper.commands, bundle_contents

--- a/api/src/opentrons/tools/__init__.py
+++ b/api/src/opentrons/tools/__init__.py
@@ -18,15 +18,11 @@ def connect_to_port(hardware):
 
 driver = opentrons.drivers.smoothie_drivers.SimulatingDriver()
 
-if opentrons.config.feature_flags.use_protocol_api_v2():
-    api = opentrons.hardware_control.API
-    hardware = opentrons.hardware_control.adapters.SynchronousAdapter.build(
-        api.build_hardware_controller)
-else:
-    hardware = opentrons.robot
-
 if opentrons.config.IS_ROBOT:
     if opentrons.config.feature_flags.use_protocol_api_v2():
+        api = opentrons.hardware_control.API
+        hardware = opentrons.hardware_control.adapters.SynchronousAdapter.build(
+            api.build_hardware_controller)
         driver = hardware._backend._smoothie_driver
     else:
         hardware = opentrons.robot

--- a/api/src/opentrons/tools/__init__.py
+++ b/api/src/opentrons/tools/__init__.py
@@ -21,7 +21,8 @@ driver = opentrons.drivers.smoothie_drivers.SimulatingDriver()
 if opentrons.config.IS_ROBOT:
     if opentrons.config.feature_flags.use_protocol_api_v2():
         api = opentrons.hardware_control.API
-        hardware = opentrons.hardware_control.adapters.SynchronousAdapter.build(
+        adapter = opentrons.hardware_control.adapters
+        hardware = adapter.SynchronousAdapter.build(
             api.build_hardware_controller)
         driver = hardware._backend._smoothie_driver
     else:

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -360,7 +360,6 @@ async def test_jog_calibrate_bottom_v2(
 
 @pytest.mark.api1_only
 async def test_jog_calibrate_bottom_v1(
-        dummy_db,
         main_router,
         model,
         calibrate_bottom_flag):
@@ -413,7 +412,6 @@ async def test_jog_calibrate_bottom_v1(
 
 @pytest.mark.api2_only
 async def test_jog_calibrate_top_v2(
-        dummy_db,
         main_router,
         model):
 
@@ -437,7 +435,6 @@ async def test_jog_calibrate_top_v2(
 
 @pytest.mark.api1_only
 async def test_jog_calibrate_top(
-        dummy_db,
         main_router,
         model,
         monkeypatch):

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -226,8 +226,8 @@ async def test_home_api1(main_router, model):
 
 
 @pytest.mark.api1_only
-@pytest.mark.parametrize('labware', ['trough-1row-25ml'])
-async def test_move_to_top_api1_1well(main_router, model, labware):
+@pytest.mark.parametrize('labware_name', ['trough-1row-25ml'])
+async def test_move_to_top_api1_1well(main_router, model, labware_name):
     with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
         main_router.calibration_manager.move_to(
             model.instrument,

--- a/api/tests/opentrons/commands/test_description.py
+++ b/api/tests/opentrons/commands/test_description.py
@@ -13,6 +13,7 @@ def containers():
     }
 
 
+@pytest.mark.api1_only
 def test_all(containers):
     assert stringify_location(containers['1'][0]) == 'well A1 in "1"'
     assert stringify_location(containers['1'].rows(0)) == \

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -236,10 +236,7 @@ async def dc_session(request, async_server, monkeypatch, loop):
     ses = endpoints.SessionManager(hw)
     endpoints.session = ses
     monkeypatch.setattr(endpoints, 'session', ses)
-    # try:
     yield ses
-    # finally:
-    #     endpoints.session = None
 
 
 @pytest.mark.apiv1
@@ -458,17 +455,11 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
             return result
 
 
-@pytest.fixture(
-    params=[
-        pytest.param(using_api1, marks=pytest.mark.apiv1),
-        pytest.param(using_sync_api2, marks=pytest.mark.apiv2)])
+@pytest.fixture
 def model(robot, hardware, loop, request):
     # Use with pytest.mark.parametrize(’labware’, [some-labware-name])
     # to have a different labware loaded as .container. If not passed,
     # defaults to the version-appropriate way to do 96 flat
-    from opentrons.legacy_api.containers import load
-    from opentrons.legacy_api.instruments.pipette import Pipette
-
     try:
         lw_name = request.getfixturevalue('labware_name')
     except Exception:
@@ -485,6 +476,8 @@ def model(robot, hardware, loop, request):
         rob = hardware
         container = models.Container(plate, context=ctx)
     else:
+        from opentrons.legacy_api.containers import load
+        from opentrons.legacy_api.instruments.pipette import Pipette
         pipette = Pipette(robot,
                           ul_per_mm=18.5, max_volume=300, mount='right')
         plate = load(robot, lw_name or '96-flat', '1')

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -85,7 +85,7 @@ def config_tempdir(tmpdir):
 
 
 @pytest.fixture(autouse=True)
-def clear_feature_flags(config_tempdir):
+def clear_feature_flags():
     ff_file = config.CONFIG['feature_flags_file']
     if os.path.exists(ff_file):
         os.remove(ff_file)
@@ -95,7 +95,7 @@ def clear_feature_flags(config_tempdir):
 
 
 @pytest.fixture
-def wifi_keys_tempdir(config_tempdir):
+def wifi_keys_tempdir():
     old_wifi_keys = config.CONFIG['wifi_keys_dir']
     with tempfile.TemporaryDirectory() as td:
         config.CONFIG['wifi_keys_dir'] = pathlib.Path(td)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -189,14 +189,12 @@ def using_api1(loop):
     oldenv = os.environ.get('OT_API_FF_useProtocolApi2')
     if oldenv:
         os.environ.pop('OT_API_FF_useProtocolApi2')
-    opentrons.reset_globals()
     try:
-        yield opentrons.hardware
+        yield opentrons.robot
     finally:
-        opentrons.hardware.reset()
+        opentrons.robot.reset()
         if None is not oldenv:
             os.environ['OT_API_FF_useProtocolApi2'] = oldenv
-        opentrons.reset_globals()
         opentrons.robot.config = config.robot_configs.load()
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -458,7 +458,10 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
             return result
 
 
-@pytest.fixture
+@pytest.fixture(
+    params=[
+        pytest.param(using_api1, marks=pytest.mark.apiv1),
+        pytest.param(using_sync_api2, marks=pytest.mark.apiv2)])
 def model(robot, hardware, loop, request):
     # Use with pytest.mark.parametrize(’labware’, [some-labware-name])
     # to have a different labware loaded as .container. If not passed,

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -22,6 +22,7 @@ from opentrons.api import models
 from opentrons.data_storage import database
 from opentrons.server import rpc
 from opentrons import config, types
+from opentrons.config import feature_flags as ff
 from opentrons.server import init
 from opentrons.deck_calibration import endpoints
 from opentrons import hardware_control as hc
@@ -200,12 +201,12 @@ def using_api1(loop):
 
 def _should_skip_api1(request):
     return request.node.get_closest_marker('api1_only')\
-        and request.param != using_api1
+        and request.param != using_api1 or ff.use_protocol_api_v2()
 
 
 def _should_skip_api2(request):
     return request.node.get_closest_marker('api2_only')\
-        and request.param != using_api2
+        and request.param != using_api2 or not ff.use_protocol_api_v2()
 
 
 @pytest.fixture(params=[using_api1, using_api2])

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -72,13 +72,7 @@ def log_by_axis(log, axis):
     return reduce(reducer, log, {axis: [] for axis in axis})
 
 
-def print_db_path(db):
-    cursor = database.db_conn.cursor()
-    cursor.execute("PRAGMA database_list")
-    db_info = cursor.fetchone()
-    print("Database: ", db_info[2])
-
-
+@pytest.mark.apiv1
 @pytest.fixture
 def config_tempdir(tmpdir):
     os.environ['OT_API_CONFIG_DIR'] = str(tmpdir)
@@ -110,6 +104,7 @@ def wifi_keys_tempdir(config_tempdir):
 
 
 # Builds a temp db to allow mutations during testing
+@pytest.mark.apiv1
 @pytest.fixture(autouse=True)
 def dummy_db(config_tempdir):
     _, old_db_path = config_tempdir

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -21,6 +21,7 @@ from tests.opentrons import generate_plate
 # TODO: Modify calls that expect Deck and Slot to be Placeables
 
 
+@pytest.mark.api1_only
 def test_load_same_slot_force(robot):
     container_name = '96-flat'
     slot = '1'
@@ -48,6 +49,7 @@ def test_load_same_slot_force(robot):
     assert len(robot.get_containers()) == 4
 
 
+@pytest.mark.api1_only
 def test_load_legacy_slot_names(robot):
     slots_old = [
         'A1', 'B1', 'C1',
@@ -79,6 +81,7 @@ def test_load_legacy_slot_names(robot):
     warnings.filterwarnings('default')
 
 
+@pytest.mark.api1_only
 def test_new_slot_names(robot):
     trough = 'usascientific_12_reservoir_22ml'
     plate = 'corning_96_wellplate_360ul_flat'
@@ -92,6 +95,7 @@ def test_new_slot_names(robot):
     assert isinstance(cont, Container)
 
 
+@pytest.mark.api1_only
 def test_load_new_trough(robot):
     trough = 'usascientific_12_reservoir_22ml'
     cont = new_load(trough)
@@ -100,34 +104,40 @@ def test_load_new_trough(robot):
         == (13.94, 42.9 + 31.4475, 2.29)
 
 
+@pytest.mark.api1_only
 def test_load_fixed_trash(robot):
     from opentrons.config.pipette_config import Y_OFFSET_MULTI
     assert robot.fixed_trash[0]._coordinates == (
         82.84, 53.56 + Y_OFFSET_MULTI, 82)
 
 
+@pytest.mark.api1_only
 def test_containers_list(robot):
     res = containers_list()
     assert res
 
 
+@pytest.mark.api1_only
 def test_bad_unpack_containers(robot):
     with pytest.raises(ValueError):
         unpack_location(1)
 
 
+@pytest.mark.api1_only
 def test_iterate_without_parent(robot):
     c = generate_plate(4, 2, (5, 5), (0, 0), 5)
     with pytest.raises(Exception):
         next(c)
 
 
+@pytest.mark.api1_only
 def test_back_container_getitem(robot):
     c = generate_plate(4, 2, (5, 5), (0, 0), 5)
     with pytest.raises(TypeError):
         c.__getitem__((1, 1))
 
 
+@pytest.mark.api1_only
 def test_iterator(robot):
     c = generate_plate(4, 2, (5, 5), (0, 0), 5)
     res = [well.coordinates() for well in c]
@@ -135,6 +145,7 @@ def test_iterator(robot):
     assert res == expected
 
 
+@pytest.mark.api1_only
 def test_next(robot):
     c = generate_plate(4, 2, (5, 5), (0, 0), 5)
     well = c['A1']
@@ -143,6 +154,7 @@ def test_next(robot):
     assert next(well) == expected
 
 
+@pytest.mark.api1_only
 def test_int_index(robot):
     c = generate_plate(4, 2, (5, 5), (0, 0), 5)
 
@@ -150,6 +162,7 @@ def test_int_index(robot):
     assert c[1] == c.get_child_by_name('B1')
 
 
+@pytest.mark.api1_only
 def test_named_well(robot):
     deck = Deck()
     slot = Slot()
@@ -164,6 +177,7 @@ def test_named_well(robot):
     assert deck['A1'][0]['Red'] == red
 
 
+@pytest.mark.api1_only
 def test_generate_plate(robot):
     c = generate_plate(
         wells=96,
@@ -177,6 +191,7 @@ def test_generate_plate(robot):
     assert c['B2'].coordinates() == (15, 30, 0)
 
 
+@pytest.mark.api1_only
 def test_coordinates(robot):
     deck = Deck()
     slot = Slot()
@@ -193,6 +208,7 @@ def test_coordinates(robot):
     assert plate['A1'].coordinates(deck) == (105, 215, 0)
 
 
+@pytest.mark.api1_only
 def test_get_name(robot):
     deck = Deck()
     slot = Slot()
@@ -207,6 +223,7 @@ def test_get_name(robot):
     assert red.get_name() == 'Red'
 
 
+@pytest.mark.api1_only
 def test_well_from_center(robot):
     deck = Deck()
     slot = Slot()

--- a/api/tests/opentrons/containers/test_default_containers.py
+++ b/api/tests/opentrons/containers/test_default_containers.py
@@ -31,9 +31,7 @@ def test_new_containers(robot, instruments):
 def test_fixed_trash(robot, instruments):
     robot.reset()
     p300 = instruments.P300_Single(mount='right')
-    print(pose_tracker.absolute(robot.poses, p300))
     p300.move_to(p300.trash_container)
-    print(pose_tracker.absolute(robot.poses, p300))
     assert isclose(
             pose_tracker.absolute(robot.poses, p300),
             (355.0, 361.43, 85.0)).all()

--- a/api/tests/opentrons/containers/test_default_containers.py
+++ b/api/tests/opentrons/containers/test_default_containers.py
@@ -1,12 +1,14 @@
+import pytest
+
 from opentrons.legacy_api.containers import load as containers_load
-from opentrons import instruments, robot
 from opentrons.trackers import pose_tracker
 from numpy import isclose
-import pytest
+
 # TODO: Remove in favor of a minimum membership test on `labware.list`
 
 
-def test_new_containers():
+@pytest.mark.api1_only
+def test_new_containers(robot, instruments):
     robot.reset()
     trash_box = containers_load(robot, 'trash-box', '1')
     tip_rack = containers_load(robot, 'tiprack-200ul', '3')
@@ -26,7 +28,7 @@ def test_new_containers():
 
 
 @pytest.mark.xfail
-def test_fixed_trash():
+def test_fixed_trash(robot, instruments):
     robot.reset()
     p300 = instruments.P300_Single(mount='right')
     print(pose_tracker.absolute(robot.poses, p300))

--- a/api/tests/opentrons/containers/test_grid.py
+++ b/api/tests/opentrons/containers/test_grid.py
@@ -10,6 +10,7 @@ def plate(robot):
     return load(robot, '96-flat', '4')
 
 
+@pytest.mark.api1_only
 def test_rows_cols(plate):
     wells = [
         plate.rows[1]['2'],
@@ -27,6 +28,7 @@ def test_rows_cols(plate):
         assert well == next_well
 
 
+@pytest.mark.api1_only
 def test_serial_dilution(robot):
     plate = load(
         robot,

--- a/api/tests/opentrons/containers/test_labware_fns.py
+++ b/api/tests/opentrons/containers/test_labware_fns.py
@@ -1,8 +1,9 @@
-from opentrons import labware
 # TODO: Revise to match new schemas and use json-schema validation in test
+import pytest
 
 
-def test_labware_create(dummy_db):
+@pytest.mark.api1_only
+def test_labware_create(labware):
     n_cols = 6
     n_rows = 4
     x_dist = 19.6

--- a/api/tests/opentrons/database/test_database.py
+++ b/api/tests/opentrons/database/test_database.py
@@ -4,13 +4,12 @@ from opentrons.legacy_api.containers import load as containers_load
 from opentrons.legacy_api.containers.placeable import Well, Container
 from opentrons.data_storage import database
 from opentrons.util.vector import Vector
-from opentrons import robot
 # TODO: Modify all calls to get a Well to use the `wells` method
 # TODO: Revise for new data (top-center) and add json-schema check
 
 
 @pytest.mark.xfail
-def test_container_from_container_load():
+def test_container_from_container_load(robot):
     robot.reset()
     plate = containers_load(robot, '96-flat', '1')
     actual = plate._coordinates
@@ -19,7 +18,8 @@ def test_container_from_container_load():
     assert actual == expected
 
 
-def test_well_from_container_load():
+@pytest.mark.api1_only
+def test_well_from_container_load(robot):
     robot.reset()
     plate = containers_load(robot, '96-flat', '1')
     assert plate[3].top()[1] == Vector(3.20, 3.20, 10.50)
@@ -32,7 +32,7 @@ def test_well_from_container_load():
 
 
 @pytest.mark.xfail
-def test_container_parse():
+def test_container_parse(robot):
     robot.reset()
     plate = containers_load(robot, '96-flat', '1')
     expected = {'x': 14.34, 'y': 11.24, 'z': 10.50}
@@ -40,7 +40,7 @@ def test_container_parse():
 
 
 @pytest.mark.xfail
-def test_load_persisted_container():
+def test_load_persisted_container(robot):
     plate = database.load_container("96-flat")
     assert isinstance(plate, Container)
     assert isinstance(plate, Container)
@@ -55,7 +55,8 @@ def test_load_persisted_container():
     assert plate['D6'].coordinates() == well_d6
 
 
-def test_invalid_container_name():
+@pytest.mark.api1_only
+def test_invalid_container_name(robot):
     error_type = ValueError
     with pytest.raises(error_type):
         database.load_container("fake_container")

--- a/api/tests/opentrons/database/test_labware_definitions.py
+++ b/api/tests/opentrons/database/test_labware_definitions.py
@@ -3,11 +3,14 @@
 # TODO: Modify calibration file shape to fit new design
 import os
 
+import pytest
+
 from opentrons.data_storage import database
 
 file_dir = os.path.abspath(os.path.dirname(__file__))
 
 
+@pytest.mark.api1_only
 def test_labware_create(dummy_db):
     from opentrons import labware
     lw_name = '15-well-plate'

--- a/api/tests/opentrons/database/test_labware_definitions.py
+++ b/api/tests/opentrons/database/test_labware_definitions.py
@@ -11,7 +11,7 @@ file_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 @pytest.mark.api1_only
-def test_labware_create(dummy_db):
+def test_labware_create():
     from opentrons import labware
     lw_name = '15-well-plate'
     if lw_name in labware.list():

--- a/api/tests/opentrons/drivers/rpi_drivers/test_gpio.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_gpio.py
@@ -35,9 +35,7 @@ def test_init_sequence(monkeypatch):
         (gpio.INPUT_PINS['WINDOW_INPUT'], "{}/export".format(gpio._path_prefix)),                           # NOQA
         (gpio.IN, "{0}/gpio{1}/direction".format(gpio._path_prefix, gpio.INPUT_PINS['WINDOW_INPUT']))       # NOQA
     ]
-    # from pprint import pprint
-    # pprint(init_log)
-    # pprint(expected_log)
+
     assert init_log == expected_log
 
 

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -253,8 +253,6 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M114.2'],
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
     command_log = []
 
@@ -263,8 +261,6 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+'],
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
     command_log = []
 
@@ -275,8 +271,6 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005'],
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
     command_log = []
 
@@ -295,8 +289,6 @@ def test_plunger_commands(smoothie, monkeypatch):
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005'],
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 
@@ -345,8 +337,6 @@ def test_set_active_current(smoothie, monkeypatch):
         ['M114.2'],  # update the position
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 
@@ -408,8 +398,6 @@ def test_set_acceleration(smoothie, monkeypatch):
         ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
         ['M400'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 
@@ -833,8 +821,6 @@ def test_speed_change(robot, instruments, monkeypatch):
         ['G0F2400'],  # pipette's default dispense speed in mm/min
         ['G0F24000'],
     ]
-    # from pprint import pprint
-    # pprint(command_log)
     fuzzy_assert(result=command_log, expected=expected)
 
 
@@ -990,8 +976,6 @@ def test_unstick_axes(robot, smoothie):
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',  # low current C
         'M203.1 A125 B40 C40 X600 Y400 Z125'  # reset max-speeds
     ]
-    # from pprint import pprint
-    # pprint(current_log)
     assert current_log == expected
 
     def send_command_mock(self, command, timeout=None):

--- a/api/tests/opentrons/hardware_control/test_socket_server.py
+++ b/api/tests/opentrons/hardware_control/test_socket_server.py
@@ -237,7 +237,7 @@ async def test_complex_method(hc_stream_server, loop, monkeypatch):
         (Optional[CriticalPoint], CriticalPoint.NOZZLE, 'NOZZLE'),
     ]
 )
-def test_serializers(paramtype, native, serializable, config_tempdir):
+def test_serializers(paramtype, native, serializable):
     assert paramtype in sockserv._SERDES
     serdes = sockserv._SERDES[paramtype]
     assert serdes.serializer(native) == serializable

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -5,6 +5,7 @@ from tests.opentrons.conftest import state, log_by_axis
 from numpy import isclose, subtract
 from opentrons.trackers import pose_tracker
 
+
 @pytest.mark.api1_only
 @pytest.fixture
 def smoke(robot):

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -1,14 +1,13 @@
 import pytest
 
-from opentrons import robot
 from tests.opentrons.conftest import state, log_by_axis
 
 from numpy import isclose, subtract
 from opentrons.trackers import pose_tracker
 
-
+@pytest.mark.api1_only
 @pytest.fixture
-def smoke():
+def smoke(robot):
     robot.connect()
     robot.reset()
     robot.home()
@@ -16,7 +15,8 @@ def smoke():
     from tests.opentrons.data import smoke  # NOQA
 
 
-def test_smoke(virtual_smoothie_env, smoke):
+@pytest.mark.api1_only
+def test_smoke(virtual_smoothie_env, smoke, robot):
     by_axis = log_by_axis(robot._driver.log, 'XYA')
     coords = [
         (x, y, z)
@@ -28,7 +28,8 @@ def test_smoke(virtual_smoothie_env, smoke):
 
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
-async def test_multi_single(main_router, protocol, protocol_file, dummy_db):
+async def test_multi_single(
+        main_router, protocol, protocol_file, dummy_db, robot):
     robot.connect()
     robot.home()
     session = main_router.session_manager.create(
@@ -44,7 +45,7 @@ async def test_multi_single(main_router, protocol, protocol_file, dummy_db):
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(
-        main_router, protocol, protocol_file, dummy_db, monkeypatch):
+        main_router, protocol, protocol_file, dummy_db, monkeypatch, robot):
     import tempfile
     temp = tempfile.gettempdir()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)

--- a/api/tests/opentrons/integration/test_api.py
+++ b/api/tests/opentrons/integration/test_api.py
@@ -30,7 +30,7 @@ def test_smoke(virtual_smoothie_env, smoke, robot):
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_multi_single(
-        main_router, protocol, protocol_file, dummy_db, robot):
+        main_router, protocol, protocol_file, robot):
     robot.connect()
     robot.home()
     session = main_router.session_manager.create(
@@ -46,7 +46,7 @@ async def test_multi_single(
 @pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['multi-single.py'])
 async def test_load_jog_save_run(
-        main_router, protocol, protocol_file, dummy_db, monkeypatch, robot):
+        main_router, protocol, protocol_file, monkeypatch, robot):
     import tempfile
     temp = tempfile.gettempdir()
     monkeypatch.setenv('USER_DEFN_ROOT', temp)

--- a/api/tests/opentrons/integration/test_protocol.py
+++ b/api/tests/opentrons/integration/test_protocol.py
@@ -1,9 +1,12 @@
+import pytest
+
 from opentrons.legacy_api.containers import load as containers_load
 from opentrons.legacy_api.containers.placeable import Container, Deck
 from opentrons.legacy_api.instruments import pipette
 # TODO: Modify all calls to get a Well to use the `wells` method
 
 
+@pytest.mark.api1_only
 def test_protocol_container_setup(robot):
     plate = containers_load(robot, '96-flat', '1', 'myPlate')
     tiprack = containers_load(robot, 'tiprack-10ul', '5')
@@ -17,6 +20,7 @@ def test_protocol_container_setup(robot):
     assert tiprack in containers_list
 
 
+@pytest.mark.api1_only
 def test_protocol_head(robot):
     trash = containers_load(robot, 'point', '1', 'myTrash')
     tiprack = containers_load(robot, 'tiprack-10ul', '5')
@@ -38,6 +42,7 @@ def test_protocol_head(robot):
     assert instruments_list[0] == ('left', p200)
 
 
+@pytest.mark.api1_only
 def test_deck_setup(robot):
     deck = robot.deck
 

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -422,7 +422,7 @@ def test_delay_calls(monkeypatch, instruments):
 
 
 @pytest.mark.xfail
-def test_drop_tip_in_trash(virtual_smoothie_env, monkeypatch):
+def test_drop_tip_in_trash(virtual_smoothie_env, monkeypatch, instruments):
     from opentrons import robot, labware
     from opentrons.legacy_api.instruments.pipette import Pipette
     robot.reset()

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -4,14 +4,13 @@ from numpy import isclose
 from unittest import mock
 import pytest
 
-from opentrons import instruments, robot
 from opentrons.legacy_api.containers import load as containers_load
 from opentrons.config import pipette_config
 from opentrons.trackers import pose_tracker
 
 
 @pytest.mark.api1_only
-def test_use_filter_tips():
+def test_use_filter_tips(instruments, robot):
     # test tips with lower working volume than max volume of pipette used to
     # ensure that the pipette never over-aspirates with a smaller pipette tip
     tipracks = [
@@ -42,7 +41,7 @@ def test_use_filter_tips():
 
 
 @pytest.mark.api1_only
-def test_shake_during_pick_up(monkeypatch):
+def test_shake_during_pick_up(monkeypatch, robot, instruments):
     robot.reset()
     pip = instruments._create_pipette_from_config(
             config=pipette_config.load('p1000_single_v2.0'),
@@ -76,7 +75,7 @@ def test_shake_during_pick_up(monkeypatch):
 
 
 @pytest.mark.api1_only
-def test_shake_during_drop(monkeypatch):
+def test_shake_during_drop(monkeypatch, robot, instruments):
     robot.reset()
     pip = instruments._create_pipette_from_config(
             config=pipette_config.load('p1000_single_v1.5'),
@@ -135,7 +134,8 @@ def test_shake_during_drop(monkeypatch):
     pip.tip_attached = False
 
 
-def test_pipette_version_1_0_and_1_3_extended_travel():
+@pytest.mark.api1_only
+def test_pipette_version_1_0_and_1_3_extended_travel(robot, instruments):
     models = [
         'p10_single', 'p10_multi', 'p50_single', 'p50_multi',
         'p300_single', 'p300_multi', 'p1000_single'
@@ -164,7 +164,8 @@ def test_pipette_version_1_0_and_1_3_extended_travel():
         assert right_diff > left_diff
 
 
-def test_all_pipette_models_can_transfer():
+@pytest.mark.api1_only
+def test_all_pipette_models_can_transfer(robot, instruments):
     from opentrons.config import pipette_config
 
     models = [
@@ -191,7 +192,8 @@ def test_all_pipette_models_can_transfer():
         right.aspirate().dispense()
 
 
-def test_pipette_models_reach_max_volume():
+@pytest.mark.api1_only
+def test_pipette_models_reach_max_volume(robot, instruments):
 
     for model in pipette_config.config_models:
         config = pipette_config.load(model)
@@ -209,7 +211,8 @@ def test_pipette_models_reach_max_volume():
         assert pos[0] < pipette.plunger_positions['top']
 
 
-def test_flow_rate():
+@pytest.mark.api1_only
+def test_flow_rate(robot, instruments):
     # Test new flow-rate functionality on all pipettes with different max vols
     robot.reset()
     p10 = instruments.P10_Single(mount='right')
@@ -264,7 +267,8 @@ def test_flow_rate():
     assert p1000.speeds['dispense'] == expected_mm_per_sec
 
 
-def test_pipette_max_deck_height():
+@pytest.mark.api1_only
+def test_pipette_max_deck_height(robot, instruments):
     robot.reset()
     tallest_point = robot._driver.homed_position['Z']
     p = instruments.P300_Single(mount='left')
@@ -277,8 +281,9 @@ def test_pipette_max_deck_height():
         p._remove_tip(length=tip_length)
 
 
-def test_retract():
-    robot.reset()
+@pytest.mark.api1_only
+def test_retract(robot, instruments):
+    # robot.reset()
     plate = containers_load(robot, '96-flat', '1')
     p300 = instruments.P300_Single(mount='left')
     from opentrons.drivers.smoothie_drivers.driver_3_0 import HOMED_POSITION
@@ -300,7 +305,8 @@ def test_retract():
     assert current_pos[2] == HOMED_POSITION['A']
 
 
-def test_aspirate_move_to(old_aspiration):
+@pytest.mark.api1_only
+def test_aspirate_move_to(old_aspiration, robot, instruments):
     # TODO: it seems like this test is checking that the aspirate point is
     # TODO: *fully* at the bottom of the well, which isn't the expected
     # TODO: behavior of aspirate when a location is not specified. This should
@@ -332,7 +338,8 @@ def test_aspirate_move_to(old_aspiration):
     assert isclose(current_pos, (161,  116.7,   10.5)).all()
 
 
-def test_dispense_move_to(old_aspiration):
+@pytest.mark.api1_only
+def test_dispense_move_to(old_aspiration, robot, instruments):
     # TODO: same as for aspirate
     robot.reset()
     tip_rack = containers_load(robot, 'tiprack-200ul', '3')
@@ -361,7 +368,8 @@ def test_dispense_move_to(old_aspiration):
     assert isclose(current_pos, (161,  116.7,   10.5)).all()
 
 
-def test_trough_move_to():
+@pytest.mark.api1_only
+def test_trough_move_to(robot, instruments):
     # TODO: new labware system should center multichannel pipettes within wells
     # TODO: (correct single-channel position currently corresponds to back-
     # TODO: most tip of multi-channel), so calculate against that
@@ -378,7 +386,8 @@ def test_trough_move_to():
     assert isclose(current_pos, (0, 0, 38)).all()
 
 
-def test_delay_calls(monkeypatch):
+@pytest.mark.api1_only
+def test_delay_calls(monkeypatch, instruments):
     from opentrons import robot
     from opentrons.legacy_api.instruments import pipette
     robot.reset()

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -40,12 +40,14 @@ def local_test_pipette(robot):
     return trash, tiprack1, tiprack2, plate, p200
 
 
+@pytest.mark.api1_only
 def test_bad_volume_percentage(local_test_pipette):
     _, _1, _2, _3, p200 = local_test_pipette
     with pytest.raises(RuntimeError):
         p200._volume_percentage(-1)
 
 
+@pytest.mark.api1_only
 def test_add_instrument(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     robot.reset()
@@ -57,6 +59,7 @@ def test_add_instrument(local_test_pipette, robot):
                 ul_per_mm=10)
 
 
+@pytest.mark.api1_only
 def test_aspirate_zero_volume(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     assert robot.commands() == []
@@ -65,6 +68,7 @@ def test_aspirate_zero_volume(local_test_pipette, robot):
     assert robot.commands() == ['Aspirating 0 uL from ? at 1.0 speed']  # noqa
 
 
+@pytest.mark.api1_only
 def test_get_plunger_position(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     assert p200._get_plunger_position('top') == 0
@@ -80,6 +84,7 @@ def test_get_plunger_position(local_test_pipette, robot):
         p200._get_plunger_position('roll_out')
 
 
+@pytest.mark.api1_only
 def test_deprecated_axis_call(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     import warnings
@@ -96,6 +101,7 @@ def test_deprecated_axis_call(local_test_pipette, robot):
     warnings.filterwarnings('default')
 
 
+@pytest.mark.api1_only
 def test_get_instruments_by_name(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p1000 = Pipette(
@@ -115,6 +121,7 @@ def test_get_instruments_by_name(local_test_pipette, robot):
     assert result == [('right', p1000)]
 
 
+@pytest.mark.api1_only
 def test_placeables_reference(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.tip_attached = True
@@ -132,6 +139,7 @@ def test_placeables_reference(local_test_pipette):
     assert p200.placeables == expected
 
 
+@pytest.mark.api1_only
 def test_unpack_location(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     # TODO: remove when new labware system is promoted to production (it
@@ -144,6 +152,7 @@ def test_unpack_location(local_test_pipette):
     assert res == (plate[0], plate[0].from_center(x=0, y=0, z=1))
 
 
+@pytest.mark.api1_only
 def test_aspirate_invalid_max_volume(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.tip_attached = True
@@ -151,6 +160,7 @@ def test_aspirate_invalid_max_volume(local_test_pipette):
         p200.aspirate(500)
 
 
+@pytest.mark.api1_only
 def test_volume_percentage(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     with pytest.raises(RuntimeError):
@@ -163,6 +173,7 @@ def test_volume_percentage(local_test_pipette, robot):
     assert len(robot.get_warnings()) == 1
 
 
+@pytest.mark.api1_only
 def test_add_tip(local_test_pipette, robot):
     """
     This deals with z accrual behavior during tip add/remove, when +/- get
@@ -177,6 +188,7 @@ def test_add_tip(local_test_pipette, robot):
     assert (new_position == prior_position).all()
 
 
+@pytest.mark.api1_only
 def test_set_speed(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.set_speed(aspirate=100)
@@ -186,6 +198,7 @@ def test_set_speed(local_test_pipette):
     assert p200.speeds['dispense'] == 100
 
 
+@pytest.mark.api1_only
 def test_distribute(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -297,6 +310,7 @@ def test_distribute(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_consolidate(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -401,6 +415,7 @@ def test_consolidate(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_transfer(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -504,6 +519,7 @@ def test_transfer(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_bad_transfer(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -521,6 +537,7 @@ def test_bad_transfer(local_test_pipette):
         p200.transfer(30, plate[0], plate[1], new_tip='sometimes')
 
 
+@pytest.mark.api1_only
 def test_divisible_locations(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -596,6 +613,7 @@ def test_divisible_locations(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_transfer_mix(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -625,6 +643,7 @@ def test_transfer_mix(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_transfer_air_gap(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -649,6 +668,7 @@ def test_transfer_air_gap(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_consolidate_air_gap(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -672,6 +692,7 @@ def test_consolidate_air_gap(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_distribute_air_gap(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -701,6 +722,7 @@ def test_distribute_air_gap(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_distribute_air_gap_and_disposal_vol(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -733,6 +755,7 @@ def test_distribute_air_gap_and_disposal_vol(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_consolidate_mix(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -765,6 +788,7 @@ def test_consolidate_mix(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_distribute_mix(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -797,6 +821,7 @@ def test_distribute_mix(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_transfer_multichannel(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -823,6 +848,7 @@ def test_transfer_multichannel(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_transfer_single_channel(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.reset()
@@ -882,6 +908,7 @@ def test_transfer_single_channel(local_test_pipette, robot):
     robot.clear_commands()
 
 
+@pytest.mark.api1_only
 def test_touch_tip(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.pick_up_tip()
@@ -951,6 +978,7 @@ def test_touch_tip(local_test_pipette):
     assert expected == p200.robot.move_to.mock_calls
 
 
+@pytest.mark.api1_only
 def test_mix(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     # It is necessary to aspirate before it is mocked out
@@ -975,6 +1003,7 @@ def test_mix(local_test_pipette):
     assert p200.aspirate.mock_calls == aspirate_expected
 
 
+@pytest.mark.api1_only
 def test_air_gap(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.pick_up_tip()
@@ -998,12 +1027,14 @@ def test_air_gap(local_test_pipette):
     assert p200.current_volume == 50
 
 
+@pytest.mark.api1_only
 def test_pipette_home(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.home()
     assert len(robot.commands()) == 1
 
 
+@pytest.mark.api1_only
 def test_mix_with_named_args(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.current_volume = 100
@@ -1029,6 +1060,7 @@ def test_mix_with_named_args(local_test_pipette):
         ]
 
 
+@pytest.mark.api1_only
 def test_tip_tracking_simple(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.move_to = mock.Mock()
@@ -1041,6 +1073,7 @@ def test_tip_tracking_simple(local_test_pipette):
         build_pick_up_tip(p200, tiprack1[1])
 
 
+@pytest.mark.api1_only
 def test_simulate_plunger_while_enqueing(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
 
@@ -1065,6 +1098,7 @@ def test_simulate_plunger_while_enqueing(local_test_pipette):
     p200.drop_tip()
 
 
+@pytest.mark.api1_only
 def test_tip_tracking_chain(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     # TODO (ben 20171130): revise this test to make more sense in the
@@ -1115,6 +1149,7 @@ def test_tip_tracking_chain(local_test_pipette, robot):
         p200.pick_up_tip()
 
 
+@pytest.mark.api1_only
 def test_tip_tracking_chain_multi_channel(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     # TODO (ben 20171130): revise this test to make more sense in the
@@ -1150,6 +1185,7 @@ def test_tip_tracking_chain_multi_channel(local_test_pipette, robot):
     assert p200_multi.move_to.mock_calls == expected
 
 
+@pytest.mark.api1_only
 def test_tip_tracking_start_at_tip(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.start_at_tip(tiprack1['B2'])
@@ -1157,6 +1193,7 @@ def test_tip_tracking_start_at_tip(local_test_pipette):
     assert tiprack1['B2'] == p200.current_tip()
 
 
+@pytest.mark.api1_only
 def test_tip_tracking_return(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     # Note: because this test mocks out `drop_tip`, as a side-effect
@@ -1180,6 +1217,7 @@ def test_tip_tracking_return(local_test_pipette):
     assert p200.drop_tip.mock_calls == expected
 
 
+@pytest.mark.api1_only
 def test_direct_movement_within_well(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     robot.move_to = mock.Mock()
@@ -1207,6 +1245,7 @@ def test_direct_movement_within_well(local_test_pipette, robot):
     assert robot.move_to.mock_calls == expected
 
 
+@pytest.mark.api1_only
 def build_pick_up_tip(pipette, well):
     return [
         mock.call(well.top()),

--- a/api/tests/opentrons/labware/test_pipette_unittest.py
+++ b/api/tests/opentrons/labware/test_pipette_unittest.py
@@ -912,6 +912,7 @@ def test_transfer_single_channel(local_test_pipette, robot):
 def test_touch_tip(local_test_pipette):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
     p200.pick_up_tip()
+    old_move = p200.robot.move_to
     p200.robot.move_to = mock.Mock()
     p200.touch_tip(plate[0])
     p200.touch_tip(v_offset=-3)
@@ -976,6 +977,7 @@ def test_touch_tip(local_test_pipette):
     ]
 
     assert expected == p200.robot.move_to.mock_calls
+    p200.robot.move_to = old_move
 
 
 @pytest.mark.api1_only
@@ -1220,6 +1222,7 @@ def test_tip_tracking_return(local_test_pipette):
 @pytest.mark.api1_only
 def test_direct_movement_within_well(local_test_pipette, robot):
     trash, tiprack1, tiprack2, plate, p200 = local_test_pipette
+    old_move = robot.move_to
     robot.move_to = mock.Mock()
     p200.move_to(plate[0])
     p200.move_to(plate[0].top())
@@ -1243,6 +1246,7 @@ def test_direct_movement_within_well(local_test_pipette, robot):
             plate[2].bottom(), instrument=p200, strategy='direct')
     ]
     assert robot.move_to.mock_calls == expected
+    robot.move_to = old_move
 
 
 @pytest.mark.api1_only

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -4,7 +4,8 @@ from opentrons.protocol_api import back_compat, ProtocolContext
 from opentrons.types import Mount
 
 
-def test_add_instrument(loop, monkeypatch):
+@pytest.mark.api2_only
+def test_add_instrument(loop, monkeypatch, singletons):
     requested_instr, requested_mount = None, None
 
     def fake_load(instr_name, mount):
@@ -13,36 +14,38 @@ def test_add_instrument(loop, monkeypatch):
         requested_instr = instr_name
         requested_mount = mount
 
-    monkeypatch.setattr(back_compat.instruments._ctx,
+    instruments = singletons['instruments']
+    monkeypatch.setattr(instruments._ctx,
                         'load_instrument', fake_load)
 
-    back_compat.instruments.P1000_Single('left')
+    instruments.P1000_Single('left')
     assert requested_instr == 'p1000_single'
     assert requested_mount == Mount.LEFT
-    back_compat.instruments.P10_Single('right')
+    instruments.P10_Single('right')
     assert requested_instr == 'p10_single'
     assert requested_mount == Mount.RIGHT
-    back_compat.instruments.P10_Multi('left')
+    instruments.P10_Multi('left')
     assert requested_instr == 'p10_multi'
     assert requested_mount == Mount.LEFT
-    back_compat.instruments.P50_Single('right')
+    instruments.P50_Single('right')
     assert requested_instr == 'p50_single'
     assert requested_mount == Mount.RIGHT
-    back_compat.instruments.P50_Multi('left')
+    instruments.P50_Multi('left')
     assert requested_instr == 'p50_multi'
     assert requested_mount == Mount.LEFT
-    back_compat.instruments.P300_Single('right')
+    instruments.P300_Single('right')
     assert requested_instr == 'p300_single'
     assert requested_mount == Mount.RIGHT
-    back_compat.instruments.P300_Multi('left')
+    instruments.P300_Multi('left')
     assert requested_instr == 'p300_multi'
     assert requested_mount == Mount.LEFT
-    back_compat.instruments.P1000_Single('right')
+    instruments.P1000_Single('right')
     assert requested_instr == 'p1000_single'
     assert requested_mount == Mount.RIGHT
 
 
-def test_labware_mappings(loop, monkeypatch):
+@pytest.mark.api2_only
+def test_labware_mappings(loop, monkeypatch, singletons):
     lw_name, lw_label = None, None
 
     def fake_ctx_load(labware_name, location, label=None):
@@ -52,18 +55,17 @@ def test_labware_mappings(loop, monkeypatch):
         lw_label = label
         return 'heres a fake labware'
 
-    ctx = ProtocolContext(loop)
-    bc = back_compat.BCLabware(ctx)
-    monkeypatch.setattr(ctx, 'load_labware', fake_ctx_load)
-    obj = bc.load('384-plate', 2, 'hey there')
+    labware = singletons['labware']
+    monkeypatch.setattr(labware._ctx, 'load_labware', fake_ctx_load)
+    obj = labware.load('384-plate', 2, 'hey there')
     assert obj == 'heres a fake labware'
     assert lw_name == 'corning_384_wellplate_112ul_flat'
     assert lw_label == 'hey there'
 
     with pytest.raises(NotImplementedError,
                        match='Labware 24-vial-rack is not supported'):
-        bc.load('24-vial-rack', 2)
+        labware.load('24-vial-rack', 2)
 
     with pytest.raises(NotImplementedError,
                        match='Module load not yet implemented'):
-        bc.load('magdeck', 3)
+        labware.load('magdeck', 3)

--- a/api/tests/opentrons/protocol_api/test_back_compat.py
+++ b/api/tests/opentrons/protocol_api/test_back_compat.py
@@ -1,6 +1,5 @@
 import pytest
 
-from opentrons.protocol_api import back_compat, ProtocolContext
 from opentrons.types import Mount
 
 

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -2,6 +2,16 @@ import pytest
 from opentrons.protocol_api import execute, ProtocolContext
 from opentrons.protocols.parse import parse
 
+v1_protocol_testcases = [
+    ("""from opentrons import labware, instruments, robot"""),
+    ("""
+metadata = {
+    "apiLevel": '1'
+}
+import opentrons
+opentrons.robot
+    """)]
+
 
 def test_api2_runfunc():
     def noargs():
@@ -37,6 +47,12 @@ def test_execute_ok(protocol, protocol_file, ensure_api2, loop):
     proto = parse(protocol.text, protocol.filename)
     ctx = ProtocolContext(loop)
     execute.run_protocol(proto, context=ctx)
+
+
+@pytest.mark.parametrize('protocol', v1_protocol_testcases)
+def test_execute_v1_imports(protocol, ensure_api2):
+    proto = parse(protocol)
+    execute.run_protocol(proto)
 
 
 def test_bad_protocol(ensure_api2, loop):

--- a/api/tests/opentrons/robot/test_mover.py
+++ b/api/tests/opentrons/robot/test_mover.py
@@ -1,4 +1,6 @@
+import pytest
 from numpy import array, isclose
+
 from opentrons.legacy_api.instruments import Pipette
 from opentrons.legacy_api.robot.mover import Mover
 from opentrons.trackers.pose_tracker import (
@@ -8,6 +10,7 @@ from opentrons.trackers.pose_tracker import (
 # TODO: the pose_tracker
 
 
+@pytest.mark.api1_only
 def test_functional(smoothie):
     scale = array([
         [2, 0, 0, -1],
@@ -65,6 +68,7 @@ def test_functional(smoothie):
     assert isclose(change_base(state, src='right'), (3, 2, 4)).all()
 
 
+@pytest.mark.api1_only
 def test_integration(robot):
     left = Pipette(robot, mount='left', ul_per_mm=1000, max_volume=1000)
     robot.home()

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -1,16 +1,23 @@
-from opentrons.legacy_api.containers import load as containers_load
-from opentrons import robot, instruments, labware
-from opentrons.trackers import pose_tracker
-from opentrons.util import vector
+import pytest
 from numpy import isclose
 from unittest import mock
-import pytest
+
+from opentrons.legacy_api.containers import load as containers_load
+try:
+    from opentrons import robot, instruments, labware
+except ImportError:
+    pytest.mark.skip()
+from opentrons.trackers import pose_tracker
+from opentrons.util import vector
+
+
 # TODO: Modify all calls to get a Well to use the `wells` method
 # TODO: Modify calls as needed to check absolute position with refactor of
 # TODO: pose_tracker
 # TODO: Get rid of Vector
 
 
+@pytest.mark.api1_only
 def test_reset(virtual_smoothie_env):
     """
     This test may need to be expanded to include various other conditions that
@@ -31,6 +38,7 @@ def test_reset(virtual_smoothie_env):
     assert not p.tip_attached
 
 
+@pytest.mark.api1_only
 def test_configurable_mount_offsets():
     def _test_offset(x, y, z):
         robot.reset()
@@ -64,6 +72,7 @@ def test_configurable_mount_offsets():
     robot.config = old_config
 
 
+@pytest.mark.api1_only
 def test_pos_tracker_persistance(virtual_smoothie_env):
     robot.reset()
     p300 = instruments.P300_Single(mount='left')
@@ -77,6 +86,7 @@ def test_pos_tracker_persistance(virtual_smoothie_env):
     assert robot.max_placeable_height_on_deck(plate) == 10.0
 
 
+@pytest.mark.api1_only
 def test_calibrated_max_z(virtual_smoothie_env):
     robot.reset()
 
@@ -84,6 +94,7 @@ def test_calibrated_max_z(virtual_smoothie_env):
     assert robot.max_deck_height() == 82
 
 
+@pytest.mark.api1_only
 def test_get_serial_ports_list(monkeypatch):
     robot.reset()
     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
@@ -92,6 +103,7 @@ def test_get_serial_ports_list(monkeypatch):
     assert 'Virtual Smoothie' in robot.get_serial_ports_list()
 
 
+@pytest.mark.api1_only
 def test_add_container(virtual_smoothie_env):
     robot.reset()
     c1 = robot.add_container('96-flat', '1')
@@ -106,6 +118,7 @@ def test_add_container(virtual_smoothie_env):
     assert set(res) == set(expected)
 
 
+@pytest.mark.api1_only
 def test_comment(virtual_smoothie_env):
     robot.reset()
     robot.clear_commands()
@@ -113,6 +126,7 @@ def test_comment(virtual_smoothie_env):
     assert robot.commands() == ['hello']
 
 
+@pytest.mark.api1_only
 def test_create_arc(virtual_smoothie_env):
     from opentrons.legacy_api.robot.robot import (TIP_CLEARANCE_DECK,
                                                   TIP_CLEARANCE_LABWARE)
@@ -163,6 +177,7 @@ def test_create_arc(virtual_smoothie_env):
     assert res == expected
 
 
+@pytest.mark.api1_only
 def test_robot_move_to(virtual_smoothie_env):
     robot.reset()
     robot.home()
@@ -176,6 +191,7 @@ def test_robot_move_to(virtual_smoothie_env):
     ).all()
 
 
+@pytest.mark.api1_only
 def test_move_head(virtual_smoothie_env):
     robot.reset()
     robot.move_head(x=100, y=0)
@@ -206,6 +222,7 @@ def test_drop_tip_default_trash(virtual_smoothie_env):
             strategy='arc')
 
 
+@pytest.mark.api1_only
 def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
     import tempfile
     temp = tempfile.mkdtemp()
@@ -227,6 +244,7 @@ def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
     assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
 
 
+@pytest.mark.api1_only
 def test_cache_instruments(monkeypatch):
     # Test that smoothie runtime configs are set at run when
     # cache_instrument_models is called

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -1,4 +1,5 @@
 import pytest
+
 from numpy import isclose
 from unittest import mock
 
@@ -11,256 +12,257 @@ from opentrons.util import vector
 # TODO: Modify calls as needed to check absolute position with refactor of
 # TODO: pose_tracker
 # TODO: Get rid of Vector
-#
-#
-# @pytest.mark.api1_only
-# def test_reset(robot, instruments, labware):
-#     """
-#     This test may need to be expanded to include various other conditions that
-#     should be reset.
-#
-#     :param virtual_smoothie_env: pytest fixture to simulate Smoothie connection
-#     """
-#     # Not testing this one--this is needed to clean the robot singleton from
-#     # other tests. This is an inherent problem with the use of the singleton--
-#     # it entangles both runtime code and tests in unpredictable ways.
-#
-#     lw = labware.load('opentrons-tiprack-300ul', '1')
-#     p = instruments.P300_Single(mount='right', tip_racks=[lw])
-#     p.pick_up_tip()
-#     assert p.tip_attached
-#     robot.reset()
-#     assert not p.tip_attached
-#
-#
-# @pytest.mark.api1_only
-# def test_configurable_mount_offsets(robot, instruments):
-#     def _test_offset(x, y, z):
-#         robot.config = robot.config._replace(
-#             mount_offset=(x, y, z))
-#         robot.reset()
-#         left = instruments.P300_Single(mount='left')
-#         right = instruments.P300_Single(mount='right')
-#         robot.home()
-#         left_pos = pose_tracker.absolute(robot.poses, left)
-#         right_pos = pose_tracker.absolute(robot.poses, right)
-#         assert left_pos[0] == right_pos[0] + x
-#         assert left_pos[1] == right_pos[1] + y
-#         assert left_pos[2] == right_pos[2] + z
-#
-#     robot.config = robot.config._replace(
-#         instrument_offset={
-#             'right': {
-#                 'single': (0.0, 0.0, 0.0),
-#                 'multi': (0.0, 0.0, 0.0)
-#             },
-#             'left': {
-#                 'single': (0.0, 0.0, 0.0),
-#                 'multi': (0.0, 0.0, 0.0)
-#             }
-#         }
-#     )
-#     old_config = robot.config
-#     _test_offset(-34, 0, 0)
-#     _test_offset(-32, 0, 0)
-#     _test_offset(100, 3, 1.234)
-#     robot.config = old_config
-#
-#
-# @pytest.mark.api1_only
-# def test_pos_tracker_persistance(robot, instruments):
-#     p300 = instruments.P300_Single(mount='left')
-#     plate = containers_load(robot, 'trough-12row', '5')
-#     assert robot.max_placeable_height_on_deck(plate) == \
-#         plate[0].coordinates()[2]
-#
-#     robot.poses = p300._move(robot.poses, x=10, y=10, z=10)
-#     robot.calibrate_container_with_instrument(plate, p300, save=False)
-#
-#     assert robot.max_placeable_height_on_deck(plate) == 10.0
-#
-#
-# @pytest.mark.api1_only
-# def test_calibrated_max_z(robot, instruments):
-#     instruments.P300_Single(mount='left')
-#     assert robot.max_deck_height() == 82
-#
-#
-# @pytest.mark.api1_only
-# def test_get_serial_ports_list(robot, monkeypatch):
-#     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
-#     assert 'Virtual Smoothie' not in robot.get_serial_ports_list()
-#     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
-#     assert 'Virtual Smoothie' in robot.get_serial_ports_list()
-#
-#
-# @pytest.mark.api1_only
-# def test_add_container(robot):
-#     c1 = robot.add_container('96-flat', '1')
-#     trash = robot.fixed_trash
-#     res = robot.get_containers()
-#     expected = [c1, trash]
-#     assert set(res) == set(expected)
-#
-#     c2 = robot.add_container('96-flat', '4', 'my-special-plate')
-#     res = robot.get_containers()
-#     expected = [c1, c2, trash]
-#     assert set(res) == set(expected)
-#
-#
-# @pytest.mark.api1_only
-# def test_comment(robot):
-#     robot.comment('hello')
-#     assert robot.commands() == ['hello']
-#
-#
-# @pytest.mark.api1_only
-# def test_create_arc(robot, instruments):
-#     from opentrons.legacy_api.robot.robot import (TIP_CLEARANCE_DECK,
-#                                                   TIP_CLEARANCE_LABWARE)
-#
-#     p300 = instruments.P300_Single(mount='left')
-#     plate = containers_load(robot, '96-flat', '1')
-#     plate2 = containers_load(robot, '96-flat', '2')
-#
-#     new_labware_height = 10
-#     robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
-#     robot.calibrate_container_with_instrument(plate, p300, save=False)
-#
-#     trash_height = robot.max_placeable_height_on_deck(robot.fixed_trash)
-#     assert robot.max_deck_height() == trash_height
-#
-#     res = robot._create_arc(p300, (0, 0, 0), plate[0])
-#     arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
-#     expected = [
-#         {'z': arc_top},
-#         {'x': 0, 'y': 0},
-#         {'z': 0}
-#     ]
-#     assert res == expected
-#
-#     res = robot._create_arc(p300, (0, 0, 0), plate[1])
-#     arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
-#     expected = [
-#         {'z': arc_top},
-#         {'x': 0, 'y': 0},
-#         {'z': 0}
-#     ]
-#     assert res == expected
-#
-#     new_labware_height = 200
-#     robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
-#     robot.calibrate_container_with_instrument(plate2, p300, save=False)
-#
-#     assert robot.max_deck_height() == new_labware_height
-#
-#     res = robot._create_arc(p300, (0, 0, 0), plate2[0])
-#     arc_top = p300._max_deck_height()
-#     expected = [
-#         {'z': arc_top},
-#         {'x': 0, 'y': 0},
-#         {'z': 0}
-#     ]
-#     assert res == expected
-#
-#
-# @pytest.mark.api1_only
-# def test_robot_move_to(robot, instruments):
-#     robot.home()
-#     p300 = instruments.P300_Single(mount='right')
-#     robot.move_to((robot._deck, (100, 0, 0)), p300)
-#     assert isclose(
-#         pose_tracker.absolute(
-#             robot.poses,
-#             p300),
-#         (100, 0, 0)
-#     ).all()
-#
-#
-# @pytest.mark.api1_only
-# def test_move_head(robot):
-#     robot.move_head(x=100, y=0)
-#     assert isclose(
-#         pose_tracker.absolute(
-#             robot.poses,
-#             robot.gantry)[:2],
-#         (100, 0, 0)[:2]
-#     ).all()
-#
-#
-# @pytest.mark.xfail
-# def test_drop_tip_default_trash(robot, instruments):
-#     tiprack = containers_load(robot, 'tiprack-200ul', '1')
-#     pip = instruments.P300_Single(mount='right', tip_racks=[tiprack])
-#
-#     trash_loc = vector.Vector([80.00, 80.00, 80.00])
-#
-#     pip.pick_up_tip()
-#
-#     with mock.patch.object(robot, 'move_to') as move_to:  # NOQA
-#         pip.drop_tip()
-#
-#         move_to.assert_called_with(
-#             (robot.fixed_trash[0], trash_loc),
-#             instrument=pip,
-#             strategy='arc')
-#
-#
-# @pytest.mark.api1_only
-# def test_calibrate_labware(robot, instruments, labware, monkeypatch):
-#     import tempfile
-#     temp = tempfile.mkdtemp()
-#     monkeypatch.setenv('USER_DEFN_ROOT', temp)
-#
-#     plate = labware.load('96-flat', '1')
-#     pip = instruments.P300_Single(mount='right')
-#
-#     old_x, old_y, old_z = pose_tracker.absolute(robot.poses, plate[0])
-#
-#     pip.move_to(plate[0])
-#     robot.poses = pip._jog(robot.poses, 'x', 1)
-#     robot.poses = pip._jog(robot.poses, 'y', 2)
-#     robot.poses = pip._jog(robot.poses, 'z', -3)
-#     robot.calibrate_container_with_instrument(plate, pip, save=False)
-#     new_pose = pose_tracker.absolute(robot.poses, plate[0])
-#
-#     assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
-#
-#
-# @pytest.mark.api1_only
-# def test_cache_instruments(robot, monkeypatch):
-#     # Test that smoothie runtime configs are set at run when
-#     # cache_instrument_models is called
-#     fake_pip = {'left': {
-#                     'model': 'p10_single_v1.3',
-#                     'id': 'FakePip2',
-#                     'name': 'p10_single'},
-#                 'right': {
-#                     'model': 'p300_single_v2.0',
-#                     'id': 'FakePip',
-#                     'name': 'p300_single_gen2'}}
-#     monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
-#
-#     def fake_func1(value):
-#         return value
-#
-#     def fake_func2(mount, value):
-#         return mount, value
-#
-#     def fake_read(mount):
-#         return robot.model_by_mount[mount]['model']
-#     # With nothing specified at init or expected, we should have nothing
-#     robot._driver.update_steps_per_mm = mock.Mock(fake_func1)
-#     robot._driver.update_pipette_config = mock.Mock(fake_func2)
-#     monkeypatch.setattr(robot._driver, 'read_pipette_model', fake_read)
-#     robot.cache_instrument_models()
-#     steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
-#     pip_config_calls = [
-#         mock.call('Z', {'home': 220}),
-#         mock.call('A', {'home': 172.15}),
-#         mock.call('B', {'max_travel': 30}),
-#         mock.call('C', {'max_travel': 60})]
-#     robot._driver.update_steps_per_mm.assert_has_calls(
-#         steps_mm_calls, any_order=True)
-#     robot._driver.update_pipette_config.assert_has_calls(
-#         pip_config_calls, any_order=True)
+
+
+@pytest.mark.api1_only
+def test_reset(robot, instruments, labware):
+    """
+    This test may need to be expanded to include various other conditions that
+    should be reset.
+
+    :param virtual_smoothie_env: pytest fixture to simulate Smoothie connection
+    """
+    # Not testing this one--this is needed to clean the robot singleton from
+    # other tests. This is an inherent problem with the use of the singleton--
+    # it entangles both runtime code and tests in unpredictable ways.
+
+    lw = labware.load('opentrons-tiprack-300ul', '1')
+    p = instruments.P300_Single(mount='right', tip_racks=[lw])
+    p.pick_up_tip()
+    assert p.tip_attached
+    robot.reset()
+    assert not p.tip_attached
+
+
+@pytest.mark.api1_only
+def test_configurable_mount_offsets(robot, instruments):
+    def _test_offset(x, y, z):
+        robot.config = robot.config._replace(
+            mount_offset=(x, y, z))
+        robot.reset()
+        left = instruments.P300_Single(mount='left')
+        right = instruments.P300_Single(mount='right')
+        robot.home()
+        left_pos = pose_tracker.absolute(robot.poses, left)
+        right_pos = pose_tracker.absolute(robot.poses, right)
+        assert left_pos[0] == right_pos[0] + x
+        assert left_pos[1] == right_pos[1] + y
+        assert left_pos[2] == right_pos[2] + z
+
+    robot.config = robot.config._replace(
+        instrument_offset={
+            'right': {
+                'single': (0.0, 0.0, 0.0),
+                'multi': (0.0, 0.0, 0.0)
+            },
+            'left': {
+                'single': (0.0, 0.0, 0.0),
+                'multi': (0.0, 0.0, 0.0)
+            }
+        }
+    )
+    old_config = robot.config
+    _test_offset(-34, 0, 0)
+    _test_offset(-32, 0, 0)
+    _test_offset(100, 3, 1.234)
+    robot.config = old_config
+
+
+@pytest.mark.api1_only
+def test_pos_tracker_persistance(robot, instruments):
+    p300 = instruments.P300_Single(mount='left')
+    plate = containers_load(robot, 'trough-12row', '5')
+    assert robot.max_placeable_height_on_deck(plate) == \
+        plate[0].coordinates()[2]
+
+    robot.poses = p300._move(robot.poses, x=10, y=10, z=10)
+    robot.calibrate_container_with_instrument(plate, p300, save=False)
+
+    assert robot.max_placeable_height_on_deck(plate) == 10.0
+
+
+@pytest.mark.api1_only
+def test_calibrated_max_z(robot, instruments):
+    instruments.P300_Single(mount='left')
+    assert robot.max_deck_height() == 82
+
+
+@pytest.mark.api1_only
+def test_get_serial_ports_list(robot, monkeypatch):
+    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+    assert 'Virtual Smoothie' not in robot.get_serial_ports_list()
+    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
+    assert 'Virtual Smoothie' in robot.get_serial_ports_list()
+
+
+@pytest.mark.api1_only
+def test_add_container(robot):
+    c1 = robot.add_container('96-flat', '1')
+    trash = robot.fixed_trash
+    res = robot.get_containers()
+    expected = [c1, trash]
+    assert set(res) == set(expected)
+
+    c2 = robot.add_container('96-flat', '4', 'my-special-plate')
+    res = robot.get_containers()
+    expected = [c1, c2, trash]
+    assert set(res) == set(expected)
+
+
+@pytest.mark.api1_only
+def test_comment(robot):
+    robot.comment('hello')
+    assert robot.commands() == ['hello']
+
+
+@pytest.mark.api1_only
+def test_create_arc(robot, instruments):
+    from opentrons.legacy_api.robot.robot import (TIP_CLEARANCE_DECK,
+                                                  TIP_CLEARANCE_LABWARE)
+
+    p300 = instruments.P300_Single(mount='left')
+    plate = containers_load(robot, '96-flat', '1')
+    plate2 = containers_load(robot, '96-flat', '2')
+
+    new_labware_height = 10
+    robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
+    robot.calibrate_container_with_instrument(plate, p300, save=False)
+
+    trash_height = robot.max_placeable_height_on_deck(robot.fixed_trash)
+    assert robot.max_deck_height() == trash_height
+
+    res = robot._create_arc(p300, (0, 0, 0), plate[0])
+    arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
+    expected = [
+        {'z': arc_top},
+        {'x': 0, 'y': 0},
+        {'z': 0}
+    ]
+    assert res == expected
+
+    res = robot._create_arc(p300, (0, 0, 0), plate[1])
+    arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
+    expected = [
+        {'z': arc_top},
+        {'x': 0, 'y': 0},
+        {'z': 0}
+    ]
+    assert res == expected
+
+    new_labware_height = 200
+    robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
+    robot.calibrate_container_with_instrument(plate2, p300, save=False)
+
+    assert robot.max_deck_height() == new_labware_height
+
+    res = robot._create_arc(p300, (0, 0, 0), plate2[0])
+    arc_top = p300._max_deck_height()
+    expected = [
+        {'z': arc_top},
+        {'x': 0, 'y': 0},
+        {'z': 0}
+    ]
+    assert res == expected
+
+
+@pytest.mark.api1_only
+def test_robot_move_to(robot, instruments):
+    robot.reset()
+    robot.home()
+    p300 = instruments.P300_Single(mount='right')
+    robot.move_to((robot._deck, (100, 0, 0)), p300)
+    assert isclose(
+        pose_tracker.absolute(
+            robot.poses,
+            p300),
+        (100, 0, 0)
+    ).all()
+
+
+@pytest.mark.api1_only
+def test_move_head(robot):
+    robot.move_head(x=100, y=0)
+    assert isclose(
+        pose_tracker.absolute(
+            robot.poses,
+            robot.gantry)[:2],
+        (100, 0, 0)[:2]
+    ).all()
+
+
+@pytest.mark.xfail
+def test_drop_tip_default_trash(robot, instruments):
+    tiprack = containers_load(robot, 'tiprack-200ul', '1')
+    pip = instruments.P300_Single(mount='right', tip_racks=[tiprack])
+
+    trash_loc = vector.Vector([80.00, 80.00, 80.00])
+
+    pip.pick_up_tip()
+
+    with mock.patch.object(robot, 'move_to') as move_to:  # NOQA
+        pip.drop_tip()
+
+        move_to.assert_called_with(
+            (robot.fixed_trash[0], trash_loc),
+            instrument=pip,
+            strategy='arc')
+
+
+@pytest.mark.api1_only
+def test_calibrate_labware(robot, instruments, labware, monkeypatch):
+    import tempfile
+    temp = tempfile.mkdtemp()
+    monkeypatch.setenv('USER_DEFN_ROOT', temp)
+
+    plate = labware.load('96-flat', '1')
+    pip = instruments.P300_Single(mount='right')
+
+    old_x, old_y, old_z = pose_tracker.absolute(robot.poses, plate[0])
+
+    pip.move_to(plate[0])
+    robot.poses = pip._jog(robot.poses, 'x', 1)
+    robot.poses = pip._jog(robot.poses, 'y', 2)
+    robot.poses = pip._jog(robot.poses, 'z', -3)
+    robot.calibrate_container_with_instrument(plate, pip, save=False)
+    new_pose = pose_tracker.absolute(robot.poses, plate[0])
+
+    assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
+
+
+@pytest.mark.api1_only
+def test_cache_instruments(robot, monkeypatch):
+    # Test that smoothie runtime configs are set at run when
+    # cache_instrument_models is called
+    fake_pip = {'left': {
+                    'model': 'p10_single_v1.3',
+                    'id': 'FakePip2',
+                    'name': 'p10_single'},
+                'right': {
+                    'model': 'p300_single_v2.0',
+                    'id': 'FakePip',
+                    'name': 'p300_single_gen2'}}
+    monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
+
+    def fake_func1(value):
+        return value
+
+    def fake_func2(mount, value):
+        return mount, value
+
+    def fake_read(mount):
+        return robot.model_by_mount[mount]['model']
+    # With nothing specified at init or expected, we should have nothing
+    robot._driver.update_steps_per_mm = mock.Mock(fake_func1)
+    robot._driver.update_pipette_config = mock.Mock(fake_func2)
+    monkeypatch.setattr(robot._driver, 'read_pipette_model', fake_read)
+    robot.cache_instrument_models()
+    steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
+    pip_config_calls = [
+        mock.call('Z', {'home': 220}),
+        mock.call('A', {'home': 172.15}),
+        mock.call('B', {'max_travel': 30}),
+        mock.call('C', {'max_travel': 60})]
+    robot._driver.update_steps_per_mm.assert_has_calls(
+        steps_mm_calls, any_order=True)
+    robot._driver.update_pipette_config.assert_has_calls(
+        pip_config_calls, any_order=True)

--- a/api/tests/opentrons/robot/test_robot.py
+++ b/api/tests/opentrons/robot/test_robot.py
@@ -3,10 +3,6 @@ from numpy import isclose
 from unittest import mock
 
 from opentrons.legacy_api.containers import load as containers_load
-try:
-    from opentrons import robot, instruments, labware
-except ImportError:
-    pytest.mark.skip()
 from opentrons.trackers import pose_tracker
 from opentrons.util import vector
 
@@ -15,270 +11,256 @@ from opentrons.util import vector
 # TODO: Modify calls as needed to check absolute position with refactor of
 # TODO: pose_tracker
 # TODO: Get rid of Vector
-
-
-@pytest.mark.api1_only
-def test_reset(virtual_smoothie_env):
-    """
-    This test may need to be expanded to include various other conditions that
-    should be reset.
-
-    :param virtual_smoothie_env: pytest fixture to simulate Smoothie connection
-    """
-    # Not testing this one--this is needed to clean the robot singleton from
-    # other tests. This is an inherent problem with the use of the singleton--
-    # it entangles both runtime code and tests in unpredictable ways.
-    robot.reset()
-
-    lw = labware.load('opentrons-tiprack-300ul', '1')
-    p = instruments.P300_Single(mount='right', tip_racks=[lw])
-    p.pick_up_tip()
-    assert p.tip_attached
-    robot.reset()
-    assert not p.tip_attached
-
-
-@pytest.mark.api1_only
-def test_configurable_mount_offsets():
-    def _test_offset(x, y, z):
-        robot.reset()
-        robot.config = robot.config._replace(
-            mount_offset=(x, y, z))
-        left = instruments.P300_Single(mount='left')
-        right = instruments.P300_Single(mount='right')
-        robot.home()
-        left_pos = pose_tracker.absolute(robot.poses, left)
-        right_pos = pose_tracker.absolute(robot.poses, right)
-        assert left_pos[0] == right_pos[0] + x
-        assert left_pos[1] == right_pos[1] + y
-        assert left_pos[2] == right_pos[2] + z
-
-    robot.config = robot.config._replace(
-        instrument_offset={
-            'right': {
-                'single': (0.0, 0.0, 0.0),
-                'multi': (0.0, 0.0, 0.0)
-            },
-            'left': {
-                'single': (0.0, 0.0, 0.0),
-                'multi': (0.0, 0.0, 0.0)
-            }
-        }
-    )
-    old_config = robot.config
-    _test_offset(-34, 0, 0)
-    _test_offset(-32, 0, 0)
-    _test_offset(100, 3, 1.234)
-    robot.config = old_config
-
-
-@pytest.mark.api1_only
-def test_pos_tracker_persistance(virtual_smoothie_env):
-    robot.reset()
-    p300 = instruments.P300_Single(mount='left')
-    plate = containers_load(robot, 'trough-12row', '5')
-    assert robot.max_placeable_height_on_deck(plate) == \
-        plate[0].coordinates()[2]
-
-    robot.poses = p300._move(robot.poses, x=10, y=10, z=10)
-    robot.calibrate_container_with_instrument(plate, p300, save=False)
-
-    assert robot.max_placeable_height_on_deck(plate) == 10.0
-
-
-@pytest.mark.api1_only
-def test_calibrated_max_z(virtual_smoothie_env):
-    robot.reset()
-
-    instruments.P300_Single(mount='left')
-    assert robot.max_deck_height() == 82
-
-
-@pytest.mark.api1_only
-def test_get_serial_ports_list(monkeypatch):
-    robot.reset()
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
-    assert 'Virtual Smoothie' not in robot.get_serial_ports_list()
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
-    assert 'Virtual Smoothie' in robot.get_serial_ports_list()
-
-
-@pytest.mark.api1_only
-def test_add_container(virtual_smoothie_env):
-    robot.reset()
-    c1 = robot.add_container('96-flat', '1')
-    trash = robot.fixed_trash
-    res = robot.get_containers()
-    expected = [c1, trash]
-    assert set(res) == set(expected)
-
-    c2 = robot.add_container('96-flat', '4', 'my-special-plate')
-    res = robot.get_containers()
-    expected = [c1, c2, trash]
-    assert set(res) == set(expected)
-
-
-@pytest.mark.api1_only
-def test_comment(virtual_smoothie_env):
-    robot.reset()
-    robot.clear_commands()
-    robot.comment('hello')
-    assert robot.commands() == ['hello']
-
-
-@pytest.mark.api1_only
-def test_create_arc(virtual_smoothie_env):
-    from opentrons.legacy_api.robot.robot import (TIP_CLEARANCE_DECK,
-                                                  TIP_CLEARANCE_LABWARE)
-    robot.reset()
-
-    p300 = instruments.P300_Single(mount='left')
-    plate = containers_load(robot, '96-flat', '1')
-    plate2 = containers_load(robot, '96-flat', '2')
-
-    new_labware_height = 10
-    robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
-    robot.calibrate_container_with_instrument(plate, p300, save=False)
-
-    trash_height = robot.max_placeable_height_on_deck(robot.fixed_trash)
-    assert robot.max_deck_height() == trash_height
-
-    res = robot._create_arc(p300, (0, 0, 0), plate[0])
-    arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
-    expected = [
-        {'z': arc_top},
-        {'x': 0, 'y': 0},
-        {'z': 0}
-    ]
-    assert res == expected
-
-    res = robot._create_arc(p300, (0, 0, 0), plate[1])
-    arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
-    expected = [
-        {'z': arc_top},
-        {'x': 0, 'y': 0},
-        {'z': 0}
-    ]
-    assert res == expected
-
-    new_labware_height = 200
-    robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
-    robot.calibrate_container_with_instrument(plate2, p300, save=False)
-
-    assert robot.max_deck_height() == new_labware_height
-
-    res = robot._create_arc(p300, (0, 0, 0), plate2[0])
-    arc_top = p300._max_deck_height()
-    expected = [
-        {'z': arc_top},
-        {'x': 0, 'y': 0},
-        {'z': 0}
-    ]
-    assert res == expected
-
-
-@pytest.mark.api1_only
-def test_robot_move_to(virtual_smoothie_env):
-    robot.reset()
-    robot.home()
-    p300 = instruments.P300_Single(mount='right')
-    robot.move_to((robot._deck, (100, 0, 0)), p300)
-    assert isclose(
-        pose_tracker.absolute(
-            robot.poses,
-            p300),
-        (100, 0, 0)
-    ).all()
-
-
-@pytest.mark.api1_only
-def test_move_head(virtual_smoothie_env):
-    robot.reset()
-    robot.move_head(x=100, y=0)
-    assert isclose(
-        pose_tracker.absolute(
-            robot.poses,
-            robot.gantry)[:2],
-        (100, 0, 0)[:2]
-    ).all()
-
-
-@pytest.mark.xfail
-def test_drop_tip_default_trash(virtual_smoothie_env):
-    robot.reset()
-    tiprack = containers_load(robot, 'tiprack-200ul', '1')
-    pip = instruments.P300_Single(mount='right', tip_racks=[tiprack])
-
-    trash_loc = vector.Vector([80.00, 80.00, 80.00])
-
-    pip.pick_up_tip()
-
-    with mock.patch.object(robot, 'move_to') as move_to:  # NOQA
-        pip.drop_tip()
-
-        move_to.assert_called_with(
-            (robot.fixed_trash[0], trash_loc),
-            instrument=pip,
-            strategy='arc')
-
-
-@pytest.mark.api1_only
-def test_calibrate_labware(virtual_smoothie_env, monkeypatch):
-    import tempfile
-    temp = tempfile.mkdtemp()
-    monkeypatch.setenv('USER_DEFN_ROOT', temp)
-    robot.reset()
-
-    plate = labware.load('96-flat', '1')
-    pip = instruments.P300_Single(mount='right')
-
-    old_x, old_y, old_z = pose_tracker.absolute(robot.poses, plate[0])
-
-    pip.move_to(plate[0])
-    robot.poses = pip._jog(robot.poses, 'x', 1)
-    robot.poses = pip._jog(robot.poses, 'y', 2)
-    robot.poses = pip._jog(robot.poses, 'z', -3)
-    robot.calibrate_container_with_instrument(plate, pip, save=False)
-    new_pose = pose_tracker.absolute(robot.poses, plate[0])
-
-    assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
-
-
-@pytest.mark.api1_only
-def test_cache_instruments(monkeypatch):
-    # Test that smoothie runtime configs are set at run when
-    # cache_instrument_models is called
-    robot.reset()
-    fake_pip = {'left': {
-                    'model': 'p10_single_v1.3',
-                    'id': 'FakePip2',
-                    'name': 'p10_single'},
-                'right': {
-                    'model': 'p300_single_v2.0',
-                    'id': 'FakePip',
-                    'name': 'p300_single_gen2'}}
-    monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
-
-    def fake_func1(value):
-        return value
-
-    def fake_func2(mount, value):
-        return mount, value
-
-    def fake_read(mount):
-        return robot.model_by_mount[mount]['model']
-    # With nothing specified at init or expected, we should have nothing
-    robot._driver.update_steps_per_mm = mock.Mock(fake_func1)
-    robot._driver.update_pipette_config = mock.Mock(fake_func2)
-    monkeypatch.setattr(robot._driver, 'read_pipette_model', fake_read)
-    robot.cache_instrument_models()
-    steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
-    pip_config_calls = [
-        mock.call('Z', {'home': 220}),
-        mock.call('A', {'home': 172.15}),
-        mock.call('B', {'max_travel': 30}),
-        mock.call('C', {'max_travel': 60})]
-    robot._driver.update_steps_per_mm.assert_has_calls(
-        steps_mm_calls, any_order=True)
-    robot._driver.update_pipette_config.assert_has_calls(
-        pip_config_calls, any_order=True)
+#
+#
+# @pytest.mark.api1_only
+# def test_reset(robot, instruments, labware):
+#     """
+#     This test may need to be expanded to include various other conditions that
+#     should be reset.
+#
+#     :param virtual_smoothie_env: pytest fixture to simulate Smoothie connection
+#     """
+#     # Not testing this one--this is needed to clean the robot singleton from
+#     # other tests. This is an inherent problem with the use of the singleton--
+#     # it entangles both runtime code and tests in unpredictable ways.
+#
+#     lw = labware.load('opentrons-tiprack-300ul', '1')
+#     p = instruments.P300_Single(mount='right', tip_racks=[lw])
+#     p.pick_up_tip()
+#     assert p.tip_attached
+#     robot.reset()
+#     assert not p.tip_attached
+#
+#
+# @pytest.mark.api1_only
+# def test_configurable_mount_offsets(robot, instruments):
+#     def _test_offset(x, y, z):
+#         robot.config = robot.config._replace(
+#             mount_offset=(x, y, z))
+#         robot.reset()
+#         left = instruments.P300_Single(mount='left')
+#         right = instruments.P300_Single(mount='right')
+#         robot.home()
+#         left_pos = pose_tracker.absolute(robot.poses, left)
+#         right_pos = pose_tracker.absolute(robot.poses, right)
+#         assert left_pos[0] == right_pos[0] + x
+#         assert left_pos[1] == right_pos[1] + y
+#         assert left_pos[2] == right_pos[2] + z
+#
+#     robot.config = robot.config._replace(
+#         instrument_offset={
+#             'right': {
+#                 'single': (0.0, 0.0, 0.0),
+#                 'multi': (0.0, 0.0, 0.0)
+#             },
+#             'left': {
+#                 'single': (0.0, 0.0, 0.0),
+#                 'multi': (0.0, 0.0, 0.0)
+#             }
+#         }
+#     )
+#     old_config = robot.config
+#     _test_offset(-34, 0, 0)
+#     _test_offset(-32, 0, 0)
+#     _test_offset(100, 3, 1.234)
+#     robot.config = old_config
+#
+#
+# @pytest.mark.api1_only
+# def test_pos_tracker_persistance(robot, instruments):
+#     p300 = instruments.P300_Single(mount='left')
+#     plate = containers_load(robot, 'trough-12row', '5')
+#     assert robot.max_placeable_height_on_deck(plate) == \
+#         plate[0].coordinates()[2]
+#
+#     robot.poses = p300._move(robot.poses, x=10, y=10, z=10)
+#     robot.calibrate_container_with_instrument(plate, p300, save=False)
+#
+#     assert robot.max_placeable_height_on_deck(plate) == 10.0
+#
+#
+# @pytest.mark.api1_only
+# def test_calibrated_max_z(robot, instruments):
+#     instruments.P300_Single(mount='left')
+#     assert robot.max_deck_height() == 82
+#
+#
+# @pytest.mark.api1_only
+# def test_get_serial_ports_list(robot, monkeypatch):
+#     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+#     assert 'Virtual Smoothie' not in robot.get_serial_ports_list()
+#     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
+#     assert 'Virtual Smoothie' in robot.get_serial_ports_list()
+#
+#
+# @pytest.mark.api1_only
+# def test_add_container(robot):
+#     c1 = robot.add_container('96-flat', '1')
+#     trash = robot.fixed_trash
+#     res = robot.get_containers()
+#     expected = [c1, trash]
+#     assert set(res) == set(expected)
+#
+#     c2 = robot.add_container('96-flat', '4', 'my-special-plate')
+#     res = robot.get_containers()
+#     expected = [c1, c2, trash]
+#     assert set(res) == set(expected)
+#
+#
+# @pytest.mark.api1_only
+# def test_comment(robot):
+#     robot.comment('hello')
+#     assert robot.commands() == ['hello']
+#
+#
+# @pytest.mark.api1_only
+# def test_create_arc(robot, instruments):
+#     from opentrons.legacy_api.robot.robot import (TIP_CLEARANCE_DECK,
+#                                                   TIP_CLEARANCE_LABWARE)
+#
+#     p300 = instruments.P300_Single(mount='left')
+#     plate = containers_load(robot, '96-flat', '1')
+#     plate2 = containers_load(robot, '96-flat', '2')
+#
+#     new_labware_height = 10
+#     robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
+#     robot.calibrate_container_with_instrument(plate, p300, save=False)
+#
+#     trash_height = robot.max_placeable_height_on_deck(robot.fixed_trash)
+#     assert robot.max_deck_height() == trash_height
+#
+#     res = robot._create_arc(p300, (0, 0, 0), plate[0])
+#     arc_top = robot.max_deck_height() + TIP_CLEARANCE_DECK
+#     expected = [
+#         {'z': arc_top},
+#         {'x': 0, 'y': 0},
+#         {'z': 0}
+#     ]
+#     assert res == expected
+#
+#     res = robot._create_arc(p300, (0, 0, 0), plate[1])
+#     arc_top = robot.max_placeable_height_on_deck(plate) + TIP_CLEARANCE_LABWARE
+#     expected = [
+#         {'z': arc_top},
+#         {'x': 0, 'y': 0},
+#         {'z': 0}
+#     ]
+#     assert res == expected
+#
+#     new_labware_height = 200
+#     robot.poses = p300._move(robot.poses, x=10, y=10, z=new_labware_height)
+#     robot.calibrate_container_with_instrument(plate2, p300, save=False)
+#
+#     assert robot.max_deck_height() == new_labware_height
+#
+#     res = robot._create_arc(p300, (0, 0, 0), plate2[0])
+#     arc_top = p300._max_deck_height()
+#     expected = [
+#         {'z': arc_top},
+#         {'x': 0, 'y': 0},
+#         {'z': 0}
+#     ]
+#     assert res == expected
+#
+#
+# @pytest.mark.api1_only
+# def test_robot_move_to(robot, instruments):
+#     robot.home()
+#     p300 = instruments.P300_Single(mount='right')
+#     robot.move_to((robot._deck, (100, 0, 0)), p300)
+#     assert isclose(
+#         pose_tracker.absolute(
+#             robot.poses,
+#             p300),
+#         (100, 0, 0)
+#     ).all()
+#
+#
+# @pytest.mark.api1_only
+# def test_move_head(robot):
+#     robot.move_head(x=100, y=0)
+#     assert isclose(
+#         pose_tracker.absolute(
+#             robot.poses,
+#             robot.gantry)[:2],
+#         (100, 0, 0)[:2]
+#     ).all()
+#
+#
+# @pytest.mark.xfail
+# def test_drop_tip_default_trash(robot, instruments):
+#     tiprack = containers_load(robot, 'tiprack-200ul', '1')
+#     pip = instruments.P300_Single(mount='right', tip_racks=[tiprack])
+#
+#     trash_loc = vector.Vector([80.00, 80.00, 80.00])
+#
+#     pip.pick_up_tip()
+#
+#     with mock.patch.object(robot, 'move_to') as move_to:  # NOQA
+#         pip.drop_tip()
+#
+#         move_to.assert_called_with(
+#             (robot.fixed_trash[0], trash_loc),
+#             instrument=pip,
+#             strategy='arc')
+#
+#
+# @pytest.mark.api1_only
+# def test_calibrate_labware(robot, instruments, labware, monkeypatch):
+#     import tempfile
+#     temp = tempfile.mkdtemp()
+#     monkeypatch.setenv('USER_DEFN_ROOT', temp)
+#
+#     plate = labware.load('96-flat', '1')
+#     pip = instruments.P300_Single(mount='right')
+#
+#     old_x, old_y, old_z = pose_tracker.absolute(robot.poses, plate[0])
+#
+#     pip.move_to(plate[0])
+#     robot.poses = pip._jog(robot.poses, 'x', 1)
+#     robot.poses = pip._jog(robot.poses, 'y', 2)
+#     robot.poses = pip._jog(robot.poses, 'z', -3)
+#     robot.calibrate_container_with_instrument(plate, pip, save=False)
+#     new_pose = pose_tracker.absolute(robot.poses, plate[0])
+#
+#     assert isclose(new_pose, (old_x + 1, old_y + 2, old_z - 3)).all()
+#
+#
+# @pytest.mark.api1_only
+# def test_cache_instruments(robot, monkeypatch):
+#     # Test that smoothie runtime configs are set at run when
+#     # cache_instrument_models is called
+#     fake_pip = {'left': {
+#                     'model': 'p10_single_v1.3',
+#                     'id': 'FakePip2',
+#                     'name': 'p10_single'},
+#                 'right': {
+#                     'model': 'p300_single_v2.0',
+#                     'id': 'FakePip',
+#                     'name': 'p300_single_gen2'}}
+#     monkeypatch.setattr(robot, 'model_by_mount', fake_pip)
+#
+#     def fake_func1(value):
+#         return value
+#
+#     def fake_func2(mount, value):
+#         return mount, value
+#
+#     def fake_read(mount):
+#         return robot.model_by_mount[mount]['model']
+#     # With nothing specified at init or expected, we should have nothing
+#     robot._driver.update_steps_per_mm = mock.Mock(fake_func1)
+#     robot._driver.update_pipette_config = mock.Mock(fake_func2)
+#     monkeypatch.setattr(robot._driver, 'read_pipette_model', fake_read)
+#     robot.cache_instrument_models()
+#     steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
+#     pip_config_calls = [
+#         mock.call('Z', {'home': 220}),
+#         mock.call('A', {'home': 172.15}),
+#         mock.call('B', {'max_travel': 30}),
+#         mock.call('C', {'max_travel': 60})]
+#     robot._driver.update_steps_per_mm.assert_has_calls(
+#         steps_mm_calls, any_order=True)
+#     robot._driver.update_pipette_config.assert_has_calls(
+#         pip_config_calls, any_order=True)

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -19,6 +19,7 @@ from opentrons.hardware_control.types import CriticalPoint
 # should be replaced with something that accurately reflects actual robot
 # operation, and then these tests should be revised to match expected reality.
 
+
 @pytest.mark.api1_only
 async def test_transform_from_moves(async_server, async_client, monkeypatch):
     test_mount, test_model = ('left', 'p300_multi_v1')
@@ -75,6 +76,8 @@ async def test_transform_from_moves(async_server, async_client, monkeypatch):
     else:
         expected1 = pt1
 
+    print(absolute(hardware.poses, pipette))
+    print(expected1)
     assert np.isclose(absolute(hardware.poses, pipette), expected1).all()
 
     # Jog to calculated position for transform

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from opentrons import types
+
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
 from opentrons.trackers.pose_tracker import absolute
@@ -17,7 +18,6 @@ from opentrons.hardware_control.types import CriticalPoint
 # Smoothie board sees the position of itself--after a fashion). Simulating mode
 # should be replaced with something that accurately reflects actual robot
 # operation, and then these tests should be revised to match expected reality.
-
 
 @pytest.mark.api1_only
 async def test_transform_from_moves(async_server, async_client, monkeypatch):

--- a/api/tests/opentrons/server/calibration_integration_test.py
+++ b/api/tests/opentrons/server/calibration_integration_test.py
@@ -76,8 +76,6 @@ async def test_transform_from_moves(async_server, async_client, monkeypatch):
     else:
         expected1 = pt1
 
-    print(absolute(hardware.poses, pipette))
-    print(expected1)
     assert np.isclose(absolute(hardware.poses, pipette), expected1).all()
 
     # Jog to calculated position for transform

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -2,7 +2,7 @@ import json
 
 import numpy as np
 
-from opentrons import robot, instruments
+import opentrons
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
 from opentrons.config import robot_configs
@@ -26,7 +26,7 @@ async def test_add_and_remove_tip(async_server, dc_session):
     version = async_server['api_version']
     if version == 1:
         hardware.reset()
-        pip = instruments.P10_Single(mount=mount)
+        pip = opentrons.instruments.P10_Single(mount=mount)
         dc_session.current_mount = mount
     else:
         hardware.reset()
@@ -92,7 +92,7 @@ async def test_save_xy(async_server, dc_session):
     if version == 1:
         mount = 'left'
         hardware.reset()
-        pip = instruments.P10_Single(mount=mount)
+        pip = opentrons.instruments.P10_Single(mount=mount)
     else:
         mount = types.Mount.LEFT
         hardware.reset()
@@ -128,8 +128,8 @@ async def test_save_xy(async_server, dc_session):
     actual = dc_session.points[point]
     if version == 1:
         expected = (
-            robot._driver.position['X'] + hardware.config.mount_offset[0],
-            robot._driver.position['Y']
+            hardware._driver.position['X'] + hardware.config.mount_offset[0],
+            hardware._driver.position['Y']
         )
     else:
         coordinates = hardware.gantry_position(types.Mount.LEFT)
@@ -152,7 +152,7 @@ async def test_save_z(async_server, dc_session, monkeypatch):
     if async_server['api_version'] == 1:
         mount = 'left'
         hardware.reset()
-        pip = instruments.P10_Single(mount=mount)
+        pip = opentrons.instruments.P10_Single(mount=mount)
     else:
         mount = types.Mount.LEFT
         hardware.reset()
@@ -342,13 +342,13 @@ async def test_release(async_client, async_server, monkeypatch, dc_session):
     """
     if async_server['api_version'] == 1:
         test_model = 'p300_multi_v1'
-
+        hardware = async_server['com.opentrons.hardware']
         def dummy_read_model(mount):
             return test_model
 
         monkeypatch.setattr(
-            robot._driver, 'read_pipette_model', dummy_read_model)
-        robot.reset()
+            hardware._driver, 'read_pipette_model', dummy_read_model)
+        hardware.reset()
 
     resp1 = await async_client.post('/calibration/deck/start')
     assert resp1.status == 409
@@ -380,13 +380,13 @@ async def test_forcing_new_session(
     """
     test_model = 'p300_multi_v1'
     if async_server['api_version'] == 1:
-
+        hardware = async_server['com.opentrons.hardware']
         def dummy_read_model(mount):
             return test_model
 
         monkeypatch.setattr(
-            robot._driver, 'read_pipette_model', dummy_read_model)
-        robot.reset()
+            hardware._driver, 'read_pipette_model', dummy_read_model)
+        hardware.reset()
 
     dummy_token = 'fake token'
 

--- a/api/tests/opentrons/server/test_calibration_endpoints.py
+++ b/api/tests/opentrons/server/test_calibration_endpoints.py
@@ -2,7 +2,6 @@ import json
 
 import numpy as np
 
-import opentrons
 from opentrons import deck_calibration as dc
 from opentrons.deck_calibration import endpoints
 from opentrons.config import robot_configs
@@ -20,13 +19,13 @@ from opentrons import types
 # operation, and then these tests should be revised to match expected reality.
 
 # ------------ Function tests (unit) ----------------------
-async def test_add_and_remove_tip(async_server, dc_session):
+async def test_add_and_remove_tip(async_server, dc_session, instruments):
     hardware = dc_session.adapter
     mount = 'left'
     version = async_server['api_version']
     if version == 1:
         hardware.reset()
-        pip = opentrons.instruments.P10_Single(mount=mount)
+        pip = instruments.P10_Single(mount=mount)
         dc_session.current_mount = mount
     else:
         hardware.reset()
@@ -85,14 +84,14 @@ async def test_add_and_remove_tip(async_server, dc_session):
         assert hardware.attached_instruments[mount]['has_tip'] is False
 
 
-async def test_save_xy(async_server, dc_session):
+async def test_save_xy(async_server, dc_session, instruments):
     hardware = dc_session.adapter
     version = async_server['api_version']
 
     if version == 1:
         mount = 'left'
         hardware.reset()
-        pip = opentrons.instruments.P10_Single(mount=mount)
+        pip = instruments.P10_Single(mount=mount)
     else:
         mount = types.Mount.LEFT
         hardware.reset()
@@ -140,10 +139,10 @@ async def test_save_xy(async_server, dc_session):
     assert actual == expected
 
 
-async def test_save_z(async_server, dc_session, monkeypatch):
+async def test_save_z(async_server, dc_session, monkeypatch, instruments):
+    dc_session.adapter.reset()
     hardware = dc_session.adapter
     model = 'p10_single_v1'
-
     # Z values were bleeding in from other tests, mock robot configs
     # to encapsulate this test
     fake_config = robot_configs.load()
@@ -152,7 +151,7 @@ async def test_save_z(async_server, dc_session, monkeypatch):
     if async_server['api_version'] == 1:
         mount = 'left'
         hardware.reset()
-        pip = opentrons.instruments.P10_Single(mount=mount)
+        pip = instruments.P10_Single(mount=mount)
     else:
         mount = types.Mount.LEFT
         hardware.reset()
@@ -172,7 +171,7 @@ async def test_save_z(async_server, dc_session, monkeypatch):
 
     z_target = 80.0
     if async_server['api_version'] == 1:
-        hardware.home()
+        # hardware.home()
         dc_session.pipettes.get(mount).move_to(
             (hardware.deck, (0, 0, z_target)))
     else:
@@ -343,6 +342,7 @@ async def test_release(async_client, async_server, monkeypatch, dc_session):
     if async_server['api_version'] == 1:
         test_model = 'p300_multi_v1'
         hardware = async_server['com.opentrons.hardware']
+
         def dummy_read_model(mount):
             return test_model
 
@@ -381,6 +381,7 @@ async def test_forcing_new_session(
     test_model = 'p300_multi_v1'
     if async_server['api_version'] == 1:
         hardware = async_server['com.opentrons.hardware']
+
         def dummy_read_model(mount):
             return test_model
 

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -8,7 +8,6 @@ from opentrons.legacy_api import modules as legacy_modules
 
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons.hardware_control import modules
-from opentrons import instruments
 from opentrons.config import pipette_config
 
 
@@ -401,6 +400,7 @@ async def test_instrument_reuse(async_server, async_client, monkeypatch):
     # connected afterwards
     test_model = 'p300_multi_v1'
     if async_server['api_version'] == 1:
+        from opentrons import instruments
 
         def dummy_read_model(mount):
             return test_model

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 import pytest
 
-from opentrons import robot, types
+from opentrons import types
 from opentrons.legacy_api import modules as legacy_modules
 
 from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
@@ -51,7 +51,8 @@ async def test_get_pipettes_uncommissioned(
         monkeypatch.setattr(
             async_server['com.opentrons.hardware']._driver,
             'update_steps_per_mm', fake_update_steps_per_mm)
-        robot._driver.simulating = False
+        hw = async_server['com.opentrons.hardware']
+        hw._driver.simulating = False
 
     else:
         hw = async_server['com.opentrons.hardware']._backend
@@ -60,7 +61,7 @@ async def test_get_pipettes_uncommissioned(
 
     resp = await async_client.get('/pipettes?refresh=true')
     if async_server['api_version'] == 1:
-        robot._driver.simulating = True
+        hw._driver.simulating = True
     text = await resp.text()
     assert resp.status == 200
     assert json.loads(text) == expected

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -11,6 +11,7 @@ from opentrons.hardware_control import modules
 from opentrons.config import pipette_config
 
 
+@pytest.mark.api1_only
 async def test_get_pipettes_uncommissioned(
         async_server, loop, async_client, monkeypatch):
 
@@ -66,6 +67,7 @@ async def test_get_pipettes_uncommissioned(
     assert json.loads(text) == expected
 
 
+@pytest.mark.api1_only
 async def test_get_pipettes(async_server, async_client, monkeypatch):
     test_model = 'p300_multi_v1'
     test_name = 'p300_multi'
@@ -210,6 +212,7 @@ async def test_execute_module_command_v1(
     assert body['message'] == 'Success'
 
 
+@pytest.mark.api1_only
 async def test_get_cached_pipettes(async_server, async_client, monkeypatch):
     test_model = 'p300_multi_v1'
     test_name = 'p300_multi'
@@ -313,6 +316,7 @@ async def test_get_cached_pipettes(async_server, async_client, monkeypatch):
     assert json.loads(text2) == expected2
 
 
+@pytest.mark.api1_only
 async def test_disengage_axes(async_client, monkeypatch):
     def mock_send(self, command, timeout=None):
         pass
@@ -353,6 +357,7 @@ async def test_disengage_axes(async_client, monkeypatch):
     assert json.loads(result2) == alltrue
 
 
+@pytest.mark.api1_only
 async def test_robot_info(async_client):
     res = await async_client.get('/robot/positions')
     assert res.status == 200
@@ -366,6 +371,7 @@ async def test_robot_info(async_client):
     assert len(body['positions']['attach_tip']['point']) == 3
 
 
+@pytest.mark.api1_only
 async def test_home_pipette(async_client):
     test_data = {
         'target': 'pipette',
@@ -378,7 +384,9 @@ async def test_home_pipette(async_client):
     assert res2.status == 200
 
 
-async def test_instrument_reuse(async_server, async_client, monkeypatch):
+@pytest.mark.api1_only
+async def test_instrument_reuse(
+        async_server, async_client, monkeypatch, instruments):
     hw = async_server['com.opentrons.hardware']
 
     # With no pipette connected before homing pipettes, we should a) not crash
@@ -400,7 +408,6 @@ async def test_instrument_reuse(async_server, async_client, monkeypatch):
     # connected afterwards
     test_model = 'p300_multi_v1'
     if async_server['api_version'] == 1:
-        from opentrons import instruments
 
         def dummy_read_model(mount):
             return test_model
@@ -427,6 +434,7 @@ async def test_instrument_reuse(async_server, async_client, monkeypatch):
     assert data['left']['model'] == test_model
 
 
+@pytest.mark.api1_only
 async def test_home_robot(async_client):
     test_data = {
         'target': 'robot'}
@@ -436,6 +444,7 @@ async def test_home_robot(async_client):
     assert res.status == 200
 
 
+@pytest.mark.api1_only
 async def test_home_pipette_bad_request(async_client):
     test_data = {}
     res = await async_client.post('/robot/home', json=test_data)
@@ -465,6 +474,7 @@ async def test_home_pipette_bad_request(async_client):
     assert res4.status == 400
 
 
+@pytest.mark.api1_only
 async def test_move_bad_request(async_client):
     data0 = {
         'target': 'other'
@@ -497,6 +507,7 @@ async def test_move_bad_request(async_client):
     assert res.status == 400
 
 
+@pytest.mark.api1_only
 async def test_move_mount(async_client):
     resp = await async_client.post('/robot/home',
                                    json={'target': 'robot'})
@@ -510,6 +521,7 @@ async def test_move_mount(async_client):
     assert res.status == 200
 
 
+@pytest.mark.api1_only
 async def test_move_pipette(async_client):
     resp = await async_client.post('/robot/home',
                                    json={'target': 'robot'})
@@ -524,7 +536,9 @@ async def test_move_pipette(async_client):
     assert res.status == 200
 
 
-async def test_move_and_home_existing_pipette(async_server, async_client):
+@pytest.mark.api1_only
+async def test_move_and_home_existing_pipette(
+        async_server, async_client, instruments):
     hw = async_server['com.opentrons.hardware']
     if async_server['api_version'] == 1:
         hw.reset()
@@ -533,7 +547,6 @@ async def test_move_and_home_existing_pipette(async_server, async_client):
     resp = await async_client.post('/robot/home', json={'target': 'robot'})
     assert resp.status == 200
     if async_server['api_version'] == 1:
-        from opentrons import instruments
         instruments.P300_Single(mount='right')
     move_data = {
         'target': 'pipette',

--- a/api/tests/opentrons/server/test_serialize.py
+++ b/api/tests/opentrons/server/test_serialize.py
@@ -3,7 +3,6 @@ import pytest
 
 from collections import OrderedDict
 from opentrons.server import serialize
-from opentrons import robot, instruments, containers
 
 
 @pytest.fixture
@@ -37,8 +36,13 @@ def type_id(instance):
     return id(type(instance))
 
 
-def test_robot():
+@pytest.mark.api1_only
+def test_robot(singletons):
+    robot = singletons['robot']
+    containers = singletons['labware']
+    instruments = singletons['instruments']
     robot.reset()
+
     containers.load('trough-12row', '3', 'trough')
     containers.load('96-PCR-flat', '1', 'plate')
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -124,6 +124,7 @@ async def test_available_resets(async_client, async_server):
         == sorted(options, key=lambda el: el['id'])
 
 
+@pytest.mark.api1_only
 async def execute_reset_tests_v1(cli):
     # Make sure we actually delete the database
     resp = await cli.post('/settings/reset', json={'labwareCalibration': True})

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -7,7 +7,6 @@ import tempfile
 import pytest
 
 from opentrons.server import init
-from opentrons.data_storage import database as db
 from opentrons.config import pipette_config
 from opentrons import config, types
 

--- a/api/tests/opentrons/server/test_settings_endpoints.py
+++ b/api/tests/opentrons/server/test_settings_endpoints.py
@@ -129,7 +129,7 @@ async def execute_reset_tests_v1(cli):
     # Make sure we actually delete the database
     resp = await cli.post('/settings/reset', json={'labwareCalibration': True})
     body = await resp.json()
-    assert not os.path.exists(db.database_path)
+    assert not os.path.exists(config.CONFIG['labware_database_file'])
     assert resp.status == 200
     assert body == {}
 
@@ -211,8 +211,8 @@ async def test_reset_v1(virtual_smoothie_env, loop, async_client):
     # work locally) and checks the error handling
 
     # precondition
-    assert os.path.exists(db.database_path)
-    with restore_db(db.database_path):
+    assert os.path.exists(config.CONFIG['labware_database_file'])
+    with restore_db(config.CONFIG['labware_database_file']):
         await execute_reset_tests_v1(async_client)
 
 
@@ -285,7 +285,6 @@ async def test_modify_pipette_settings(
     assert resp.status == 200
     check = await async_client.get('/settings/pipettes/{}'.format(test_id))
     body = await check.json()
-    print(patch_body)
     assert body['fields'] == patch_body['fields']
 
     # Check that None reverts a setting to default

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -7,7 +7,6 @@ from aiohttp import web
 from opentrons.server import init
 from opentrons.server.endpoints import update
 from opentrons.server.endpoints import serverlib_fallback
-from opentrons import modules
 
 
 async def test_restart(
@@ -100,8 +99,9 @@ async def test_ignore_updates(
     assert json.loads(r3body) == {'version': '3.1.3'}
 
 
+@pytest.mark.api1_only
 @pytest.fixture
-def dummy_attached_modules():
+def dummy_attached_modules(modules):
     temp_module = modules.TempDeck()
     temp_port = 'tty1_tempdeck'
     temp_serial = 'tdYYYYMMDD987'
@@ -123,7 +123,8 @@ async def test_update_module_firmware(
         aiohttp_client,
         monkeypatch,
         async_client,
-        async_server):
+        async_server,
+        modules):
 
     client = async_client
     hw = async_server['com.opentrons.hardware']
@@ -173,7 +174,8 @@ async def test_fail_update_module_firmware(
         virtual_smoothie_env,
         monkeypatch,
         async_client,
-        async_server):
+        async_server,
+        modules):
 
     client = async_client
     hw = async_server['com.opentrons.hardware']

--- a/api/tests/opentrons/server/test_update_endpoints.py
+++ b/api/tests/opentrons/server/test_update_endpoints.py
@@ -4,6 +4,7 @@ import tempfile
 import asyncio
 import pytest
 from aiohttp import web
+# from opentrons import *
 from opentrons.server import init
 from opentrons.server.endpoints import update
 from opentrons.server.endpoints import serverlib_fallback
@@ -116,6 +117,7 @@ def dummy_attached_modules(modules):
     }
 
 
+@pytest.mark.api1_only
 async def test_update_module_firmware(
         dummy_attached_modules,
         virtual_smoothie_env,
@@ -169,6 +171,7 @@ async def test_update_module_firmware(
     assert res == expected_res
 
 
+@pytest.mark.api1_only
 async def test_fail_update_module_firmware(
         dummy_attached_modules,
         virtual_smoothie_env,

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -6,6 +6,7 @@ import pytest
 from opentrons import simulate, protocols
 
 
+@pytest.mark.api2_only
 @pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
 def test_simulate_function_apiv2(ensure_api2,
                                  protocol,
@@ -21,6 +22,7 @@ def test_simulate_function_apiv2(ensure_api2,
         ]
 
 
+@pytest.mark.api2_only
 def test_simulate_function_json_apiv2(ensure_api2,
                                       get_json_protocol_fixture):
     jp = get_json_protocol_fixture('3', 'simple', False)
@@ -38,6 +40,7 @@ def test_simulate_function_json_apiv2(ensure_api2,
     ]
 
 
+@pytest.mark.api2_only
 def test_simulate_function_bundle_apiv2(ensure_api2,
                                         get_bundle_fixture):
     bundle = get_bundle_fixture('simple_bundle')
@@ -63,6 +66,7 @@ def test_simulate_function_bundle_apiv2(ensure_api2,
         ]
 
 
+@pytest.mark.api1_only
 @pytest.mark.parametrize('protocol_file', ['testosaur.py'])
 def test_simulate_function_apiv1(ensure_api1, protocol, protocol_file):
     runlog, bundle = simulate.simulate(protocol.filelike, 'testosaur.py')
@@ -77,6 +81,7 @@ def test_simulate_function_apiv1(ensure_api1, protocol, protocol_file):
     ]
 
 
+@pytest.mark.api1_only
 def test_simulate_function_json_apiv1(ensure_api1,
                                       get_json_protocol_fixture):
     jp = get_json_protocol_fixture('3', 'simple', False)

--- a/api/tests/opentrons/tools/test_qc_scripts.py
+++ b/api/tests/opentrons/tools/test_qc_scripts.py
@@ -1,5 +1,6 @@
 import pytest
-from opentrons import tools, robot
+
+from opentrons.config import feature_flags as ff
 
 pipette_barcode_to_model = {
     'P10S20180101A01': 'p10_single_v1',
@@ -27,8 +28,12 @@ pipette_barcode_to_model = {
 
 
 @pytest.fixture
-def driver_import(monkeypatch):
-    monkeypatch.setattr(tools, 'driver', robot._driver)
+def driver_import(monkeypatch, robot):
+    from opentrons import tools
+    if ff.use_protocol_api_v2():
+        monkeypatch.setattr(tools, 'driver', robot._backend._smoothie_driver)
+    else:
+        monkeypatch.setattr(tools, 'driver', robot._driver)
 
 
 def test_parse_model_from_barcode(driver_import):

--- a/api/tests/opentrons/tools/test_qc_scripts.py
+++ b/api/tests/opentrons/tools/test_qc_scripts.py
@@ -31,7 +31,10 @@ pipette_barcode_to_model = {
 def driver_import(monkeypatch, robot):
     from opentrons import tools
     if ff.use_protocol_api_v2():
-        monkeypatch.setattr(tools, 'driver', robot._backend._smoothie_driver)
+        monkeypatch.setattr(
+            tools,
+            'driver',
+            robot._hw_manager._current._backend._smoothie_driver)
     else:
         monkeypatch.setattr(tools, 'driver', robot._driver)
 
@@ -51,26 +54,29 @@ def test_parse_model_from_barcode(driver_import):
         wpm._parse_model_from_barcode('aP300S20180101A01')
 
 
-def test_read_old_pipette_id_and_model(driver_import):
+@pytest.mark.api1_only
+def test_read_old_pipette_id_and_model(driver_import, monkeypatch):
     import io
-    import types
     from contextlib import redirect_stdout
     from opentrons.tools import driver, write_pipette_memory as wpm
-    from opentrons.drivers.smoothie_drivers.driver_3_0 import \
-        GCODES, _byte_array_to_hex_string
+    from opentrons.drivers.smoothie_drivers.driver_3_0 import GCODES
 
-    driver.simulating = False
-    _old_send_command = driver._send_command
-
-    def _new_send_message(self, command, timeout=None):
+    def _new_send_message(command):
         if GCODES['READ_INSTRUMENT_ID'] in command:
-            return ''
+            return command.split(' ')[1]
         elif GCODES['READ_INSTRUMENT_MODEL'] in command:
-            return ''
+            return command.split(' ')[1]
         else:
             return ''
 
-    driver._send_command = types.MethodType(_new_send_message, driver)
+    def read_id(mount):
+        return _new_send_message(command='')
+
+    def read_model(mount):
+        return _new_send_message(command='')
+
+    monkeypatch.setattr(driver, 'read_pipette_id', read_id)
+    monkeypatch.setattr(driver, 'read_pipette_model', read_model)
 
     f = io.StringIO()
     with redirect_stdout(f):
@@ -81,15 +87,14 @@ def test_read_old_pipette_id_and_model(driver_import):
 
     for old_id, old_model in pipette_barcode_to_model.items():
 
-        def _new_send_message(self, command, timeout=None):
-            if GCODES['READ_INSTRUMENT_ID'] in command:
-                return 'R:' + _byte_array_to_hex_string(old_id.encode())
-            elif GCODES['READ_INSTRUMENT_MODEL'] in command:
-                return 'R:' + _byte_array_to_hex_string(old_model.encode())
-            else:
-                return ''
+        def read_id(mount):
+            return _new_send_message(command=f'M369 {old_id}')
 
-        driver._send_command = types.MethodType(_new_send_message, driver)
+        def read_model(mount):
+            return _new_send_message(command=f'M371 {old_model}')
+
+        monkeypatch.setattr(driver, 'read_pipette_id', read_id)
+        monkeypatch.setattr(driver, 'read_pipette_model', read_model)
 
         f = io.StringIO()
         with redirect_stdout(f):
@@ -99,33 +104,32 @@ def test_read_old_pipette_id_and_model(driver_import):
             old_id, old_model)
         assert out.strip() == exp
 
-    driver._send_command = _old_send_command
 
-
-def test_write_new_pipette_id_and_model(driver_import):
-    import types
+@pytest.mark.api1_only
+def test_write_new_pipette_id_and_model(driver_import, monkeypatch):
     from opentrons.tools import driver, write_pipette_memory as wpm
     from opentrons.drivers.smoothie_drivers.driver_3_0 import \
-        GCODES, _byte_array_to_hex_string
-
-    driver.simulating = False
-    _old_send_command = driver._send_command
+        GCODES
 
     for new_id, new_model in pipette_barcode_to_model.items():
 
-        def _new_send_message(self, command, timeout=None):
+        def _new_send_message(command, timeout=None):
             nonlocal new_id, new_model
             if GCODES['READ_INSTRUMENT_ID'] in command:
-                return 'R:' + _byte_array_to_hex_string(new_id.encode())
+                return new_id
             elif GCODES['READ_INSTRUMENT_MODEL'] in command:
-                return 'R:' + _byte_array_to_hex_string(new_model.encode())
+                return new_model
             else:
                 return ''
 
-        driver._send_command = types.MethodType(_new_send_message, driver)
+        def read_id(mount):
+            return _new_send_message(command='M369')
 
+        def read_model(mount):
+            return _new_send_message(command='M371')
+
+        monkeypatch.setattr(driver, 'read_pipette_id', read_id)
+        monkeypatch.setattr(driver, 'read_pipette_model', read_model)
         # this will raise an error if the received id/model does not match
         # the id/model that was written
         wpm.write_identifiers('right', new_id, new_model)
-
-    driver._send_command = _old_send_command


### PR DESCRIPTION
## overview

Closes #3538. With this PR, you can now _upload_ an api v1 protocol with the api v2 feature flag flipped. *Note* The protocol will not run correctly as the rest of the tickets in the [backcompat milestone](https://github.com/Opentrons/opentrons/milestone/103).

## changelog


## review requests

Please run some protocols in different use-cases including through the app/jupyter/commandline in v1 and v2.
