### PR TITLE
refactor(labware-library): Update subdomain navlink styles

### DIFF
--- a/labware-library/src/components/website-navigation/styles.css
+++ b/labware-library/src/components/website-navigation/styles.css
@@ -72,7 +72,7 @@
   height: 100%;
 }
 
-.subdomain_link {
+a.subdomain_link {
   margin-left: var(--spacing-subdomain);
   font-size: var(--fs-body-1);
   font-weight: var(--fw-semibold);
@@ -82,6 +82,10 @@
 
   &:hover {
     color: var(--c-font-dark);
+  }
+
+  &:visited {
+    color: var(--c-nav-gray);
   }
 }
 


### PR DESCRIPTION
## overview

This PR serves as it own ticket. Some of the LC link styles were updated last week, to allow for easier overwriting links styles (links as buttons). Unfortunately, this applied the blue text color to all subdomain nav links. This PR sneaks in a little specificity to override that and once again, match the main website navigation.

Before:
<img width="1164" alt="Screen Shot 2019-10-09 at 1 27 34 PM" src="https://user-images.githubusercontent.com/3430313/66505140-b7bc2480-ea98-11e9-907d-3ef061f872e1.png">

Now:
<img width="1160" alt="Screen Shot 2019-10-09 at 1 28 14 PM" src="https://user-images.githubusercontent.com/3430313/66505150-bb4fab80-ea98-11e9-9a8c-885bfcab7832.png">

## changelog

- refactor(labware-library): Update subdomain navlink styles

## review requests

- [ ] Subdomain nav links are now gray
