### PR TITLE
ci(travis): disable travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 # opentrons platform travis config
-cache:
-  pip: true
-  yarn: true
+cache: false
 
 stages:
   - test


### PR DESCRIPTION
Travis cache upload is taking a very (very) long time at least on osx release builds; disable it, at least for now