### PR TITLE
fix(api): change trash definitions to avoid y head crash

### DIFF
--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -3,7 +3,6 @@ import itertools
 import logging
 import json
 from opentrons.config import CONFIG
-from opentrons.config.pipette_config import Y_OFFSET_MULTI
 from opentrons.data_storage import database
 from opentrons.util.vector import Vector
 from opentrons.types import Point
@@ -189,7 +188,7 @@ def _load_new_well(well_data, saved_offset, lw_quirks):
     if "fixedTrash" in lw_quirks:
         well_tuple = (
             well_data['x'] + saved_offset.x,
-            well_data['y'] + Y_OFFSET_MULTI + saved_offset.y,
+            well_data['y'] + saved_offset.y,
             well_data['z'] + saved_offset.z)
     elif "centerMultichannelOnWells" in lw_quirks:
         well_tuple = (

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -101,7 +101,6 @@ def test_load_new_trough(robot):
 
 
 def test_load_fixed_trash(robot):
-    from opentrons.config.pipette_config import Y_OFFSET_MULTI
     assert robot.fixed_trash[0]._coordinates == (
         82.84, 80, 82)
 

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -103,7 +103,7 @@ def test_load_new_trough(robot):
 def test_load_fixed_trash(robot):
     from opentrons.config.pipette_config import Y_OFFSET_MULTI
     assert robot.fixed_trash[0]._coordinates == (
-        82.84, 53.56 + Y_OFFSET_MULTI, 82)
+        82.84, 80, 82)
 
 
 def test_containers_list(robot):

--- a/shared-data/labware/definitions/2/opentrons_1_trash_1100ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_1100ml_fixed/1.json
@@ -19,7 +19,7 @@
     "isTiprack": false,
     "loadName": "opentrons_1_trash_1100ml_fixed",
     "isMagneticModuleCompatible": false,
-    "quirks": ["fixedTrash"]
+    "quirks": ["fixedTrash", "centerMultichannelOnWells"]
   },
   "wells": {
     "A1": {

--- a/shared-data/labware/definitions/2/opentrons_1_trash_1100ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_1100ml_fixed/1.json
@@ -19,7 +19,7 @@
     "isTiprack": false,
     "loadName": "opentrons_1_trash_1100ml_fixed",
     "isMagneticModuleCompatible": false,
-    "quirks": ["fixedTrash", "centerMultichannelOnWells"]
+    "quirks": ["fixedTrash"]
   },
   "wells": {
     "A1": {
@@ -29,7 +29,7 @@
       "totalLiquidVolume": 1100000,
       "depth": 0,
       "x": 82.84,
-      "y": 53.56,
+      "y": 80,
       "z": 82
     }
   },

--- a/shared-data/labware/definitions/2/opentrons_1_trash_850ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_850ml_fixed/1.json
@@ -19,7 +19,7 @@
     "isTiprack": false,
     "loadName": "opentrons_1_trash_850ml_fixed",
     "isMagneticModuleCompatible": false,
-    "quirks": ["fixedTrash"]
+    "quirks": ["fixedTrash", "centerMultichannelOnWells"]
   },
   "wells": {
     "A1": {

--- a/shared-data/labware/definitions/2/opentrons_1_trash_850ml_fixed/1.json
+++ b/shared-data/labware/definitions/2/opentrons_1_trash_850ml_fixed/1.json
@@ -19,7 +19,7 @@
     "isTiprack": false,
     "loadName": "opentrons_1_trash_850ml_fixed",
     "isMagneticModuleCompatible": false,
-    "quirks": ["fixedTrash", "centerMultichannelOnWells"]
+    "quirks": ["fixedTrash"]
   },
   "wells": {
     "A1": {
@@ -29,7 +29,7 @@
       "totalLiquidVolume": 850000,
       "depth": 0,
       "x": 82.84,
-      "y": 53.56,
+      "y": 80,
       "z": 58
     }
   },


### PR DESCRIPTION
In 42deac230ce334e0a6ace69b756a1df5d8dd63e0 we changed the behavior of container
load to load v2 trash containers and dynamically modify the geometry to move the
"center" point +y by half the size of a multichannel pipette. This let our
multichannel pipettes dispense in the middle of the trash without having to
special case behavior at runtime. It also let us use the v2 trash definitions in
apiv1, which are more correct.

Unfortunately, one of the ways in which the old trash definitions were incorrect
was to put the "center" of the trash well at a very specific location for both
multi and single pipettes - y+80mm. With the correct geometry and special casing
based on the size of a multi, we were using y+85mm or so. This interacts badly
with a sheet metal change on the gantry, and robots using these definitions
collide when dropping tips in the trash.

This commit removes the geometry modifications at runtime in favor of altering
the v2 trash geometry to place the y-center at the exact right place. It also
removes the centerMultichannelOnWells quirk from the new trash defs since that
isn't accurate anymore - the backmost channel of the multi should go to this
very specific position.

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
