### PR TITLE
ci(travis): Do not cache the node_modules folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 cache:
   pip: true
   yarn: true
+  npm: false
 
 stages:
   - test


### PR DESCRIPTION
## overview

- In July 2019, Travis [enabled the npm cache setting by default](https://docs.travis-ci.com/user/caching/#npm-cache)
- The npm cache setting will either:
    - Cache the npm system package cache if your `install` script is `npm ci`
    - Cache the repository's `node_modules` folder otherwise
- We have the yarn cache setting enabled, which caches yarn's system package cache

Since our `install` script is not `npm ci`, the end result for us is that we cache both the system level yarn package cache **and** the repository's node_modules folder. This is bad for us, because we want a fresh `node_modules` folder on every build to ensure any native dependencies are properly built.

We have been seeing intermittent build failures do to improperly built native depedencies that can only be cleared by manually deleting the Travis cache. This PR explicitly disables the npm cache setting while leaving the yarn cache setting untouched 

## changelog

- ci(travis): Do not cache the node_modules folder

## review requests

- [ ] CI builds properly

This PR _may_ increase our build times slightly, but the system level yarn cache should do its job and keep the install time mostly the same
