### PR TITLE
refactor(pd): update FS snippet; enable linting/flow

### DIFF
--- a/protocol-designer/src/analytics/actions.js
+++ b/protocol-designer/src/analytics/actions.js
@@ -1,17 +1,17 @@
 // @flow
-import { initializeAnalytics, shutdownAnalytics } from './integrations'
+import { initializeFullstory, shutdownFullstory } from './fullstory'
 
-export type SetOptIn = {
+export type SetOptIn = {|
   type: 'SET_OPT_IN',
   payload: boolean,
-}
+|}
 
 const _setOptIn = (payload: $PropertyType<SetOptIn, 'payload'>): SetOptIn => {
   // side effects
   if (payload) {
-    initializeAnalytics()
+    initializeFullstory()
   } else {
-    shutdownAnalytics()
+    shutdownFullstory()
   }
 
   return {

--- a/protocol-designer/src/analytics/fullstory.js
+++ b/protocol-designer/src/analytics/fullstory.js
@@ -1,7 +1,7 @@
-/* eslint-disable */
+// @flow
 import cookie from 'cookie'
 
-export const shutdownAnalytics = () => {
+export const shutdownFullstory = () => {
   if (window[window['_fs_namespace']]) {
     window[window['_fs_namespace']].shutdown()
   }
@@ -13,7 +13,7 @@ const _setAnalyticsTags = () => {
   const { ot_email: email, ot_name: displayName } = cookies
   const commit_str = process.env.OT_PD_COMMIT_HASH
   const version_str = process.env.OT_PD_VERSION
-  const buildDate_date = new Date(process.env.OT_PD_BUILD_DATE)
+  const buildDate_date = new Date((process.env.OT_PD_BUILD_DATE: any))
 
   // NOTE: fullstory expects the keys 'displayName' and 'email' verbatim
   // though all other key names must be fit the schema described here
@@ -25,50 +25,57 @@ const _setAnalyticsTags = () => {
       commit_str,
       version_str,
       buildDate_date,
+      ot_application_name_str: 'protocol-designer', // NOTE: to distinguish from other apps using the org
     })
   }
 }
 
-// NOTE: this code snippet is distributed by FullStory and formatting has been maintained
+// NOTE: this code snippet is distributed by Fullstory and formatting has been maintained
 window['_fs_debug'] = false
 window['_fs_host'] = 'fullstory.com'
 window['_fs_org'] = process.env.OT_PD_FULLSTORY_ORG
 window['_fs_namespace'] = 'FS'
 
-export const initializeAnalytics = () => {
-  ;(function(m, n, e, t, l, o, g, y) {
+export const initializeFullstory = () => {
+  ;(function(m, n, e, t, l, o, g: any, y: any) {
     if (e in m) {
       if (m.console && m.console.log) {
         m.console.log(
-          'FullStory namespace conflict. Please set window["_fs_namespace"].'
+          'Fullstory namespace conflict. Please set window["_fs_namespace"].'
         )
       }
       return
     }
-    g = m[e] = function(a, b) {
-      g.q ? g.q.push([a, b]) : g._api(a, b)
+    g = m[e] = function(a, b, s) {
+      g.q ? g.q.push([a, b, s]) : g._api(a, b, s)
     }
     g.q = []
     o = n.createElement(t)
+    // $FlowFixMe
     o.async = 1
-    o.src = 'https://' + _fs_host + '/s/fs.js'
+    o.crossOrigin = 'anonymous'
+    o.src = 'https://' + global._fs_host + '/s/fs.js'
     y = n.getElementsByTagName(t)[0]
+    // $FlowFixMe
     y.parentNode.insertBefore(o, y)
-    g.identify = function(i, v) {
-      g(l, { uid: i })
-      if (v) g(l, v)
+    g.identify = function(i, v, s) {
+      g(l, { uid: i }, s)
+      if (v) g(l, v, s)
     }
-    g.setUserVars = function(v) {
-      g(l, v)
+    g.setUserVars = function(v, s) {
+      g(l, v, s)
     }
-    g.event = function(i, v) {
-      g('event', { n: i, p: v })
+    g.event = function(i, v, s) {
+      g('event', { n: i, p: v }, s)
     }
     g.shutdown = function() {
       g('rec', !1)
     }
     g.restart = function() {
       g('rec', !0)
+    }
+    g.log = function(a, b) {
+      g('log', [a, b])
     }
     g.consent = function(a) {
       g('consent', !arguments.length || a)
@@ -80,6 +87,6 @@ export const initializeAnalytics = () => {
       g(o, v)
     }
     g.clearUserCookie = function() {}
-  })(window, document, window['_fs_namespace'], 'script', 'user')
+  })(global, global.document, global['_fs_namespace'], 'script', 'user')
   _setAnalyticsTags()
 }

--- a/protocol-designer/src/initialize.js
+++ b/protocol-designer/src/initialize.js
@@ -3,7 +3,7 @@
 import i18n from './localization'
 import { selectors as loadFileSelectors } from './load-file'
 import { selectors as analyticsSelectors } from './analytics'
-import { initializeAnalytics } from './analytics/integrations'
+import { initializeFullstory } from './analytics/fullstory'
 
 const initialize = (store: Object) => {
   if (process.env.NODE_ENV === 'production') {
@@ -16,7 +16,7 @@ const initialize = (store: Object) => {
 
     // Initialize analytics if user has already opted in
     if (analyticsSelectors.getHasOptedIn(store.getState())) {
-      initializeAnalytics()
+      initializeFullstory()
     }
   }
 }


### PR DESCRIPTION
## overview

Make similar changes to PD's Fullstory stuff so it mirrors LL/LC's FS setup in #4177

## changelog

- Update Fullstory snippet, they've added additional arguments
- Enable linting and flow checking this file
- Rename generic things to Fullstory where relevant (I imagine if we have multiple integrations, they'll use their own files instead of 1 big file)
- Add `ot_application_name_str: 'protocol-designer'` analytics tag b/c we're re-using the same FS org across apps and it might be helpful to filter on this?

## review requests

- Should work the same as before, please test in sandbox and check FS